### PR TITLE
fix(tooling): find clang-tidy-19 in the pre-commit hook, as clang-format is

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,12 +129,19 @@ vayu/
   probes the version and says so rather than passing silently - if you see that
   warning, install a newer clang-tidy (Ubuntu 24.04 ships 18 by default;
   `apt install clang-tidy-19` is what CI uses) or lean on CI, which lints the
-  engine sources your pull request changes on clang-tidy 19. A finding fails in
-  both places - the hook refuses the commit, CI fails the engine job - and both
-  gate the **lines** you changed, not the whole file, so a finding older than
-  your diff stops neither (#902). A hook refusal is therefore a merge blocker
-  you are seeing early. To lint whole staged files instead, backlog and all,
-  commit once with `VAYU_TIDY_FULL=1`. See
+  engine sources your pull request changes on clang-tidy 19.
+
+  The hook finds what that install gives you: like the formatter above, it looks
+  for `clang-tidy-19` first and a plain `clang-tidy` second, because apt leaves
+  the plain name at the distribution's 18 while Homebrew's LLVM and the Windows
+  installer use it (#918). Both tools share one lookup, so the two cannot drift
+  apart again.
+
+  A finding fails in both places - the hook refuses the commit, CI fails the
+  engine job - and both gate the **lines** you changed, not the whole file, so
+  a finding older than your diff stops neither (#902). A hook refusal is
+  therefore a merge blocker you are seeing early. To lint whole staged files
+  instead, backlog and all, commit once with `VAYU_TIDY_FULL=1`. See
   [Static Analysis](docs/engine/building.md#static-analysis).
 
 #### Naming Conventions

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -588,7 +588,9 @@ second - `apt install clang-format-19` leaves the plain name at Ubuntu's 18,
 while Homebrew's LLVM 19 installs it under the plain name - and when neither is
 a 19 it says so and checks nothing, on the same reasoning as the clang-tidy
 probe: the pin is exact, so an answer from another major is a wrong answer
-rather than a missing one. `git clang-format --staged` is deliberately not used;
+rather than a missing one. That two-name lookup is
+[shared with the clang-tidy pass](#static-analysis), not duplicated in it.
+`git clang-format --staged` is deliberately not used;
 it formats the changed lines, and a staged file it called clean could still fail
 this whole-file check.
 
@@ -745,6 +747,21 @@ Both need **clang-tidy 19 or newer**: `engine/.clang-tidy` uses
 the config file and lints nothing. The hook probes the version and warns loudly
 instead of exiting clean over an empty scan; a contributor without a current
 clang-tidy loses the early warning, not the check.
+
+The hook looks for `clang-tidy-19` first and a plain `clang-tidy` second, for
+the reason the formatter does: `apt install clang-tidy-19` - the instruction the
+warning itself gives - leaves the plain name at Ubuntu's 18, while Homebrew's
+LLVM 19 and the Windows installer use the plain name. Probing only the plain
+name meant the most common setup installed a 19, found the 18, and was told to
+install a 19 (#918); the warning now names the nearest candidate it rejected, so
+"you have an 18" reads differently from "you have nothing".
+
+**One `find_llvm_tool` in `scripts/pre-commit` answers for both tools**, with
+the comparison a parameter - `exact` for clang-format, whose pin is not a floor,
+and `minimum` for clang-tidy, whose pin is. It is shared rather than copied
+because that is precisely how the two halves came to disagree: the formatter
+learned about the packaging split and the linter did not. `pre-commit_test.sh`
+pins the sharing as well as the behaviour.
 
 CI's version differs per leg, and none of it is a free choice:
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -39,7 +39,11 @@ engine/
   costs a five-figure-line rewrite.
 - Linter: clang-tidy (`.clang-tidy` configs in `engine/`, `engine/src/runtime/`,
   `engine/tests/`), **19 or newer** - the root config uses
-  `ExcludeHeaderFilterRegex`, which an older binary rejects outright. **A
+  `ExcludeHeaderFilterRegex`, which an older binary rejects outright. The hook
+  finds it under `clang-tidy-19` or a plain `clang-tidy`, through the same
+  `find_llvm_tool` the formatter uses (`exact` there, `minimum` here) - apt
+  splits the names and Homebrew does not, and probing the plain name alone made
+  the hook skip on the setup CONTRIBUTING.md prescribes (#918). **A
   finding is a failure now** (#885): `WarningsAsErrors: '*'` in
   `engine/.clang-tidy` is the one place that says so, and both consumers read
   their verdict from clang-tidy's exit status - the pre-commit hook refuses the

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -17,6 +17,65 @@ elif [ -d "/usr/local/opt/llvm/bin" ]; then
     export PATH="/usr/local/opt/llvm/bin:$PATH"
 fi
 
+# Finds the binary for a pinned LLVM tool, which is not simply its plain name.
+# `apt install clang-format-19` - what CONTRIBUTING.md tells an Ubuntu
+# contributor to run - installs `/usr/bin/clang-format-19` and leaves the plain
+# `clang-format` at the distribution's 18, while Homebrew's LLVM 19 and the
+# Windows installer both use the plain name. Only apt splits them, so both names
+# are tried, versioned first.
+#
+# One helper rather than a copy per tool (issue #918). The clang-tidy pass used
+# to look under the plain name alone, so a contributor who followed that install
+# instruction to the letter still got the 18, was told to install a 19, and
+# linted nothing - the very packaging split the clang-format pass had already
+# been taught about. A second copy of the lookup would drift from the first the
+# next time either pin moved.
+#
+# $1 tool, $2 the major it is pinned to, $3 how to compare: `exact` for
+# clang-format, where another major is a wrong answer rather than a missing one,
+# or `minimum` for clang-tidy, whose pin is the floor that can parse the config.
+# The comparison is a parameter because it is the only thing the two lookups do
+# not share.
+#
+# Sets LLVM_TOOL to the binary that satisfied the pin, empty when none did, and
+# LLVM_TOOL_NEAREST to a "name version" for the last candidate that did not -
+# which is what lets the warning name what you have instead of repeating what to
+# install. A candidate whose `--version` prints nothing numeric is rejected, not
+# assumed current.
+find_llvm_tool() {
+    local tool="$1" want="$2" mode="$3"
+    local candidate version major accepted
+    LLVM_TOOL=
+    LLVM_TOOL_NEAREST=
+    for candidate in "${tool}-${want}" "$tool"; do
+        if ! command -v "$candidate" &> /dev/null; then
+            continue
+        fi
+        # The tolerant of the two regexes this replaces: it also matches a
+        # two-component `19.1`, which some builds report.
+        version=$("$candidate" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)
+        major=${version%%.*}
+        accepted=
+        case "$mode" in
+            exact) [ "$major" = "$want" ] && accepted=1 ;;
+            minimum) [ -n "$major" ] && [ "$major" -ge "$want" ] 2>/dev/null && accepted=1 ;;
+            # Reachable only by editing this file wrongly, and silent if it were
+            # tolerated: an unknown mode would accept nothing and every pass
+            # would skip, which is the failure this hook exists to stop being.
+            *)
+                echo "pre-commit: find_llvm_tool got an unknown comparison mode '$mode'" >&2
+                exit 1
+                ;;
+        esac
+        if [ -n "$accepted" ]; then
+            LLVM_TOOL="$candidate"
+            return 0
+        fi
+        LLVM_TOOL_NEAREST="$candidate ${version:-(unknown version)}"
+    done
+    return 1
+}
+
 # The oldest clang-tidy that can parse engine/.clang-tidy. `ExcludeHeaderFilterRegex`
 # landed in LLVM 19; an older binary rejects the whole config file, so it lints
 # *nothing* and still exits 0 - a hook that scans an empty set and reports success
@@ -68,24 +127,11 @@ done
 # Nothing engine-side staged: no probe, no message. An app-only commit has no
 # business hearing about the C++ formatter.
 if [ ${#FORMAT_FILES[@]} -gt 0 ]; then
-    # Discovery before the probe, and under both names, because the two ways to
-    # have a 19 look different: `apt install clang-format-19`, which is what
-    # CONTRIBUTING.md tells an Ubuntu contributor to run, leaves plain
-    # `clang-format` at the distribution's 18, while Homebrew's LLVM 19 installs
-    # it as `clang-format`.
-    CLANG_FORMAT=
-    NEAREST_CLANG_FORMAT=
-    for CANDIDATE in "clang-format-${CLANG_FORMAT_MAJOR}" clang-format; do
-        if ! command -v "$CANDIDATE" &> /dev/null; then
-            continue
-        fi
-        CANDIDATE_VERSION=$("$CANDIDATE" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)
-        NEAREST_CLANG_FORMAT="$CANDIDATE ${CANDIDATE_VERSION:-(unknown version)}"
-        if [ "${CANDIDATE_VERSION%%.*}" = "$CLANG_FORMAT_MAJOR" ]; then
-            CLANG_FORMAT="$CANDIDATE"
-            break
-        fi
-    done
+    # Discovery before the probe, under both names, and `exact` because this pin
+    # is not a floor: a 20 is as wrong an answer here as an 18.
+    find_llvm_tool clang-format "$CLANG_FORMAT_MAJOR" exact
+    CLANG_FORMAT="$LLVM_TOOL"
+    NEAREST_CLANG_FORMAT="$LLVM_TOOL_NEAREST"
 
     if [ -z "$CLANG_FORMAT" ]; then
         # A skip rather than a refusal, on the same reasoning as the clang-tidy
@@ -129,32 +175,33 @@ end_hook() {
     exit 0
 }
 
+# Discovery and version probe, before any file is linted, and said loudly and
+# once: the failure this replaces was silent, and a contributor on 18 had no way
+# to tell "clean" from "never ran". Absent and too-old share one message because
+# they share one cure; the nearest candidate is what tells them apart, and
+# naming it is what stops the warning from reading as advice already followed
+# (issue #918).
+#
+# The `Lint changed engine sources` step in .github/workflows/pr-tests.yml lints
+# the same lines on clang-tidy 19 before a pull request can merge, so this stays
+# a skip rather than a refusal to commit - a missing or old local toolchain costs
+# a contributor nothing but the early warning.
+find_llvm_tool clang-tidy "$MIN_CLANG_TIDY_MAJOR" minimum
+CLANG_TIDY="$LLVM_TOOL"
+if [ -z "$CLANG_TIDY" ]; then
+    echo "WARNING: no clang-tidy ${MIN_CLANG_TIDY_MAJOR} or newer found${LLVM_TOOL_NEAREST:+ (nearest: ${LLVM_TOOL_NEAREST})}."
+    echo "         engine/.clang-tidy uses ExcludeHeaderFilterRegex, which needs clang-tidy"
+    echo "         >= ${MIN_CLANG_TIDY_MAJOR}; an older binary rejects the whole config and lints nothing."
+    echo "         NOTHING WAS LINTED. Install it ('apt install clang-tidy-${MIN_CLANG_TIDY_MAJOR}',"
+    echo "         'brew install llvm@${MIN_CLANG_TIDY_MAJOR}') or rely on CI, which lints the same"
+    echo "         lines on clang-tidy ${MIN_CLANG_TIDY_MAJOR}."
+    end_hook
+fi
+
 # What it looks at - the lines this commit changes, or whole files under
-# VAYU_TIDY_FULL - is announced below, once the staged set is known.
-echo "Running clang-tidy on staged C++ changes..."
-
-# Check if clang-tidy is installed
-if ! command -v clang-tidy &> /dev/null; then
-    echo "clang-tidy not found. Skipping linting."
-    end_hook
-fi
-
-# Version probe, before any file is linted. Said loudly and once: the failure this
-# replaces was silent, and a contributor on 18 had no way to tell "clean" from
-# "never ran". The `Lint changed engine sources` step in
-# .github/workflows/pr-tests.yml lints the same lines on clang-tidy 19 before a
-# pull request can merge, so this stays a skip rather than a refusal to commit -
-# a missing or old local toolchain costs a contributor nothing but the early
-# warning.
-CLANG_TIDY_VERSION=$(clang-tidy --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-CLANG_TIDY_MAJOR=${CLANG_TIDY_VERSION%%.*}
-if [ -z "$CLANG_TIDY_MAJOR" ] || [ "$CLANG_TIDY_MAJOR" -lt "$MIN_CLANG_TIDY_MAJOR" ] 2>/dev/null; then
-    echo "WARNING: clang-tidy ${CLANG_TIDY_VERSION:-(unknown version)} cannot read engine/.clang-tidy."
-    echo "         It uses ExcludeHeaderFilterRegex, which needs clang-tidy >= ${MIN_CLANG_TIDY_MAJOR}."
-    echo "         NOTHING WAS LINTED. Install a newer clang-tidy (e.g. 'apt install clang-tidy-19')"
-    echo "         or rely on CI, which lints the same lines on clang-tidy 19."
-    end_hook
-fi
+# VAYU_TIDY_FULL - is announced below, once the staged set is known. The binary
+# is named because it need not be the plain one.
+echo "Running ${CLANG_TIDY} on staged C++ changes..."
 
 # Turns one file's staged hunk headers into clang-tidy `--line-filter` ranges.
 #
@@ -296,13 +343,18 @@ for FILE in $LINT_FILES; do
     # no `-Wno-` flag covers. This hook does not do that, because reconfiguring
     # someone's build tree from a git hook would throw away their next
     # incremental build.
+    #
+    # `$CLANG_TIDY`, not `clang-tidy`, in both branches: the discovery above can
+    # settle on `clang-tidy-19` while the plain name is an 18 that cannot read
+    # the config at all, so a branch that invoked the plain name would lint
+    # nothing and say it had linted.
     if [ -f "engine/build/compile_commands.json" ]; then
-        clang-tidy --allow-no-checks --extra-arg=-Wno-ignored-gch \
+        "$CLANG_TIDY" --allow-no-checks --extra-arg=-Wno-ignored-gch \
             "${LINE_FILTER_ARG[@]}" -p engine/build "$FILE" || STATUS=1
     else
         echo "Warning: compile_commands.json not found in engine/build. clang-tidy might report false positives."
         # Fallback: try to include common directories
-        clang-tidy --allow-no-checks "${LINE_FILTER_ARG[@]}" "$FILE" \
+        "$CLANG_TIDY" --allow-no-checks "${LINE_FILTER_ARG[@]}" "$FILE" \
             -- -Iengine/include -Iengine/vendor/quickjs-ng || STATUS=1
     fi
 done

--- a/scripts/test/pre-commit_test.sh
+++ b/scripts/test/pre-commit_test.sh
@@ -29,6 +29,14 @@
 # `|| FORMAT_STATUS=1` that keeps its status, or widening the scope past those
 # three roots, reddens the cases below.
 #
+# The fifth is where the binaries are looked for (issue #918). Both tools are
+# packaged two ways - `apt install clang-tidy-19` leaves the plain name at
+# Ubuntu's 18, Homebrew and the Windows installer use the plain name - and the
+# hook knew that about clang-format only, so the clang-tidy half skipped on the
+# setup CONTRIBUTING.md prescribes. One `find_llvm_tool` now answers for both,
+# with the exact-vs-minimum comparison a parameter; reverting either call to a
+# bare name reddens the discovery cases below.
+#
 # Everything here drives the real hook with a stubbed `clang-tidy` on PATH.
 # Linux only: the hook prepends Homebrew's LLVM directory when it exists, which
 # would shadow the stub on a Mac, and the probe itself has no platform-specific
@@ -174,8 +182,16 @@ make_sandbox_path() {
 # range the filter lists for that file, and a run with no filter at all reports
 # every line. Emulated rather than mocked away - a stub that ignored the filter
 # would pass whether or not the hook computed one, which is the whole question.
+#
+# $4, when given, is the single binary name to install it under. By default it
+# goes in under **both** `clang-tidy` and `clang-tidy-19` - the shape of a
+# Homebrew or Windows LLVM, where one install answers to both names, and the
+# only way a case stays a statement about the hook now that it looks under the
+# versioned name first (issue #918): a machine or runner image carrying a real
+# `clang-tidy-19` would otherwise answer instead of the stub, exactly as
+# `make_sandbox_path` keeps a real clang-format out of the format cases.
 make_stub() {
-    local version="$1" flagged="${2:-}" line="${3:-1}" dir
+    local version="$1" flagged="${2:-}" line="${3:-1}" only_name="${4:-}" dir
     dir="$(mktemp -d)"
     cat > "$dir/clang-tidy" <<EOF
 #!/usr/bin/env bash
@@ -228,6 +244,11 @@ fi
 exit 0
 EOF
     chmod +x "$dir/clang-tidy"
+    if [ -z "$only_name" ]; then
+        cp "$dir/clang-tidy" "$dir/clang-tidy-19"
+    elif [ "$only_name" != "clang-tidy" ]; then
+        mv "$dir/clang-tidy" "$dir/$only_name"
+    fi
     echo "$dir"
 }
 
@@ -323,12 +344,72 @@ repo="$(make_repo)"
 stub="$(mktemp -d)"
 printf '#!/usr/bin/env bash\necho "clang-tidy from somewhere"\nexit 0\n' > "$stub/clang-tidy"
 chmod +x "$stub/clang-tidy"
+# Both names, for the reason make_stub installs both: the hook looks under
+# `clang-tidy-19` first, and a real one on PATH would answer this question.
+cp "$stub/clang-tidy" "$stub/clang-tidy-19"
 out="$(cd "$repo" && PATH="$stub:$PATH" bash "$HOOK" 2>&1)"
 rm -rf "$repo" "$stub"
 if [[ "$out" == *"NOTHING WAS LINTED"* ]]; then
     pass "a clang-tidy whose version cannot be read is refused, not assumed current"
 else
     fail "an unreadable version is refused" "got: $out"
+fi
+
+# --- Where the binary is looked for (issue #918) ------------------------------
+echo
+echo "pre-commit clang-tidy discovery"
+
+# Ubuntu 24.04's shape, on the half of the hook that had never been told about
+# it: `apt install clang-tidy-19` - which is what the warning above, and
+# CONTRIBUTING.md, tell you to run - installs `/usr/bin/clang-tidy-19` and
+# leaves the plain `clang-tidy` at the distribution's 18. The hook probed the
+# plain name alone, so following that instruction to the letter still linted
+# nothing and printed the same instruction again.
+#
+# The 18 is placed *earlier* on PATH than the 19, so PATH order alone would find
+# it: what is under test is that the versioned name is preferred by name.
+#
+# Mutation-check: revert the clang-tidy discovery to the plain name and both
+# cases below redden, while the 18-skip cases above stay green.
+repo="$(make_repo)"
+plain="$(make_stub 18.1.3 "" 1 clang-tidy)"
+versioned="$(make_stub 19.1.0 main.cpp 1 clang-tidy-19)"
+set +e
+out="$(cd "$repo" && PATH="$plain:$versioned:$(make_sandbox_path)" bash "$HOOK" 2>&1)"
+status=$?
+set -e
+rm -rf "$repo" "$plain" "$versioned"
+if [[ "$out" == *"Running clang-tidy-19 "* && "$out" == *"STUB_LINTED"* ]]; then
+    pass "clang-tidy-19 is preferred over a plain clang-tidy that is 18"
+else
+    fail "clang-tidy-19 is found beside an 18" "exit $status: $out"
+fi
+
+# The half that makes the first one mean something: the 19 it found is the one
+# that lints, and its finding is still a refusal. A hook that discovered the
+# versioned binary and then invoked the plain name would satisfy the case above
+# and gate nothing.
+if [[ "$status" -ne 0 && "$out" != *"NOTHING WAS LINTED"* ]]; then
+    pass "a finding from the versioned clang-tidy refuses the commit"
+else
+    fail "the versioned clang-tidy's finding refuses the commit" "exit $status: $out"
+fi
+
+# One lookup, not one per tool - the drift this issue exists to end, since the
+# clang-format half learned about the packaging split and the clang-tidy half
+# did not. A source scan, and it proves it read the hook first: a guard that
+# counts matches in an empty string reports two of nothing and passes.
+if [[ ! -s "$HOOK" ]]; then
+    fail "scripts/pre-commit was read" "empty or missing: $HOOK"
+else
+    definitions="$(grep -cE '^find_llvm_tool\(\)' "$HOOK" || true)"
+    calls="$(grep -cE '^[[:space:]]*find_llvm_tool ' "$HOOK" || true)"
+    if [[ "$definitions" -eq 1 && "$calls" -eq 2 ]]; then
+        pass "discovery is one helper, called by both the format and the lint pass"
+    else
+        fail "discovery is shared, not copied" \
+             "definitions: $definitions, calls: $calls (want 1 and 2)"
+    fi
 fi
 
 # --- The hook's verdict (issue #885) -----------------------------------------


### PR DESCRIPTION
## Description

**Plan.** Root cause: `scripts/pre-commit` invoked clang-tidy under the plain name only, but `apt install clang-tidy-19` - what the hook's own warning and `CONTRIBUTING.md` tell an Ubuntu contributor to run - installs `/usr/bin/clang-tidy-19` and leaves plain `clang-tidy` at the distribution's 18. So the prescribed setup still linted nothing and printed the same advice back. #908 had already taught the clang-format pass about that packaging split, leaving the two halves of one file disagreeing about it. Approach: extract the lookup as one `find_llvm_tool` helper called by both passes, with the comparison a parameter (`exact` for clang-format, whose pin is not a floor; `minimum` for clang-tidy, whose pin is what can parse `ExcludeHeaderFilterRegex`). Rejected alternative: copying the clang-format loop into the clang-tidy pass - two lookups is exactly how the halves came to disagree, and the copy would drift again the next time either pin moved.

Verified the problem still exists as described at `886dc86`; the code matches the issue's anchors exactly, so no adaptation was needed.

Blast radius traced. `scripts/pre-commit` has two consumers: contributors via `scripts/install-git-hooks.sh`, and `scripts/test/pre-commit_test.sh` in the `Test the pre-commit hook` CI step. Nothing else sources it. Both clang-tidy call sites (compile-database branch and fallback) now use the discovered binary - either one left on the plain name would lint nothing and report that it had linted, which is the same "written but never read" wiring shape. Removed variables (`CLANG_TIDY_VERSION`, `CLANG_TIDY_MAJOR`, `CANDIDATE_VERSION`) grepped for readers; none remain.

Two deliberate consequences worth naming:

- **Absent and too-old now share one warning**, because they share one cure. What tells them apart is the nearest rejected candidate, which the message names - so "you have an 18" no longer reads identically to "you have nothing". This replaces the quiet `clang-tidy not found. Skipping linting.` one-liner with the loud form the issue asks for.
- **Of the two version-probe regexes, only the tolerant one survives** (`[0-9]+(\.[0-9]+)+`), per the issue's item 3, so a two-component `19.1` is still read.

The `PATH` prepend for Homebrew is untouched, as the issue notes it should be.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`bash scripts/test/pre-commit_test.sh` - **34 passed, 0 failed** (was 31 before; 3 new cases).

New cases, all in the new `pre-commit clang-tidy discovery` block:

1. `clang-tidy-19` at 19 is preferred over a plain `clang-tidy` at 18. The 18 is placed **earlier** on `PATH`, so PATH order alone would find it - what is under test is preference by name.
2. The 19 it found is the one that lints, and its finding still refuses the commit. Without this, a hook that discovered the versioned binary and then invoked the plain name would satisfy (1) and gate nothing.
3. A source scan pinning that discovery is one helper with two callers, which fails loudly if it read an empty `scripts/pre-commit` rather than counting two of nothing.

**Mutation-check, run:** reverting the clang-tidy discovery to a plain-name probe reddens exactly those 3 and leaves all 6 existing probe cases (18 skips loudly, 19 lints, 20 is not "less than" 19, an unreadable version is refused) green. Restored and re-ran: 34/34.

The stub factory now installs under both `clang-tidy` and `clang-tidy-19` by default, for the reason the format cases run on `make_sandbox_path`: now that the hook looks under the versioned name first, a machine or runner image carrying a real `clang-tidy-19` would answer instead of the stub and the suite would be testing its LLVM. `make_stub`'s new 4th parameter overrides that for the case that needs two different versions under the two names.

Also run:

- `shellcheck` **v0.10.0** (the pinned version), CI's exact invocation over all 12 tracked scripts - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - builds, including the new same-page `#static-analysis` anchor (`anchors: warn` + `--strict`).
- Real-environment smoke on a box with only LLVM 18: both warnings render in the same shape, each naming what you actually have, and the hook still exits 0 (a missing toolchain is a skip, not a refusal).

No engine or app suite was run: the diff is two shell scripts and three Markdown files, so no C++ or TypeScript test could change colour - per `CLAUDE.md`'s "scale the verification to what the change could actually break". No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, as the issue lists them: `CONTRIBUTING.md` (the Linting bullet now says the hook finds `clang-tidy-19`), `docs/engine/building.md` (Static Analysis gains the discovery paragraph and the shared-helper note, and the Formatting section's equivalent paragraph now cross-links it instead of implying the lookup is its own), `engine/CLAUDE.md` (the linter bullet names `find_llvm_tool` and its two modes).

## Related Issues
Closes #918

---
_Generated by [Claude Code](https://claude.ai/code/session_016nVQT8VjqSztQ7VuMxUnBj)_