### PR TITLE
ci(scripts): lint every tracked shell and Python file on one job, and stop build.py's bare excepts eating Ctrl-C

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -64,6 +64,7 @@ jobs:
       engine: ${{ steps.area.outputs.engine }}
       installer: ${{ steps.area.outputs.installer }}
       build_script: ${{ steps.area.outputs.build_script }}
+      scripts: ${{ steps.area.outputs.scripts }}
     steps:
       # Two invocations, because `predicate-quantifier` applies to the whole
       # action and the two kinds of filter need opposite ones. This one answers
@@ -92,6 +93,15 @@ jobs:
           # change to *this* workflow, or to codeql/labeler/release, must still
           # run the matrix. Each of these is checked by the `Docs site` workflow
           # instead, which runs `mkdocs build --strict` on the same paths.
+          #
+          # `.github/hooks/**` and `scripts/install-git-hooks.sh` used to be
+          # excluded here too, on that same reasoning - neither can change a
+          # build artifact. They are back in because #887 gave shell and Python
+          # a linter and both are among the files it reads: a gate whose own
+          # inputs cannot trigger it is the repository's "written but never
+          # read" defect in wiring form. `code` admits them; the area filter
+          # below routes them to `Script lint` alone, so the matrix they still
+          # cannot affect still does not run.
           filters: |
             code:
               - '**'
@@ -100,9 +110,7 @@ jobs:
               - '!**/*.md'
               - '!LICENSE'
               - '!.gitignore'
-              - '!scripts/install-git-hooks.sh'
               - '!.github/mkdocs.yml'
-              - '!.github/hooks/**'
               - '!.github/workflows/docs.yml'
               - '!requirements-docs.txt'
 
@@ -151,10 +159,25 @@ jobs:
               - 'install.sh'
               - 'scripts/test/install_test.sh'
               - 'scripts/test/install_e2e.sh'
-              # The git hook rides this job because it is the only one with a
-              # shell toolchain (shellcheck, bash) already stood up.
+              # The git hook's suite rides this job because it is the only one
+              # with a bash toolchain already stood up. Linting both of them is
+              # `scripts` below, for every shell script at once.
               - 'scripts/pre-commit'
               - 'scripts/test/pre-commit_test.sh'
+              - '.github/workflows/pr-tests.yml'
+            # Globs rather than a list, deliberately: the `Script lint` job
+            # takes its files from `git ls-files`, so a script added tomorrow is
+            # linted the day it lands, and this filter has to be able to see the
+            # same file or the job would never run on it.
+            scripts:
+              # Both forms of each glob, for the reason the `code` filter above
+              # gives: the bare one covers root-level files (`install.sh`,
+              # `build.py`), the `**/` one covers nested.
+              - '*.sh'
+              - '**/*.sh'
+              - '*.py'
+              - '**/*.py'
+              - 'scripts/pre-commit'
               - '.github/workflows/pr-tests.yml'
 
   # Lint, formatting and type-check are platform-independent, so one runner
@@ -705,45 +728,23 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Pinned, and the same build on both runners. Ubuntu's apt and Homebrew
-      # ship different versions, and shellcheck's findings differ between them:
-      # a file clean under one has twice failed here on a rule the other does
-      # not emit, and once the *same* finding arrived under a different code
-      # (SC2317 in 0.9/0.10, SC2329 in 0.11). Pinning makes a local run mean
-      # something, and moves a version bump into a commit someone chose to make.
-      - name: Install shellcheck
+      # Only the suites run here. shellcheck used to run beside each of them,
+      # over the five scripts this job happens to own; it now runs once over
+      # every tracked script in the `Script lint` job below (#887), which is
+      # both cheaper - one runner instead of this two-runner matrix - and the
+      # only version of it that a newly added script cannot escape.
+      - name: Test installer script
         shell: bash
