### PR TITLE
test(ci): assert the pr-tests.yml path-filter routing table

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -65,6 +65,7 @@ jobs:
       installer: ${{ steps.area.outputs.installer }}
       build_script: ${{ steps.area.outputs.build_script }}
       scripts: ${{ steps.area.outputs.scripts }}
+      ci_routing: ${{ steps.area.outputs.ci_routing }}
     steps:
       # Two invocations, because `predicate-quantifier` applies to the whole
       # action and the two kinds of filter need opposite ones. This one answers
@@ -207,6 +208,15 @@ jobs:
               - '**/*.py'
               - 'scripts/pre-commit'
               - '.github/workflows/pr-tests.yml'
+            # The routing table's own suite (#915). Narrow on purpose: it reads
+            # the filters out of this file, so the only two things that can
+            # change its answer are this file and the suite itself. It does not
+            # ride `scripts` above, which routes on every tracked `.sh` and
+            # `.py` in the repository and would run it on changes it cannot be
+            # affected by - and, the other way round, could not see a `.mjs`.
+            ci_routing:
+              - '.github/workflows/pr-tests.yml'
+              - 'scripts/test/routing/**'
 
       # The routing, said out loud. Every job below is gated on these five
       # booleans, and until this step existed the only way to answer "why did
@@ -1082,6 +1092,51 @@ jobs:
           printf '  %s\n' "${files[@]}"
           ruff check --no-cache "${files[@]}"
 
+  # The routing table above, asserted (#915). Its own job rather than a step in
+  # `Script lint`, for two reasons: that job's `if:` is every tracked shell and
+  # Python file, which is a far wider trigger than this can answer differently
+  # to, and its file list comes from `git ls-files` over those two extensions,
+  # which cannot see this suite at all. A dedicated `ci_routing` filter runs it
+  # exactly when the table or the suite changes - which is rare, so the extra
+  # runner start costs almost nothing across a week of pull requests.
+  #
+  # It needs Node for picomatch, which is the point: matching with anything but
+  # the action's own glob engine would prove nothing about CI. That is a
+  # `setup-node` and an `npm ci` over two dependencies, not the app toolchain -
+  # no pnpm, no workspace, no build.
+  ci-routing:
+    name: CI routing
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.ci_routing == 'true'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: scripts/test/routing/package-lock.json
+
+      # `ci`, not `install`: the lockfile pins picomatch to the major the action
+      # itself depends on, and a resolution that drifts off it would silently
+      # test different glob rules than CI runs.
+      - name: Install the matcher
+        working-directory: scripts/test/routing
+        run: npm ci
+
+      - name: Assert the path-filter routing table
+        working-directory: scripts/test/routing
+        run: node paths_filter_test.mjs
+
   ci-gate:
     name: CI gate
     runs-on: ubuntu-latest
@@ -1089,7 +1144,8 @@ jobs:
     # filter cannot be read as "nothing to test". Without it, a broken `changes`
     # job skips everything, and "skipped" would pass this gate on a change
     # nobody ran.
-    needs: [changes, quality, app, engine, engine-format, installer, build-script, scripts]
+    needs:
+      [changes, quality, app, engine, engine-format, installer, build-script, scripts, ci-routing]
     if: always()
     # `actions: read` is what lets the download below reach this run's own
     # artifacts; everything else here reads job results, which need nothing.
@@ -1178,6 +1234,7 @@ jobs:
           check installer "${{ needs.installer.result }}"
           check build-script "${{ needs['build-script'].result }}"
           check scripts   "${{ needs.scripts.result }}"
+          check ci-routing "${{ needs['ci-routing'].result }}"
 
           if [[ $status -ne 0 ]]; then
             echo "CI failed"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 # ./data relative to the working directory). Anchored so it only matches here -
 # the in-tree location, engine/data/, is ignored by engine/.gitignore.
 /data/
+
+# The routing suite's two dependencies (#915). app/node_modules is covered by
+# app/.gitignore; this tree is outside it and has its own tiny package.
+/scripts/test/routing/node_modules/

--- a/docs/building.md
+++ b/docs/building.md
@@ -371,6 +371,11 @@ The project uses GitHub Actions for automated builds:
     later cannot escape them
   - The Windows frontend suite runs as two vitest shards on two runners; the
     `CI gate` job proves they covered every test file between them
