### PR TITLE
build(engine): make -Werror a real CI gate (#884)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -344,12 +344,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
+          # VAYU_WERROR turns the GCC/Clang warning set into build errors, on
+          # both legs that use it (issue #884) - a warning that only one
+          # compiler emits is exactly the kind this gate exists to catch, so
+          # gating Linux alone would leave Clang-only diagnostics unwatched.
+          # Windows needs no flag: MSVC builds /WX unconditionally.
           - os: ubuntu-latest
             preset: linux-prod
+            configureArgs: "['-DVAYU_BUILD_TESTS=ON', '-DVAYU_WERROR=ON']"
           - os: windows-latest
             preset: windows-prod
+            configureArgs: "['-DVAYU_BUILD_TESTS=ON']"
           - os: macos-latest
             preset: macos-prod
+            configureArgs: "['-DVAYU_BUILD_TESTS=ON', '-DVAYU_WERROR=ON']"
     timeout-minutes: 60
     env:
       VCPKG_COMMIT: '94a541197763a4f449a1b91478df48c0584a6256'
@@ -436,7 +444,7 @@ jobs:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: ${{ matrix.preset }}
           buildPreset: ${{ matrix.preset }}
-          configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
+          configurePresetAdditionalArgs: "${{ matrix.configureArgs }}"
 
       # The engine must depend on nothing outside Windows itself. ctest below
       # runs on a runner that already has the Visual C++ redistributable, so it

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -116,6 +116,9 @@ cmake -B build -DCMAKE_BUILD_TYPE=Debug -DVAYU_USE_ASAN=ON
 
 # Enable ThreadSanitizer (debug builds)
 cmake -B build -DCMAKE_BUILD_TYPE=Debug -DVAYU_USE_TSAN=ON
+
+# Treat compiler warnings as errors (what CI does)
+cmake -B build -DVAYU_WERROR=ON
 ```
 
 ## Build Outputs
@@ -515,6 +518,19 @@ cmake --build --preset linux-prod --clean-first 2>&1 | grep -c 'warning:'
 The flags are on `vayu_warnings` in `engine/CMakeLists.txt` - `-Wall -Wextra
 -Wpedantic` plus `-Wconversion`, `-Wsign-conversion`, `-Wdouble-promotion`,
 `-Wformat=2` and `-Wnull-dereference` on GCC and clang, `/W4 /WX` on MSVC.
+
+**A warning fails the build in CI** (`VAYU_WERROR`, default `OFF`). The engine
+job passes `-DVAYU_WERROR=ON` on the Linux and macOS legs, which adds `-Werror`;
+Windows needs no flag, because MSVC has always built `/WX`. It is off by default
+so a work-in-progress local build is not blocked by a warning - run the count
+above, or configure with `-DVAYU_WERROR=ON` to get exactly what CI gets. Setting
+the legacy `VAYU_STRICT_BUILD` environment variable to a truthy value turns it on
+too, so an existing local workflow keeps working. Both GCC/clang legs are gated
+rather than only Linux: a diagnostic one compiler emits and the other does not is
+precisely what the gate is for - the macOS SDK spells `NAN` as `__builtin_nanf`,
+which made a line in vendored `quickjs.h` a `-Wdouble-promotion` error there and
+nowhere else (vendored headers are `SYSTEM` includes now, so third-party code
+cannot fail our build).
 
 Three GCC 13 diagnostics fire only on code the engine did not write, and those
 are suppressed - narrowly, one function at a time, through the macros in

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -16,6 +16,21 @@ option(VAYU_BUILD_ENGINE "Build daemon" ON)
 option(VAYU_USE_ASAN "Enable AddressSanitizer" OFF)
 option(VAYU_USE_TSAN "Enable ThreadSanitizer" OFF)
 
+# Treat compiler warnings as errors. Off for local dev so a work-in-progress
+# build is not blocked by a warning, on in CI so a warning cannot merge - the
+# warning set below is only a gate if something fails on it. #900 took the
+# inventory to zero; this is what keeps it there. CI passes -DVAYU_WERROR=ON;
+# the legacy VAYU_STRICT_BUILD environment variable still turns it on (default
+# only - an explicit -DVAYU_WERROR wins) so an existing local workflow keeps
+# working. See docs/engine/building.md.
+set(_vayu_werror_default OFF)
+if(DEFINED ENV{VAYU_STRICT_BUILD}
+   AND NOT "$ENV{VAYU_STRICT_BUILD}" STREQUAL ""
+   AND NOT "$ENV{VAYU_STRICT_BUILD}" STREQUAL "0")
+    set(_vayu_werror_default ON)
+endif()
+option(VAYU_WERROR "Treat compiler warnings as errors (CI gate)" ${_vayu_werror_default})
+
 # ============================================================================
 # C++ Standard and Compiler Settings
 # ============================================================================
@@ -71,7 +86,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         -Wall
         -Wextra
         -Wpedantic
-        $<$<BOOL:$ENV{VAYU_STRICT_BUILD}>:-Werror>
+        $<$<BOOL:${VAYU_WERROR}>:-Werror>
         -Wno-unused-parameter
         -Wconversion
         -Wsign-conversion
@@ -82,23 +97,43 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(vayu_warnings INTERFACE
         /W4
+        # /WX is unconditional on MSVC and predates VAYU_WERROR: Windows CI has
+        # always built warnings-as-errors, so what keeps it green is the list
+        # below rather than a strict/lax toggle.
         /WX
         /permissive-
         /FS
+        # 4324: 'structure was padded due to alignas' - deliberate, on the
+        # cache-line-aligned SPSC queue members (spsc_queue.hpp); the padding
+        # is the point. Permanent.
         /wd4324
-        /wd4101
+        # 4100: 'unreferenced formal parameter' - the -Wno-unused-parameter
+        # counterpart above; interface signatures keep named parameters for
+        # documentation even where one leg does not use them. Permanent.
         /wd4100
-        /wd4456
-        /wd4244
+        # 4101 ('unreferenced local variable'), 4456 ('declaration hides
+        # previous local') and 4244 ('conversion, possible loss of data') used
+        # to be suppressed here and are not any more (issue #884). Each hid a
+        # real defect class - 4244 is precisely what -Wconversion catches on the
+        # GCC/Clang legs - and removing them found one: the `data` shadow in
+        # event_loop_worker.cpp, which no warning we enable elsewhere reports.
     )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_SYSTEM_NAME MATCHES "Linux")
     target_compile_options(vayu_warnings INTERFACE
         -Wno-deprecated-declarations
-        -Wno-missing-designated-field-initializers
         -Wno-implicit-int-float-conversion
     )
+    # -Wno-missing-designated-field-initializers landed in Clang 19. Passing it
+    # to an older Clang is a -Wunknown-warning-option warning, which VAYU_WERROR
+    # turns into a build failure - so the suppression itself would break every
+    # strict build on Clang 18 (Ubuntu 24.04's default) rather than quieten it.
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19)
+        target_compile_options(vayu_warnings INTERFACE
+            -Wno-missing-designated-field-initializers
+        )
+    endif()
 endif()
 
 # ============================================================================
@@ -165,6 +200,18 @@ if(EXISTS ${QUICKJS_DIR}/CMakeLists.txt)
         # Vendored code builds with its own flags: no vayu warnings, no
         # clang-tidy (same treatment the old in-tree QuickJS build had).
         set_target_properties(qjs PROPERTIES C_CLANG_TIDY "" CXX_CLANG_TIDY "")
+        # ...and its *headers* are system headers to whoever includes them.
+        # Building the vendored sources quietly is only half the exemption: on
+        # a plain -I, a diagnostic inside quickjs.h is attributed to our
+        # translation unit and, under VAYU_WERROR, fails our build for third
+        # party code we do not maintain. macOS is where this bites - the SDK
+        # spells NAN as __builtin_nanf, so `v.u.float64 = NAN` in quickjs.h is
+        # a -Wdouble-promotion error there and nowhere else.
+        get_target_property(_qjs_include_dirs qjs INTERFACE_INCLUDE_DIRECTORIES)
+        if(_qjs_include_dirs)
+            set_target_properties(qjs PROPERTIES
+                INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_qjs_include_dirs}")
+        endif()
         set(QUICKJS_FOUND TRUE)
         message(STATUS "Found and configured QuickJS-NG at ${QUICKJS_DIR}")
     else()
@@ -192,7 +239,9 @@ if(EXISTS ${HDRHISTOGRAM_DIR}/src/hdr_histogram.c)
         ${HDRHISTOGRAM_DIR}/src/hdr_writer_reader_phaser.c
         ${HDRHISTOGRAM_DIR}/src/hdr_histogram_log_no_op.c
     )
-    target_include_directories(hdrhistogram PUBLIC ${HDRHISTOGRAM_DIR}/include)
+    # SYSTEM for the same reason as quickjs above: vendored headers must not
+    # fail a consumer's build under VAYU_WERROR.
+    target_include_directories(hdrhistogram SYSTEM PUBLIC ${HDRHISTOGRAM_DIR}/include)
     
     # Platform-specific threading
     if(NOT WIN32)

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -873,12 +873,12 @@ size_t MetricsCollector::memory_usage_bytes () const {
         if (!record.capture.has_value ()) {
             return 0;
         }
-        size_t bytes = record.capture->body.capacity () +
+        size_t record_bytes = record.capture->body.capacity () +
         record.capture->content_type.capacity ();
         for (const auto& [name, value] : record.capture->headers) {
-            bytes += name.capacity () + value.capacity ();
+            record_bytes += name.capacity () + value.capacity ();
         }
-        return bytes;
+        return record_bytes;
     };
 
     // Errors vector

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1768,7 +1768,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 
                     db.add_metric_tick ({ 0, context->run_id, tick_wall_ms,
                     build_metric_tick_payload (sample).dump () });
-                } catch (const std::exception& e) {
+                } catch (const std::exception&) {
                     // Continue on error
                 }
 

--- a/engine/src/http/event_loop/event_loop_worker.cpp
+++ b/engine/src/http/event_loop/event_loop_worker.cpp
@@ -450,12 +450,15 @@ void EventLoopWorker::run_loop () {
                 CURL* easy      = msg->easy_handle;
                 CURLcode result = msg->data.result;
 
-                std::unique_ptr<TransferData> data;
+                // Named for the transfer that just finished rather than `data`,
+                // which is the fetch phase's handle on the transfer being
+                // *submitted* and stays in scope here (MSVC C4456).
+                std::unique_ptr<TransferData> completed;
                 {
                     // No lock needed - private resource
                     auto it = active_transfers.find (easy);
                     if (it != active_transfers.end ()) {
-                        data = std::move (it->second);
+                        completed = std::move (it->second);
                         active_transfers.erase (it);
                         // Update atomic size
                         current_active_count.store (
@@ -463,12 +466,13 @@ void EventLoopWorker::run_loop () {
                     }
                 }
 
-                if (data) {
-                    auto response_result = extract_response (easy, data.get (), result);
-                    if (data->callback)
-                        data->callback (data->request_id, response_result);
-                    if (data->has_promise)
-                        data->promise.set_value (std::move (response_result));
+                if (completed) {
+                    auto response_result =
+                    extract_response (easy, completed.get (), result);
+                    if (completed->callback)
+                        completed->callback (completed->request_id, response_result);
+                    if (completed->has_promise)
+                        completed->promise.set_value (std::move (response_result));
                     local_processed.fetch_add (1, std::memory_order_relaxed);
                 }
 

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1146,10 +1146,10 @@ void register_execution_routes (RouteContext& ctx) {
                 (response.has_error () ? vayu::RunStatus::Failed :
                                          vayu::RunStatus::Completed);
 
-                const bool has_scripts = !post_request_script.empty () ||
+                const bool has_script_output = !post_request_script.empty () ||
                 !pre_script_result.tests.empty () ||
                 !pre_script_result.console_output.empty () || !pre_script_result.success;
-                if (has_scripts) {
+                if (has_script_output) {
                     // Guarded as a whole: a script surface that threw where
                     // `execute_script` does not catch - building the runtime,
                     // applying a cookie write - must not cost the run its

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -386,7 +386,7 @@ void register_metrics_routes (RouteContext& ctx) {
                             return false;
                         }
                     }
-                } catch (const std::exception& e) {
+                } catch (const std::exception&) {
                     break;
                 }
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -43,6 +43,11 @@
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
 #if defined(__clang__)
+// Must come first: the names below are not all known to every Clang
+// (-Wcast-function-type-mismatch is 19+), and an unrecognised one is itself a
+// warning - which VAYU_WERROR turns into a build failure, so the suppression
+// block would break the build it exists to keep quiet.
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wc99-extensions"
 #pragma GCC diagnostic ignored "-Wcast-function-type-mismatch"
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -736,15 +736,15 @@ Result<std::vector<FormField>> parse_form_fields (const Json& body_json, BodyMod
         for (const auto& [name, target] :
         { std::pair<const char*, std::string*>{ "src", &field.src },
         { "fileName", &field.file_name }, { "contentType", &field.content_type } }) {
-            const auto entry = item.find (name);
-            if (entry == item.end () || entry->is_null ()) {
+            const auto member = item.find (name);
+            if (member == item.end () || member->is_null ()) {
                 continue;
             }
-            if (!entry->is_string ()) {
+            if (!member->is_string ()) {
                 return Error{ ErrorCode::InternalError,
                     std::string{ "Body field '" } + name + "' must be a string" };
             }
-            *target = entry->get<std::string> ();
+            *target = member->get<std::string> ();
         }
         // A text part carrying a file's source is ambiguous in the one direction
         // that matters: the caller pointed at a file and nothing would send it.

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -62,7 +62,7 @@ class MockHttpBin {
         });
 
         // GET /redirect/1 - one redirect to /get
-        svr_.Get ("/redirect/1", [this] (const httplib::Request&, httplib::Response& res) {
+        svr_.Get ("/redirect/1", [] (const httplib::Request&, httplib::Response& res) {
             res.set_redirect ("/get", 302);
         });
 

--- a/engine/tests/http_version_test.cpp
+++ b/engine/tests/http_version_test.cpp
@@ -7,11 +7,12 @@ using vayu::HttpVersion;
 TEST (HttpVersionDomain, EnumerationCoversTheWholeEnum) {
     // Every other test in this file iterates all_http_versions() rather than
     // the enum, so a member added to HttpVersion but forgotten here would slip
-    // past all of them. Nothing else catches it either: MSVC's
-    // missing-enumerator warnings (C4061/C4062) are off at /W4, and -Werror on
-    // GCC/Clang is gated behind VAYU_STRICT_BUILD, which CI does not set - so a
-    // forgotten member compiles clean and falls through to CURL_HTTP_VERSION_NONE.
-    // This count is the trip-wire that forces a look at the vector.
+    // past all of them. A forgotten member would trip -Wswitch in the
+    // to_string()/http_version_label() switches (they carry no default), but
+    // all_http_versions() is a hand-maintained vector, not a switch, so nothing
+    // the compiler emits catches a member missing from it - it just falls
+    // through to CURL_HTTP_VERSION_NONE. This count is the trip-wire that forces
+    // a look at the vector.
     EXPECT_EQ (vayu::all_http_versions ().size (), 3U);
 }
 

--- a/engine/tests/sse_load_stream_test.cpp
+++ b/engine/tests/sse_load_stream_test.cpp
@@ -86,7 +86,7 @@ class LoadStreamServer {
             });
         });
 
-        svr_.Get ("/finite", [this] (const httplib::Request&, httplib::Response& res) {
+        svr_.Get ("/finite", [] (const httplib::Request&, httplib::Response& res) {
             res.set_chunked_content_provider (
             "text/event-stream", [] (size_t, httplib::DataSink& sink) {
                 const std::string body = "data: a\n\n: ping\n\ndata: b\n\ndata: c\n\n";


### PR DESCRIPTION
## Description

Warnings-as-errors bound on no platform that could report one. The GCC/Clang `-Werror` was gated on `$ENV{VAYU_STRICT_BUILD}`, which nothing in the repo ever set, so every warning scrolled by uninspected; MSVC's `/WX` was held green by five `/wd` suppressions, three of which hid real defect classes. #900 took the warning inventory to **zero** - this is the half that keeps it there.

**Rebased onto `75efb14` (post-#900) and reduced to what #900 does not cover.** Everything #900 fixed at the declaration - the NSDMI structs, the six scoped `diagnostics.hpp` suppressions, the `-Wconversion` / sign-conversion / range-loop / `-Wcomment` sites, the `Result` scalars, the `scripting.cpp` captures - is dropped from this PR rather than duplicated or contradicted. In particular the global `-Wno-missing-field-initializers` and the two `-Wno-error=` lines an earlier revision of this PR carried are **gone**: `docs/engine/building.md` now says never to widen a suppression into `vayu_warnings`, and that was exactly what they did. See the discussion below.

**Plan.** Replace the dead env-var gate with a `VAYU_WERROR` CMake option (default `OFF` locally, `VAYU_STRICT_BUILD` still sets the default for back-compat) and have CI pass `-DVAYU_WERROR=ON`. Turning it on then surfaced four things that only exist once warnings are fatal, each found on the leg that reports it:

| Leg | Finding | Fix |
|---|---|---|
| macOS (Clang) | Vendored `quickjs.h` failed the build: the SDK spells `NAN` as `__builtin_nanf`, so `v.u.float64 = NAN` is `-Wdouble-promotion` there and nowhere else | Vendored `quickjs-ng` / `hdrhistogram` headers propagate as **SYSTEM** includes. Compiling vendored *sources* with their own flags was only half the exemption - on a plain `-I` the diagnostic is attributed to our TU. |
| Windows (MSVC) | With `/wd4456` gone, C4456 caught a **genuine shadow** in `event_loop_worker.cpp`: the completion branch redeclares `data` while the fetch phase's `data` is still in scope | Inner name is now `completed`. A local `-Wshadow=local` sweep found three more (`json.cpp`, `metrics_collector.cpp`, `execution.cpp`); each inner name now says what it holds. |
| Clang 18 | `-Wno-missing-designated-field-initializers` (19+) and `-Wcast-function-type-mismatch` (19+) are *unknown* names on 18, and an unknown-warning-option is itself a warning - so `-Werror` makes each suppression break the build it exists to quieten | Flag gated on Clang >= 19; the pragma block in `script_engine.cpp` leads with `-Wunknown-warning-option`. |
| Clang | One unused `[this]` capture in `sse_load_stream_test.cpp` | Removed. Its sibling handlers keep theirs - their nested lambdas capture `this` through them, so removing those would not compile. |

`/wd4101`, `/wd4456` and `/wd4244` are **removed**, which answers #884's "removed or its retention argued" by removal. `/wd4324` (alignas padding on the cache-line-aligned SPSC queue) and `/wd4100` (the `-Wno-unused-parameter` counterpart) stay, each with a one-line reason.

macOS is gated as well as Linux, deliberately: gating one GCC/Clang leg leaves the other compiler's diagnostics unwatched, and the `NAN` failure above is exactly that class.

Note: `-Werror` is part of the sccache command-line hash, so the two gated legs may see reduced reuse of the `cache-warm` scope until their own scope repopulates. Broadening `-DVAYU_WERROR=ON` to `cache-warm.yml` / `release.yml` is deliberately not done here.

## Type of Change
- [x] Bug fix (a CI gate that never gated, plus the shadow and the two self-defeating suppressions it exposed)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (`docs/engine/building.md`)

## Testing

| Build | Result |
|---|---|
| `linux-prod` + tests, `-DVAYU_WERROR=ON`, **GCC 13.3** | **0 warnings, 0 errors** |
| `linux-prod` + tests, `-DVAYU_WERROR=ON`, **Clang 18** | **0 warnings, 0 errors** |
| Engine suite on the strict tree | **2359 / 2359 passed** |

- Mutation check on the gate: injecting a `double -> int` narrowing fails the strict build with `-Werror=float-conversion`; reverting restores green.
- Mechanism check: `VAYU_STRICT_BUILD=1` configure yields 236 `-Werror` entries in `compile_commands.json`; no env yields 0 (default off).
- macOS and Windows were verified **on their own runners** - both findings above were read from failing jobs on this branch and fixed, which is the only way they could have been found from a Linux session.
- `mkdocs build --strict` clean; `pr-tests.yml` YAML validated (matrix `configureArgs` parse as strings).

No pre-existing failures on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable: CI itself is the test #884 asks for, and the mutation check above is the behavioural proof the gate binds
- [x] I have updated documentation

## Related Issues
Closes #884
Builds on #900 (#897). Makes #898 obsolete - the `/wd` audit it defers happened here.