-        env:
-          SHELLCHECK_VERSION: v0.10.0
-        run: |
-          case "${RUNNER_OS}-$(uname -m)" in
-            Linux-x86_64)   target=linux.x86_64 ;;
-            Linux-aarch64)  target=linux.aarch64 ;;
-            macOS-arm64)    target=darwin.aarch64 ;;
-            macOS-x86_64)   target=darwin.x86_64 ;;
-            *) echo "::error::No pinned shellcheck build for ${RUNNER_OS}-$(uname -m)"; exit 1 ;;
-          esac
-          url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.${target}.tar.xz"
-          curl -fsSL "$url" | tar -xJ
-          sudo install "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-          shellcheck --version
-
-      - name: Lint and test installer script
-        shell: bash
-        run: |
-          shellcheck install.sh scripts/test/install_test.sh scripts/test/install_e2e.sh
-          bash scripts/test/install_test.sh
+        run: bash scripts/test/install_test.sh
 
       # The pre-commit hook's clang-tidy version probe (#659). Linux only: the
       # hook prepends Homebrew's LLVM directory when it exists, which shadows
       # the stubbed clang-tidy the suite drives it with, and the probe has no
       # platform-specific half worth running twice.
-      - name: Lint and test the pre-commit hook
+      - name: Test the pre-commit hook
         if: runner.os == 'Linux'
         shell: bash
-        run: |
-          shellcheck scripts/pre-commit scripts/test/pre-commit_test.sh
-          bash scripts/test/pre-commit_test.sh
+        run: bash scripts/test/pre-commit_test.sh
 
       # The dry-run suite above asserts on the commands the installer would have
       # run. This one runs it: a real download from a local release, a real
@@ -790,6 +791,93 @@ jobs:
       - name: Test the stale-vcpkg-baseline self-heal
         run: python3 scripts/test/vcpkg_baseline_test.py
 
+  # The repository's two unlinted languages (#887). Both checks are seconds of
+  # work on a runner that needs neither a C++ toolchain nor Node, so they share
+  # one Linux job rather than riding a matrix that would run each of them two or
+  # three times for one answer - the same reasoning that gave `quality` its own
+  # job.
+  #
+  # Both take their files from `git ls-files`, not an enumerated list. The list
+  # this replaces had drifted to five of the twelve tracked shell scripts, and an
+  # enumeration cannot do better: it records what existed the day it was written.
+  # An empty file list fails rather than passing, per CLAUDE.md - a scan that
+  # looked at nothing is the one failure mode a lint gate cannot survive quietly.
+  scripts:
+    name: Script lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.scripts == 'true'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # Pinned. Ubuntu's apt and Homebrew ship different versions, and
+      # shellcheck's findings differ between them: a file clean under one has
+      # twice failed here on a rule the other does not emit, and once the *same*
+      # finding arrived under a different code (SC2317 in 0.9/0.10, SC2329 in
+      # 0.11). Pinning makes a local run mean something, and moves a version
+      # bump into a commit someone chose to make.
+      - name: Install shellcheck
+        shell: bash
+        env:
+          SHELLCHECK_VERSION: v0.10.0
+        run: |
+          case "$(uname -m)" in
+            x86_64)  target=linux.x86_64 ;;
+            aarch64) target=linux.aarch64 ;;
+            *) echo "::error::No pinned shellcheck build for $(uname -m)"; exit 1 ;;
+          esac
+          url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.${target}.tar.xz"
+          curl -fsSL "$url" | tar -xJ
+          sudo install "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+
+      # `scripts/pre-commit` is named on its own because it carries no
+      # extension; `engine/vendor/` is dropped because upstream's scripts are
+      # not ours to keep clean.
+      - name: Shellcheck every tracked shell script
+        shell: bash
+        run: |
+          mapfile -t files < <(git ls-files -- '*.sh' 'scripts/pre-commit' | grep -v '^engine/vendor/')
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::No shell scripts to check - the file list is broken, not the tree"
+            exit 1
+          fi
+          printf '  %s\n' "${files[@]}"
+          shellcheck "${files[@]}"
+
+      # Pinned for the reason shellcheck is, and one more: ruff's default rule
+      # set grows between releases, so an unpinned gate can turn a pull request
+      # red over a rule that arrived in a version bump nobody made.
+      - name: Install ruff
+        shell: bash
+        env:
+          RUFF_VERSION: 0.15.8
+        run: |
+          python3 -m pip install --disable-pip-version-check "ruff==${RUFF_VERSION}"
+          ruff --version
+
+      # Default rules only. The tree is clean against them after #887, and a
+      # wider selection is not: `--select F,E,W` reports 122 findings, nearly
+      # all line length in build.py, which is a reformat rather than a lint fix
+      # and belongs in a change someone chose to make.
+      - name: Ruff every tracked Python file
+        shell: bash
+        run: |
+          mapfile -t files < <(git ls-files -- '*.py' | grep -v '^engine/vendor/')
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::No Python files to check - the file list is broken, not the tree"
+            exit 1
+          fi
+          printf '  %s\n' "${files[@]}"
+          ruff check --no-cache "${files[@]}"
+
   ci-gate:
     name: CI gate
     runs-on: ubuntu-latest
