### PR TITLE
feat(tooling): format-check staged engine sources in the pre-commit hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ React UI, communicating over HTTP on port 9876.
 - **App** (`app/`): Electron + React + TypeScript, Apache-2.0
 - **`build.py`**: the single entry point for every build operation
 - **`VERSION`**: single source of truth for the version
-- **`scripts/`**: `pre-commit` (clang-tidy on staged C++), `install-git-hooks.sh`,
+- **`scripts/`**: `pre-commit` (clang-format and clang-tidy on staged C++),
+  `install-git-hooks.sh`,
   and `test/` (load-test fixtures + mock server, installer suites)
 
 This file holds only what applies to *every* session. Deeper material loads on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,13 @@ vayu/
   clang-format-19 --style=file -i <file>...
   ```
 
+  The `scripts/pre-commit` hook runs the same check over the engine sources you
+  stage and refuses the commit on a difference, so the gate is reachable before
+  the push (#908). It looks for `clang-format-19` first and a plain
+  `clang-format` second, and skips - loudly, checking nothing - when neither is
+  a 19, because a check by another major is a wrong answer rather than a missing
+  one.
+
   The `Engine formatting` job checks the **whole tree**, not just your changed
   lines - the tree is clean, so there is no pre-existing noise to grandfather.
   The bulk-format commit that made it clean is in `.git-blame-ignore-revs`; run

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -177,7 +177,8 @@ All platforms script with the same vendored engine: QuickJS-NG
 
 - Requires Xcode Command Line Tools
 - The `scripts/pre-commit` hook prepends Homebrew's LLVM directory, so a
-  `brew install llvm` clang-tidy is found without touching `PATH` yourself
+  `brew install llvm` clang-tidy and clang-format are found without touching
+  `PATH` yourself
 
 ### Windows
 
@@ -571,6 +572,25 @@ clang-format-19 --style=file --dry-run -Werror \
 # Fix
 clang-format-19 --style=file -i <file>...
 ```
