### PR TITLE
ci(engine): validate a declared reformatting commit before skipping lint on it

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,6 +18,12 @@
 # clang-tidy would otherwise re-parse the whole tree for a whitespace change.
 # So a commit listed here is excused from linting too - one more reason it must
 # be mechanical and nothing else.
+#
+# That much is checked rather than taken on trust (#916): the `Engine
+# formatting` job runs `scripts/ci/declared-reformat.sh check`, which re-runs
+# clang-format 19 over the parent of any commit listed here that a pull request
+# contains, and fails if the result is not what that commit holds. A commit that
+# reformats and also changes something is refused by name.
 
 # style(engine): bulk-format engine/{src,include,tests} at clang-format 19 (#886)
 1132ece2e334ec26c15a001a627e4d6839c4498d

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -175,8 +175,17 @@ jobs:
               - 'build.py'
               - 'VERSION'
               - '.clang-format'
+              - '.git-blame-ignore-revs'
               - '.github/check-windows-deps.py'
               - '.github/workflows/pr-tests.yml'
+              # Load-bearing for two engine gates rather than only lintable:
+              # the clang-tidy step takes its base from `declared-reformat.sh`
+              # and `Engine formatting` validates the declaration with it, so a
+              # change to the script - or to the suite that pins it - has to run
+              # them. A gate whose own inputs cannot trigger it is this
+              # repository's "written but never read" defect in wiring form.
+              - 'scripts/ci/**'
+              - 'scripts/test/declared-reformat_test.sh'
               - '!*.md'
               - '!**/*.md'
             build_script:
@@ -592,8 +601,8 @@ jobs:
       #
       # `HEAD^1` is the base side of the pull request's merge commit, which is
       # what actions/checkout leaves at HEAD for a `pull_request` event; hence
-      # `fetch-depth: 2` above, and the check below rather than a silent empty
-      # diff if that ever stops being true.
+      # the full history this job checks out above, and the check below rather
+      # than a silent empty diff if that ever stops being true.
       #
       # `-allow-no-checks` is for `engine/src/runtime/`, whose `.clang-tidy` sets
       # `Checks: '-*'`: without it clang-tidy calls an empty check list a usage
@@ -656,36 +665,19 @@ jobs:
           #
           # `.git-blame-ignore-revs` is the declaration, the same one `git
           # blame` reads: "this commit changed formatting and nothing else".
-          # Blame trusts it and so does this, which is a second reason a commit
-          # listed there must be mechanical and nothing else - the file says so.
+          # Blame trusts it; this does not, since #916 - the `Engine formatting`
+          # job proves a declared commit mechanical before this one skips
+          # anything on the strength of it. The selection rule lives in
+          # `scripts/ci/declared-reformat.sh` rather than here because that job
+          # has to pick the same commit this one does, and two copies of the
+          # rule would drift.
           #
           # The newest such commit wins, because a reformat rewrites whatever
           # preceded it. The cost is that a *real* commit placed before the
           # reformat in the same pull request is not linted here; that is the
           # right trade, since the formatter has rewritten those lines anyway,
           # and the alternative is the 168-complexity noise above.
-          ignored=()
-          if [[ -f .git-blame-ignore-revs ]]; then
-            while IFS= read -r line; do
-              line="${line%%#*}"
-              line="${line//[[:space:]]/}"
-              [[ -n "$line" ]] && ignored+=("$line")
-            done < .git-blame-ignore-revs
-          fi
-
-          # `git rev-list` lists newest first, so the first match is the newest.
-          # `--no-merges` because HEAD *is* a merge commit here - the one
-          # actions/checkout leaves for a pull_request event - and a merge
-          # authors no lines of its own.
-          base=HEAD^1
-          for rev in $(git rev-list --no-merges HEAD^1..HEAD); do
-            for ig in ${ignored[@]+"${ignored[@]}"}; do
-              if [[ "$rev" == "$ig" ]]; then
-                base="$rev"
-                break 2
-              fi
-            done
-          done
+          base=$(bash scripts/ci/declared-reformat.sh base HEAD^1 HEAD)
 
           changed=()
           while IFS= read -r file; do
@@ -895,10 +887,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # Full history, for the same reason the engine job takes it: the
+      # declaration check below enumerates the pull request's own commits and
+      # reads the parent of one of them, and a shallow clone contains neither.
+      # Seconds against a job that has an apt install in it either way.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       # 19, the same major the clang-tidy gate pins on Linux and the same one
       # CONTRIBUTING.md tells contributors to install, so one LLVM answers for
@@ -948,6 +944,51 @@ jobs:
           echo "- clang-format $major checked **${#files[@]}** engine source(s)" >> "$GITHUB_STEP_SUMMARY"
 
           clang-format-19 --style=file --dry-run -Werror "${files[@]}"
