### PR TITLE
fix(app): give the Mac keyboard a delete key and a row menu it can reach

### DIFF
--- a/app/src/components/layout/TabStrip.keyboard.test.tsx
+++ b/app/src/components/layout/TabStrip.keyboard.test.tsx
@@ -140,6 +140,23 @@ describe("TabStrip keyboard navigation", () => {
 		expect(ids).toEqual(["t2", "t3"]);
 	});
 
+	/*
+	 * The macOS half of that key (#931). A Mac keyboard's "delete" reports
+	 * "Backspace" - "Delete" is forward-delete, Fn+Delete - so the case above
+	 * passed everywhere while closing nothing on a Mac.
+	 *
+	 * Asserted as a key, not as a platform: the handler has no `isMac` branch, so
+	 * both keys close a tab in the same run wherever it runs.
+	 */
+	it("closes the focused tab with Backspace too, since Mac delete is Backspace", () => {
+		renderStrip();
+		screen.getAllByRole("tab")[0].focus();
+
+		press("Backspace");
+
+		expect(useTabsStore.getState().openTabs.map((t) => t.id)).toEqual(["t2", "t3"]);
+	});
+
 	it("leaves other keys alone so typing is not swallowed", () => {
 		renderStrip();
 		screen.getAllByRole("tab")[0].focus();

--- a/app/src/components/layout/TabStrip.tsx
+++ b/app/src/components/layout/TabStrip.tsx
@@ -94,7 +94,13 @@ function TabItem({
 				// Closing was mouse-only: the X is `tabIndex={-1}` and only appears
 				// on hover, and no close shortcut existed anywhere in the app. Delete
 				// on the focused tab is the WAI-ARIA pattern for a deletable tab.
-				if (e.key === "Delete") {
+				// Backspace is the same key on a Mac keyboard: the one labelled
+				// "delete" there reports `"Backspace"`, and `"Delete"` is
+				// forward-delete (Fn+Delete), so a `"Delete"`-only handler closes
+				// nothing on macOS (#931). Accepted on every platform rather than
+				// behind an `isMac` fork - a tab is a view, so closing one loses no
+				// work and the request it showed is still in its collection.
+				if (e.key === "Delete" || e.key === "Backspace") {
 					e.preventDefault();
 					closeTab(tab.id);
 				}

--- a/app/src/modules/collections/useRovingTreeFocus.test.tsx
+++ b/app/src/modules/collections/useRovingTreeFocus.test.tsx
@@ -204,6 +204,46 @@ describe("useRovingTreeFocus", () => {
 		expect(menu).toHaveBeenCalledTimes(2);
 	});
 
+	/*
+	 * The macOS half of those two keys (#931). The key labelled "delete" on a Mac
+	 * keyboard reports "Backspace", and Mac keyboards have neither a Menu key nor
+	 * a usable F10 - so each of the three cases below is a path that fires on
+	 * Windows and did nothing at all on a Mac.
+	 *
+	 * These assert the *key*, never the host platform: the hook has no platform
+	 * branch, so both keys must work in one run wherever it happens to run.
+	 */
+	it("deletes on Backspace as well as Delete, since Mac delete is Backspace", () => {
+		render(<Tree expanded />);
+		byName("req-1").focus();
+
+		key("Backspace");
+		expect(del).toHaveBeenCalledTimes(1);
+
+		key("Delete");
+		expect(del).toHaveBeenCalledTimes(2);
+	});
+
+	it("opens the row menu on Shift+Enter, the Mac-reachable path", () => {
+		render(<Tree expanded />);
+		byName("demo").focus();
+
+		key("Enter", { shiftKey: true });
+		expect(menu).toHaveBeenCalledTimes(1);
+		// Shift+Enter is the menu, not a second way to open the row.
+		expect(activate).not.toHaveBeenCalled();
+	});
+
+	it("still activates on plain Enter and on Space", () => {
+		render(<Tree expanded />);
+		byName("demo").focus();
+
+		key("Enter");
+		key(" ");
+		expect(activate).toHaveBeenCalledTimes(2);
+		expect(menu).not.toHaveBeenCalled();
+	});
+
 	// F2 is the keyboard path to the rename control the ⋯ menu also offers.
 	it("renames the focused row with F2", () => {
 		render(<Tree expanded />);

--- a/app/src/modules/collections/useRovingTreeFocus.ts
+++ b/app/src/modules/collections/useRovingTreeFocus.ts
@@ -21,14 +21,27 @@
  * this needs nothing threaded through CollectionItem's prop list:
  *   data-tree-activate  the primary control (open the collection/request)
  *   data-tree-toggle    expand/collapse control (collections only)
- *   data-tree-menu      row actions            (Shift+F10 / Menu key)
+ *   data-tree-menu      row actions            (Shift+F10 / Menu / Shift+Enter)
  *   data-tree-rename    rename control         (F2 key)
- *   data-tree-delete    delete control         (Delete key)
+ *   data-tree-delete    delete control         (Delete / Backspace)
  *   data-tree-label     the row's name         (typeahead)
  *   data-tree-move-*    reorder controls       (Alt+Arrow)
  *
  * Focus is deliberately separate from selection: arrows move focus without
  * opening anything; Enter/Space opens.
+ *
+ * **Two of those keys do not exist on a Mac keyboard**, which is why each has a
+ * second binding (#931):
+ *
+ *   - The key labelled "delete" on a Mac reports `"Backspace"`. `"Delete"` is
+ *     forward-delete, Fn+Delete, which effectively nobody presses - so a
+ *     `"Delete"`-only handler is dead on macOS. Both are accepted here on every
+ *     platform rather than behind an `isMac` fork: Backspace-to-delete is
+ *     standard list behaviour, and the control this clicks opens the
+ *     confirm dialog, so a mistaken press costs a dialog rather than data.
+ *   - Mac keyboards have no Menu key, and F10 is a media key by default, so the
+ *     row menu had no keyboard path at all there. **Shift+Enter** is the third
+ *     one; plain Enter still activates.
  */
 
 import { useCallback, useEffect, useRef, type RefObject } from "react";
@@ -177,13 +190,18 @@ export function useRovingTreeFocus(treeRef: RefObject<HTMLElement | null>) {
 				case "Enter":
 				case " ":
 					take();
-					click("[data-tree-activate]");
+					// Shift+Enter is the row menu's Mac-reachable path (see the
+					// header note). Space is left alone: it is the activate key
+					// that does not double as a chord anywhere in the app.
+					if (e.key === "Enter" && e.shiftKey) click("[data-tree-menu]");
+					else click("[data-tree-activate]");
 					break;
 				case "F2":
 					take();
 					click("[data-tree-rename]");
 					break;
 				case "Delete":
+				case "Backspace":
 					take();
 					click("[data-tree-delete]");
 					break;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1316,17 +1316,24 @@ workspace with 2 collections and 4 requests cost 17 presses to tab past.
   collections, `aria-selected` for the open entity.
 - Rows render `tabIndex={-1}`; `useRovingTreeFocus` promotes exactly one to `0`.
 - Keys: Up/Down move, Home/End jump, Right expands then steps in, Left collapses
-  then moves to the parent, Enter/Space opens, **F2** renames, **Delete**
-  deletes, **Shift+F10 / Menu** opens row actions, **typeahead** jumps to the
-  next row whose name starts with what you type, **`*`** expands every folder at
-  the focused row's level.
+  then moves to the parent, Enter/Space opens, **F2** renames, **Delete /
+  Backspace** deletes, **Shift+F10 / Menu / Shift+Enter** opens row actions,
+  **typeahead** jumps to the next row whose name starts with what you type,
+  **`*`** expands every folder at the focused row's level.
+- **The second binding on those two is what a Mac keyboard can reach.** The key
+  labelled "delete" on a Mac reports `"Backspace"` (`"Delete"` is forward-delete,
+  Fn+Delete), and Mac keyboards have no Menu key and default F10 to a media key -
+  so the `Delete`-only and `Shift+F10`-only versions were dead on macOS while
+  passing every test, since jsdom reports one platform. Both bindings are live on
+  every platform rather than behind an `isMac` fork; the tests fire both keys and
+  assert neither the host nor a stubbed platform.
 - **Alt+Arrow moves the row itself**, the keyboard half of drag-and-reorder:
   Up/Down among its siblings, Right into the folder rendered above it, Left out
   to after its parent. Alt because the tree owns the bare arrows and the app owns
   Ctrl/Cmd; every move is announced in the live region below, and the row menu's
   **"Move to..."** is the same move with no chord at all.
-- Every control inside a row is `tabIndex={-1}`, so Delete and Shift+F10 are the
-  keyboard path to row actions - do not remove them without providing another.
+- Every control inside a row is `tabIndex={-1}`, so those keys are the *only*
+  keyboard path to row actions - do not remove one without providing another.
   Both row types must render every hidden control: a folder row without
   `data-tree-delete` swallowed Delete silently for months, because the hook
   `preventDefault`s the key whether or not it finds something to click.


### PR DESCRIPTION
## Description

**Root cause.** A Mac keyboard's `delete` key reports `key === "Backspace"`; `key === "Delete"` is forward-delete (Fn+Delete), which effectively nobody presses. Both bare-key handlers in the app listened for `"Delete"` alone, so keyboard delete was dead on macOS in both places it exists - `useRovingTreeFocus.ts` (the tree's roving-focus handler, which clicks the row's hidden `[data-tree-delete]`) and `TabStrip.tsx` (close the focused tab). The same handler carried a second macOS-unreachable path: the tree's row menu opened on `ContextMenu` or `Shift+F10`, and Mac keyboards have neither a Menu key nor a non-media F10, so the row menu had *no* keyboard path there at all.

**Approach.** Accept `Backspace` beside `Delete` in both handlers, on every platform rather than behind an `isMac` fork, and add `Shift+Enter` as the row menu's third binding (plain Enter still activates; Space is untouched). The rejected alternative was an `isMac` branch keying off `lib/platform.ts`: it doubles the handler's states, makes every test assert a stubbed platform instead of a key, and buys nothing - Backspace-to-delete is standard list behaviour on all three platforms, the tree's control opens the `DeleteConfirmDialog` (so a mistaken press costs a dialog, not data), and a tab is a view whose request survives closing it.

**Blast radius checked.** `useRovingTreeFocus` has a second consumer: the GraphQL schema explorer (`graphql-explorer/SchemaExplorer.tsx`), which wraps it to add `/`-focuses-search. Its rows carry no `[data-tree-delete]` or `[data-tree-menu]`, so Backspace there is a `preventDefault` and nothing else - the same as `ContextMenu` today. One deliberate behaviour change lands there: `Shift+Enter` used to fall through to activate (insert the field), and now resolves to the absent row menu, i.e. a no-op. Bare `Shift+Enter` is claimed by nothing in `constants/shortcuts.ts` or in the docs (only the `mod`-carrying `⌘⇧↵` load-test chord), and the insertion was incidental rather than designed. `VariablesCategoryTree` has no key-driven delete and is unaffected; the chord system is not involved, since these are bare-key handlers.

`constants/shortcuts.ts` needed no change - it holds mod-key `Chord`s (Send, Load Test, Palette) that `formatChord` renders per platform, not the tree's bare keys, and there is no keyboard-help surface listing them. The place those keys *are* written down is `docs/design-system.md`, updated in this commit.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green:

- **`pnpm test`**: 517 files, 5557 tests passed (3 new cases).
- **`pnpm type-check`**: clean on all three projects (renderer, electron, electron-tests).
- **`pnpm lint`**: 0 errors, 0 warnings. **`pnpm format:check`**: clean.

No engine build or `ctest` run: the diff is TypeScript and one Markdown file, so no C++ test could change colour (per CLAUDE.md's scale-the-verification rule). `mkdocs build --strict` was not run - mkdocs is not installed in this environment - but the docs edit changes only prose inside an existing bullet list: no heading, anchor, link or nav entry moved.

New cases, per the repo's platform-test rule - they fire the **key** and assert neither the host platform nor a stubbed one, because the handlers have no platform branch and so both keys must work in the same run wherever it runs:

- `useRovingTreeFocus.test.tsx`: "deletes on Backspace as well as Delete", "opens the row menu on Shift+Enter" (and asserts activate did *not* fire), "still activates on plain Enter and on Space".
- `TabStrip.keyboard.test.tsx`: "closes the focused tab with Backspace too".

**Mutation-checked**, all three arms reverted in one run: dropping `case "Backspace"` reddens the tree delete case, dropping the `Shift+Enter` branch reddens the menu case, dropping `|| e.key === "Backspace"` reddens the tab case - 3 failed / 30 passed, each failure its own case, then restored.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #931

Acceptance criteria: the tree's confirm dialog and the tab close now fire for `Backspace` and still for `Delete`, proven by both-key tests rather than by the CI host's platform; the row menu is keyboard-reachable on macOS via `Shift+Enter`, recorded in the hook's header comment and in `docs/design-system.md`; the mutation checks above redden the new cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQU3LJ9r9zzh991SSSyzcD)_