+  - Which of those jobs runs at all is decided by the `Detect changes` job's
+    path filters, and `CI routing` asserts that table - it reads the filters
+    out of the workflow and checks a list of (changed files) -> (areas) with
+    the action's own glob matcher, so a glob that stops matching fails loudly
+    instead of silently skipping a matrix
 
 - **Release Build**: `.github/workflows/release.yml`
   - Triggers on version tags (`v*`)

--- a/scripts/test/routing/package-lock.json
+++ b/scripts/test/routing/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "vayu-ci-routing-test",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vayu-ci-routing-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "js-yaml": "4.1.0",
+        "picomatch": "2.3.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    }
+  }
+}

--- a/scripts/test/routing/package-lock.json
+++ b/scripts/test/routing/package-lock.json
@@ -1,46 +1,56 @@
 {
-  "name": "vayu-ci-routing-test",
-  "version": "0.0.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "vayu-ci-routing-test",
-      "version": "0.0.0",
-      "dependencies": {
-        "js-yaml": "4.1.0",
-        "picomatch": "2.3.1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    }
-  }
+	"name": "vayu-ci-routing-test",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "vayu-ci-routing-test",
+			"version": "0.0.0",
+			"dependencies": {
+				"js-yaml": "4.3.1",
+				"picomatch": "2.3.2"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		}
+	}
 }

--- a/scripts/test/routing/package.json
+++ b/scripts/test/routing/package.json
@@ -8,7 +8,7 @@
 		"test": "node paths_filter_test.mjs"
 	},
 	"dependencies": {
-		"js-yaml": "4.1.0",
-		"picomatch": "2.3.1"
+		"js-yaml": "4.3.1",
+		"picomatch": "2.3.2"
 	}
 }

--- a/scripts/test/routing/package.json
+++ b/scripts/test/routing/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "vayu-ci-routing-test",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Asserts the pr-tests.yml path-filter routing table (issue #915). Deliberately separate from app/: this is CI plumbing, not renderer code, and the app's dependency tree should not grow a glob matcher for it.",
+	"type": "module",
+	"scripts": {
+		"test": "node paths_filter_test.mjs"
+	},
+	"dependencies": {
+		"js-yaml": "4.1.0",
+		"picomatch": "2.3.1"
+	}
+}