+
+      # The declaration the clang-tidy gate skips on (#916). That gate reads
+      # `.git-blame-ignore-revs` at the pull request's own HEAD and, until now,
+      # believed it: any commit on the author's branch could be listed and the
+      # gate would skip linting every change up to it. The mechanism built for
+      # #886's legitimate bulk format works identically for a commit that is not
+      # mechanical at all, and the only control was that the edit to the file
+      # shows up in the diff for a human to notice.
+      #
+      # What is checked is that re-running the pinned formatter over the
+      # declared commit's *parent* reproduces the commit byte for byte. Note
+      # that "the commit is format-clean" would not do: this job already proves
+      # every pull request's tip clean, so an author who runs the formatter
+      # satisfies that much while changing behaviour freely.
+      #
+      # Here rather than in the engine job's lint step because the check needs
+      # clang-format 19 and this job is the one that pins it - the Windows leg
+      # of that matrix has only its image's 20, which would report differences
+      # that are the formatter's rather than the commit's. Both jobs pick the
+      # commit with the same script, so they cannot disagree about which one is
+      # in question. Costs nothing on a pull request that declares nothing,
+      # which is nearly all of them; the real 149-file declaration validates in
+      # about three seconds.
+      - name: Validate any declared reformatting commit
+        shell: bash
+        run: |
+          # The assertion the lint step makes about the same two revisions, for
+          # the same reason: on an ordinary commit `HEAD^1` quietly becomes the
+          # previous commit, and a declaration made earlier in the pull request
+          # would go unexamined here while the lint step still skipped on it.
+          if ! git rev-parse --verify --quiet HEAD^2 > /dev/null; then
+            echo "::error::HEAD is not the pull request merge commit (it has no second parent), so HEAD^1 is not the base of this pull request"
+            exit 1
+          fi
+
+          bash scripts/ci/declared-reformat.sh check HEAD^1 HEAD
+
+      # The suite for the script above, riding this job because it is the one
+      # with a pinned clang-format 19 already stood up - the same reason the
+      # pre-commit hook's suite rides the installer job. It drives the real
+      # script against throwaway repositories, including the evasion this whole
+      # check exists to refuse.
+      - name: Test the reformatting-declaration check
+        shell: bash
+        run: bash scripts/test/declared-reformat_test.sh
 
   installer:
     name: Installer script on ${{ matrix.os }}

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -743,6 +743,42 @@ The contract runs the other way too: **do not list a commit in
 excuses it from linting as well as from blame. That rule is written in the file
 itself.
 
