### PR TITLE
fix(engine): give the pre-commit hook CI's line scope

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -114,15 +114,36 @@ jobs:
               - '!.github/workflows/docs.yml'
               - '!requirements-docs.txt'
 
-      # Default quantifier (`some`) on purpose: each filter below is a union of
-      # paths, so "matched at least one" is the question being asked. These are
-      # deliberately *not* responsible for excluding documentation - a change to
-      # app/src/modules/README.md matches `app/**` here and is rejected by
-      # `code` above instead, so the docs rule stays written down once.
+      # `some-with-excludes`: a file routes to an area if it matches at least
+      # one of the paths listed - they are a union - and no `!` pattern rejects
+      # it. Plain `some` cannot express the second half, because a lone `!`
+      # pattern under it matches every file *outside* the tree and turns the
+      # filter permanently true; `every` cannot express the first, because it
+      # turns the union into an intersection no file can satisfy.
+      #
+      # These filters used to leave documentation entirely to `code` above, on
+      # the reasoning that the docs rule should be written down once - a
+      # README.md under app/ matched `app/**` here and `code` rejected it. That
+      # is wrong whenever a pull request touches both, because the two filters
+      # are evaluated over the *changeset*, not per file: `code` asks "is any
+      # file here not documentation", the area asks "is any file here in this
+      # tree", and the job condition ANDs two answers that different files gave.
+      # A change to `engine/CLAUDE.md` plus any script therefore ran the engine
+      # matrix on all three platforms with no engine source touched (seen on
+      # #913, where the two answers came from `engine/CLAUDE.md` and
+      # `scripts/pre-commit`). The docs rule is still written once per area
+      # rather than once per repository, which is the smallest place it can live
+      # and still be true.
+      #
+      # Only `app` and `engine` carry it, because only their unions contain a
+      # tree glob that a `.md` can fall inside. The other three name individual
+      # files or extension globs that no `.md` can match. Add a `**` glob to one
+      # of them and it needs these two lines too.
       - name: Route to the trees the change can affect
         uses: dorny/paths-filter@v4
         id: area
         with:
+          predicate-quantifier: some-with-excludes
           # `shared/**` belongs to the app: vitest and vite both alias it to
           # `@shared`, so an icon or asset there is compiled into the renderer.
           # `build.py` and `VERSION` are listed under both trees because either
@@ -145,6 +166,10 @@ jobs:
               - 'build.py'
               - 'VERSION'
               - '.github/workflows/pr-tests.yml'
+              # Both forms, for the reason the `code` filter gives above: the
+              # bare one covers a root-level file, the `**/` one covers nested.
+              - '!*.md'
+              - '!**/*.md'
             engine:
               - 'engine/**'
               - 'build.py'
@@ -152,6 +177,8 @@ jobs:
               - '.clang-format'
               - '.github/check-windows-deps.py'
               - '.github/workflows/pr-tests.yml'
+              - '!*.md'
+              - '!**/*.md'
             build_script:
               - 'build.py'
               - 'scripts/test/vcpkg_baseline_test.py'
@@ -180,6 +207,24 @@ jobs:
               - '**/*.py'
               - 'scripts/pre-commit'
               - '.github/workflows/pr-tests.yml'