+
+It runs in two places, and both of them can stop a change:
+
+| Where | What it checks | What a difference does |
+|-------|----------------|------------------------|
+| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **whole** of every staged `engine/{src,include,tests}` source | Refuses the commit |
+| `Engine formatting`, a job of its own in `.github/workflows/pr-tests.yml` | The **whole tree** under those three roots | Fails CI |
+
+Unlike the two clang-tidy gates below, these two agree on scope, because
+formatting has no backlog to grandfather - so the hook can be exactly as strict
+as CI and no stricter, which is what keeps `--no-verify` from becoming a reflex
+(#908). The hook looks for `clang-format-19` first and a plain `clang-format`
+second - `apt install clang-format-19` leaves the plain name at Ubuntu's 18,
+while Homebrew's LLVM 19 installs it under the plain name - and when neither is
+a 19 it says so and checks nothing, on the same reasoning as the clang-tidy
+probe: the pin is exact, so an answer from another major is a wrong answer
+rather than a missing one. `git clang-format --staged` is deliberately not used;
+it formats the changed lines, and a staged file it called clean could still fail
+this whole-file check.
 
 The gate checks the **whole tree**, not the changed lines - the opposite of the
 clang-tidy gate below, because formatting has no backlog to grandfather. Issue

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -22,7 +22,10 @@ engine/
   under 18). **A difference is a failure now** (#886): the `Engine formatting`
   job in `pr-tests.yml` runs `--dry-run -Werror` over the whole of
   `engine/{src,include,tests}` - whole tree, unlike the clang-tidy gate, because
-  the bulk-format commit left no backlog to grandfather. The config was derived
+  the bulk-format commit left no backlog to grandfather. `scripts/pre-commit`
+  runs the same check over the engine sources a commit stages and refuses it on
+  a difference (#908), so the two agree on scope; without a clang-format 19 it
+  skips loudly rather than answering from another major. The config was derived
   by measuring the bulk diff each setting produces, so its two odd-looking
   settings (`ColumnLimit: 80` with `PenaltyExcessCharacter: 1`, and
   `ContinuationIndentWidth: 0`) are what the code is written to, not oversights;

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# Run clang-tidy on the staged C++ changes. What it looks at - the lines this
-# commit changes, or whole files under VAYU_TIDY_FULL - is announced below, once
-# the staged set is known.
-echo "Running clang-tidy on staged C++ changes..."
+# Two checks over the staged C++ changes, each mirroring a CI gate that can fail
+# a pull request: clang-format over whole staged engine sources (issue #908),
+# then clang-tidy over the lines this commit changes - or whole files under
+# VAYU_TIDY_FULL, announced below once the staged set is known.
+#
+# Neither is stricter than the gate it mirrors, which is the property that keeps
+# `--no-verify` from becoming a reflex: a refusal here is a merge blocker seen
+# early, never a local rule of its own.
 
-# Add common Homebrew paths for LLVM on macOS to ensure clang-tidy is found
+# Add common Homebrew paths for LLVM on macOS to ensure clang-tidy and
+# clang-format are found - one LLVM install carries both.
 if [ -d "/opt/homebrew/opt/llvm/bin" ]; then
     export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 elif [ -d "/usr/local/opt/llvm/bin" ]; then
@@ -26,10 +31,112 @@ if [ -z "$FILES" ]; then
     exit 0
 fi
 
+# The formatting half (issue #908). The `Engine formatting` job is two seconds
+# of work that used to be reachable only after a push and a CI round trip; this
+# runs the same check, on the same major, over the sources this commit stages.
+#
+# **Whole files, not changed lines** - the opposite of the clang-tidy pass below
+# and for the opposite reason. The bulk-format commit in `.git-blame-ignore-revs`
+# left the tree clean at the pinned version, so formatting has no backlog to
+# grandfather and file scope already agrees with CI's tree scope.
+#
+# `git clang-format --staged` ships beside clang-format and was the primitive to
+# reuse here; it is the wrong one, because it formats the *changed lines*. A
+# staged file it called clean could still fail CI's whole-file check - the
+# asymmetry #902 removed from the tidy pass, reintroduced at the other end.
+#
+# Files are read from the working tree, as the tidy pass reads them, rather than
+# from the index: a hook that reported on blobs the working tree no longer
+# matches would name lines the author cannot see in their editor.
+CLANG_FORMAT_MAJOR=19
+
+FORMAT_STATUS=0
+FORMAT_FILES=()
+for FILE in $FILES; do
+    case "$FILE" in
+        engine/src/* | engine/include/* | engine/tests/*) ;;
+        # Everything else, `engine/vendor/` included - it carries
+        # `DisableFormat: true` of its own and CI's gate does not reach it either.
+        *) continue ;;
+    esac
+    if [ ! -f "$FILE" ]; then
+        continue
+    fi
+    FORMAT_FILES+=("$FILE")
+done
+
+# Nothing engine-side staged: no probe, no message. An app-only commit has no
+# business hearing about the C++ formatter.
+if [ ${#FORMAT_FILES[@]} -gt 0 ]; then
+    # Discovery before the probe, and under both names, because the two ways to
+    # have a 19 look different: `apt install clang-format-19`, which is what
+    # CONTRIBUTING.md tells an Ubuntu contributor to run, leaves plain
+    # `clang-format` at the distribution's 18, while Homebrew's LLVM 19 installs
+    # it as `clang-format`.
+    CLANG_FORMAT=
+    NEAREST_CLANG_FORMAT=
+    for CANDIDATE in "clang-format-${CLANG_FORMAT_MAJOR}" clang-format; do
+        if ! command -v "$CANDIDATE" &> /dev/null; then
+            continue
+        fi
+        CANDIDATE_VERSION=$("$CANDIDATE" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)
+        NEAREST_CLANG_FORMAT="$CANDIDATE ${CANDIDATE_VERSION:-(unknown version)}"
+        if [ "${CANDIDATE_VERSION%%.*}" = "$CLANG_FORMAT_MAJOR" ]; then
+            CLANG_FORMAT="$CANDIDATE"
+            break
+        fi
+    done
+
+    if [ -z "$CLANG_FORMAT" ]; then
+        # A skip rather than a refusal, on the same reasoning as the clang-tidy
+        # probe below - and a loud one, because this pin is *exact*: 39 of the
+        # 285 engine sources format differently under 18 than under 19, so a
+        # check run by another major is a wrong answer rather than a missing one.
+        echo "WARNING: no clang-format ${CLANG_FORMAT_MAJOR} found${NEAREST_CLANG_FORMAT:+ (nearest: ${NEAREST_CLANG_FORMAT})}."
+        echo "         The engine's format is pinned to ${CLANG_FORMAT_MAJOR} exactly; another major disagrees"
+        echo "         with the gate about 39 of the 285 engine sources."
+        echo "         NOTHING WAS FORMAT-CHECKED. Install it ('apt install clang-format-${CLANG_FORMAT_MAJOR}',"
+        echo "         'brew install llvm@${CLANG_FORMAT_MAJOR}') or rely on CI, whose 'Engine formatting'"
+        echo "         job checks the whole tree on ${CLANG_FORMAT_MAJOR}."
+    else
+        echo "Checking ${#FORMAT_FILES[@]} staged engine source(s) with ${CLANG_FORMAT}..."
+        # The exit status is the verdict, and `-Werror` is what makes there be
+        # one: without it clang-format prints the replacements it would make and
+        # exits 0 - the same shape as the discarded clang-tidy status of issue
+        # #885. Nothing may swallow this status.
+        "$CLANG_FORMAT" --style=file --dry-run -Werror "${FORMAT_FILES[@]}" || FORMAT_STATUS=1
+    fi
+fi
+
+# The one way out of this hook, so that a verdict is reported where it will be
+# read - last, under whatever else ran - and so that no exit can lose one. The
+# clang-tidy pass below has three legitimate early exits (no clang-tidy, one too
+# old to read the config, a deletions-only change); none of them is a reason to
+# forget that clang-format already refused this commit.
+STATUS=0
+end_hook() {
+    if [ "$FORMAT_STATUS" -ne 0 ]; then
+        echo
+        echo "clang-format ${CLANG_FORMAT_MAJOR} would rewrite the staged engine sources named"
+        echo "above; the commit was refused. Fix them in place:"
+        echo "    ${CLANG_FORMAT} --style=file -i <file>..."
+        echo "The 'Engine formatting' job checks the same files the same way, so this is a"
+        echo "merge blocker you are seeing early. To commit anyway: git commit --no-verify"
+    fi
+    if [ "$STATUS" -ne 0 ] || [ "$FORMAT_STATUS" -ne 0 ]; then
+        exit 1
+    fi
+    exit 0
+}
+
+# What it looks at - the lines this commit changes, or whole files under
+# VAYU_TIDY_FULL - is announced below, once the staged set is known.
+echo "Running clang-tidy on staged C++ changes..."
+
 # Check if clang-tidy is installed
 if ! command -v clang-tidy &> /dev/null; then
     echo "clang-tidy not found. Skipping linting."
-    exit 0
+    end_hook
 fi
 
 # Version probe, before any file is linted. Said loudly and once: the failure this
@@ -46,7 +153,7 @@ if [ -z "$CLANG_TIDY_MAJOR" ] || [ "$CLANG_TIDY_MAJOR" -lt "$MIN_CLANG_TIDY_MAJO
     echo "         It uses ExcludeHeaderFilterRegex, which needs clang-tidy >= ${MIN_CLANG_TIDY_MAJOR}."
     echo "         NOTHING WAS LINTED. Install a newer clang-tidy (e.g. 'apt install clang-tidy-19')"
     echo "         or rely on CI, which lints the same lines on clang-tidy 19."
-    exit 0
+    end_hook
 fi
 
 # Turns one file's staged hunk headers into clang-tidy `--line-filter` ranges.
@@ -133,7 +240,7 @@ else
 
     if [ -z "$SCOPED_FILES" ]; then
         echo "Staged C++ changes add no lines (deletions only); nothing to lint."
-        exit 0
+        end_hook
     fi
 
     LINT_FILES="$SCOPED_FILES"
@@ -148,8 +255,8 @@ fi
 # contributor with the hook installed and a current clang-tidy could commit code
 # it had just flagged (issue #885). The status is only meaningful because
 # `engine/.clang-tidy` sets `WarningsAsErrors: '*'`; with that empty, clang-tidy
-# prints its findings and exits 0.
-STATUS=0
+# prints its findings and exits 0. `STATUS` is declared beside `end_hook` above,
+# which is where it is finally read.
 
 # Run clang-tidy
 for FILE in $LINT_FILES; do
@@ -215,7 +322,6 @@ if [ "$STATUS" -ne 0 ]; then
         echo "staged files instead, backlog included: VAYU_TIDY_FULL=1 git commit"
     fi
     echo "To commit anyway: git commit --no-verify"
-    exit 1
 fi
 
-exit 0
+end_hook

--- a/scripts/test/pre-commit_test.sh
+++ b/scripts/test/pre-commit_test.sh
@@ -22,6 +22,13 @@
 # built from the staged hunk headers; dropping that argument, or widening it past
 # the staged range, reddens the line-scope cases.
 #
+# The fourth is the formatting check (issue #908). The hook linted but never
+# format-checked, so the whole-tree `Engine formatting` gate - two seconds of
+# work - was reachable only after a push. It now runs clang-format 19 over the
+# whole of every staged `engine/{src,include,tests}` source; dropping the
+# `|| FORMAT_STATUS=1` that keeps its status, or widening the scope past those
+# three roots, reddens the cases below.
+#
 # Everything here drives the real hook with a stubbed `clang-tidy` on PATH.
 # Linux only: the hook prepends Homebrew's LLVM directory when it exists, which
 # would shadow the stub on a Mac, and the probe itself has no platform-specific
@@ -77,6 +84,83 @@ make_repo_with_history() {
     git -C "$dir" commit --quiet -m "base"
     printf 'int a() { return 0; }\nint b() { return 0; }\nint c() { return 1; }\nint d() { return 0; }\n' > "$dir/legacy.cpp"
     git -C "$dir" add legacy.cpp
+    echo "$dir"
+}
+
+# A throwaway git repo whose staged set spans the two scopes the format check
+# distinguishes: one source under `engine/src`, which it must check, and two
+# files outside `engine/{src,include,tests}` which it must not. `engine/vendor/`
+# is the one that matters - it carries a `DisableFormat: true` config CI's gate
+# never reaches either, so a hook that formatted it would be answering a
+# question CI does not ask.
+make_repo_engine() {
+    local dir
+    dir="$(mktemp -d)"
+    git -C "$dir" init --quiet
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    mkdir -p "$dir/engine/src" "$dir/engine/vendor"
+    printf 'int engine_fn() { return 0; }\n' > "$dir/engine/src/engine.cpp"
+    printf 'int vendored() { return 0; }\n' > "$dir/engine/vendor/vendored.cpp"
+    printf 'int scratch() { return 0; }\n' > "$dir/scratch.cpp"
+    git -C "$dir" add engine/src/engine.cpp engine/vendor/vendored.cpp scratch.cpp
+    echo "$dir"
+}
+
+# A clang-format on PATH under the binary name $1, reporting $2 as its version.
+# Under `--dry-run -Werror` it exits 1 for any file whose path contains $3
+# (empty = none) and 0 for the rest. Prints the directory to prepend.
+#
+# `-Werror` is honoured rather than assumed: real clang-format prints the
+# replacements it would make and still exits 0 without it, which is the shape of
+# the discarded-status defect issue #885 fixed for clang-tidy. A stub that
+# failed regardless would pass whether or not the hook asked for a verdict.
+make_format_stub() {
+    local name="$1" version="$2" dirty="${3:-}" dir
+    dir="$(mktemp -d)"
+    cat > "$dir/$name" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo "Ubuntu clang-format version ${version} (1ubuntu1)"
+    exit 0
+fi
+echo "STUB_FORMATTED \$*"
+
+werror=
+for arg in "\$@"; do
+    case "\$arg" in
+        -Werror) werror=1 ;;
+    esac
+done
+
+if [ -n "${dirty}" ] && [ -n "\$werror" ]; then
+    for arg in "\$@"; do
+        case "\$arg" in
+            -*) continue ;;
+            *"${dirty}"*)
+                echo "\$arg:1:1: error: code should be clang-formatted [-Wclang-format-violations]" >&2
+                exit 1
+                ;;
+        esac
+    done
+fi
+exit 0
+EOF
+    chmod +x "$dir/$name"
+    echo "$dir"
+}
+
+# A PATH tail holding only the tools the hook and the stubs call - and so, no
+# clang-format at all. The cases about an absent clang-format need that to be a
+# fact about the test rather than about whichever LLVM the machine happens to
+# ship; the container this suite runs in has an 18 on PATH. Prints the directory.
+make_sandbox_path() {
+    local dir tool resolved
+    dir="$(mktemp -d)"
+    for tool in bash git grep awk head sed tr cat env; do
+        resolved="$(command -v "$tool" 2>/dev/null)" || continue
+        [ -n "$resolved" ] && ln -s "$resolved" "$dir/$tool"
+    done
     echo "$dir"
 }
 
@@ -152,18 +236,38 @@ EOF
 # make_repo). Sets HOOK_OUTPUT and HOOK_STATUS - a global rather than a printed
 # value, because the status has to survive the call and a command substitution
 # would run this in a subshell. TIDY_FULL is the `VAYU_TIDY_FULL` the hook sees.
+#
+# FORMAT_STUB_VERSION, when set, puts a clang-format stub of that version on
+# PATH under FORMAT_STUB_NAME, reporting files matching FORMAT_STUB_DIRTY as
+# unformatted. FORMAT_SANDBOX=1 replaces the machine's PATH with the curated one
+# above, so no real clang-format can answer.
 HOOK_OUTPUT=""
 HOOK_STATUS=0
 TIDY_FULL=""
+FORMAT_STUB_NAME="clang-format"
+FORMAT_STUB_VERSION=""
+FORMAT_STUB_DIRTY=""
+FORMAT_SANDBOX=""
 run_hook() {
-    local version="$1" flagged="${2:-}" line="${3:-1}" factory="${4:-make_repo}" repo stub
+    local version="$1" flagged="${2:-}" line="${3:-1}" factory="${4:-make_repo}"
+    local repo stub tail fstub="" sandbox=""
     repo="$("$factory")"
     stub="$(make_stub "$version" "$flagged" "$line")"
+    if [ -n "$FORMAT_SANDBOX" ]; then
+        sandbox="$(make_sandbox_path)"
+        tail="$sandbox"
+    else
+        tail="$PATH"
+    fi
+    if [ -n "$FORMAT_STUB_VERSION" ]; then
+        fstub="$(make_format_stub "$FORMAT_STUB_NAME" "$FORMAT_STUB_VERSION" "$FORMAT_STUB_DIRTY")"
+        tail="$fstub:$tail"
+    fi
     set +e
-    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$PATH" VAYU_TIDY_FULL="$TIDY_FULL" bash "$HOOK" 2>&1)"
+    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$tail" VAYU_TIDY_FULL="$TIDY_FULL" bash "$HOOK" 2>&1)"
     HOOK_STATUS=$?
     set -e
-    rm -rf "$repo" "$stub"
+    rm -rf "$repo" "$stub" ${fstub:+"$fstub"} ${sandbox:+"$sandbox"}
 }
 
 # Runs the hook against a stub of $1 that flags nothing. Prints the combined
@@ -390,6 +494,137 @@ elif grep -qE '^[[:space:]]*ExtraArgs:' "$tidy_config"; then
          "found: $(grep -nE '^[[:space:]]*ExtraArgs:' "$tidy_config")"
 else
     pass "engine/.clang-tidy declares no ExtraArgs, so CI's header path stays clean"
+fi
+
+# --- The formatting check (issue #908) ---------------------------------------
+echo
+echo "pre-commit clang-format check"
+
+# The defect: `Engine formatting` is a two-second check that only a push could
+# reach, so a formatting slip cost a CI round trip and a fixup commit.
+#
+# Mutation-check: drop the `|| FORMAT_STATUS=1` from the clang-format
+# invocation in scripts/pre-commit, or the `-Werror` that gives it a status to
+# keep, and this case reddens.
+#
+# Every case here runs on the sandbox PATH, so the only clang-format in reach is
+# the stub: a machine that happens to have a real 19 installed - a contributor's
+# laptop, a runner image that grows one - would otherwise answer these questions
+# instead of the stub, and the suite would be testing its LLVM.
+FORMAT_SANDBOX=1
+FORMAT_STUB_VERSION="19.1.7"
+FORMAT_STUB_DIRTY="engine.cpp"
+run_hook 19.1.0 "" 1 make_repo_engine
+if [[ "$HOOK_STATUS" -ne 0 ]]; then
+    pass "a staged engine source clang-format would rewrite refuses the commit"
+else
+    fail "an unformatted staged source refuses the commit" "the hook exited 0: $HOOK_OUTPUT"
+fi
+
+if [[ "$HOOK_OUTPUT" == *"the commit was refused"* && "$HOOK_OUTPUT" == *"--style=file -i"* ]]; then
+    pass "the formatting refusal says what happened and how to fix it"
+else
+    fail "the formatting refusal explains itself" "got: $HOOK_OUTPUT"
+fi
+
+# The scope, named rather than inferred: whole files (no line filter), and only
+# the three roots CI's gate walks. Widening the `case` in scripts/pre-commit to
+# `engine/*` reddens the second half - `engine/vendor/` has a `DisableFormat`
+# config of its own and formatting it would be a rule CI does not have.
+if [[ "$HOOK_OUTPUT" == *"STUB_FORMATTED"*"--style=file --dry-run -Werror"*"engine/src/engine.cpp"* ]]; then
+    pass "the check runs clang-format the way CI does, over the whole staged file"
+else
+    fail "the check matches CI's invocation" "got: $HOOK_OUTPUT"
+fi
+
+format_line="$(printf '%s\n' "$HOOK_OUTPUT" | grep -F "STUB_FORMATTED" || true)"
+if [[ -n "$format_line" && "$format_line" != *"vendor"* && "$format_line" != *"scratch.cpp"* ]]; then
+    pass "files outside engine/{src,include,tests} are never format-checked"
+else
+    fail "the format scope is the three engine roots" "got: $format_line"
+fi
+
+# The other half. Without it, "refuse everything" would pass the cases above.
+FORMAT_STUB_DIRTY=""
+run_hook 19.1.0 "" 1 make_repo_engine
+if [[ "$HOOK_STATUS" -eq 0 && "$HOOK_OUTPUT" == *"STUB_FORMATTED"* ]]; then
+    pass "a format-clean staged source is checked and commits through"
+else
+    fail "a clean source commits through" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# The pin is 19 *exactly*: 39 of the 285 engine sources format differently under
+# 18, so an 18 that reported "clean" would be a wrong answer rather than a
+# missing one. It must skip, loudly, and check nothing - and still let the
+# commit through, because CI is the gate and a local toolchain is a convenience.
+FORMAT_STUB_VERSION="18.1.3"
+FORMAT_STUB_DIRTY="engine.cpp"
+run_hook 19.1.0 "" 1 make_repo_engine
+if [[ "$HOOK_STATUS" -eq 0 && "$HOOK_OUTPUT" == *"NOTHING WAS FORMAT-CHECKED"* && "$HOOK_OUTPUT" == *"18.1.3"* ]]; then
+    pass "clang-format 18 is refused loudly, naming the version, and does not refuse the commit"
+else
+    fail "clang-format 18 skips loudly" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+if [[ "$HOOK_OUTPUT" != *"STUB_FORMATTED"* ]]; then
+    pass "clang-format 18 checks nothing, rather than pretending to"
+else
+    fail "clang-format 18 checks nothing" "the hook ran it anyway: $HOOK_OUTPUT"
+fi
+
+# The same branch, reached the other way. The sandbox PATH is what makes this a
+# statement about the hook rather than about the runner's LLVM.
+FORMAT_STUB_VERSION=""
+FORMAT_STUB_DIRTY=""
+run_hook 19.1.0 "" 1 make_repo_engine
+if [[ "$HOOK_STATUS" -eq 0 && "$HOOK_OUTPUT" == *"NOTHING WAS FORMAT-CHECKED"* ]]; then
+    pass "an absent clang-format skips loudly rather than passing silently"
+else
+    fail "an absent clang-format skips loudly" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# ...but only when there was something to check. A commit that stages no engine
+# source must not hear about the C++ formatter at all, whatever is installed.
+run_hook 19.1.0
+if [[ "$HOOK_STATUS" -eq 0 && "$HOOK_OUTPUT" != *"FORMAT-CHECKED"* ]]; then
+    pass "a commit staging no engine source says nothing about clang-format"
+else
+    fail "no engine source, no formatter message" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+fi
+
+# Ubuntu 24.04's shape, and the reason the hook looks under two names: `apt
+# install clang-format-19` leaves plain `clang-format` at the distribution's 18,
+# so a hook that probed only the plain name would skip on the very setup
+# CONTRIBUTING.md tells contributors to build.
+repo="$(make_repo_engine)"
+stub="$(make_stub 19.1.0)"
+versioned="$(make_format_stub clang-format-19 19.1.7 engine.cpp)"
+plain="$(make_format_stub clang-format 18.1.3 "")"
+set +e
+out="$(cd "$repo" && PATH="$stub:$plain:$versioned:$(make_sandbox_path)" bash "$HOOK" 2>&1)"
+status=$?
+set -e
+rm -rf "$repo" "$stub" "$versioned" "$plain"
+if [[ "$status" -ne 0 && "$out" == *"clang-format-19"* ]]; then
+    pass "clang-format-19 is preferred over a plain clang-format that is not 19"
+else
+    fail "clang-format-19 is found beside an 18" "exit $status: $out"
+fi
+
+# The formatting verdict has to survive every exit the clang-tidy half takes -
+# an absent or old clang-tidy is a reason to skip linting, not a reason to
+# forget that clang-format already refused this commit. Mutation-check: turn
+# either `exit "$FORMAT_STATUS"` in scripts/pre-commit back into `exit 0`.
+FORMAT_STUB_VERSION="19.1.7"
+FORMAT_STUB_DIRTY="engine.cpp"
+run_hook 18.1.3 "" 1 make_repo_engine
+FORMAT_STUB_VERSION=""
+FORMAT_STUB_DIRTY=""
+FORMAT_SANDBOX=""
+if [[ "$HOOK_STATUS" -ne 0 && "$HOOK_OUTPUT" == *"NOTHING WAS LINTED"* ]]; then
+    pass "a formatting refusal survives a clang-tidy the hook had to skip"
+else
+    fail "the formatting verdict survives a tidy skip" "exit $HOOK_STATUS: $HOOK_OUTPUT"
 fi
 
 echo


### PR DESCRIPTION
## Description

The hook linted but never format-checked, so the `Engine formatting` gate - about two seconds of work - was reachable only after a push and a CI round trip, paid for with a red check and a fixup commit. It now runs `clang-format --style=file --dry-run -Werror` over the whole of every staged `engine/{src,include,tests}` source before the clang-tidy pass, and refuses the commit on a difference.

**Plan (root cause, approach, rejected alternative).** The root cause is a missing local half, not a broken one: #886 shipped the whole-tree CI gate and left extending `scripts/pre-commit` as optional, so clang-tidy had a hook and clang-format did not. The approach mirrors the existing tidy pass rather than inventing a second shape - same staged-file list, same "probe the version and skip loudly rather than answer from the wrong major" reasoning, same "the exit status is the verdict" discipline #885 had to install at the tidy call sites. **Whole files, not changed lines**, which is the opposite of the tidy pass and for the opposite reason: the bulk-format commit left no backlog to grandfather, so file scope already agrees with CI's tree scope and the hook stays exactly as strict as the gate it mirrors - the property #902 restored and that keeps `--no-verify` from becoming a reflex. The alternative the issue asked me to check, `git clang-format --staged`, is the wrong primitive despite shipping in the same package: it formats the **changed lines**, so a staged file it called clean could still fail CI's whole-file check - the asymmetry #902 removed from the tidy pass, reintroduced at the other end.

Two details worth a reviewer's eye:

- **Binary discovery under two names.** `clang-format-19` first, plain `clang-format` second, because `apt install clang-format-19` - what CONTRIBUTING.md tells an Ubuntu contributor to run - leaves the plain name at the distribution's 18, while Homebrew's LLVM 19 installs it *as* `clang-format`. Probing only the plain name would skip on the very setup the docs tell people to build. With neither at 19 the check skips loudly and scans nothing: the pin is exact (39 of the 285 engine sources format differently under 18), so another major is a wrong answer rather than a missing one. A commit staging no engine source says nothing about the formatter at all.
- **One exit.** Every exit from the clang-tidy pass now goes through `end_hook`, so an absent or too-old clang-tidy skips linting without discarding a formatting refusal, and the verdict prints last, where it will be read. Before this the three tidy early exits were plain `exit 0`.

Deliberate deviation from the issue spec: none. Item 3 of the pathway (`git-clang-format`) was checked and rejected with the reason above, which the issue invited.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `bash scripts/test/pre-commit_test.sh` - **31 passed, 0 failed** (was 20 cases; 11 new). The new cases drive the real hook against a stubbed clang-format on a **sandboxed PATH** holding only the tools the hook calls, so no real LLVM on the machine can answer them - the container this ran in has both an 18 and a 19 installed, and neither changes the result.
- Mutation-checked, each reddening the intended case and only it: dropping `|| FORMAT_STATUS=1` (4 cases red), dropping `-Werror` (5), widening the scope `case` to `engine/*` (1 - the vendor case), turning an `end_hook` back into `exit 0` (1), probing only the plain binary name (1), making the skip quiet (2).
- End-to-end against real clang-format 19.1.1 and a real clone: a format-clean staged engine source commits through (exit 0); a badly formatted one is refused (exit 1) with the diagnostics and the fix command, *while* clang-tidy 18 on the same machine skipped - the verdict survived; a staged `engine/vendor/` source is silently out of scope.
- `shellcheck` 0.10.0 (the pinned version) clean on both scripts.
- `mkdocs build --strict` clean.

Not run, per CLAUDE.md's verification scaling: no engine rebuild and neither suite - this changes a shell hook, its own suite, and four Markdown files, so nothing compiled could go from green to red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `CONTRIBUTING.md` (the Formatting bullet now says both places check it), `docs/engine/building.md` (a "runs in two places" table beside the Formatting section, mirroring the Static Analysis one, plus the macOS Homebrew note), `engine/CLAUDE.md` (the formatter bullet), root `CLAUDE.md` (the one-line description of `scripts/pre-commit`).

## Related Issues
Closes #908

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6TGowvZa8UTHTqv1zMG7E)_