@@ -797,7 +885,7 @@ jobs:
     # filter cannot be read as "nothing to test". Without it, a broken `changes`
     # job skips everything, and "skipped" would pass this gate on a change
     # nobody ran.
-    needs: [changes, quality, app, engine, installer, build-script]
+    needs: [changes, quality, app, engine, installer, build-script, scripts]
     if: always()
     # `actions: read` is what lets the download below reach this run's own
     # artifacts; everything else here reads job results, which need nothing.
@@ -884,6 +972,7 @@ jobs:
           check engine    "${{ needs.engine.result }}"
           check installer "${{ needs.installer.result }}"
           check build-script "${{ needs['build-script'].result }}"
+          check scripts   "${{ needs.scripts.result }}"
 
           if [[ $status -ne 0 ]]; then
             echo "CI failed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,35 @@ violation, an unformatted file or a type error fails CI. Where a rule genuinely
 cannot be satisfied, suppress it on the single line with a comment saying why -
 an unexplained `eslint-disable` is treated as a defect.
 
+### Shell and Python (tooling)
+
+The installer, the git hook, the test harnesses and `build.py` are the
+repository's third language pair, and CI lints both on its `Script lint` job:
+
+```bash
+shellcheck $(git ls-files '*.sh' 'scripts/pre-commit' | grep -v '^engine/vendor/')
+ruff check $(git ls-files '*.py')
+```
+
+Two things are worth knowing before you run those locally:
+
+- **The versions are pinned** - shellcheck **v0.10.0** and ruff **0.15.8**, the
+  same builds the job installs. Both tools change their findings between
+  releases (shellcheck has twice failed here on a rule the other distribution's
+  build does not emit, once under a renumbered code), so an unpinned local run
+  can disagree with CI in either direction.
+- **The file lists come from `git ls-files`**, not from a list in the workflow.
+  A script added anywhere in the tree is linted the day it lands, without an
+  edit to CI - which is the point: the enumerated list this replaced had drifted
+  to five of the twelve tracked shell scripts.
+
+ruff runs on its **default** rules. A finding is a fix, not a suppression,
+unless the code cannot be written another way. Bare `except:` in particular is
+a defect rather than a style question here: it swallows `KeyboardInterrupt`, so
+a Ctrl-C during one of `build.py`'s slow toolchain probes is eaten instead of
+aborting the build. Catch what the call can actually raise - for a subprocess
+probe that is `(OSError, subprocess.SubprocessError)`.
+
 ## Testing
 
 ### Engine (C++)

--- a/app/installer/linux-postinst.sh
+++ b/app/installer/linux-postinst.sh
@@ -9,7 +9,7 @@ LOCK_FILE="$HOME/.config/vayu/vayu.lock"
 
 if [ -f "$LOCK_FILE" ]; then
     # Check if the PID in the lock file is still running
-    PID=$(cat "$LOCK_FILE" 2>/dev/null | tr -d '\n' || echo "")
+    PID=$(tr -d '\n' 2>/dev/null < "$LOCK_FILE" || echo "")
     
     if [ -n "$PID" ] && [ "$PID" -eq "$PID" ] 2>/dev/null; then
         # Check if process is running AND is vayu-engine