+**And it is checked, not trusted** (#916). The gate reads the file at the pull
+request's own HEAD, so listing a commit is something an author can do to their
+own branch - the mechanism built for #886's bulk format works identically for a
+commit that is not mechanical at all, and the only control used to be that the
+edit to the file shows up in the diff for a reviewer to notice. The
+`Engine formatting` job now validates any declaration the pull request contains,
+before the lint gate skips anything on the strength of it:
+
+```bash
+# What CI runs; the range is the pull request's base and its merge commit
+bash scripts/ci/declared-reformat.sh check HEAD^1 HEAD
+```
+
+For every engine source the declared commit modified, re-running clang-format 19
+over the **parent's** version of that file has to reproduce what the commit
+holds, byte for byte. That is stronger than asking whether the commit is
+format-clean, which would prove almost nothing here: the whole-tree gate above
+already leaves every pull request's tip clean, so an author who runs the
+formatter satisfies it while changing behaviour freely. A declaration also fails
+if it modifies no engine source at all, since it would then move the lint base -
+and excuse every engine change before it - for nothing. Files outside
+`engine/{src,include,tests}` are reported rather than failed over: clang-tidy
+never reads them, so the declaration cannot excuse them either. The real
+149-file declaration validates in about three seconds; a pull request that
+declares nothing pays nothing.
+
+The same script picks the base for the lint gate (`declared-reformat.sh base`),
+so the job that validates a commit and the job that skips on it cannot disagree
+about which commit is in question. `scripts/test/declared-reformat_test.sh` is
+its suite, and it runs in that job too.
+
+What remains trusted is narrower than it was, and is worth knowing: the skip
+moves the base wholesale, so a *genuine* mechanical reformat placed last in a
+pull request still excuses the commits before it, whether or not the formatter
+rewrote those files. That is the documented trade above; #932 tracks closing it.
+
 **CI lints on Linux and Windows**, not Linux alone. clang-tidy analyses a
 translation unit, so an `#ifdef _WIN32` branch is preprocessed away before a
 Linux run sees it - `platform.hpp`'s per-OS split and the Windows-only blocks in

--- a/scripts/ci/declared-reformat.sh
+++ b/scripts/ci/declared-reformat.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# The reformatting-commit declaration, in one place.
+#
+# `.git-blame-ignore-revs` is how this repository declares that a commit changed
+# formatting and nothing else. `git blame` reads it, and so does the clang-tidy
+# gate in `.github/workflows/pr-tests.yml`: a declared commit inside a pull
+# request becomes the base that gate diffs from, because a reformat rewrites a
+# line in every file it touches and would otherwise widen the line filter to
+# nearly the whole tree - #886's 149-file bulk format asked the gate for 152
+# translation units and killed the job at its timeout.
+#
+# That makes the declaration load-bearing for a gate rather than only for blame,
+# so it is checked rather than trusted (#916). Two subcommands, deliberately in
+# one file: the rule that picks the base and the rule that validates it are the
+# same rule, and two copies of it would drift.
+#
+#   base  <range-start> <head>   print the commit the lint gate should diff from
+#   check <range-start> <head>   prove that commit is a mechanical reformat
+#
+# What `check` demands is that re-running the pinned formatter over the commit's
+# *parent* reproduces the commit byte for byte, for every engine source it
+# touched. That is what "purely mechanical reformatting" means, and it is
+# strictly more than "the commit is format-clean": the `Engine formatting` job
+# already proves every pull request's tip clean, so an author who runs the
+# formatter satisfies that much while changing behaviour freely.
+#
+# Needs the pinned clang-format ($CLANG_FORMAT, default `clang-format-19`) and a
+# clone deep enough to contain the pull request's own commits (`fetch-depth: 0`).
+
+set -euo pipefail
+
+# The roots the clang-tidy gate lints, and therefore the only files a
+# declaration can excuse. `engine/vendor/` is outside them and carries a
+# `DisableFormat: true` config of its own besides.
+ROOTS=(engine/src engine/include engine/tests)
+SOURCE_RE='\.(c|cpp|h|hpp)$'
+
+# 19, the major every other formatting gate here pins - `Engine formatting`,
+# `scripts/pre-commit` and CONTRIBUTING.md. Not decoration: 39 of the 285 engine
+# sources format differently under 18, so a validation run under another major
+# would report mismatches that say nothing about the commit.
+CLANG_FORMAT=${CLANG_FORMAT:-clang-format-19}
+CLANG_FORMAT_MAJOR=19
+
+# How many files to name before summarising the rest. The count is always
+# printed, so a long list is never a silently truncated one.
+PRINT_LIMIT=20
+
+die() {
+    echo "::error::$*" >&2
+    exit 1
+}
+
+# Echoed for whoever reads the log, and appended to the job summary when there
+# is one, so the answer survives the log's fold.
+summary() {
+    echo "$*"
+    if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+        echo "$*" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+# Every commit the file declares, resolved to a full SHA. An entry naming no
+# commit in this clone is skipped rather than fatal: it can match nothing in the
+# range either way, which is how `git blame` treats it too.
+declared_shas() {
+    [[ -f $ignore_file ]] || return 0
+    local line sha
+    # `|| [[ -n $line ]]` so a final line with no trailing newline is still read.
+    while IFS= read -r line || [[ -n $line ]]; do
+        line=${line%%#*}
+        line=${line//[[:space:]]/}
+        [[ -n $line ]] || continue
+        sha=$(git rev-parse --verify --quiet "${line}^{commit}") || continue
+        printf '%s\n' "$sha"
+    done < "$ignore_file"
+}
+
+# The newest declared commit in the range, because a reformat rewrites whatever
+# preceded it; the range start when there is none. `--no-merges` because HEAD is
+# the merge commit actions/checkout leaves for a `pull_request` event, and a
+# merge authors no lines of its own.
+select_base() {
+    local range_start="$1" head="$2" rev declared
+    declared=$(declared_shas)
+    if [[ -n $declared ]]; then
+        for rev in $(git rev-list --no-merges "$range_start..$head"); do
+            if printf '%s\n' "$declared" | grep -qxF "$rev"; then
+                printf '%s\n' "$rev"
+                return 0
+            fi
+        done
+    fi
+    printf '%s\n' "$range_start"
+}
+
+# Asserted rather than trusted, on the pattern both CI gates use: an answer from
+# another major is a wrong answer rather than a missing one.
+assert_formatter() {
+    local major
+    "$CLANG_FORMAT" --version > /dev/null 2>&1 \
+        || die "$CLANG_FORMAT is not runnable - this check needs the pinned clang-format $CLANG_FORMAT_MAJOR"
+    major=$("$CLANG_FORMAT" --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -1)
+    if [[ $major != "$CLANG_FORMAT_MAJOR" ]]; then
+        die "clang-format ${major:-(version unreadable)} is not the $CLANG_FORMAT_MAJOR this repository pins - differences it reported would be the formatter's, not the commit's"
+    fi
+}
+
+# The check itself: for every engine source the commit modified, format the
+# parent's version of that file and require the result to be exactly what the
+# commit holds.
+validate_commit() {
+    local commit="$1"
+    local resolved short parent_count status file worktree_root worktree outside_list
+    local -a modified=() irregular=() mismatched=() outside=()
+
+    resolved=$(git rev-parse --verify --quiet "${commit}^{commit}") \
+        || die "$ignore_name declares $commit, which is not a commit in this clone"
+    short=$(git rev-parse --short "$resolved")
+
+    # An ordinary commit, so that "the parent's version of this file" names one
+    # thing. A merge has two parents and a root commit none.
+    parent_count=$(( $(git rev-list --parents -n 1 "$resolved" | wc -w) - 1 ))
+    if [[ $parent_count -ne 1 ]]; then
+        die "declared reformatting commit $short has $parent_count parents - a reformat is an ordinary commit with exactly one"
+    fi
+
+    git cat-file -e "$resolved:.clang-format" 2> /dev/null \
+        || die "declared reformatting commit $short has no .clang-format at its root, so there is no style to reproduce it with"
+
+    while IFS=$'\t' read -r status file; do
+        case "$status" in
+            M) modified+=("$file") ;;
+            *) irregular+=("$status $file") ;;
+        esac
+    done < <(git diff --name-status "$resolved^" "$resolved" -- "${ROOTS[@]}" \
+        | grep -E "$SOURCE_RE" || true)
+
+    # Everything else the commit touched. Not a failure - clang-tidy reads none
+    # of it, so the skip cannot excuse it - but named, because a declaration
+    # quietly carrying a second kind of change is what a reviewer is looking for.
+    while IFS= read -r file; do
+        outside+=("$file")
+    done < <(git diff --name-only "$resolved^" "$resolved" \
+        | grep -vE "^(${ROOTS[0]}|${ROOTS[1]}|${ROOTS[2]})/.*$SOURCE_RE" || true)
+
+    if [[ ${#irregular[@]} -gt 0 ]]; then
+        printf '  %s\n' "${irregular[@]}" >&2
+        die "declared reformatting commit $short adds, deletes or renames the engine source(s) above - a reformat only modifies files in place"
+    fi
+
+    # The non-empty-scan proof this repository asks of every source-scanning
+    # guard, and here it also closes the cheapest evasion: a commit that
+    # reformatted no engine source still moves the lint base, which would excuse
+    # every engine change before it in the pull request for nothing.
+    if [[ ${#modified[@]} -eq 0 ]]; then
+        die "declared reformatting commit $short modifies no engine source under ${ROOTS[*]}, so it cannot be the base the engine lint gate diffs from - a reformat of other trees belongs in its own pull request"
+    fi
+
+    assert_formatter
+
+    # A worktree at the commit rather than formatting through
+    # `--assume-filename`, so `--style=file` resolves the `.clang-format` that
+    # commit shipped. A pull request that changes the config and reformats to it
+    # in one commit is exactly the shape this has to get right.
+    worktree_root=$(mktemp -d)
+    worktree="$worktree_root/tree"
+    # shellcheck disable=SC2064  # expanded now on purpose: the paths must outlive this function
+    trap "git worktree remove --force '$worktree' > /dev/null 2>&1 || true; rm -rf '$worktree_root'" EXIT
+    git worktree add --detach --quiet "$worktree" "$resolved"
+
+    for file in "${modified[@]}"; do
+        git show "$resolved^:$file" > "$worktree/$file"
+    done
+    ( cd "$worktree" && "$CLANG_FORMAT" --style=file -i "${modified[@]}" )
+
+    # One diff for the whole set: whatever still differs from what the commit
+    # holds is a change the formatter did not make.
+    while IFS= read -r file; do
+        mismatched+=("$file")
+    done < <(git -C "$worktree" diff --name-only -- "${modified[@]}")
+
+    if [[ ${#mismatched[@]} -gt 0 ]]; then
+        printf '  %s\n' "${mismatched[@]:0:$PRINT_LIMIT}" >&2
+        if [[ ${#mismatched[@]} -gt $PRINT_LIMIT ]]; then
+            echo "  ... and $(( ${#mismatched[@]} - PRINT_LIMIT )) more" >&2
+        fi
+        die "declared reformatting commit $short changed ${#mismatched[@]} of ${#modified[@]} engine source(s) in ways clang-format $CLANG_FORMAT_MAJOR does not reproduce from their parent versions - it is not purely mechanical, and the lint gate must not take it as a base"
+    fi
+
+    summary "- reformatting declaration: \`$short\` reproduces exactly under clang-format $CLANG_FORMAT_MAJOR for all **${#modified[@]}** engine source(s) it modifies, so the clang-tidy gate takes it as its base"
+    if [[ ${#outside[@]} -gt 0 ]]; then
+        outside_list=$(printf '%s ' "${outside[@]:0:$PRINT_LIMIT}")
+        summary "  - (it also touches **${#outside[@]}** file(s) the engine lint gate never reads, which the declaration does not excuse: \`${outside_list% }\`)"
+    fi
+}
+
+usage() {
+    echo "usage: $0 base|check <range-start> <head>" >&2
+    exit 2
+}
+
+[[ $# -eq 3 ]] || usage
+
+cd "$(git rev-parse --show-toplevel)"
+ignore_name=.git-blame-ignore-revs
+ignore_file="$PWD/$ignore_name"
+
+command="$1"
+range_start="$2"
+head="$3"
+
+case "$command" in
+    base)
+        select_base "$range_start" "$head"
+        ;;
+    check)
+        base=$(select_base "$range_start" "$head")
+        if [[ $base == "$range_start" ]]; then
+            echo "No commit in $range_start..$head is declared in $ignore_name - nothing to validate."
+            exit 0
+        fi
+        validate_commit "$base"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/scripts/test/declared-reformat_test.sh
+++ b/scripts/test/declared-reformat_test.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+#
+# `scripts/ci/declared-reformat.sh`: the reformatting-commit declaration that
+# the clang-tidy gate reads out of `.git-blame-ignore-revs` (issue #916).
+#
+# The gate skips linting up to a commit the repository has declared to be pure
+# reformatting. Nothing used to check that declaration, so any commit on a pull
+# request's own branch could be listed and the gate would skip every change up
+# to it - the mechanism built for #886's legitimate 149-file bulk format works
+# identically for a commit that is not mechanical at all.
+#
+# What the script demands is that re-running the pinned clang-format over the
+# declared commit's *parent* reproduces the commit byte for byte. Every case
+# below is mutation-checked against that: drop the reproduce loop in
+# `validate_commit` and the "changes code" case goes green; drop the
+# `${#modified[@]} -eq 0` guard and the "reformats no engine source" case does;
+# drop the `select_base` range and the "declared commit outside the range" case
+# does.
+#
+# The fixtures are throwaway git repositories with a minimal `.clang-format` of
+# their own, so the suite says nothing about this repository's style and does
+# not move when that style does. It needs a real clang-format 19, which is why
+# it runs in the `Engine formatting` job - the one that already pins one.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/ci/declared-reformat.sh"
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format-19}"
+
+PASSED=0
+FAILED=0
+declare -a FIXTURES=()
+
+pass() {
+    echo "  ok - $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "  FAIL - $1"
+    echo "         $2"
+    FAILED=$((FAILED + 1))
+}
+
+# The pin is asserted, not assumed: the script under test refuses any other
+# major, so a suite running under one would be reporting on the refusal rather
+# than on the declaration.
+major="$("$CLANG_FORMAT" --version 2> /dev/null | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -1)" || true
+if [[ "$major" != "19" ]]; then
+    echo "This suite needs clang-format 19 (found: ${major:-none}). Install clang-format-19, or set CLANG_FORMAT." >&2
+    exit 1
+fi
+
+# A repository with one unformatted engine source committed, and the roots the
+# gate reads. Prints the directory.
+make_repo() {
+    local dir
+    dir="$(mktemp -d)"
+    FIXTURES+=("$dir")
+    git -C "$dir" init --quiet -b main
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    mkdir -p "$dir/engine/src"
+    printf 'BasedOnStyle: LLVM\nColumnLimit: 80\n' > "$dir/.clang-format"
+    printf 'int    main( ) {return   0;}\n' > "$dir/engine/src/main.cpp"
+    printf '# declared reformatting commits\n\n' > "$dir/.git-blame-ignore-revs"
+    git -C "$dir" add -A
+    git -C "$dir" commit --quiet -m "initial"
+    echo "$dir"
+}
+
+# Run the formatter over the tracked engine sources and commit the result: a
+# genuine mechanical reformat. Prints its SHA.
+commit_reformat() {
+    local dir="$1"
+    ( cd "$dir" && "$CLANG_FORMAT" --style=file -i engine/src/*.cpp )
+    git -C "$dir" commit --quiet -a -m "style: reformat"
+    git -C "$dir" rev-parse HEAD
+}
+
+# Declare a commit, the way a pull request does: a later commit that appends the
+# SHA to the file the gate reads.
+declare_commit() {
+    local dir="$1" sha="$2"
+    echo "$sha" >> "$dir/.git-blame-ignore-revs"
+    git -C "$dir" commit --quiet -a -m "chore: declare $sha as reformatting"
+}
+
+# `$OUT` and `$STATUS` are what every case reads.
+run() {
+    local dir="$1"
+    shift
+    set +e
+    OUT="$(cd "$dir" && bash "$SCRIPT" "$@" 2>&1)"
+    STATUS=$?
+    set -e
+}
+
+cleanup() {
+    local dir
+    for dir in ${FIXTURES[@]+"${FIXTURES[@]}"}; do
+        rm -rf "$dir"
+    done
+}
+trap cleanup EXIT
+
+echo "declared-reformat.sh"
+
+# --- base selection -------------------------------------------------------
+
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+printf 'int main() { return 1; }\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "feat: a real change"
+run "$repo" base "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == "$base_before" ]]; then
+    pass "base is the range start when the range declares nothing"
+else
+    fail "base with no declaration" "exit $STATUS: $OUT"
+fi
+
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+reformat="$(commit_reformat "$repo")"
+declare_commit "$repo" "$reformat"
+run "$repo" base "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == "$reformat" ]]; then
+    pass "base is the declared commit when the range contains one"
+else
+    fail "base with a declaration" "exit $STATUS: $OUT"
+fi
+
+# Two declared commits: the newest wins, because a reformat rewrites whatever
+# preceded it. Mutation-check: drop the `break`-on-first-match in `select_base`
+# and this returns the older one.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+first="$(commit_reformat "$repo")"
+declare_commit "$repo" "$first"
+printf 'int    second( ) {return   2;}\n' > "$repo/engine/src/second.cpp"
+git -C "$repo" add engine/src/second.cpp
+git -C "$repo" commit --quiet -m "feat: a second source"
+second="$(commit_reformat "$repo")"
+declare_commit "$repo" "$second"
+run "$repo" base "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == "$second" ]]; then
+    pass "the newest declared commit in the range wins"
+else
+    fail "newest declaration wins" "exit $STATUS: $OUT"
+fi
+
+# A declared commit that is already in the base is not in the pull request, so
+# it cannot move the gate's base - the one thing that stops a declaration from
+# reaching backwards into history.
+repo="$(make_repo)"
+old_reformat="$(commit_reformat "$repo")"
+declare_commit "$repo" "$old_reformat"
+range_start="$(git -C "$repo" rev-parse HEAD)"
+printf 'int main() { return 3; }\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "feat: a change after the reformat"
+run "$repo" base "$range_start" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == "$range_start" ]]; then
+    pass "a declared commit outside the range does not move the base"
+else
+    fail "declaration outside the range" "exit $STATUS: $OUT"
+fi
+
+# The file is a comment-carrying list, and the real one is mostly comments.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+reformat="$(commit_reformat "$repo")"
+{
+    echo "# a comment naming $(git -C "$repo" rev-parse HEAD)"
+    echo ""
+    echo "0000000000000000000000000000000000000000"
+    echo "  $reformat  # trailing comment"
+} >> "$repo/.git-blame-ignore-revs"
+git -C "$repo" commit --quiet -a -m "chore: declare with comments around it"
+run "$repo" base "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == "$reformat" ]]; then
+    pass "comments, blanks and an unknown SHA do not break the declaration list"
+else
+    fail "declaration list parsing" "exit $STATUS: $OUT"
+fi
+
+# --- check ----------------------------------------------------------------
+
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+printf 'int main() { return 1; }\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "feat: a real change"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == *"nothing to validate"* ]]; then
+    pass "check is a no-op when the range declares nothing"
+else
+    fail "check with no declaration" "exit $STATUS: $OUT"
+fi
+
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+reformat="$(commit_reformat "$repo")"
+declare_commit "$repo" "$reformat"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == *"reproduces exactly"* ]]; then
+    pass "a genuine mechanical reformat is accepted"
+else
+    fail "genuine reformat accepted" "exit $STATUS: $OUT"
+fi
+
+# The hole this whole script exists to close: a declared commit that also
+# changes code. It is format-clean - `clang-format --dry-run` on it reports
+# nothing - which is why being format-clean is not the check.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+( cd "$repo" && "$CLANG_FORMAT" --style=file -i engine/src/main.cpp )
+printf 'int main() { return 42; }\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "style: reformat (and quietly change behaviour)"
+sneaky="$(git -C "$repo" rev-parse HEAD)"
+declare_commit "$repo" "$sneaky"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -ne 0 && "$OUT" == *"not purely mechanical"* \
+    && "$OUT" == *"$(git -C "$repo" rev-parse --short "$sneaky")"* ]]; then
+    pass "a declared commit that also changes code fails, named"
+else
+    fail "non-mechanical declaration fails" "exit $STATUS: $OUT"
+fi
+
+# Same shape, minus the formatting: a declaration that is purely a code change.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+printf 'int    main( ) {return   99;}\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "feat: not a reformat at all"
+declare_commit "$repo" "$(git -C "$repo" rev-parse HEAD)"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -ne 0 && "$OUT" == *"not purely mechanical"* ]]; then
+    pass "a declaration that reformatted nothing at all fails"
+else
+    fail "code-only declaration fails" "exit $STATUS: $OUT"
+fi
+
+# A commit that touches no engine source still moves the base, so it would
+# excuse every engine change before it in the pull request for nothing.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+printf 'int main() { return 4; }\n' > "$repo/engine/src/main.cpp"
+git -C "$repo" commit --quiet -a -m "feat: a real engine change"
+printf '# notes\n' > "$repo/README.md"
+git -C "$repo" add README.md
+git -C "$repo" commit --quiet -m "docs: nothing the gate lints"
+declare_commit "$repo" "$(git -C "$repo" rev-parse HEAD)"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -ne 0 && "$OUT" == *"modifies no engine source"* ]]; then
+    pass "a declaration that modifies no engine source fails"
+else
+    fail "engine-less declaration fails" "exit $STATUS: $OUT"
+fi
+
+# A reformat modifies files in place. Anything else - an added source riding
+# along - is a change the parent's version cannot be compared against.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+( cd "$repo" && "$CLANG_FORMAT" --style=file -i engine/src/main.cpp )
+printf 'int added() { return 0; }\n' > "$repo/engine/src/added.cpp"
+git -C "$repo" add -A
+git -C "$repo" commit --quiet -m "style: reformat, plus a new file"
+declare_commit "$repo" "$(git -C "$repo" rev-parse HEAD)"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -ne 0 && "$OUT" == *"adds, deletes or renames"* ]]; then
+    pass "a declaration that adds an engine source fails"
+else
+    fail "added-source declaration fails" "exit $STATUS: $OUT"
+fi
+
+# Files outside the three roots are not linted, so the declaration does not
+# excuse them and cannot fail over them - but they are named, on this
+# repository's no-silent-caps rule.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+( cd "$repo" && "$CLANG_FORMAT" --style=file -i engine/src/main.cpp )
+printf '# notes\n' > "$repo/README.md"
+git -C "$repo" add -A
+git -C "$repo" commit --quiet -m "style: reformat, and a file the gate never reads"
+declare_commit "$repo" "$(git -C "$repo" rev-parse HEAD)"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == *"README.md"* && "$OUT" == *"does not excuse"* ]]; then
+    pass "files outside the linted roots are reported, not failed over"
+else
+    fail "outside-the-roots reporting" "exit $STATUS: $OUT"
+fi
+
+# The style a commit is reproduced under is the one that commit shipped, so a
+# pull request that changes `.clang-format` and reformats to it in one commit
+# validates against the new config rather than the old.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+printf 'BasedOnStyle: LLVM\nColumnLimit: 80\nIndentWidth: 8\n' > "$repo/.clang-format"
+( cd "$repo" && "$CLANG_FORMAT" --style=file -i engine/src/main.cpp )
+git -C "$repo" commit --quiet -a -m "style: new config, and the reformat to it"
+declare_commit "$repo" "$(git -C "$repo" rev-parse HEAD)"
+run "$repo" check "$base_before" HEAD
+if [[ "$STATUS" -eq 0 && "$OUT" == *"reproduces exactly"* ]]; then
+    pass "a config change and its reformat in one commit is reproduced under the new config"
+else
+    fail "config-changing reformat" "exit $STATUS: $OUT"
+fi
+
+# The pin, from the other side: a formatter of another major would report
+# differences that are its own, so the script refuses rather than reporting them.
+repo="$(make_repo)"
+base_before="$(git -C "$repo" rev-parse HEAD)"
+reformat="$(commit_reformat "$repo")"
+declare_commit "$repo" "$reformat"
+stub="$(mktemp -d)"
+FIXTURES+=("$stub")
+printf '#!/usr/bin/env bash\necho "clang-format version 18.1.3"\n' > "$stub/clang-format"
+chmod +x "$stub/clang-format"
+set +e
+OUT="$(cd "$repo" && CLANG_FORMAT="$stub/clang-format" bash "$SCRIPT" check "$base_before" HEAD 2>&1)"
+STATUS=$?
+set -e
+if [[ "$STATUS" -ne 0 && "$OUT" == *"is not the 19"* ]]; then
+    pass "a clang-format of another major is refused, not believed"
+else
+    fail "formatter pin asserted" "exit $STATUS: $OUT"
+fi
+
+echo
+echo "passed: $PASSED, failed: $FAILED"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Description

The clang-tidy gate skips linting up to a commit listed in `.git-blame-ignore-revs`, read at the pull request's own HEAD, and validated nothing about it. The mechanism exists for #886's legitimate 149-file bulk format; it works identically for a commit that is not mechanical at all, so an author could list any SHA on their own branch and the gate would stop looking at every change up to it. The only control was the review-visible edit to that file.

**Plan (root cause, approach, rejected alternative).** The root cause is that the declaration is an author-writable input to a gate, and nothing re-derived it: `pr-tests.yml` read the file, matched a SHA against the pull request's commits, and moved the lint base. The approach is to make the `Engine formatting` job prove the declaration before the lint gate acts on it - for every engine source the declared commit modified, re-running the pinned clang-format 19 over the **parent's** version of that file must reproduce what the commit holds, byte for byte, which is what "purely mechanical reformatting" actually asserts. The alternative I rejected is #916's option 1 as literally written - `clang-format --dry-run -Werror` at that commit. It is nearly vacuous as a control: this same job already proves the whole tree clean at every pull request's tip, so an author who runs the formatter satisfies format-cleanliness while changing behaviour freely. Option 2 (write the trust down and keep it) was available but strictly weaker for about a dozen lines of difference. **Deviation from the issue spec, stated:** the check is a superset of option 1 - a commit that reproduces under the formatter is necessarily format-clean - and it additionally refuses a declaration that modifies no engine source at all, since such a commit still moves the lint base and would excuse every engine change before it for nothing.

**Where the logic lives.** Two jobs now need the same rule - the lint step to pick its base, the formatting job to know which commit to validate - so it moved into `scripts/ci/declared-reformat.sh` (`base` and `check` subcommands) rather than being copied. The validation runs in `Engine formatting` rather than in the engine matrix because it needs clang-format **19** and that job is the one that pins it; the Windows leg of the engine matrix carries only its image's 20, which would report differences that are the formatter's rather than the commit's.

Also in this pull request:

- The ride-along from the issue thread: the lint step's comment said "hence `fetch-depth: 2` above" while the engine job checks out full history.
- `.git-blame-ignore-revs` and `scripts/ci/**` join the `engine` area filter, so a change to the gate's own inputs runs the gate - the wiring form of this repository's written-but-never-read defect. `engine-format` takes `fetch-depth: 0`, which the check needs to reach a commit's parent.
- `.git-blame-ignore-revs`' own header now says the contract is machine-checked, and `docs/engine/building.md` gained the mechanism, the command, and one honest paragraph about what is still trusted.

**Not fixed here, filed instead (#932):** the skip moves the base *wholesale*, so a genuine mechanical reformat placed last in a pull request still excuses the commits before it, whether or not the formatter rewrote those files. The obvious tightening (fail when an earlier-changed file is not among the reformatted set) false-positives on a source added earlier in the same pull request that was already formatted, so the real fix is to lint those files from the true base rather than refuse them - which is a different change from this one.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Scaled to what this can break: no engine source changes, so neither C++ suite could go from green to red and neither was run. What did run, all on this branch:

- `bash scripts/test/declared-reformat_test.sh` - **14 cases, 14 passed, 0 failed**, under clang-format 19.1.1 (the same 19.1.1 apt gives CI). Covers base selection (nothing declared, one declared, newest of two, one outside the range, comments/blanks/unknown SHAs in the list) and the check (no-op, genuine reformat accepted, a reformat that also changes code refused **by name**, a code-only declaration refused, a declaration modifying no engine source refused, an added source refused, files outside the roots reported not failed over, a config change plus its reformat in one commit reproduced under the new config, a formatter of another major refused).
- **Mutation-checked**, both directions: replacing the mismatch branch in `validate_commit` with `if false` turns 2 cases red (`non-mechanical declaration fails`, `code-only declaration fails`); doing the same to the no-engine-source guard turns 1 red (`engine-less declaration fails`). Restored: 14/14.
- The real declaration, end to end: `bash scripts/ci/declared-reformat.sh check 1132ece^ origin/master` reproduces #886's bulk-format commit exactly for **all 149** engine sources it modifies, in **3.3s** - so the strict check does not false-fail the one legitimate declaration this repository has.
- `shellcheck 0.10.0` (the pinned version) clean on both new scripts; `pr-tests.yml` parses as YAML; `mkdocs build --strict -f .github/mkdocs.yml` clean.

No pre-existing failures were encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #916

Follow-up filed: #932

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3ue155GMFuzaKic3JSLiY)_