### PR TITLE
build(engine): zero the compiler-warning inventory - 205 warnings to 0

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -499,6 +499,39 @@ directly (`daemon.cpp`, `cli.cpp`, `http/client.cpp`, `http/server.cpp`,
 first. Including `vayu/version.hpp` from a `.cpp` is fine, and from a header only
 where that header is not itself broadly included.
 
+### Compiler warnings, and the three that are suppressed
+
+The engine builds **warning-clean** on Linux and macOS, and a release build is
+where that is measured - several of the analyses below only run once the
+optimizer does. If a change adds a warning, fix it rather than leave it: the
+count is the signal, and it is only useful while it is zero.
+
+```bash
+# The build the count is read off: release, tests included, from cold.
+cmake --preset linux-prod -DVAYU_BUILD_TESTS=ON
+cmake --build --preset linux-prod --clean-first 2>&1 | grep -c 'warning:'
+```
+
+The flags are on `vayu_warnings` in `engine/CMakeLists.txt` - `-Wall -Wextra
+-Wpedantic` plus `-Wconversion`, `-Wsign-conversion`, `-Wdouble-promotion`,
+`-Wformat=2` and `-Wnull-dereference` on GCC and clang, `/W4 /WX` on MSVC.
+
+Three GCC 13 diagnostics fire only on code the engine did not write, and those
+are suppressed - narrowly, one function at a time, through the macros in
+`engine/include/vayu/utils/diagnostics.hpp`, which carry the reason and the
+trace beside each one:
+
+| Family | Where it comes from |
+|--------|---------------------|
+| `-Wdangling-reference` | GCC 13's ref-in/ref-out heuristic, on a test helper that indexes a caller-owned document and returns a reference into it |
+| `-Wnull-dereference` | Inlined libstdc++: a `basic_streambuf` pointer GCC cannot prove non-null, and nlohmann's internal `swap` |
+| `-Warray-bounds` / `-Wstringop-overflow` | GCC 13's string-concatenation family, which reasons about the 32-byte small-string buffer as though it were the whole object. One diagnostic under two names, so both are named together |
+
+**Never widen these into `vayu_warnings`.** A `-Wno-...` there hides the next
+genuine instance of the same family across the whole engine, which is the entire
+value of having the flag on. A suppression that a code change could remove
+should be that code change instead.
+
 ### Static Analysis
 
 The pre-commit hook (`scripts/pre-commit`, installed by

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -713,7 +713,8 @@ if(VAYU_BUILD_TESTS)
 
     target_link_libraries(vayu_tests PRIVATE
         vayu_core
-        GTest::gtest
+        # gtest_main already carries gtest; naming both made Apple's linker
+        # report "ignoring duplicate libraries: libgtest.a" on every macOS build.
         GTest::gtest_main
         httplib::httplib
         vayu_warnings

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -72,16 +72,22 @@ struct ScenarioStep {
     /// `request`'s `{{data.column}}` tokens, split once here so no executor has
     /// to re-scan the step per iteration. Empty for a step that carries none,
     /// which is what both executors test before doing any join work at all.
-    StepDataTemplate data_template;
+    ///
+    /// Every field from here down carries a `{}`: the plan tests build steps by
+    /// aggregate init and stop at `stored_url`, so a trailing field without a
+    /// default member initializer is a -Wmissing-field-initializers warning at
+    /// each of those sites. The defaults are what default construction already
+    /// produced.
+    StepDataTemplate data_template{};
     /// The step's parsed auth, kept **only** when its credentials carry a
     /// `{{data.column}}`. `NoAuth` for every other step, whose auth is already
     /// resolved into `request` above.
-    vayu::http::Auth auth;
+    vayu::http::Auth auth{};
     /// The stored `requests.spec_operation` text, "" for a step whose request
     /// names no operation. Carried on the step so contract coverage (#629) can
     /// resolve each step's identity **once**, when the tally is built, rather
     /// than parsing it per completion on the load path.
-    std::string spec_operation;
+    std::string spec_operation{};
     /// `auth`'s tokens, split once here like `data_template`.
     ///
     /// **Non-empty means this step's auth was deferred**: `request` carries no
@@ -89,7 +95,7 @@ struct ScenarioStep {
     /// sending or the request goes out unauthenticated. Deferral only ever
     /// happens in a run that has rows - a data token with no data set is
     /// refused when the plan resolves - so an executor always has a row for it.
-    StepDataTemplate auth_template;
+    StepDataTemplate auth_template{};
 };
 
 /** An ordered, immutable sequence of composed steps. */

--- a/engine/include/vayu/http/oauth_client.hpp
+++ b/engine/include/vayu/http/oauth_client.hpp
@@ -30,8 +30,12 @@ struct TokenError {
                            // | "oauth2_provider_error" | "oauth2_network_error"
     std::string message;
     int provider_status = 0;
-    std::string provider_error;             // RFC 6749 "error"
-    std::string provider_error_description; // RFC 6749 "error_description"
+    // `{}` rather than bare declarations: every construction here is a
+    // three-field aggregate init for a failure that carries no provider body,
+    // and without the default member initializer each of those eight sites is
+    // a -Wmissing-field-initializers warning. Empty is the intended value.
+    std::string provider_error{};             // RFC 6749 "error"
+    std::string provider_error_description{}; // RFC 6749 "error_description"
 };
 
 /**

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -796,7 +796,10 @@ struct Variable {
     bool secret  = false;
     bool enabled = true;
     std::string type = "string";
-    std::optional<int64_t> created_at;
+    // `{}` rather than a bare declaration so the ~43 aggregate initializations
+    // that stop short of this trailing field are not each a
+    // -Wmissing-field-initializers warning; absent still means "unknown age".
+    std::optional<int64_t> created_at{};
 
     bool operator== (const Variable&) const = default;
 };
@@ -1222,19 +1225,26 @@ struct MetricTick {
  * `build_monitor_sample_payload`).
  */
 struct MonitorSample {
-    int id;
+    // Every scalar is default-initialized: a default-constructed row whose id
+    // the caller never sets is copied into a vector by test and helper code,
+    // and reading an indeterminate `int` on the way is formally UB. The DB fills
+    // these on the read path, so zero is never a value anything believes.
+    int id = 0;
     std::string run_id;
-    int64_t timestamp;   // Unix ms - when the engine scraped it
-    std::string payload; // JSON object: {timestamp, series:{name: value}}
+    int64_t timestamp = 0; // Unix ms - when the engine scraped it
+    std::string payload;   // JSON object: {timestamp, series:{name: value}}
 };
 
 struct Result {
-    int id;
+    // Default-initialized for the reason on `MonitorSample` above - production
+    // fills `id` from the DB and the rest from the transfer, but a row built
+    // field-by-field and then copied used to read four indeterminate scalars.
+    int id = 0;
     std::string run_id;
-    int64_t timestamp;
-    int status_code;
+    int64_t timestamp = 0;
+    int status_code   = 0;
     std::string status_text; // Wire reason phrase, or canonical IANA text
-    double latency_ms;
+    double latency_ms = 0.0;
     std::string error;
     // JSON. Design mode stores the whole exchange here (request + response,
     // nested). A load run stores only the timing breakdown - never a body -
@@ -1386,8 +1396,11 @@ struct ConfigEntry {
     //
     // Declared after `updated_at` on purpose: the seeds aggregate-initialize
     // positionally up to that member, so every field added since is a trailing
-    // defaulted one set through a wrapper in `seed_default_config`.
-    std::optional<std::string> unit;
+    // defaulted one set through a wrapper in `seed_default_config`. The `{}` is
+    // load-bearing for the same reason: without a default member initializer,
+    // every one of those 53 positional seeds is a `-Wmissing-field-initializers`
+    // warning, and the cure belongs on the field rather than at each site.
+    std::optional<std::string> unit{};
 };
 
 /**

--- a/engine/include/vayu/utils/diagnostics.hpp
+++ b/engine/include/vayu/utils/diagnostics.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file utils/diagnostics.hpp
+ * @brief Scoped suppressions for the three GCC diagnostics that fire only on
+ *        code we did not write (issue #897).
+ *
+ * The engine builds warning-clean, and every suppression here is a *proven*
+ * false positive rather than a warning someone found inconvenient - each macro
+ * names the family, the analysis that produces it, and what would have to
+ * change for the suppression to be deleted. A real defect gets fixed at the
+ * source; nothing belongs here that a code change could remove.
+ *
+ * Two rules the shape enforces:
+ *
+ *  - **Scoped, never global.** Each macro is a `push` that a matching
+ *    `VAYU_DIAGNOSTIC_POP` ends, so a suppression covers the one function whose
+ *    inlining produces the diagnostic and nothing after it. Adding `-Wno-...`
+ *    to `vayu_warnings` would hide the next genuine instance of the same family
+ *    everywhere, which is the whole value of having the flag on.
+ *  - **GCC only.** These are GCC 13 heuristics; clang has no
+ *    `-Wdangling-reference` at all, and an unknown name inside a diagnostic
+ *    pragma is itself a warning there (`-Wunknown-warning-option`). MSVC has
+ *    neither the pragma spelling nor the analyses. So off GCC each macro
+ *    expands to nothing.
+ *
+ * Written once here rather than as raw pragmas at each site because the
+ * compiler guard is the part that is easy to get subtly wrong, and a hand-rolled
+ * copy of it would not receive this one's fixes.
+ */
+
+#if defined(__GNUC__) && !defined(__clang__)
+
+/**
+ * GCC 13's ref-in/ref-out heuristic: a function taking a reference and
+ * returning one is assumed to return a reference *into a temporary*, whether or
+ * not the argument was one. A helper that indexes into a caller-owned object
+ * and hands back a reference to a member trips it at every call site.
+ *
+ * Delete this when the engine's minimum GCC carries `[[gnu::no_dangling]]`
+ * (GCC 14), which states the fact at the function instead of at its callers.
+ */
+#define VAYU_IGNORE_FALSE_DANGLING_REFERENCE                                             \
+    _Pragma ("GCC diagnostic push")                                                      \
+    _Pragma ("GCC diagnostic ignored \"-Wdangling-reference\"")
+
+/**
+ * `-Wnull-dereference` traced into libstdc++, never into our own code: the
+ * pointer GCC cannot prove non-null belongs to a `std::basic_streambuf` or to
+ * nlohmann's internal `swap`, both reached only by inlining at `-O2`. Both are
+ * known false-positive families - a stream we opened and checked has a buffer,
+ * and a `basic_json` we just constructed has a value.
+ *
+ * The flag is opt-in here (`vayu_warnings` adds it on top of `-Wextra`), so it
+ * is worth keeping for the cases it would catch in our own code - which is
+ * exactly why these are suppressed one function at a time.
+ */
+#define VAYU_IGNORE_FALSE_NULL_DEREFERENCE                                               \
+    _Pragma ("GCC diagnostic push")                                                      \
+    _Pragma ("GCC diagnostic ignored \"-Wnull-dereference\"")
+
+/**
+ * GCC 13's string-concatenation family: folding `operator+` over a
+ * `std::string` makes the optimizer reason about the 32-byte small-string
+ * buffer as though it were the whole object, and it reports the heap copy that
+ * follows as an out-of-bounds `memcpy`. Nothing is out of bounds - the string
+ * has already reallocated by the time the copy runs.
+ *
+ * **Both flags, because it is one diagnostic wearing two names.** GCC reports
+ * the same `char_traits.h:435` `memcpy` as `-Warray-bounds` or as
+ * `-Wstringop-overflow` depending on which pass reaches it first, so silencing
+ * one alone just moves the warning to the other spelling.
+ */
+#define VAYU_IGNORE_FALSE_STRING_CONCAT_BOUNDS                                           \
+    _Pragma ("GCC diagnostic push")                                                      \
+    _Pragma ("GCC diagnostic ignored \"-Warray-bounds\"")                                \
+    _Pragma ("GCC diagnostic ignored \"-Wstringop-overflow\"")
+
+/// Ends the region opened by any `VAYU_IGNORE_FALSE_*` above.
+#define VAYU_DIAGNOSTIC_POP _Pragma ("GCC diagnostic pop")
+
+#else
+
+#define VAYU_IGNORE_FALSE_DANGLING_REFERENCE
+#define VAYU_IGNORE_FALSE_NULL_DEREFERENCE
+#define VAYU_IGNORE_FALSE_STRING_CONCAT_BOUNDS
+#define VAYU_DIAGNOSTIC_POP
+
+#endif

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -20,6 +20,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
+#include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/version.hpp"
@@ -68,6 +69,10 @@ For more information, visit: https://github.com/vayu/vayu
 )";
 }
 
+// `istreambuf_iterator` over a stream we just checked is open: GCC cannot see
+// that `rdbuf()` is non-null once inlined, and reports the buffer's `gptr()`
+// reads as potential null dereferences. See utils/diagnostics.hpp.
+VAYU_IGNORE_FALSE_NULL_DEREFERENCE
 std::string read_file (const std::string& path) {
     std::ifstream file (path);
     if (!file.is_open ()) {
@@ -84,6 +89,7 @@ std::string read_file (const std::string& path) {
 
     return content;
 }
+VAYU_DIAGNOSTIC_POP
 
 void print_response (const vayu::Response& response, bool color) {
     // Status line

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -228,7 +228,8 @@ bool MetricsCollector::claim_status_exemplar (int status_code) {
     const int slot = (status_code >= 0 && status_code < STATUS_CODE_SLOTS - 1) ?
     status_code :
     STATUS_CODE_SLOTS - 1;
-    const size_t claimed = exemplar_claims_[slot].fetch_add (1, std::memory_order_relaxed);
+    const size_t claimed =
+    exemplar_claims_[static_cast<size_t> (slot)].fetch_add (1, std::memory_order_relaxed);
     return claimed < constants::metrics_collector::EXEMPLARS_PER_STATUS;
 }
 
@@ -734,7 +735,8 @@ MetricsCollector::Percentiles MetricsCollector::sample_window_percentiles () {
 void MetricsCollector::record_status_code (int status_code) {
     if (status_code >= 0 && status_code < STATUS_CODE_SLOTS) {
         // Hot path: single relaxed atomic increment, no lock.
-        status_code_counts_[status_code].fetch_add (1, std::memory_order_relaxed);
+        status_code_counts_[static_cast<size_t> (status_code)].fetch_add (
+        1, std::memory_order_relaxed);
         return;
     }
     // Out-of-range (non-standard) code: dead path for real HTTP traffic.
@@ -745,7 +747,8 @@ void MetricsCollector::record_status_code (int status_code) {
 std::map<int, size_t> MetricsCollector::status_code_distribution () const {
     std::map<int, size_t> result;
     for (int code = 0; code < STATUS_CODE_SLOTS; ++code) {
-        size_t count = status_code_counts_[code].load (std::memory_order_relaxed);
+        size_t count =
+        status_code_counts_[static_cast<size_t> (code)].load (std::memory_order_relaxed);
         if (count > 0) {
             result[code] = count;
         }

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -669,6 +669,11 @@ Json media_type_body (std::string_view content_type, const Json& value) {
  * Nothing is inferred about the endpoint here either: the schema is read off
  * the body that is actually stored, and a mode whose stored text is not the
  * body the endpoint receives writes nothing at all.
+ *
+ * Every `Json` answer leaves through `std::make_optional`: copy-initializing an
+ * `optional<Json>` from a `Json` puts nlohmann's `operator ValueType()` up
+ * against `optional`'s converting constructor, which GCC reports as
+ * -Wconversion. Direct-initializing considers the constructor alone.
  */
 std::optional<Json> request_body_object (const ExportBody& body) {
     const std::string_view content = trim (body.content);
@@ -676,7 +681,8 @@ std::optional<Json> request_body_object (const ExportBody& body) {
         if (content.empty ()) {
             return std::nullopt;
         }
-        return media_type_body ("application/json", example_value (body.content));
+        return std::make_optional (
+        media_type_body ("application/json", example_value (body.content)));
     }
     if (body.mode == "xml") {
         // The text as it stands, never parsed: an XML body is not JSON, so the
@@ -684,13 +690,13 @@ std::optional<Json> request_body_object (const ExportBody& body) {
         if (content.empty ()) {
             return std::nullopt;
         }
-        return media_type_body ("application/xml", body.content);
+        return std::make_optional (media_type_body ("application/xml", body.content));
     }
     if (body.mode == "text") {
         if (content.empty ()) {
             return std::nullopt;
         }
-        return media_type_body ("text/plain", body.content);
+        return std::make_optional (media_type_body ("text/plain", body.content));
     }
     if (body.mode == "form-data" || body.mode == "x-www-form-urlencoded") {
         Json properties = Json::object ();
@@ -709,8 +715,8 @@ std::optional<Json> request_body_object (const ExportBody& body) {
         // states what the collection holds rather than a shape read off one
         // sample - it carries no derivation note.
         Json schema{ { "type", "object" }, { "properties", std::move (properties) } };
-        return Json{ { "content",
-        Json{ { content_type, Json{ { "schema", std::move (schema) } } } } } };
+        return std::make_optional (Json{ { "content",
+        Json{ { content_type, Json{ { "schema", std::move (schema) } } } } } });
     }
     // `graphql` and `none`. GraphQL over HTTP posts a JSON envelope, but the
     // stored body is the query text alone - Vayu composes the envelope at send

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -18,6 +18,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/http/managed_listener.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -56,6 +57,10 @@ bool is_valid_port (int port) {
  * than the last one winning: `Set-Cookie` and `Forwarded` legitimately repeat,
  * and a capture that showed one of two is a capture that lies.
  */
+// nlohmann's internal `swap` inlined into the object build: GCC cannot see that
+// a `basic_json` it just constructed holds a value, and reports the move as a
+// potential null dereference. See utils/diagnostics.hpp.
+VAYU_IGNORE_FALSE_NULL_DEREFERENCE
 nlohmann::json headers_to_json (const httplib::Headers& headers) {
     nlohmann::json out = nlohmann::json::object ();
     for (const auto& [name, value] : headers) {
@@ -67,6 +72,7 @@ nlohmann::json headers_to_json (const httplib::Headers& headers) {
     }
     return out;
 }
+VAYU_DIAGNOSTIC_POP
 
 /// The raw query string of a request target, without the '?'.
 std::string query_of (const std::string& target) {

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -1441,7 +1441,7 @@ void register_scripting_routes (RouteContext& ctx) {
      * This is a startup API - frontend fetches once and caches.
      */
     ctx.server.Get ("/scripting/completions",
-    [&ctx] (const httplib::Request&, httplib::Response& res) {
+    [] (const httplib::Request&, httplib::Response& res) {
         vayu::utils::log_info (
         "GET /scripting/completions - Fetching script API completions");
         try {
@@ -1466,7 +1466,7 @@ void register_scripting_routes (RouteContext& ctx) {
      * app can cache on `version` without re-parsing the declarations.
      */
     ctx.server.Get ("/scripting/types",
-    [&ctx] (const httplib::Request&, httplib::Response& res) {
+    [] (const httplib::Request&, httplib::Response& res) {
         vayu::utils::log_info (
         "GET /scripting/types - Generating script type declarations");
         try {

--- a/engine/src/http/routes/spec_sync.cpp
+++ b/engine/src/http/routes/spec_sync.cpp
@@ -373,7 +373,11 @@ class DocumentedExamples {
         if (!found) {
             return std::nullopt;
         }
-        return draft_example_rows (drafts_[*found].draft.examples);
+        // `make_optional` rather than a bare return: copy-initializing an
+        // `optional<json>` from a `json` puts nlohmann's `operator ValueType()`
+        // up against `optional`'s converting constructor, which GCC reports as
+        // -Wconversion. Direct-initializing considers the constructor alone.
+        return std::make_optional (draft_example_rows (drafts_[*found].draft.examples));
     }
 
     private:

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -206,9 +206,9 @@ JSValue cast_variable_to_jsvalue (JSContext* ctx, const Variable& var) {
         [] (unsigned char c) { return std::tolower (c); });
         // Trim whitespace
         auto isspace_pred = [] (unsigned char c) { return std::isspace (c); };
-        while (!lowered.empty () && isspace_pred (lowered.front ()))
+        while (!lowered.empty () && isspace_pred (static_cast<unsigned char> (lowered.front ())))
             lowered.erase (lowered.begin ());
-        while (!lowered.empty () && isspace_pred (lowered.back ()))
+        while (!lowered.empty () && isspace_pred (static_cast<unsigned char> (lowered.back ())))
             lowered.pop_back ();
 
         if (lowered == "true" || lowered == "1" || lowered == "yes")
@@ -351,8 +351,10 @@ struct ExpectState {
     bool deep   = false;
     bool nested = false;
     // chai's second argument to `expect(value, message)`, empty when the script
-    // passed one argument. Read only by `throw_expect_failure`.
-    std::string message;
+    // passed one argument. Read only by `throw_expect_failure`. The `{}` keeps
+    // `create_expectation`'s two-field aggregate init, which assigns this
+    // separately, out of -Wmissing-field-initializers.
+    std::string message{};
 };
 
 JSClassID expect_class_id = 0;
@@ -1668,7 +1670,7 @@ JSValue expect_string (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
 }
 
 JSValue create_expectation (JSContext* ctx, JSValue actual, std::string message) {
-    JSValue obj = JS_NewObjectClass (ctx, static_cast<int> (expect_class_id));
+    JSValue obj = JS_NewObjectClass (ctx, expect_class_id);
     if (JS_IsException (obj)) {
         return obj;
     }
@@ -2509,9 +2511,15 @@ JSAtom prop) {
     return -1;
 }
 
-JSClassExoticMethods response_chain_exotic = {
-    .get_own_property = response_chain_unknown_member,
-};
+// Value-initialized and then assigned rather than written as a designated
+// initializer: this is a QuickJS C struct, so it cannot carry default member
+// initializers, and naming one of its seven hooks leaves the other six as
+// -Wmissing-field-initializers warnings.
+JSClassExoticMethods response_chain_exotic = [] {
+    JSClassExoticMethods exotic{};
+    exotic.get_own_property = response_chain_unknown_member;
+    return exotic;
+}();
 
 JSClassDef response_chain_class = { .class_name = "ResponseAssertionChain",
     .finalizer                                  = nullptr,
@@ -2520,7 +2528,7 @@ JSClassDef response_chain_class = { .class_name = "ResponseAssertionChain",
     .exotic                                     = &response_chain_exotic };
 
 JSValue create_response_chain_object (JSContext* ctx) {
-    return JS_NewObjectClass (ctx, static_cast<int> (response_chain_class_id));
+    return JS_NewObjectClass (ctx, response_chain_class_id);
 }
 
 // Arms the unknown-member hook. Call once the object holds every member it is

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -394,7 +394,7 @@ TEST_F (ImportApplyRouteTest, RejectsAnObjectFieldGivenANonObject) {
     };
 
     for (const auto& c : cases) {
-        for (const json bad_shape :
+        for (const json& bad_shape :
         { json (42), json ("bearer"), json::array ({ 1, 2 }) }) {
             json item     = c.item;
             item[c.field] = bad_shape;

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -342,7 +342,8 @@ TEST_F (MetricsCollectorTest, ThreadSafePerCodeCounts) {
     for (int t = 0; t < num_threads; ++t) {
         threads.emplace_back ([this, &codes] () {
             for (int i = 0; i < requests_per_thread; ++i) {
-                collector->record_success (codes[i % codes.size ()], 5.0, 0.0);
+                collector->record_success (
+                codes[static_cast<size_t> (i) % codes.size ()], 5.0, 0.0);
             }
         });
     }
@@ -357,7 +358,7 @@ TEST_F (MetricsCollectorTest, ThreadSafePerCodeCounts) {
     std::map<int, size_t> expected;
     for (int t = 0; t < num_threads; ++t)
         for (int i = 0; i < requests_per_thread; ++i)
-            expected[codes[i % codes.size ()]]++;
+            expected[codes[static_cast<size_t> (i) % codes.size ()]]++;
 
     for (const auto& [code, count] : expected) {
         EXPECT_EQ (distribution[code], count) << "code " << code;

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -30,6 +30,7 @@
 
 #include "vayu/core/openapi_document.hpp"
 #include "vayu/core/openapi_export.hpp"
+#include "vayu/utils/diagnostics.hpp"
 
 using vayu::core::export_openapi;
 using vayu::core::ExportCollection;
@@ -105,6 +106,11 @@ const ExportCollection& collection        = PETSTORE) {
     return { json::parse (outcome.text), outcome.notes, outcome.text, outcome.file_name };
 }
 
+// `operation_of` takes a reference and returns one into it, which is GCC 13's
+// ref-in/ref-out heuristic exactly; every call below chains into a live
+// `exported.document`, so nothing dangles. See utils/diagnostics.hpp - the
+// suppression covers the rest of the file because every use is a call site.
+VAYU_IGNORE_FALSE_DANGLING_REFERENCE
 const json&
 operation_of (const json& document, const std::string& path, const std::string& method) {
     return document.at ("paths").at (path).at (method);
@@ -553,3 +559,4 @@ TEST (ExportSerialization, NamesTheFileAfterTheCollectionHoweverItIsNamed) {
     EXPECT_EQ (named ("Pet Store / v2"), "pet-store-v2.openapi.json");
     EXPECT_EQ (named ("   "), "collection.openapi.json");
 }
+VAYU_DIAGNOSTIC_POP

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -239,7 +239,7 @@ TEST (RunConfigValidation, NumericDurationIsRejected) {
 }
 
 TEST (RunConfigValidation, NonStringDurationTypesAreRejected) {
-    for (const nlohmann::json bad :
+    for (const nlohmann::json& bad :
     { nlohmann::json (true), nlohmann::json (nlohmann::json::array ({ 1 })),
     nlohmann::json (nlohmann::json::object ()) }) {
         auto config        = valid_config ();
@@ -547,7 +547,7 @@ TEST (RunConfigValidation, AValidCapacityConfigIsAccepted) {
 }
 
 TEST (RunConfigValidation, AnUnparseableStepDurationIsRejected) {
-    for (const nlohmann::json bad : { nlohmann::json (5000), nlohmann::json ("soon"),
+    for (const nlohmann::json& bad : { nlohmann::json (5000), nlohmann::json ("soon"),
     nlohmann::json ("0s"), nlohmann::json ("-1s"), nlohmann::json (true) }) {
         auto config            = valid_config ();
         config["stepDuration"] = bad;
@@ -571,7 +571,7 @@ TEST (RunConfigValidation, ANullStepDurationIsAcceptedAsAbsent) {
 }
 
 TEST (RunConfigValidation, AnOutOfRangeSloIsRejected) {
-    for (const nlohmann::json bad :
+    for (const nlohmann::json& bad :
     { nlohmann::json (0), nlohmann::json (-1), nlohmann::json (60001), nlohmann::json ("fast") }) {
         auto config     = valid_config ();
         config["sloMs"] = bad;
@@ -590,7 +590,7 @@ TEST (RunConfigValidation, AnOutOfRangeSloIsRejected) {
 TEST (RunConfigValidation, ANonBooleanBooleanSettingIsRejected) {
     for (const char* key :
     { "phase_histograms", "save_timing_breakdown", "capture_response_bodies" }) {
-        for (const nlohmann::json bad : { nlohmann::json ("true"),
+        for (const nlohmann::json& bad : { nlohmann::json ("true"),
              nlohmann::json (1), nlohmann::json (nlohmann::json::array ()) }) {
             auto config = valid_config ();
             config[key] = bad;

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -25,6 +25,7 @@
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/spec_coverage.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/json.hpp"
 
 using nlohmann::json;
@@ -90,6 +91,9 @@ class RunsRouteTest : public ::testing::Test {
     /// One stored exchange for @p run_id. `trace_data` is deliberately large:
     /// the list must never read this column, and a row that does shows up as a
     /// payload, not as a failure.
+    // The 4 KB filler concatenation below is what GCC 13 reports as reading past
+    // the small-string buffer. See utils/diagnostics.hpp.
+    VAYU_IGNORE_FALSE_STRING_CONCAT_BOUNDS
     void seed_result (const std::string& run_id, int status_code, double latency_ms) {
         vayu::db::Result result;
         result.run_id      = run_id;
@@ -100,6 +104,7 @@ class RunsRouteTest : public ::testing::Test {
         result.trace_data = R"({"response":{"body":")" + std::string (4096, 'x') + R"("}})";
         db_->add_result (result);
     }
+    VAYU_DIAGNOSTIC_POP
 
     std::unique_ptr<vayu::db::Database> db_;
 };

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -15,6 +15,7 @@
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/script_parts.hpp"
 #include "vayu/types.hpp"
+#include "vayu/utils/diagnostics.hpp"
 
 using namespace vayu;
 using namespace vayu::runtime;
@@ -3319,6 +3320,10 @@ TEST_F (ScriptEngineTest, DocExampleRewritesAJsonBodyThenDerivesFromIt) {
     std::to_string (request.body.content.size ()));
 }
 
+// Concatenating the script source onto a call line: GCC 13 reports the heap
+// copy that follows as reading past the small-string buffer. See
+// utils/diagnostics.hpp.
+VAYU_IGNORE_FALSE_STRING_CONCAT_BOUNDS
 TEST_F (ScriptEngineTest, DocExampleSetsAQueryParamAcrossItsThreeCases) {
     static constexpr const char* kSetQueryParam = R"JS(
         function setQueryParam(url, name, value) {
@@ -3364,6 +3369,7 @@ TEST_F (ScriptEngineTest, DocExampleSetsAQueryParamAcrossItsThreeCases) {
         EXPECT_EQ (req.url, c.expected) << "input: " << c.url;
     }
 }
+VAYU_DIAGNOSTIC_POP
 
 // scripting.md's "Sign a request" example, with the timestamp pinned so the
 // signature is reproducible. Until #187 this section taught an FNV-1a checksum

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -28,6 +28,7 @@
 
 #include "vayu/http/routes.hpp"
 #include "vayu/runtime/script_engine.hpp"
+#include "vayu/utils/diagnostics.hpp"
 
 namespace vayu::http::routes {
 // Defined in scripting.cpp.
@@ -383,6 +384,9 @@ TEST (ScriptTypesTest, AListFieldDeclaresAnArrayOfItsElementType) {
  * and commit the result, so a change to the surface shows up as a diff in the
  * declarations the editor will serve.
  */
+// Reading the fixture through `istreambuf_iterator`: GCC cannot see that the
+// stream we just asserted `good()` on has a buffer. See utils/diagnostics.hpp.
+VAYU_IGNORE_FALSE_NULL_DEREFERENCE
 TEST (ScriptTypesTest, TheCheckedInDeclarationsMatchTheGenerator) {
     const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
     "tests" / "fixtures" / "script-typedefs.d.ts";
@@ -409,6 +413,7 @@ TEST (ScriptTypesTest, TheCheckedInDeclarationsMatchTheGenerator) {
     << "the checked-in declarations are stale. Regenerate with "
        "VAYU_UPDATE_SCRIPT_TYPEDEFS=1 ctest --preset linux-dev -R ScriptTypes";
 }
+VAYU_DIAGNOSTIC_POP
 
 // Documentation is what hover text renders; a `*/` inside it would close the
 // comment early and drop every declaration after it.

--- a/engine/tests/version_isolation_test.cpp
+++ b/engine/tests/version_isolation_test.cpp
@@ -54,10 +54,10 @@ std::string read_file (const std::filesystem::path& path) {
  * delete the explanation. Scanning code and not prose is the honest version.
  *
  * Newlines are preserved so the remaining text keeps its shape. String literals
- * are not modelled: none of the scanned headers contains a `//` or `/*` inside
- * one, and the failure mode if one appeared would be over-stripping, i.e. a
- * lenient guard - which `TheGuardStillSeesTheVersionInCode` below is what
- * catches.
+ * are not modelled: none of the scanned headers opens a comment of either kind
+ * inside one, and the failure mode if one appeared would be over-stripping,
+ * i.e. a lenient guard - which `TheGuardStillSeesTheVersionInCode` below is
+ * what catches.
  */
 std::string strip_comments (const std::string& source) {
     std::string out;


### PR DESCRIPTION
## Description

A cold `linux-prod` + tests build at `0fe0e67` emitted **205 warnings at 148 sites across 10 flags**. It now emits **zero**, on the release *and* the debug leg, on all three platforms. This is the prerequisite half of #884: this PR makes the count zero, #884 makes warnings fatal.

**Plan.** The root cause of 143 of the 205 was not 100+ careless brace-inits - it was five structs (and one C struct) whose *trailing* fields carry no default member initializer, so every aggregate init that legitimately stops short of them is a warning. GCC does not warn for a member that has an NSDMI, so the cure belongs on the field. The approach is therefore "fix the declaration, never the call site", and the diff touches zero of the ~140 initialization sites. The one genuine defect in the set is `db::Result` / `db::MonitorSample`, whose bare scalars were read indeterminate when a partly-built row was copied - that is formally UB and is now defined zero. The alternative I rejected was adding `-Wno-...` entries to `vayu_warnings` for the 27 false-positive emissions: it is one line instead of six scoped suppressions, and it would hide the next *genuine* instance of each family across the whole engine, which is the entire value of having `-Wnull-dereference` on in the first place.

Verified against live code rather than the issue's snapshot; two things had drifted and are handled as found:

- `-Wuninitialized` fires on `Result::timestamp` and `Result::latency_ms` as well as `Result::id`. All four scalars on `Result` and both on `MonitorSample` are now `= 0` - same struct-level fix, no extra sites.
- `ScenarioStep` warns on **four** trailing fields (`data_template`, `auth`, `spec_operation`, `auth_template`), not one. All four get `{}`.

Per the correction comment on #884, this PR **takes all five `-Wconversion` sites**, `spec_sync.cpp:376` included - the acceptance criterion here is a zero count, which #884's site would otherwise break. #884 rebases trivially over it.

### The root causes

| Flag | Was | Fix |
|---|---|---|
| `-Wmissing-field-initializers` | 143 | NSDMI on `ConfigEntry::unit` (53), `Variable::created_at` (43), `TokenError::provider_error{,_description}` (16), `ScenarioStep`'s four trailing fields (24), `ExpectState::message` (1); `JSClassExoticMethods` value-initialized then assigned (6) |
| `-Wnull-dereference` | 16 | false positive - scoped suppression |
| `-Wconversion` | 12 | `std::make_optional` at 5 sites |
| `-Wsign-conversion` | 9 | `static_cast`s; two vestigial casts **to `int`** on a `JSClassID` dropped |
| `-Wdangling-reference` | 9 | false positive - scoped suppression |
| `-Wuninitialized` / `-Wmaybe-uninitialized` | 8 | **real UB** - `Result` / `MonitorSample` scalars defined-zero |
| `-Wrange-loop-construct` | 5 | take the loop variable by reference instead of copying a `json` per iteration |
| `-Warray-bounds=` | 2 | false positive - scoped suppression |
| `-Wcomment` | 1 | reworded the prose that opened a comment |

`-Wconversion` detail: copy-initializing an optional-of-json from a json puts nlohmann's `operator ValueType()` up against the optional's converting constructor. `std::make_optional` direct-initializes, which considers the constructor alone - the answer `utils/json.cpp:45` already used.

### The suppressions

New `engine/include/vayu/utils/diagnostics.hpp`. Three macros, each carrying the analysis that produces the family, why it is provably wrong here, and what would let us delete it. Six call sites, each a `push` closed by a matching `VAYU_DIAGNOSTIC_POP` around one function (the export test's is file-scoped, as the issue recommends, because every use of `operation_of` is a call site). GCC-only, because clang has no `-Wdangling-reference` and an unknown name inside a diagnostic pragma is itself a warning there.

One finding worth recording: **`-Warray-bounds` and `-Wstringop-overflow` are the same diagnostic wearing two names.** Suppressing only the first moved the identical `char_traits.h:435` `memcpy` to the second, so the macro names both. That is not in the issue's plan; it is what the build said.

### macOS / clang extras

The two `/scripting` handlers captured a `ctx` they never use (`-Wunused-lambda-capture`), and `vayu_tests` linked both `GTest::gtest` and `GTest::gtest_main` - `gtest_main` already carries `gtest`, so Apple's linker reported a duplicate library on every macOS build. Both fixed and both confirmed gone by macOS CI (see below).

### Deliberate deviations from the issue spec

- **`Result` / `MonitorSample` get every scalar defaulted**, not only `id`. The measured warnings named `timestamp` and `latency_ms` too, and `status_code` is the same shape - leaving a known-indeterminate sibling behind would have been a warning nobody sees rather than a bug that is not there.
- **The MSVC enumeration (acceptance criterion 5) is not in this PR.** By the issue's own wording it is recorded "here (or in #884) after the `/wd` review", and #884 is what reviews the five `/wd` suppressions currently hiding these classes on Windows. Nothing is orphaned by closing this issue - the work lives in that open issue.

## Type of Change

- [x] Bug fix (the `-Wuninitialized` set is real UB)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

**Zero warnings, cold release build with tests** - the issue's proof-of-completion artifact, GCC 13.3.0 / Ubuntu:

```
$ cmake --preset linux-prod -DVAYU_BUILD_TESTS=ON
$ cmake --build --preset linux-prod --clean-first 2>&1 | tee after.log
...
[253/253] Linking CXX executable vayu_tests
$ grep -c 'warning:' after.log
0
```

Same command at the base commit `0fe0e67` for comparison: **205**.

**Locally, both presets:**

| | Warnings | Tests |
|---|---|---|
| `linux-prod` (Release, cold, `--clean-first`) | **0** (was 205) | **2359 passed, 0 failed** |
| `linux-dev` (Debug, cold) | **0** | **2359 passed, 0 failed** |

**CI, all three platforms** (head `1b252e5`, `CI gate` success):

| Leg | Engine build | Tests |
|---|---|---|
| ubuntu-latest (GCC) | success | 2359 passed |
| macos-latest (clang) | success | 2359 passed |
| windows-latest (MSVC) | success | 2360 passed |

The macOS job log has **0** lines matching `warning:` and **0** `ld: ignoring duplicate libraries` - acceptance criterion 4. Windows compiles with `/W4 /WX`, so a warning there is already a build failure; its green build means the Windows leg emits zero MSVC warnings *with the five `/wd` entries still in force*, which is one useful data point for #884's review of them.

**Docs:** `mkdocs build --strict -f .github/mkdocs.yml` builds clean.

No pre-existing failures on the base commit; the base build is green apart from the 205 warnings this PR removes.

The app is untouched - the issue's "App changes: none" is correct, and no app test could change colour, so neither app suite was run.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable: every change is a declaration-level default equal to what default construction already produced, a cast, or a suppression. The behavioural lock is the existing suite passing unchanged on both presets and all three platforms; the warning count itself is the regression signal, and `docs/engine/building.md` now states the command that reads it.
- [x] I have updated documentation - `docs/engine/building.md` gains a "Compiler warnings, and the three that are suppressed" section: the flags in force, the command the count is read off, a table of the three suppressed families and where each comes from, and the rule that they are never widened into `vayu_warnings`.

## Related Issues

Closes #897

Prerequisite for #884 (`-Werror` / `/WX`); overlaps #886's future bulk-format at the comment/whitespace level only.