### PR TITLE
chore(repo): hygiene micro batch - a root .prettierignore, the three naked TODOs, the three bare eslint-disables

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,21 @@
+# Prettier's domain in this repository is `app/`, and nothing else.
+#
+# `app/` is 100% prettier-clean and CI keeps it that way (`pnpm format:check`,
+# run from `app/` with an app-relative glob, so it never reaches out here).
+# Every other tree is unclean by policy: docs prose is hand-wrapped, the
+# workflows are written to be read as YAML rather than as prettier output, and
+# `docs/design-system.md` reflows ~480 lines on a single pass. CLAUDE.md has
+# said so in prose since before this file existed; prose is what an editor's
+# "format on save" or a stray repo-root `prettier --write` does not read.
+#
+# Written as "ignore everything, then allow `app/`" rather than as a list of the
+# trees that happen to be dirty today, so a tree added tomorrow is protected by
+# default instead of by someone remembering to add a line here. Adding a second
+# prettier-owned tree means one `!` line beside the one below.
+#
+# This changes nothing about `pnpm format:check`, whose cwd and glob never left
+# `app/` - it is the guard rail for every tool that resolves ignores from the
+# repository root.
+
+/*
+!/app/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,14 @@ assert **both** branches.
 
 - **No em-dashes anywhere in the repo.** Use ` - `.
 - **Never run prettier or `eslint --fix` repo-wide**, and never format
-  `docs/design-system.md` - most of the tree isn't prettier-clean and formatting
-  that file reflows ~480 lines. Format only files you touched that were clean
-  before.
+  `docs/design-system.md` - a run reflows ~480 lines of it. The split is not
+  "most of the tree isn't clean": `app/` is prettier-clean to the file and CI
+  keeps it that way (`pnpm format:check`, from `app/` with an app-relative
+  glob), while everything *outside* `app/` is unclean by policy - 64 of the 71
+  Markdown and workflow files there fail a check. The repo-root
+  `.prettierignore` now enforces that boundary mechanically: prettier's domain
+  is `app/`, so a root-resolved run or an editor's format-on-save cannot reflow
+  a doc. Format only files you touched that were clean before.
 - **"Written but never read" is this codebase's most repeated defect** - found
   nine times: state one layer records and no layer displays (SSE errors,
   save-failure reasons, an import phase, parsed cookie attributes), and config

--- a/app/src/errors/error-logger.ts
+++ b/app/src/errors/error-logger.ts
@@ -25,7 +25,11 @@ export interface ErrorContext {
 }
 
 /**
- * Log error to console (and potentially to external service in the future)
+ * Log an error to the console, at the level its severity earns.
+ *
+ * The console is the whole of it. Vayu runs on the user's machine and ships no
+ * telemetry; sending errors anywhere else is a product decision nobody has
+ * made, not a wiring gap to be filled in passing.
  */
 export function logError(
 	error: Error,
@@ -62,9 +66,6 @@ export function logError(
 			console.info("[INFO]", logEntry);
 			break;
 	}
-
-	// TODO: In the future, send to external logging service
-	// Example: sendToLoggingService(logEntry);
 }
 
 /**

--- a/app/src/modules/dashboard/components/charts/uplot/UPlotChart.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/UPlotChart.tsx
@@ -377,6 +377,11 @@ export function UPlotChart({
 			activePlot?.destroy();
 			plotRef.current = null;
 		};
+		// `shapeSig` is the serialized form of everything this effect reads -
+		// series identity, theme, height, sync key, live/x-axis flags - so the
+		// omitted deps are all inside it. Listing `series` or `data` instead
+		// would tear the plot down and rebuild it on every data tick, which the
+		// `setData` effect below exists to avoid.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [shapeSig]);
 

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.diagnostics.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.diagnostics.test.tsx
@@ -97,6 +97,7 @@ vi.mock("@/components/ui", async (importOriginal) => ({
 			if (language !== "json") return;
 			const model = stubModel(VARIABLES_URI, value);
 			onMount?.({ getModel: () => model }, stubMonaco());
+			// Mount once, exactly as a real editor does.
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, []);
 		return <div data-testid={`editor-${language}`} />;

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.tsx
@@ -431,6 +431,10 @@ export function GraphQLBody({
 			clearTimeout(id);
 			useSchemaCache.getState().clearActiveTarget(schemaTarget);
 		};
+		// `targetKey` is `schemaTarget` serialized, which is the identity the
+		// comment above keys on; `schemaTarget` itself is rebuilt every render,
+		// so depending on it would re-introspect the same endpoint on every
+		// keystroke.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [targetKey]);
 

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -139,11 +139,26 @@ export interface ImportMeta {
 	 * Shown in the import preview beside the request and folder counts.
 	 */
 	exampleCount: number;
