### PR TITLE
fix(engine): stop claiming a restart for `workers`, which every run re-reads

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -440,10 +440,14 @@ describe("engine config tools", () => {
 		const client = fakeClient({
 			getConfig: vi.fn().mockResolvedValue({
 				entries: [
+					// A key the engine really does read once, when it opens the
+					// database. `workers` used to stand here and stopped being
+					// restart-gated in #873 - the run reads it - so the example
+					// moved rather than teaching the next reader the old claim.
 					{
-						key: "workers",
-						value: "16",
-						label: "Worker Threads",
+						key: "dbCacheSize",
+						value: "67108864",
+						label: "Database Cache Size",
 						requiresRestart: true,
 					},
 					{
@@ -457,13 +461,13 @@ describe("engine config tools", () => {
 		});
 		const res = await dispatchTool(
 			"update_engine_config",
-			{ entries: { workers: "16", timeoutMs: "5000" } },
+			{ entries: { dbCacheSize: "67108864", timeoutMs: "5000" } },
 			ctxWith(client, { allowWrites: true })
 		);
 		expect(res.isError).toBeFalsy();
 		const out = res.structuredContent as { changedKeys: string[]; restartRequired: string[] };
-		expect(out.changedKeys.sort()).toEqual(["timeoutMs", "workers"]);
-		expect(out.restartRequired).toEqual(["workers"]);
+		expect(out.changedKeys.sort()).toEqual(["dbCacheSize", "timeoutMs"]);
+		expect(out.restartRequired).toEqual(["dbCacheSize"]);
 		// The human-readable text warns about the restart.
 		expect(firstText(res)).toMatch(/restart required/i);
 	});

--- a/app/src/components/layout/Dock.pending-restart.test.tsx
+++ b/app/src/components/layout/Dock.pending-restart.test.tsx
@@ -69,13 +69,17 @@ describe("the Dock's pending-restart signal", () => {
 	});
 
 	it("appears once a restart-required setting has been saved", () => {
-		useEngineStore.getState().addRestartRequiredKey("workers");
+		// Any key would do - the store holds what the engine flagged and the Dock
+		// never branches on which. `dbCacheSize` is one the engine really does
+		// read once, at DB open; `workers` stood here until #873, where it stopped
+		// being restart-gated because every run re-reads it.
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
 		renderDock();
 		expect(signal()).not.toBeNull();
 	});
 
 	it("restarts the engine and lowers itself", async () => {
-		useEngineStore.getState().addRestartRequiredKey("workers");
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
 		renderDock();
 
 		fireEvent.click(signal()!);
@@ -91,7 +95,7 @@ describe("the Dock's pending-restart signal", () => {
 
 	it("keeps standing when the restart fails, and says why", async () => {
 		restartEngine.mockResolvedValue({ success: false, error: "engine did not come back" });
-		useEngineStore.getState().addRestartRequiredKey("workers");
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
 		renderDock();
 
 		fireEvent.click(signal()!);

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -473,7 +473,7 @@ min/max/options):
       "default": "8",
       "min": "1",
       "max": "128",
-      "requiresRestart": true,
+      "requiresRestart": false,
       "advanced": false,
       "keywords": ["cores", "parallelism"],
       "updatedAt": 1234567890
@@ -531,7 +531,12 @@ hand-maintained value-to-label map. `value` and `default` are always strings;
   signal in the Dock too, once such a setting has been saved). Consumers must
   read the field rather than parse the label - the old `(Requires Restart)`
   suffix drifted out of step with the mechanism and misinformed the settings
-  screen and the MCP `update_config` result at the same time.
+  screen and the MCP `update_config` result at the same time. Exactly three
+  entries carry it - `dbCacheSize`, `dbBusyTimeout` and `dbSynchronous`, all
+  read when the database is opened. `workers` carried it too until
+  [#873](https://github.com/athrvk/vayu/issues/873), which is the same drift in
+  the field's own terms: the engine reads it at the start of every run, so the
+  restart it asked for was never needed. `config_route_test.cpp` pins the set.
 - **`advanced`** - an internal with no everyday user story (`dbBusyTimeout`, the
   four `oauth2Refresh*` watchdog knobs, `inboxLivePollIntervalMs`,
   `sseIdleTimeoutMs`, `maxStepsPerIteration`, `monitorScrapeTimeoutMs`,

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -321,11 +321,10 @@ reproduced and should not be quoted.
 ## Config semantics: live, restart-gated, and retired
 
 Every entry below was verified by locating the read site in the engine source.
-This matters because the seeded labels are wrong in places.
 
 | Key | Read site | When it applies |
 |---|---|---|
-| `workers` | `core/run_manager.cpp` | **Per run.** No restart, despite the entry's `requiresRestart: true` |
+| `workers` | `core/run_manager.cpp` | **Per run.** No restart - and the entry says so since [#873](https://github.com/athrvk/vayu/issues/873), which dropped the `requiresRestart: true` it had carried |
 | `eventLoopMaxPerHost` | `core/run_manager.cpp` | Per run |
 | `eventLoopMaxConcurrent` | `core/run_manager.cpp` | Per run, but **overridden** by the run's own `concurrency` |
 | `dnsCacheTimeout` | `core/run_manager.cpp` | Per run |
@@ -358,8 +357,9 @@ Tracked in [#197](https://github.com/athrvk/vayu/issues/197).
 
 ## Engine tuning notes
 
-Knobs that move RPS (set via `POST /config`; most are read **per run** - no
-restart needed despite `requiresRestart: true` on some):
+Knobs that move RPS (set via `POST /config`; all of the engine-config ones below
+are read **per run**, so none needs a restart - and none is flagged
+`requiresRestart` either, since [#873](https://github.com/athrvk/vayu/issues/873)):
 
 - **run `concurrency`** - the dominant lever, and it is a property of the run,
   not the engine config. **64** on this target. Note the MCP safety cap

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -2437,14 +2437,17 @@ void Database::seed_default_config () {
     // Limits, leaving the four settings that describe the engine itself.
     // =========================================================================
 
-    upsert_config (restart_required (keywords ({ "cores", "parallelism" }) (
-    ConfigEntry{ "workers",
+    // Not restart_required: `run_manager` reads this at the start of every run
+    // and builds that run's EventLoop from it, so a change is in force for the
+    // next run started. It carried the flag until #873, which told the user to
+    // restart for a setting the engine had already picked up.
+    upsert_config (keywords ({ "cores", "parallelism" }) (ConfigEntry{ "workers",
     std::to_string (std::thread::hardware_concurrency ()), "integer", "Worker Threads",
     "Number of background worker threads. Higher values improve throughput on "
     "multi-core systems but increase RAM usage. "
     "Default equals CPU core count.",
     "general_engine", std::to_string (std::thread::hardware_concurrency ()),
-    "1", "128", std::nullopt, now })));
+    "1", "128", std::nullopt, now }));
 
     upsert_config (restart_required (unit ("bytes") (
     keywords ({ "ram" }) (ConfigEntry{ "dbCacheSize",

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -255,7 +255,9 @@ TEST_F (ConfigRouteTest, RestartRequiredSerializesAsATypedFlagBothWays) {
     vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"4"}})");
     ASSERT_EQ (status, 200);
 
-    json restarts = find_entry (body, "workers");
+    // Applied to every connection from the value read when the database is
+    // opened, so the running engine keeps the old one.
+    json restarts = find_entry (body, "dbCacheSize");
     ASSERT_TRUE (restarts.contains ("requiresRestart"));
     EXPECT_TRUE (restarts["requiresRestart"].get<bool> ());
 
@@ -263,6 +265,46 @@ TEST_F (ConfigRouteTest, RestartRequiredSerializesAsATypedFlagBothWays) {
     json does_not = find_entry (body, "defaultTimeout");
     ASSERT_TRUE (does_not.contains ("requiresRestart"));
     EXPECT_FALSE (does_not["requiresRestart"].get<bool> ());
+}
+
+// #873: `workers` carried the flag while `run_manager` read it at the start of
+// every run, so Settings, the Dock and MCP `update_engine_config` all asked the
+// user to restart for a value the engine had already picked up. Asserted on the
+// serialized entry rather than the seed, because the flag is only ever read
+// there.
+TEST_F (ConfigRouteTest, WorkersIsNotRestartRequiredBecauseEveryRunRereadsIt) {
+    auto [status, body] =
+    vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"4"}})");
+    ASSERT_EQ (status, 200);
+
+    json workers = find_entry (body, "workers");
+    ASSERT_TRUE (workers.contains ("requiresRestart"));
+    EXPECT_FALSE (workers["requiresRestart"].get<bool> ())
+    << "`workers` is read by run_manager at the start of every run - a restart "
+       "is not required and must not be claimed";
+}
+
+// The set, not one entry: the defect #873 fixed is a wrapper on an entry the
+// engine re-reads, and the cure only holds while every flagged key is one read
+// once at startup. The three below are read when the database is opened
+// (db/database.cpp applies them per connection / as PRAGMAs); anything else
+// arriving in this set is either a genuine startup read - name it here - or the
+// same defect again.
+TEST_F (ConfigRouteTest, RestartRequiredIsClaimedOnlyByTheEntriesReadAtStartup) {
+    auto entries = db_->get_all_config_entries ();
+    ASSERT_GT (entries.size (), 20u)
+    << "catalogue empty or unseeded - nothing was scanned";
+
+    const std::set<std::string> read_once_at_startup{ "dbBusyTimeout",
+        "dbCacheSize", "dbSynchronous" };
+
+    std::set<std::string> flagged;
+    for (const auto& entry : entries) {
+        if (entry.requires_restart) {
+            flagged.insert (entry.key);
+        }
+    }
+    EXPECT_EQ (flagged, read_once_at_startup);
 }
 
 // The convention this replaced, guarded against creeping back: the flag is the


### PR DESCRIPTION
## Description

`workers` was seeded wrapped in `restart_required (...)`, so `GET /config` answered `requiresRestart: true` for it. **Nothing reads it at startup**: `run_manager.cpp:986` reads it with `get_config_int ("workers", 0)` at the start of every run and builds that run's `EventLoop` from it (`:999`). #197's 2026-07-29 tuning session measured the same thing from outside the process - the engine's OS thread count went 29 -> 25 with no restart when `workers` went 12 -> 8.

**Plan.** Root cause: one wrapper on one seed entry. Three surfaces state the falsehood - the Settings "Restart Required" chip and its saved "Pending" banner (`SettingsMain.tsx:69`), the Dock's pending signal, and MCP `update_engine_config`'s `restartRequired: ["workers"]` with its warning sentence (`restartRequiredAmong`, `tools.ts:2230-2239`) - and none of the three branches per key: they all render the engine's typed flag, which is what #703 made it for. So the fix is the seed edit, and the alternative I rejected is patching any client: a per-key exception in Settings or in `restartRequiredAmong` would be a second opinion about which settings need a restart, which is the drift #703 removed when it replaced the `(Requires Restart)` label substring.

**An upgraded database sheds the flag on its next `init ()`**, no migration needed: `upsert_config` keeps a user's *value* and replaces the rest of the row's metadata (`database.cpp:2416-2428`), which is the same path every label and description edit has relied on.

The `/health` half of the same #197 comment (item 4 - the `workers` field there is `hardware_concurrency ()`) is **not** in this PR. It is a genuine fork, since the obvious cure puts the liveness probe behind the global DB mutex, and it is filed as #874 for your decision.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

The `GET /config` body for `workers` changes (`requiresRestart` `true` -> `false`). Worth naming as a wire change even though it is the correction: any consumer reading the field gets a different answer for that key.

## Testing

**Engine** - `python build.py -e -t`, then `ctest --preset linux-dev --output-on-failure`: **2310 of 2311 passed**. The one failure is `InboxListenerTest.ASecondInboxCannotShareARunningInboxsPort`, which **passes on its own** (`ctest -R` on it: 1/1) - it binds a port and lost the race against the suite's own `-j8` in this shared container. Nothing in this diff touches port binding. Not fixed and not hidden, per the pre-existing-failure rule.

`ConfigRouteTest` alone: **42 of 42 passed.**

**Mutation-checked**, both new cases, by restoring the `restart_required` wrapper and rebuilding:

- `WorkersIsNotRestartRequiredBecauseEveryRunRereadsIt` - fails with `Actual: true / Expected: false`.
- `RestartRequiredIsClaimedOnlyByTheEntriesReadAtStartup` - fails, since the flagged set gains a fourth key.

Both pass again with the fix restored. That second test is the one worth keeping: the defect is *a wrapper on an entry the engine re-reads*, so it pins the flagged set to the three entries read once at DB open (`dbCacheSize`, `dbBusyTimeout`, `dbSynchronous`) rather than asserting one key, and it asserts it scanned a non-empty catalogue.

`RestartRequiredSerializesAsATypedFlagBothWays` used `workers` as its `true` example and so reddened by construction; its example moved to `dbCacheSize`, which the engine really does read at DB open. The `false` side (`defaultTimeout`) is unchanged.

**App** - `pnpm test`: **523 files, 5761 tests passed**. `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean on the touched files. The two app tests using `"workers"` as a synthetic restart-required key (`tools.test.ts`, `Dock.pending-restart.test.tsx`) redden nothing - both mock the entry rather than reading the seed - but they taught the claim this PR removes, so their example key moved with it.

**Docs** - `mkdocs build --strict`: clean.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: the `GET /config` example entry for `workers` (`requiresRestart: false`), a sentence under the field's description naming which three entries carry it and why `workers` no longer does, and the two `docs/engine/benchmarks.md` lines (`:328`, `:362`) that existed only to explain the contradiction - the table row already read *"Per run. No restart, despite the entry's `requiresRestart: true`"*.

## Related Issues

Closes #873

Carved from #197 (item 5 of its 2026-07-29 field-data comment, mechanism-corrected by the 2026-08-17 anchor refresh), which cannot close on it: everything else that issue asks for is a benchmark needing a quiet host. This removes one of its step-3 edits rather than blocking on it. The sibling fork is #874.

---
_Generated by [Claude Code](https://claude.ai/code/session_017UdF7N8tmqH3NeqjVoGaBu)_