### PR TITLE
feat(engine): adopt C++23 - probe the floor, flip the standard, fix the backwards error type

### DIFF
--- a/.github/workflows/cxx-feature-probe.yml
+++ b/.github/workflows/cxx-feature-probe.yml
@@ -1,0 +1,118 @@
+name: C++ feature probe
+
+# The toolchain floor, measured rather than remembered (issue #901, phase 0).
+#
+# A standard bump is a decision about the *worst* compiler in the matrix, and
+# the matrix is three vendors whose library support lands years apart -
+# libstdc++ ships std::expected in GCC 13, clang 18 on the same libstdc++
+# cannot see it, and AppleClang and MSVC answer for themselves. Nobody can hold
+# that table in their head, and a table written down in an issue is out of date
+# the next time a runner image rolls. So it is a job: one tiny translation unit
+# per feature, compiled at the probed standard on every CI platform, reporting
+# what exists where.
+#
+# It gates nothing. The feature verdicts never fail the job - a "no" is the
+# answer, not an error - and the job stays green while reporting one. What does
+# fail it is the probe being unable to measure at all (see the dialect
+# self-check in scripts/cxx-feature-probe/CMakeLists.txt), because a broken
+# instrument reporting "no" nine times looks exactly like a verdict.
+#
+# `paths:` here is safe in the way pr-tests.yml explains it is not there: that
+# workflow owns the required `CI gate` check, so a run it never starts leaves a
+# pull request unmergeable. This one is required by nothing. A pull request
+# that does not touch the probe has nothing to learn from running it, and the
+# standard question comes up about once a language version.
+on:
+  workflow_dispatch:
+    inputs:
+      standard:
+        description: 'C++ standard to probe (23, 26, ...)'
+        required: false
+        default: '23'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'scripts/cxx-feature-probe/**'
+      - '.github/workflows/cxx-feature-probe.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    # Minutes, not tens of minutes: this configures a CMake project with no
+    # dependencies and builds nothing. The timeout is a runaway guard.
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The three legs the engine actually ships on, each on the compiler
+          # its pr-tests.yml counterpart uses by default...
+          - os: ubuntu-latest
+            label: Ubuntu / default g++
+          - os: macos-latest
+            label: macOS / AppleClang
+          - os: windows-latest
+            label: Windows / MSVC
+          # ...plus the one alternative #901 names as a live decision: if
+          # ubuntu's default GCC fails a feature phase 2 wants, the choice is
+          # between pinning this compiler on the runner and dropping the
+          # feature. That is only answerable with both columns in front of you.
+          - os: ubuntu-latest
+            label: Ubuntu / g++-14
+            cxx: g++-14
+            apt: g++-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install the compiler this leg probes
+        if: matrix.apt != ''
+        # `|| true`: "the image does not offer this compiler" is a result the
+        # probe step reports, not a job failure. Failing here would answer the
+        # pinning question with a red X instead of with a table.
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends ${{ matrix.apt }} || true
+
+      - name: Probe
+        shell: bash
+        env:
+          LABEL: ${{ matrix.label }}
+          PROBE_CXX: ${{ matrix.cxx }}
+          # Empty on a pull_request run, where the default below applies.
+          STANDARD: ${{ inputs.standard }}
+        run: |
+          set -euo pipefail
+          standard="${STANDARD:-23}"
+
+          echo "### ${LABEL}" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "${PROBE_CXX:-}" ] && ! command -v "$PROBE_CXX" >/dev/null 2>&1; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`$PROBE_CXX\` is not available on this runner image, so nothing was probed." \
+              >> "$GITHUB_STEP_SUMMARY"
+            echo "$PROBE_CXX is not available on this runner image."
+            exit 0
+          fi
+
+          args=(-S scripts/cxx-feature-probe -B probe-build -DVAYU_PROBE_STANDARD="$standard")
+          if [ -n "${PROBE_CXX:-}" ]; then
+            args+=(-DCMAKE_CXX_COMPILER="$PROBE_CXX")
+          fi
+
+          cmake "${args[@]}"
+
+          {
+            echo ""
+            cat probe-build/probe-results.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -693,6 +693,46 @@ jobs:
           done < <(git diff --name-only "$base" HEAD -- "${roots[@]}" \
             | grep -E '\.(c|cpp|h|hpp)$' || true)
 
+          # Windows cannot lint a *header* as an input, so it does not try.
+          #
+          # `compile_commands.json` holds one entry per translation unit and so
+          # none for a `.hpp`; clang-tidy synthesises a command for a file it
+          # cannot look up. On Linux that synthesised command still finds the
+          # standard library. On Windows it does not find the MSVC one, and the
+          # result is not a lint finding but a parse failure of the whole STL -
+          # `no template named 'optional' in namespace 'std'` at every
+          # `std::optional` in `types.hpp`, twenty errors deep, before any check
+          # runs. `WarningsAsErrors: '*'` turns that into a failed engine job.
+          # Measured on #926, where the same run linted every changed `.cpp`
+          # cleanly on the same runner and failed only on the two headers.
+          #
+          # What is lost is smaller than it looks: `HeaderFilterRegex` in
+          # engine/.clang-tidy already reports diagnostics *inside* a header
+          # through every translation unit that includes it, so a header changed
+          # alongside its consumers is still linted here. What is genuinely not
+          # covered on this leg is a pull request that changes a header and no
+          # `.cpp` at all. #930 has the flags that would let clang-tidy parse
+          # the MSVC STL directly, which is the real fix; this keeps the gate
+          # honest on the other two legs in the meantime rather than turning it
+          # off everywhere.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            headers=()
+            translation_units=()
+            for file in ${changed[@]+"${changed[@]}"}; do
+              case "$file" in
+                *.h | *.hpp) headers+=("$file") ;;
+                *) translation_units+=("$file") ;;
+              esac
+            done
+            if [[ ${#headers[@]} -gt 0 ]]; then
+              {
+                echo "- clang-tidy (Windows): **${#headers[@]}** changed header(s) are not linted as inputs here - the synthesised command cannot parse the MSVC standard library (#930). They are still linted through the translation units that include them:"
+                printf '  - `%s`\n' "${headers[@]}"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+            changed=(${translation_units[@]+"${translation_units[@]}"})
+          fi
+
           # The non-empty-scan proof this repository asks of every source
           # scanning guard: name what is about to be linted, so a step that
           # silently narrowed to nothing cannot read as a pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Vayu - Claude Code Guide
 
 Vayu is a high-performance API testing and load-testing platform. It uses a
-**sidecar architecture**: a C++20 engine (daemon) runs alongside an Electron +
+**sidecar architecture**: a C++23 engine (daemon) runs alongside an Electron +
 React UI, communicating over HTTP on port 9876.
 
-- **Engine** (`engine/`): C++20, CMake + vcpkg, AGPL-3.0
+- **Engine** (`engine/`): C++23, CMake + vcpkg, AGPL-3.0
 - **App** (`app/`): Electron + React + TypeScript, Apache-2.0
 - **`build.py`**: the single entry point for every build operation
 - **`VERSION`**: single source of truth for the version
@@ -44,7 +44,8 @@ python build.py -t            # Build with tests enabled
 cd app && pnpm run electron:dev   # Run the app
 ```
 