--- a/build.py
+++ b/build.py
@@ -279,7 +279,7 @@ def find_visual_studio() -> Optional[str]:
         vs_path = result.stdout.strip()
         if vs_path and Path(vs_path).exists():
             return vs_path
-    except:
+    except (OSError, subprocess.SubprocessError):
         pass
 
     return None
@@ -449,7 +449,7 @@ def find_pnpm_windows() -> Optional[str]:
             for path in pnpm_paths:
                 if path.exists():
                     return str(path)
-    except:
+    except (OSError, subprocess.SubprocessError):
         pass
 
     # Check npm's global directory (alternative method)
@@ -472,7 +472,7 @@ def find_pnpm_windows() -> Optional[str]:
             for path in pnpm_paths:
                 if path.exists():
                     return str(path)
-    except:
+    except (OSError, subprocess.SubprocessError):
         pass
 
     # Check common npm locations (where npm installs global .cmd wrappers)
@@ -549,7 +549,7 @@ def check_tool(name: str, command: List[str]) -> Tuple[bool, str]:
                 # Store for later use
                 CMAKE_PATH = cmake_path
                 return True, version
-            except:
+            except (OSError, subprocess.SubprocessError):
                 return False, ""
         return False, ""
 
@@ -566,7 +566,7 @@ def check_tool(name: str, command: List[str]) -> Tuple[bool, str]:
                 if ninja_dir not in os.environ.get("PATH", "").split(os.pathsep):
                     os.environ["PATH"] = ninja_dir + os.pathsep + os.environ.get("PATH", "")
                 return True, version
-            except:
+            except (OSError, subprocess.SubprocessError):
                 return False, ""
         return False, ""
 
@@ -586,7 +586,7 @@ def check_tool(name: str, command: List[str]) -> Tuple[bool, str]:
                 # Store for later use
                 PNPM_PATH = pnpm_path
                 return True, version
-            except:
+            except (OSError, subprocess.SubprocessError):
                 # If execution fails, fall through to standard check
                 pass
         # Fall through to standard check if Windows-specific search failed
@@ -607,7 +607,7 @@ def check_tool(name: str, command: List[str]) -> Tuple[bool, str]:
             if name == "pnpm":
                 PNPM_PATH = tool_path
             return True, version
-        except:
+        except (OSError, subprocess.SubprocessError):
             return False, ""
     return False, ""
 
@@ -1248,7 +1248,7 @@ def run_tests_only(preset: str, project_root: Path) -> bool:
     test_binary = find_build_artifact(build_dir, build_type, "vayu_tests")
 
     if not test_binary:
-        print_error(f"Tests not found. Build with tests first:\npython build.py -e -t")
+        print_error("Tests not found. Build with tests first:\npython build.py -e -t")
         return False
 
     log_dim(f'Build directory: {build_dir}')

--- a/docs/building.md
+++ b/docs/building.md
@@ -365,6 +365,10 @@ The project uses GitHub Actions for automated builds:
   - Tests engine and frontend on Linux/Windows/macOS
   - Lint, formatting and type-check run once, on their own Linux job, rather
     than in front of a suite they cannot affect
+  - `Script lint` does the same for the other two languages: shellcheck
+    (v0.10.0) over every tracked shell script and ruff (0.15.8) over every
+    tracked `.py`, both file lists taken from `git ls-files` so a script added
+    later cannot escape them
   - The Windows frontend suite runs as two vitest shards on two runners; the
     `CI gate` job proves they covered every test file between them
 

--- a/scripts/test/run-load-test.sh
+++ b/scripts/test/run-load-test.sh
@@ -88,9 +88,6 @@ format_json() {
     fi
 }
 