--- a/scripts/test/routing/paths_filter_test.mjs
+++ b/scripts/test/routing/paths_filter_test.mjs
@@ -1,0 +1,461 @@
+/**
+ * The pr-tests.yml path-filter routing table (issue #915).
+ *
+ * The `changes` job's two `dorny/paths-filter` invocations decide, for every
+ * pull request, which of the areas a change routes to - and therefore whether
+ * the three-platform engine matrix, the app matrix, the installer suites and
+ * the script lint run at all. Both failure directions cost something and only
+ * one of them is visible: routing too much wastes runners (#913, where a
+ * change to `engine/CLAUDE.md` plus any script ran the engine matrix with no
+ * engine source touched), and routing too little makes a job quietly *not*
+ * run - a green pull request that never compiled the engine looks exactly like
+ * a green pull request that did.
+ *
+ * So this reads the filters **out of the workflow file** and asserts a table of
+ * (changed files) -> (areas). It never keeps a second copy of the globs: a
+ * copy would drift and go on passing while the real thing was wrong, which is
+ * the failure it exists to catch.
+ *
+ * It also uses the matcher the action uses - picomatch with `{dot: true}`, and
+ * paths-filter's own quantifier semantics transcribed from its `filter.ts`.
+ * Reimplementing the glob engine here would be the copy-of-a-primitive trap in
+ * its purest form: a hand-rolled matcher that disagrees with picomatch would
+ * report a pass for a routing that CI does differently.
+ *
+ * Run: cd scripts/test/routing && npm ci && node paths_filter_test.mjs
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import yaml from "js-yaml";
+import picomatch from "picomatch";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const WORKFLOW = path.join(REPO_ROOT, ".github", "workflows", "pr-tests.yml");
+
+// paths-filter's own matcher options (`MatchOptions` in src/filter.ts). `dot`
+// is what makes `engine/**` match `engine/.clang-tidy`.
+const MATCH_OPTIONS = { dot: true };
+
+// The action's package.json pins `picomatch: ^2.3.1`, so this package pins 2.x
+// too. A major bump on either side changes glob behaviour, and a test matching
+// under different rules than CI proves nothing - hence the ref check below.
+const EXPECTED_USES = "dorny/paths-filter@v4";
+
+let passed = 0;
+let failed = 0;
+
+function ok(name) {
+	console.log(`  ok - ${name}`);
+	passed += 1;
+}
+
+function bad(name, detail) {
+	console.log(`  FAIL - ${name}`);
+	console.log(`         ${detail}`);
+	failed += 1;
+}
+
+function check(name, condition, detail) {
+	if (condition) ok(name);
+	else bad(name, detail);
+}
+
+// --- reading the filters out of the workflow ------------------------------
+
+/**
+ * Pull every `dorny/paths-filter` invocation out of the `changes` job.
+ *
+ * Throws rather than returning an empty table on anything unexpected. A
+ * selector that silently reads no filters would pass every case below while
+ * asserting nothing, which is the one failure mode this suite cannot survive
+ * quietly (CLAUDE.md's source-scan rule).
+ */
+function readPathFilters(workflowText) {
+	const doc = yaml.load(workflowText);
+	const steps = doc?.jobs?.changes?.steps;
+	if (!Array.isArray(steps)) {
+		throw new Error(
+			"pr-tests.yml has no `changes` job with steps - the filters cannot be read"
+		);
+	}
+
+	const invocations = [];
+	for (const step of steps) {
+		if (typeof step?.uses !== "string" || !step.uses.startsWith("dorny/paths-filter@"))
+			continue;
+		const filtersYaml = step.with?.filters;
+		if (typeof filtersYaml !== "string") {
+			throw new Error(`paths-filter step '${step.id}' has no inline \`filters\` string`);
+		}
+		const parsed = yaml.load(filtersYaml);
+		if (!parsed || typeof parsed !== "object") {
+			throw new Error(`paths-filter step '${step.id}' parsed to no filters`);
+		}
+		invocations.push({
+			id: step.id,
+			uses: step.uses,
+			// The action's own default when the input is absent.
+			quantifier: step.with?.["predicate-quantifier"] ?? "some",
+			filters: parsed,
+		});
+	}
+
+	if (invocations.length === 0) {
+		throw new Error("no paths-filter invocations found in the `changes` job");
+	}
+
+	// One flat name -> rule map. The split into two invocations exists because
+	// the quantifiers differ, and each filter carries its own from here on.
+	const table = {};
+	for (const invocation of invocations) {
+		for (const [name, patterns] of Object.entries(invocation.filters)) {
+			// A filter item can also be a `added|modified:` status map, which changes
+			// what a match means. None of ours is one, and a silent one would make
+			// every expectation below a guess.
+			if (!Array.isArray(patterns) || patterns.some((p) => typeof p !== "string")) {
+				throw new Error(`filter '${name}' is not a plain list of patterns`);
+			}
+			if (patterns.length === 0) {
+				throw new Error(`filter '${name}' has no patterns`);
+			}
+			if (name in table) {
+				throw new Error(`filter '${name}' is declared twice`);
+			}
+			table[name] = { quantifier: invocation.quantifier, patterns, uses: invocation.uses };
+		}
+	}
+	return table;
+}
+
+// --- paths-filter's matching semantics ------------------------------------
+
+// Transcribed from `createRuleItem` in dorny/paths-filter's src/filter.ts.
+// picomatch inverts the result of a matcher built from a negated pattern, so
+// inverting it back gives "the files this pattern excludes".
+function compileRule(pattern) {
+	const matcher = picomatch(pattern, MATCH_OPTIONS, true);
+	const negated = matcher.state.negated;
+	return {
+		isMatch: (file) => matcher(file),
+		isInclude: negated ? undefined : (file) => matcher(file),
+		isExclude: negated ? (file) => !matcher(file) : undefined,
+	};
+}
+
+// Transcribed from `Filter.isMatch`. Each pattern in the list is its own rule
+// item, which is what makes `every` an intersection over patterns.
+function fileMatches(rules, file, quantifier) {
+	switch (quantifier) {
+		case "every":
+			return rules.every((rule) => rule.isMatch(file));
+		case "some-with-excludes": {
+			let included = false;
+			for (const rule of rules) {
+				// An exclusion is final - no later pattern can include the file back.
+				if (rule.isExclude?.(file)) return false;
+				if (!included && rule.isInclude?.(file)) included = true;
+			}
+			return included;
+		}
+		case "some":
+			return rules.some((rule) => rule.isMatch(file));
+		default:
+			throw new Error(`unsupported predicate-quantifier '${quantifier}'`);
+	}
+}
+
+/**
+ * What the `changes` job would output for a changeset.
+ *
+ * A filter is true when *any* changed file satisfies it - the action reports
+ * per filter, not per file, which is the whole of #913: the job conditions AND
+ * two answers that different files may have given.
+ */
+function route(table, files) {
+	const result = {};
+	for (const [name, { quantifier, patterns }] of Object.entries(table)) {
+		const rules = patterns.map(compileRule);
+		result[name] = files.some((file) => fileMatches(rules, file, quantifier));
+	}
+	return result;
+}
+
+// --- the table ------------------------------------------------------------
+
+// Every case names the *complete* set of areas it routes to, so an over-route
+// reddens as loudly as a missing one. `code` is separate because it is not an
+// area: it is the "is there anything here a build could care about" half that
+// every job condition ANDs with its area.
+const CASES = [
+	{
+		name: "an engine source routes to the engine matrix",
+		files: ["engine/src/http/server.cpp"],
+		code: true,
+		areas: ["engine"],
+	},
+	{
+		// What `dot: true` buys. Without it `engine/**` skips every dotfile and the
+		// tidy config could change with no engine job running.
+		name: "an engine dotfile routes to the engine matrix",
+		files: ["engine/.clang-tidy"],
+		code: true,
+		areas: ["engine"],
+	},
+	{
+		name: "an app source routes to the app matrix",
+		files: ["app/src/renderer/App.tsx"],
+		code: true,
+		areas: ["app"],
+	},
+	{
+		// shared/ is aliased to @shared by vitest and vite, so it is app code.
+		name: "a shared asset routes to the app matrix",
+		files: ["shared/icons/logo.svg"],
+		code: true,
+		areas: ["app"],
+	},
+	{
+		name: "build.py routes to both matrices, its own suite and the script lint",
+		files: ["build.py"],
+		code: true,
+		areas: ["app", "engine", "build_script", "scripts"],
+	},
+	{
+		name: "VERSION routes to both matrices and nothing else",
+		files: ["VERSION"],
+		code: true,
+		areas: ["app", "engine"],
+	},
+	{
+		name: ".clang-format routes to the engine matrix alone",
+		files: [".clang-format"],
+		code: true,
+		areas: ["engine"],
+	},
+	{
+		// The #913 defect, in its single-file form.
+		name: "documentation inside a code tree routes nowhere",
+		files: ["engine/CLAUDE.md"],
+		code: false,
+		areas: [],
+	},
+	{
+		// ...and the overshoot the #913 fix must not have: the tree still routes
+		// when a real source changed beside the documentation.
+		name: "documentation beside a source in the same tree still routes",
+		files: ["engine/CLAUDE.md", "engine/src/http/server.cpp"],
+		code: true,
+		areas: ["engine"],
+	},
+	{
+		// The exact changeset from #913: two files, two different halves of the
+		// job condition. `code` is true (the script is not documentation) and the
+		// engine must still be false.
+		name: "documentation plus an unrelated script does not wake the engine matrix",
+		files: ["engine/CLAUDE.md", "scripts/pre-commit"],
+		code: true,
+		areas: ["installer", "scripts"],
+	},
+	{
+		// `*.md` and `**/*.md` are separate patterns because the first does not
+		// match a nested file and the second does not match a root-level one.
+		name: "a root-level markdown file routes nowhere and is not code",
+		files: ["README.md"],
+		code: false,
+		areas: [],
+	},
+	{
+		name: "a nested markdown file routes nowhere and is not code",
+		files: ["docs/architecture.md"],
+		code: false,
+		areas: [],
+	},
+	{
+		name: "the pre-commit hook routes to the installer job and the script lint",
+		files: ["scripts/pre-commit"],
+		code: true,
+		areas: ["installer", "scripts"],
+	},
+	{
+		name: "build.py's own suite routes to the build-script job and the script lint",
+		files: ["scripts/test/vcpkg_baseline_test.py"],
+		code: true,
+		areas: ["build_script", "scripts"],
+	},
+	{
+		// On purpose: a pull request editing the split sees every job it describes.
+		name: "pr-tests.yml routes to every area",
+		files: [".github/workflows/pr-tests.yml"],
+		code: true,
+		areas: ["app", "engine", "build_script", "installer", "scripts", "ci_routing"],
+	},
+	{
+		// This suite's own routing. It is not a `.sh` or a `.py`, so the `scripts`
+		// area cannot carry it and `ci_routing` has to.
+		name: "this suite routes to the routing job alone",
+		files: ["scripts/test/routing/paths_filter_test.mjs"],
+		code: true,
+		areas: ["ci_routing"],
+	},
+	{
+		// `code` without an area is a pass, not a hole: repository metadata has its
+		// own workflows and cannot alter a build artifact.
+		name: "repository metadata is code but routes to no area",
+		files: [".github/labeler.yml"],
+		code: true,
+		areas: [],
+	},
+	{
+		name: "the docs-site machinery is not code",
+		files: [".github/mkdocs.yml", "requirements-docs.txt"],
+		code: false,
+		areas: [],
+	},
+];
+
+function areaNames(table) {
+	return Object.keys(table).filter((name) => name !== "code");
+}
+
+function runCases(table) {
+	const areas = areaNames(table);
+	for (const testCase of CASES) {
+		const routed = route(table, testCase.files);
+		const actualAreas = areas.filter((name) => routed[name]);
+		const expected = [...testCase.areas].sort().join(", ") || "(none)";
+		const actual = [...actualAreas].sort().join(", ") || "(none)";
+		check(
+			testCase.name,
+			routed.code === testCase.code && actual === expected,
+			`${testCase.files.join(" + ")}: code=${routed.code} (expected ${testCase.code}), ` +
+				`areas ${actual} (expected ${expected})`
+		);
+	}
+}
+
+// --- the suite's own completeness -----------------------------------------
+
+function checkTableIsWhatWeThink(table) {
+	check(
+		"the workflow yielded a non-empty filter table",
+		Object.keys(table).length > 0 && Object.values(table).every((f) => f.patterns.length > 0),
+		"no filters were parsed - the suite would have proved nothing"
+	);
+
+	check(
+		"the code filter uses `every` and the areas use `some-with-excludes`",
+		table.code?.quantifier === "every" &&
+			areaNames(table).every((name) => table[name].quantifier === "some-with-excludes"),
+		`quantifiers: ${Object.entries(table)
+			.map(([name, f]) => `${name}=${f.quantifier}`)
+			.join(" ")}`
+	);
+
+	const uses = [...new Set(Object.values(table).map((f) => f.uses))];
+	check(
+		"the action is the version this suite mirrors",
+		uses.length === 1 && uses[0] === EXPECTED_USES,
+		`workflow uses ${uses.join(", ")}, this suite transcribes ${EXPECTED_USES} - ` +
+			"re-read its filter.ts and package.json (picomatch major) before bumping this"
+	);
+
+	// An area nobody gates on is this repository's "written but never read"
+	// defect in wiring form, and an area no case covers is this suite going
+	// blind on the half of the table that grew after it was written.
+	const workflow = fs.readFileSync(WORKFLOW, "utf8");
+	const unread = areaNames(table).filter(
+		(name) => !workflow.includes(`needs.changes.outputs.${name} ==`)
+	);
+	check(
+		"every area filter gates at least one job",
+		unread.length === 0,
+		`no job condition reads: ${unread.join(", ")}`
+	);
+
+	const covered = new Set(CASES.flatMap((c) => c.areas));
+	const uncovered = areaNames(table).filter((name) => !covered.has(name));
+	check(
+		"every area filter has a case that expects it",
+		uncovered.length === 0,
+		`no case routes to: ${uncovered.join(", ")} - add one rather than trusting the glob`
+	);
+}
+
+// --- mutation checks ------------------------------------------------------
+
+// The repository asks for behavioural tests to be mutation-checked: revert the
+// fix, confirm the failure, restore. These run the revert every time rather
+// than once in a pull request body, because a table-driven suite that has gone
+// insensitive still prints a wall of `ok`.
+function checkSensitivity(table) {
+	const asShipped = route(table, ["engine/CLAUDE.md"]);
+	const quantifierReverted = structuredClone(table);
+	quantifierReverted.engine.quantifier = "some";
+	const withRevert = route(quantifierReverted, ["engine/CLAUDE.md"]);
+	check(
+		"reverting #913's quantifier reddens the documentation case",
+		asShipped.engine === false && withRevert.engine === true,
+		`engine routed ${asShipped.engine} as shipped and ${withRevert.engine} under \`some\` - ` +
+			"the case no longer detects the defect it was written for"
+	);
+
+	const engineSource = ["engine/src/http/server.cpp"];
+	const narrowed = structuredClone(table);
+	narrowed.engine.patterns = narrowed.engine.patterns.map((p) =>
+		p === "engine/**" ? "engine/src/db/**" : p
+	);
+	check(
+		"narrowing `engine/**` reddens the engine-source case",
+		route(table, engineSource).engine === true &&
+			route(narrowed, engineSource).engine === false &&
+			narrowed.engine.patterns.includes("engine/src/db/**"),
+		"the engine-source case survives a narrowed tree glob - it would not catch a rename"
+	);
+
+	// The reader must refuse an empty table rather than hand back one, since
+	// every check above would then pass over nothing.
+	let refused = false;
+	try {
+		readPathFilters("jobs:\n  changes:\n    steps:\n      - name: nothing\n");
+	} catch {
+		refused = true;
+	}
+	check(
+		"a workflow with no paths-filter step is refused, not read as empty",
+		refused,
+		"readPathFilters returned a table for a workflow that has no filters"
+	);
+}
+
+// --- main -----------------------------------------------------------------
+
+function main() {
+	console.log("pr-tests.yml path-filter routing table");
+	console.log();
+
+	let table;
+	try {
+		table = readPathFilters(fs.readFileSync(WORKFLOW, "utf8"));
+	} catch (error) {
+		console.log("  FAIL - the filters could not be read out of the workflow");
+		console.log(`         ${error.message}`);
+		return 1;
+	}
+
+	checkTableIsWhatWeThink(table);
+	runCases(table);
+	checkSensitivity(table);
+
+	console.log();
+	console.log(`  ${passed} passed, ${failed} failed`);
+	if (passed === 0) {
+		console.log("  no assertions ran - the suite proved nothing");
+		return 1;
+	}
+	return failed ? 1 : 0;
+}
+
+process.exit(main());

