### PR TITLE
docs(engine): the Windows manifest keeps one live dependent, and #858 is when it retires

### DIFF
--- a/.github/check-windows-deps.py
+++ b/.github/check-windows-deps.py
@@ -33,6 +33,15 @@ embeds it via `vayu_embed_windows_manifest()`, and `vayu_tests` asserts its own
 copy in `HttpVersionSupport.WindowsOsVersionIsNotShimmed` - but a gtest can only
 vouch for the binary it is running in, and the binary users get is this one.
 
+That chain is dormant rather than gone, which is what #856 established. Since
+#851 the engine verifies with OpenSSL, whose ALPN is not gated on an OS version
+- but Schannel is still *compiled into* this binary (the curl port's `http2`
+feature depends on `curl[ssl]`, which resolves to Schannel on Windows, so the
+build is MultiSSL; #858 is the move to one backend). The process runs on
+OpenSSL because `pin_tls_backend()` selects it at startup, and that call is
+deliberately non-fatal if it fails. So the manifest still guards a reachable
+path, and it retires when #858 removes Schannel from the build - not before.
+
 Usage:
     python .github/check-windows-deps.py <path-to-exe-or-dll>
 """
@@ -58,7 +67,9 @@ ALLOWED_EXACT = {
     # Networking
     "ws2_32.dll", "wsock32.dll", "iphlpapi.dll", "mswsock.dll", "dnsapi.dll",
     "winhttp.dll", "wininet.dll", "netapi32.dll",
-    # Crypto / TLS (curl uses Schannel on Windows)
+    # Crypto / TLS. The engine verifies with OpenSSL on every platform (#851),
+    # but Schannel is still compiled in here (MultiSSL, #858) and OpenSSL reads
+    # the native certificate store through crypt32 - so these stay allowlisted.
     "crypt32.dll", "bcrypt.dll", "ncrypt.dll", "secur32.dll", "sspicli.dll",
     "wintrust.dll",
 }
@@ -76,16 +87,20 @@ RT_MANIFEST = 24
 # supportedOS ids that must appear in it. The 8.1 id is the one HTTP/2 hangs
 # on: curl's Schannel ALPN gate asks for >= 6.3, and an unmanifested process is
 # told 6.2. The 10/11 id is what makes the reported version the real one on a
-# modern box, which curl's other version gates (e.g. the >= 6.1 check that
-# allows a CA bundle) read the same way.
+# modern box - #856 found no live reader of a shimmed version above 6.3 (every
+# other libcurl version gate runs after Curl_win32_init() and so reads ntdll's
+# true answer), so it is the invariant that is asserted rather than a specific
+# caller, and vayu_tests probes for the same two ids.
 REQUIRED_SUPPORTED_OS = {
     "{1f676c76-80e1-4239-95bb-83d0f6d0da78}": (
-        "Windows 8.1 - clears curl's Schannel ALPN gate. Without it every "
-        "HTTPS request is HTTP/1.1, silently."
+        "Windows 8.1 - clears curl's Schannel ALPN gate. Schannel is still in "
+        "this build (MultiSSL, #858); on any path that selects it, every HTTPS "
+        "request would be HTTP/1.1, silently."
     ),
     "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}": (
         "Windows 10/11 - makes the OS version reported to the process the "
-        "real one, which curl's other version gates also read."
+        "real one rather than capping it at 6.3. No current caller reads it "
+        "(#856), but a half-declared manifest is drift, not a decision."
     ),
 }
 
@@ -130,9 +145,11 @@ def check_manifest(path: str) -> int:
     if manifest is None:
         print(
             f"\nFAILED: {path} has no embedded application manifest.\n"
-            "  Windows will report itself as 6.2 to this process, curl's Schannel\n"
-            "  backend will disable ALPN, and every HTTPS request will be HTTP/1.1\n"
-            "  regardless of the requested httpVersion - with a 200 and no error.\n"
+            "  Windows will report itself as 6.2 to this process. Schannel is still\n"
+            "  compiled into this build (MultiSSL - see #858), and on any path that\n"
+            "  selects it that reported version disables ALPN, so every HTTPS request\n"
+            "  is HTTP/1.1 regardless of the requested httpVersion - with a 200 and\n"
+            "  no error.\n"
             "  Fix: vayu_embed_windows_manifest() in engine/CMakeLists.txt must be\n"
             "  called for this target (engine/res/vayu-windows.manifest).",
             file=sys.stderr,
@@ -159,7 +176,10 @@ def check_manifest(path: str) -> int:
             print(f"\n  {guid}\n    {why}", file=sys.stderr)
         return 1
 
-    print("\nOK: the supportedOS manifest is embedded - ALPN, and so HTTP/2, work.")
+    print(
+        "\nOK: the supportedOS manifest is embedded - this process is told its "
+        "real OS version, so a Schannel path could still negotiate ALPN."
+    )
     return 0
 
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -224,24 +224,23 @@ Two consequences worth knowing before you change the build:
 
 `engine/res/vayu-windows.manifest` is embedded into `vayu-engine`, `vayu-cli`
 and `vayu_tests` by `vayu_embed_windows_manifest()` in
-`engine/CMakeLists.txt`, and both guards below still assert it.
+`engine/CMakeLists.txt`, and both guards below assert it.
 
-**The chain it was added for is historical since
-[#851](https://github.com/athrvk/vayu/issues/851)**, and it is written out
-because no part of it is guessable from the flag - and because a return to
-Schannel brings it straight back:
+The chain it was added for, written out because no part of it is guessable from
+the flag (line numbers are curl 8.21.0, the pinned version):
 
-1. libcurl on Windows used the Schannel TLS backend, and HTTP/2 over TLS is
-   only reachable through ALPN.
-2. curl's Schannel backend enables ALPN only when the OS is at least Windows
-   8.1 (`s_win_has_alpn`, `lib/vtls/schannel.c`).
+1. libcurl's Schannel backend reaches HTTP/2 over TLS only through ALPN.
+2. It enables ALPN only when the OS is at least Windows 8.1 (`s_win_has_alpn`,
+   `lib/vtls/schannel.c:2620`).
 3. That check prefers ntdll's `RtlVerifyVersionInfo`, which tells the truth -
-   but resolves the pointer to it in `Curl_win32_init()`, which libcurl's
-   `global_init()` runs *after* `Curl_ssl_init()`. The one call that decided
-   ALPN for the whole process therefore fell back to `VerifyVersionInfoW`.
+   but resolves the pointer to it in `Curl_win32_init()`, which `global_init()`
+   runs *after* `Curl_ssl_init()` (`lib/easy.c:143` then `:153`).
+   `s_win_has_alpn` is assigned inside `schannel_init()`, i.e. from within
+   `Curl_ssl_init()`, so the one call that decides ALPN for the whole process
+   falls back to `VerifyVersionInfoW` (`lib/curlx/version_win32.c:207-210`).
 4. `VerifyVersionInfoW` is version-shimmed: since Windows 8.1 it reports 6.2 to
    any process whose manifest does not declare support for a later OS. 6.2 <
-   6.3, so ALPN was switched off for the life of the process - **HTTP/2 never
+   6.3, so ALPN is switched off for the life of the process - **HTTP/2 never
    negotiated**, with a `200 OK` and a reported `HTTP/1.1` for a request that
    asked for h2.
 
@@ -249,17 +248,57 @@ The manifest's `supportedOS` ids turn the shim off. v0.11.0 through v0.14.0
 shipped without it and HTTP/2 was dead on Windows the whole time
 ([#215](https://github.com/athrvk/vayu/issues/215)) - the failure is invisible,
 which is why it is guarded twice: `HttpVersionSupport.WindowsOsVersionIsNotShimmed`
-asserts that the test binary is not being version-lied to, and
-`check-windows-deps.py` scans the *shipped* `vayu-engine.exe` for the ids, since
-a gtest can only vouch for the process it runs in.
+asserts that the test binary is not being version-lied to (both ids, since
+`check-windows-deps.py` requires both), and `check-windows-deps.py` scans the
+*shipped* `vayu-engine.exe` for the same ids, since a gtest can only vouch for
+the process it runs in.
 
-Since #851 the Windows build verifies with OpenSSL, whose ALPN is not gated on
-an OS version check - so step 2 no longer runs and HTTP/2 on Windows does not
-depend on the manifest. The manifest and its two guards stay: they are cheap,
-they are what makes a return to Schannel safe, and whether anything *else*
-still needs them is
-[#856](https://github.com/athrvk/vayu/issues/856) rather than a deletion made
-in passing.
+##### Why it is still here, and when it goes
+
+[#851](https://github.com/athrvk/vayu/issues/851) put every leg on OpenSSL,
+whose ALPN is not gated on an OS version at all, which reads like step 2 no
+longer running. [#856](https://github.com/athrvk/vayu/issues/856) asked what
+still depends on the manifest, and the answer is: **the chain is dormant, not
+gone, because Schannel is still compiled into this binary.**
+
+The curl port's `http2` feature depends on `curl[ssl]`, which resolves to
+Schannel on Windows, so the shipped libcurl is MultiSSL - getting the build down
+to one backend is [#858](https://github.com/athrvk/vayu/issues/858). The process
+runs on OpenSSL because `pin_tls_backend()` names it through
+`curl_global_sslset` before `curl_global_init`, and on a MultiSSL build
+`Curl_ssl_init()` calls `init()` on the selected backend alone
+(`lib/vtls/vtls.c:595-601`), so `schannel_init()` never runs and step 2 is never
+evaluated. That is a runtime selection whose failure path is deliberately
+non-fatal - `pin_tls_backend()` logs and continues - so a process that reaches
+`curl_global_init` first lands on libcurl's own choice, which reads
+`CURL_SSL_BACKEND` from the environment before falling back.
+
+**So the retirement condition is #858, not a date.** When the Windows build is
+genuinely single-backend, `schannel_init()` leaves the binary, the manifest's
+last dependent goes with it, and the manifest, the gtest and the
+`check-windows-deps.py` manifest check are deleted together.
+
+##### What else reads a shimmed OS version: nothing
+
+The `supportedOS` ids change what `GetVersionEx` / `VerifyVersionInfoW` report
+to the **whole process**, so #856 enumerated every other reader in the engine
+and its statically-linked dependencies. Callers of ntdll's `RtlGetVersion` /
+`RtlVerifyVersionInfo` are immune by construction - the shim does not touch
+those - so only the `kernel32` family matters:
+
+| Where | Reads a shimmed version? |
+|-------|--------------------------|
+| Vayu's own sources (`engine/src`, `engine/include`, `engine/vendor`) | No - none read an OS version at all |
+| libcurl `lib/vtls/schannel.c:2620` (`s_win_has_alpn`) | **Yes** - the one dependent, and only when `schannel_init()` runs |
+| libcurl's nine other version gates: `lib/cf-socket.c:193` (the `TCP_KEEP*` `setsockopt` gate, which is backend-independent), five more in `schannel.c`, three in `schannel_verify.c` | No - all evaluated at connect, handshake or verify time, after `Curl_win32_init()` resolved the ntdll pointer, so they read the true OS whatever the manifest says |
+| OpenSSL 3.6.3 | No - calls neither API |
+| SQLite (`sqlite3_win32_is_nt()`) | No - it calls `GetVersionEx[AW]`, but reads only `dwPlatformId` (NT vs Win9x), which the shim does not change; and the call compiles out entirely on this SDK target (`NTDDI_VERSION >= NTDDI_WINBLUE`), leaving `osIsNT()` a constant |
+| nghttp2, cpp-httplib, libsodium, zlib, brotli, sqlite-orm, GoogleTest, rapidyaml/c4core, valijson, quickjs-ng, HdrHistogram | No |
+
+The file itself is only the `supportedOS` ids - no `requestedExecutionLevel`
+(the engine is an unprivileged sidecar and must stay one), no DPI awareness (it
+has no windows), no long-path or code-page declaration - so there is no second
+reason hiding in it that would survive the first one going away.
 
 Add a fourth executable that links libcurl and you must call
 `vayu_embed_windows_manifest()` for it too. Note that the mechanism is a

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -227,8 +227,11 @@ endif()
 # `VerifyVersionInfoW` reports Windows 8 to the process, curl's Schannel
 # backend concludes the OS is too old for ALPN, and HTTP/2 can never be
 # negotiated - silently, with a 200 and an `httpVersion` of "HTTP/1.1"
-# (issue #215). The full chain is written out in the manifest file itself;
-# read that before removing any of this.
+# (issue #215). The engine selects OpenSSL at startup, so that path is dormant
+# rather than gone: Schannel is still compiled into this build (MultiSSL) and
+# leaves it with #858, which is when this function and both its guards retire.
+# The full chain and the enumeration behind that decision (#856) are written
+# out in the manifest file itself; read that before removing any of this.
 #
 # The mechanism is a plain `.manifest` source, not a linker flag. CMake feeds
 # any `.manifest` source through `mt` and merges it into the one manifest it

--- a/engine/res/vayu-windows.manifest
+++ b/engine/res/vayu-windows.manifest
@@ -2,47 +2,75 @@
 <!--
   Windows application manifest for every Vayu engine executable.
 
-  This file exists for exactly one reason: WITHOUT IT, HTTP/2 IS IMPOSSIBLE ON
-  WINDOWS. Not slower, not occasionally - never negotiated, silently, with a
-  200 OK and an `httpVersion` of "HTTP/1.1" for a request that asked for h2.
-  That was issue #215, and it took a libcurl source read to explain, so the
-  whole chain is written down here rather than in a commit message.
+  It exists to stop one thing: HTTP/2 silently switching itself off on Windows.
+  Not slower, not occasionally - never negotiated, with a 200 OK and an
+  `httpVersion` of "HTTP/1.1" for a request that asked for h2. That was issue
+  #215, and it took a libcurl source read to explain, so the whole chain is
+  written down here rather than in a commit message.
 
-  The chain:
+  The chain (line numbers are curl 8.21.0, the pinned version):
 
-  1. libcurl on Windows uses the Schannel TLS backend (see engine/vcpkg.json -
-     `curl[http2]`, whose `ssl` feature resolves to Schannel on Windows, which
-     is also why check-windows-deps.py allowlists secur32/bcrypt and no
-     OpenSSL). HTTP/2 over TLS is only reachable through ALPN.
-
-  2. curl's Schannel backend gates ALPN on the OS being at least Windows 8.1:
-     `s_win_has_alpn = curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
-     VERSION_GREATER_THAN_EQUAL)` in lib/vtls/schannel.c. With that false,
+  1. libcurl's Schannel backend reaches HTTP/2 over TLS only through ALPN, and
+     gates ALPN on the OS being at least Windows 8.1: `s_win_has_alpn =
+     curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
+     VERSION_GREATER_THAN_EQUAL)` (lib/vtls/schannel.c:2620). With that false,
      `backend->use_alpn` is false, curl never sends an ALPN extension, and the
      connection can only ever be HTTP/1.1.
 
-  3. That version check prefers ntdll's `RtlVerifyVersionInfo`, which reports
+  2. That version check prefers ntdll's `RtlVerifyVersionInfo`, which reports
      the true OS - but the pointer to it is resolved in `Curl_win32_init()`,
-     which libcurl's `global_init()` (lib/easy.c) calls *after*
-     `Curl_ssl_init()`. So the one call that decides ALPN for the process runs
-     while the pointer is still null and falls back to `VerifyVersionInfoW`.
+     which `global_init()` calls *after* `Curl_ssl_init()` (lib/easy.c:143 then
+     :153). `s_win_has_alpn` is assigned inside `schannel_init()`, i.e. from
+     within `Curl_ssl_init()` - so it runs while the pointer is still null and
+     falls back to `VerifyVersionInfoW` (lib/curlx/version_win32.c:207-210).
 
-  4. `VerifyVersionInfoW` is version-shimmed. Since Windows 8.1 it reports 6.2
+  3. `VerifyVersionInfoW` is version-shimmed. Since Windows 8.1 it reports 6.2
      (Windows 8) to any process whose manifest does not declare support for a
      later OS. 6.2 < 6.3 - so on Windows 10 and 11 the check fails, and ALPN,
      and with it HTTP/2, is switched off for the life of the process.
 
   The `supportedOS` ids below are what turns the shim off. With them,
-  VerifyVersionInfoW answers truthfully, step 2 passes, and curl offers
+  VerifyVersionInfoW answers truthfully, step 1 passes, and curl offers
   `h2,http/1.1`. Verified by A/B: the same probe binary against the same
   libcurl, with and only with this manifest, goes from no ALPN line at all to
   "ALPN: server accepted h2".
 
-  Consequences of deleting this file, in order of how likely they are to be
-  noticed: none, none, none, and a user measuring HTTP/2 throughput gets
-  HTTP/1.1 numbers labelled HTTP/2. There is a test - `WindowsOsVersionShim` in
-  engine/tests/http_version_support_test.cpp - and a check on the shipped
-  binary in .github/check-windows-deps.py, because a silent failure needs two.
+  WHY IT IS STILL HERE, given that the engine verifies with OpenSSL (#851),
+  whose ALPN is not gated on an OS version at all - answered by #856:
+
+  Because Schannel is still *in this binary*. The curl port's `http2` feature
+  depends on `curl[ssl]`, which resolves to Schannel on Windows, so the shipped
+  libcurl is MultiSSL; getting the build down to one backend is #858. The
+  process runs on OpenSSL because `pin_tls_backend()` (engine/src/http/
+  client.cpp) names it through `curl_global_sslset` before `curl_global_init`,
+  and on a MultiSSL build `Curl_ssl_init()` calls `init()` on the selected
+  backend alone (lib/vtls/vtls.c:595-601) - so `schannel_init()` does not run
+  and step 1 is never evaluated. That is a runtime selection, and its failure
+  path is deliberately non-fatal: `pin_tls_backend()` logs and continues, and
+  anything that reaches `curl_global_init` before it lands on libcurl's own
+  choice, which reads `CURL_SSL_BACKEND` from the environment first.
+
+  So the dependent is real and reachable, not hypothetical. **When #858 makes
+  the Windows build single-backend, `schannel_init()` leaves the binary, this
+  file's last dependent goes with it, and the manifest and both its guards can
+  be deleted.** That is the retirement condition; until then, keep them.
+
+  Nothing else reads a shimmed OS version. #856 enumerated the alternatives:
+  Vayu's own sources read none; libcurl's other nine version gates
+  (lib/cf-socket.c:193's TCP_KEEP* setsockopt gate, five more in schannel.c,
+  three in schannel_verify.c) all run at connect or handshake time, after
+  `Curl_win32_init()` resolved the ntdll pointer, so they read the true OS
+  whatever this file says; OpenSSL 3.6.3 calls neither API; and SQLite's
+  `sqlite3_win32_is_nt()` reads only `dwPlatformId`, which the shim does not
+  touch, and compiles out entirely on this SDK target. See
+  docs/engine/building.md.
+
+  Consequences of deleting this file today: none until something puts the
+  process on Schannel, and then a user measuring HTTP/2 throughput gets
+  HTTP/1.1 numbers labelled HTTP/2. Because that failure is invisible it is
+  guarded twice - `HttpVersionSupport.WindowsOsVersionIsNotShimmed` in
+  engine/tests/http_version_support_test.cpp for the test binary, and
+  .github/check-windows-deps.py for the shipped one.
 
   Nothing else here is a compatibility knob to tune: no requestedExecutionLevel
   (the engine is an unprivileged sidecar and must stay one), no dpiAwareness

--- a/engine/tests/http_version_support_test.cpp
+++ b/engine/tests/http_version_support_test.cpp
@@ -94,30 +94,42 @@ bool os_at_least (DWORD major, DWORD minor, bool use_rtl) {
 } // namespace
 
 /**
- * On Windows, HTTP/2 used to live or die by this process's *reported* OS
- * version, and this is what keeps that from silently coming back.
+ * On Windows, HTTP/2 can live or die by this process's *reported* OS version,
+ * and this is what keeps that from silently happening.
  *
  * curl's Schannel backend enables ALPN only when the OS is at least Windows 8.1
- * (`s_win_has_alpn`, lib/vtls/schannel.c), and without ALPN a TLS connection
- * can never be anything but HTTP/1.1. That check prefers ntdll's
+ * (`s_win_has_alpn`, lib/vtls/schannel.c:2620), and without ALPN a TLS
+ * connection can never be anything but HTTP/1.1. That check prefers ntdll's
  * RtlVerifyVersionInfo, but resolves the pointer to it in Curl_win32_init(),
- * which libcurl's global_init() runs *after* Curl_ssl_init() - so the one call
- * that decided ALPN for the process fell back to VerifyVersionInfoW, which
- * reports Windows 8 (6.2) to any unmanifested process. 6.2 < 6.3, ALPN off,
- * HTTP/2 gone - silently, with a 200 and an httpVersion of "HTTP/1.1".
+ * which libcurl's global_init() runs *after* Curl_ssl_init() - and
+ * `s_win_has_alpn` is assigned inside schannel_init(), i.e. from within
+ * Curl_ssl_init(). So the one call that decides ALPN for the process falls back
+ * to VerifyVersionInfoW, which reports Windows 8 (6.2) to any unmanifested
+ * process. 6.2 < 6.3, ALPN off, HTTP/2 gone - silently, with a 200 and an
+ * httpVersion of "HTTP/1.1" (issue #215).
  *
  * So the invariant is not "the OS is new enough" but "this process is not being
  * lied to about it": the shimmed and unshimmed answers must agree. That holds
  * only while engine/res/vayu-windows.manifest is embedded in the binary, which
  * is what this actually guards.
  *
- * **Since #851 this build verifies with OpenSSL on Windows**, whose ALPN is not
- * gated on an OS version at all - so the chain above no longer runs and HTTP/2
- * here does not depend on the manifest. The assertion stays because it is what
- * makes a return to Schannel safe: the failure it catches is invisible, and a
- * backend change that silently re-armed it would ship an HTTP/1.1-only Windows
- * build reporting success. Whether the manifest is still earning its place for
- * any *other* reason is #856, not a deletion to make in passing.
+ * **Why it still matters after #851 put every leg on OpenSSL** (whose ALPN is
+ * not gated on an OS version at all), which is the question #856 asked and
+ * this is the answer to: Schannel is still compiled into the shipped libcurl.
+ * The curl port's `http2` feature depends on `curl[ssl]`, which resolves to
+ * Schannel on Windows, so the build is MultiSSL and getting it to one backend
+ * is #858. This process runs on OpenSSL only because pin_tls_backend() names it
+ * through curl_global_sslset before curl_global_init, and Curl_ssl_init() then
+ * calls init() on the selected backend alone - so schannel_init() does not run.
+ * That selection is a runtime call whose failure is deliberately non-fatal, so
+ * the chain above is dormant rather than absent. **When #858 removes Schannel
+ * from the build, this test, the manifest and check-windows-deps.py's manifest
+ * check retire together** - that is the deletion condition, and it is not
+ * satisfied yet.
+ *
+ * Both supportedOS ids the manifest ships are probed, because
+ * check-windows-deps.py requires both on the shipped binary and a guard that
+ * asserted only one would pass on half a manifest.
  *
  * Scope: this proves it for vayu_tests. The binary that matters is
  * vayu-engine.exe, and no gtest can inspect a different executable - that half
@@ -127,22 +139,44 @@ bool os_at_least (DWORD major, DWORD minor, bool use_rtl) {
  * libcurl, call it there too.
  */
 TEST (HttpVersionSupport, WindowsOsVersionIsNotShimmed) {
-    const bool truth  = os_at_least (6, 3, /*use_rtl=*/true);
-    const bool shimmed = os_at_least (6, 3, /*use_rtl=*/false);
+    const bool truth_81   = os_at_least (6, 3, /*use_rtl=*/true);
+    const bool shimmed_81 = os_at_least (6, 3, /*use_rtl=*/false);
 
-    ASSERT_TRUE (truth) << "ntdll reports this OS as older than Windows 8.1, so "
-                           "the shim below has nothing to hide and this test can "
-                           "say nothing about the manifest - not a build defect.";
+    ASSERT_TRUE (truth_81) << "ntdll reports this OS as older than Windows 8.1, so "
+                              "the shim below has nothing to hide and this test can "
+                              "say nothing about the manifest - not a build defect.";
 
-    EXPECT_TRUE (shimmed)
+    EXPECT_TRUE (shimmed_81)
     << "This process is being version-shimmed: Windows tells it the OS is 6.2 "
        "while ntdll reports 6.3+.\n"
        "That means the supportedOS compatibility manifest is missing from this "
-       "executable, and curl has silently disabled ALPN - every HTTPS request "
-       "this binary makes is HTTP/1.1 no matter what httpVersion asks for "
+       "executable. Schannel is still in this build (MultiSSL - see #858), and "
+       "anything that puts the process on it gets ALPN silently disabled: every "
+       "HTTPS request would be HTTP/1.1 no matter what httpVersion asks for "
        "(issue #215).\n"
        "Fix: engine/res/vayu-windows.manifest must reach this target via "
        "vayu_embed_windows_manifest() in engine/CMakeLists.txt.";
+
+    // The second id. The shim can only ever under-report, never over-report, so
+    // equality is the exact statement "this process is not being lied to" - and
+    // it stays true on a genuine Windows 8.1 host, where both answers are false.
+    const bool truth_10   = os_at_least (10, 0, /*use_rtl=*/true);
+    const bool shimmed_10 = os_at_least (10, 0, /*use_rtl=*/false);
+
+    EXPECT_EQ (shimmed_10, truth_10)
+    << "ntdll reports this OS as Windows 10 or later, but the shimmed API does "
+       "not.\n"
+       "If the 6.3 probe above passed, the manifest is present but incomplete: "
+       "it is missing the Windows 10/11 supportedOS id "
+       "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}, which caps what this process is "
+       "told at 6.3.\n"
+       "Nothing reads a shimmed version above 6.3 today (#856 enumerated them), "
+       "so this is not a live defect - but the invariant this test exists for is "
+       "that the reported version is the real one, and "
+       ".github/check-windows-deps.py requires this id on the shipped binary. "
+       "Half a manifest here and a full one there is the drift both guards are "
+       "meant to catch.\n"
+       "Fix: restore the id in engine/res/vayu-windows.manifest.";
 }
 
 #else


### PR DESCRIPTION
## Description

#856 asked what still depends on `engine/res/vayu-windows.manifest` now that #851 has every leg verifying with OpenSSL, whose ALPN is not gated on an OS version.

**Plan (root cause, approach, rejected alternative).** The issue's premise is that #851 made the #215 ALPN chain historical, so the manifest and its two guards are kept only on "a return to Schannel would need them" - a reason nobody could restate, which is what the issue objects to. Checking the code first, per the issue's own instruction to verify the problem still exists as described, the premise does not hold: **#851 did not remove Schannel from the Windows build.** The curl port's `http2` feature depends on `curl[ssl]`, which resolves to Schannel there, so the shipped libcurl is MultiSSL and #858 is still open. `s_win_has_alpn` is therefore still in the binary; it is not evaluated only because `pin_tls_backend()` selects OpenSSL at startup, and that call is deliberately non-fatal on failure. So the approach is to **keep the manifest and both guards with a currently-true reason and a stated retirement condition (#858)**, and to enumerate the alternatives so the claim is checkable. The alternative I rejected is deleting the manifest now: it reads as justified from the issue's premise, and it would silently re-arm an invisible HTTP/1.1-only failure on any path that reaches `schannel_init()`.

### The enumeration (AC 1)

Read at the pinned versions - curl 8.21.0, OpenSSL 3.6.3, and current sources of every other statically linked dependency. Callers of ntdll's `RtlGetVersion` / `RtlVerifyVersionInfo` are immune by construction, so only the shimmed `kernel32` family was in scope.

| Where | Reads a shimmed version? |
|---|---|
| Vayu's own sources | No - none read an OS version at all |
| libcurl `lib/vtls/schannel.c:2620` (`s_win_has_alpn`) | **Yes - the only one** |
| libcurl's nine other version gates | No |
| OpenSSL 3.6.3 | No - calls neither API anywhere |
| SQLite (`sqlite3_win32_is_nt()`) | No |
| nghttp2, cpp-httplib, libsodium, zlib, brotli, sqlite-orm, GoogleTest, rapidyaml, c4core, valijson, quickjs-ng, HdrHistogram | No |

Three that deserve reasoning rather than a "No":

- **`s_win_has_alpn` is manifest-sensitive because of *timing*, not TLS.** It is the one gate evaluated inside `Curl_ssl_init()`, which `global_init()` runs *before* `Curl_win32_init()` (`lib/easy.c:143` then `:153`) - and `Curl_win32_init()` is what resolves `s_pRtlVerifyVersionInfo`. With that pointer null, `curlx_verify_windows_version` falls to `VerifyVersionInfoW` (`lib/curlx/version_win32.c:207-210`).
- **The other nine are immune by *when* they run.** `lib/cf-socket.c:193` is worth naming: it gates the `TCP_KEEP*` `setsockopt` path on Windows 10 1709 and is entirely backend-independent, so it would be a live dependent if it ran early. It runs at connect time. The other eight are five in `schannel.c`, three in `schannel_verify.c`.
- **SQLite calls `GetVersionEx[AW]` and is still not a dependent**, for two independent reasons: it reads only `dwPlatformId` (NT vs Win9x), which the shim does not alter, and at `NTDDI_VERSION >= NTDDI_WINBLUE` - which the `x64-windows-static` triplet gives - the call compiles out and `osIsNT()` becomes the constant 1.

On the issue's second bullet: the file declares **only** `<compatibility>/<application>/<supportedOS>` - no `requestedExecutionLevel`, DPI, long-path or code-page section - so no unrelated reason is hiding in it.

### Deliberate deviation from the issue spec

The issue offered "if the only remaining reason is *a return to Schannel would need it*, say that in the guard's failure message". The reason recorded is **stronger and different**: Schannel is in the shipped binary *right now*, so the dependent is dormant rather than hypothetical, and the retirement condition is #858 landing rather than a judgement call. Saying "a return to Schannel" would have been the false version of this.

### One gap fixed beyond the literal ACs

`HttpVersionSupport.WindowsOsVersionIsNotShimmed` asserted only the Windows 8.1 id while `check-windows-deps.py` requires **both**, so the test binary could have carried half a manifest and stayed green. It now probes both. The second probe asserts `shimmed == truth` at 10.0, which is the exact statement "this process is not being lied to" and stays correct on a genuine 8.1 host, where both answers are false. This is AC 2's "the guards assert the ids they depend on" rather than new scope.

## Type of Change

- [x] Documentation update
- [x] Test coverage (the second supportedOS id is now asserted)

## Testing

Local, on this branch:

| Check | Result |
|---|---|
| `python build.py -e -t` | Build complete (10m 40s), tests 33.5s |
| `cd engine && ctest --preset linux-dev --output-on-failure` | **2252 / 2252 passed, 0 failed** |
| `cd app && pnpm test` | **5776 passed, 524 files** |
| `cd app && pnpm type-check` | clean (renderer, electron, electron-tests) |
| `mkdocs build --strict` | clean |

Two checks that no Linux run can cover, done directly:

- **The Windows-only gtest block** was type-checked with `g++ -std=c++20 -fsyntax-only -Wall -Wextra -D_WIN32` against a minimal Win32/gtest shim - a Linux build compiles none of that code, so this is the only local compile proof. MSVC on the Windows CI leg is the real gate.
- **`check-windows-deps.py`** was exercised against the real manifest through all three `check_manifest` paths, including the mutation check: removing the Windows 10/11 id makes it fail with the new, currently-true reason; restoring it passes.

No pre-existing failures encountered.

Note for the reviewer: `engine/res/vayu-windows.manifest` is an XML comment, where `--` is illegal - the rewritten header was validated by parsing the file, so the ids still reach the linker.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (the second supportedOS id probe)
- [x] I have updated documentation (`docs/engine/building.md`, in the same commit)

`engine/tests/http_version_support_test.cpp` was already not clang-format clean before this change (8 pre-existing violations), so per CLAUDE.md it was not reformatted; the added lines follow the file's existing hand-formatted style.

## Related Issues

Closes #856
Refs #215, #851, #858

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFqwCfaWpppPwt8PBfxbTz)_