-Prerequisites: CMake >= 3.25, Ninja, a C++20 compiler, Node.js >= 20.19 (22 LTS
+Prerequisites: CMake >= 3.25, Ninja, a C++23 compiler (GCC 13+, Clang 19+ on
+libstdc++, MSVC 2022+), Node.js >= 20.19 (22 LTS
 recommended, see `app/.nvmrc`), pnpm >= 10, and vcpkg with `$VCPKG_ROOT` set on
 Linux/macOS. On Linux and macOS also `autoconf`, `autoconf-archive`, `automake`
 and `libtool` - vcpkg builds libsodium from source there and runs `autoreconf`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Vayu collapses that workflow into one app. Build a request once, point the load 
 
 ## Performance
 
-The HTTP core is a multi-worker libcurl event loop in C++20, isolated from the Electron UI by a local HTTP sidecar so rendering never blocks on the request load. In practice that lets a single laptop saturate a gigabit link while the dashboard keeps streaming metrics frame-by-frame - well past what Node.js-backed Electron tools manage on the same hardware.
+The HTTP core is a multi-worker libcurl event loop in C++23, isolated from the Electron UI by a local HTTP sidecar so rendering never blocks on the request load. In practice that lets a single laptop saturate a gigabit link while the dashboard keeps streaming metrics frame-by-frame - well past what Node.js-backed Electron tools manage on the same hardware.
 
 **Proof - head-to-head vs `wrk` and `vegeta`.** Same mock server, same machine, same session, matched concurrency (64), measured from a standalone engine:
 
@@ -156,7 +156,7 @@ See [Architecture Documentation](https://athrvk.github.io/vayu/architecture/) fo
 | UI state | Zustand |
 | Server state | TanStack Query |
 | Styling | Tailwind CSS v4 |
-| HTTP engine | C++20 + libcurl |
+| HTTP engine | C++23 + libcurl |
 | Scripting | QuickJS (embedded JS engine) |
 | Database | SQLite via sqlite_orm |
 | Build | CMake + vcpkg (C++), pnpm + Vite (app) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  How Vayu works: an Electron UI and a C++20 engine as a local sidecar over HTTP, the process lifecycle, and why the split exists.
+  How Vayu works: an Electron UI and a C++23 engine as a local sidecar over HTTP, the process lifecycle, and why the split exists.
 ---
 
 # Vayu System Architecture
@@ -92,7 +92,7 @@ The Engine is the "muscle"-a headless daemon optimized for maximum I/O throughpu
 - Data persistence (SQLite)
 
 **Technology Stack:**
-- **C++20**: Core language
+- **C++23**: Core language
 - **cpp-httplib**: HTTP server
 - **libcurl**: HTTP client (HTTP/1.1, HTTP/2 via nghttp2 - HTTP/3 is not supported)
 - **QuickJS**: JavaScript engine for scripts

--- a/docs/compare/vayu-vs-bruno.md
+++ b/docs/compare/vayu-vs-bruno.md
@@ -44,7 +44,7 @@ in both PEM-pair and PKCS#12 form. Detail:
 
 Bruno's collection runner executes your requests in sequence on a Node.js
 runtime - correct for a functional suite, and not built to be a load generator.
-Vayu's engine is a separate C++20 process driving a multi-worker libcurl event
+Vayu's engine is a separate C++23 process driving a multi-worker libcurl event
 loop, which is why a single laptop reaches **tens of thousands of req/s** and why
 the interface stays smooth while it does: the renderer never shares a thread with
 the request load. On a loopback target the engine measured **56,880 req/s**,

--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -48,7 +48,7 @@ JMeter's classic constraint is its concurrency model: one thread per virtual
 user, on a JVM, which means the load generator's own resource profile becomes
 something you tune before you can trust the numbers - heap size, thread ramp,
 and the standing advice to run without the GUI because the GUI itself distorts
-the result. Vayu's engine is a multi-worker libcurl event loop in C++20, so
+the result. Vayu's engine is a multi-worker libcurl event loop in C++23, so
 concurrency is not threads, and it runs as a **sidecar process** next to the UI
 rather than inside it. That is the architectural reason you can watch a live
 dashboard *while* the run saturates a target: the renderer never shares a thread

--- a/docs/compare/vayu-vs-postman.md
+++ b/docs/compare/vayu-vs-postman.md
@@ -47,7 +47,7 @@ works: *does it still work at a thousand a second?* That is a second tool - k6,
 JMeter, or the Postman collection runner at a fraction of the throughput - which
 means a second config, a second copy of the endpoint, and a context switch every
 time. In Vayu the load tester points at the request you already built. The
-engine is a multi-worker libcurl event loop in C++20, running as a sidecar
+engine is a multi-worker libcurl event loop in C++23, running as a sidecar
 process so the UI never shares a thread with the request load, and it sustains
 **tens of thousands of req/s** while the dashboard streams percentiles live.
 The numbers, the method, and a one-command reproduction are on the

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -64,6 +64,32 @@ The HTTP server handles all API requests from the Electron UI. It runs on `127.0
 - Server-Sent Events (SSE) for real-time metrics streaming
 - Single-threaded request handling (non-blocking I/O)
 
+#### How a route says no
+
+Two shapes, and the difference between them is the point:
+
+- A **testable core** - `create_collection_response`, `import_apply_response` -
+  returns `std::pair<int, nlohmann::json>`. Success and failure are both
+  something to send, so the pair is the *response*, and the handler around it
+  only writes it to the wire. `error_response (status, message)` builds the
+  failing one.
+- A **field applier or guard** - `apply_json_field`, `reject_client_supplied_id`,
+  `apply_request_fields` - returns `RouteResult`, which is
+  `std::expected<void, RouteError>`: nothing on success, and on failure the
+  `{status, body}` the caller should answer with. `route_error (status, message)`
+  builds the refusal; `as_response` turns one into the pair a core returns.
+
+These used to be `std::optional<std::pair<int, nlohmann::json>>`, where an
+*empty* optional meant success (issue #901). That reads backwards at every call
+site - `if (err)` is the failure path, `return std::nullopt` means "fine" - and
+a dropped return value silently means "no error", which is why the two most
+dangerous of them carried `[[nodiscard]]` by hand. `std::expected` puts the
+direction in the type: `if (auto outcome = f (...); !outcome) return outcome;`
+propagates, and the response is reachable only through `.error ()`.
+
+All error bodies, either way, come from `error_body` - one shape,
+`{"error": {"code", "message"}}`, which the app's http-client reads.
+
 ### Listeners
 
 This is the engine's whole listener inventory. The management API is the only long-lived one;

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -504,6 +504,38 @@ directly (`daemon.cpp`, `cli.cpp`, `http/client.cpp`, `http/server.cpp`,
 first. Including `vayu/version.hpp` from a `.cpp` is fine, and from a header only
 where that header is not itself broadly included.
 
+### The C++ standard, and the probe that answers a bump
+
+The engine is C++20 (`CMAKE_CXX_STANDARD 20`, `STANDARD_REQUIRED ON`). Raising
+that is a decision about the **worst compiler in the matrix**, not about the
+best: the three platforms ship library support years apart, so "C++23 has
+`std::expected`" is not a fact about the build until each of GCC, AppleClang and
+MSVC has been asked.
+
+`scripts/cxx-feature-probe/` asks them. It is a standalone CMake project - one
+tiny translation unit per feature, compiled *and linked* at a standard the
+engine has not adopted, reporting a per-feature table:
+
+```bash
+cmake -S scripts/cxx-feature-probe -B /tmp/probe                       # default compiler
+cmake -S scripts/cxx-feature-probe -B /tmp/probe -DCMAKE_CXX_COMPILER=g++-14
+cmake -S scripts/cxx-feature-probe -B /tmp/probe -DVAYU_PROBE_STANDARD=26
+```
+
+There is no build step; the table lands in the configure log and in
+`<build dir>/probe-results.md`. In CI it is the `C++ feature probe` workflow -
+four legs (Ubuntu on its default `g++` and on `g++-14`, macOS on AppleClang,
+Windows on MSVC), run from **Run workflow** and automatically on a pull request
+that changes the probe. It gates nothing: an unavailable feature is the answer,
+and the job stays green reporting it. The job fails only when the probe cannot
+measure - which it checks for, rather than assuming, by asserting that the
+requested dialect actually reached the compiler before it trusts a single
+verdict.
+
+Results are recorded on the issue that asked for them (#901 for C++23), not in
+the repository, so no checked-in file can drift out of date against a runner
+image that rolled last week. See `scripts/cxx-feature-probe/README.md`.
+
 ### Compiler warnings, and the three that are suppressed
 
 The engine builds **warning-clean** on Linux and macOS, and a release build is

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -763,6 +763,17 @@ disables every check, and clang-tidy calls an empty check list a usage error
 rather than a clean run, so the one exempt directory would otherwise be the only
 one that fails.
 
+**A changed header is an input on Linux only.** `compile_commands.json` has one
+entry per translation unit and none for a `.hpp`, so clang-tidy synthesises a
+command for a header handed to it directly. On Linux that command still finds
+libstdc++; on Windows it does not find the MSVC STL, and the result is the whole
+standard library failing to parse - `no template named 'optional' in namespace
+'std'` - which `WarningsAsErrors: '*'` turns into a failed job. The Windows leg
+therefore lints translation units only. Little is lost, because
+`HeaderFilterRegex` reports findings *inside* a header through every translation
+unit that includes it; what is not covered there is a pull request that changes
+a header and no `.cpp`. Issue #930 carries the flags that would fix it properly.
+
 ### The precompiled header
 
 The engine builds with a PCH, and clang-tidy replays the compile command that

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -29,10 +29,16 @@ python build.py --test-only
 ## Prerequisites
 
 - **CMake**: 3.25 or higher
-- **C++ Compiler**: C++20 compatible
-  - Clang 15+ (recommended)
-  - GCC 12+
-  - MSVC 2022+ (Windows)
+- **C++ Compiler**: C++23 capable, which since #901 means the library, not just
+  the dialect flag
+  - GCC 13+ (13.3 is what CI builds on)
+  - Clang 19+ against libstdc++ - clang 18 compiles C++23 but cannot see
+    libstdc++'s `<expected>`, which is gated behind a concepts macro it does not
+    advertise; against libc++ it is fine from 18
+  - AppleClang as shipped with a current Xcode (CI measures 21)
+  - MSVC 2022+ (Windows; CI measures 19.51)
+
+  These are measurements, not folklore - see the feature probe below.
 - **vcpkg**: Package manager (auto-detected or install separately)
 - **Ninja**: Build system (optional, but recommended for faster builds)
 - **Autotools** (Linux and macOS only): `autoconf`, `autoconf-archive`,
@@ -506,11 +512,27 @@ where that header is not itself broadly included.
 
 ### The C++ standard, and the probe that answers a bump
 
-The engine is C++20 (`CMAKE_CXX_STANDARD 20`, `STANDARD_REQUIRED ON`). Raising
-that is a decision about the **worst compiler in the matrix**, not about the
-best: the three platforms ship library support years apart, so "C++23 has
-`std::expected`" is not a fact about the build until each of GCC, AppleClang and
-MSVC has been asked.
+The engine is C++23 (`CMAKE_CXX_STANDARD 23`, `STANDARD_REQUIRED ON`), raised
+from 20 by issue #901. Raising it is a decision about the **worst compiler in
+the matrix**, not about the best: the three platforms ship library support years
+apart, so "C++23 has `std::expected`" was not a fact about the build until each
+of GCC, AppleClang and MSVC had been asked.
+
+What the measurement settled, and what it means for the floor:
+
+| | Ubuntu `g++` 13.3 | macOS AppleClang 21 | Windows MSVC 19.51 |
+|---|---|---|---|
+| `std::expected` | yes | yes | yes |
+| `std::optional` (monadic) | yes | yes | yes |
+| `std::format` (C++20) | yes | yes | yes |
+| `std::move_only_function` | yes | **no** | yes |
+
+The engine uses the first three. It does **not** use `std::move_only_function`,
+however much `thread_pool.hpp`'s `std::function` queue would like to - libc++
+has not shipped it, so on macOS it does not exist. Ubuntu pins no compiler: its
+default GCC covers everything the engine adopted, and `g++-14` adds only
+features that are not on the list (`std::print`, `std::ranges::to`, deducing
+`this`). Re-run the probe before reaching for anything not in the table.
 
 `scripts/cxx-feature-probe/` asks them. It is a standalone CMake project - one
 tiny translation unit per feature, compiled *and linked* at a standard the

--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,7 @@ the tree, variables, auth and scripts.
 
 ## How it fits together
 
-Vayu is a **sidecar**: the Electron + React UI talks to a C++20 daemon over HTTP
+Vayu is a **sidecar**: the Electron + React UI talks to a C++23 daemon over HTTP
 on `127.0.0.1:9876`. That split is why the interface stays responsive while the
 engine saturates a target - and why the engine can be driven on its own, from the
 [command line](engine/cli.md) or by a coding agent over
@@ -283,7 +283,7 @@ persists.
 
 ## Reference
 
-**Engine** - the C++20 daemon: execution, load generation, persistence, scripting.
+**Engine** - the C++23 daemon: execution, load generation, persistence, scripting.
 
 | Document | Covers |
 |---|---|

--- a/engine/.clang-tidy
+++ b/engine/.clang-tidy
@@ -8,10 +8,11 @@ Checks: '
   -bugprone-easily-swappable-parameters,
   -modernize-use-trailing-return-type,
   -readability-convert-member-functions-to-static,
+  -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers
 '
-# Why each of the five above is off. They were unexplained for as long as this
+# Why each of the six above is off. They were unexplained for as long as this
 # file has existed, which is what makes them relitigable - none is a hard call,
 # and a line each is cheaper than having the argument twice.
 #
@@ -23,6 +24,19 @@ Checks: '
 #   modernize-use-trailing-return-type
 #     `auto f() -> T` is a style this codebase does not use. Turning it on
 #     rewrites every declaration in the tree and settles nothing.
+#   readability-function-cognitive-complexity
+#     Reports at the *function declaration*, never at the line that made the
+#     function complex - so the changed-lines scoping the gate is built on
+#     (#885, #902) cannot honour it. Ten functions in the routes layer are over
+#     the threshold today, three of them far over (spec_sync_response 208,
+#     register_execution_routes 168, a spec_sync lambda 126), all of it older
+#     than any diff; the effect is that editing one line anywhere inside one of
+#     them fails the pull request for complexity nobody in it wrote. #926 was
+#     the first to hit this and turned the check off rather than scatter a
+#     NOLINT per function, which would have fixed the gate for exactly the
+#     functions one pull request happened to touch. **#929 owns the debt**: the
+#     numbers, the splits worth doing, and whether a function-scoped check
+#     belongs in a line-scoped gate at all or in a report-only job.
 #   readability-convert-member-functions-to-static
 #     Proposes making a member static whenever its body happens not to touch
 #     `this`. On a public class that is an API change decided by an

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -16,7 +16,12 @@ engine/
 
 ## Conventions
 
-- Standard: C++20, `-Wall -Wextra -Wpedantic`
+- Standard: C++20, `-Wall -Wextra -Wpedantic`. What a *later* standard offers on
+  each platform is measured, not remembered: `scripts/cxx-feature-probe/` is a
+  standalone CMake project that compiles and links one tiny translation unit per
+  feature at a standard the engine has not adopted, and the `C++ feature probe`
+  workflow runs it on all three platforms plus `g++-14`. It gates nothing - see
+  `docs/engine/building.md`, and #901 for the recorded C++23 results.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -1,4 +1,4 @@
-# Engine (C++20 daemon)
+# Engine (C++23 daemon)
 
 The load-testing and request-execution engine. AGPL-3.0. See the repo root
 `CLAUDE.md` for build commands, commit rules and repo-wide conventions.
@@ -16,12 +16,20 @@ engine/
 
 ## Conventions
 
-- Standard: C++20, `-Wall -Wextra -Wpedantic`. What a *later* standard offers on
+- Standard: C++23 (#901), `-Wall -Wextra -Wpedantic`. What a standard offers on
   each platform is measured, not remembered: `scripts/cxx-feature-probe/` is a
   standalone CMake project that compiles and links one tiny translation unit per
-  feature at a standard the engine has not adopted, and the `C++ feature probe`
-  workflow runs it on all three platforms plus `g++-14`. It gates nothing - see
-  `docs/engine/building.md`, and #901 for the recorded C++23 results.
+  feature, and the `C++ feature probe` workflow runs it on all three platforms
+  plus `g++-14`. It gates nothing - see `docs/engine/building.md`, and #901 for
+  the recorded results. The one measurement that shapes the code: **libc++ has no
+  `std::move_only_function`**, so `thread_pool.hpp`'s queue stays
+  `std::function` and every queued task stays copyable. Run the probe before
+  reaching for a C++23 library feature the engine does not already use.
+- An error-or-nothing API is `RouteResult` (`std::expected<void, RouteError>`),
+  never `std::optional<...>` with an empty optional for success - that shape
+  reads backwards at every call site and lets a dropped return pass for "fine".
+  `route_error` builds the refusal, `as_response` converts one to the pair a
+  testable core answers with.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -35,7 +35,7 @@ option(VAYU_WERROR "Treat compiler warnings as errors (CI gate)" ${_vayu_werror_
 # C++ Standard and Compiler Settings
 # ============================================================================
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/engine/include/vayu/http/mock_server.hpp
+++ b/engine/include/vayu/http/mock_server.hpp
@@ -10,6 +10,7 @@
 #include "vayu/db/database.hpp"
 
 #include <cstdint>
+#include <expected>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -132,7 +133,7 @@ struct MockParseError {
 };
 
 /**
- * Validate a `POST /mock/start` payload.
+ * Validate a `POST /mock/start` payload, and yield the request it describes.
  *
  * `collectionId` is the one required field; every other rejection is loud
  * rather than a fallback to the default, for the reason `parse_inbox_start`
@@ -142,9 +143,14 @@ struct MockParseError {
  * There is no `bind`: a mock is loopback-only in v1. Unlike an inbox there is
  * no case for exposing it - it answers with stored example bodies, which can
  * carry whatever a recorded response carried, and the engine has no route auth.
+ *
+ * The parsed request is the *value*, not an out-parameter: this used to return
+ * `std::optional<MockParseError>` with the result written through a reference,
+ * so an empty return meant success and a caller could read a half-filled `out`
+ * it never checked. `std::expected` makes the request unreachable unless the
+ * payload was accepted.
  */
-std::optional<MockParseError>
-parse_mock_start (const nlohmann::json& json, MockStartRequest& out);
+std::expected<MockStartRequest, MockParseError> parse_mock_start (const nlohmann::json& json);
 
 /**
  * Reduce a stored request URL to the path template the mock matches on.

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -10,6 +10,8 @@
 #include <httplib.h>
 
 #include <chrono>
+#include <expected>
+#include <format>
 #include <functional>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -112,6 +114,67 @@ error_body (int status, const std::string& message, std::string_view code = {}) 
     const std::string error_code =
     code.empty () ? default_error_code (status) : std::string (code);
     return nlohmann::json{ { "error", { { "code", error_code }, { "message", message } } } };
+}
+
+/**
+ * The response a refusal produces: the HTTP status, and the body to send with
+ * it.
+ *
+ * Named fields rather than a `std::pair`, because `error->first` at a call site
+ * says nothing about which half is the status - and a helper that builds the
+ * pair by hand can put a 400 in one half and a 500-shaped body in the other.
+ * `route_error` below builds both from one status, so they cannot disagree.
+ */
+struct RouteError {
+    int status = 500;
+    nlohmann::json body;
+};
+
+/**
+ * "Did what it was asked, or here is the response to send instead."
+ *
+ * Every field applier and every guard below returns this. It used to be
+ * `std::optional<std::pair<int, nlohmann::json>>`, where an *empty* optional
+ * meant success - a shape that reads backwards at every call site (`if (err)`
+ * on the failure path, `return std::nullopt` to mean "fine") and that lets a
+ * dropped return value pass silently for "no error". With `std::expected` the
+ * type carries which way is up: `if (!result) return result;` propagates, and
+ * `result.error()` is the only way to reach the response.
+ */
+using RouteResult = std::expected<void, RouteError>;
+
+/**
+ * Build the refusal. One status in, and both halves of the error come out of
+ * it - the duplication that used to spell the status twice
+ * (`std::make_pair (400, error_body (400, ...))`) is gone with it.
+ */
+[[nodiscard]] inline std::unexpected<RouteError>
+route_error (int status, const std::string& message, std::string_view code = {}) {
+    return std::unexpected (RouteError{ status, error_body (status, message, code) });
+}
+
+/**
+ * The `{status, body}` pair a testable route core answers with, built from a
+ * refusal one of the helpers produced.
+ *
+ * The cores return the *response* - success or failure, both are something to
+ * send - so they keep the pair; only the helpers that mean "nothing to report
+ * unless it went wrong" carry `RouteResult`. This is the one seam between the
+ * two, spelled out rather than left as `{ e.status, e.body }` at thirty sites.
+ */
+[[nodiscard]] inline std::pair<int, nlohmann::json> as_response (const RouteError& error) {
+    return { error.status, error.body };
+}
+
+/**
+ * The refusal a core answers with directly, without a helper in between - the
+ * pair-shaped counterpart of `route_error`, and here for the same reason:
+ * `{ 400, error_body (400, ...) }` spells the status twice and the two halves
+ * can drift.
+ */
+[[nodiscard]] inline std::pair<int, nlohmann::json>
+error_response (int status, const std::string& message, std::string_view code = {}) {
+    return { status, error_body (status, message, code) };
 }
 
 /**
@@ -227,8 +290,7 @@ bool is_create) {
  * `[[nodiscard]]` because dropping the returned error is exactly the silent
  * acceptance this helper exists to prevent.
  */
-[[nodiscard]] inline std::optional<std::pair<int, nlohmann::json>>
-apply_json_field (const nlohmann::json& json,
+[[nodiscard]] inline RouteResult apply_json_field (const nlohmann::json& json,
 const char* key,
 std::string& out,
 const char* default_value,
@@ -237,62 +299,61 @@ bool is_create) {
         if (is_create) {
             out = default_value;
         }
-        return std::nullopt;
+        return {};
     }
     const auto& value = json[key];
     if (value.is_null ()) {
         out = default_value;
-        return std::nullopt;
+        return {};
     }
     if (!value.is_object ()) {
-        return std::make_pair (400,
-        error_body (400, std::string ("Invalid '") + key + "': must be a JSON object"));
+        return route_error (400, std::format ("Invalid '{}': must be a JSON object", key));
     }
     out = value.dump ();
-    return std::nullopt;
+    return {};
 }
 
 /**
  * Same rule for a field stored as a dumped **array** of KeyValueEntry
  * (`params` / `headers` on a request, `headers` on a saved example). A null
  * resets to `[]`; a present value must be an array whose every entry carries
- * string `key`/`value` and boolean `enabled`. Returns the 400 body on a
- * malformed entry, nullopt otherwise.
+ * string `key`/`value` and boolean `enabled`. Returns the 400 on a malformed
+ * entry.
  *
  * Here rather than in requests.cpp because saved examples store the same shape
  * and must validate it the same way - a second copy would drift the moment the
  * entry shape gains a field.
  */
-[[nodiscard]] inline std::optional<std::pair<int, nlohmann::json>>
+[[nodiscard]] inline RouteResult
 apply_key_value_field (const nlohmann::json& json, const char* key, std::string& out, bool is_create) {
     if (!json.contains (key)) {
         if (is_create) {
             out = "[]";
         }
-        return std::nullopt;
+        return {};
     }
     const auto& value = json[key];
     if (value.is_null ()) {
         out = "[]";
-        return std::nullopt;
+        return {};
     }
     if (!value.is_array ()) {
-        return std::make_pair (400,
-        error_body (400, std::string ("Invalid '") + key + "': must be an array of {key, value, enabled}"));
+        return route_error (
+        400, std::format ("Invalid '{}': must be an array of {{key, value, enabled}}", key));
     }
     for (size_t i = 0; i < value.size (); ++i) {
         const auto& entry = value[i];
         if (!entry.contains ("key") || !entry["key"].is_string () ||
         !entry.contains ("value") || !entry["value"].is_string () ||
         !entry.contains ("enabled") || !entry["enabled"].is_boolean ()) {
-            return std::make_pair (400,
-            error_body (400,
-            std::string ("Invalid ") + key + " entry at index " + std::to_string (i) +
-            ": missing required field (key, value, or enabled)"));
+            return route_error (400,
+            std::format ("Invalid {} entry at index {}: missing required field "
+                         "(key, value, or enabled)",
+            key, i));
         }
     }
     out = value.dump ();
-    return std::nullopt;
+    return {};
 }
 
 /** Same rule for a boolean field. A non-boolean, non-null value is ignored. */
@@ -361,8 +422,7 @@ inline std::string http_version_valid_list () {
  * drift apart - a hand-written accept-list here would be exactly the risk
  * `all_http_versions()` exists to prevent.
  */
-inline std::optional<std::pair<int, nlohmann::json>> apply_http_version_field (
-const nlohmann::json& json,
+inline RouteResult apply_http_version_field (const nlohmann::json& json,
 const char* key,
 std::string& out,
 const std::string& seed,
@@ -371,11 +431,11 @@ bool is_create) {
         if (is_create) {
             out = seed;
         }
-        return std::nullopt;
+        return {};
     }
     if (json[key].is_null ()) {
         out = seed;
-        return std::nullopt;
+        return {};
     }
 
     if (json[key].is_string ()) {
@@ -385,41 +445,41 @@ bool is_create) {
         // deserialize_request and the config seed accept.
         if (vayu::http_version_from_string (candidate).has_value ()) {
             out = candidate;
-            return std::nullopt;
+            return {};
         }
-        return std::make_pair (400,
-        error_body (400,
-        std::string ("Invalid '") + key + "': '" + candidate +
-        "' is not a valid HTTP version. Valid values: " + http_version_valid_list ()));
+        return route_error (400,
+        std::format (
+        "Invalid '{}': '{}' is not a valid HTTP version. Valid values: {}", key,
+        candidate, http_version_valid_list ()));
     }
 
-    return std::make_pair (400,
-    error_body (400,
-    std::string ("Invalid '") + key +
-    "': must be a string. Valid values: " + http_version_valid_list ()));
+    return route_error (400,
+    std::format ("Invalid '{}': must be a string. Valid values: {}", key,
+    http_version_valid_list ()));
 }
 
 /**
  * A field with no default: absent on create and `null` on either verb are both
- * 400s, because there is nothing to fall back to. Returns the error response
- * body, or nullopt when the value is acceptable (including "absent on update",
- * which keeps the stored value).
+ * 400s, because there is nothing to fall back to. Succeeds when the value is
+ * acceptable, "absent on update" (which keeps the stored value) included.
  */
-inline std::optional<std::pair<int, nlohmann::json>>
-apply_required_string_field (const nlohmann::json& json, const char* key, std::string& out, bool is_create) {
+inline RouteResult apply_required_string_field (const nlohmann::json& json,
+const char* key,
+std::string& out,
+bool is_create) {
     if (!json.contains (key)) {
         if (is_create) {
-            return std::make_pair (400,
-            error_body (400, std::string ("Missing required field: ") + key));
+            return route_error (400, std::format ("Missing required field: {}", key));
         }
-        return std::nullopt; // Absent on update -> keep.
+        return {}; // Absent on update -> keep.
     }
     if (json[key].is_null ()) {
-        return std::make_pair (400,
-        error_body (400, std::string ("Invalid '") + key + "': null is not allowed (this field has no default)"));
+        return route_error (400,
+        std::format (
+        "Invalid '{}': null is not allowed (this field has no default)", key));
     }
     out = json[key].get<std::string> ();
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -435,15 +495,13 @@ apply_required_string_field (const nlohmann::json& json, const char* key, std::s
  * is exactly the caller this catches, and accepting `{"id": null}` would leave
  * it believing the field is honoured.
  */
-inline std::optional<std::pair<int, nlohmann::json>> reject_client_supplied_id (
-const nlohmann::json& json) {
+inline RouteResult reject_client_supplied_id (const nlohmann::json& json) {
     if (!json.contains ("id")) {
-        return std::nullopt;
+        return {};
     }
-    return std::make_pair (400,
-    error_body (400,
+    return route_error (400,
     "id is assigned by the engine; omit it "
-    "(bulk import: POST /import/apply)"));
+    "(bulk import: POST /import/apply)");
 }
 
 /**
@@ -456,16 +514,16 @@ const nlohmann::json& json) {
  * Runs before the record lookup, so the answer to a malformed body does not
  * depend on whether the target happens to exist.
  */
-inline std::optional<std::pair<int, nlohmann::json>>
-reject_mismatched_body_id (const nlohmann::json& json, const std::string& path_id) {
+inline RouteResult reject_mismatched_body_id (const nlohmann::json& json,
+const std::string& path_id) {
     if (!json.contains ("id")) {
-        return std::nullopt;
+        return {};
     }
     if (json["id"].is_string () && json["id"].get<std::string> () == path_id) {
-        return std::nullopt;
+        return {};
     }
-    return std::make_pair (400,
-    error_body (400, "Body 'id' must match the id in the path ('" + path_id + "') or be omitted"));
+    return route_error (400,
+    std::format ("Body 'id' must match the id in the path ('{}') or be omitted", path_id));
 }
 
 /**
@@ -475,30 +533,31 @@ reject_mismatched_body_id (const nlohmann::json& json, const std::string& path_i
  * re-deriving the null-vs-absent rule or the per-field validation - a second
  * copy would drift the moment a field is added.
  *
- * Each returns an error response {http_status, json_body} when a no-default
- * field is missing or null (or, for collections, when the proposed parent would
- * form a cycle), and nullopt on success. `is_create` selects the absent-field
- * behaviour; see the rule above. Defined in collections.cpp / requests.cpp /
- * environments.cpp.
+ * Each fails with the response to send when a no-default field is missing or
+ * null (or, for collections, when the proposed parent would form a cycle).
+ * `is_create` selects the absent-field behaviour; see the rule above. Defined
+ * in collections.cpp / requests.cpp / environments.cpp.
  */
-std::optional<std::pair<int, nlohmann::json>> apply_collection_fields (vayu::db::Database& db,
+RouteResult apply_collection_fields (vayu::db::Database& db,
 vayu::db::Collection& c,
 const nlohmann::json& json,
 bool is_create);
-std::optional<std::pair<int, nlohmann::json>> apply_request_fields (vayu::db::Database& db,
+RouteResult apply_request_fields (vayu::db::Database& db,
 vayu::db::Request& r,
 const nlohmann::json& json,
 bool is_create);
-std::optional<std::pair<int, nlohmann::json>>
-apply_environment_fields (vayu::db::Environment& e, const nlohmann::json& json, bool is_create);
+RouteResult apply_environment_fields (vayu::db::Environment& e,
+const nlohmann::json& json,
+bool is_create);
 /**
  * Saved example responses (issue #481) follow the same rule, and the same
  * shared-applier reason: `POST /import/apply` writes examples nested under
  * their request item, so both paths must agree on what a field means and where
  * the body cap sits. Defined in examples.cpp.
  */
-std::optional<std::pair<int, nlohmann::json>>
-apply_request_example_fields (vayu::db::RequestExample& x, const nlohmann::json& json, bool is_create);
+RouteResult apply_request_example_fields (vayu::db::RequestExample& x,
+const nlohmann::json& json,
+bool is_create);
 
 /**
  * Hex-encoded SHA-256 of an OpenAPI document's text (issue #637) - what
@@ -655,7 +714,7 @@ struct SpecComparison {
  * the only failure left here is a binding naming a document the store no longer
  * holds, returned as the `409` both routes give it. Defined in spec_diff.cpp.
  */
-std::optional<std::pair<int, nlohmann::json>> compare_bound_spec (vayu::db::Database& db,
+RouteResult compare_bound_spec (vayu::db::Database& db,
 const std::vector<vayu::db::Collection>& collections,
 const std::unordered_set<std::string>& subtree,
 const std::string& spec_id,
@@ -705,7 +764,7 @@ const vayu::Response& response);
  * write in the same transaction; every path but import passes an empty set.
  * Defined in specs.cpp.
  */
-std::optional<std::pair<int, nlohmann::json>> reject_unbindable_spec (vayu::db::Database& db,
+RouteResult reject_unbindable_spec (vayu::db::Database& db,
 const std::string& openapi,
 const std::unordered_set<std::string>& pending);
 

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -150,7 +150,8 @@ using RouteResult = std::expected<void, RouteError>;
  */
 [[nodiscard]] inline std::unexpected<RouteError>
 route_error (int status, const std::string& message, std::string_view code = {}) {
-    return std::unexpected (RouteError{ status, error_body (status, message, code) });
+    return std::unexpected (
+    RouteError{ .status = status, .body = error_body (status, message, code) });
 }
 
 /**

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -57,24 +57,23 @@ namespace {
  * opposite of what the client asked for and is invisible until the wrong
  * certificate is presented somewhere else.
  */
-std::optional<std::pair<int, nlohmann::json>>
-apply_port_field (const nlohmann::json& json, std::optional<int>& out, bool is_create) {
+RouteResult apply_port_field (const nlohmann::json& json, std::optional<int>& out, bool is_create) {
     if (!json.contains ("port")) {
         if (is_create) {
             out.reset ();
         }
-        return std::nullopt;
+        return {};
     }
     if (json["port"].is_null ()) {
         out.reset ();
-        return std::nullopt;
+        return {};
     }
     if (!json["port"].is_number_integer ()) {
-        return std::make_pair (400,
-        error_body (400, "Invalid 'port': must be an integer 1..65535, or null for every port"));
+        return route_error (400,
+        "Invalid 'port': must be an integer 1..65535, or null for every port");
     }
     out = json["port"].get<int> ();
-    return std::nullopt;
+    return {};
 }
 
 /// Hosts are stored lower-cased, so a match is a compare rather than a second
@@ -90,7 +89,7 @@ std::string lowered (std::string value) {
  *
  * @param self_id The row being updated, which is allowed to keep its own pair.
  */
-std::optional<std::pair<int, nlohmann::json>> reject_duplicate_target (vayu::db::Database& db,
+RouteResult reject_duplicate_target (vayu::db::Database& db,
 const vayu::db::ClientCertificate& candidate,
 const std::string& self_id) {
     for (const auto& row : db.get_client_certificates ()) {
@@ -101,13 +100,12 @@ const std::string& self_id) {
             const std::string target = candidate.port ?
             candidate.host + ":" + std::to_string (*candidate.port) :
             candidate.host;
-            return std::make_pair (409,
-            error_body (409,
+            return route_error (409,
             "A client certificate is already registered for '" + target +
-            "' (id " + row.id + "); update or delete that entry instead"));
+            "' (id " + row.id + "); update or delete that entry instead");
         }
     }
-    return std::nullopt;
+    return {};
 }
 
 /// The wire spellings a `certFormat` may take, for the tail of a rejection.
@@ -140,8 +138,7 @@ std::string cert_format_valid_list () {
  * because "PKCS12" was not the word we wanted is a handshake failure against
  * the endpoint later.
  */
-std::optional<std::pair<int, nlohmann::json>> apply_cert_format_field (
-const nlohmann::json& json,
+RouteResult apply_cert_format_field (const nlohmann::json& json,
 std::string& out,
 std::string_view cert_path,
 bool is_create) {
@@ -154,26 +151,24 @@ bool is_create) {
         if (is_create) {
             seed ();
         }
-        return std::nullopt;
+        return {};
     }
     if (json["certFormat"].is_null ()) {
         seed ();
-        return std::nullopt;
+        return {};
     }
     if (!json["certFormat"].is_string ()) {
-        return std::make_pair (400,
-        error_body (400,
-        "Invalid 'certFormat': must be a string. Valid values: " + cert_format_valid_list ()));
+        return route_error (400,
+        "Invalid 'certFormat': must be a string. Valid values: " + cert_format_valid_list ());
     }
     const std::string candidate = json["certFormat"].get<std::string> ();
     if (!vayu::http::client_cert_format_from_string (candidate)) {
-        return std::make_pair (400,
-        error_body (400,
+        return route_error (400,
         "Invalid 'certFormat': '" + candidate +
-        "' is not a certificate format. Valid values: " + cert_format_valid_list ()));
+        "' is not a certificate format. Valid values: " + cert_format_valid_list ());
     }
     out = candidate;
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -183,23 +178,24 @@ bool is_create) {
  * The check runs on the *merged* row rather than on the body, which is what
  * makes a PUT that moves only `keyPath` still prove the pair works together.
  */
-std::optional<std::pair<int, nlohmann::json>> apply_client_certificate_fields (
-vayu::db::ClientCertificate& c,
+RouteResult apply_client_certificate_fields (vayu::db::ClientCertificate& c,
 const nlohmann::json& json,
 bool is_create) {
-    if (auto err = apply_required_string_field (json, "host", c.host, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "host", c.host, is_create); !outcome) {
+        return outcome;
     }
     c.host = lowered (std::move (c.host));
-    if (auto err = apply_port_field (json, c.port, is_create)) {
-        return err;
+    if (auto outcome = apply_port_field (json, c.port, is_create); !outcome) {
+        return outcome;
     }
-    if (auto err = apply_required_string_field (json, "certPath", c.cert_path, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "certPath", c.cert_path, is_create);
+    !outcome) {
+        return outcome;
     }
     // After `certPath`, because an absent format is read off that file.
-    if (auto err = apply_cert_format_field (json, c.cert_format, c.cert_path, is_create)) {
-        return err;
+    if (auto outcome = apply_cert_format_field (json, c.cert_format, c.cert_path, is_create);
+    !outcome) {
+        return outcome;
     }
     // `keyPath` is required for a PEM pair and must be absent for a PKCS#12
     // bundle, so it cannot go through `apply_required_string_field`: what a
@@ -212,10 +208,9 @@ bool is_create) {
         if (json["keyPath"].is_null ()) {
             c.key_path.clear ();
         } else if (!json["keyPath"].is_string ()) {
-            return std::make_pair (400,
-            error_body (400,
+            return route_error (400,
             "Invalid 'keyPath': must be a string, or null for a "
-            "PKCS#12 entry that carries its own key"));
+            "PKCS#12 entry that carries its own key");
         } else {
             c.key_path = json["keyPath"].get<std::string> ();
         }
@@ -233,17 +228,16 @@ bool is_create) {
     // avoid, and the caller can fix it by naming `certFormat` here.
     const auto format = vayu::http::client_cert_format_from_string (c.cert_format);
     if (!format) {
-        return std::make_pair (400,
-        error_body (400,
-        "Stored 'certFormat' is '" + c.cert_format + "', which is not a certificate format - set it explicitly. Valid values: " +
-        cert_format_valid_list ()));
+        return route_error (400,
+        "Stored 'certFormat' is '" +
+        c.cert_format + "', which is not a certificate format - set it explicitly. Valid values: " +
+        cert_format_valid_list ());
     }
     if (const auto rejection = vayu::http::client_cert_rejection (
         c.host, c.port, *format, c.cert_path, c.key_path)) {
-        return std::make_pair (
-        400, error_body (400, "Invalid client certificate: " + *rejection));
+        return route_error (400, "Invalid client certificate: " + *rejection);
     }
-    return std::nullopt;
+    return {};
 }
 
 } // namespace
@@ -255,8 +249,8 @@ bool is_create) {
  */
 std::pair<int, nlohmann::json>
 create_client_certificate_response (vayu::db::Database& db, const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
 
     vayu::db::ClientCertificate c;
@@ -264,11 +258,11 @@ create_client_certificate_response (vayu::db::Database& db, const nlohmann::json
     c.created_at = now_ms ();
     c.updated_at = now_ms ();
 
-    if (auto err = apply_client_certificate_fields (c, json, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_client_certificate_fields (c, json, /*is_create=*/true); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = reject_duplicate_target (db, c, /*self_id=*/"")) {
-        return *err;
+    if (auto outcome = reject_duplicate_target (db, c, /*self_id=*/""); !outcome) {
+        return as_response (outcome.error ());
     }
 
     db.save_client_certificate (c);
@@ -283,8 +277,8 @@ create_client_certificate_response (vayu::db::Database& db, const nlohmann::json
 std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json) {
-    if (auto err = reject_mismatched_body_id (json, id)) {
-        return *err;
+    if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
+        return as_response (outcome.error ());
     }
     auto existing = db.get_client_certificate (id);
     if (!existing) {
@@ -292,11 +286,12 @@ const nlohmann::json& json) {
     }
 
     vayu::db::ClientCertificate c = *existing;
-    if (auto err = apply_client_certificate_fields (c, json, /*is_create=*/false)) {
-        return *err;
+    if (auto outcome = apply_client_certificate_fields (c, json, /*is_create=*/false);
+    !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = reject_duplicate_target (db, c, /*self_id=*/id)) {
-        return *err;
+    if (auto outcome = reject_duplicate_target (db, c, /*self_id=*/id); !outcome) {
+        return as_response (outcome.error ());
     }
     c.updated_at = now_ms ();
 

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -24,10 +24,9 @@
 namespace vayu::http::routes {
 
 /**
- * Testable core of the parent-id validation for POST /collections, returning
- * an error response {http_status, json_body} when the proposed parent would
- * form a cycle in the collection tree, or std::nullopt when the assignment is
- * legal.
+ * Testable core of the parent-id validation for POST /collections. Fails with
+ * the error response to send when the proposed parent would form a cycle in the
+ * collection tree, and succeeds when the assignment is legal.
  *
  * Two shapes are rejected, both with 400:
  *   - Self-parent (`parentId == id`): a collection cannot be its own parent.
@@ -47,23 +46,21 @@ namespace vayu::http::routes {
  * collections_route_test.cpp. The error body is built by `error_body`, like
  * every other error the engine emits.
  */
-std::optional<std::pair<int, nlohmann::json>> validate_parent_assignment (
-vayu::db::Database& db,
+RouteResult validate_parent_assignment (vayu::db::Database& db,
 const std::string& id,
 const std::optional<std::string>& parent_id) {
     if (!parent_id.has_value ()) {
-        return std::nullopt; // No parent -> no cycle possible.
+        return {}; // No parent -> no cycle possible.
     }
     if (*parent_id == id) {
-        return std::make_pair (400, error_body (400, "A collection cannot be its own parent"));
+        return route_error (400, "A collection cannot be its own parent");
     }
 
     std::unordered_set<std::string> visited;
     std::optional<std::string> cursor = parent_id;
     while (cursor.has_value ()) {
         if (*cursor == id) {
-            return std::make_pair (400,
-            error_body (400, "Cannot move a collection into its own descendant"));
+            return route_error (400, "Cannot move a collection into its own descendant");
         }
         if (!visited.insert (*cursor).second) {
             break; // Already seen -> pre-existing corrupt cycle; stop, bounded.
@@ -74,7 +71,7 @@ const std::optional<std::string>& parent_id) {
         }
         cursor = ancestor->parent_id;
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -122,53 +119,46 @@ constexpr size_t MAX_DATA_SCHEMA_COLUMN_CHARS = 256;
  * with `is_create=true` while the payload's parents are still unwritten, so a
  * check that reached for another record would refuse a legal bulk import.
  */
-static std::optional<std::pair<int, nlohmann::json>> validate_data_schema (
-const nlohmann::json& schema) {
+static RouteResult validate_data_schema (const nlohmann::json& schema) {
     if (schema.contains ("columns")) {
         const auto& columns = schema["columns"];
         if (!columns.is_array ()) {
-            return std::make_pair (400,
-            error_body (400, "Invalid 'dataSchema.columns': must be an array of strings"));
+            return route_error (400, "Invalid 'dataSchema.columns': must be an array of strings");
         }
         if (columns.size () > MAX_DATA_SCHEMA_COLUMNS) {
-            return std::make_pair (400,
-            error_body (400,
+            return route_error (400,
             "Invalid 'dataSchema.columns': " + std::to_string (columns.size ()) +
-            " columns, over the limit of " + std::to_string (MAX_DATA_SCHEMA_COLUMNS)));
+            " columns, over the limit of " + std::to_string (MAX_DATA_SCHEMA_COLUMNS));
         }
         std::unordered_set<std::string> seen;
         for (const auto& column : columns) {
             if (!column.is_string ()) {
-                return std::make_pair (400,
-                error_body (400, "Invalid 'dataSchema.columns': every column must be a string"));
+                return route_error (400,
+                "Invalid 'dataSchema.columns': every column must be a string");
             }
             const auto name = column.get<std::string> ();
             if (name.empty ()) {
-                return std::make_pair (400,
-                error_body (400, "Invalid 'dataSchema.columns': a column name cannot be empty"));
+                return route_error (400,
+                "Invalid 'dataSchema.columns': a column name cannot be empty");
             }
             if (name.size () > MAX_DATA_SCHEMA_COLUMN_CHARS) {
-                return std::make_pair (400,
-                error_body (400,
+                return route_error (400,
                 "Invalid 'dataSchema.columns': a column name is longer than " +
-                std::to_string (MAX_DATA_SCHEMA_COLUMN_CHARS) + " characters"));
+                std::to_string (MAX_DATA_SCHEMA_COLUMN_CHARS) + " characters");
             }
             if (!seen.insert (name).second) {
-                return std::make_pair (400,
-                error_body (400,
-                "Invalid 'dataSchema.columns': duplicate column '" + name + "'"));
+                return route_error (400,
+                "Invalid 'dataSchema.columns': duplicate column '" + name + "'");
             }
         }
     }
     if (schema.contains ("declaredAt") && !schema["declaredAt"].is_number ()) {
-        return std::make_pair (400,
-        error_body (400, "Invalid 'dataSchema.declaredAt': must be a number"));
+        return route_error (400, "Invalid 'dataSchema.declaredAt': must be a number");
     }
     if (schema.contains ("fileName") && !schema["fileName"].is_string ()) {
-        return std::make_pair (400,
-        error_body (400, "Invalid 'dataSchema.fileName': must be a string"));
+        return route_error (400, "Invalid 'dataSchema.fileName': must be a string");
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -188,27 +178,23 @@ const nlohmann::json& schema) {
  * `reject_unbindable_spec`'s, called by each write path with whatever it knows
  * is about to exist.
  */
-static std::optional<std::pair<int, nlohmann::json>> validate_openapi_binding (
-const nlohmann::json& binding) {
+static RouteResult validate_openapi_binding (const nlohmann::json& binding) {
     if (binding.empty ()) {
-        return std::nullopt; // Unbound; nothing to check.
+        return {}; // Unbound; nothing to check.
     }
     if (!binding.contains ("specId") || !binding["specId"].is_string () ||
     binding["specId"].get<std::string> ().empty ()) {
-        return std::make_pair (400,
-        error_body (400,
+        return route_error (400,
         "Invalid 'openapi.specId': a binding must name a stored spec "
-        "(send openapi: {} or null to unbind)"));
+        "(send openapi: {} or null to unbind)");
     }
     if (binding.contains ("specHash") && !binding["specHash"].is_string ()) {
-        return std::make_pair (
-        400, error_body (400, "Invalid 'openapi.specHash': must be a string"));
+        return route_error (400, "Invalid 'openapi.specHash': must be a string");
     }
     if (binding.contains ("syncedAt") && !binding["syncedAt"].is_number ()) {
-        return std::make_pair (
-        400, error_body (400, "Invalid 'openapi.syncedAt': must be a number"));
+        return route_error (400, "Invalid 'openapi.syncedAt': must be a number");
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -218,17 +204,17 @@ const nlohmann::json& binding) {
  * between them is `is_create`.
  *
  * Returns an error response when a no-default field (`name`) is missing or
- * null, or when the proposed parent would form a cycle; nullopt on success.
+ * null, or when the proposed parent would form a cycle.
  *
  * Declared in routes.hpp because `POST /import/apply` applies the same fields to
  * every collection in a bulk payload (issue #96).
  */
-std::optional<std::pair<int, nlohmann::json>> apply_collection_fields (vayu::db::Database& db,
+RouteResult apply_collection_fields (vayu::db::Database& db,
 vayu::db::Collection& c,
 const nlohmann::json& json,
 bool is_create) {
-    if (auto err = apply_required_string_field (json, "name", c.name, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "name", c.name, is_create); !outcome) {
+        return outcome;
     }
 
     apply_string_field (json, "description", c.description, "", is_create);
@@ -257,39 +243,43 @@ bool is_create) {
         c.order = next_sibling_order (db, c.parent_id, c.id);
     }
 
-    if (auto err = apply_json_field (json, "variables", c.variables, "{}", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "variables", c.variables, "{}", is_create);
+    !outcome) {
+        return outcome;
     }
     // Collection auth is never 'inherit' - a collection is the root of a chain.
-    if (auto err = apply_json_field (json, "auth", c.auth, R"({"mode":"none"})", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "auth", c.auth, R"({"mode":"none"})", is_create);
+    !outcome) {
+        return outcome;
     }
     apply_string_field (json, "preRequestScript", c.pre_request_script, "", is_create);
     apply_string_field (json, "postRequestScript", c.post_request_script, "", is_create);
 
     // The declared data contract (issue #599). `{}` is "no contract", which is
     // what both an absent field on create and an explicit null on update mean.
-    if (auto err = apply_json_field (json, "dataSchema", c.data_schema, "{}", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "dataSchema", c.data_schema, "{}", is_create);
+    !outcome) {
+        return outcome;
     }
     // Shape is `apply_json_field`'s; contents are this one's. Only a value the
     // caller actually sent is checked - a stored schema is left alone, so an
     // update that says nothing about it cannot be refused by it.
     if (json.contains ("dataSchema") && json["dataSchema"].is_object ()) {
-        if (auto err = validate_data_schema (json["dataSchema"])) {
-            return err;
+        if (auto outcome = validate_data_schema (json["dataSchema"]); !outcome) {
+            return outcome;
         }
     }
 
     // The OpenAPI binding (issue #637). `{}` is "bound to nothing", which both
     // an absent field on create and an explicit null on update mean - so
     // unbinding is `{"openapi": null}` and needs no verb of its own.
-    if (auto err = apply_json_field (json, "openapi", c.openapi, "{}", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "openapi", c.openapi, "{}", is_create);
+    !outcome) {
+        return outcome;
     }
     if (json.contains ("openapi") && json["openapi"].is_object ()) {
-        if (auto err = validate_openapi_binding (json["openapi"])) {
-            return err;
+        if (auto outcome = validate_openapi_binding (json["openapi"]); !outcome) {
+            return outcome;
         }
     }
 
@@ -297,10 +287,10 @@ bool is_create) {
     // or reparent into a descendant) before they reach the DB - a cycle makes
     // cascade delete loop forever under the global mutex. Cycle/self checks
     // only; parent existence is not required (import creates in bulk).
-    if (auto err = validate_parent_assignment (db, c.id, c.parent_id)) {
-        return err;
+    if (auto outcome = validate_parent_assignment (db, c.id, c.parent_id); !outcome) {
+        return outcome;
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -320,8 +310,8 @@ bool is_create) {
  */
 std::pair<int, nlohmann::json>
 create_collection_response (vayu::db::Database& db, const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
     const std::string id = vayu::utils::generate_id ("col_");
 
@@ -334,8 +324,8 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
     c.created_at = now_ms ();
     c.updated_at = now_ms ();
 
-    if (auto err = apply_collection_fields (db, c, json, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_collection_fields (db, c, json, /*is_create=*/true); !outcome) {
+        return as_response (outcome.error ());
     }
 
     // The spec check and the write are one composite, so they are one lock
@@ -348,8 +338,8 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
     // bulk import binds specs it is about to write - see its declaration.
     std::pair<int, nlohmann::json> result;
     db.with_lock ([&] {
-        if (auto err = reject_unbindable_spec (db, c.openapi, {})) {
-            result = *err;
+        if (auto outcome = reject_unbindable_spec (db, c.openapi, {}); !outcome) {
+            result = as_response (outcome.error ());
             return;
         }
         stamp_binding_from_store (db, c.openapi);
@@ -372,8 +362,8 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
 std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json) {
-    if (auto err = reject_mismatched_body_id (json, id)) {
-        return *err;
+    if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
+        return as_response (outcome.error ());
     }
     auto existing = db.get_collection (id);
     if (!existing) {
@@ -381,8 +371,8 @@ const nlohmann::json& json) {
     }
 
     vayu::db::Collection c = *existing;
-    if (auto err = apply_collection_fields (db, c, json, /*is_create=*/false)) {
-        return *err;
+    if (auto outcome = apply_collection_fields (db, c, json, /*is_create=*/false); !outcome) {
+        return as_response (outcome.error ());
     }
     c.updated_at = now_ms ();
 
@@ -395,8 +385,8 @@ const nlohmann::json& json) {
     std::pair<int, nlohmann::json> result;
     db.with_lock ([&] {
         if (json.contains ("openapi")) {
-            if (auto err = reject_unbindable_spec (db, c.openapi, {})) {
-                result = *err;
+            if (auto outcome = reject_unbindable_spec (db, c.openapi, {}); !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             stamp_binding_from_store (db, c.openapi);

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -41,17 +41,19 @@ namespace vayu::http::routes {
  * Declared in routes.hpp because `POST /import/apply` applies the same fields to
  * every environment in a bulk payload (issue #96).
  */
-std::optional<std::pair<int, nlohmann::json>>
-apply_environment_fields (vayu::db::Environment& e, const nlohmann::json& json, bool is_create) {
-    if (auto err = apply_required_string_field (json, "name", e.name, is_create)) {
-        return err;
+RouteResult apply_environment_fields (vayu::db::Environment& e,
+const nlohmann::json& json,
+bool is_create) {
+    if (auto outcome = apply_required_string_field (json, "name", e.name, is_create); !outcome) {
+        return outcome;
     }
     apply_string_field (json, "description", e.description, "", is_create);
-    if (auto err = apply_json_field (json, "variables", e.variables, "{}", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "variables", e.variables, "{}", is_create);
+    !outcome) {
+        return outcome;
     }
     apply_bool_field (json, "isActive", e.is_active, false, is_create);
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -63,8 +65,8 @@ apply_environment_fields (vayu::db::Environment& e, const nlohmann::json& json, 
  */
 std::pair<int, nlohmann::json>
 create_environment_response (vayu::db::Database& db, const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
     const std::string id = vayu::utils::generate_id ("env_");
 
@@ -77,8 +79,8 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
     e.created_at = now_ms ();
     e.updated_at = now_ms ();
 
-    if (auto err = apply_environment_fields (e, json, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_environment_fields (e, json, /*is_create=*/true); !outcome) {
+        return as_response (outcome.error ());
     }
 
     db.save_environment (e);
@@ -94,8 +96,8 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
 std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json) {
-    if (auto err = reject_mismatched_body_id (json, id)) {
-        return *err;
+    if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
+        return as_response (outcome.error ());
     }
     auto existing = db.get_environment (id);
     if (!existing) {
@@ -103,8 +105,8 @@ const nlohmann::json& json) {
     }
 
     vayu::db::Environment e = *existing;
-    if (auto err = apply_environment_fields (e, json, /*is_create=*/false)) {
-        return *err;
+    if (auto outcome = apply_environment_fields (e, json, /*is_create=*/false); !outcome) {
+        return as_response (outcome.error ());
     }
     e.updated_at = now_ms ();
 

--- a/engine/src/http/routes/examples.cpp
+++ b/engine/src/http/routes/examples.cpp
@@ -43,12 +43,11 @@ constexpr int MAX_HTTP_STATUS = 599;
  * /requests/gone/examples/exa_1` must answer "no such request" rather than
  * silently reading an example whose owner has been deleted.
  */
-std::optional<std::pair<int, nlohmann::json>>
-reject_missing_request (vayu::db::Database& db, const std::string& request_id) {
+RouteResult reject_missing_request (vayu::db::Database& db, const std::string& request_id) {
     if (db.get_request (request_id).has_value ()) {
-        return std::nullopt;
+        return {};
     }
-    return std::make_pair (404, error_body (404, "Request not found"));
+    return route_error (404, "Request not found");
 }
 
 /**
@@ -58,16 +57,16 @@ reject_missing_request (vayu::db::Database& db, const std::string& request_id) {
  * from this path's point of view the resource genuinely does not exist, and
  * saying otherwise would leak which ids are taken.
  */
-std::optional<std::pair<int, nlohmann::json>> load_owned_example (vayu::db::Database& db,
+RouteResult load_owned_example (vayu::db::Database& db,
 const std::string& request_id,
 const std::string& example_id,
 vayu::db::RequestExample& out) {
     auto stored = db.get_request_example (example_id);
     if (!stored || stored->request_id != request_id) {
-        return std::make_pair (404, error_body (404, "Example not found"));
+        return route_error (404, "Example not found");
     }
     out = *stored;
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -99,8 +98,7 @@ bool order_is_defaulted (const nlohmann::json& json) {
  * `import` would hand a user-saved example to the next spec sync to overwrite,
  * and a typo is a payload bug worth naming rather than absorbing.
  */
-std::optional<std::pair<int, nlohmann::json>>
-apply_origin_field (const nlohmann::json& json, std::string& out, bool is_create) {
+RouteResult apply_origin_field (const nlohmann::json& json, std::string& out, bool is_create) {
     namespace example_bounds = vayu::core::constants::request_example;
     const std::string default_origin{ example_bounds::ORIGIN_IMPORT };
 
@@ -108,24 +106,23 @@ apply_origin_field (const nlohmann::json& json, std::string& out, bool is_create
         if (is_create) {
             out = default_origin;
         }
-        return std::nullopt;
+        return {};
     }
     if (json["origin"].is_null ()) {
         out = default_origin;
-        return std::nullopt;
+        return {};
     }
     if (json["origin"].is_string ()) {
         const std::string candidate = json["origin"].get<std::string> ();
         if (candidate == example_bounds::ORIGIN_IMPORT ||
         candidate == example_bounds::ORIGIN_USER) {
             out = candidate;
-            return std::nullopt;
+            return {};
         }
     }
-    return std::make_pair (400,
-    error_body (400,
+    return route_error (400,
     std::string ("Invalid 'origin': must be '") + example_bounds::ORIGIN_IMPORT +
-    "' or '" + example_bounds::ORIGIN_USER + "'"));
+    "' or '" + example_bounds::ORIGIN_USER + "'");
 }
 
 } // namespace
@@ -149,30 +146,29 @@ apply_origin_field (const nlohmann::json& json, std::string& out, bool is_create
  * Declared in routes.hpp because `POST /import/apply` applies the same fields
  * to every example nested in a bulk payload.
  */
-std::optional<std::pair<int, nlohmann::json>>
-apply_request_example_fields (vayu::db::RequestExample& x, const nlohmann::json& json, bool is_create) {
-    if (auto err = apply_required_string_field (json, "name", x.name, is_create)) {
-        return err;
+RouteResult apply_request_example_fields (vayu::db::RequestExample& x,
+const nlohmann::json& json,
+bool is_create) {
+    if (auto outcome = apply_required_string_field (json, "name", x.name, is_create); !outcome) {
+        return outcome;
     }
 
     apply_int_field (json, "status", x.status, 200, is_create);
     if (x.status < MIN_HTTP_STATUS || x.status > MAX_HTTP_STATUS) {
-        return std::make_pair (400,
-        error_body (400,
+        return route_error (400,
         "Invalid 'status': " + std::to_string (x.status) + " is not an HTTP status code (" +
-        std::to_string (MIN_HTTP_STATUS) + "-" + std::to_string (MAX_HTTP_STATUS) + ")"));
+        std::to_string (MIN_HTTP_STATUS) + "-" + std::to_string (MAX_HTTP_STATUS) + ")");
     }
 
-    if (auto err = apply_key_value_field (json, "headers", x.headers, is_create)) {
-        return err;
+    if (auto outcome = apply_key_value_field (json, "headers", x.headers, is_create); !outcome) {
+        return outcome;
     }
 
     apply_string_field (json, "body", x.body, "", is_create);
     if (x.body.size () > vayu::core::constants::request_example::MAX_BODY_BYTES) {
-        return std::make_pair (400,
-        error_body (400,
+        return route_error (400,
         "Example body is " + std::to_string (x.body.size ()) + " bytes, over the " +
-        std::to_string (vayu::core::constants::request_example::MAX_BODY_BYTES) + "-byte limit"));
+        std::to_string (vayu::core::constants::request_example::MAX_BODY_BYTES) + "-byte limit");
     }
 
     apply_string_field (json, "contentType", x.content_type, "", is_create);
@@ -194,8 +190,8 @@ apply_request_example_fields (vayu::db::RequestExample& x, const nlohmann::json&
  */
 std::pair<int, nlohmann::json> list_request_examples_response (vayu::db::Database& db,
 const std::string& request_id) {
-    if (auto err = reject_missing_request (db, request_id)) {
-        return *err;
+    if (auto outcome = reject_missing_request (db, request_id); !outcome) {
+        return as_response (outcome.error ());
     }
     nlohmann::json out = nlohmann::json::array ();
     for (const auto& x : db.get_request_examples (request_id)) {
@@ -216,11 +212,11 @@ const std::string& request_id) {
 std::pair<int, nlohmann::json> create_request_example_response (vayu::db::Database& db,
 const std::string& request_id,
 const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = reject_missing_request (db, request_id)) {
-        return *err;
+    if (auto outcome = reject_missing_request (db, request_id); !outcome) {
+        return as_response (outcome.error ());
     }
 
     const auto limit = vayu::core::constants::request_example::MAX_PER_REQUEST;
@@ -243,8 +239,8 @@ const nlohmann::json& json) {
     x.created_at = now_ms ();
     x.updated_at = x.created_at;
 
-    if (auto err = apply_request_example_fields (x, json, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_request_example_fields (x, json, /*is_create=*/true); !outcome) {
+        return as_response (outcome.error ());
     }
     if (order_is_defaulted (json)) {
         x.order = next_example_order (db, request_id);
@@ -262,19 +258,19 @@ std::pair<int, nlohmann::json> update_request_example_response (vayu::db::Databa
 const std::string& request_id,
 const std::string& example_id,
 const nlohmann::json& json) {
-    if (auto err = reject_mismatched_body_id (json, example_id)) {
-        return *err;
+    if (auto outcome = reject_mismatched_body_id (json, example_id); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = reject_missing_request (db, request_id)) {
-        return *err;
+    if (auto outcome = reject_missing_request (db, request_id); !outcome) {
+        return as_response (outcome.error ());
     }
     vayu::db::RequestExample x;
-    if (auto err = load_owned_example (db, request_id, example_id, x)) {
-        return *err;
+    if (auto outcome = load_owned_example (db, request_id, example_id, x); !outcome) {
+        return as_response (outcome.error ());
     }
 
-    if (auto err = apply_request_example_fields (x, json, /*is_create=*/false)) {
-        return *err;
+    if (auto outcome = apply_request_example_fields (x, json, /*is_create=*/false); !outcome) {
+        return as_response (outcome.error ());
     }
     x.updated_at = now_ms ();
 
@@ -300,12 +296,12 @@ const nlohmann::json& json) {
 std::pair<int, nlohmann::json> delete_request_example_response (vayu::db::Database& db,
 const std::string& request_id,
 const std::string& example_id) {
-    if (auto err = reject_missing_request (db, request_id)) {
-        return *err;
+    if (auto outcome = reject_missing_request (db, request_id); !outcome) {
+        return as_response (outcome.error ());
     }
     vayu::db::RequestExample x;
-    if (auto err = load_owned_example (db, request_id, example_id, x)) {
-        return *err;
+    if (auto outcome = load_owned_example (db, request_id, example_id, x); !outcome) {
+        return as_response (outcome.error ());
     }
 
     if (x.origin == vayu::core::constants::request_example::ORIGIN_IMPORT) {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -162,26 +162,26 @@ void seed_run_times (vayu::db::Run& run, int64_t started_at) {
 // The validated value is written back onto `json["httpVersion"]` so it reaches
 // deserialize_request as a concrete string; `null` would otherwise hit
 // `.get<std::string>()` there and throw.
-std::optional<std::pair<int, nlohmann::json>> normalize_run_http_version (
-nlohmann::json& json) {
+RouteResult normalize_run_http_version (nlohmann::json& json) {
     if (!json.contains ("httpVersion")) {
-        return std::nullopt;
+        return {};
     }
     if (json["httpVersion"].is_null ()) {
         json.erase ("httpVersion");
-        return std::nullopt;
+        return {};
     }
     // Both early returns above mean the key is present and non-null by now, so
     // the two branches of apply_http_version_field that consume `seed` are
     // unreachable from here. The argument is required by the signature; it does
     // not select behaviour at this call site.
     std::string version;
-    if (auto err = apply_http_version_field (json, "httpVersion", version,
-        vayu::to_string (vayu::DEFAULT_HTTP_VERSION), /*is_create=*/false)) {
-        return err;
+    if (auto outcome = apply_http_version_field (json, "httpVersion", version,
+        vayu::to_string (vayu::DEFAULT_HTTP_VERSION), /*is_create=*/false);
+    !outcome) {
+        return outcome;
     }
     json["httpVersion"] = version;
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -1374,11 +1374,11 @@ void register_execution_routes (RouteContext& ctx) {
         // built, so a rejected request leaves no row behind, and the snapshot
         // still reflects the raw client body (sanitize_config_snapshot reads
         // req.body directly, not this normalized `json`).
-        if (auto err = normalize_run_http_version (json)) {
+        if (auto outcome = normalize_run_http_version (json); !outcome) {
             vayu::utils::log_warning (
-            "POST /runs - Invalid httpVersion: " + err->second.dump ());
-            res.status = err->first;
-            res.set_content (err->second.dump (), "application/json");
+            "POST /runs - Invalid httpVersion: " + outcome.error ().body.dump ());
+            res.status = outcome.error ().status;
+            res.set_content (outcome.error ().body.dump (), "application/json");
             return;
         }
 

--- a/engine/src/http/routes/globals.cpp
+++ b/engine/src/http/routes/globals.cpp
@@ -41,8 +41,10 @@ save_globals_response (vayu::db::Database& db, const nlohmann::json& json) {
     vayu::db::Globals g;
     g.id = "globals"; // Singleton ID
 
-    if (auto err = apply_json_field (json, "variables", g.variables, "{}", /*is_create=*/true)) {
-        return *err;
+    if (auto outcome =
+        apply_json_field (json, "variables", g.variables, "{}", /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
 
     g.updated_at = now_ms ();

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -340,7 +340,7 @@ constexpr size_t MAX_IMPORT_ITEMS = 10000;
 const nlohmann::json EMPTY_ITEMS = nlohmann::json::array ();
 
 /** A 400 about the payload as a whole. */
-std::pair<int, nlohmann::json> body_error (const std::string& message) {
+RouteError body_error (const std::string& message) {
     return { 400, error_body (400, message) };
 }
 
@@ -350,8 +350,7 @@ std::pair<int, nlohmann::json> body_error (const std::string& message) {
  * endpoint's documented error shape and sits *inside* the error object, next to
  * the code and message, so a client reads one place for the whole failure.
  */
-std::pair<int, nlohmann::json>
-item_error (const std::string& message, const std::string& temp_id) {
+RouteError item_error (const std::string& message, const std::string& temp_id) {
     auto body             = error_body (400, message);
     body["error"]["item"] = temp_id;
     return { 400, body };
@@ -363,17 +362,18 @@ item_error (const std::string& message, const std::string& temp_id) {
  * is not an array is a 400 naming the field rather than a silently skipped
  * section.
  */
-std::optional<std::pair<int, nlohmann::json>>
+RouteResult
 read_items (const nlohmann::json& body, const char* key, const nlohmann::json*& out) {
     out = &EMPTY_ITEMS;
     if (!body.contains (key) || body[key].is_null ()) {
-        return std::nullopt;
+        return {};
     }
     if (!body[key].is_array ()) {
-        return body_error (std::string ("Invalid '") + key + "': must be an array");
+        return std::unexpected (
+        body_error (std::string ("Invalid '") + key + "': must be an array"));
     }
     out = &body[key];
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -386,7 +386,7 @@ read_items (const nlohmann::json& body, const char* key, const nlohmann::json*& 
  * owns ids here (that is the point of the endpoint), and silently ignoring the
  * field would leave a client believing its id was honoured.
  */
-std::optional<std::pair<int, nlohmann::json>> claim_temp_id (const nlohmann::json& item,
+RouteResult claim_temp_id (const nlohmann::json& item,
 const char* kind,
 const char* prefix,
 size_t index,
@@ -394,22 +394,24 @@ std::unordered_map<std::string, std::string>& id_map,
 std::string& temp_id_out) {
     const std::string at = std::string (kind) + " at index " + std::to_string (index);
     if (!item.is_object ()) {
-        return body_error ("Invalid " + at + ": must be an object");
+        return std::unexpected (body_error ("Invalid " + at + ": must be an object"));
     }
     if (item.contains ("id")) {
-        return body_error ("Invalid " +
-        at + ": 'id' is not accepted - the engine assigns ids; reference items by 'tempId'");
+        return std::unexpected (body_error ("Invalid " +
+        at + ": 'id' is not accepted - the engine assigns ids; reference items by 'tempId'"));
     }
     if (!item.contains ("tempId") || !item["tempId"].is_string () ||
     item["tempId"].get<std::string> ().empty ()) {
-        return body_error ("Invalid " + at + ": 'tempId' must be a non-empty string");
+        return std::unexpected (
+        body_error ("Invalid " + at + ": 'tempId' must be a non-empty string"));
     }
     temp_id_out = item["tempId"].get<std::string> ();
     if (id_map.contains (temp_id_out)) {
-        return item_error ("Duplicate tempId '" + temp_id_out + "'", temp_id_out);
+        return std::unexpected (
+        item_error ("Duplicate tempId '" + temp_id_out + "'", temp_id_out));
     }
     id_map.emplace (temp_id_out, vayu::utils::generate_id (prefix));
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -433,7 +435,7 @@ struct TempIds {
 };
 
 /** Claims every tempId in one section, in payload order. */
-std::optional<std::pair<int, nlohmann::json>> claim_section (const nlohmann::json& items,
+RouteResult claim_section (const nlohmann::json& items,
 const char* kind,
 const char* prefix,
 std::unordered_map<std::string, std::string>& id_map,
@@ -441,33 +443,38 @@ std::vector<std::string>& claimed) {
     claimed.reserve (items.size ());
     for (size_t i = 0; i < items.size (); ++i) {
         std::string temp;
-        if (auto err = claim_temp_id (items[i], kind, prefix, i, id_map, temp)) {
-            return err;
+        if (auto outcome = claim_temp_id (items[i], kind, prefix, i, id_map, temp); !outcome) {
+            return outcome;
         }
         claimed.push_back (temp);
     }
-    return std::nullopt;
+    return {};
 }
 
 /** Pass 1 - claim every tempId across the four sections, then note the owners. */
-std::optional<std::pair<int, nlohmann::json>> claim_all (const nlohmann::json& collections,
+RouteResult claim_all (const nlohmann::json& collections,
 const nlohmann::json& requests,
 const nlohmann::json& environments,
 const nlohmann::json& specs,
 TempIds& temps) {
-    if (auto err = claim_section (
-        collections, "collection", "col_", temps.real, temps.collections)) {
-        return err;
+    if (auto outcome = claim_section (
+        collections, "collection", "col_", temps.real, temps.collections);
+    !outcome) {
+        return outcome;
     }
-    if (auto err = claim_section (requests, "request", "req_", temps.real, temps.requests)) {
-        return err;
+    if (auto outcome =
+        claim_section (requests, "request", "req_", temps.real, temps.requests);
+    !outcome) {
+        return outcome;
     }
-    if (auto err = claim_section (
-        environments, "environment", "env_", temps.real, temps.environments)) {
-        return err;
+    if (auto outcome = claim_section (
+        environments, "environment", "env_", temps.real, temps.environments);
+    !outcome) {
+        return outcome;
     }
-    if (auto err = claim_section (specs, "spec", "spec_", temps.real, temps.specs)) {
-        return err;
+    if (auto outcome = claim_section (specs, "spec", "spec_", temps.real, temps.specs);
+    !outcome) {
+        return outcome;
     }
     for (const auto& temp : temps.collections) {
         temps.is_collection.insert (temp);
@@ -476,15 +483,14 @@ TempIds& temps) {
         temps.is_spec.insert (temp);
         temps.pending_spec_ids.insert (temps.real.at (temp));
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
  * Pass 2a - resolve `parentTempId` against the claimed collection temp ids.
  * References may point forward, which is why this cannot happen during pass 1.
  */
-std::optional<std::pair<int, nlohmann::json>>
-resolve_parents (const nlohmann::json& collections, TempIds& temps) {
+RouteResult resolve_parents (const nlohmann::json& collections, TempIds& temps) {
     for (size_t i = 0; i < collections.size (); ++i) {
         const auto& item        = collections[i];
         const std::string& temp = temps.collections[i];
@@ -492,16 +498,17 @@ resolve_parents (const nlohmann::json& collections, TempIds& temps) {
             continue;
         }
         if (!item["parentTempId"].is_string ()) {
-            return item_error (
-            "Invalid 'parentTempId': must be a string or null", temp);
+            return std::unexpected (
+            item_error ("Invalid 'parentTempId': must be a string or null", temp));
         }
         const std::string parent = item["parentTempId"].get<std::string> ();
         if (!temps.is_collection.contains (parent)) {
-            return item_error ("Unknown parentTempId '" + parent + "'", temp);
+            return std::unexpected (
+            item_error ("Unknown parentTempId '" + parent + "'", temp));
         }
         temps.parent_of.emplace (temp, parent);
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -514,7 +521,7 @@ resolve_parents (const nlohmann::json& collections, TempIds& temps) {
  * cycle, so `acyclic` keeps this linear rather than quadratic on a deeply nested
  * import.
  */
-std::optional<std::pair<int, nlohmann::json>> detect_parent_cycles (const TempIds& temps) {
+RouteResult detect_parent_cycles (const TempIds& temps) {
     std::unordered_set<std::string> acyclic;
     for (const auto& temp : temps.collections) {
         std::vector<std::string> path;
@@ -522,8 +529,8 @@ std::optional<std::pair<int, nlohmann::json>> detect_parent_cycles (const TempId
         std::string cursor = temp;
         while (!acyclic.contains (cursor)) {
             if (!on_path.insert (cursor).second) {
-                return item_error (
-                "Cycle in parentTempId references at '" + cursor + "'", temp);
+                return std::unexpected (item_error (
+                "Cycle in parentTempId references at '" + cursor + "'", temp));
             }
             path.push_back (cursor);
             auto next = temps.parent_of.find (cursor);
@@ -534,7 +541,7 @@ std::optional<std::pair<int, nlohmann::json>> detect_parent_cycles (const TempId
         }
         acyclic.insert (path.begin (), path.end ());
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -544,21 +551,22 @@ std::optional<std::pair<int, nlohmann::json>> detect_parent_cycles (const TempId
  * one transaction and the client would be told nothing about why it was lost.
  */
 template <typename Apply>
-std::optional<std::pair<int, nlohmann::json>>
-apply_item_fields (Apply apply, const char* kind, const std::string& temp_id) {
-    std::optional<std::pair<int, nlohmann::json>> err;
+RouteResult apply_item_fields (Apply apply, const char* kind, const std::string& temp_id) {
+    RouteResult outcome;
     try {
-        err = apply ();
+        outcome = apply ();
     } catch (const nlohmann::json::exception& e) {
-        return item_error (std::string ("Invalid ") + kind + ": " + e.what (), temp_id);
+        return std::unexpected (
+        item_error (std::string ("Invalid ") + kind + ": " + e.what (), temp_id));
     }
-    if (err) {
+    if (!outcome) {
         // Inside the error object, next to the code and message the shared
         // applier already built - the same place `item_error` puts it.
-        err->second["error"]["item"] = temp_id;
-        return err;
+        RouteError refused            = outcome.error ();
+        refused.body["error"]["item"] = temp_id;
+        return std::unexpected (refused);
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -575,36 +583,40 @@ apply_item_fields (Apply apply, const char* kind, const std::string& temp_id) {
  * Both at once is a 400: they are two answers to one question, and picking one
  * would leave the caller believing the other was honoured.
  */
-std::optional<std::pair<int, nlohmann::json>>
-resolve_spec_binding (nlohmann::json& fields, const TempIds& temps, const std::string& temp) {
+RouteResult resolve_spec_binding (nlohmann::json& fields,
+const TempIds& temps,
+const std::string& temp) {
     auto binding = fields.find ("openapi");
     if (binding == fields.end () || binding->is_null () || !binding->is_object ()) {
-        return std::nullopt; // Unbound, or a shape the applier will reject.
+        return {}; // Unbound, or a shape the applier will reject.
     }
     auto spec_temp = binding->find ("specTempId");
     if (spec_temp == binding->end () || spec_temp->is_null ()) {
-        return std::nullopt;
+        return {};
     }
     if (!spec_temp->is_string ()) {
-        return item_error ("Invalid 'openapi.specTempId': must be a string", temp);
+        return std::unexpected (
+        item_error ("Invalid 'openapi.specTempId': must be a string", temp));
     }
     if (binding->contains ("specId")) {
-        return item_error ("Invalid 'openapi': send either 'specTempId' (a "
-                           "spec in this payload) or "
-                           "'specId' (one already stored), not both",
-        temp);
+        return std::unexpected (
+        item_error ("Invalid 'openapi': send either 'specTempId' (a "
+                    "spec in this payload) or "
+                    "'specId' (one already stored), not both",
+        temp));
     }
     const std::string named = spec_temp->get<std::string> ();
     if (!temps.is_spec.contains (named)) {
-        return item_error ("Unknown openapi.specTempId '" + named + "'", temp);
+        return std::unexpected (
+        item_error ("Unknown openapi.specTempId '" + named + "'", temp));
     }
     binding->erase ("specTempId");
     (*binding)["specId"] = temps.real.at (named);
-    return std::nullopt;
+    return {};
 }
 
 /** Pass 3a - collection rows, through the same applier POST /collections uses. */
-std::optional<std::pair<int, nlohmann::json>> build_collection_rows (vayu::db::Database& db,
+RouteResult build_collection_rows (vayu::db::Database& db,
 const nlohmann::json& collections,
 const TempIds& temps,
 int64_t now,
@@ -623,8 +635,8 @@ std::vector<vayu::db::Collection>& out) {
            nlohmann::json (nullptr) :
            nlohmann::json (temps.real.at (parent->second));
 
-        if (auto err = resolve_spec_binding (fields, temps, temp)) {
-            return err;
+        if (auto outcome = resolve_spec_binding (fields, temps, temp); !outcome) {
+            return outcome;
         }
 
         vayu::db::Collection c;
@@ -632,12 +644,13 @@ std::vector<vayu::db::Collection>& out) {
         c.created_at = now;
         c.updated_at = now;
 
-        if (auto err = apply_item_fields (
+        if (auto outcome = apply_item_fields (
             [&] {
                 return apply_collection_fields (db, c, fields, /*is_create=*/true);
             },
-            "collection", temp)) {
-            return err;
+            "collection", temp);
+        !outcome) {
+            return outcome;
         }
 
         // An absent `order` means "append after the current siblings", which
@@ -654,7 +667,7 @@ std::vector<vayu::db::Collection>& out) {
         }
         out.push_back (std::move (c));
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -670,33 +683,35 @@ std::vector<vayu::db::Collection>& out) {
  * `POST /requests/:id/examples` uses - so an imported example and a created one
  * cannot disagree about a default, a required field or the body cap.
  */
-std::optional<std::pair<int, nlohmann::json>> build_example_rows (const nlohmann::json& item,
+RouteResult build_example_rows (const nlohmann::json& item,
 const std::string& request_id,
 const std::string& temp,
 int64_t now,
 std::vector<vayu::db::RequestExample>& out) {
     if (!item.contains ("examples") || item["examples"].is_null ()) {
-        return std::nullopt;
+        return {};
     }
     if (!item["examples"].is_array ()) {
-        return item_error ("Invalid 'examples': must be an array", temp);
+        return std::unexpected (
+        item_error ("Invalid 'examples': must be an array", temp));
     }
     const auto& examples = item["examples"];
     if (examples.size () > vayu::core::constants::request_example::MAX_PER_REQUEST) {
-        return item_error ("Too many examples: " + std::to_string (examples.size ()) +
-        " exceeds the limit of " +
+        return std::unexpected (item_error (
+        "Too many examples: " + std::to_string (examples.size ()) + " exceeds the limit of " +
         std::to_string (vayu::core::constants::request_example::MAX_PER_REQUEST) + " per request",
-        temp);
+        temp));
     }
 
     for (size_t i = 0; i < examples.size (); ++i) {
         const auto& example = examples[i];
         if (!example.is_object ()) {
-            return item_error ("Invalid example: must be an object", temp);
+            return std::unexpected (
+            item_error ("Invalid example: must be an object", temp));
         }
         if (example.contains ("id")) {
-            return item_error (
-            "Invalid example: 'id' is not accepted - the engine assigns ids", temp);
+            return std::unexpected (item_error (
+            "Invalid example: 'id' is not accepted - the engine assigns ids", temp));
         }
 
         vayu::db::RequestExample x;
@@ -705,12 +720,13 @@ std::vector<vayu::db::RequestExample>& out) {
         x.created_at = now;
         x.updated_at = now;
 
-        if (auto err = apply_item_fields (
+        if (auto outcome = apply_item_fields (
             [&] {
                 return apply_request_example_fields (x, example, /*is_create=*/true);
             },
-            "example", temp)) {
-            return err;
+            "example", temp);
+        !outcome) {
+            return outcome;
         }
         // Payload order, unless the payload states its own. The create route's
         // append-scan cannot help here: none of these rows are stored yet, so
@@ -721,11 +737,11 @@ std::vector<vayu::db::RequestExample>& out) {
         }
         out.push_back (std::move (x));
     }
-    return std::nullopt;
+    return {};
 }
 
 /** Pass 3b - request rows, owner resolved from `collectionTempId`. */
-std::optional<std::pair<int, nlohmann::json>> build_request_rows (vayu::db::Database& db,
+RouteResult build_request_rows (vayu::db::Database& db,
 const nlohmann::json& requests,
 const TempIds& temps,
 int64_t now,
@@ -737,13 +753,15 @@ std::vector<vayu::db::RequestExample>& examples_out) {
         const std::string& temp = temps.requests[i];
 
         if (!item.contains ("collectionTempId") || !item["collectionTempId"].is_string ()) {
-            return item_error ("Invalid 'collectionTempId': must be the tempId "
-                               "of a collection in this payload",
-            temp);
+            return std::unexpected (
+            item_error ("Invalid 'collectionTempId': must be the tempId "
+                        "of a collection in this payload",
+            temp));
         }
         const std::string owner = item["collectionTempId"].get<std::string> ();
         if (!temps.is_collection.contains (owner)) {
-            return item_error ("Unknown collectionTempId '" + owner + "'", temp);
+            return std::unexpected (
+            item_error ("Unknown collectionTempId '" + owner + "'", temp));
         }
 
         nlohmann::json fields  = item;
@@ -754,19 +772,20 @@ std::vector<vayu::db::RequestExample>& examples_out) {
         r.created_at = now;
         r.updated_at = now;
 
-        if (auto err = apply_item_fields (
+        if (auto outcome = apply_item_fields (
             [&] {
                 return apply_request_fields (db, r, fields, /*is_create=*/true);
             },
-            "request", temp)) {
-            return err;
+            "request", temp);
+        !outcome) {
+            return outcome;
         }
-        if (auto err = build_example_rows (item, r.id, temp, now, examples_out)) {
-            return err;
+        if (auto outcome = build_example_rows (item, r.id, temp, now, examples_out); !outcome) {
+            return outcome;
         }
         out.push_back (std::move (r));
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -779,7 +798,7 @@ std::vector<vayu::db::RequestExample>& examples_out) {
  * caller, and the size cap is the live `maxSpecDocumentBytes` - are made by the
  * same two helpers the route core uses, so the paths cannot drift on either.
  */
-std::optional<std::pair<int, nlohmann::json>> build_spec_rows (vayu::db::Database& db,
+RouteResult build_spec_rows (vayu::db::Database& db,
 const nlohmann::json& specs,
 const TempIds& temps,
 int64_t now,
@@ -793,12 +812,14 @@ std::vector<vayu::db::SpecDocument>& out) {
 
         if (!item.contains ("content") || !item["content"].is_string () ||
         item["content"].get<std::string> ().empty ()) {
-            return item_error ("Invalid 'content': must be a non-empty string", temp);
+            return std::unexpected (
+            item_error ("Invalid 'content': must be a non-empty string", temp));
         }
         for (const char* derived : { "hash", "fetchedAt" }) {
             if (item.contains (derived)) {
-                return item_error (std::string ("Invalid '") + derived + "': computed by the engine; omit it",
-                temp);
+                return std::unexpected (item_error (std::string ("Invalid '") +
+                derived + "': computed by the engine; omit it",
+                temp));
             }
         }
 
@@ -806,21 +827,21 @@ std::vector<vayu::db::SpecDocument>& out) {
         s.id      = temps.real.at (temp);
         s.content = item["content"].get<std::string> ();
         if (s.content.size () > cap) {
-            return item_error ("Spec document is " +
+            return std::unexpected (item_error ("Spec document is " +
             std::to_string (s.content.size ()) + " bytes, over the limit of " +
             std::to_string (cap) + " (raise the 'maxSpecDocumentBytes' setting to allow more)",
-            temp);
+            temp));
         }
         s.hash       = spec_content_hash (s.content);
         s.fetched_at = now;
         if (auto reason = read_spec_indexes (item, s, cap)) {
-            return item_error (*reason, temp);
+            return std::unexpected (item_error (*reason, temp));
         }
 
         if (item.contains ("sourceUrl") && !item["sourceUrl"].is_null ()) {
             if (!item["sourceUrl"].is_string ()) {
-                return item_error (
-                "Invalid 'sourceUrl': must be a string or null", temp);
+                return std::unexpected (
+                item_error ("Invalid 'sourceUrl': must be a string or null", temp));
             }
             const auto url = item["sourceUrl"].get<std::string> ();
             if (!url.empty ()) {
@@ -829,12 +850,11 @@ std::vector<vayu::db::SpecDocument>& out) {
         }
         out.push_back (std::move (s));
     }
-    return std::nullopt;
+    return {};
 }
 
 /** Pass 3d - environment rows; nothing to resolve, they reference nobody. */
-std::optional<std::pair<int, nlohmann::json>> build_environment_rows (
-const nlohmann::json& environments,
+RouteResult build_environment_rows (const nlohmann::json& environments,
 const TempIds& temps,
 int64_t now,
 std::vector<vayu::db::Environment>& out) {
@@ -847,16 +867,17 @@ std::vector<vayu::db::Environment>& out) {
         e.created_at = now;
         e.updated_at = now;
 
-        if (auto err = apply_item_fields (
+        if (auto outcome = apply_item_fields (
             [&] {
                 return apply_environment_fields (e, environments[i], /*is_create=*/true);
             },
-            "environment", temp)) {
-            return err;
+            "environment", temp);
+        !outcome) {
+            return outcome;
         }
         out.push_back (std::move (e));
     }
-    return std::nullopt;
+    return {};
 }
 
 } // namespace
@@ -887,24 +908,24 @@ std::vector<vayu::db::Environment>& out) {
 std::pair<int, nlohmann::json>
 import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (!body.is_object ()) {
-        return body_error ("Body must be a JSON object");
+        return as_response (body_error ("Body must be a JSON object"));
     }
 
     const nlohmann::json* collections  = nullptr;
     const nlohmann::json* requests     = nullptr;
     const nlohmann::json* environments = nullptr;
     const nlohmann::json* specs        = nullptr;
-    if (auto err = read_items (body, "collections", collections)) {
-        return *err;
+    if (auto outcome = read_items (body, "collections", collections); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "requests", requests)) {
-        return *err;
+    if (auto outcome = read_items (body, "requests", requests); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "environments", environments)) {
-        return *err;
+    if (auto outcome = read_items (body, "environments", environments); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "specs", specs)) {
-        return *err;
+    if (auto outcome = read_items (body, "specs", specs); !outcome) {
+        return as_response (outcome.error ());
     }
 
     // Examples count toward the cap even though they are nested rather than a
@@ -920,19 +941,20 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     const size_t total = collections->size () + requests->size () +
     environments->size () + nested_examples + specs->size ();
     if (total > MAX_IMPORT_ITEMS) {
-        return body_error ("Import too large: " + std::to_string (total) +
-        " items exceeds the limit of " + std::to_string (MAX_IMPORT_ITEMS) + " per call");
+        return as_response (body_error ("Import too large: " + std::to_string (total) +
+        " items exceeds the limit of " + std::to_string (MAX_IMPORT_ITEMS) + " per call"));
     }
 
     TempIds temps;
-    if (auto err = claim_all (*collections, *requests, *environments, *specs, temps)) {
-        return *err;
+    if (auto outcome = claim_all (*collections, *requests, *environments, *specs, temps);
+    !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = resolve_parents (*collections, temps)) {
-        return *err;
+    if (auto outcome = resolve_parents (*collections, temps); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = detect_parent_cycles (temps)) {
-        return *err;
+    if (auto outcome = detect_parent_cycles (temps); !outcome) {
+        return as_response (outcome.error ());
     }
 
     const int64_t now = now_ms ();
@@ -943,17 +965,20 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     std::vector<vayu::db::SpecDocument> spec_rows;
     // Ahead of the collections that may bind them, so a binding is validated
     // against rows that have already been built.
-    if (auto err = build_spec_rows (db, *specs, temps, now, spec_rows)) {
-        return *err;
+    if (auto outcome = build_spec_rows (db, *specs, temps, now, spec_rows); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = build_collection_rows (db, *collections, temps, now, collection_rows)) {
-        return *err;
+    if (auto outcome = build_collection_rows (db, *collections, temps, now, collection_rows);
+    !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = build_request_rows (db, *requests, temps, now, request_rows, example_rows)) {
-        return *err;
+    if (auto outcome = build_request_rows (db, *requests, temps, now, request_rows, example_rows);
+    !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = build_environment_rows (*environments, temps, now, environment_rows)) {
-        return *err;
+    if (auto outcome = build_environment_rows (*environments, temps, now, environment_rows);
+    !outcome) {
+        return as_response (outcome.error ());
     }
 
     // The hash of every spec this payload is about to write, by the id it will
@@ -977,13 +1002,14 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     std::pair<int, nlohmann::json> result{ 200, nlohmann::json{ { "idMap", temps.real } } };
     db.with_lock ([&] {
         for (size_t i = 0; i < collection_rows.size (); ++i) {
-            if (auto err = apply_item_fields (
+            if (auto outcome = apply_item_fields (
                 [&] {
                     return reject_unbindable_spec (
                     db, collection_rows[i].openapi, temps.pending_spec_ids);
                 },
-                "collection", temps.collections[i])) {
-                result = *err;
+                "collection", temps.collections[i]);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             // Stamped here rather than in `resolve_spec_binding`, so that the
@@ -1023,16 +1049,17 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
 std::pair<int, nlohmann::json>
 import_parse_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (!body.is_object ()) {
-        return body_error ("Body must be a JSON object");
+        return as_response (body_error ("Body must be a JSON object"));
     }
     const auto content_field = body.find ("content");
     if (content_field == body.end () || !content_field->is_string ()) {
-        return body_error ("Invalid 'content': must be the document's text");
+        return as_response (
+        body_error ("Invalid 'content': must be the document's text"));
     }
     const auto content = content_field->get<std::string> ();
     if (content.empty ()) {
-        return body_error (
-        "Invalid 'content': an empty document is not an import");
+        return as_response (
+        body_error ("Invalid 'content': an empty document is not an import"));
     }
 
     // The same cap a stored spec document is held to, because an OpenAPI import
@@ -1053,15 +1080,16 @@ import_parse_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (auto found = body.find ("importEnvironments");
     found != body.end () && !found->is_null ()) {
         if (!found->is_boolean ()) {
-            return body_error (
-            "Invalid 'importEnvironments': must be a boolean");
+            return as_response (
+            body_error ("Invalid 'importEnvironments': must be a boolean"));
         }
         options.import_environments = found->get<bool> ();
     }
     if (auto found = body.find ("importScripts");
     found != body.end () && !found->is_null ()) {
         if (!found->is_boolean ()) {
-            return body_error ("Invalid 'importScripts': must be a boolean");
+            return as_response (
+            body_error ("Invalid 'importScripts': must be a boolean"));
         }
         options.import_scripts = found->get<bool> ();
     }
@@ -1069,21 +1097,23 @@ import_parse_response (vayu::db::Database& db, const nlohmann::json& body) {
     vayu::core::ImportSource source;
     if (auto found = body.find ("fileName"); found != body.end () && !found->is_null ()) {
         if (!found->is_string ()) {
-            return body_error ("Invalid 'fileName': must be a string");
+            return as_response (
+            body_error ("Invalid 'fileName': must be a string"));
         }
         source.file_name = found->get<std::string> ();
     }
     if (auto found = body.find ("sourceUrl"); found != body.end () && !found->is_null ()) {
         if (!found->is_string ()) {
-            return body_error ("Invalid 'sourceUrl': must be a string");
+            return as_response (
+            body_error ("Invalid 'sourceUrl': must be a string"));
         }
         source.source_url = found->get<std::string> ();
     }
     if (auto found = body.find ("unresolvedRefs");
     found != body.end () && !found->is_null ()) {
         if (!found->is_number_integer () || found->get<long long> () < 0) {
-            return body_error (
-            "Invalid 'unresolvedRefs': must be a non-negative integer");
+            return as_response (body_error (
+            "Invalid 'unresolvedRefs': must be a non-negative integer"));
         }
         source.unresolved_refs = found->get<int> ();
     }
@@ -1094,7 +1124,7 @@ import_parse_response (vayu::db::Database& db, const nlohmann::json& body) {
         // into a parse failure: the two are different answers to the user - one
         // says "Vayu does not read this kind of file", the other "this file is
         // broken" - and the import dialog says different things about them.
-        return body_error (parsed.error);
+        return as_response (body_error (parsed.error));
     }
     return { 200, std::move (parsed.result) };
 }
@@ -1119,11 +1149,12 @@ import_parse_response (vayu::db::Database& db, const nlohmann::json& body) {
 std::pair<int, nlohmann::json>
 import_document_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (!body.is_object ()) {
-        return body_error ("Body must be a JSON object");
+        return as_response (body_error ("Body must be a JSON object"));
     }
     const auto content_field = body.find ("content");
     if (content_field == body.end () || !content_field->is_string ()) {
-        return body_error ("Invalid 'content': must be the document's text");
+        return as_response (
+        body_error ("Invalid 'content': must be the document's text"));
     }
     const auto content = content_field->get<std::string> ();
     const size_t cap   = spec_size_cap (db);
@@ -1137,7 +1168,7 @@ import_document_response (vayu::db::Database& db, const nlohmann::json& body) {
 
     const vayu::core::DocumentRead read = vayu::core::read_document (content);
     if (!read.ok ()) {
-        return body_error ("Invalid 'content': " + read.error);
+        return as_response (body_error ("Invalid 'content': " + read.error));
     }
     return { 200, nlohmann::json{ { "document", read.root } } };
 }

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -353,7 +353,7 @@ RouteError body_error (const std::string& message) {
 RouteError item_error (const std::string& message, const std::string& temp_id) {
     auto body             = error_body (400, message);
     body["error"]["item"] = temp_id;
-    return { 400, body };
+    return { .status = 400, .body = body };
 }
 
 /**

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -178,8 +178,10 @@ read_bounded_int (const nlohmann::json& json, const char* key, int low, int high
         return {};
     }
     if (!it->is_number_integer () || it->get<int> () < low || it->get<int> () > high) {
-        return std::unexpected (MockParseError{ 400, "bad_request",
-        std::format ("Invalid '{}': must be an integer between {} and {}", key, low, high) });
+        return std::unexpected (MockParseError{ .http_status = 400,
+        .code                                                = "bad_request",
+        .message                                             = std::format (
+        "Invalid '{}': must be an integer between {} and {}", key, low, high) });
     }
     out = it->get<int> ();
     return {};
@@ -189,14 +191,17 @@ read_bounded_int (const nlohmann::json& json, const char* key, int low, int high
 
 std::expected<MockStartRequest, MockParseError> parse_mock_start (const nlohmann::json& json) {
     if (!json.is_object ()) {
-        return std::unexpected (
-        MockParseError{ 400, "bad_request", "Request body must be a JSON object" });
+        return std::unexpected (MockParseError{ .http_status = 400,
+        .code                                                = "bad_request",
+        .message = "Request body must be a JSON object" });
     }
 
     const auto collection = json.find ("collectionId");
     if (collection == json.end () || !collection->is_string () ||
     collection->get<std::string> ().empty ()) {
-        return std::unexpected (MockParseError{ 400, "bad_request",
+        return std::unexpected (MockParseError{ .http_status = 400,
+        .code                                                = "bad_request",
+        .message =
         "'collectionId' is required and must be a non-empty string" });
     }
 

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -38,6 +38,8 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <expected>
+#include <format>
 #include <set>
 #include <string_view>
 #include <thread>
@@ -169,49 +171,51 @@ namespace {
 
 /// Read a bounded integer field, or say why it was refused. Absent and `null`
 /// both keep @p out, which the caller seeded with the default.
-std::optional<MockParseError>
+std::expected<void, MockParseError>
 read_bounded_int (const nlohmann::json& json, const char* key, int low, int high, int& out) {
     const auto it = json.find (key);
     if (it == json.end () || it->is_null ()) {
-        return std::nullopt;
+        return {};
     }
     if (!it->is_number_integer () || it->get<int> () < low || it->get<int> () > high) {
-        return MockParseError{ 400, "bad_request",
-            std::string ("Invalid '") + key + "': must be an integer between " +
-            std::to_string (low) + " and " + std::to_string (high) };
+        return std::unexpected (MockParseError{ 400, "bad_request",
+        std::format ("Invalid '{}': must be an integer between {} and {}", key, low, high) });
     }
     out = it->get<int> ();
-    return std::nullopt;
+    return {};
 }
 
 } // namespace
 
-std::optional<MockParseError>
-parse_mock_start (const nlohmann::json& json, MockStartRequest& out) {
-    out = MockStartRequest{};
+std::expected<MockStartRequest, MockParseError> parse_mock_start (const nlohmann::json& json) {
     if (!json.is_object ()) {
-        return MockParseError{ 400, "bad_request", "Request body must be a JSON object" };
+        return std::unexpected (
+        MockParseError{ 400, "bad_request", "Request body must be a JSON object" });
     }
 
     const auto collection = json.find ("collectionId");
     if (collection == json.end () || !collection->is_string () ||
     collection->get<std::string> ().empty ()) {
-        return MockParseError{ 400, "bad_request",
-            "'collectionId' is required and must be a non-empty string" };
+        return std::unexpected (MockParseError{ 400, "bad_request",
+        "'collectionId' is required and must be a non-empty string" });
     }
-    out.collection_id = collection->get<std::string> ();
 
-    if (auto err = read_bounded_int (json, "port", 0, 65535, out.port)) {
-        return err;
+    MockStartRequest parsed;
+    parsed.collection_id = collection->get<std::string> ();
+
+    if (auto outcome = read_bounded_int (json, "port", 0, 65535, parsed.port); !outcome) {
+        return std::unexpected (outcome.error ());
     }
-    if (auto err = read_bounded_int (json, "latencyMs", 0,
-        constants::mock_server::MAX_LATENCY_MS, out.latency_ms)) {
-        return err;
+    if (auto outcome = read_bounded_int (json, "latencyMs", 0,
+        constants::mock_server::MAX_LATENCY_MS, parsed.latency_ms);
+    !outcome) {
+        return std::unexpected (outcome.error ());
     }
-    if (auto err = read_bounded_int (json, "errorRatePct", 0, 100, out.error_rate_pct)) {
-        return err;
+    if (auto outcome = read_bounded_int (json, "errorRatePct", 0, 100, parsed.error_rate_pct);
+    !outcome) {
+        return std::unexpected (outcome.error ());
     }
-    return std::nullopt;
+    return parsed;
 }
 
 // ---------------------------------------------------------------------------
@@ -739,14 +743,15 @@ void register_mock_server_routes (RouteContext& ctx) {
             send_error (res, 400, std::string ("Invalid JSON body: ") + e.what ());
             return;
         }
-        MockStartRequest start;
-        if (auto error = parse_mock_start (body, start); error) {
-            vayu::utils::log_warning ("POST /mock/start - " + error->message);
-            send_error (res, error->http_status, error->message, error->code);
+        const auto start = parse_mock_start (body);
+        if (!start) {
+            const auto& refusal = start.error ();
+            vayu::utils::log_warning ("POST /mock/start - " + refusal.message);
+            send_error (res, refusal.http_status, refusal.message, refusal.code);
             return;
         }
         try {
-            auto result = ctx.mock_server_manager.start (ctx.db, start);
+            auto result = ctx.mock_server_manager.start (ctx.db, *start);
             if (!result.ok) {
                 vayu::utils::log_warning ("POST /mock/start - " + result.error_message);
                 send_error (res, result.http_status, result.error_message,

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -82,7 +82,7 @@ RouteResult read_kind (const nlohmann::json& entry, const std::string& at, Kind&
     }
     if (!entry.contains ("type") || !entry["type"].is_string ()) {
         return std::unexpected (body_error (
-        "Invalid " + at + ": 'type' must be \"collection\" or \"request\""));
+        "Invalid " + at + R"(: 'type' must be "collection" or "request")"));
     }
     const std::string type = entry["type"].get<std::string> ();
     if (type == "collection") {

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -37,7 +37,7 @@ namespace {
 constexpr size_t MAX_REORDER_ENTRIES = 10000;
 
 /** A 400 about the payload as a whole. */
-std::pair<int, nlohmann::json> body_error (const std::string& message) {
+RouteError body_error (const std::string& message) {
     return { 400, error_body (400, message) };
 }
 
@@ -76,24 +76,24 @@ struct Move {
 };
 
 /** Reads and validates `type`, the one field both entry shapes share. */
-std::optional<std::pair<int, nlohmann::json>>
-read_kind (const nlohmann::json& entry, const std::string& at, Kind& out) {
+RouteResult read_kind (const nlohmann::json& entry, const std::string& at, Kind& out) {
     if (!entry.is_object ()) {
-        return body_error ("Invalid " + at + ": must be an object");
+        return std::unexpected (body_error ("Invalid " + at + ": must be an object"));
     }
     if (!entry.contains ("type") || !entry["type"].is_string ()) {
-        return body_error ("Invalid " + at + ": 'type' must be \"collection\" or \"request\"");
+        return std::unexpected (body_error (
+        "Invalid " + at + ": 'type' must be \"collection\" or \"request\""));
     }
     const std::string type = entry["type"].get<std::string> ();
     if (type == "collection") {
         out = Kind::Collection;
-        return std::nullopt;
+        return {};
     }
     if (type == "request") {
         out = Kind::Request;
-        return std::nullopt;
+        return {};
     }
-    return body_error ("Invalid " + at + ": unknown type '" + type + "'");
+    return std::unexpected (body_error ("Invalid " + at + ": unknown type '" + type + "'"));
 }
 
 /**
@@ -107,39 +107,43 @@ read_kind (const nlohmann::json& entry, const std::string& at, Kind& out) {
  * writes rows that cannot see each other yet. Nothing here is bulk-created, so a
  * scope that resolves to no row is a client bug, not an ordering artifact.
  */
-std::optional<std::pair<int, nlohmann::json>>
+RouteResult
 read_scope (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Scope& out) {
     const std::string at = "normalize entry at index " + std::to_string (index);
-    if (auto err = read_kind (entry, at, out.kind)) {
-        return err;
+    if (auto outcome = read_kind (entry, at, out.kind); !outcome) {
+        return outcome;
     }
     if (out.kind == Kind::Collection) {
         if (!entry.contains ("parentId")) {
-            return body_error ("Invalid " +
-            at + ": 'parentId' must be stated (null normalizes the root collections)");
+            return std::unexpected (body_error ("Invalid " +
+            at + ": 'parentId' must be stated (null normalizes the root collections)"));
         }
         const auto& parent = entry["parentId"];
         if (parent.is_null ()) {
             out.parent = std::nullopt;
-            return std::nullopt;
+            return {};
         }
         if (!parent.is_string ()) {
-            return body_error ("Invalid " + at + ": 'parentId' must be a string or null");
+            return std::unexpected (
+            body_error ("Invalid " + at + ": 'parentId' must be a string or null"));
         }
         out.parent = parent.get<std::string> ();
         if (!db.get_collection (*out.parent).has_value ()) {
-            return body_error ("Collection '" + *out.parent + "' does not exist");
+            return std::unexpected (
+            body_error ("Collection '" + *out.parent + "' does not exist"));
         }
-        return std::nullopt;
+        return {};
     }
     if (!entry.contains ("collectionId") || !entry["collectionId"].is_string ()) {
-        return body_error ("Invalid " + at + ": 'collectionId' must be a string");
+        return std::unexpected (
+        body_error ("Invalid " + at + ": 'collectionId' must be a string"));
     }
     out.collection = entry["collectionId"].get<std::string> ();
     if (!db.get_collection (out.collection).has_value ()) {
-        return body_error ("Collection '" + out.collection + "' does not exist");
+        return std::unexpected (
+        body_error ("Collection '" + out.collection + "' does not exist"));
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -151,27 +155,29 @@ read_scope (vayu::db::Database& db, const nlohmann::json& entry, size_t index, S
  * the single-row endpoints use - absent keeps the current owner, present states
  * a move - except that a stated owner must exist, for the reason in `read_scope`.
  */
-std::optional<std::pair<int, nlohmann::json>>
+RouteResult
 read_move (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Move& out) {
     const std::string at = "move at index " + std::to_string (index);
-    if (auto err = read_kind (entry, at, out.kind)) {
-        return err;
+    if (auto outcome = read_kind (entry, at, out.kind); !outcome) {
+        return outcome;
     }
     if (!entry.contains ("id") || !entry["id"].is_string () ||
     entry["id"].get<std::string> ().empty ()) {
-        return body_error ("Invalid " + at + ": 'id' must be a non-empty string");
+        return std::unexpected (
+        body_error ("Invalid " + at + ": 'id' must be a non-empty string"));
     }
     out.id = entry["id"].get<std::string> ();
 
     if (!entry.contains ("order") || !entry["order"].is_number_integer () ||
     entry["order"].get<int64_t> () < 0) {
-        return body_error ("Invalid " + at + ": 'order' must be a non-negative integer");
+        return std::unexpected (
+        body_error ("Invalid " + at + ": 'order' must be a non-negative integer"));
     }
     out.order = entry["order"].get<int> ();
 
     if (out.kind == Kind::Collection) {
         if (!db.get_collection (out.id).has_value ()) {
-            return body_error ("Collection '" + out.id + "' does not exist");
+            return std::unexpected (body_error ("Collection '" + out.id + "' does not exist"));
         }
         if (entry.contains ("parentId")) {
             out.states_owner   = true;
@@ -181,29 +187,33 @@ read_move (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Mo
             } else if (parent.is_string ()) {
                 out.parent = parent.get<std::string> ();
                 if (!db.get_collection (*out.parent).has_value ()) {
-                    return body_error ("Collection '" + *out.parent + "' does not exist");
+                    return std::unexpected (
+                    body_error ("Collection '" + *out.parent + "' does not exist"));
                 }
             } else {
-                return body_error ("Invalid " + at + ": 'parentId' must be a string or null");
+                return std::unexpected (body_error (
+                "Invalid " + at + ": 'parentId' must be a string or null"));
             }
         }
-        return std::nullopt;
+        return {};
     }
 
     if (!db.get_request (out.id).has_value ()) {
-        return body_error ("Request '" + out.id + "' does not exist");
+        return std::unexpected (body_error ("Request '" + out.id + "' does not exist"));
     }
     if (entry.contains ("collectionId")) {
         if (!entry["collectionId"].is_string ()) {
-            return body_error ("Invalid " + at + ": 'collectionId' must be a string");
+            return std::unexpected (
+            body_error ("Invalid " + at + ": 'collectionId' must be a string"));
         }
         out.states_owner = true;
         out.collection   = entry["collectionId"].get<std::string> ();
         if (!db.get_collection (out.collection).has_value ()) {
-            return body_error ("Collection '" + out.collection + "' does not exist");
+            return std::unexpected (
+            body_error ("Collection '" + out.collection + "' does not exist"));
         }
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -225,8 +235,7 @@ read_move (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Mo
  * explicitly tolerated by `validate_parent_assignment`) from hanging the
  * validator.
  */
-std::optional<std::pair<int, nlohmann::json>>
-reject_post_move_cycles (vayu::db::Database& db, const std::vector<Move>& moves) {
+RouteResult reject_post_move_cycles (vayu::db::Database& db, const std::vector<Move>& moves) {
     std::unordered_map<std::string, std::optional<std::string>> parent_of;
     for (const auto& c : db.get_collections ()) {
         parent_of[c.id] = c.parent_id;
@@ -242,14 +251,15 @@ reject_post_move_cycles (vayu::db::Database& db, const std::vector<Move>& moves)
             continue;
         }
         if (move.parent.has_value () && *move.parent == move.id) {
-            return body_error ("Collection '" + move.id + "' cannot be its own parent");
+            return std::unexpected (
+            body_error ("Collection '" + move.id + "' cannot be its own parent"));
         }
         std::unordered_set<std::string> seen;
         std::optional<std::string> cursor = move.parent;
         while (cursor.has_value ()) {
             if (*cursor == move.id) {
-                return body_error (
-                "Cannot move collection '" + move.id + "' into its own descendant");
+                return std::unexpected (body_error ("Cannot move collection '" +
+                move.id + "' into its own descendant"));
             }
             if (!seen.insert (*cursor).second) {
                 break; // Pre-existing corrupt cycle; bounded, and not this batch's.
@@ -261,7 +271,7 @@ reject_post_move_cycles (vayu::db::Database& db, const std::vector<Move>& moves)
             cursor = next->second;
         }
     }
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -380,7 +390,7 @@ std::pair<int, nlohmann::json> reorder_locked (vayu::db::Database& db,
 const nlohmann::json& body,
 const std::function<void ()>& before_write) {
     if (!body.is_object ()) {
-        return body_error ("Body must be a JSON object");
+        return as_response (body_error ("Body must be a JSON object"));
     }
 
     const nlohmann::json empty     = nlohmann::json::array ();
@@ -388,29 +398,31 @@ const std::function<void ()>& before_write) {
     const nlohmann::json* norm_in  = &empty;
     if (body.contains ("moves") && !body["moves"].is_null ()) {
         if (!body["moves"].is_array ()) {
-            return body_error ("Invalid 'moves': must be an array");
+            return as_response (
+            body_error ("Invalid 'moves': must be an array"));
         }
         moves_in = &body["moves"];
     }
     if (body.contains ("normalize") && !body["normalize"].is_null ()) {
         if (!body["normalize"].is_array ()) {
-            return body_error ("Invalid 'normalize': must be an array");
+            return as_response (
+            body_error ("Invalid 'normalize': must be an array"));
         }
         norm_in = &body["normalize"];
     }
 
     const size_t total = moves_in->size () + norm_in->size ();
     if (total > MAX_REORDER_ENTRIES) {
-        return body_error ("Reorder too large: " + std::to_string (total) +
-        " entries exceeds the limit of " + std::to_string (MAX_REORDER_ENTRIES) + " per call");
+        return as_response (body_error ("Reorder too large: " + std::to_string (total) +
+        " entries exceeds the limit of " + std::to_string (MAX_REORDER_ENTRIES) + " per call"));
     }
 
     std::vector<Scope> scopes;
     scopes.reserve (norm_in->size ());
     for (size_t i = 0; i < norm_in->size (); ++i) {
         Scope scope;
-        if (auto err = read_scope (db, (*norm_in)[i], i, scope)) {
-            return *err;
+        if (auto outcome = read_scope (db, (*norm_in)[i], i, scope); !outcome) {
+            return as_response (outcome.error ());
         }
         scopes.push_back (std::move (scope));
     }
@@ -420,20 +432,20 @@ const std::function<void ()>& before_write) {
     std::unordered_set<std::string> claimed;
     for (size_t i = 0; i < moves_in->size (); ++i) {
         Move move;
-        if (auto err = read_move (db, (*moves_in)[i], i, move)) {
-            return *err;
+        if (auto outcome = read_move (db, (*moves_in)[i], i, move); !outcome) {
+            return as_response (outcome.error ());
         }
         // Two positions for one row is not a resolvable batch - whichever won
         // would be an accident of iteration order, and the client that sent it
         // has a bug the 400 names.
         if (!claimed.insert (move.id).second) {
-            return body_error ("Duplicate move for '" + move.id + "'");
+            return as_response (body_error ("Duplicate move for '" + move.id + "'"));
         }
         moves.push_back (std::move (move));
     }
 
-    if (auto err = reject_post_move_cycles (db, moves)) {
-        return *err;
+    if (auto outcome = reject_post_move_cycles (db, moves); !outcome) {
+        return as_response (outcome.error ());
     }
 
     const int64_t now = now_ms ();

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -126,47 +126,43 @@ static std::string http_version_seed (vayu::db::Database& db) {
  * templated path, so it is required to start with `/` - a concrete URL stored
  * here would never match the document it came from.
  */
-static std::optional<std::pair<int, nlohmann::json>>
-apply_spec_operation_field (const nlohmann::json& json,
+static RouteResult apply_spec_operation_field (const nlohmann::json& json,
 std::optional<std::string>& out,
 bool is_create) {
     if (!json.contains ("specOperation")) {
         if (is_create) {
             out = std::nullopt;
         }
-        return std::nullopt;
+        return {};
     }
     const auto& value = json["specOperation"];
     if (value.is_null ()) {
         out = std::nullopt;
-        return std::nullopt;
+        return {};
     }
     if (!value.is_object ()) {
-        return std::make_pair (400,
-        error_body (400, "Invalid 'specOperation': must be a JSON object or null"));
+        return route_error (400, "Invalid 'specOperation': must be a JSON object or null");
     }
 
     for (const char* key : { "method", "path" }) {
         if (!value.contains (key) || !value[key].is_string () ||
         value[key].get<std::string> ().empty ()) {
-            return std::make_pair (400,
-            error_body (400, std::string ("Invalid 'specOperation.") + key + "': must be a non-empty string"));
+            return route_error (400,
+            std::string ("Invalid 'specOperation.") + key + "': must be a non-empty string");
         }
     }
     if (value["path"].get<std::string> ().front () != '/') {
-        return std::make_pair (400,
-        error_body (400,
+        return route_error (400,
         "Invalid 'specOperation.path': must be the templated path from the "
-        "document and start with '/' (e.g. '/pets/{petId}')"));
+        "document and start with '/' (e.g. '/pets/{petId}')");
     }
     if (value.contains ("operationId") && !value["operationId"].is_null () &&
     !value["operationId"].is_string ()) {
-        return std::make_pair (400,
-        error_body (400, "Invalid 'specOperation.operationId': must be a string"));
+        return route_error (400, "Invalid 'specOperation.operationId': must be a string");
     }
 
     out = value.dump ();
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -180,49 +176,54 @@ bool is_create) {
  * Declared in routes.hpp because `POST /import/apply` applies the same fields to
  * every request in a bulk payload (issue #96).
  */
-std::optional<std::pair<int, nlohmann::json>> apply_request_fields (vayu::db::Database& db,
+RouteResult apply_request_fields (vayu::db::Database& db,
 vayu::db::Request& r,
 const nlohmann::json& json,
 bool is_create) {
-    if (auto err = apply_required_string_field (
-        json, "collectionId", r.collection_id, is_create)) {
-        return err;
+    if (auto outcome =
+        apply_required_string_field (json, "collectionId", r.collection_id, is_create);
+    !outcome) {
+        return outcome;
     }
-    if (auto err = apply_required_string_field (json, "name", r.name, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "name", r.name, is_create); !outcome) {
+        return outcome;
     }
 
     std::string method_str = to_string (r.method);
-    if (auto err = apply_required_string_field (json, "method", method_str, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "method", method_str, is_create);
+    !outcome) {
+        return outcome;
     }
     auto method = vayu::parse_method (method_str);
     if (!method) {
-        return std::make_pair (400, error_body (400, "Invalid HTTP method"));
+        return route_error (400, "Invalid HTTP method");
     }
     r.method = *method;
 
-    if (auto err = apply_required_string_field (json, "url", r.url, is_create)) {
-        return err;
+    if (auto outcome = apply_required_string_field (json, "url", r.url, is_create); !outcome) {
+        return outcome;
     }
 
     apply_string_field (json, "description", r.description, "", is_create);
 
-    if (auto err = apply_key_value_field (json, "params", r.params, is_create)) {
-        return err;
+    if (auto outcome = apply_key_value_field (json, "params", r.params, is_create); !outcome) {
+        return outcome;
     }
-    if (auto err = apply_key_value_field (json, "headers", r.headers, is_create)) {
-        return err;
+    if (auto outcome = apply_key_value_field (json, "headers", r.headers, is_create); !outcome) {
+        return outcome;
     }
 
-    if (auto err = apply_json_field (json, "body", r.body, R"({"mode":"none"})", is_create)) {
-        return err;
+    if (auto outcome = apply_json_field (json, "body", r.body, R"({"mode":"none"})", is_create);
+    !outcome) {
+        return outcome;
     }
     apply_string_field (json, "bodyType", r.body_type, "none", is_create);
     // A request's auth may be 'inherit' - that is its default, and the app
     // resolves the collection chain before the request is executed.
-    if (auto err = apply_json_field (json, "auth", r.auth, R"({"mode":"inherit"})", is_create)) {
-        return err;
+    if (auto outcome =
+        apply_json_field (json, "auth", r.auth, R"({"mode":"inherit"})", is_create);
+    !outcome) {
+        return outcome;
     }
     apply_string_field (json, "preRequestScript", r.pre_request_script, "", is_create);
     apply_string_field (json, "postRequestScript", r.post_request_script, "", is_create);
@@ -243,9 +244,10 @@ bool is_create) {
     // than coerced - see apply_http_version_field in routes.hpp. The seed is
     // read fresh here (not hoisted above the field applications) so it always
     // reflects the config entry as of this write.
-    if (auto err = apply_http_version_field (json, "httpVersion",
-        r.http_version, http_version_seed (db), is_create)) {
-        return err;
+    if (auto outcome = apply_http_version_field (
+        json, "httpVersion", r.http_version, http_version_seed (db), is_create);
+    !outcome) {
+        return outcome;
     }
 
     // Consume the response as an event stream (issue #574). Through the shared
@@ -257,11 +259,12 @@ bool is_create) {
     // the same reason `stream` is: `POST /import/apply` runs this same applier,
     // and an importer that recovered the operation a request came from must be
     // able to store it in the one call that writes the tree.
-    if (auto err = apply_spec_operation_field (json, r.spec_operation, is_create)) {
-        return err;
+    if (auto outcome = apply_spec_operation_field (json, r.spec_operation, is_create);
+    !outcome) {
+        return outcome;
     }
 
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -275,13 +278,12 @@ bool is_create) {
  * `POST /import/apply` runs the shared applier against collection rows it has
  * not written yet - every id would look missing there.
  */
-static std::optional<std::pair<int, nlohmann::json>>
-reject_missing_collection (vayu::db::Database& db, const std::string& collection_id) {
+static RouteResult reject_missing_collection (vayu::db::Database& db,
+const std::string& collection_id) {
     if (db.get_collection (collection_id).has_value ()) {
-        return std::nullopt;
+        return {};
     }
-    return std::make_pair (
-    400, error_body (400, "Collection '" + collection_id + "' does not exist"));
+    return route_error (400, "Collection '" + collection_id + "' does not exist");
 }
 
 /**
@@ -321,8 +323,8 @@ static bool order_is_defaulted (const nlohmann::json& json) {
  */
 std::pair<int, nlohmann::json>
 create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
     const std::string id = vayu::utils::generate_id ("req_");
 
@@ -335,11 +337,11 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
     r.created_at = now_ms ();
     r.updated_at = now_ms ();
 
-    if (auto err = apply_request_fields (db, r, json, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_request_fields (db, r, json, /*is_create=*/true); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = reject_missing_collection (db, r.collection_id)) {
-        return *err;
+    if (auto outcome = reject_missing_collection (db, r.collection_id); !outcome) {
+        return as_response (outcome.error ());
     }
     if (order_is_defaulted (json)) {
         r.order = next_request_order (db, r.collection_id);
@@ -358,8 +360,8 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
 std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json) {
-    if (auto err = reject_mismatched_body_id (json, id)) {
-        return *err;
+    if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
+        return as_response (outcome.error ());
     }
     auto existing = db.get_request (id);
     if (!existing) {
@@ -367,15 +369,15 @@ const nlohmann::json& json) {
     }
 
     vayu::db::Request r = *existing;
-    if (auto err = apply_request_fields (db, r, json, /*is_create=*/false)) {
-        return *err;
+    if (auto outcome = apply_request_fields (db, r, json, /*is_create=*/false); !outcome) {
+        return as_response (outcome.error ());
     }
     // Only when the write states a collection: an already-stranded row (written
     // before this check existed) must stay repairable by a PUT that moves it
     // somewhere real, rather than becoming unwritable.
     if (json.contains ("collectionId")) {
-        if (auto err = reject_missing_collection (db, r.collection_id)) {
-            return *err;
+        if (auto outcome = reject_missing_collection (db, r.collection_id); !outcome) {
+            return as_response (outcome.error ());
         }
     }
     // A move that states no `order` appends in the destination. Carrying the

--- a/engine/src/http/routes/spec_bind.cpp
+++ b/engine/src/http/routes/spec_bind.cpp
@@ -98,9 +98,10 @@ bind_spec_response (vayu::db::Database& db, const nlohmann::json& body) {
     }
 
     std::string collection_id;
-    if (auto err = apply_required_string_field (
-        body, "collectionId", collection_id, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_required_string_field (
+        body, "collectionId", collection_id, /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     if (collection_id.empty ()) {
         return body_error (
@@ -119,9 +120,10 @@ bind_spec_response (vayu::db::Database& db, const nlohmann::json& body) {
         }
     }
     std::string content;
-    if (auto err = apply_required_string_field (
-        spec_item, "content", content, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_required_string_field (
+        spec_item, "content", content, /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     if (content.empty ()) {
         return body_error (
@@ -211,8 +213,9 @@ bind_spec_response (vayu::db::Database& db, const nlohmann::json& body) {
             // Through the applier every other write of this column uses, so a
             // stamp written by a bind and one written by an import are the same
             // bytes, validated by the same rule.
-            if (auto err = apply_request_fields (db, row, fields, /*is_create=*/false)) {
-                result = *err;
+            if (auto outcome = apply_request_fields (db, row, fields, /*is_create=*/false);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             batch.updated.push_back (std::move (row));

--- a/engine/src/http/routes/spec_diff.cpp
+++ b/engine/src/http/routes/spec_diff.cpp
@@ -262,7 +262,7 @@ nlohmann::json draft_request_fields_json (const vayu::core::DraftRequest& draft)
         { "headers", rows_json (draft.headers) }, { "body", std::move (body) } };
 }
 
-std::optional<std::pair<int, nlohmann::json>> compare_bound_spec (vayu::db::Database& db,
+RouteResult compare_bound_spec (vayu::db::Database& db,
 const std::vector<vayu::db::Collection>& collections,
 const std::unordered_set<std::string>& subtree,
 const std::string& spec_id,
@@ -270,10 +270,9 @@ const nlohmann::ordered_json& fetched_document,
 SpecComparison& out) {
     const auto stored = db.get_spec_document (spec_id);
     if (!stored) {
-        return std::make_pair (409,
-        error_body (409,
+        return route_error (409,
         "Collection is bound to spec '" + spec_id +
-        "', which is not stored - rebind it before syncing"));
+        "', which is not stored - rebind it before syncing");
     }
     out.bound_content = stored->content;
     out.fetched       = vayu::core::spec_request_drafts_of (fetched_document);
@@ -311,7 +310,7 @@ SpecComparison& out) {
 
     out.diff =
     vayu::core::diff_spec (out.fetched, bound ? &*bound : nullptr, out.requests);
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -385,9 +384,10 @@ diff_spec_response (vayu::db::Database& db, const nlohmann::json& json) {
     // that says what would change and the route that changes it read one answer,
     // so an apply cannot write rows its preview never showed.
     SpecComparison comparison;
-    if (auto err = compare_bound_spec (
-        db, collections, subtree, spec_id, fetched_read.root, comparison)) {
-        return *err;
+    if (auto outcome = compare_bound_spec (
+        db, collections, subtree, spec_id, fetched_read.root, comparison);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     const auto& fetched              = comparison.fetched;
     const auto& requests             = comparison.requests;

--- a/engine/src/http/routes/spec_sync.cpp
+++ b/engine/src/http/routes/spec_sync.cpp
@@ -187,7 +187,7 @@ constexpr size_t MAX_SYNC_ITEMS = 10000;
 /** Absent or null section - a stable empty list to hand out. */
 const nlohmann::json EMPTY_ITEMS = nlohmann::json::array ();
 
-std::pair<int, nlohmann::json> body_error (const std::string& message) {
+RouteError body_error (const std::string& message) {
     return { 400, error_body (400, message) };
 }
 
@@ -198,46 +198,47 @@ std::pair<int, nlohmann::json> body_error (const std::string& message) {
  * being created and the real id for one being updated or deleted - in both
  * cases the only handle the caller has on it.
  */
-std::pair<int, nlohmann::json>
-item_error (int status, const std::string& message, const std::string& item) {
+RouteError item_error (int status, const std::string& message, const std::string& item) {
     auto body             = error_body (status, message);
     body["error"]["item"] = item;
     return { status, body };
 }
 
 /** Reads one optional top-level array; anything else that is not an array is a 400. */
-std::optional<std::pair<int, nlohmann::json>>
+RouteResult
 read_items (const nlohmann::json& body, const char* key, const nlohmann::json*& out) {
     out = &EMPTY_ITEMS;
     if (!body.contains (key) || body[key].is_null ()) {
-        return std::nullopt;
+        return {};
     }
     if (!body[key].is_array ()) {
-        return body_error (std::string ("Invalid '") + key + "': must be an array");
+        return std::unexpected (
+        body_error (std::string ("Invalid '") + key + "': must be an array"));
     }
     out = &body[key];
-    return std::nullopt;
+    return {};
 }
 
 /** Turns an applier's failure - its own error body, or a json type error - into a 400. */
 template <typename Apply>
-std::optional<std::pair<int, nlohmann::json>>
-apply_item_fields (Apply apply, const char* kind, const std::string& item) {
-    std::optional<std::pair<int, nlohmann::json>> err;
+RouteResult apply_item_fields (Apply apply, const char* kind, const std::string& item) {
+    RouteResult outcome;
     try {
-        err = apply ();
+        outcome = apply ();
     } catch (const nlohmann::json::exception& e) {
-        return item_error (400, std::string ("Invalid ") + kind + ": " + e.what (), item);
+        return std::unexpected (
+        item_error (400, std::string ("Invalid ") + kind + ": " + e.what (), item));
     }
-    if (err) {
-        err->second["error"]["item"] = item;
-        return err;
+    if (!outcome) {
+        RouteError refused            = outcome.error ();
+        refused.body["error"]["item"] = item;
+        return std::unexpected (refused);
     }
-    return std::nullopt;
+    return {};
 }
 
 /** Validates a `tempId`, rejects a client-supplied `id`, and claims a real one. */
-std::optional<std::pair<int, nlohmann::json>> claim_temp_id (const nlohmann::json& item,
+RouteResult claim_temp_id (const nlohmann::json& item,
 const char* kind,
 const char* prefix,
 size_t index,
@@ -245,22 +246,24 @@ std::unordered_map<std::string, std::string>& id_map,
 std::string& temp_id_out) {
     const std::string at = std::string (kind) + " at index " + std::to_string (index);
     if (!item.is_object ()) {
-        return body_error ("Invalid " + at + ": must be an object");
+        return std::unexpected (body_error ("Invalid " + at + ": must be an object"));
     }
     if (item.contains ("id")) {
-        return body_error ("Invalid " +
-        at + ": 'id' is not accepted - the engine assigns ids; reference items by 'tempId'");
+        return std::unexpected (body_error ("Invalid " +
+        at + ": 'id' is not accepted - the engine assigns ids; reference items by 'tempId'"));
     }
     if (!item.contains ("tempId") || !item["tempId"].is_string () ||
     item["tempId"].get<std::string> ().empty ()) {
-        return body_error ("Invalid " + at + ": 'tempId' must be a non-empty string");
+        return std::unexpected (
+        body_error ("Invalid " + at + ": 'tempId' must be a non-empty string"));
     }
     temp_id_out = item["tempId"].get<std::string> ();
     if (id_map.contains (temp_id_out)) {
-        return item_error (400, "Duplicate tempId '" + temp_id_out + "'", temp_id_out);
+        return std::unexpected (
+        item_error (400, "Duplicate tempId '" + temp_id_out + "'", temp_id_out));
     }
     id_map.emplace (temp_id_out, vayu::utils::generate_id (prefix));
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -279,7 +282,7 @@ std::string& temp_id_out) {
  * back would make that delete a suggestion. Empty on the create path: a
  * request being created now has nothing behind it to have deleted.
  */
-std::optional<std::pair<int, nlohmann::json>> build_example_rows (const nlohmann::json& examples,
+RouteResult build_example_rows (const nlohmann::json& examples,
 const std::string& request_id,
 const std::string& owner,
 int base_order,
@@ -303,12 +306,13 @@ const std::unordered_set<int>& suppressed_statuses = {}) {
         // these rows are the engine's own: a field the applier learns - the way
         // `origin` and `suppressed` were learned - must reach a sync's rows too,
         // and a second construction here is how it would not.
-        if (auto err = apply_item_fields (
+        if (auto outcome = apply_item_fields (
             [&] {
                 return apply_request_example_fields (x, example, /*is_create=*/true);
             },
-            "example", owner)) {
-            return err;
+            "example", owner);
+        !outcome) {
+            return outcome;
         }
         if (suppressed_statuses.contains (x.status)) {
             continue;
@@ -321,14 +325,14 @@ const std::unordered_set<int>& suppressed_statuses = {}) {
     }
 
     if (rows.size () + surviving > vayu::core::constants::request_example::MAX_PER_REQUEST) {
-        return item_error (400,
+        return std::unexpected (item_error (400,
         "Too many examples: " + std::to_string (rows.size () + surviving) + " exceeds the limit of " +
         std::to_string (vayu::core::constants::request_example::MAX_PER_REQUEST) + " per request",
-        owner);
+        owner));
     }
     out.insert (out.end (), std::make_move_iterator (rows.begin ()),
     std::make_move_iterator (rows.end ()));
-    return std::nullopt;
+    return {};
 }
 
 /**
@@ -373,7 +377,7 @@ class DocumentedExamples {
         }
         const std::optional<size_t> found = index_->resolve (spec_operation);
         if (!found) {
-            return std::nullopt;
+            return {};
         }
         // `make_optional` rather than a bare return: copy-initializing an
         // `optional<json>` from a `json` puts nlohmann's `operator ValueType()`
@@ -630,38 +634,40 @@ struct ClaimedIds {
 std::pair<int, nlohmann::json>
 spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (!body.is_object ()) {
-        return body_error ("Body must be a JSON object");
+        return as_response (body_error ("Body must be a JSON object"));
     }
 
     std::string collection_id;
-    if (auto err = apply_required_string_field (
-        body, "collectionId", collection_id, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_required_string_field (
+        body, "collectionId", collection_id, /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     if (collection_id.empty ()) {
-        return body_error (
-        "Invalid 'collectionId': must be a non-empty string");
+        return as_response (
+        body_error ("Invalid 'collectionId': must be a non-empty string"));
     }
 
     if (!body.contains ("spec") || !body["spec"].is_object ()) {
-        return body_error (
-        "Invalid 'spec': must be an object with the re-fetched document");
+        return as_response (body_error (
+        "Invalid 'spec': must be an object with the re-fetched document"));
     }
     const auto& spec_item = body["spec"];
     for (const char* engine_owned : { "id", "hash", "fetchedAt" }) {
         if (spec_item.contains (engine_owned)) {
-            return body_error (std::string ("Invalid 'spec.") + engine_owned +
-            "': computed by the engine; omit it");
+            return as_response (body_error (std::string ("Invalid 'spec.") +
+            engine_owned + "': computed by the engine; omit it"));
         }
     }
     std::string content;
-    if (auto err = apply_required_string_field (
-        spec_item, "content", content, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_required_string_field (
+        spec_item, "content", content, /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     if (content.empty ()) {
-        return body_error (
-        "Invalid 'spec.content': an empty document is not a spec");
+        return as_response (
+        body_error ("Invalid 'spec.content': an empty document is not a spec"));
     }
 
     /*
@@ -682,20 +688,21 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
     if (const auto stated_policy = body.find ("policy");
     stated_policy != body.end () && !stated_policy->is_null ()) {
         if (!stated_policy->is_string ()) {
-            return body_error ("Invalid 'policy': must be a string");
+            return as_response (
+            body_error ("Invalid 'policy': must be a string"));
         }
         policy = stated_policy->get<std::string> ();
         if (policy != "safe") {
-            return body_error ("Invalid 'policy': '" + policy +
+            return as_response (body_error ("Invalid 'policy': '" + policy +
             "' is not a policy this engine has; the only one is \"safe\" - "
             "everything the "
             "document adds, every field it moved that nobody here had edited, "
-            "and no deletions");
+            "and no deletions"));
         }
         for (const char* section : { "collections", "create", "update", "delete" }) {
             if (body.contains (section) && !body[section].is_null ()) {
-                return body_error (std::string ("Invalid '") +
-                section + "': a policy sync decides its own rows; send 'policy' or the rows, not both");
+                return as_response (body_error (std::string ("Invalid '") +
+                section + "': a policy sync decides its own rows; send 'policy' or the rows, not both"));
             }
         }
     }
@@ -704,17 +711,17 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
     const nlohmann::json* creates         = nullptr;
     const nlohmann::json* updates         = nullptr;
     const nlohmann::json* deletes         = nullptr;
-    if (auto err = read_items (body, "collections", new_collections)) {
-        return *err;
+    if (auto outcome = read_items (body, "collections", new_collections); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "create", creates)) {
-        return *err;
+    if (auto outcome = read_items (body, "create", creates); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "update", updates)) {
-        return *err;
+    if (auto outcome = read_items (body, "update", updates); !outcome) {
+        return as_response (outcome.error ());
     }
-    if (auto err = read_items (body, "delete", deletes)) {
-        return *err;
+    if (auto outcome = read_items (body, "delete", deletes); !outcome) {
+        return as_response (outcome.error ());
     }
 
     // The rows the payload asks for. The example rows a refresh writes are the
@@ -727,8 +734,8 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
     size_t stated = new_collections->size () + creates->size () +
     updates->size () + deletes->size ();
     if (stated > MAX_SYNC_ITEMS) {
-        return body_error ("Sync too large: " + std::to_string (stated) +
-        " items exceeds the limit of " + std::to_string (MAX_SYNC_ITEMS) + " per call");
+        return as_response (body_error ("Sync too large: " + std::to_string (stated) +
+        " items exceeds the limit of " + std::to_string (MAX_SYNC_ITEMS) + " per call"));
     }
 
     std::pair<int, nlohmann::json> result;
@@ -743,17 +750,18 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         }
         const std::string bound_id = bound_spec_id (root->openapi);
         if (bound_id.empty ()) {
-            result = body_error ("Collection '" + collection_id +
-            "' is not bound to a spec; bind it before syncing");
+            result = as_response (body_error ("Collection '" + collection_id +
+            "' is not bound to a spec; bind it before syncing"));
             return;
         }
         const auto subtree = collection_subtree_ids (stored_collections, collection_id);
 
         const size_t cap = spec_size_cap (db);
         if (content.size () > cap) {
-            result = body_error ("Spec document is " + std::to_string (content.size ()) +
+            result = as_response (
+            body_error ("Spec document is " + std::to_string (content.size ()) +
             " bytes, over the limit of " + std::to_string (cap) +
-            " (raise the 'maxSpecDocumentBytes' setting to allow more)");
+            " (raise the 'maxSpecDocumentBytes' setting to allow more)"));
             return;
         }
 
@@ -768,14 +776,14 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         // them a second time would be a second answer about them.
         nlohmann::ordered_json document;
         if (auto reason = read_spec_indexes (spec_item, batch.spec, cap, &document)) {
-            result = body_error (*reason);
+            result = as_response (body_error (*reason));
             return;
         }
         DocumentedExamples documented (document);
         if (spec_item.contains ("sourceUrl") && !spec_item["sourceUrl"].is_null ()) {
             if (!spec_item["sourceUrl"].is_string ()) {
-                result = body_error (
-                "Invalid 'spec.sourceUrl': must be a string or null");
+                result = as_response (body_error (
+                "Invalid 'spec.sourceUrl': must be a string or null"));
                 return;
             }
             const auto url = spec_item["sourceUrl"].get<std::string> ();
@@ -792,9 +800,10 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         nlohmann::json policy_rows;
         if (!policy.empty ()) {
             SpecComparison comparison;
-            if (auto err = compare_bound_spec (db, stored_collections, subtree,
-                bound_id, document, comparison)) {
-                result = *err;
+            if (auto outcome = compare_bound_spec (
+                db, stored_collections, subtree, bound_id, document, comparison);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             policy_rows = safe_sync_payload (collection_id, stored_collections, comparison);
@@ -805,8 +814,9 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             stated          = new_collections->size () + creates->size () +
             updates->size () + deletes->size ();
             if (stated > MAX_SYNC_ITEMS) {
-                result = body_error ("Sync too large: " + std::to_string (stated) +
-                " items exceeds the limit of " + std::to_string (MAX_SYNC_ITEMS) + " per call");
+                result = as_response (body_error (
+                "Sync too large: " + std::to_string (stated) + " items exceeds the limit of " +
+                std::to_string (MAX_SYNC_ITEMS) + " per call"));
                 return;
             }
         }
@@ -822,18 +832,20 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         for (size_t i = 0; i < new_collections->size (); ++i) {
             const auto& item = (*new_collections)[i];
             std::string temp;
-            if (auto err = claim_temp_id (item, "collection", "col_", i, claimed.real, temp)) {
-                result = *err;
+            if (auto outcome =
+                claim_temp_id (item, "collection", "col_", i, claimed.real, temp);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             claimed.collections.insert (temp);
 
             if (item.contains ("openapi")) {
-                result = item_error (400,
+                result = as_response (item_error (400,
                 "Invalid 'openapi': a folder a sync creates is part of the "
                 "document being "
                 "synced, not a document of its own",
-                temp);
+                temp));
                 return;
             }
 
@@ -841,14 +853,15 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             std::string parent    = collection_id;
             if (item.contains ("parentId") && !item["parentId"].is_null ()) {
                 if (!item["parentId"].is_string ()) {
-                    result = item_error (400, "Invalid 'parentId': must be a string", temp);
+                    result = as_response (
+                    item_error (400, "Invalid 'parentId': must be a string", temp));
                     return;
                 }
                 parent = item["parentId"].get<std::string> ();
                 if (!subtree.contains (parent)) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'parentId': '" + parent + "' is not the collection being synced or one beneath it",
-                    temp);
+                    temp));
                     return;
                 }
             }
@@ -858,12 +871,13 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             folder.id         = claimed.real.at (temp);
             folder.created_at = now;
             folder.updated_at = now;
-            if (auto err = apply_item_fields (
+            if (auto outcome = apply_item_fields (
                 [&] {
                     return apply_collection_fields (db, folder, fields, /*is_create=*/true);
                 },
-                "collection", temp)) {
-                result = *err;
+                "collection", temp);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             if (!item.contains ("order") || item["order"].is_null ()) {
@@ -878,16 +892,18 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         for (size_t i = 0; i < creates->size (); ++i) {
             const auto& item = (*creates)[i];
             std::string temp;
-            if (auto err = claim_temp_id (item, "request", "req_", i, claimed.real, temp)) {
-                result = *err;
+            if (auto outcome =
+                claim_temp_id (item, "request", "req_", i, claimed.real, temp);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             if (item.contains ("examples")) {
-                result = item_error (400,
+                result = as_response (item_error (400,
                 "Invalid 'examples': a sync writes the responses the document "
                 "it stores "
                 "documents; omit it",
-                temp);
+                temp));
                 return;
             }
 
@@ -895,22 +911,22 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             std::string owner;
             if (item.contains ("collectionTempId") && !item["collectionTempId"].is_null ()) {
                 if (!item["collectionTempId"].is_string ()) {
-                    result = item_error (
-                    400, "Invalid 'collectionTempId': must be a string", temp);
+                    result = as_response (item_error (
+                    400, "Invalid 'collectionTempId': must be a string", temp));
                     return;
                 }
                 const auto named = item["collectionTempId"].get<std::string> ();
                 if (!claimed.collections.contains (named)) {
-                    result =
-                    item_error (400, "Unknown collectionTempId '" + named + "'", temp);
+                    result = as_response (item_error (
+                    400, "Unknown collectionTempId '" + named + "'", temp));
                     return;
                 }
                 if (item.contains ("collectionId")) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid request: send either 'collectionTempId' (a folder "
                     "in this "
                     "payload) or 'collectionId' (one already stored), not both",
-                    temp);
+                    temp));
                     return;
                 }
                 owner = claimed.real.at (named);
@@ -918,19 +934,18 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
                 next_request_order.try_emplace (owner, 0);
             } else {
                 if (!item.contains ("collectionId") || !item["collectionId"].is_string ()) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'collectionId': must name a collection beneath "
                     "the one being "
                     "synced, or use 'collectionTempId'",
-                    temp);
+                    temp));
                     return;
                 }
                 owner = item["collectionId"].get<std::string> ();
                 if (!subtree.contains (owner)) {
-                    result = item_error (400,
-                    "Invalid 'collectionId': '" + owner +
-                    "' is not the collection being synced or one beneath it",
-                    temp);
+                    result = as_response (item_error (400,
+                    "Invalid 'collectionId': '" + owner + "' is not the collection being synced or one beneath it",
+                    temp));
                     return;
                 }
                 if (!next_request_order.contains (owner)) {
@@ -948,12 +963,13 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             row.id         = claimed.real.at (temp);
             row.created_at = now;
             row.updated_at = now;
-            if (auto err = apply_item_fields (
+            if (auto outcome = apply_item_fields (
                 [&] {
                     return apply_request_fields (db, row, fields, /*is_create=*/true);
                 },
-                "request", temp)) {
-                result = *err;
+                "request", temp);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
             if (!item.contains ("order") || item["order"].is_null ()) {
@@ -969,17 +985,18 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
              */
             if (row.spec_operation) {
                 if (auto rows = documented.rows_for (*row.spec_operation)) {
-                    if (auto err = build_example_rows (*rows, row.id, temp,
-                        /*base_order=*/0, now, batch.examples, /*surviving=*/0)) {
-                        result = *err;
+                    if (auto outcome = build_example_rows (*rows, row.id, temp,
+                        /*base_order=*/0, now, batch.examples, /*surviving=*/0);
+                    !outcome) {
+                        result = as_response (outcome.error ());
                         return;
                     }
                 } else {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'specOperation': the document being synced "
                     "declares no such "
                     "operation, so there is nothing to create for it",
-                    temp);
+                    temp));
                     return;
                 }
             }
@@ -991,20 +1008,20 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         for (size_t i = 0; i < updates->size (); ++i) {
             const auto& item = (*updates)[i];
             if (!item.is_object ()) {
-                result = body_error ("Invalid update at index " +
-                std::to_string (i) + ": must be an object");
+                result = as_response (body_error ("Invalid update at index " +
+                std::to_string (i) + ": must be an object"));
                 return;
             }
             if (!item.contains ("id") || !item["id"].is_string () ||
             item["id"].get<std::string> ().empty ()) {
-                result = body_error ("Invalid update at index " +
-                std::to_string (i) + ": 'id' must be the id of a stored request");
+                result = as_response (body_error ("Invalid update at index " +
+                std::to_string (i) + ": 'id' must be the id of a stored request"));
                 return;
             }
             const std::string id = item["id"].get<std::string> ();
             if (!touched.insert (id).second) {
-                result = item_error (
-                400, "Request '" + id + "' appears twice in this sync", id);
+                result = as_response (item_error (
+                400, "Request '" + id + "' appears twice in this sync", id));
                 return;
             }
             auto stored = db.get_request (id);
@@ -1012,31 +1029,33 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
                 // The diff was computed against a row that has since gone. A
                 // conflict, not a bad request: nothing about the payload is
                 // malformed, the ground moved under it.
-                result = item_error (409, "Request '" + id + "' no longer exists", id);
+                result = as_response (
+                item_error (409, "Request '" + id + "' no longer exists", id));
                 return;
             }
             if (!subtree.contains (stored->collection_id)) {
-                result = item_error (400,
-                "Request '" + id + "' is not beneath the collection being synced", id);
+                result = as_response (item_error (400,
+                "Request '" + id + "' is not beneath the collection being synced", id));
                 return;
             }
             if (item.contains ("collectionId")) {
-                result = item_error (400,
+                result = as_response (item_error (400,
                 "Invalid 'collectionId': a sync updates a request where it is; "
                 "move it with "
                 "PUT /requests/:id",
-                id);
+                id));
                 return;
             }
 
             vayu::db::Request row = *stored;
             row.updated_at        = now;
-            if (auto err = apply_item_fields (
+            if (auto outcome = apply_item_fields (
                 [&] {
                     return apply_request_fields (db, row, item, /*is_create=*/false);
                 },
-                "request", id)) {
-                result = *err;
+                "request", id);
+            !outcome) {
+                result = as_response (outcome.error ());
                 return;
             }
 
@@ -1052,43 +1071,44 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             if (const auto decision = item.find ("examples");
             decision != item.end () && !decision->is_null ()) {
                 if (!decision->is_boolean ()) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'examples': must be true to refresh this "
                     "request's imported "
                     "examples from the document being synced, or absent to "
                     "leave them - a "
                     "sync writes the responses the document documents, not "
                     "rows you state",
-                    id);
+                    id));
                     return;
                 }
                 refresh = decision->get<bool> ();
             }
             if (refresh) {
                 if (!row.spec_operation) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'examples': this request records no operation, so "
                     "the document "
                     "documents no responses for it",
-                    id);
+                    id));
                     return;
                 }
                 const auto rows = documented.rows_for (*row.spec_operation);
                 if (!rows) {
-                    result = item_error (400,
+                    result = as_response (item_error (400,
                     "Invalid 'examples': the document being synced declares no "
                     "operation "
                     "this request records, so it documents no responses for it",
-                    id);
+                    id));
                     return;
                 }
                 const auto plan = refresh_examples (db.get_request_examples (id),
                 db.get_suppressed_request_examples (id));
                 batch.deleted_examples.insert (batch.deleted_examples.end (),
                 plan.replaced.begin (), plan.replaced.end ());
-                if (auto err = build_example_rows (*rows, id, id, plan.base_order,
-                    now, batch.examples, plan.surviving, plan.suppressed_statuses)) {
-                    result = *err;
+                if (auto outcome = build_example_rows (*rows, id, id, plan.base_order,
+                    now, batch.examples, plan.surviving, plan.suppressed_statuses);
+                !outcome) {
+                    result = as_response (outcome.error ());
                     return;
                 }
             }
@@ -1099,14 +1119,14 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         for (size_t i = 0; i < deletes->size (); ++i) {
             const auto& item = (*deletes)[i];
             if (!item.is_string () || item.get<std::string> ().empty ()) {
-                result = body_error ("Invalid delete at index " +
-                std::to_string (i) + ": must be the id of a stored request");
+                result = as_response (body_error ("Invalid delete at index " +
+                std::to_string (i) + ": must be the id of a stored request"));
                 return;
             }
             const std::string id = item.get<std::string> ();
             if (!touched.insert (id).second) {
-                result = item_error (
-                400, "Request '" + id + "' appears twice in this sync", id);
+                result = as_response (item_error (
+                400, "Request '" + id + "' appears twice in this sync", id));
                 return;
             }
             auto stored = db.get_request (id);
@@ -1117,8 +1137,8 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
                 continue;
             }
             if (!subtree.contains (stored->collection_id)) {
-                result = item_error (400,
-                "Request '" + id + "' is not beneath the collection being synced", id);
+                result = as_response (item_error (400,
+                "Request '" + id + "' is not beneath the collection being synced", id));
                 return;
             }
             batch.deleted.push_back (id);
@@ -1131,8 +1151,8 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
         // that stopped counting them would bound a smaller transaction than the
         // one it was written for.
         if (const size_t writing = stated + batch.examples.size (); writing > MAX_SYNC_ITEMS) {
-            result = body_error ("Sync too large: " + std::to_string (writing) +
-            " items exceeds the limit of " + std::to_string (MAX_SYNC_ITEMS) + " per call");
+            result = as_response (body_error ("Sync too large: " + std::to_string (writing) +
+            " items exceeds the limit of " + std::to_string (MAX_SYNC_ITEMS) + " per call"));
             return;
         }
 

--- a/engine/src/http/routes/spec_sync.cpp
+++ b/engine/src/http/routes/spec_sync.cpp
@@ -201,7 +201,7 @@ RouteError body_error (const std::string& message) {
 RouteError item_error (int status, const std::string& message, const std::string& item) {
     auto body             = error_body (status, message);
     body["error"]["item"] = item;
-    return { status, body };
+    return { .status = status, .body = body };
 }
 
 /** Reads one optional top-level array; anything else that is not an array is a 400. */

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -275,24 +275,24 @@ const vayu::Response& response) {
  * write path passes an empty set, because everything it may bind is already
  * stored.
  */
-std::optional<std::pair<int, nlohmann::json>> reject_unbindable_spec (vayu::db::Database& db,
+RouteResult reject_unbindable_spec (vayu::db::Database& db,
 const std::string& openapi,
 const std::unordered_set<std::string>& pending) {
     std::string spec_id;
     try {
         const auto parsed = nlohmann::json::parse (openapi);
         if (!parsed.is_object ()) {
-            return std::nullopt;
+            return {};
         }
         spec_id = parsed.value ("specId", std::string ());
     } catch (const std::exception&) {
-        return std::nullopt; // Not a binding; the applier already had its say.
+        return {}; // Not a binding; the applier already had its say.
     }
     if (spec_id.empty () || pending.contains (spec_id) ||
     db.get_spec_document (spec_id).has_value ()) {
-        return std::nullopt;
+        return {};
     }
-    return std::make_pair (400, error_body (400, "Spec '" + spec_id + "' does not exist"));
+    return route_error (400, "Spec '" + spec_id + "' does not exist");
 }
 
 /**
@@ -337,8 +337,8 @@ void stamp_binding_from_store (vayu::db::Database& db, std::string& openapi) {
  */
 std::pair<int, nlohmann::json>
 create_spec_document_response (vayu::db::Database& db, const nlohmann::json& json) {
-    if (auto err = reject_client_supplied_id (json)) {
-        return *err;
+    if (auto outcome = reject_client_supplied_id (json); !outcome) {
+        return as_response (outcome.error ());
     }
     for (const char* derived : { "hash", "fetchedAt" }) {
         if (json.contains (derived)) {
@@ -347,8 +347,9 @@ create_spec_document_response (vayu::db::Database& db, const nlohmann::json& jso
     }
 
     std::string content;
-    if (auto err = apply_required_string_field (json, "content", content, /*is_create=*/true)) {
-        return *err;
+    if (auto outcome = apply_required_string_field (json, "content", content, /*is_create=*/true);
+    !outcome) {
+        return as_response (outcome.error ());
     }
     if (content.empty ()) {
         return { 400, error_body (400, "Invalid 'content': an empty document is not a spec") };

--- a/engine/tests/collections_route_test.cpp
+++ b/engine/tests/collections_route_test.cpp
@@ -30,14 +30,14 @@
 
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/routes.hpp"
 
 using nlohmann::json;
 
 namespace vayu::http::routes {
-// Defined in collections.cpp; returns std::nullopt when the parent assignment
-// is legal, else {http_status, json_body} describing the 400 rejection.
-std::optional<std::pair<int, nlohmann::json>> validate_parent_assignment (
-vayu::db::Database& db,
+// Defined in collections.cpp; succeeds when the parent assignment is legal,
+// and fails with the 400 to send when it is not.
+RouteResult validate_parent_assignment (vayu::db::Database& db,
 const std::string& id,
 const std::optional<std::string>& parent_id);
 } // namespace vayu::http::routes
@@ -94,16 +94,17 @@ class CollectionsRouteTest : public ::testing::Test {
 
 TEST_F (CollectionsRouteTest, NullParentIsAllowed) {
     seed_collection ("col_a", "A");
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", std::nullopt);
-    EXPECT_FALSE (err.has_value ());
+    EXPECT_TRUE (
+    vayu::http::routes::validate_parent_assignment (*db_, "col_a", std::nullopt).has_value ());
 }
 
 TEST_F (CollectionsRouteTest, SelfParentRejectedWith400) {
     seed_collection ("col_a", "A");
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_a");
-    ASSERT_TRUE (err.has_value ());
-    EXPECT_EQ (err->first, 400);
-    EXPECT_EQ (err->second["error"]["message"], "A collection cannot be its own parent");
+    const auto outcome =
+    vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_a");
+    ASSERT_FALSE (outcome.has_value ());
+    EXPECT_EQ (outcome.error ().status, 400);
+    EXPECT_EQ (outcome.error ().body["error"]["message"], "A collection cannot be its own parent");
 }
 
 TEST_F (CollectionsRouteTest, ReparentIntoDescendantRejectedWith400) {
@@ -112,30 +113,31 @@ TEST_F (CollectionsRouteTest, ReparentIntoDescendantRejectedWith400) {
     seed_collection ("col_b", "B", "col_a");
     seed_collection ("col_c", "C", "col_b");
 
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_c");
-    ASSERT_TRUE (err.has_value ());
-    EXPECT_EQ (err->first, 400);
-    EXPECT_EQ (err->second["error"]["message"],
+    const auto outcome =
+    vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_c");
+    ASSERT_FALSE (outcome.has_value ());
+    EXPECT_EQ (outcome.error ().status, 400);
+    EXPECT_EQ (outcome.error ().body["error"]["message"],
     "Cannot move a collection into its own descendant");
 }
 
 TEST_F (CollectionsRouteTest, LegalReparentSucceeds) {
     // A -> B, and a sibling D. Moving D under B is legal (B is not a descendant
-    // of D). Validation returns nullopt.
+    // of D), so validation succeeds.
     seed_collection ("col_a", "A");
     seed_collection ("col_b", "B", "col_a");
     seed_collection ("col_d", "D");
 
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_d", "col_b");
-    EXPECT_FALSE (err.has_value ());
+    EXPECT_TRUE (
+    vayu::http::routes::validate_parent_assignment (*db_, "col_d", "col_b").has_value ());
 }
 
 TEST_F (CollectionsRouteTest, MissingParentEndsWalkCleanly) {
     // Parent existence is intentionally not required (import creates in bulk).
     // A parent id that resolves to nothing must pass, not throw or reject.
     seed_collection ("col_a", "A");
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_ghost");
-    EXPECT_FALSE (err.has_value ());
+    EXPECT_TRUE (
+    vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_ghost").has_value ());
 }
 
 TEST_F (CollectionsRouteTest, PreExistingCycleDoesNotHangValidator) {
@@ -146,9 +148,9 @@ TEST_F (CollectionsRouteTest, PreExistingCycleDoesNotHangValidator) {
     seed_collection ("col_y", "Y", "col_x");
     seed_collection ("col_z", "Z");
 
-    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_z", "col_x");
     // col_z is not on the x/y cycle, so the walk simply terminates: legal.
-    EXPECT_FALSE (err.has_value ());
+    EXPECT_TRUE (
+    vayu::http::routes::validate_parent_assignment (*db_, "col_z", "col_x").has_value ());
 }
 
 // -- Cascade delete --------------------------------------------------------

--- a/engine/tests/execution_http_version_test.cpp
+++ b/engine/tests/execution_http_version_test.cpp
@@ -15,12 +15,12 @@
 
 #include <nlohmann/json.hpp>
 
+#include "vayu/http/routes.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::http::routes {
 // Declared in execution.cpp.
-std::optional<std::pair<int, nlohmann::json>> normalize_run_http_version (
-nlohmann::json& json);
+RouteResult normalize_run_http_version (nlohmann::json& json);
 } // namespace vayu::http::routes
 
 namespace {
@@ -29,7 +29,7 @@ using vayu::http::routes::normalize_run_http_version;
 
 TEST (NormalizeRunHttpVersion, AbsentLeavesJsonUntouched) {
     auto json = nlohmann::json::parse (R"({"method":"GET","url":"http://x"})");
-    EXPECT_EQ (normalize_run_http_version (json), std::nullopt);
+    EXPECT_TRUE (normalize_run_http_version (json).has_value ());
     EXPECT_FALSE (json.contains ("httpVersion"));
 }
 
@@ -39,7 +39,7 @@ TEST (NormalizeRunHttpVersion, AcceptsEveryValidVersion) {
     for (const auto version : vayu::all_http_versions ()) {
         const std::string wire = vayu::to_string (version);
         auto json = nlohmann::json::parse (R"({"httpVersion":")" + wire + "\"}");
-        EXPECT_EQ (normalize_run_http_version (json), std::nullopt) << wire;
+        EXPECT_TRUE (normalize_run_http_version (json).has_value ()) << wire;
         ASSERT_TRUE (json.contains ("httpVersion")) << wire;
         EXPECT_EQ (json["httpVersion"], wire) << wire;
     }
@@ -52,17 +52,18 @@ TEST (NormalizeRunHttpVersion, NullIsErasedSoItBehavesLikeAnAbsentKey) {
     // default - erasing is what stops the two diverging once anything resolves
     // a default at this layer.
     auto json = nlohmann::json::parse (R"({"url":"https://x/y","httpVersion":null})");
-    EXPECT_EQ (normalize_run_http_version (json), std::nullopt);
+    EXPECT_TRUE (normalize_run_http_version (json).has_value ());
     EXPECT_FALSE (json.contains ("httpVersion"));
     EXPECT_EQ (json["url"], "https://x/y"); // nothing else disturbed
 }
 
 TEST (NormalizeRunHttpVersion, RejectsUnrecognizedString) {
-    auto json = nlohmann::json::parse (R"({"httpVersion":"spdy"})");
-    auto err  = normalize_run_http_version (json);
-    ASSERT_TRUE (err.has_value ());
-    EXPECT_EQ (err->first, 400);
-    const std::string message = err->second["error"]["message"].get<std::string> ();
+    auto json          = nlohmann::json::parse (R"({"httpVersion":"spdy"})");
+    const auto outcome = normalize_run_http_version (json);
+    ASSERT_FALSE (outcome.has_value ());
+    EXPECT_EQ (outcome.error ().status, 400);
+    const std::string message =
+    outcome.error ().body["error"]["message"].get<std::string> ();
     EXPECT_NE (message.find ("httpVersion"), std::string::npos);
     // Every wire value must be named in the rejection, the same guarantee
     // resource_write_route_test.cpp holds the CRUD route to.
@@ -73,12 +74,11 @@ TEST (NormalizeRunHttpVersion, RejectsUnrecognizedString) {
 }
 
 TEST (NormalizeRunHttpVersion, RejectsNonStringValue) {
-    auto json = nlohmann::json::parse (R"({"httpVersion":2})");
-    auto err  = normalize_run_http_version (json);
-    ASSERT_TRUE (err.has_value ());
-    EXPECT_EQ (err->first, 400);
-    EXPECT_NE (
-    err->second["error"]["message"].get<std::string> ().find ("httpVersion"),
+    auto json          = nlohmann::json::parse (R"({"httpVersion":2})");
+    const auto outcome = normalize_run_http_version (json);
+    ASSERT_FALSE (outcome.has_value ());
+    EXPECT_EQ (outcome.error ().status, 400);
+    EXPECT_NE (outcome.error ().body["error"]["message"].get<std::string> ().find ("httpVersion"),
     std::string::npos);
 }
 

--- a/engine/tests/mock_server_routes_test.cpp
+++ b/engine/tests/mock_server_routes_test.cpp
@@ -50,34 +50,38 @@ int64_t now_ms () {
 // ---------------------------------------------------------------------------
 
 TEST (MockParseStart, RequiresACollectionAndDefaultsTheRest) {
-    MockStartRequest out;
-    ASSERT_FALSE (
-    vayu::http::parse_mock_start (json{ { "collectionId", "col_1" } }, out).has_value ());
-    EXPECT_EQ (out.collection_id, "col_1");
-    EXPECT_EQ (out.port, 0);
-    EXPECT_EQ (out.latency_ms, 0);
-    EXPECT_EQ (out.error_rate_pct, 0);
+    const auto parsed =
+    vayu::http::parse_mock_start (json{ { "collectionId", "col_1" } });
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->collection_id, "col_1");
+    EXPECT_EQ (parsed->port, 0);
+    EXPECT_EQ (parsed->latency_ms, 0);
+    EXPECT_EQ (parsed->error_rate_pct, 0);
 
     // A mock with no collection has nothing to serve, so absence is a 400
     // rather than a listener that 404s everything.
-    EXPECT_TRUE (vayu::http::parse_mock_start (json::object (), out).has_value ());
-    EXPECT_TRUE (
-    vayu::http::parse_mock_start (json{ { "collectionId", "" } }, out).has_value ());
-    EXPECT_TRUE (
-    vayu::http::parse_mock_start (json{ { "collectionId", 7 } }, out).has_value ());
-    EXPECT_TRUE (vayu::http::parse_mock_start (json ("not an object"), out).has_value ());
+    EXPECT_FALSE (vayu::http::parse_mock_start (json::object ()).has_value ());
+    EXPECT_FALSE (
+    vayu::http::parse_mock_start (json{ { "collectionId", "" } }).has_value ());
+    EXPECT_FALSE (vayu::http::parse_mock_start (json{ { "collectionId", 7 } }).has_value ());
+    EXPECT_FALSE (vayu::http::parse_mock_start (json ("not an object")).has_value ());
+
+    // The refusal carries the status and code the route sends, so a caller
+    // that never looks at the value still answers correctly.
+    const auto refused = vayu::http::parse_mock_start (json::object ());
+    ASSERT_FALSE (refused.has_value ());
+    EXPECT_EQ (refused.error ().http_status, 400);
+    EXPECT_EQ (refused.error ().code, "bad_request");
+    EXPECT_FALSE (refused.error ().message.empty ());
 }
 
 TEST (MockParseStart, ReadsAndBoundsEveryTuningField) {
-    MockStartRequest out;
-    ASSERT_FALSE (
-    vayu::http::parse_mock_start (json{ { "collectionId", "col_1" }, { "port", 41234 },
-                                  { "latencyMs", 25 }, { "errorRatePct", 10 } },
-    out)
-    .has_value ());
-    EXPECT_EQ (out.port, 41234);
-    EXPECT_EQ (out.latency_ms, 25);
-    EXPECT_EQ (out.error_rate_pct, 10);
+    const auto parsed = vayu::http::parse_mock_start (json{ { "collectionId", "col_1" },
+    { "port", 41234 }, { "latencyMs", 25 }, { "errorRatePct", 10 } });
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->port, 41234);
+    EXPECT_EQ (parsed->latency_ms, 25);
+    EXPECT_EQ (parsed->error_rate_pct, 10);
 
     // Out of range is refused rather than clamped: a mock silently answering
     // with no delay when one was asked for is a mock doing something other than
@@ -90,8 +94,7 @@ TEST (MockParseStart, ReadsAndBoundsEveryTuningField) {
          json{ { "latencyMs", "fast" } } }) {
         json body = base;
         body.update (bad);
-        EXPECT_TRUE (vayu::http::parse_mock_start (body, out).has_value ())
-        << body.dump ();
+        EXPECT_FALSE (vayu::http::parse_mock_start (body).has_value ()) << body.dump ();
     }
 }
 

--- a/scripts/cxx-feature-probe/CMakeLists.txt
+++ b/scripts/cxx-feature-probe/CMakeLists.txt
@@ -1,0 +1,115 @@
+# The C++ standard floor probe (issue #901, phase 0).
+#
+# Compiles one tiny translation unit per language/library feature at the
+# standard set below, on whatever toolchain it is pointed at, and reports a
+# pass/fail table. It answers "does this feature exist on this platform's CI
+# compiler", which is the question a standard bump turns from folklore into a
+# decision - and it answers it again later, for the next standard, by changing
+# VAYU_PROBE_STANDARD rather than by rewriting anything.
+#
+# It is deliberately not part of the engine build: nothing here is compiled
+# into a Vayu artifact, and the engine's own standard (engine/CMakeLists.txt)
+# is not read or written by this project. Run it from CI
+# (.github/workflows/cxx-feature-probe.yml) or by hand:
+#
+#   cmake -S scripts/cxx-feature-probe -B /tmp/probe            # default compiler
+#   cmake -S scripts/cxx-feature-probe -B /tmp/probe \
+#         -DCMAKE_CXX_COMPILER=g++-14                           # a specific one
+#
+# Everything happens at configure time - there is no build step, and the table
+# lands in the log and in <build dir>/probe-results.md.
+
+cmake_minimum_required(VERSION 3.25)
+
+project(vayu-cxx-feature-probe LANGUAGES CXX)
+
+set(VAYU_PROBE_STANDARD "23" CACHE STRING "C++ standard to probe (a CMAKE_CXX_STANDARD value)")
+
+# The dialect self-check below asserts "newer than C++20", which is what makes
+# it robust across compilers that report an in-progress __cplusplus value. That
+# only works for standards after the engine's own baseline, so refuse anything
+# older loudly rather than reporting a table the self-check would have to lie
+# about.
+if(VAYU_PROBE_STANDARD LESS 23)
+    message(FATAL_ERROR
+        "VAYU_PROBE_STANDARD is '${VAYU_PROBE_STANDARD}': this probe only measures standards "
+        "newer than the engine's C++20 baseline (23, 26, ...).")
+endif()
+
+include(CheckCXXSourceCompiles)
+
+# CMP0067 (NEW under the 3.25 minimum above) is what makes try_compile - and so
+# every check below - honour CMAKE_CXX_STANDARD. Without it each probe would be
+# compiled at the compiler's *default* dialect and the whole table would be a
+# measurement of the wrong thing; the dialect self-check below exists so that a
+# silent failure of this cannot be mistaken for a feature verdict.
+set(CMAKE_CXX_STANDARD ${VAYU_PROBE_STANDARD})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(_probe_sources "${CMAKE_CURRENT_LIST_DIR}/probes")
+set(_probe_rows "")
+
+# One row of the report. `key` is what the reader sees, `source` is a file
+# under probes/, `note` is why the answer matters to #901.
+function(vayu_probe key source note)
+    file(READ "${_probe_sources}/${source}" _code)
+    string(MAKE_C_IDENTIFIER "VAYU_PROBE_${source}" _cache_var)
+    # Each configure re-measures: a cached verdict from a previous compiler
+    # would be worse than no verdict at all.
+    unset(${_cache_var} CACHE)
+    check_cxx_source_compiles("${_code}" ${_cache_var})
+    if(${_cache_var})
+        set(_verdict "yes")
+    else()
+        set(_verdict "**no**")
+    endif()
+    set(_probe_rows "${_probe_rows}| `${key}` | ${_verdict} | ${note} |\n" PARENT_SCOPE)
+endfunction()
+
+set(_report "## C++${VAYU_PROBE_STANDARD} feature probe\n\n")
+set(_report "${_report}- platform: `${CMAKE_SYSTEM_NAME}`\n")
+set(_report "${_report}- compiler: `${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}` (`${CMAKE_CXX_COMPILER}`)\n")
+set(_report "${_report}- cmake: `${CMAKE_VERSION}`\n\n")
+
+if(NOT "cxx_std_${VAYU_PROBE_STANDARD}" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    # A real, reportable fact about this toolchain rather than a broken run:
+    # the compiler offers no flag for this standard at all.
+    set(_report "${_report}This toolchain offers no C++${VAYU_PROBE_STANDARD} dialect (no `cxx_std_${VAYU_PROBE_STANDARD}` in `CMAKE_CXX_COMPILE_FEATURES`), so no feature was probed.\n")
+else()
+    # The self-check first: a probe result is only meaningful if the dialect
+    # actually reached the compiler. See probes/dialect_selected.cpp.
+    file(READ "${_probe_sources}/dialect_selected.cpp" _dialect_check)
+    unset(VAYU_PROBE_DIALECT CACHE)
+    check_cxx_source_compiles("${_dialect_check}" VAYU_PROBE_DIALECT)
+    if(NOT VAYU_PROBE_DIALECT)
+        # Not a verdict about the toolchain - the probe itself is broken, and
+        # saying so loudly is the only honest outcome.
+        message(FATAL_ERROR
+            "The probe did not compile at C++${VAYU_PROBE_STANDARD}: the dialect self-check "
+            "failed although the compiler advertises cxx_std_${VAYU_PROBE_STANDARD}. Results would "
+            "measure the default dialect, so none were produced.")
+    endif()
+
+    vayu_probe("std::expected"            std_expected.cpp        "phase 2.1 - the two optional-as-error APIs")
+    vayu_probe("std::optional (monadic)"  optional_monadic.cpp    "phase 2.3 - adopt in touched code")
+    vayu_probe("std::move_only_function"  move_only_function.cpp  "phase 2.2 - the thread pool queue")
+    vayu_probe("std::format"              std_format.cpp          "C++20 already - the five ostringstream sites")
+    vayu_probe("std::print"               std_print.cpp           "non-goal unless all three legs offer it")
+    vayu_probe("std::ranges::to"          ranges_to.cpp           "non-goal - no ranges rewrite planned")
+    vayu_probe("std::stacktrace"          std_stacktrace.cpp      "non-goal - probed compiling *and linking*")
+    vayu_probe("deducing this"            deducing_this.cpp       "non-goal unless all three legs offer it")
+    vayu_probe("std::flat_map"            flat_map.cpp            "dropped from the plan - libstdc++ 15")
+
+    set(_report "${_report}| Feature | Available | Note |\n|---|---|---|\n${_probe_rows}")
+endif()
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/probe-results.md" "${_report}")
+
+# The log copy, so a job that never reaches the summary step still says what it
+# found.
+string(REPLACE "\n" ";" _report_lines "${_report}")
+message(STATUS "----- C++${VAYU_PROBE_STANDARD} feature probe -----")
+foreach(_line IN LISTS _report_lines)
+    message(STATUS "${_line}")
+endforeach()

--- a/scripts/cxx-feature-probe/README.md
+++ b/scripts/cxx-feature-probe/README.md
@@ -1,0 +1,60 @@
+# C++ feature probe
+
+Measures which C++ features a toolchain actually offers, per platform, at a
+standard the engine has not adopted yet. It exists because the engine ships on
+three vendors whose library support lands years apart, and a standard bump is a
+decision about the worst of them - a question that is answerable by measurement
+and unanswerable from memory.
+
+Nothing here is compiled into a Vayu artifact, and the engine's own standard
+(`engine/CMakeLists.txt`) is neither read nor written by this project.
+
+## Running it
+
+Everything happens at CMake configure time; there is no build step.
+
+```bash
+# the default compiler
+cmake -S scripts/cxx-feature-probe -B /tmp/probe
+
+# a specific one - which is how the "should the runner pin gcc-14" kind of
+# question gets an answer
+cmake -S scripts/cxx-feature-probe -B /tmp/probe -DCMAKE_CXX_COMPILER=g++-14
+
+# a later standard, once C++23 is the baseline
+cmake -S scripts/cxx-feature-probe -B /tmp/probe -DVAYU_PROBE_STANDARD=26
+```
+
+The table lands in the configure log and in `<build dir>/probe-results.md`.
+
+In CI it is `.github/workflows/cxx-feature-probe.yml`: four legs (Ubuntu on its
+default `g++` and on `g++-14`, macOS on AppleClang, Windows on MSVC), run on
+demand through **Run workflow** and automatically on a pull request that
+changes the probe or its workflow. Each leg writes its table into the job
+summary.
+
+## What a result means
+
+A feature is reported available only if its translation unit **compiles and
+links**. That is deliberate and it is not the same as "the header exists":
+`<stacktrace>` is present on libstdc++ 13 and unusable without `-lstdc++exp`,
+which the probe does not pass. The usable definition is the one a migration
+needs.
+
+A "no" is an answer, not a failure - the job stays green while reporting one.
+The probe fails only when it cannot measure: an unknown standard
+(`VAYU_PROBE_STANDARD` older than the engine's C++20 baseline), or the dialect
+self-check in `probes/dialect_selected.cpp` failing, which means the standard
+never reached the compiler and every verdict below it would be a measurement of
+the wrong dialect.
+
+## Adding a probe
+
+One self-contained `probes/<feature>.cpp` with a `main`, plus one `vayu_probe()`
+line in `CMakeLists.txt` naming it and saying why the answer matters. Write the
+source so it cannot compile without the feature - a probe that passes on a
+toolchain lacking the feature is worse than no probe.
+
+The recorded results, and the floor decision taken from them, live on the issue
+that asked for the measurement (#901 for C++23) rather than in this directory,
+so that no file here can quietly drift out of date against the runner images.

--- a/scripts/cxx-feature-probe/probes/deducing_this.cpp
+++ b/scripts/cxx-feature-probe/probes/deducing_this.cpp
@@ -1,0 +1,11 @@
+// Deducing this (explicit object parameter) - a language feature, so the
+// answer is the compiler's alone, not the standard library's.
+struct Counter {
+    int n = 0;
+    [[nodiscard]] int value (this const Counter& self) { return self.n; }
+};
+
+int main () {
+    const Counter counter{5};
+    return counter.value () == 5 ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/dialect_selected.cpp
+++ b/scripts/cxx-feature-probe/probes/dialect_selected.cpp
@@ -1,0 +1,16 @@
+// Not a feature probe - the harness's own self-check, kept out of the report.
+//
+// Every verdict in the table is worthless if the standard did not actually
+// reach the compiler, so this asserts that the selected dialect is newer than
+// C++20 before any feature is measured. It asserts "newer than C++20" rather
+// than the C++23 value on purpose: GCC 13 reports __cplusplus as 202100L at
+// -std=c++23 and MSVC reports _MSVC_LANG as 202004L at /std:c++latest, while a
+// dialect that never got applied leaves the compiler default (C++17 for GCC
+// 13) in place - which is the only case this has to catch.
+#if defined(_MSVC_LANG)
+static_assert (_MSVC_LANG > 202002L, "the probed dialect was not applied");
+#else
+static_assert (__cplusplus > 202002L, "the probed dialect was not applied");
+#endif
+
+int main () { return 0; }

--- a/scripts/cxx-feature-probe/probes/flat_map.cpp
+++ b/scripts/cxx-feature-probe/probes/flat_map.cpp
@@ -1,0 +1,9 @@
+// std::flat_map - dropped from #901's plan as years from the floor. Probed so
+// that "years away" stays a measurement rather than a memory.
+#include <flat_map>
+
+int main () {
+    std::flat_map<int, int> map;
+    map.insert ({1, 2});
+    return map.at (1) == 2 ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/move_only_function.cpp
+++ b/scripts/cxx-feature-probe/probes/move_only_function.cpp
@@ -1,0 +1,13 @@
+// std::move_only_function - what thread_pool.hpp's queue wants in place of
+// std::function, which forces every queued task to be copyable (phase 2.2 of
+// #901). The move-only capture below is the whole point: it does not compile
+// against std::function.
+#include <functional>
+#include <memory>
+
+int main () {
+    auto owned = std::make_unique<int> (3);
+    std::move_only_function<int ()> task
+        = [captured = std::move (owned)] { return *captured; };
+    return task () == 3 ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/optional_monadic.cpp
+++ b/scripts/cxx-feature-probe/probes/optional_monadic.cpp
@@ -1,0 +1,12 @@
+// Monadic std::optional (and_then / transform / or_else) - adopted in touched
+// code under phase 2.3 of #901, never as a sweep of the ~426 existing sites.
+#include <optional>
+
+int main () {
+    const std::optional<int> value{2};
+    const auto result
+        = value.and_then ([] (int x) { return std::optional<int>{x * 2}; })
+              .transform ([] (int x) { return x + 1; })
+              .or_else ([] { return std::optional<int>{0}; });
+    return result.value_or (0) == 5 ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/ranges_to.cpp
+++ b/scripts/cxx-feature-probe/probes/ranges_to.cpp
@@ -1,0 +1,10 @@
+// std::ranges::to - the piece that makes a ranges pipeline terminate in a
+// container. A declared non-goal of #901 on its own; probed because it is what
+// a "ranges rewrite" would need if that decision is ever revisited.
+#include <ranges>
+#include <vector>
+
+int main () {
+    const auto values = std::views::iota (0, 4) | std::ranges::to<std::vector<int>> ();
+    return values.size () == 4 ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/std_expected.cpp
+++ b/scripts/cxx-feature-probe/probes/std_expected.cpp
@@ -1,0 +1,13 @@
+// std::expected - the error-or-value type two engine APIs already spell as
+// std::optional (phase 2.1 of #901: parse_mock_start, apply_json_field).
+#include <expected>
+#include <string>
+
+std::expected<int, std::string> parse (bool ok) {
+    if (!ok) {
+        return std::unexpected ("refused");
+    }
+    return 7;
+}
+
+int main () { return parse (true).value_or (0) == 7 ? 0 : 1; }

--- a/scripts/cxx-feature-probe/probes/std_format.cpp
+++ b/scripts/cxx-feature-probe/probes/std_format.cpp
@@ -1,0 +1,10 @@
+// std::format - C++20, not C++23. Probed anyway because #901 names the five
+// ostringstream sites it would replace, and "already available" is a claim the
+// probe should keep honest on every platform rather than assert once.
+#include <format>
+#include <string>
+
+int main () {
+    const std::string rendered = std::format ("{}:{}", "port", 9876);
+    return rendered == "port:9876" ? 0 : 1;
+}

--- a/scripts/cxx-feature-probe/probes/std_print.cpp
+++ b/scripts/cxx-feature-probe/probes/std_print.cpp
@@ -1,0 +1,8 @@
+// std::print / std::println - a convenience, and a declared non-goal of #901
+// unless all three legs offer it. Probed so the answer is a fact.
+#include <print>
+
+int main () {
+    std::println ("{}", 1);
+    return 0;
+}

--- a/scripts/cxx-feature-probe/probes/std_stacktrace.cpp
+++ b/scripts/cxx-feature-probe/probes/std_stacktrace.cpp
@@ -1,0 +1,7 @@
+// std::stacktrace. The header exists on libstdc++ well before the feature is
+// usable, so this probe *links* as well as compiles - on libstdc++ 13 that
+// needs -lstdc++exp, which the probe deliberately does not pass. A "no" here
+// therefore means "not usable as written", which is the answer #901 needs.
+#include <stacktrace>
+
+int main () { return std::stacktrace::current ().empty () ? 1 : 0; }


### PR DESCRIPTION
## Description

#901, phases 0, 1 and 2.1, plus the ungated part of 2.3. **Phase 2.2 (`std::move_only_function`) is deliberately out** - see below.

**The plan.** Root cause: the adoption decision rested on a per-platform availability table nobody could hold in their head and no file could hold honestly - libstdc++ ships `std::expected` in GCC 13 while clang 18 on that same libstdc++ cannot see it, and AppleClang and MSVC had never been asked. So the first commit builds an instrument rather than a note: `scripts/cxx-feature-probe/`, a standalone CMake project that compiles **and links** one small translation unit per feature at a standard the engine has not adopted, plus a `C++ feature probe` workflow (Ubuntu default `g++` and `g++-14`, macOS, Windows) that runs on demand and on any PR touching the probe. Its first run measured the floor, and the second commit spends it: the standard flips to 23, and the `optional`-as-error APIs #901 called out become `std::expected`. The alternative I rejected for the probe was the obvious one - a throwaway step in `pr-tests.yml` for the duration of the bump - which answers C++23 once and then either lingers on every engine PR forever or is deleted and rebuilt when C++26 comes up, which #901 says will happen.

### What the probe measured ([run](https://github.com/athrvk/vayu/actions/runs/32578225324), full table on [#901](https://github.com/athrvk/vayu/issues/901#issuecomment-5380863937))

| Feature | Ubuntu `g++` 13.3 | Ubuntu `g++-14` | macOS AppleClang 21 | Windows MSVC 19.51 |
|---|---|---|---|---|
| `std::expected` | yes | yes | yes | yes |
| `std::optional` (monadic) | yes | yes | yes | yes |
| `std::format` | yes | yes | yes | yes |
| `std::move_only_function` | yes | yes | **no** | yes |

Ubuntu pins no compiler: its default GCC already has everything phase 2 wanted, and `g++-14` adds only features #901 declared non-goals.

### Phase 1 - the flip

`CMAKE_CXX_STANDARD 23`, and the docs that said C++20 now say C++23, with a prerequisites list that names measured floors instead of remembered ones (GCC 13+; clang 19+ against libstdc++, because clang 18 cannot see its `<expected>`).

### Phase 2.1 - the error type

An "error or nothing" API was `std::optional<std::pair<int, nlohmann::json>>`, where an **empty** optional meant success. It reads backwards at every call site - `if (err)` is the failure path, `return std::nullopt` means "fine" - and a dropped return silently means "no error", which is why the two most dangerous appliers carried `[[nodiscard]]` by hand. It is now:

```cpp
struct RouteError { int status = 500; nlohmann::json body; };
using RouteResult = std::expected<void, RouteError>;

if (auto outcome = apply_json_field (json, "variables", c.variables, "{}", is_create); !outcome) {
    return outcome;            // or as_response (outcome.error ()) in a core
}
```

Three builders come with it, each removing a duplication that could drift: `route_error (status, message)` builds the refusal from **one** status instead of spelling it twice (`std::make_pair (400, error_body (400, ...))`), `as_response` converts a refusal into the pair a testable core answers with, and `error_response` is the pair-shaped counterpart for a core that refuses directly. `parse_mock_start` returns its result rather than writing through an out-parameter, so a half-filled `MockStartRequest` is no longer reachable.

**One deliberate widening of #901's scope**, flagged per the issue's own instruction not to exceed it silently: the criterion names `mock_server.hpp` and `routes.hpp`, but the same idiom lives in the per-file builders and static guards (`item_error`, `body_error`, `claim_temp_id`, ...). Converting half of it would have left an adapter at every boundary between the halves, so the whole family moved - 56 declarations across 16 files. No `std::optional<std::pair<int, nlohmann::json>>` remains in the engine.

### What is **not** here, and why

- **Phase 2.2, `std::move_only_function`.** AppleClang 21's libc++ has not shipped it, so `thread_pool.hpp`'s queue stays `std::function` and every queued task stays copyable. No runner pin fixes a library gap. This is the one thing the probe found that the hand-written analysis did not, and the reason it is worth having.
- **The five `ostringstream` -> `std::format` conversions #901 lists.** They do not survive contact with the code: `transport_policy.cpp:121` slurps a file (`<< in.rdbuf ()`), `requests.cpp:68/72` need real streams because `serialize_to_stream` takes one, and `json.cpp`'s pair is a recursive accumulator `std::format` does not improve. Forcing them would be churn. `std::format` is adopted where it genuinely reads better in code this PR already touches - the error messages in `routes.hpp` and `mock_server.cpp`.
- **A monadic-`optional` sweep.** #901 says adopt in touched code, never sweep the ~426 sites; nothing in the touched code wanted it.

## Type of Change
- [x] New feature (toolchain + internal API)
- [x] Documentation update

## Testing

- **`ctest --preset linux-dev`: 2359/2359 pass** at C++23. The route refusal tests are the behaviour pin for the migration and were **not** modified; the only test edits are the three files that name a migrated signature directly, two of which re-declared it locally - that mismatch was an ODR violation that aborted 11 tests until the declarations were fixed, which is exactly the kind of thing a local re-declaration hides.
- **`cmake --preset linux-prod -DVAYU_BUILD_TESTS=ON -DVAYU_WERROR=ON` builds clean** - no new diagnostic from the standard bump under the gate #884/#897 put there for this.
- **clang-format 19**: clean over every touched engine source (`--dry-run -Werror`).
- **clang-tidy 19** over the changed lines, the way `pr-tests.yml` runs it: no finding.
- **`mkdocs build --strict`**: clean.
- The probe's own checks from the first commit still hold: it reproduces GCC 13.3 and clang 18.1.3 exactly, and both of its failure paths are mutation-checked.
- No app changes: the wire shapes are untouched (`error_body` still builds every error), so no renderer, MCP or CLI consumer sees a difference.

No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `CLAUDE.md`, `engine/CLAUDE.md`, `docs/engine/building.md` (prerequisites, the standard, the probe), `docs/engine/architecture.md` (a new "How a route says no" section documenting the two shapes), plus the C++20 -> C++23 mentions in `README.md`, `docs/architecture.md`, `docs/index.md` and the three compare pages, all same-commit

## Related Issues

Phases 0, 1, 2.1 and the adoptable part of 2.3 of #901. Not `Closes #901`: phase 2.2 stays open until libc++ ships `std::move_only_function`, and #901's acceptance list wants that recorded rather than silently dropped - the measurement and the amendment are [on the issue](https://github.com/athrvk/vayu/issues/901#issuecomment-5380863937).