--- a/scripts/test/routing/paths_filter_test.mjs
+++ b/scripts/test/routing/paths_filter_test.mjs
@@ -39,9 +39,10 @@ const WORKFLOW = path.join(REPO_ROOT, ".github", "workflows", "pr-tests.yml");
 // is what makes `engine/**` match `engine/.clang-tidy`.
 const MATCH_OPTIONS = { dot: true };
 
-// The action's package.json pins `picomatch: ^2.3.1`, so this package pins 2.x
-// too. A major bump on either side changes glob behaviour, and a test matching
-// under different rules than CI proves nothing - hence the ref check below.
+// The action's package.json depends on `picomatch: ^2.3.1`, so this package
+// pins 2.3.2 - the patched release that range resolves to, and the same major.
+// A major bump on either side changes glob behaviour, and a test matching under
+// different rules than CI proves nothing - hence the ref check below.
 const EXPECTED_USES = "dorny/paths-filter@v4";
 
 let passed = 0;


### PR DESCRIPTION
## Description

The `changes` job's two `dorny/paths-filter` invocations decide which areas every pull request routes to, and nothing tested them. #913 fixed a routing defect and verified it with an ad-hoc script that did not ship.

**The plan.** Root cause: the routing table is a wiring surface with no reader - both failure directions are reachable and only one is visible. Routing too much wastes runners (#913: `engine/CLAUDE.md` plus any script ran the three-platform engine matrix with no engine source touched, because the two filters are evaluated over the *changeset*, not per file). Routing too little is silent - a green pull request that never compiled the engine looks exactly like one that did. The approach is a suite that reads the filters **out of the workflow file** and asserts a table of (changed files) -> (areas), matching with the action's own engine: picomatch 2.x with `{dot: true}`, and paths-filter's `every` / `some-with-excludes` semantics transcribed from its `filter.ts`. The alternative I rejected is the issue's option (3), asserting the *outcomes* of a synthetic routing report - cheaper to land, but it tests the reporting step rather than the table, and it would still have been green through the #913 defect. Option (2), resolving picomatch at test time over the network, is a gate that fails when npm does. A second copy of the globs was never on the table: it would drift and go on passing while the real thing was wrong, which is the failure this exists to catch.

**Where it runs.** Its own `CI routing` job, gated by a narrow new `ci_routing` filter - this workflow plus `scripts/test/routing/**`. The issue suggested hosting it in `Script lint`; I confirmed that job *can* take a Node step (`setup-node` + `npm ci` over two dependencies, no pnpm and no app toolchain), but not that it should: that job's condition is every tracked `.sh` and `.py` in the repository, which is far wider than anything this can answer differently to, and its file list comes from `git ls-files` over those two extensions, so it could never see a `.mjs`. A dedicated filter runs the suite exactly when the table or the suite changes. **Deviation from the issue noted here** - it recommends `Script lint` as the first candidate.

**Guarding its own blind spots.** A table-driven suite that has gone insensitive still prints a wall of `ok`, so:

- it throws rather than returning an empty table if no paths-filter step, no inline `filters`, or a status-map filter item is found - the source-scan rule;
- it fails if an area filter gates no job (`written but never read`, in wiring form) or has no case expecting it, so a sixth area cannot be added and silently go unasserted;
- it pins the action ref it mirrors, with a message naming what to re-read before bumping;
- both required mutations run **every time** rather than being claimed once in this body: reverting #913's quantifier must redden the documentation case, and narrowing `engine/**` must redden the engine-source case.

## Type of Change

- [x] New feature (a CI test where there was none)
- [x] Documentation update (`docs/building.md` job list)

## Testing

`node scripts/test/routing/paths_filter_test.mjs` - **26 assertions, 26 passed, 0 failed.** 18 routing cases (engine source, engine dotfile, app source, `shared/`, `build.py`, `VERSION`, `.clang-format`, doc-in-a-code-tree alone and beside a source, the exact #913 changeset, root-level and nested `.md`, `scripts/pre-commit`, `vcpkg_baseline_test.py`, `pr-tests.yml` routing everywhere, this suite's own routing, `.github/labeler.yml`, the docs-site machinery), 5 structural checks, 3 sensitivity checks. Each case names the **complete** expected area set, so an over-route reddens as loudly as a missing one.

Mutation-checked against the real workflow file, not just in memory:

| Mutation | Result |
|---|---|
| `some-with-excludes` -> `some` on the area step (revert #913) | 17 failed, including `documentation inside a code tree routes nowhere` |
| `engine/**` -> `engine/src/db/**` | 4 failed, including `an engine source routes to the engine matrix` |
| `dot: true` -> `dot: false` in the suite | 4 failed, including `an engine dotfile routes to the engine matrix` |
| drop `needs.changes.outputs.ci_routing` from the job condition | 1 failed: `every area filter gates at least one job` |

`mkdocs build --strict` clean. `npm audit` clean (see below). Prettier-clean against the repo config.

No engine or app source changed, so per CLAUDE.md's verification-scaling rule neither suite could change colour and neither was run - the routing suite and the docs build are what a failure here would look like.

**Second commit:** the versions first committed (picomatch 2.3.1, js-yaml 4.1.0) carry open high-severity advisories - ReDoS and POSIX character-class method injection in picomatch, prototype pollution and three quadratic-complexity DoS reports in js-yaml. Neither is reachable here (the only YAML read is this repository's own workflow, the only globs are the ones it declares), but they would have arrived as Dependabot security alerts against a two-dependency test package. Both are pinned to the patched release on the same major, and picomatch 2.3.2 is what paths-filter's own `^2.3.1` range resolves to - so this still matches with what the action installs.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (the change *is* the test)
- [x] I have updated documentation (`docs/building.md`, same commit)

## Related Issues

Closes #915

---
_Generated by [Claude Code](https://claude.ai/code/session_014xkAF9r6S5UEDXZP4GFtLW)_