-# Track if we've seen the complete event
-COMPLETE_SEEN=false
-
 # Function to stream from an SSE endpoint
 # Returns 0 if successfully streamed data, 1 otherwise
 stream_sse() {


### PR DESCRIPTION
## Description

Two commits. The first clears the tree, the second gates it.

1. **`3740eb8`** - `build.py`'s seven bare `except:` narrowed, plus the two shellcheck findings.
2. **`fbfcc5f`** - the `Script lint` job, its change-detection wiring, and the docs.

### Plan, and the alternative rejected

**Root cause** is that the shellcheck file list was written where it was *convenient* - inline in the two installer-job steps that already had the tool - so it recorded the scripts that job happens to own rather than the scripts the repository has. It was correct the day it was written and has drifted since; Python never had a gate at all, so `build.py` accumulated seven bare `except:` with nothing to say so.

**The approach** is therefore to stop enumerating: both linters take their files from `git ls-files`, so a script added anywhere is linted the day it lands and CI needs no edit. **The alternative I rejected** is the one the issue proposes literally - "add the three scripts to the existing shellcheck step(s)" - which fixes today's list and leaves tomorrow's to drift the same way. The issue's own acceptance criterion allows either and names the glob first; the measurement below is why it is the better half of the choice.

### Verifying the problem still exists as described

It does, and the inventory in the issue was **low**. Against master `b3c881a`, at the pinned shellcheck v0.10.0:

| | Issue said | Actually |
|---|---|---|
| Tracked shell scripts | 8 | **12** |
| Covered by CI | 5 | 5 |
| Shellcheck findings | 1 (SC2034) | **2** |
| Tracked `.py` files | 7 | **6** |
| ruff default-rule findings | 8 | 8 (7x E722 + 1 F541) |

The four scripts the issue's list missed are `.claude/hooks/session-start.sh` and the three Debian maintainer scripts under `app/installer/`, and one of those carried the extra finding - `linux-postinst.sh:12` pipes `cat` into `tr` to read the lock file (SC2002). Exactly the drift an enumerated list produces, arriving while the issue was open. The `.py` count is 6, not 7, because nothing under `engine/vendor/` is Python; the 8 findings are unchanged and all in `build.py`.

### What changed, and why

**`build.py`** - the seven probes (vswhere, the two npm prefix scans, the cmake/ninja/pnpm/generic version checks) now catch `(OSError, subprocess.SubprocessError)`. That is what "run a tool, read its version" can actually raise: a missing binary, a non-zero exit under `check=True`, a `timeout=5` expiring. It is not a new idiom - `build.py:679` already reads that way. `except Exception:` would also let Ctrl-C through, but says less about what the code expects. The stray `f` prefix on a constant string goes with them.

**`run-load-test.sh`** - `COMPLETE_SEEN` was set under a comment saying it tracked the complete event, and read by nothing: the SSE loop returns from inside its own `event: complete` branch. Deleted, comment and all.

**`linux-postinst.sh`** - `PID=$(cat "$LOCK_FILE" 2>/dev/null | tr -d '\n' || echo "")` becomes `PID=$(tr -d '\n' 2>/dev/null < "$LOCK_FILE" || echo "")`. The `2>/dev/null` goes **before** the input redirection deliberately: bash applies redirections left to right, so stderr is already discarded when a failed `< "$LOCK_FILE"` reports itself - which is what preserves the old behaviour of an unreadable file yielding an empty PID silently under `set -e`. Verified all three ways (readable, unreadable, missing).

**The job.** `Script lint`, one Linux runner, for the reason `quality` is its own job: neither check needs a compiler or Node, and riding the installer's two-runner matrix ran the same platform-independent lint twice for one answer. shellcheck leaves the installer job entirely, so that job loses its toolchain install and its macOS leg loses a duplicate run; the suites there are untouched.

**Change-detection wiring, which is the half a lint gate usually gets wrong.** `.github/hooks/**` and `scripts/install-git-hooks.sh` were excluded from the `code` filter - neither can change a build artifact - so with them excluded, a change to a file the new gate reads would skip the gate. That is this repository's "written but never read" defect in wiring form. Both come back into `code`, and a new `scripts` area filter routes them to `Script lint` **alone**, so the build matrix they still cannot affect still does not run. Its globs are doubled (`*.sh` **and** `**/*.sh`) for the reason the `code` filter already documents: the bare form is what matches root-level files like `install.sh` and `build.py`.

**Pins.** shellcheck v0.10.0 is the pin the installer job already carried, moved with its reasoning. ruff is pinned to 0.15.8 for the same reason plus one: its default rule set grows between releases, so an unpinned gate can redden a pull request over a rule that arrived in a version bump nobody made. Installed with `python3 -m pip install`, the pattern `docs.yml` already uses on this runner.

**Default rules only.** `--select F,E,W` reports 122 findings, nearly all line length in `build.py` - a reformat, not a lint fix, and one someone should choose to make rather than have smuggled in under a gate.

## Type of Change

- [x] Bug fix - `KeyboardInterrupt` no longer swallowed by a toolchain probe
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Tooling / CI

## Testing

| Check | Result |
|---|---|
| `shellcheck` v0.10.0, all 12 tracked scripts (the job's exact command) | **PASS** - clean |
| `ruff check` 0.15.8, all 6 tracked `.py` (the job's exact command) | **PASS** - `All checks passed!` |
| `bash scripts/test/install_test.sh` | **PASS** - 5/5 |
| `bash scripts/test/pre-commit_test.sh` | **PASS** - 12 passed, 0 failed |
| `python3 scripts/test/vcpkg_baseline_test.py` | **PASS** - 23 passed, 0 failed |
| `python3 build.py --help` | **PASS** |
| `mkdocs build --strict -f .github/mkdocs.yml` | **PASS** |
| `pr-tests.yml` parses; 8 jobs; `ci-gate` needs and checks the new one | **PASS** |

No engine or app suite: nothing they cover changed. Per CLAUDE.md's verification-scaling rule, the checks that could go from green to red here are the linters themselves and the three script suites, and all four ran.

**Mutation-checked**, four ways:

1. **The gate catches what it is for** - a staged `scripts/test/zz_probe.sh` with an unquoted expansion and a useless `cat` makes the job's exact shellcheck command exit 1; removing it restores 0. Note the file was **never named anywhere** - that is the `git ls-files` property being tested, not shellcheck's.
2. **The empty-list guard fires** - pointed at a pattern matching nothing, the file list is empty and the step errors rather than reporting success.
3. **Reverting one narrowed `except`** to a bare `except:` reddens `ruff check`; restoring it greens it.
4. **Restoring `COMPLETE_SEEN`** reddens shellcheck on that file alone.

And the behaviour behind fix 1, which no linter can see: with `subprocess.run` stubbed to raise `KeyboardInterrupt`, `check_tool("pnpm", ...)` now propagates it instead of returning `(False, "")`, while a stubbed `FileNotFoundError` still returns `(False, "")`.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the gates are the tests; the four mutation checks above are how they were verified. `CONTRIBUTING.md` and `docs/building.md` were prettier-dirty before this change and were left unformatted, per the repo rule about formatting only files that were clean.
- [x] I have updated documentation - `CONTRIBUTING.md` (new Shell and Python section: both commands, both pins, why bare `except:` is a defect here) and `docs/building.md` (the `Script lint` bullet), both in the commit that adds the job

## Related Issues

Closes #887

Notes for the reviewer:

- **Deviation from the issue spec, stated deliberately**: the issue asks for the three missing scripts to be added to the existing steps and for a ruff step on "the lint job". This PR uses a `git ls-files` glob and a job of its own instead - the first because the acceptance criterion offers it and the drift above argues for it, the second because the only existing lint job (`App quality checks`) is gated on `app/**` and would never fire for a change to `build.py`.
- **Adjacent, left alone**: `docs/lock-file-handling.md:45,50` still points at `build/linux-postinst.sh`; the maintainer scripts live under `app/installer/`. Not this diff's scope - filed as a note here rather than fixed in passing.
- Touches `.github/workflows/pr-tests.yml`, as #909 does. The two edit different regions (that PR adds an `Engine formatting` job; this one adds `Script lint` plus the `changes` filters), so whichever lands second needs a trivial merge in the `ci-gate` needs list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUt1pFRoFL3uhh7bsrEcc9)_