### PR TITLE
feat(mcp): an agent can ask whether a contract has drifted

### DIFF
--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -360,6 +360,20 @@ export class EngineClient {
 	}
 
 	/**
+	 * What a re-fetched document would change about the collection bound to it
+	 * (`POST /specs/diff`, issue #854).
+	 *
+	 * A POST that writes nothing: the document is compared, never stored, and
+	 * the collection keeps its binding and its stamps. Neither the requests nor
+	 * the bound document ride in the payload - the engine walks the subtree and
+	 * reads the binding itself, because a caller that could supply the
+	 * "previous" side could turn its own edits into the document's.
+	 */
+	diffSpec(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", "/specs/diff", payload, signal);
+	}
+
+	/**
 	 * A collection back out as an OpenAPI document (`POST /specs/export`, issue
 	 * #855) - its own bound document updated, or a skeleton when it binds none.
 	 *

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -21,6 +21,7 @@ import {
 	MAX_REPORT_TRACE_BYTES,
 	MAX_RUN_SERIES_LIMIT,
 	MAX_SLOW_THRESHOLD_MS,
+	MAX_SPEC_DIFF_ENTRIES,
 	MAX_SUCCESS_SAMPLE_PERIOD,
 	REQUEST_SETTINGS_KEYS,
 	toolCatalog,
@@ -179,6 +180,49 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 			text: '{\n  "openapi": "3.1.0"\n}\n',
 			fileName: "api.openapi.json",
 			notes: { direction: "document", dialect: "OpenAPI 3.1.0", requestsExported: 2 },
+		}),
+		diffSpec: vi.fn().mockResolvedValue({
+			identical: false,
+			added: [
+				{
+					operation: { operationId: "listOwners", method: "GET", path: "/owners" },
+					folder: "owners",
+					draft: { name: "List owners", method: "GET", url: "{{baseUrl}}/owners" },
+				},
+			],
+			removed: [
+				{
+					requestId: "req_9",
+					name: "Delete a pet",
+					operation: {
+						operationId: "deletePet",
+						method: "DELETE",
+						path: "/pets/{petId}",
+					},
+				},
+			],
+			changed: [
+				{
+					requestId: "req_1",
+					name: "List pets",
+					boundOperation: { operationId: "listPets", method: "GET", path: "/pets" },
+					operation: { operationId: "listPets", method: "GET", path: "/pets" },
+					matchedBy: "operationId",
+					renamed: false,
+					previousUnknown: false,
+					fields: [
+						{
+							field: "name",
+							current: "List pets",
+							next: "List all the pets",
+							userTouched: false,
+						},
+					],
+					draft: { name: "List all the pets", method: "GET", url: "{{baseUrl}}/pets" },
+				},
+			],
+			unchanged: 12,
+			unmapped: 1,
 		}),
 		listRequestExamples: vi.fn().mockResolvedValue([]),
 		createRequestExample: vi
@@ -7171,6 +7215,197 @@ describe("OpenAPI spec binding tools", () => {
 		const res = await dispatchTool("export_spec", { collectionId: "col_1" }, ctxWith(client));
 		expect(res.isError).toBe(true);
 		expect(allText(res)).toContain("spec_1");
+	});
+
+	test("diff_spec sends the candidate document and nothing it could compare wrongly", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: '{"openapi":"3.1.0"}' },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		// Neither the requests nor the bound document ride in the payload: the
+		// engine walks the subtree and reads the binding itself, so a caller
+		// cannot make a stale copy the "previous" side of a three-way compare.
+		expect(client.diffSpec).toHaveBeenCalledWith(
+			{ collectionId: "col_1", spec: { content: '{"openapi":"3.1.0"}' } },
+			undefined
+		);
+		expect(client.listRequests).not.toHaveBeenCalled();
+		expect(client.getSpec).not.toHaveBeenCalled();
+		expect(client.getCollection).not.toHaveBeenCalled();
+
+		const value = JSON.parse(firstText(res));
+		expect(value.identical).toBe(false);
+		expect(value.summary).toEqual({
+			added: 1,
+			removed: 1,
+			changed: 1,
+			unchanged: 12,
+			unmapped: 1,
+		});
+		expect(value.added[0].operation.operationId).toBe("listOwners");
+		expect(value.removed[0].requestId).toBe("req_9");
+		expect(value.changed[0].fields[0]).toMatchObject({
+			field: "name",
+			current: "List pets",
+			next: "List all the pets",
+			userTouched: false,
+		});
+		expect(value.entriesTruncated).toBe(false);
+		// Reads only, and the caveat says so rather than leaving an agent to
+		// assume a diff applied something.
+		expect(allText(res)).toContain("Nothing was written");
+	});
+
+	test("diff_spec drops the drafts the engine attaches to every entry", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(client)
+		);
+		// `draft` is what an apply *would* write, and `POST /specs/sync` re-reads
+		// it off the document being stored rather than being handed it - so no
+		// reader on either side of this tool consumes it. Passing it through
+		// would be the heaviest field in the answer and the "written but never
+		// read" defect at once. The rendered current/next pair, which is what
+		// says *what* moved, survives - asserted above.
+		expect(firstText(res)).not.toContain("draft");
+		expect(firstText(res)).not.toContain("{{baseUrl}}");
+	});
+
+	test("diff_spec names the fields a person edited, and stays quiet when none were", async () => {
+		const edited = {
+			identical: false,
+			added: [],
+			removed: [],
+			changed: [
+				{
+					requestId: "req_1",
+					name: "List pets",
+					operation: { operationId: "listPets", method: "GET", path: "/pets" },
+					matchedBy: "operationId",
+					renamed: false,
+					previousUnknown: false,
+					fields: [{ field: "url", current: "{{host}}/pets", next: "{{baseUrl}}/pets" }],
+				},
+			],
+			unchanged: 0,
+			unmapped: 0,
+		};
+		const untouched = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(fakeClient({ diffSpec: vi.fn().mockResolvedValue(edited) }))
+		);
+		// The flag rides on every field either way; what must not appear is the
+		// warning, which is about fields somebody actually edited.
+		expect(allText(untouched)).not.toContain("overwrites a person's work");
+
+		// The same drift with the flag set is the one an agent must not propose
+		// applying silently, so it is named rather than left inside the JSON.
+		const client = fakeClient({
+			diffSpec: vi.fn().mockResolvedValue({
+				...edited,
+				changed: [
+					{
+						...edited.changed[0],
+						fields: [{ ...edited.changed[0].fields[0], userTouched: true }],
+					},
+				],
+			}),
+		});
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(client)
+		);
+		expect(allText(res)).toContain("userTouched");
+		expect(allText(res)).toContain("overwrites a person's work");
+		expect(JSON.parse(firstText(res)).changed[0].fields[0].userTouched).toBe(true);
+	});
+
+	test("diff_spec says a byte-identical document has nothing to apply", async () => {
+		const client = fakeClient({
+			diffSpec: vi.fn().mockResolvedValue({
+				identical: true,
+				added: [],
+				removed: [],
+				changed: [],
+				unchanged: 14,
+				unmapped: 0,
+			}),
+		});
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(client)
+		);
+		const value = JSON.parse(firstText(res));
+		expect(value.identical).toBe(true);
+		expect(value.summary).toEqual({
+			added: 0,
+			removed: 0,
+			changed: 0,
+			unchanged: 14,
+			unmapped: 0,
+		});
+		expect(allText(res)).toContain("byte-identical");
+	});
+
+	test("diff_spec caps each bucket and keeps the counts true", async () => {
+		const over = MAX_SPEC_DIFF_ENTRIES + 7;
+		const client = fakeClient({
+			diffSpec: vi.fn().mockResolvedValue({
+				identical: false,
+				added: Array.from({ length: over }, (_unused, index) => ({
+					operation: { operationId: `op_${index}`, method: "GET", path: `/p${index}` },
+					folder: "",
+				})),
+				removed: [],
+				changed: [],
+				unchanged: 0,
+				unmapped: 0,
+			}),
+		});
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(client)
+		);
+		const value = JSON.parse(firstText(res));
+		expect(value.added).toHaveLength(MAX_SPEC_DIFF_ENTRIES);
+		// The count an agent reads to decide whether a contract drifted is the
+		// engine's, never the cut list's length - a total read off the list
+		// would report 50 additions for a document that made 57.
+		expect(value.summary.added).toBe(over);
+		expect(value.entriesTruncated).toBe(true);
+		expect(allText(res)).toContain(`capped at ${MAX_SPEC_DIFF_ENTRIES}`);
+	});
+
+	test("diff_spec passes the engine's refusal through rather than inventing one", async () => {
+		// A collection that binds nothing has no middle term for the three-way
+		// comparison, and the engine's sentence already says what to do about it.
+		const client = fakeClient({
+			diffSpec: vi
+				.fn()
+				.mockRejectedValue(
+					new EngineRequestError(
+						"Engine responded 400",
+						400,
+						"Collection 'col_1' is not bound to a spec; bind it before asking what a document would change"
+					)
+				),
+		});
+		const res = await dispatchTool(
+			"diff_spec",
+			{ collectionId: "col_1", content: "{}" },
+			ctxWith(client)
+		);
+		expect(res.isError).toBe(true);
+		expect(allText(res)).toContain("not bound to a spec");
 	});
 
 	test("unbind_spec is refused while writes are off, and reads nothing", async () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -3263,6 +3263,119 @@ function describeBind(outcome: unknown): string {
 	return parts.join(" ");
 }
 
+/**
+ * How many entries of one spec-diff bucket a tool result carries (issue #871).
+ *
+ * Nothing caps the buckets upstream: a document that renamed every operation
+ * puts one `changed` entry per request in the collection, and each carries its
+ * changed fields. Fifty is the number that keeps the common answer whole while
+ * bounding the pathological one, and - the rule the run-report rows follow -
+ * the *counts* stay true, so a cut list is visible as one rather than reading
+ * as the whole drift.
+ */
+export const MAX_SPEC_DIFF_ENTRIES = 50;
+
+/**
+ * One bucket of `POST /specs/diff`, capped, with what it was cut from.
+ *
+ * The engine's own count is the second element rather than the length of the
+ * first: an agent deciding whether a contract drifted reads the total, and a
+ * total read off a cut list would say it did not.
+ */
+function boundedBucket(value: unknown, shape: (entry: Record<string, unknown>) => unknown) {
+	const entries = Array.isArray(value) ? value : [];
+	return {
+		entries: entries.slice(0, MAX_SPEC_DIFF_ENTRIES).map((entry) => shape(asRecord(entry))),
+		total: entries.length,
+	};
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return isRecord(value) ? value : {};
+}
+
+/**
+ * A changed request, as an agent reads one.
+ *
+ * `draft` is dropped rather than passed through. It is what an apply *would*
+ * write, and `POST /specs/sync` re-reads it off the document being stored
+ * rather than being handed it (the same split `POST /specs/match` and
+ * `POST /specs/bind` follow), so nothing on either side of this tool consumes
+ * it - it would be the heaviest field in the answer and the "written but never
+ * read" defect at once. The rendered `current` / `next` pair survives, which is
+ * what says *what* moved; the engine already truncates both for display.
+ */
+function changedEntry(item: Record<string, unknown>): Record<string, unknown> {
+	const fields = Array.isArray(item.fields) ? item.fields : [];
+	return {
+		requestId: item.requestId ?? null,
+		name: item.name ?? null,
+		boundOperation: item.boundOperation ?? null,
+		operation: item.operation ?? null,
+		matchedBy: item.matchedBy ?? null,
+		renamed: item.renamed === true,
+		previousUnknown: item.previousUnknown === true,
+		fields: fields.map((field) => {
+			const row = asRecord(field);
+			return {
+				field: row.field ?? null,
+				current: row.current ?? null,
+				next: row.next ?? null,
+				userTouched: row.userTouched === true,
+			};
+		}),
+	};
+}
+
+/** Whether any field of @p item is one a person edited by hand. */
+function hasUserEdit(item: Record<string, unknown>): boolean {
+	const fields = Array.isArray(item.fields) ? item.fields : [];
+	return fields.some((field) => asRecord(field).userTouched === true);
+}
+
+/**
+ * What a document would change, in a sentence (issue #871).
+ *
+ * The counts are in the structured body; this says the three things that change
+ * what an agent should do next. **Hand-edited fields are named on their own**:
+ * they are the one part of a drift that an apply may not take silently, and an
+ * agent reading only "6 changed" would propose overwriting somebody's edit.
+ * `unmapped` is named for the reason the diff reports it at all - a collection
+ * half of which carries no operation is one this answer describes half of.
+ *
+ * Defensive about the shape for `describeBind`'s reason: an engine answering
+ * something unexpected must cost the caveat, never the result.
+ */
+function describeSpecDiff(answer: Record<string, unknown>): string {
+	const bucket = (value: unknown): number => (Array.isArray(value) ? value.length : 0);
+	const count = (value: unknown): number => (typeof value === "number" ? value : 0);
+	const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
+
+	if (answer.identical === true) {
+		return "This document is byte-identical to the one the collection is bound to, so there is nothing to apply.";
+	}
+
+	const changed = Array.isArray(answer.changed) ? answer.changed : [];
+	const edited = changed.filter((item) => hasUserEdit(asRecord(item))).length;
+	const parts = [
+		`${plural(bucket(answer.added), "operation")} added, ${plural(bucket(answer.removed), "request")} no longer declared, ${plural(changed.length, "request")} changed, ${count(answer.unchanged)} unchanged.`,
+	];
+	if (edited > 0) {
+		parts.push(
+			`${plural(edited, "changed request")} hold a field somebody edited by hand (userTouched) - applying the document there overwrites a person's work, not an import's.`
+		);
+	}
+	if (count(answer.unmapped) > 0) {
+		parts.push(
+			`${plural(count(answer.unmapped), "request")} in this collection carry no operation at all and are not part of the comparison.`
+		);
+	}
+	parts.push(
+		"Nothing was written: this is the read half of a sync. Applying one is done in the Vayu app (Collection -> Spec -> Sync) - see https://github.com/athrvk/vayu/issues/871."
+	);
+	return parts.join(" ");
+}
+
 // --- Tool definitions --------------------------------------------------------
 
 export const TOOLS: McpTool[] = [
@@ -4048,6 +4161,89 @@ export const TOOLS: McpTool[] = [
 			} catch (err) {
 				return engineErrorResult(err);
 			}
+		},
+	},
+	{
+		name: "diff_spec",
+		category: "read",
+		invalidates: [],
+		description:
+			"Check whether an OpenAPI contract has drifted from the collection bound to it, and where. Pass the collection and the re-fetched document text; the engine compares it against the document the collection is currently bound to AND against every request in its subtree, and answers which operations the document adds, which requests it no longer declares, and which requests changed field by field with the current and next value of each. Reads only: nothing is stored, no binding moves, no request is stamped, so it is safe to ask about a document you have not decided to apply. `identical` is decided on the stored bytes and is the 'already up to date' answer. A field flagged `userTouched` is one somebody edited by hand rather than one the last import wrote - applying the document there would overwrite a person's work. `unmapped` counts requests carrying no operation identity at all, which no comparison covers. APPLYING a drift is app-only for now (Collection -> Spec -> Sync); this tool is the read half.",
+		annotations: {
+			title: "Diff OpenAPI spec against collection",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			collectionId: z
+				.string()
+				.describe(
+					"Collection to compare. It must already be bound to a document - the comparison is three-way and the bound document is the middle term. Its whole subtree is read, since an imported spec files its requests under one sub-collection per tag."
+				),
+			content: z
+				.string()
+				.describe(
+					"The re-fetched OpenAPI document text, JSON or YAML. Not stored - this is the candidate, compared against the bytes the collection is bound to. Capped by the maxSpecDocumentBytes setting, the same cap a bind applies."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const collectionId = requireStr(args, "collectionId");
+			const content = requireStr(args, "content");
+			// The requests and the bound document are deliberately not sent: the
+			// engine walks the subtree and reads the binding itself, so a caller
+			// cannot make its own stale copy the "previous" side of a three-way
+			// comparison. Nothing is worked out here for the same reason
+			// `bind_spec` works nothing out - the comparison is the engine's
+			// (`core::diff_spec`), off the bytes handed to it.
+			let answer: unknown;
+			try {
+				answer = await ctx.client.diffSpec({ collectionId, spec: { content } }, signal);
+			} catch (err) {
+				// The engine's own sentence is the useful one: a 400 names the
+				// collection that binds nothing and says to bind it first, a 404
+				// names the collection, and a 409 names the binding whose document
+				// the store no longer holds.
+				return engineErrorResult(err);
+			}
+			const diff = asRecord(answer);
+			const added = boundedBucket(diff.added, (entry) => ({
+				operation: entry.operation ?? null,
+				folder: entry.folder ?? null,
+			}));
+			const removed = boundedBucket(diff.removed, (entry) => ({
+				requestId: entry.requestId ?? null,
+				name: entry.name ?? null,
+				operation: entry.operation ?? null,
+			}));
+			const changed = boundedBucket(diff.changed, changedEntry);
+			const truncated = [added, removed, changed].some(
+				(bucket) => bucket.entries.length < bucket.total
+			);
+			return withCaveat(
+				jsonResult({
+					collectionId,
+					identical: diff.identical === true,
+					// The engine's totals, not these lists' lengths - see
+					// `MAX_SPEC_DIFF_ENTRIES` for why the two can differ.
+					summary: {
+						added: added.total,
+						removed: removed.total,
+						changed: changed.total,
+						unchanged: typeof diff.unchanged === "number" ? diff.unchanged : 0,
+						unmapped: typeof diff.unmapped === "number" ? diff.unmapped : 0,
+					},
+					added: added.entries,
+					removed: removed.entries,
+					changed: changed.entries,
+					entriesTruncated: truncated,
+				}),
+				`\n\n${describeSpecDiff(diff)}${
+					truncated
+						? ` Each list here is capped at ${MAX_SPEC_DIFF_ENTRIES} entries; the counts in \`summary\` are the true totals.`
+						: ""
+				}`
+			);
 		},
 	},
 	{

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -166,6 +166,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `update_collection`    | write    | `GET /collections` (scan, only when variables change) + `PUT /collections/:id` (merge-patch) | write toggle; `variables` merges like `update_environment`'s, `removeVariables` deletes names |
 | `delete_collection`    | write    | `GET /collections` + `GET /requests?…` (×N) + `DELETE /collections/:id` | write toggle + confirm |
 | `get_spec`             | read     | `GET /collections` (scan, only for `collectionId`) + `GET /specs/:id/meta`, or `GET /specs/:id` with `includeContent` | - (document text off by default and capped at 32 KB; a collection binding nothing answers `bound: false`) |
+| `diff_spec`            | read     | `POST /specs/diff`                           | - (each bucket capped at 50 entries, with `summary` carrying the true totals; the per-entry `draft` is dropped) |
 | `bind_spec`            | write    | `POST /specs/bind`                           | write toggle; one transaction - stores the document, moves the binding, stamps what matched and **clears** what no longer does |
 | `export_spec`          | read     | `POST /specs/export`                         | - (document text capped at 32 KB, with `contentBytes` for the true size; `notes` says what the export could not carry) |
 | `unbind_spec`          | write    | `GET /collections` (scan) + `PUT /collections/:id` (`openapi: null`) | write toggle; the document and the requests' recorded operations are kept |
@@ -245,10 +246,13 @@ Notes:
   no such field - every transfer is bounded by the `defaultTimeout` setting
   (`resolve_request_timeout_ms`), which `update_engine_config` changes. Recorded
   here so it is not re-derived as a gap each time the schema is read.
-- **An agent can bind a collection to a spec now, and export one** (issues
-  [#862](https://github.com/athrvk/vayu/issues/862) and
-  [#855](https://github.com/athrvk/vayu/issues/855)); **spec sync and import
-  stay app-only.** `get_spec` says what a collection is bound to, `bind_spec`
+- **An agent can bind a collection to a spec now, export one, and ask whether a
+  contract has drifted** (issues
+  [#862](https://github.com/athrvk/vayu/issues/862),
+  [#855](https://github.com/athrvk/vayu/issues/855) and
+  [#871](https://github.com/athrvk/vayu/issues/871)); **applying a drift, and
+  import, stay app-only.** `get_spec` says what a collection is bound to,
+  `diff_spec` says what a re-fetched document would change about it, `bind_spec`
   binds one, `export_spec` writes it back out as a document, and `unbind_spec`
   detaches it. `bind_spec` takes the document text and nothing else - no pairing
   - because everything it needs is engine-side after #761's phase B: the engine
@@ -266,6 +270,22 @@ Notes:
   The tool result reports `cleared` beside `stamped` for that reason - it is the
   half a caller would otherwise discover from a later run. `unbind_spec` still
   leaves stamps alone, so unbind-then-rebind of the same document costs nothing.
+- **`diff_spec` is the read half of a sync** (issue
+  [#871](https://github.com/athrvk/vayu/issues/871)). It sends the collection and
+  the candidate document and nothing else: the requests and the **bound**
+  document are the engine's to read, because a caller that could supply the
+  "previous" side of a three-way comparison could turn its own edits into the
+  document's. Three things about the answer are this tool's rather than the
+  route's. The per-entry `draft` is **dropped** - it is what an apply would
+  write, and `POST /specs/sync` re-reads it off the document it stores rather
+  than being handed it, so nothing on either side of the tool consumes it; the
+  rendered `current` / `next` pair, which is what says what moved, survives. Each
+  bucket is capped at 50 entries while `summary` keeps the engine's true totals,
+  so a document that renamed every operation comes back described rather than
+  whole. And a field flagged `userTouched` is named in the caveat sentence, not
+  just carried in the JSON: it is the one part of a drift an apply may not take
+  silently, and an agent reading "6 changed" would otherwise propose overwriting
+  somebody's edit.
 - **`get_run_report` carries contract coverage** for a run of a collection bound
   to an OpenAPI document (issue #629): which of the contract's operations the run
   exercised, which of their declared responses it saw, and any statuses the
@@ -1427,10 +1447,14 @@ builds on the mechanism the spec is deprecating and the payoff is client-depende
   provenance.
 - **`vayu mcp` bin** - package the stdio CLI as a first-class command
   ([#693](https://github.com/athrvk/vayu/issues/693)).
-- **OpenAPI bind / sync / import / export** - phase B of
-  [#761](https://github.com/athrvk/vayu/issues/761), gated on deciding where
-  operation matching, the sync diff and export assembly should live (see the
-  note under [Tools](#tools)).
+- **Applying a spec drift (`sync_spec`), and raw-document import** -
+  [#871](https://github.com/athrvk/vayu/issues/871). The rest of #761's phase B
+  shipped: bind, export and the drift read are tools, and match, diff and
+  assembly are all engine-side, so what is left is not the architecture question
+  this entry used to name. `sync_spec` waits on where the *selection* lives - the
+  rules in the renderer's `spec-apply.ts` that decide which fields an apply may
+  write - since `electron/` may not import `src/`. Import waits on the renderer's
+  parser stack, which is still a second reader of an OpenAPI document.
 - **Live push over HTTP** - stateful sessions (see Design notes).
 - **Hosted MCP for Vayu Cloud** - OAuth-gated, remote.
 


### PR DESCRIPTION
## Description

Phase 1 of #871: `diff_spec`, the read half of a sync over MCP. The collection and a re-fetched document in, the engine's `added` / `removed` / `changed` / `unchanged` / `unmapped` answer out.

**Plan.** The root cause is a parity gap that outlived its blocker: #761's phase B moved match, diff and assembly engine-side (#852, #861, #863, #866, #868, #870), so `POST /specs/diff` and `POST /specs/sync` both exist, and no MCP tool calls either - while `docs/engine/mcp.md` still recorded the gap as "gated on deciding where operation matching, the sync diff and export assembly should live", a gate that closed on 2026-08-19. The approach is the shape `export_spec` already has: a `category: "read"` relay of a route that stores nothing, with the engine's own refusals passed through. **The alternative I rejected: shipping `sync_spec` in the same PR.** A sync payload is a *selection* - which additions to create, which fields of which changed request to write, which removals to delete - and those rules are `app/src/services/openapi/spec-apply.ts`, which `electron/` may not import (`docs/engine/mcp.md:1253`). Getting there means either mirroring the selection in `electron/` behind a conformance test (the `compare.ts` precedent) or moving the decision engine-side the way #869 reduced `examples` from rows to a boolean. That is a real architecture fork of the same class as #853's dependency question, so it is stated on the issue for the owner rather than settled in a PR.

**Verified before writing**, since #871's problem statement is mine: the registry has 61 tools and none of them is a diff, sync or import (`rg 'name: "..."' app/electron/mcp/tools.ts`); `engine-client.ts` had `getSpec`, `bindSpec` and `exportSpec` and no `diffSpec`; `POST /specs/diff` reads only and derives the "previous" side from the collection's own binding (`engine/src/http/routes/spec_diff.cpp`); and `SpecFieldDiff::current` / `next` are already display-truncated engine-side (`engine/src/core/spec_diff.cpp`), which is why carrying them is cheap and carrying `draft` is not.

### Three decisions the tool makes on top of the route

- **The per-entry `draft` is dropped.** It is what an apply *would* write, and `POST /specs/sync` re-reads it off the document it stores rather than being handed it (the same split `POST /specs/match` and `POST /specs/bind` follow), so nothing on either side of this tool consumes it. Passing it through would be the heaviest field in the answer and the "written but never read" defect at once. The rendered `current` / `next` pair, which is what says *what* moved, survives.
- **Each bucket is capped at 50 entries, and `summary` carries the engine's true totals.** Nothing caps the buckets upstream - a document that renamed every operation puts one `changed` entry per request in the collection - and a count read off a cut list would understate a drift.
- **`userTouched` is named in the caveat sentence**, not only carried in the JSON. It is the one part of a drift an apply may not take silently, and an agent reading "6 changed" would otherwise propose overwriting somebody's edit.

The payload carries neither the requests nor the bound document, for the reason the route refuses them: a caller that could supply the "previous" side of a three-way comparison could turn its own edits into the document's.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

No breaking change: one tool added, none altered. No renderer change, verified - nothing in `src/` reads the MCP registry, and `POST /specs/diff` stores nothing, so no query key can go stale.

## Testing

All green on this branch, on Linux:

- `cd app && pnpm test` - **5761 passed, 523 files** (6 new cases in `tools.test.ts`).
- `pnpm type-check`, `pnpm lint` and `pnpm format:check` on the touched files all clean.
- `mkdocs build --strict -f .github/mkdocs.yml` clean.

No engine build or `ctest` run: this PR touches no C++, so no engine test could change colour (CLAUDE.md's rule about scaling verification to what a change could break).

**Mutation-checked**, each reverted after confirming the redness:

| Mutation | Test that reddens |
|---|---|
| `boundedBucket` stops slicing | `diff_spec caps each bucket and keeps the counts true` |
| `summary.added` read off the cut list's length | same case |
| `changedEntry` passes `draft` through | `diff_spec drops the drafts the engine attaches to every entry` |

The other three cases cover the payload the tool sends (and the calls it must *not* make), the byte-identical answer, and the engine's 400 for a collection that binds nothing passing through in the engine's own words.

No pre-existing failures were observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

`docs/engine/mcp.md` in the same commit: the tool table row, the OpenAPI paragraph under Tools (which said sync and import stay app-only and now distinguishes the drift *read* from the apply), and the Deferred entry, whose stated gate no longer exists.

## Related Issues

Refs #871 - phase 1 of two. The issue stays open for the `sync_spec` fork, which is the owner's call; raw-document import is named there as out of scope and waiting on the renderer's parser stack.

One note on provenance, since it is unusual and I would rather state it than have it inferred: **#871 was filed in the same run that opened this PR.** Every open issue was ineligible - #134, #473 and #693 parked in as many words, #197 and #287 needing a quiet benchmark host, #690's only live item a tracking record with no action, #753 and #761 parents, #853 landed, and #467 still blocked on a stable TypeScript 7.1 (re-verified live: `latest` is 7.0.2, and `typescript-eslint@8.67.0` peers `typescript <6.1.0`). The gap this PR closes was tracked nowhere but on a parent issue and in a doc sentence describing a blocker that no longer existed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LobbY7LZ3eF89Y8UPYQsHR)_