+
+      # The routing, said out loud. Every job below is gated on these five
+      # booleans, and until this step existed the only way to answer "why did
+      # the engine matrix run on a change that touched no engine source" was to
+      # re-evaluate the globs by hand - which is how the doc-routing defect
+      # above went unnoticed. Note that a change to *this file* routes to every
+      # area on purpose, so a pull request editing the split sees the full
+      # matrix regardless of what else it touches.
+      - name: Report the routing
+        shell: bash
+        env:
+          CODE: ${{ steps.code.outputs.code }}
+          AREAS: ${{ toJSON(steps.area.outputs) }}
+        run: |
+          {
+            echo "- non-documentation changes: \`$CODE\`"
+            echo "- areas: \`$AREAS\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Lint, formatting and type-check are platform-independent, so one runner
   # answers for all three - they used to run inside the app job, where roughly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,10 +123,11 @@ vayu/
   warning, install a newer clang-tidy (Ubuntu 24.04 ships 18 by default;
   `apt install clang-tidy-19` is what CI uses) or lean on CI, which lints the
   engine sources your pull request changes on clang-tidy 19. A finding fails in
-  both places - the hook refuses the commit, CI fails the engine job - but they
-  are scoped differently: CI gates the **lines** your pull request changes,
-  while the hook lints whole staged files and so also reports findings that were
-  already there. See
+  both places - the hook refuses the commit, CI fails the engine job - and both
+  gate the **lines** you changed, not the whole file, so a finding older than
+  your diff stops neither (#902). A hook refusal is therefore a merge blocker
+  you are seeing early. To lint whole staged files instead, backlog and all,
+  commit once with `VAYU_TIDY_FULL=1`. See
   [Static Analysis](docs/engine/building.md#static-analysis).
 
 #### Naming Conventions

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -606,7 +606,7 @@ clang-tidy runs in two places, and both of them can stop a change:
 
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
-| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | Whole staged `.c/.cpp/.h/.hpp` files | Refuses the commit |
+| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **changed lines** of staged `.c/.cpp/.h/.hpp` files | Refuses the commit |
 | `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of `engine/{src,include,tests}` sources, on all three platforms | Fails CI |
 
 A finding is a failure because `engine/.clang-tidy` sets
@@ -615,17 +615,42 @@ found and still exits 0. That single setting is what both places read their
 verdict from - do not re-state it as a `--warnings-as-errors` flag at a call
 site, or the two can disagree about what counts.
 
-**CI gates the changed lines, not the changed files**, through LLVM's own
-`clang-tidy-diff.py`. The engine had never been linted, so most files carry
-findings older than any current diff - `openapi_drafts.cpp` answered with nine
-on an untouched tree. Gating whole files would fail a pull request for code it
-did not write, in every file it happened to open. New code is held to the config
-from its first line; the backlog is paid down by whoever edits those lines.
+**Both gate the changed lines, not the changed files.** The engine had never
+been linted, so most files carry findings older than any current diff -
+`openapi_drafts.cpp` answered with nine on an untouched tree. Gating whole files
+would fail a pull request for code it did not write, in every file it happened
+to open. New code is held to the config from its first line; the backlog is paid
+down by whoever edits those lines.
 
-The pre-commit hook is the stricter of the two: it lints whole staged files, so
-it reports the backlog as well. That is deliberate for a local early warning you
-can skip with `git commit --no-verify`, and it is why a hook refusal is not by
-itself a merge blocker. Issue #902 tracks aligning the two.
+The hook used to be the stricter of the two - it gated whole staged files, so a
+one-line edit to a legacy file was refused a commit over findings CI would let
+through, and `--no-verify` was the only way past it. #902 aligned them: a hook
+that has to be bypassed to commit is advisory in practice, which is the state
+#885 set out to end.
+
+**The two compute those lines differently, and that is deliberate.** CI runs
+LLVM's own `clang-tidy-diff.py`. The hook parses the staged diff's hunk headers
+itself and passes clang-tidy `--line-filter` directly, because the driver is a
+Python script whose version has to match the binary - an 18-era copy rejects the
+`-allow-no-checks` that `engine/src/runtime/` needs - and it is packaged
+differently on each platform (`/usr/bin/clang-tidy-diff-19.py` from apt,
+`share/clang/clang-tidy-diff.py` beside the binary under Homebrew and the
+Windows LLVM installer). A CI image pins all of that; a contributor's machine
+does not, and a hook that fell back to whole-file linting whenever it could not
+find a driver or an interpreter would put the asymmetry back for exactly the
+people it hurts. `git diff --cached -U0` is always available, and with no
+context lines a hunk header's new-side range *is* the set of lines the commit
+adds, so the hook reads the headers and never the diff body.
+
+**`VAYU_TIDY_FULL=1` restores whole-file linting** for one commit:
+
+```bash
+VAYU_TIDY_FULL=1 git commit
+```
+
+That is for someone paying the backlog down on purpose - the one case where the
+findings CI ignores are the point. Everything else about the hook is unchanged
+by it.
 
 **Commits listed in `.git-blame-ignore-revs` are skipped.** The gate reads the
 same file `git blame` does, and for the same reason: a commit declared to be

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -47,12 +47,16 @@ engine/
   `event_loop_worker.cpp` / `temp_database.hpp` unlinted. macOS is excluded
   because clang-tidy 19 *and* 20 both SIGILL there on the AppleClang 21 SDK
   (#906); the only macOS-conditional code is four `#define`s, so what is lost is
-  `clang-analyzer-*` over shared code under libc++. **CI gates the changed
-  *lines***, through LLVM's
-  `clang-tidy-diff.py`: the tree had never been linted and most files carry
-  findings older than any diff, so whole-file gating would fail a pull request
-  for code it did not write. The hook is the stricter one (whole staged files);
-  #902 tracks aligning them. Nothing lints at *build*
+  `clang-analyzer-*` over shared code under libc++. **Both gate the changed
+  *lines***: the tree had never been linted and most files carry findings older
+  than any diff, so whole-file gating would fail a pull request for code it did
+  not write. The mechanisms differ on purpose (#902) - CI runs LLVM's
+  `clang-tidy-diff.py`, the hook parses `git diff --cached -U0` hunk headers and
+  passes `--line-filter` itself, because the driver needs Python and a
+  version-matched copy that is packaged differently on each platform, and a
+  fallback to whole-file linting would restore the asymmetry it removes.
+  `VAYU_TIDY_FULL=1` opts one commit back into whole staged files, for paying
+  the backlog down on purpose. Nothing lints at *build*
   time: the commented-out `CMAKE_CXX_CLANG_TIDY` block went with #885, because a
   lint that runs when someone uncomments it never runs. See
   `docs/engine/building.md`.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Run clang-tidy on changed C++ files
-echo "Running clang-tidy on changed files..."
+# Run clang-tidy on the staged C++ changes. What it looks at - the lines this
+# commit changes, or whole files under VAYU_TIDY_FULL - is announced below, once
+# the staged set is known.
+echo "Running clang-tidy on staged C++ changes..."
 
 # Add common Homebrew paths for LLVM on macOS to ensure clang-tidy is found
 if [ -d "/opt/homebrew/opt/llvm/bin" ]; then
@@ -33,7 +35,7 @@ fi
 # Version probe, before any file is linted. Said loudly and once: the failure this
 # replaces was silent, and a contributor on 18 had no way to tell "clean" from
 # "never ran". The `Lint changed engine sources` step in
-# .github/workflows/pr-tests.yml lints the same files on clang-tidy 19 before a
+# .github/workflows/pr-tests.yml lints the same lines on clang-tidy 19 before a
 # pull request can merge, so this stays a skip rather than a refusal to commit -
 # a missing or old local toolchain costs a contributor nothing but the early
 # warning.
@@ -43,8 +45,100 @@ if [ -z "$CLANG_TIDY_MAJOR" ] || [ "$CLANG_TIDY_MAJOR" -lt "$MIN_CLANG_TIDY_MAJO
     echo "WARNING: clang-tidy ${CLANG_TIDY_VERSION:-(unknown version)} cannot read engine/.clang-tidy."
     echo "         It uses ExcludeHeaderFilterRegex, which needs clang-tidy >= ${MIN_CLANG_TIDY_MAJOR}."
     echo "         NOTHING WAS LINTED. Install a newer clang-tidy (e.g. 'apt install clang-tidy-19')"
-    echo "         or rely on CI, which lints the same files on clang-tidy 19."
+    echo "         or rely on CI, which lints the same lines on clang-tidy 19."
     exit 0
+fi
+
+# Turns one file's staged hunk headers into clang-tidy `--line-filter` ranges.
+#
+# `-U0` is what makes this exact: with no context lines, a hunk's new-side range
+# `@@ -a,b +c,d @@` *is* the set of lines this commit adds or rewrites, so the
+# header alone answers the question and the body never has to be read. A hunk
+# with `d` of 0 is a pure deletion and contributes no range - there is no new
+# line there to hold to the config.
+#
+# `h[1] + 0` drops the leading `+` by arithmetic conversion, and a header with
+# no comma (`@@ -3 +3 @@`) means a count of one, which is git's own shorthand.
+staged_line_ranges() {
+    git diff --cached -U0 -- "$1" | awk '
+        /^@@ / {
+            split($3, h, ",")
+            start = h[1] + 0
+            count = (2 in h) ? h[2] + 0 : 1
+            if (count > 0) {
+                printf "%s[%d,%d]", (n++ ? "," : ""), start, start + count - 1
+            }
+        }
+    '
+}
+
+# The files to lint, in the order they were staged, minus the two the loop below
+# used to skip inline (vendored code, and a path that no longer exists on disk).
+# Computed before the line filter because that filter has to name every file in
+# one argument, and clang-tidy drops a diagnostic in any file the filter does not
+# list - so a header's findings would vanish from the translation unit that
+# includes it if the filter were built per invocation.
+LINT_FILES=
+for FILE in $FILES; do
+    if [[ "$FILE" == *"vendor/"* ]]; then
+        continue
+    fi
+    if [ ! -f "$FILE" ]; then
+        continue
+    fi
+    LINT_FILES="$LINT_FILES $FILE"
+done
+
+# What this hook looks at, and why it is not the whole file (issue #902).
+#
+# The engine had never been linted when the gates went in, so most files carry
+# findings older than any current diff. CI gates the *changed lines* for that
+# reason, and this hook used to gate whole staged files - so a contributor who
+# edited one line of a legacy file was refused a commit over findings CI would
+# let through. The predictable end of that is `--no-verify` as a reflex, which
+# costs the hook its whole value: advisory in practice, arrived at from the
+# stricter direction.
+#
+# So the two gates now look at the same lines. The mechanism differs and that is
+# deliberate: CI runs LLVM's `clang-tidy-diff.py`, which needs a Python
+# interpreter and a copy of the driver whose version matches the binary (an
+# 18-era driver rejects the `-allow-no-checks` that `engine/src/runtime/`
+# requires) - dependencies a CI image can pin and a contributor's machine
+# cannot. Falling back to whole-file linting whenever one of them is missing
+# would put the asymmetry back for exactly the people it hurts, so the ranges
+# are computed here instead, from the one thing that is always present: git.
+# `-U0` makes that a header parse rather than a diff implementation.
+#
+# `VAYU_TIDY_FULL=1` restores whole-file linting, for someone paying the backlog
+# down on purpose - that is the one case where the findings CI ignores are the
+# point.
+LINE_FILTER_ARG=()
+if [ -n "${VAYU_TIDY_FULL:-}" ]; then
+    echo "VAYU_TIDY_FULL is set: linting whole staged files, pre-existing findings included."
+else
+    SCOPED_FILES=
+    LINE_FILTER=
+    for FILE in $LINT_FILES; do
+        RANGES=$(staged_line_ranges "$FILE")
+        # Only deletions staged for this file. Parsing the translation unit
+        # would report the backlog alone, and the filter would then drop all of
+        # it - the same answer, minus the parse.
+        if [ -z "$RANGES" ]; then
+            continue
+        fi
+        SCOPED_FILES="$SCOPED_FILES $FILE"
+        [ -n "$LINE_FILTER" ] && LINE_FILTER="$LINE_FILTER,"
+        LINE_FILTER="$LINE_FILTER{\"name\":\"$FILE\",\"lines\":[$RANGES]}"
+    done
+
+    if [ -z "$SCOPED_FILES" ]; then
+        echo "Staged C++ changes add no lines (deletions only); nothing to lint."
+        exit 0
+    fi
+
+    LINT_FILES="$SCOPED_FILES"
+    LINE_FILTER_ARG=("--line-filter=[$LINE_FILTER]")
+    echo "Scoped to the lines this commit changes, as CI is. Whole files: VAYU_TIDY_FULL=1"
 fi
 
 # What makes this hook a gate rather than a report. clang-tidy is invoked once
@@ -58,17 +152,7 @@ fi
 STATUS=0
 
 # Run clang-tidy
-for FILE in $FILES; do
-    # Skip vendor files
-    if [[ "$FILE" == *"vendor/"* ]]; then
-        continue
-    fi
-
-    # Check if file exists
-    if [ ! -f "$FILE" ]; then
-        continue
-    fi
-
+for FILE in $LINT_FILES; do
     echo "Linting $FILE..."
     # We need compilation database for clang-tidy to work correctly with includes
     # Assuming build directory is engine/build
@@ -107,11 +191,12 @@ for FILE in $FILES; do
     # incremental build.
     if [ -f "engine/build/compile_commands.json" ]; then
         clang-tidy --allow-no-checks --extra-arg=-Wno-ignored-gch \
-            -p engine/build "$FILE" || STATUS=1
+            "${LINE_FILTER_ARG[@]}" -p engine/build "$FILE" || STATUS=1
     else
         echo "Warning: compile_commands.json not found in engine/build. clang-tidy might report false positives."
         # Fallback: try to include common directories
-        clang-tidy --allow-no-checks "$FILE" -- -Iengine/include -Iengine/vendor/quickjs-ng || STATUS=1
+        clang-tidy --allow-no-checks "${LINE_FILTER_ARG[@]}" "$FILE" \
+            -- -Iengine/include -Iengine/vendor/quickjs-ng || STATUS=1
     fi
 done
 
@@ -120,9 +205,15 @@ if [ "$STATUS" -ne 0 ]; then
     echo "clang-tidy reported findings in the staged files above; the commit was refused."
     echo "Fix them, or mark a deliberate exception with a NOLINT comment naming the check."
     echo
-    echo "This hook lints whole staged files, so it also reports findings that were"
-    echo "already there. CI gates the lines your pull request changes, so a finding on"
-    echo "code you did not touch will not block the merge (issue #902)."
+    if [ -n "${VAYU_TIDY_FULL:-}" ]; then
+        echo "VAYU_TIDY_FULL was set, so this run linted whole staged files and the"
+        echo "findings above may include ones that predate your change. Unset it and the"
+        echo "hook reports only the lines you touched, which is what CI gates."
+    else
+        echo "Every finding above is on a line this commit changes - the same lines CI"
+        echo "gates, so this is a merge blocker you are seeing early. To lint whole"
+        echo "staged files instead, backlog included: VAYU_TIDY_FULL=1 git commit"
+    fi
     echo "To commit anyway: git commit --no-verify"
     exit 1
 fi

--- a/scripts/test/pre-commit_test.sh
+++ b/scripts/test/pre-commit_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# The pre-commit hook: its clang-tidy version probe (issue #659 item 4) and its
-# exit status (issue #885).
+# The pre-commit hook: its clang-tidy version probe (issue #659 item 4), its
+# exit status (issue #885) and what it looks at (issue #902).
 #
 # `engine/.clang-tidy` uses `ExcludeHeaderFilterRegex`, which landed in LLVM 19.
 # An older clang-tidy rejects the whole config file, lints nothing, and still
@@ -15,6 +15,12 @@
 # it had just flagged. Reverting either half of the fix in `scripts/pre-commit` -
 # the `|| STATUS=1` on the two invocations, or the `exit 1` at the end - reddens
 # the cases below.
+#
+# The third is what it looks at. The hook gated whole staged files while CI gated
+# the changed lines, so it refused commits over findings CI would let through and
+# `--no-verify` was the way past it. It now passes clang-tidy a `--line-filter`
+# built from the staged hunk headers; dropping that argument, or widening it past
+# the staged range, reddens the line-scope cases.
 #
 # Everything here drives the real hook with a stubbed `clang-tidy` on PATH.
 # Linux only: the hook prepends Homebrew's LLVM directory when it exists, which
@@ -57,12 +63,35 @@ make_repo() {
     echo "$dir"
 }
 
+# A throwaway git repo with one *committed* four-line C++ file, of which line 3
+# is then rewritten and staged. The shape the line filter exists for: findings on
+# lines 1, 2 and 4 predate this commit, the finding on line 3 does not.
+make_repo_with_history() {
+    local dir
+    dir="$(mktemp -d)"
+    git -C "$dir" init --quiet
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    printf 'int a() { return 0; }\nint b() { return 0; }\nint c() { return 0; }\nint d() { return 0; }\n' > "$dir/legacy.cpp"
+    git -C "$dir" add legacy.cpp
+    git -C "$dir" commit --quiet -m "base"
+    printf 'int a() { return 0; }\nint b() { return 0; }\nint c() { return 1; }\nint d() { return 0; }\n' > "$dir/legacy.cpp"
+    git -C "$dir" add legacy.cpp
+    echo "$dir"
+}
+
 # A `clang-tidy` on PATH reporting $1 as its version. A lint invocation exits 0,
 # except for a file whose path contains $2 (empty = none), where it prints a
-# diagnostic and exits 1 - a stand-in for a real finding under
-# `WarningsAsErrors: '*'`. Prints the directory to prepend.
+# diagnostic at line $3 (default 1) and exits 1 - a stand-in for a real finding
+# under `WarningsAsErrors: '*'`. Prints the directory to prepend.
+#
+# The stub honours `--line-filter` the way clang-tidy does, because that is the
+# behaviour under test: a diagnostic is reported only if its line falls inside a
+# range the filter lists for that file, and a run with no filter at all reports
+# every line. Emulated rather than mocked away - a stub that ignored the filter
+# would pass whether or not the hook computed one, which is the whole question.
 make_stub() {
-    local version="$1" flagged="${2:-}" dir
+    local version="$1" flagged="${2:-}" line="${3:-1}" dir
     dir="$(mktemp -d)"
     cat > "$dir/clang-tidy" <<EOF
 #!/usr/bin/env bash
@@ -72,12 +101,42 @@ if [ "\${1:-}" = "--version" ]; then
     exit 0
 fi
 echo "STUB_LINTED \$*"
+
+filter=
+for arg in "\$@"; do
+    case "\$arg" in
+        --line-filter=*) filter="\${arg#--line-filter=}" ;;
+    esac
+done
+
+# Is line ${line} of \$1 a line this commit changed? With no filter every line
+# is, which is what whole-file linting means.
+in_scope() {
+    [ -z "\$filter" ] && return 0
+    local entry ranges range low high
+    entry="\$(printf '%s' "\$filter" | tr '{' '\n' | grep -F "\"name\":\"\$1\"")" || return 1
+    ranges="\$(printf '%s' "\$entry" | grep -oE '\[[0-9]+,[0-9]+\]')"
+    for range in \$ranges; do
+        range="\${range#[}"
+        range="\${range%]}"
+        low="\${range%,*}"
+        high="\${range#*,}"
+        if [ "${line}" -ge "\$low" ] && [ "${line}" -le "\$high" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [ -n "${flagged}" ]; then
     for arg in "\$@"; do
         case "\$arg" in
+            -*) continue ;;
             *"${flagged}"*)
-                echo "\$arg:1:1: error: stub finding [stub-check]"
-                exit 1
+                if in_scope "\$arg"; then
+                    echo "\$arg:${line}:1: error: stub finding [stub-check]"
+                    exit 1
+                fi
                 ;;
         esac
     done
@@ -89,17 +148,19 @@ EOF
 }
 
 # Runs the hook in a fresh repo against a stubbed clang-tidy of $1 which flags
-# files matching $2. Sets HOOK_OUTPUT and HOOK_STATUS - a global rather than a
-# printed value, because the status has to survive the call and a command
-# substitution would run this in a subshell.
+# files matching $2, at line $3 (default 1), in a repo built by $4 (default
+# make_repo). Sets HOOK_OUTPUT and HOOK_STATUS - a global rather than a printed
+# value, because the status has to survive the call and a command substitution
+# would run this in a subshell. TIDY_FULL is the `VAYU_TIDY_FULL` the hook sees.
 HOOK_OUTPUT=""
 HOOK_STATUS=0
+TIDY_FULL=""
 run_hook() {
-    local version="$1" flagged="${2:-}" repo stub
-    repo="$(make_repo)"
-    stub="$(make_stub "$version" "$flagged")"
+    local version="$1" flagged="${2:-}" line="${3:-1}" factory="${4:-make_repo}" repo stub
+    repo="$("$factory")"
+    stub="$(make_stub "$version" "$flagged" "$line")"
     set +e
-    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$PATH" bash "$HOOK" 2>&1)"
+    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$PATH" VAYU_TIDY_FULL="$TIDY_FULL" bash "$HOOK" 2>&1)"
     HOOK_STATUS=$?
     set -e
     rm -rf "$repo" "$stub"
@@ -216,6 +277,72 @@ if [[ "$HOOK_STATUS" -eq 0 ]]; then
     pass "an unusable clang-tidy still skips rather than refusing the commit"
 else
     fail "clang-tidy 18 still skips" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# --- What the hook looks at (issue #902) -------------------------------------
+echo
+echo "pre-commit line scope"
+
+# The defect: the hook gated whole staged files while CI gated the changed
+# lines, so a one-line edit to a legacy file was refused a commit over findings
+# CI would let through - and `--no-verify` became the way out. `legacy.cpp` has
+# a finding on line 1, which this commit does not touch.
+#
+# Mutation-check: drop `LINE_FILTER_ARG` from the clang-tidy invocations in
+# scripts/pre-commit and the stub, seeing no filter, reports every line - this
+# case reddens.
+run_hook 19.1.0 legacy.cpp 1 make_repo_with_history
+if [[ "$HOOK_STATUS" -eq 0 ]]; then
+    pass "a finding on a line this commit did not touch lets the commit through"
+else
+    fail "a pre-existing finding lets the commit through" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# The other half. Without it, "filter everything out" would pass the case above
+# - and the hook would be a gate over nothing.
+run_hook 19.1.0 legacy.cpp 3 make_repo_with_history
+if [[ "$HOOK_STATUS" -ne 0 ]]; then
+    pass "a finding on a line this commit changes still refuses the commit"
+else
+    fail "a finding on a changed line refuses the commit" "the hook exited 0: $HOOK_OUTPUT"
+fi
+
+# The ranges themselves, named rather than inferred from the verdict: line 3 is
+# the only line staged, so the filter must say exactly that. A filter naming the
+# whole file would satisfy both cases above and gate nothing.
+if [[ "$HOOK_OUTPUT" == *'--line-filter=[{"name":"legacy.cpp","lines":[[3,3]]}]'* ]]; then
+    pass "the filter carries the staged hunk's range and nothing wider"
+else
+    fail "the filter is the staged hunk's range" "got: $HOOK_OUTPUT"
+fi
+
+# The opt-in for someone paying the backlog down on purpose, which is the one
+# case where a pre-existing finding is the point.
+TIDY_FULL=1
+run_hook 19.1.0 legacy.cpp 1 make_repo_with_history
+TIDY_FULL=""
+if [[ "$HOOK_STATUS" -ne 0 && "$HOOK_OUTPUT" != *"--line-filter"* ]]; then
+    pass "VAYU_TIDY_FULL=1 lints whole staged files again, with no line filter"
+else
+    fail "VAYU_TIDY_FULL=1 lints whole files" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# A deletion-only staged change has no new line to hold to the config, so there
+# is nothing to lint - and the hook must say so rather than parsing the
+# translation unit to have every finding filtered back out.
+repo="$(make_repo_with_history)"
+printf 'int a() { return 0; }\nint b() { return 0; }\n' > "$repo/legacy.cpp"
+git -C "$repo" add legacy.cpp
+stub="$(make_stub 19.1.0 legacy.cpp 1)"
+set +e
+out="$(cd "$repo" && PATH="$stub:$PATH" bash "$HOOK" 2>&1)"
+status=$?
+set -e
+rm -rf "$repo" "$stub"
+if [[ "$status" -eq 0 && "$out" != *"STUB_LINTED"* && "$out" == *"deletions only"* ]]; then
+    pass "a deletion-only staged change lints nothing and says so"
+else
+    fail "a deletion-only change lints nothing" "exit $status: $out"
 fi
 
 # --- Where the PCH flag lives (issue #912) -----------------------------------


### PR DESCRIPTION
## Description

Two commits. The first is #902; the second is a CI routing defect this PR surfaced and you asked to fix here.

### 1. `fix(engine)`: give the pre-commit hook CI's line scope

**Root cause.** The two clang-tidy gates #885 shipped read the same verdict but looked at different code: CI gates the *changed lines* (via `clang-tidy-diff.py`), the hook gated *whole staged files*. The engine had never been linted, so most files carry findings older than any diff - a one-line edit to a legacy file was refused a commit over findings CI would let through, and the way past it is `--no-verify`, which costs the hook its whole value.

**Approach.** The hook builds clang-tidy's `--line-filter` from the staged hunk headers (`git diff --cached -U0`) and passes it on every invocation, so both gates look at the same lines. `VAYU_TIDY_FULL=1` keeps whole-file linting for someone paying the backlog down on purpose. A staged change that only deletes lines now lints nothing, rather than parsing a translation unit to have every finding filtered back out.

**Alternative rejected - a deliberate deviation from the issue's tiebreaker, so it needs stating.** The issue said to prefer reusing `clang-tidy-diff.py` *if it is findable on a stock macOS + Homebrew LLVM install*. It is - the same LLVM install rule that puts it at `share/clang/clang-tidy-diff.py` in the Windows installer CI already uses puts it in the Homebrew keg, next to the `bin/` the hook already prepends. But "findable" turned out not to be the whole question, and the rest of it fails:

- **It needs a version-matched copy.** The hook must pass `-allow-no-checks` (for `engine/src/runtime/`), which the 18-era driver does not accept - verified against the `/usr/lib/llvm-18/share/clang/clang-tidy-diff.py` on this image, whose `--help` has no such option. So the probe cannot just take any `clang-tidy-diff.py` on `PATH`; it has to find the one belonging to the resolved binary, at a path that differs per packager (`/usr/bin/clang-tidy-diff-19.py` from apt, `share/clang/clang-tidy-diff.py` beside the binary under Homebrew and the Windows installer).
- **It needs a Python interpreter**, which this hook has never depended on.
- **Its failure mode is the defect.** Every path where one of those is missing ends in falling back to whole-file linting - putting the asymmetry back for exactly the contributors who hit it, which is what the issue itself flagged as the catch.

A CI image pins interpreter, driver and version; a contributor's machine does not. `git diff --cached -U0` is always present, and with no context lines a hunk header's new-side range *is* the set of lines the commit adds - so what is "reimplemented" here is a header parse, not a diff implementation, and it cannot silently degrade. The reasoning is written into the hook and `docs/engine/building.md` so the next reader does not re-derive it.

### 2. `fix(ci)`: stop documentation inside a code tree from routing to its matrix

Your question on this PR: the engine matrix ran on all three platforms for a change that touched no engine source.

**Root cause.** `code` (is anything here not documentation?) and the area filters (is anything here in this tree?) are both evaluated over the **changeset**, not per file, and the job conditions AND them. So two *different* files can satisfy the two halves. Here `scripts/pre-commit` made `code` true and `engine/CLAUDE.md` matched `engine/**`, and the engine matrix ran. The comment above the area filters asserted the opposite - that leaving documentation to `code` keeps the rule written down once - and that assertion is what was wrong; it holds only for a changeset confined to one area.

**Fix.** The area filters carry the documentation rule themselves, under paths-filter's `some-with-excludes` quantifier: the listed paths stay a union, and a `!` pattern can reject a file. Plain `some` cannot express that (a lone negation matches every file *outside* the tree and pins the filter true - the trap the `code` filter's own comment documents), and `every` cannot express the union.

Only `app` and `engine` carry the two exclusion lines: they are the only areas whose union contains a tree glob a `.md` can fall inside. The comment says so and says what to do when a sixth area grows one.

Also added: the `changes` job now writes its routing to the job summary. Until now the only way to answer "why did the engine matrix run" was to re-evaluate globs by hand, which is how this went unnoticed. Drop that step if you find it noisy - it is the one part here that is observability rather than fix.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

**Hook (commit 1).** `bash scripts/test/pre-commit_test.sh` - **20 passed, 0 failed** (15 before, 5 new). Shellcheck clean at the pinned v0.10.0 over both scripts. `mkdocs build --strict -f .github/mkdocs.yml` builds.

No engine or app suite run, and no build: nothing in commit 1 is C++ or TypeScript, so no test in either suite could change colour (CLAUDE.md's verification-scaling rule).

The five new cases, driven by a stub that honours `--line-filter` the way clang-tidy does - emulated rather than mocked away, since a stub that ignored the filter would pass whether or not the hook computed one:

- a finding on a line the commit did not touch lets the commit through;
- a finding on a line it changes still refuses it;
- the filter carries the staged hunk's range and nothing wider;
- `VAYU_TIDY_FULL=1` lints whole staged files again, with no filter;
- a deletion-only staged change lints nothing and says so.

**Mutation-checked both ways.** Dropping `"${LINE_FILTER_ARG[@]}"` from the two clang-tidy invocations, and separately widening the filter to `[[1,99999]]`, each redden the pre-existing-finding case and the range assertion while leaving the changed-line case green - so neither half can rot into "filter nothing" or "filter everything".

**Verified against real clang-tidy 19**, not only the stub, since the stub is where a wrong assumption about clang-tidy's own semantics would hide:

- `--line-filter` matches a repo-relative `name` against the absolute path clang-tidy reports (suffix match), confirmed by running clang-tidy directly on a nested file;
- the real hook, end to end in a scratch repo with `WarningsAsErrors: '*'` and a real finding: editing an unrelated line exits 0 and reports `Suppressed 1 warnings (1 due to line filter)`; editing a line that introduces its own finding exits 1 and names it; `VAYU_TIDY_FULL=1` on the same staged state reports the pre-existing finding instead.

Not covered locally: the compile-database branch against a built engine tree (the scratch repo exercises the fallback branch). The two differ only in `-p engine/build` versus the trailing `-- -I…`; the filter argument is passed identically, and the suite asserts on the compile-database branch that it is.

**Routing (commit 2).** Verified against the action's own matcher - picomatch with `dot: true` and the `some-with-excludes` logic read out of paths-filter v4's `filter.ts` - with the filters parsed out of the workflow itself so the check cannot drift from what ships:

| Changed files | `engine` before | `engine` after |
|---|---|---|
| commit 8cadad4's five files | true | **false** |
| `engine/src/http/routes.cpp` | true | true |
| `engine/.clang-tidy` (dotfile) | true | true |
| `engine/CLAUDE.md` + `engine/src/db/database.cpp` | true | true |
| `engine/CLAUDE.md` + `app/CLAUDE.md` alone | false | false |

8cadad4's files now route to `installer` and `scripts` only - which is right: those are the jobs that run the hook suite and shellcheck.

`actionlint` reports one SC2016 *info* on this file; it is on the clang-tidy step and reproduces identically on `origin/master`, so it is pre-existing and untouched here.

**Note on this PR's own CI:** `.github/workflows/pr-tests.yml` is listed in every area on purpose, so that a change to the split is exercised by every job it describes. Commit 2 edits that file, so this PR still runs the full matrix - that is the intended behaviour, not the defect recurring. The table above is how the fix is demonstrated.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs for commit 1 in the same commit, all four places #902 named: `docs/engine/building.md` (the Static Analysis table's scope column, and the paragraph that said the hook was the stricter one, replaced with why the mechanisms differ), `CONTRIBUTING.md`, `engine/CLAUDE.md`, and the hook's own refusal message - which used to tell the reader the two gates disagree and now says a hook refusal is a merge blocker seen early. Grepped: nothing in the repo still describes the two as differently scoped.

#902's acceptance criteria, all four met. This also unblocks #908, which #902 sequenced after it and which edits the same two files.

One thing deliberately not done here: the routing table in commit 2 has no automated test, only the verification above. Filed as #915 rather than grown into this PR, since a faithful test needs picomatch and this repo has no harness for workflow globs.

## Related Issues
Closes #902