### PR TITLE
fix(app): refuse a remembered data row the file no longer has

### DIFF
--- a/app/src/modules/request-builder/components/UrlBar/SendWithRowDialog.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/SendWithRowDialog.tsx
@@ -215,6 +215,17 @@ export default function SendWithRowDialog({
 	 * and the grid always has a focusable row.
 	 */
 	const selected = typed.kind === "row" ? typed.index : (lastRowIndex ?? 0);
+	/*
+	 * Whether `selected` still names a row of the file just read (issue #894).
+	 *
+	 * Only the fallback can be stale - `parseRowEntry` refuses a number outside
+	 * the file, while neither the remembered index nor a step's repro target is
+	 * clamped against a file that has since shrunk, been re-picked, or been cut
+	 * by a lowered `maxScenarioDataRows`. Named here rather than fixed by
+	 * clamping, for the same reason the typed path refuses: binding the last row
+	 * instead would send a row the user did not ask for and say nothing.
+	 */
+	const selectedMissing = selected >= total;
 
 	const visibleRows = useMemo(
 		() => matchingRows(parsed?.rows ?? [], columns, filter),
@@ -255,7 +266,16 @@ export default function SendWithRowDialog({
 
 	const send = useCallback(
 		(index: number) => {
-			if (!parsed) return;
+			/*
+			 * The one funnel every entry path reaches, so the bounds check lives
+			 * here: `parsed.rows[index]` is typed as a row but is `undefined` for
+			 * an index the file has no row at, and `executeRequest` reads that as
+			 * an ordinary row-less send - the request goes out with every
+			 * `{{data.*}}` token unbound and nothing says so (issue #894). The UI
+			 * refuses before this point; this is what makes the silent send
+			 * unreachable rather than merely unlikely.
+			 */
+			if (!parsed || index < 0 || index >= parsed.rows.length) return;
 			onRowIndexChange(index);
 			setEntry("");
 			onOpenChange(false);
@@ -396,6 +416,17 @@ export default function SendWithRowDialog({
 						{typed.kind === "error" && (
 							<p className="text-[11px] text-destructive-text">{typed.message}</p>
 						)}
+						{/* The same refusal for the row nobody typed: a remembered index,
+						    or a step's repro target, pointing past the file as it reads
+						    now. Said rather than clamped, and the footer's button is
+						    dead while it stands. */}
+						{selectedMissing && (
+							<p className="text-[11px] text-destructive-text">
+								Row {(selected + 1).toLocaleString()} no longer exists - the file
+								has {total.toLocaleString()} {total === 1 ? "row" : "rows"}. Pick
+								one below.
+							</p>
+						)}
 
 						<DialogBody className="rounded-md border border-rule">
 							{visibleRows.length === 0 ? (
@@ -494,18 +525,24 @@ export default function SendWithRowDialog({
 							{/* Names the row it will send, so a row reached by typing a
 							    number is confirmable without hunting for it in the
 							    grid. Clicking a row still sends outright - the fast
-							    loop this feature exists for is one click. */}
+							    loop this feature exists for is one click.
+
+							    Disabled while the named row is not in the file, so the
+							    button never offers a send it would have to make without
+							    a row; the line above the grid says which row and why. */}
 							<button
 								type="button"
+								disabled={selectedMissing}
 								onClick={() => send(selected)}
 								className={cn(
 									"h-8 rounded-md px-3 text-xs font-semibold",
 									"bg-primary-fill text-white border border-primary-fill",
 									"hover:bg-primary-fill/90 hover:border-primary-fill/90",
-									"transition-colors"
+									"disabled:opacity-50 disabled:hover:bg-primary-fill",
+									"disabled:hover:border-primary-fill transition-colors"
 								)}
 							>
-								Send row {selected + 1}
+								Send row {(selected + 1).toLocaleString()}
 							</button>
 						</DialogFooter>
 					</>

--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -734,3 +734,105 @@ describe("arriving from a failed step", () => {
 		expect(useTabsStore.getState().dataRowTarget).toBeNull();
 	});
 });
+
+/**
+ * A remembered row that outlived the file it pointed into (issue #894).
+ *
+ * The typed field refuses a row the file has no row for, and the two indices
+ * nobody types - the remembered one and a step card's repro target - did not:
+ * neither is clamped, and the file underneath them can shrink between the send
+ * that recorded one and the reopen that reads it (an edited file, a re-picked
+ * one, or a lowered `maxScenarioDataRows` cutting the loaded set with no file
+ * change at all). The footer still read "Send row N", and clicking it sent the
+ * request with every `{{data.*}}` token unbound and nothing naming why.
+ *
+ * So these assert the refusal on both sides of it: the visible one (the footer
+ * dead, the reason stated) and the send funnel itself, which is what makes the
+ * silent send unreachable rather than merely hard to reach.
+ */
+describe("a row the file no longer has", () => {
+	const bigCsv = (count: number) =>
+		["id,email", ...Array.from({ length: count }, (_, i) => `${i},user${i}@example.test`)].join(
+			"\n"
+		);
+
+	/** The grid's own Enter, which sends the selected row without a click. */
+	const pressEnterOnGrid = () =>
+		fireEvent.keyDown(screen.getByRole("row", { name: /user0@example\.test/ }), {
+			key: "Enter",
+		});
+
+	it("refuses a remembered row after the file shrank under it", async () => {
+		rememberFile();
+		// The same declared path, read twice: 30 rows when the row was picked, 5
+		// by the time the picker is reopened.
+		let rows = 30;
+		stubReadDataFile(async () => csvBytes(bigCsv(rows)));
+		const execute = vi.fn(async () => {});
+		renderBar(execute, CONTRACT, "req_a");
+
+		openPicker();
+		fireEvent.click(await screen.findByRole("row", { name: /user25@example\.test/ }));
+		await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+		rows = 5;
+		openPicker();
+		await screen.findByRole("row", { name: /user4@example\.test/ });
+
+		// Named, not clamped to row 5: which row was asked for is the thing that
+		// went wrong, and binding a different one would say nothing about it.
+		expect(screen.getByText(/row 26 no longer exists - the file has 5 rows/i)).toBeTruthy();
+
+		const footer = screen.getByRole("button", { name: /^send row 26$/i });
+		expect(footer).toBeDisabled();
+		fireEvent.click(footer);
+		pressEnterOnGrid();
+		// Still the one send from before the file shrank: neither path reached
+		// `executeRequest` with no row bound.
+		expect(execute).toHaveBeenCalledTimes(1);
+
+		// Not a dead end - picking a row that does exist sends as it always did.
+		fireEvent.click(screen.getByRole("row", { name: /user3@example\.test/ }));
+		await waitFor(() => expect(execute).toHaveBeenCalledTimes(2));
+		expect(execute).toHaveBeenLastCalledWith({ id: "3", email: "user3@example.test" });
+	});
+
+	it("refuses a step's repro target the file has no row for", async () => {
+		// What `openRequestWithDataRow` leaves behind (issue #730), pointing past
+		// a file that no longer runs to 501 rows. The dialog opens on it without a
+		// click, so this state is reached with nothing typed and nothing picked.
+		rememberFile();
+		stubReadDataFile(async () => csvBytes(bigCsv(30)));
+		const execute = vi.fn(async () => {});
+		useTabsStore.setState({ dataRowTarget: { requestId: "req_a", rowIndex: 500 } });
+		renderBar(execute, CONTRACT, "req_a");
+
+		await screen.findByRole("row", { name: /user0@example\.test/ });
+		expect(screen.getByText(/row 501 no longer exists - the file has 30 rows/i)).toBeTruthy();
+
+		const footer = screen.getByRole("button", { name: /^send row 501$/i });
+		expect(footer).toBeDisabled();
+		fireEvent.click(footer);
+		pressEnterOnGrid();
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("keeps offering the row it names while the row is in the file", async () => {
+		// The guard's other half: a remembered index inside the file must not be
+		// refused, or the fix would have cost the feature its one-click re-send.
+		rememberFile();
+		stubReadDataFile(async () => csvBytes(bigCsv(30)));
+		const execute = vi.fn(async () => {});
+		useTabsStore.setState({ dataRowTarget: { requestId: "req_a", rowIndex: 25 } });
+		renderBar(execute, CONTRACT, "req_a");
+
+		await screen.findByRole("row", { name: /user25@example\.test/ });
+		expect(screen.queryByText(/no longer exists/i)).toBeNull();
+
+		const footer = screen.getByRole("button", { name: /^send row 26$/i });
+		expect(footer).not.toBeDisabled();
+		fireEvent.click(footer);
+		await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+		expect(execute).toHaveBeenCalledWith({ id: "25", email: "user25@example.test" });
+	});
+});


### PR DESCRIPTION
## Description

**Plan.** Root cause: `SendWithRowDialog`'s `selected` falls back to the remembered index (`:217`) with no bounds check, and `send()` indexed `parsed.rows[index]` unguarded - so an index that outlived the file it pointed into produced `onSend(undefined)`, which `executeRequest` reads as an ordinary row-less send (`{...(dataRow ? {data: dataRow} : {})}`). The request goes out with every `{{data.*}}` token unbound and nothing names the cause. Verified still present at `886dc86`, all three reach paths intact (a shrunken file via `rowIndexByRequest`, an unclamped `dataRowTarget.rowIndex`, and a lowered `maxScenarioDataRows` cutting the loaded set with no file edit). Approach: the component's own stated principle - refuse, don't clamp - applied to the index nobody typed, guarded at the single send funnel and stated in the UI. Alternative rejected: clamping `selected` to the last row, which is exactly what `parseRowEntry`'s doc comment refuses for the typed path ("binding row 500 instead would send something the user did not ask for and say nothing about it") - it would trade a silent wrong-token send for a silent wrong-row send. Also rejected: clearing `lastRowIndex` on file change, floated in the issue as a companion. It is not a fix on its own (the repro target arrives unclamped from another module, and the row cap shrinks the set with no file event to hang it off), and with the funnel guarded it buys nothing.

Three parts, one file:

- **The funnel.** `send()` bounds-checks its index. Every entry path - a row click, the number field's Enter, the footer, the grid's Enter - reaches it, so this is what makes the silent send unreachable rather than merely unlikely.
- **The refusal, said.** A line above the grid names the row and what the file actually has ("Row 26 no longer exists - the file has 5 rows. Pick one below."), in the same place and the same `text-destructive-text` the typed field's refusal uses.
- **The footer, dead while it stands.** `Send row N` is disabled when N is not in the file, so the button never offers a send it would have to make without a row. Disabled styling matches the caret trigger's in the same file.

A remembered index that is still in the file is untouched - the one-click re-send this feature exists for keeps working, and there is a test pinning that so the guard cannot grow into refusing the good case.

One incidental edit, on a line the diff already touches: the footer's row number is `toLocaleString()`d, so the button and the new message agree on `1,001` for a file over a thousand rows the way every other count in this dialog already does.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **515 files, 5,544 tests passed** (5,541 before; the three new ones are in `send-with-row.test.tsx`, which goes 31 → 34). `pnpm type-check`, `pnpm lint` and `pnpm format:check` all clean. No pre-existing failures.

No engine build and no `ctest`: nothing here is C++ and no engine test could change colour (CLAUDE.md's verification-scaling rule). Engine and MCP consumers re-verified as untouched - the MCP send path does not go through this dialog.

The three cases:

- a remembered row after the file shrank under it (30 rows at the send, 5 at the reopen): the reason is stated, the footer is disabled, clicking it and pressing Enter on the grid both leave `executeRequest` at its one earlier call - and picking a row that does exist still sends, so the refusal is not a dead end;
- a step's repro target past the file (`dataRowTarget.rowIndex: 500` against 30 rows), which is the path that arrives with nothing typed and nothing picked;
- a repro target *inside* the file, which must still be offered and sent.

**Mutation-checked, each half separately** - the two refusal tests redden when the funnel's bounds check is reverted to `if (!parsed) return;`, when `disabled={selectedMissing}` is dropped from the footer, and when the message is removed. So neither the visible refusal nor the guard behind it can rot without a red test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: none, as the issue predicted. `docs/design-system.md:1485`'s row-picker entry was checked on contact - it describes the dialog's `2xl` size and why, not this guard.

## Related Issues
Closes #894

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsaSyYEfN7hEAQtXCms8gS)_