### PR TITLE
fix(app): make the scrollbar rules render, then thin every system to 6px

### DIFF
--- a/app/src/components/ui/code-editor.tsx
+++ b/app/src/components/ui/code-editor.tsx
@@ -35,6 +35,22 @@ function useDarkMode() {
 	return isDark;
 }
 
+/**
+ * The app's scrollbar thickness, in px, as declared by `::-webkit-scrollbar` in
+ * `index.css`.
+ *
+ * Monaco renders its own scrollbars as DOM inside the editor, so no stylesheet
+ * rule reaches them and this is the only way to size them. It shipped at
+ * Monaco's defaults - 14px vertical, 12px horizontal - which passed unnoticed
+ * beside a 10px native bar and would be 2.3x one at 6px. An editor sits
+ * directly beside plain scroll panes in the body and script panels, so the two
+ * are read together.
+ *
+ * `scroll-area.test.ts` reads the number back out of the CSS and asserts it
+ * matches this one, which is what keeps a third system from drifting again.
+ */
+const SCROLLBAR_SIZE = 6;
+
 /** Options shared by every editor instance. */
 const DEFAULT_OPTIONS = {
 	minimap: { enabled: false },
@@ -62,6 +78,9 @@ const DEFAULT_OPTIONS = {
 		 * and let it bubble otherwise.
 		 */
 		alwaysConsumeMouseWheel: false,
+
+		verticalScrollbarSize: SCROLLBAR_SIZE,
+		horizontalScrollbarSize: SCROLLBAR_SIZE,
 	},
 	// Render suggestion/hover/context-menu widgets in a body-level overlay so they
 	// are not clipped by editor containers with `overflow: hidden` + fixed height.

--- a/app/src/components/ui/scroll-area.test.ts
+++ b/app/src/components/ui/scroll-area.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `ScrollArea` is the app's second scrollbar, and it has to be the same width
+ * as the first.
+ *
+ * The baseline in `index.css` styles every native `overflow` pane; Radix draws
+ * its bar as real DOM instead, so the width lives in two files that know
+ * nothing about each other. They drifted the moment they were written - 8px
+ * global against shadcn's 10px default - and the two are read side by side,
+ * because a `ScrollArea` pane sits next to plain scroll panes all over the UI.
+ *
+ * The expected width is derived from the CSS rather than written twice here,
+ * so lowering the baseline without lowering the primitive reddens this instead
+ * of shipping a second thickness.
+ *
+ * Source-scanned, not rendered: vitest stubs CSS imports to `""`, so the
+ * stylesheet is only readable off disk - hence the length assertions, which
+ * exist so an empty read cannot pass the file.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(here, "..", "..", "index.css"), "utf8");
+const primitive = readFileSync(join(here, "scroll-area.tsx"), "utf8");
+
+/**
+ * The `@apply` line of a `::-webkit-scrollbar` rule, by its selector prefix.
+ * The empty prefix means the baseline, so it requires whitespace ahead of the
+ * pseudo-element - otherwise it would happily match `.scrollbar-strip`'s.
+ */
+function scrollbarSize(selector: string): string {
+	const prefix = selector === "" ? "\\s" : selector;
+	const m = css.match(new RegExp(`${prefix}::-webkit-scrollbar\\s*\\{\\s*@apply ([^;]+);`));
+	if (!m) throw new Error(`no ::-webkit-scrollbar rule for "${selector || "the baseline"}"`);
+	return m[1].trim();
+}
+
+/** The class list of the Radix thumb element. */
+function thumbClasses(): string {
+	const m = primitive.match(/ScrollAreaThumb\s+className="([^"]*)"/);
+	if (!m) throw new Error("no ScrollAreaThumb className in scroll-area.tsx");
+	return m[1];
+}
+
+describe("scrollbar width", () => {
+	it("reads both sources", () => {
+		expect(css.length).toBeGreaterThan(1000);
+		expect(primitive.length).toBeGreaterThan(500);
+	});
+
+	it("gives ScrollArea the same width the native baseline uses", () => {
+		const baseline = scrollbarSize("");
+		const [width, height] = baseline.split(/\s+/);
+
+		// `w-1.5 h-1.5` - one number, applied to whichever axis the bar runs on.
+		expect(width.replace(/^w-/, "")).toBe(height.replace(/^h-/, ""));
+
+		expect(primitive).toContain(`"h-full ${width}"`);
+		expect(primitive).toContain(`"${height} flex-col"`);
+	});
+
+	it("keeps the ScrollArea thumb on the baseline's colour", () => {
+		// `--border` is the same colour as `--card` in dark, so the shadcn
+		// default (`bg-border`) is an invisible thumb on the surface this
+		// component is usually laid over.
+		expect(thumbClasses()).toContain("bg-muted-foreground/30");
+		expect(thumbClasses()).not.toContain("bg-border");
+	});
+
+	/*
+	 * Not a style preference: a scroller that declares either standard property
+	 * makes Chromium ignore every ::-webkit-scrollbar rule on it, so one such
+	 * declaration outside the guard turns the whole block above into decoration
+	 * and the bar renders at Chromium's `thin` - which is wider than the file
+	 * says, and is what this issue was reported as.
+	 */
+	it("declares the standard scrollbar properties only behind the @supports guard", () => {
+		// Comments discuss both properties by name, colon and all. Blank them
+		// out rather than matching them - keeping the offsets, so the positions
+		// below still line up with the real file.
+		const rules = css.replace(/\/\*[\s\S]*?\*\//g, (c) => " ".repeat(c.length));
+
+		const open = rules.indexOf("@supports not selector(::-webkit-scrollbar)");
+		expect(open).toBeGreaterThan(-1);
+
+		let depth = 0;
+		let close = rules.indexOf("{", open);
+		for (let i = close; i < rules.length; i++) {
+			if (rules[i] === "{") depth++;
+			else if (rules[i] === "}" && --depth === 0) {
+				close = i;
+				break;
+			}
+		}
+
+		const declarations = [...rules.matchAll(/scrollbar-(?:width|color)\s*:/g)];
+		expect(declarations.length).toBeGreaterThan(0);
+		for (const d of declarations) {
+			expect(d.index).toBeGreaterThan(open);
+			expect(d.index).toBeLessThan(close);
+		}
+	});
+
+	it("keeps the tab-strip override narrower than the baseline it overrides", () => {
+		const strip = scrollbarSize("\\.scrollbar-strip");
+		const size = (v: string) => Number.parseFloat(v.replace(/^[wh]-/, ""));
+
+		expect(size(strip.split(/\s+/)[0])).toBeLessThan(size(scrollbarSize("").split(/\s+/)[0]));
+	});
+});

--- a/app/src/components/ui/scroll-area.tsx
+++ b/app/src/components/ui/scroll-area.tsx
@@ -32,6 +32,20 @@ function ScrollArea({
 	);
 }
 
+/**
+ * The overlay scrollbar, sized and coloured to match the native one.
+ *
+ * A `ScrollArea` sits beside plain `overflow-auto` panes all over the app, so
+ * its bar is read against theirs: this is 6px because `::-webkit-scrollbar` in
+ * `index.css` is 6px, and it carries the same `muted-foreground/30` thumb for
+ * the same reason. It shipped at shadcn's 10px with a `bg-border` thumb, which
+ * is both thicker than the baseline and - since `--border` matches `--card` in
+ * dark - invisible on the surface this component is usually laid over.
+ *
+ * The 1px padding and transparent edge border shadcn insets the thumb with are
+ * gone with the width: they were a 30% inset on a 10px bar and would be a 50%
+ * one here, leaving a 3px thumb inside a 6px gutter.
+ */
 function ScrollBar({
 	className,
 	orientation = "vertical",
@@ -43,14 +57,13 @@ function ScrollBar({
 			orientation={orientation}
 			className={cn(
 				"flex touch-none select-none transition-colors",
-				orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-[1px]",
-				orientation === "horizontal" &&
-					"h-2.5 flex-col border-t border-t-transparent p-[1px]",
+				orientation === "vertical" && "h-full w-1.5",
+				orientation === "horizontal" && "h-1.5 flex-col",
 				className
 			)}
 			{...props}
 		>
-			<ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+			<ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-muted-foreground/30 hover:bg-muted-foreground/50" />
 		</ScrollAreaPrimitive.ScrollAreaScrollbar>
 	);
 }

--- a/app/src/components/ui/scrollbar-systems.test.ts
+++ b/app/src/components/ui/scrollbar-systems.test.ts
@@ -6,17 +6,18 @@
  */
 
 /**
- * `ScrollArea` is the app's second scrollbar, and it has to be the same width
- * as the first.
+ * The app draws scrollbars three ways, and they have to be one thickness.
  *
- * The baseline in `index.css` styles every native `overflow` pane; Radix draws
- * its bar as real DOM instead, so the width lives in two files that know
- * nothing about each other. They drifted the moment they were written - 8px
- * global against shadcn's 10px default - and the two are read side by side,
- * because a `ScrollArea` pane sits next to plain scroll panes all over the UI.
+ * The baseline in `index.css` styles every native `overflow` pane; Radix
+ * `ScrollArea` draws its bar as real DOM; Monaco renders its own inside the
+ * editor and takes a number, not a stylesheet. So the width lives in three
+ * files that know nothing about each other, and all three drifted apart the
+ * moment they were written - 8px global, shadcn's 10px, Monaco's 14px - while
+ * being read side by side, because an editor and a `ScrollArea` and a plain
+ * scroll pane routinely sit in the same panel.
  *
- * The expected width is derived from the CSS rather than written twice here,
- * so lowering the baseline without lowering the primitive reddens this instead
+ * Each expected width is derived from the CSS rather than written again here,
+ * so lowering the baseline without lowering the other two reddens this instead
  * of shipping a second thickness.
  *
  * Source-scanned, not rendered: vitest stubs CSS imports to `""`, so the
@@ -32,6 +33,17 @@ import { dirname, join } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(join(here, "..", "..", "index.css"), "utf8");
 const primitive = readFileSync(join(here, "scroll-area.tsx"), "utf8");
+const editor = readFileSync(join(here, "code-editor.tsx"), "utf8");
+
+/**
+ * Tailwind's spacing step, which turns `w-1.5` into the px Monaco needs. The
+ * theme does not override `--spacing`, so it is the framework default of
+ * 0.25rem; if index.css ever declares one, that wins.
+ */
+const SPACING_PX = (() => {
+	const declared = css.match(/--spacing:\s*([\d.]+)rem/);
+	return (declared ? Number.parseFloat(declared[1]) : 0.25) * 16;
+})();
 
 /**
  * The `@apply` line of a `::-webkit-scrollbar` rule, by its selector prefix.
@@ -53,9 +65,10 @@ function thumbClasses(): string {
 }
 
 describe("scrollbar width", () => {
-	it("reads both sources", () => {
+	it("reads all three sources", () => {
 		expect(css.length).toBeGreaterThan(1000);
 		expect(primitive.length).toBeGreaterThan(500);
+		expect(editor.length).toBeGreaterThan(500);
 	});
 
 	it("gives ScrollArea the same width the native baseline uses", () => {
@@ -67,6 +80,19 @@ describe("scrollbar width", () => {
 
 		expect(primitive).toContain(`"h-full ${width}"`);
 		expect(primitive).toContain(`"${height} flex-col"`);
+	});
+
+	it("sizes Monaco's own scrollbars to the same width, in px", () => {
+		const [width] = scrollbarSize("").split(/\s+/);
+		const px = Number.parseFloat(width.replace(/^w-/, "")) * SPACING_PX;
+		expect(px).toBeGreaterThan(0);
+
+		// Monaco takes a number, so this is the one place the width is written
+		// as px rather than a class - and the one that cannot be checked by
+		// reading a stylesheet at runtime.
+		expect(editor).toMatch(new RegExp(`const SCROLLBAR_SIZE = ${px};`));
+		expect(editor).toContain("verticalScrollbarSize: SCROLLBAR_SIZE");
+		expect(editor).toContain("horizontalScrollbarSize: SCROLLBAR_SIZE");
 	});
 
 	it("keeps the ScrollArea thumb on the baseline's colour", () => {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1130,21 +1130,47 @@
  * Applying it globally makes thin the default and removes the chance to forget.
  * :where() keeps specificity at zero, so any element that genuinely needs a
  * different scrollbar can still override with a plain class.
+ *
+ * 6px is the floor for a content pane: the thumb is still a mouse target at
+ * that width, and it is the width `ScrollArea` renders too, so the app shows
+ * one thickness whichever of the two systems draws the bar. Narrower belongs
+ * only to a container that is not dragged - see `.scrollbar-strip` below.
  */
 @layer base {
-	:where(*) {
-		scrollbar-width: thin;
-		scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+	/*
+	 * The standards-track properties, for an engine that has no
+	 * ::-webkit-scrollbar - and behind an @supports guard, because in Chromium
+	 * they do not coexist with it.
+	 *
+	 * Since Chromium 121 a scroller that declares `scrollbar-width` or
+	 * `scrollbar-color` renders the *standard* scrollbar and ignores every
+	 * ::-webkit-scrollbar rule that applies to it. Declared globally on
+	 * `:where(*)`, that meant every scrollbar in the app: the block below set
+	 * 8px and the app drew Chromium's `thin`, which measures 10px - thicker
+	 * than the value in the stylesheet, and the reason the bars read heavy.
+	 * The `display: none` a Monaco input uses to hide its own scrollbar was
+	 * being ignored for the same reason. Measured on Chromium 141: a scroller
+	 * with `scrollbar-width: thin` and a 6px ::-webkit-scrollbar renders 10px;
+	 * the same scroller inside this guard renders 6px.
+	 *
+	 * So the guard is not defensive - it is what makes everything below load
+	 * bearing. Anything that sets `scrollbar-width` or `scrollbar-color` on an
+	 * element outside it silently turns that element's webkit rules off.
+	 */
+	@supports not selector(::-webkit-scrollbar) {
+		:where(*) {
+			scrollbar-width: thin;
+			scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+		}
 	}
 
 	/*
-	 * Chromium honours ::-webkit-scrollbar over scrollbar-width, and Electron is
-	 * Chromium, so these rules are the ones that actually render here. Styling
-	 * ::-webkit-scrollbar at all also drops the stepper arrows, which is why the
-	 * default-styled containers showed them and the styled ones did not.
+	 * Electron is Chromium, so these are the rules that actually render here.
+	 * Styling ::-webkit-scrollbar at all also drops the stepper arrows, which is
+	 * why the default-styled containers showed them and the styled ones did not.
 	 */
 	::-webkit-scrollbar {
-		@apply w-2 h-2;
+		@apply w-1.5 h-1.5;
 	}
 
 	::-webkit-scrollbar-track {
@@ -1162,6 +1188,39 @@
 	/* The corner where two scrollbars meet; unstyled it renders as a light patch. */
 	::-webkit-scrollbar-corner {
 		@apply bg-transparent;
+	}
+}
+
+@layer utilities {
+	/*
+	 * The one blessed override of the baseline above: a tab strip.
+	 *
+	 * `RequestTabs`, `ResponseViewer` and `CollectionDetail` scroll their
+	 * `TabsList` natively, so an overflowing tab row draws the baseline bar
+	 * straight under a 24px band
+	 * of tabs - a third of the strip's own height, for a control the user reaches
+	 * by clicking a tab. 4px with a thumb that appears on hover keeps the
+	 * affordance without the permanent rule.
+	 *
+	 * Hover, not always-visible, because the bar sits directly beneath the tabs:
+	 * at rest the strip reads as one band, and the pointer that could scroll it
+	 * is the pointer that reveals it. Chromium repaints scrollbar pseudo-elements
+	 * on the scroller's own `:hover`, so no JS is involved.
+	 *
+	 * 4px is below the 6px floor the baseline keeps for content panes - a strip
+	 * is dragged rarely and scrolled by wheel or by tab focus, so the smaller
+	 * target is the right trade here and the wrong one anywhere else.
+	 */
+	.scrollbar-strip::-webkit-scrollbar {
+		@apply w-1 h-1;
+	}
+
+	.scrollbar-strip::-webkit-scrollbar-thumb {
+		@apply bg-transparent;
+	}
+
+	.scrollbar-strip:hover::-webkit-scrollbar-thumb {
+		@apply bg-muted-foreground/30;
 	}
 }
 

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -213,7 +213,7 @@ export default function CollectionDetail() {
 				{/* The active trigger's weight change used to shift its neighbours
 				    on every switch; TabLabel reserves the bold width, so it no
 				    longer can. */}
-				<TabsList className="bg-panel px-4 shrink-0 overflow-x-auto overflow-y-hidden flex-nowrap">
+				<TabsList className="bg-panel px-4 shrink-0 overflow-x-auto overflow-y-hidden flex-nowrap scrollbar-strip">
 					{TABS.map((t) => {
 						const count =
 							t.id === "variables"

--- a/app/src/modules/request-builder/components/RequestTabs/index.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/index.tsx
@@ -98,7 +98,7 @@ export default function RequestTabs() {
 			className="flex-1 flex flex-col overflow-hidden"
 		>
 			{/* Tab Headers */}
-			<TabsList className="w-full overflow-x-auto overflow-y-hidden flex-nowrap px-1">
+			<TabsList className="w-full overflow-x-auto overflow-y-hidden flex-nowrap px-1 scrollbar-strip">
 				{tabs.map((tab) => (
 					<TabsTrigger key={tab.id} value={tab.id}>
 						<TabLabel>{tab.label}</TabLabel>

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -304,7 +304,7 @@ export default function ResponseViewer() {
 					    when the right-hand group was just the actions; it matters now
 					    that the response's own facts live there.
 					 */}
-					<TabsList className="min-w-0 overflow-x-auto overflow-y-hidden flex-nowrap">
+					<TabsList className="min-w-0 overflow-x-auto overflow-y-hidden flex-nowrap scrollbar-strip">
 						<TabsTrigger value="body">
 							<TabLabel>Body</TabLabel>
 						</TabsTrigger>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1966,7 +1966,8 @@ read as a fraction, and there is no fraction to report.
 | Method bg (GET) | `bg-method-get` (and `bg-method-post`, etc.) |
 | Mono font | `font-mono` |
 | Code font (utility) | `font-code` |
-| Thin scrollbar | `scrollbar-thin` |
+| Thin scrollbar | nothing - 6px is the global baseline (see [Scrollbar](#scrollbar)) |
+| Tab-strip scrollbar | `scrollbar-strip` (4px, thumb on hover) |
 | Variable color | `text-variable` or `.variable-highlight` |
 
 ### Never use
@@ -2017,14 +2018,64 @@ container gets them; there is nothing to remember and nothing to apply.
 
 ```css
 /* index.css, @layer base */
-:where(*) {
-	scrollbar-width: thin;
-	scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+@supports not selector(::-webkit-scrollbar) {
+	:where(*) {
+		scrollbar-width: thin;
+		scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+	}
 }
 ::-webkit-scrollbar {
-	@apply w-2 h-2;
+	@apply w-1.5 h-1.5;
 }
 ```
+
+**The `@supports` guard is load-bearing, not defensive.** Since Chromium 121 a
+scroller that declares `scrollbar-width` or `scrollbar-color` renders the
+_standard_ scrollbar and ignores every `::-webkit-scrollbar` rule that applies
+to it - the two systems do not compose. The properties were declared globally
+on `:where(*)`, so the whole webkit block below them was inert: the stylesheet
+said 8px and the app drew Chromium's `thin`, which measures 10px. That gap is
+the "scrollbars read too thick" report. Measured on Chromium 141: a scroller
+with `scrollbar-width: thin` and a 6px `::-webkit-scrollbar` renders **10px**;
+the same scroller with the standard properties behind the guard renders
+**6px**.
+
+So `scrollbar-width` and `scrollbar-color` belong nowhere outside that guard.
+Setting either on an element turns that element's webkit rules off, silently -
+the bar stays, at the wrong width, in the wrong colour.
+
+**6px, and 6px in both systems.** The baseline covers native `overflow` panes;
+Radix `ScrollArea` draws its own bar in the DOM instead, so `scroll-area.tsx`
+repeats the width and the `muted-foreground/30` thumb rather than inheriting
+them. The two shipped at 8px and 10px with different thumb colours - a
+`ScrollArea` sits beside plain scroll panes throughout the app, so the pair is
+read side by side and has to be one thickness. Change one and change the other.
+
+Do not take a content pane below 6px: the thumb stops being a mouse target.
+
+### Tab strips: `scrollbar-strip`
+
+A `TabsList` that scrolls natively (request builder, response viewer,
+collection detail) draws the baseline bar directly under a 24px band of tabs.
+The scoped utility takes those strips to 4px and hides the thumb until the
+strip is hovered:
+
+```css
+/* index.css, @layer utilities */
+.scrollbar-strip::-webkit-scrollbar {
+	@apply w-1 h-1;
+}
+.scrollbar-strip::-webkit-scrollbar-thumb {
+	@apply bg-transparent;
+}
+.scrollbar-strip:hover::-webkit-scrollbar-thumb {
+	@apply bg-muted-foreground/30;
+}
+```
+
+Chromium repaints scrollbar pseudo-elements on the scroller's own `:hover`, so
+the reveal costs no JS. This is the one blessed exception to the 6px floor: a
+strip is scrolled by wheel or by tab focus rather than dragged.
 
 This was a `.scrollbar-thin` class applied per element, and it drifted badly:
 **38 of the app's 44 scroll containers never got it**, so chunky
@@ -2041,9 +2092,10 @@ unfixable by discipline alone:
 `:where()` keeps specificity at zero, so an element that genuinely needs a
 different scrollbar can still override with a plain class.
 
-Chromium honours `::-webkit-scrollbar` over `scrollbar-width`, and Electron is
-Chromium, so the webkit rules are the ones that render here; `scrollbar-width`
-is the standards-track fallback.
+Electron is Chromium, so the webkit rules are the ones that render here;
+`scrollbar-width` is the standards-track fallback for an engine that has no
+such pseudo-element, which is why it sits behind the `@supports` guard above
+rather than beside the rules it would otherwise disable.
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2044,12 +2044,25 @@ So `scrollbar-width` and `scrollbar-color` belong nowhere outside that guard.
 Setting either on an element turns that element's webkit rules off, silently -
 the bar stays, at the wrong width, in the wrong colour.
 
-**6px, and 6px in both systems.** The baseline covers native `overflow` panes;
-Radix `ScrollArea` draws its own bar in the DOM instead, so `scroll-area.tsx`
-repeats the width and the `muted-foreground/30` thumb rather than inheriting
-them. The two shipped at 8px and 10px with different thumb colours - a
-`ScrollArea` sits beside plain scroll panes throughout the app, so the pair is
-read side by side and has to be one thickness. Change one and change the other.
+**6px, and 6px in all three systems.** The app draws scrollbars three ways, and
+only the first is reached by a stylesheet at all:
+
+| System | Where the width lives | Was |
+| ------ | --------------------- | --- |
+| Native `overflow` panes | `index.css`, the block above | 8px declared, 10px drawn |
+| Radix `ScrollArea` | `scroll-area.tsx` class list | 10px, `bg-border` thumb |
+| Monaco editors | `code-editor.tsx`, `SCROLLBAR_SIZE` in px | 14px vertical, 12px horizontal |
+
+They are read side by side - a body panel puts an editor, a `ScrollArea` and a
+plain scroll pane in one view - so all three carry one number. `ScrollArea`
+also repeats the baseline's `muted-foreground/30` thumb: `--border`, shadcn's
+default, is the same colour as `--card` in dark, which is an invisible thumb on
+the surface that component is usually laid over. Monaco renders its bars as its
+own DOM inside the editor and takes a **number**, not a class, which is why no
+sweep of the stylesheet can see it drift.
+
+`scrollbar-systems.test.ts` derives the two repeats from the CSS, so the three
+move together or the suite reddens.
 
 Do not take a content pane below 6px: the thumb stops being a mouse target.
 


### PR DESCRIPTION
## Description

Thins the app's scrollbars as #914 asks - and fixes the reason they were thicker than the stylesheet said in the first place. Extended on request to cover Monaco in the same PR, so all three scrollbar systems land together.

**Plan (root cause, approach, rejected alternative).** The issue reads the thickness off `::-webkit-scrollbar { @apply w-2 h-2 }` and asks for `w-1.5 h-1.5`. Verified against the running engine, that edit would have changed nothing: since Chromium 121 a scroller that declares `scrollbar-width` or `scrollbar-color` renders the **standard** scrollbar and ignores every `::-webkit-scrollbar` rule that applies to it - the two systems do not compose. `index.css` declared both on `:where(*)`, so the entire webkit block (width, thumb colour, hover, corner) was inert and every bar in the app was Chromium's `thin`, which measures 10px. That 8px-declared / 10px-drawn gap is the "scrollbars read too thick" report. So the approach is to put the standards-track properties behind `@supports not selector(::-webkit-scrollbar)` - Chromium skips them, an engine without the pseudo-element still gets `thin` plus the thumb colour - and only then set the widths the issue asks for. The alternative was to express the whole baseline in the standard properties and drop the webkit block: rejected because `scrollbar-width` takes only `auto | thin | none`, so 6px is unreachable that way, 4px strips doubly so, and the rounded thumb and hover state would go with it.

Measured on Chromium 141 against the real built stylesheet and monaco-editor 0.55.1 (harness pages, `offsetWidth - clientWidth` and the editor's own slider elements):

| | before | after |
|---|---|---|
| content pane | 10px (declared 8px) | **6px** |
| `ScrollArea` | 10px, `bg-border` thumb | **6px**, `muted-foreground/30` thumb |
| Monaco editor | 14px vertical / 12px horizontal | **6px** |
| tab strip | 10px, permanent bar | **4px**, thumb on hover only |

Also in the diff:

- **`ScrollArea`** drops shadcn's 10px and its 1px inset padding + transparent edge border (a 30% inset at 10px, a 50% one at 6px - it would leave a 3px thumb in a 6px gutter). Its thumb moves from `bg-border` to the baseline's `muted-foreground/30`: `--border` is the same colour as `--card` in dark, i.e. an invisible thumb on the surface this component is usually laid over, and making the bar narrower without that would have made it worse.
- **Monaco** is the third system and the one no stylesheet reaches: it renders its bars as its own DOM and takes a number, so `rg "webkit-scrollbar"` cannot see it drift. `code-editor.tsx` set one key on the `scrollbar` option object and left the sizes at Monaco's defaults. Now `SCROLLBAR_SIZE = 6` feeds `verticalScrollbarSize` / `horizontalScrollbarSize`. The slider colour stays Monaco's theme default: the app uses stock `vs` / `vs-dark`, so recolouring it means defining a custom theme, which is a larger change than this issue.
- **A third tab strip.** The issue names `RequestTabs` and `ResponseViewer`; its own step 4 asks for a sweep, and `CollectionDetail/index.tsx:216` is the same `overflow-x-auto overflow-y-hidden flex-nowrap` `TabsList` construct. It gets `scrollbar-strip` too rather than keeping the chunky bar in the one place nobody listed. `TabStrip.tsx` is not a third case - it stopped scrolling and uses a `+N` overflow menu.
- The hover-reveal refinement shipped; the always-visible 4px fallback was not needed.
- `rg "webkit-scrollbar" app/src` now finds only `index.css` (baseline + strip utility) and one comment in `scroll-area.tsx`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

The issue calls this CSS-only and visual, and most of it is. One test was worth writing anyway, because this diff *is* the "hand-rolled sibling of a primitive" defect the repo keeps finding, three times over: `app/src/components/ui/scrollbar-systems.test.ts` (6 cases) derives each repeat from `index.css` instead of writing the number three times - class-for-class for `ScrollArea`, converted to px for Monaco - and holds the standard properties inside the `@supports` guard, since one declaration outside it silently turns the webkit block back into decoration. Mutation-checked, each independently: `ScrollArea` back to `w-2.5` → red; its thumb back to `bg-border` → red; baseline back to `w-2` → red; guard removed → red; `SCROLLBAR_SIZE` back to 14 → red; the Monaco option wiring deleted → red; all restored → 6 passed.

Visual verification was headless Chromium 141 against the real built `index.css` and a real Monaco instance, light and dark, screenshots at rest and hovered rather than the Electron app - the numbers in the table above come from those harnesses. The hovered 4px strip thumb is perceptible in both themes.

- `pnpm test` - **515 files, 5541 tests, all passing**
- `pnpm type-check` - clean (renderer, electron, electron-tests)
- `pnpm lint` - clean
- `prettier --check` on the touched files - clean
- `mkdocs build --strict -f .github/mkdocs.yml` - clean

No engine build or ctest run: the diff is CSS, three className strings, two components and a doc, so no engine test could change colour.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/design-system.md` in the same commits: the width values, the new `scrollbar-strip` row in the utility table (the old row named `scrollbar-thin`, a class deleted when the baseline landed), a section on the strip utility, a table naming all three systems and where each one's width lives, and - most importantly - the standing claim that "Chromium honours `::-webkit-scrollbar` over `scrollbar-width`" is now corrected with the measurement, since that sentence is exactly what would lead the next reader to re-add the properties outside the guard. Not formatted with prettier, per the repo rule.

## Related Issues

Closes #914
Closes #920