-	// TODO: populated by parsers so the Preview can warn the user about lossy imports.
-	// Vayu is HTTP-only and has no OAuth execution path; WebSocket/gRPC are dropped and
-	// oauth2/digest/aws/ntlm auth is stored-but-not-executed. Surface both rather than
-	// letting items silently vanish. See ImportModal Preview state.
+	/**
+	 * What the import dropped, so the preview can warn about a lossy import
+	 * rather than letting items silently vanish. Vayu is HTTP-only, so
+	 * WebSocket and gRPC items are dropped outright.
+	 *
+	 * Every entry is stamped by the engine's parse (issue #877), including
+	 * `external_ref` - that count reaches it as `ImportSource.unresolvedRefs`,
+	 * because bundling runs before detection and no parser can know it. Read by
+	 * `lossSummary` / `noticeSummary` in `ImportModal.tsx`, which split the list
+	 * on `INFORMATIONAL_KINDS`: a loss is shown in destructive type, a notice in
+	 * muted.
+	 */
 	skipped: SkippedItem[];
+	/**
+	 * Requests whose auth Vayu stores but does not execute - digest, aws and
+	 * ntlm, the three the engine counts (`import_document.cpp`); oauth2 is not
+	 * among them, since `POST /oauth2/token` executes it. Counted rather than
+	 * skipped: the request imports and sends, only its credentials do not
+	 * travel. Shown by `lossSummary` beside the skip counts.
+	 */
 	nonExecutableAuth: number;
 	/**
 	 * Form-data file parts that arrived without a file to send. An OpenAPI spec

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -694,7 +694,9 @@ Database::Database (const std::string& db_path) {
                 // We proceed to try to open it anyway (which will likely re-throw),
                 // or we could delete it to start fresh?
                 // Starting fresh is better than crashing loop for Vayu.
-                // TODO: Consider alerting user/admin about data loss.
+                // Nothing outside this log line records that the user's
+                // data went away, so the app cannot tell them - carrying
+                // the fact across that boundary is issue #922.
                 vayu::utils::log_warning (
                 "Deleting corrupted database to start fresh...");
                 fs::remove (db_file);


### PR DESCRIPTION
## Description

All four items of #888, one commit per story.

**Plan.** The root cause across the batch is the same: a rule that exists only as prose. CLAUDE.md forbade repo-wide prettier runs, and prose is what an editor's format-on-save does not read; the deferred-work rule says the tracker is the only backlog, and three TODOs carried no issue number; `app/CLAUDE.md` requires a suppression to state its reason, and three did not. The approach is to make each rule mechanical or make the decision explicit, one at a time. The alternative I rejected for item 1 was the issue's literal shape - a `.prettierignore` listing `docs/`, root `*.md` and `.github/` - because that is a denylist of the trees that happen to be dirty today: `engine/`'s JSON, `scripts/`, `shared/` and `.vscode/` are all prettier-parseable and all unlisted, and the next tree added would be unprotected until someone remembered. "Ignore everything, then allow `app/`" (`/*` + `!/app/`) states the actual policy - prettier's domain is `app/` - and is a superset of what the acceptance criterion asks for. Verified empirically, since gitignore re-inclusion has a real parent-directory caveat.

**1. Root `.prettierignore`.** Nothing mechanical kept prettier out of the trees CLAUDE.md protects: `app/.prettierignore` cannot reach `../docs`, and `pnpm format:check` runs from `app/` with an app-relative glob so it never went there anyway. Measured before the change, a root-resolved run flagged **64 of the 71** Markdown and workflow files outside `app/`, `docs/design-system.md` (~480 lines of reflow) among them.

**2. CLAUDE.md wording.** "Most of the tree isn't prettier-clean" undersold an enforced invariant. `app/` is clean to the file and CI keeps it that way; the unclean zone is everything outside it. Reworded to say so, and to name the new guard rail.

**3. The three TODOs**, one answer each:
- `engine/src/db/database.cpp` - **filed as #922.** Real deferred work: a corrupted database with no restorable backup is deleted at startup, and the whole record of it is two log lines. The app comes up looking like a fresh install and never tells the user their data went away; the recovery outcome is a local `bool` the constructor does not return, and `/health` knows nothing about it. The comment now names the issue and states what is missing.
- `app/src/errors/error-logger.ts` - **deleted, a decline.** Vayu runs on the user's machine and ships no telemetry; sending errors elsewhere is a product decision nobody has made, not a wiring gap. `logError`'s doc comment carried the same promise, so it now says the console is the whole of it - otherwise the TODO grows back.
- `app/src/services/importers/types.ts` - **not deferred work**, a field description mislabelled as a TODO, and stale twice: "populated by parsers" predates #877 (every parser is engine-side now), and oauth2 has not been non-executable since `POST /oauth2/token`. Rewritten as the doc comment its neighbours are, naming the writer (the engine's parse; `external_ref` arrives as `ImportSource.unresolvedRefs`, since bundling runs before detection) and the reader (`lossSummary` / `noticeSummary` in `ImportModal.tsx`, split on `INFORMATIONAL_KINDS`). `nonExecutableAuth`'s three kinds - digest, aws, ntlm - read off `import_document.cpp` rather than off the old comment.

Zero `TODO`/`FIXME` now remain in tracked source.

**4. The three bare eslint-disables.** `UPlotChart.tsx:380` and `GraphQLBody.tsx:434` are the same pattern twice: the effect depends on a serialized signature (`shapeSig`, `targetKey`) because the object behind it is rebuilt every render - `gqlSchemaTarget` is a fresh literal in `BodyPanel.tsx`, and listing `series`/`data` would tear the plot down on every data tick, which the `setData` effect exists to avoid. Each comment now names what the signature covers and what the raw dependency would cost. `GraphQLBody.diagnostics.test.tsx:100` gets the one-line reason its two sibling editor stubs already carry.

**Deviations from the issue spec.** Two, both noted above: the allowlist form of `.prettierignore`, and the disable at `GraphQLBody.diagnostics.test.tsx:100` - which the issue called borderline - resolved rather than left, since its two siblings in the same directory already carried the line. The issue's inventory of bare disables was otherwise accurate on contact: `preload.ts`, `useActiveEnvironmentRestore.ts`, `VariableTableEditor.tsx` and `error-logger.ts` all have reasons on the preceding lines.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (config, comments and CLAUDE.md; no behaviour changes)

## Testing

Everything in this PR is a config file, a comment, or Markdown, so the verification is scaled to what could change colour (CLAUDE.md's rule) - plus the two mechanical proofs the issue asks for.

- `.prettierignore` proof, from the repo root: an intentionally-dirty probe under `docs/` is **ignored** (`prettier --list-different`, exit 0) while an intentionally-dirty probe under `app/src/` is still **flagged** (exit 1), so the allowlist protects docs without exempting `app/`. `docs/design-system.md` and the 64 previously-unclean files outside `app/` now report clean from a root-resolved run.
- `cd app && pnpm format:check` - clean (the cwd and glob never left `app/`, unchanged by this PR).
- `cd app && pnpm lint` - clean, with `--report-unused-disable-directives`, which is what would catch a disable edited into suppressing nothing.
- `cd app && pnpm type-check` - clean, all three projects.
- `cd app && pnpm test` - **515 files, 5541 tests, 5541 passed.**
- `clang-format 19` (the pinned version) `--dry-run -Werror` on `engine/src/db/database.cpp` - clean.

No engine build or ctest run: the only engine change is a comment inside a function body, which cannot change compilation or behaviour. No `mkdocs build --strict`: nothing under `docs/` was touched (CLAUDE.md is not published). No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable - not applicable; no behaviour changed, and no test could go from green to red on a comment)
- [x] I have updated documentation (CLAUDE.md, in the same commit as the change it describes)

## Related Issues

Closes #888. Files #922 (the `database.cpp` TODO's real work).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1PKeNvcp8d37uY6No6kWG)_