### PR TITLE
ci(engine): replace the reformat-skip machinery with a label, settle the clang decisions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,11 +12,22 @@
 #     limit instead (90/100/120) makes the diff two to three times *worse*,
 #     because a wider limit re-joins line breaks the code chose by hand.
 #   - `ContinuationIndentWidth: 0`. Unusual, and the code is written to it -
-#     wrapped arguments sit at the enclosing block indent. Setting it to 4
-#     rewrites nearly every engine source, at roughly four times the cost of
-#     the whole bulk-format commit, and it is not the style anyone here writes,
-#     including in the last 60 commits. The table is in #907, which is where
-#     changing it gets decided - not here, and not quietly.
+#     wrapped arguments sit at the enclosing block indent. **Decided and kept**
+#     (#940, closing #907), by re-running #886's measurement at clang-format 19
+#     over the 288 non-vendor sources on master at be9be9a:
+#
+#         config                                files rewritten   lines
+#         as shipped                                          0       0
+#         ContinuationIndentWidth: 4                        250   23938
+#         ContinuationIndentWidth: 4 + AlignAfterOpenBracket: Align
+#                                                           250   28105
+#
+#     That is 3.3x and 3.8x #886's whole bulk-format commit (149 files, 7362
+#     lines), and it is not old code disagreeing: of the 191 engine sources
+#     touched in the last 60 engine commits, `ContinuationIndentWidth: 4` would
+#     rewrite 180. People writing engine code today write this style. The
+#     question is closed - do not reopen it without a measurement that says
+#     something new.
 #
 # clang-format 19 is the pinned version (CONTRIBUTING.md); the bulk-format
 # commit in .git-blame-ignore-revs was produced by it.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,12 +12,11 @@
 # that also changes behaviour must not be ignored, or the blame for that
 # behaviour disappears with it.
 #
-# This file is load-bearing for CI as well as for blame: the `Lint changed
-# engine sources` step in .github/workflows/pr-tests.yml skips the commits
-# listed here, because a reformat touches a line in every file it rewrites and
-# clang-tidy would otherwise re-parse the whole tree for a whitespace change.
-# So a commit listed here is excused from linting too - one more reason it must
-# be mechanical and nothing else.
+# Blame is all this file does. CI once read it too, to move the clang-tidy
+# gate's base past a declared reformat; that walk is gone (#940). A bulk-format
+# pull request now carries the `reformat-pr` label, which is what the gate
+# reads - visible on the pull request, applied by a human, and no input this
+# file has to be trusted for.
 
 # style(engine): bulk-format engine/{src,include,tests} at clang-format 19 (#886)
 1132ece2e334ec26c15a001a627e4d6839c4498d

--- a/.github/LABELING.md
+++ b/.github/LABELING.md
@@ -27,6 +27,7 @@ Special                                        priority:critical  🔴  Blocks o
   severity:blocking  🔴  Breaking change
   dependencies       ⚪  Dependency updates
   release            🔵  Version-bump PR (auto)
+  reformat-pr        🟧  Bulk-format PR (skips clang-tidy)
 ```
 
 ## Label Categories
@@ -123,6 +124,7 @@ These labels indicate **urgency**. Apply manually based on impact and timeline.
 | `ci` | Gray (#95A5A6) | CI/CD related | Used manually; path-based label is `component:ci` |
 | `correctness` | Red (#E74C3C) | Correctness issue | Logic error or incorrect behavior |
 | `release` | Navy (#062477) | Version-bump / release PR | Auto-applied whenever `VERSION` changes |
+| `reformat-pr` | Amber (#F39C12) | PR is bulk formatter output only | **Skips the clang-tidy gate.** Apply only to a PR that is nothing but `clang-format` output - see [building.md](https://github.com/athrvk/vayu/blob/master/docs/engine/building.md#static-analysis) |
 
 ## Labeling Guidelines
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -660,45 +660,56 @@ jobs:
           done < <(git diff --name-only HEAD^1 HEAD -- "${roots[@]}" \
             | grep -E '\.(c|cpp|h|hpp)$' || true)
 
-          # Windows cannot lint a *header* as an input, so it does not try.
+          # **This gate lints translation units. A header is never an input**,
+          # on any platform - decided in #940, where it was Windows-only.
           #
           # `compile_commands.json` holds one entry per translation unit and so
-          # none for a `.hpp`; clang-tidy synthesises a command for a file it
-          # cannot look up. On Linux that synthesised command still finds the
-          # standard library. On Windows it does not find the MSVC one, and the
-          # result is not a lint finding but a parse failure of the whole STL -
-          # `no template named 'optional' in namespace 'std'` at every
-          # `std::optional` in `types.hpp`, twenty errors deep, before any check
-          # runs. `WarningsAsErrors: '*'` turns that into a failed engine job.
-          # Measured on #926, where the same run linted every changed `.cpp`
-          # cleanly on the same runner and failed only on the two headers.
+          # none for a `.hpp`, so clang-tidy synthesises a command for a header
+          # handed to it directly. That command is a guess, and when the guess
+          # is wrong the failure is not a lint finding but a parse failure of
+          # the standard library - `no template named 'optional' in namespace
+          # 'std'`, twenty errors deep, in files no diff line touched (#926 on
+          # Windows, where the same run linted every changed `.cpp` cleanly).
           #
-          # What is lost is smaller than it looks: `HeaderFilterRegex` in
-          # engine/.clang-tidy already reports diagnostics *inside* a header
-          # through every translation unit that includes it, so a header changed
-          # alongside its consumers is still linted here. What is genuinely not
-          # covered on this leg is a pull request that changes a header and no
-          # `.cpp` at all. #930 has the flags that would let clang-tidy parse
-          # the MSVC STL directly, which is the real fix; this keeps the gate
-          # honest on the other two legs in the meantime rather than turning it
-          # off everywhere.
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            headers=()
-            translation_units=()
-            for file in ${changed[@]+"${changed[@]}"}; do
-              case "$file" in
-                *.h | *.hpp) headers+=("$file") ;;
-                *) translation_units+=("$file") ;;
-              esac
-            done
-            if [[ ${#headers[@]} -gt 0 ]]; then
-              {
-                echo "- clang-tidy (Windows): **${#headers[@]}** changed header(s) are not linted as inputs here - the synthesised command cannot parse the MSVC standard library (#930). They are still linted through the translation units that include them:"
-                printf '  - `%s`\n' "${headers[@]}"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-            changed=(${translation_units[@]+"${translation_units[@]}"})
+          # It is worse than one leg failing, and this is the part that decided
+          # it: **a `clang-diagnostic-error` is not line-filtered**. Measured on
+          # clang-tidy 19.1.1 - an error in an included header is reported even
+          # when `-line-filter` names only the translation unit and only one of
+          # its lines. So a bad synthesised command does not merely fail, it
+          # takes the gate out of changed-lines scope entirely, which is the one
+          # property the whole design rests on. Feeding clang-tidy a file the
+          # compilation database has no entry for is the only way this tree
+          # produces a compiler error at all.
+          #
+          # The MSVC include paths could be passed through instead
+          # (`--extra-arg=-imsvc...`, re-derived per image). Rejected: it buys
+          # header-as-input coverage on one more leg, at the price of toolchain
+          # plumbing that breaks when an image moves, and it leaves the
+          # error-bypass above wide open.
+          #
+          # What this costs is **not** what #926 assumed. `HeaderFilterRegex`
+          # does report diagnostics inside a header, but `clang-tidy-diff.py`
+          # builds one invocation per changed file with a `-line-filter` naming
+          # *only that file* (`clang-tidy-diff.py:344-351`), and clang-tidy
+          # drops a diagnostic in any file its filter does not list - so a
+          # changed header was never reaching this gate through its consumers
+          # either. The hook is the gate that does lint headers: it builds one
+          # filter naming every staged file, which is why it can.
+          headers=()
+          translation_units=()
+          for file in ${changed[@]+"${changed[@]}"}; do
+            case "$file" in
+              *.h | *.hpp) headers+=("$file") ;;
+              *) translation_units+=("$file") ;;
+            esac
+          done
+          if [[ ${#headers[@]} -gt 0 ]]; then
+            {
+              echo "- clang-tidy: **${#headers[@]}** changed header(s) are not linted here - this gate lints translation units only (#940). \`scripts/pre-commit\` lints them through the sources that include them:"
+              printf '  - `%s`\n' "${headers[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
+          changed=(${translation_units[@]+"${translation_units[@]}"})
 
           # The non-empty-scan proof this repository asks of every source
           # scanning guard: name what is about to be linted, so a step that
@@ -791,8 +802,7 @@ jobs:
           fi
 
           # `"${changed[@]}"`, not `"${roots[@]}"`: the roots would re-admit the
-          # headers the Windows leg dropped above, which is the one narrowing
-          # this list still carries.
+          # headers dropped above, which is the one narrowing this list carries.
           git diff -U0 HEAD^1 HEAD -- "${changed[@]}" \
             | "$python" "$tidy_diff" \
                 -clang-tidy-binary "$tidy" \

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -441,17 +441,14 @@ jobs:
       SCCACHE_GHA_ENABLED: 'true'
 
     steps:
-      # Full history, not depth 2. Depth 2 was enough while the clang-tidy step
-      # below only needed `HEAD^1` - the base side of the merge commit
-      # actions/checkout leaves at HEAD. It now also enumerates the pull
-      # request's own commits, to skip the ones the repository has declared to
-      # be pure reformatting (see that step), and a shallow clone does not
-      # contain them. A full clone of this repository costs seconds against a
-      # job that runs for minutes.
+      # Depth 2, which is all the clang-tidy step below needs: `HEAD^1`, the
+      # base side of the merge commit actions/checkout leaves at HEAD. It was
+      # briefly full history, for a commit walk that read the pull request's own
+      # commits; that walk is gone (#940) and so is its clone cost.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -568,8 +565,8 @@ jobs:
       # `client.cpp`, `event_loop_worker.cpp` and `temp_database.hpp` were code
       # no lint could reach until the Windows leg ran.
       #
-      # macOS is excluded, and it is the one exclusion here that is not a
-      # choice: clang-tidy 19.1.7 and 20.1.8 both die there with SIGILL - an
+      # macOS is excluded. That is a settled decision (#940), not an open
+      # regression: clang-tidy 19.1.7 and 20.1.8 both die there with SIGILL - an
       # `llvm_unreachable` trap - part way through the two heaviest translation
       # units, which lint clean on both other legs. Upstream clang cannot parse
       # that runner's AppleClang 21 SDK, and two consecutive majors failing the
@@ -577,7 +574,10 @@ jobs:
       # is small and measured: the engine's entire macOS-conditional surface is
       # four `#define`s in `platform.hpp` with no statement in them, so what is
       # actually missed is `clang-analyzer-*` over shared code as compiled
-      # against libc++. Issue #906 carries the evidence and the ways back in.
+      # against libc++. Lint coverage on two of three platforms is a common and
+      # accepted posture. The one condition that reopens it: a Homebrew LLVM
+      # that survives both translation units on the runner's current SDK - try
+      # it by dropping this `if`, and put it back if it traps.
       #
       # **It lints the changed lines, not the changed files.** The engine had
       # never been linted, so most files carry findings that predate the diff -
@@ -594,6 +594,21 @@ jobs:
       # what actions/checkout leaves at HEAD for a `pull_request` event; hence
       # `fetch-depth: 2` above, and the check below rather than a silent empty
       # diff if that ever stops being true.
+      #
+      # **A bulk reformat is the one change line scoping cannot help**, because
+      # it rewrites a line in every file it touches: clang-tidy would parse a
+      # whole translation unit per reformatted file and, for the ones it does
+      # lint, widen the line filter to almost the whole file, so the backlog
+      # older than the diff surfaces as failures. #886's 149-file bulk format
+      # asked for 152 translation units and hit this job's timeout. The escape
+      # is the `reformat-pr` label in the `if` below: a reviewer applies it to a
+      # pull request that is nothing but the formatter's output, sees it on the
+      # pull request, and the lint step does not run. It is deliberately not
+      # machinery - a commit walk that read the skip out of a file in the diff
+      # was tried (#909's bootstrap) and deleted (#940), because a gate whose
+      # exemption is an author-writable input needs a second gate to guard it.
+      # `.git-blame-ignore-revs` still gets the reformat's SHA, for blame, which
+      # is the only thing it is for.
       #
       # `-allow-no-checks` is for `engine/src/runtime/`, whose `.clang-tidy` sets
       # `Checks: '-*'`: without it clang-tidy calls an empty check list a usage
@@ -619,7 +634,9 @@ jobs:
       # `-j 0` rather than a CPU count: the driver reads 0 as
       # `multiprocessing.cpu_count()`, and `nproc` does not exist on macOS.
       - name: Lint changed engine sources
-        if: runner.os != 'macOS'
+        if: >-
+          runner.os != 'macOS'
+          && !contains(github.event.pull_request.labels.*.name, 'reformat-pr')
         shell: bash
         run: |
           # Assert HEAD *is* the merge commit, by asking for the second parent.
@@ -637,60 +654,10 @@ jobs:
           # A read loop rather than `mapfile`: `shell: bash` on the macOS runner
           # is /bin/bash 3.2.57, where mapfile does not exist. The installer job
           # names that trap already - it is the same one, one job over.
-          # Where the diff starts. Normally the base, `HEAD^1` - but if this
-          # pull request contains a commit the repository has declared to be
-          # pure reformatting, the diff starts at that commit instead.
-          #
-          # A reformat rewrites a line in every file it touches, which defeats
-          # line scoping twice over. It makes clang-tidy parse a whole
-          # translation unit per reformatted file - #886's 149-file bulk-format
-          # commit asked for 152 of them and killed this job at its timeout with
-          # clang-tidy still running - and for the files that *are* linted it
-          # widens the line filter to nearly the whole file, so every
-          # pre-existing finding in them surfaces. Both are the failure mode
-          # line scoping exists to prevent: a pull request failed for code it
-          # did not write. Measured on #886, starting from the base: 152 sources
-          # and findings up to "cognitive complexity of 168". Starting from the
-          # bulk-format commit: the same 7 sources that really changed, 23
-          # lines, clean.
-          #
-          # `.git-blame-ignore-revs` is the declaration, the same one `git
-          # blame` reads: "this commit changed formatting and nothing else".
-          # Blame trusts it and so does this, which is a second reason a commit
-          # listed there must be mechanical and nothing else - the file says so.
-          #
-          # The newest such commit wins, because a reformat rewrites whatever
-          # preceded it. The cost is that a *real* commit placed before the
-          # reformat in the same pull request is not linted here; that is the
-          # right trade, since the formatter has rewritten those lines anyway,
-          # and the alternative is the 168-complexity noise above.
-          ignored=()
-          if [[ -f .git-blame-ignore-revs ]]; then
-            while IFS= read -r line; do
-              line="${line%%#*}"
-              line="${line//[[:space:]]/}"
-              [[ -n "$line" ]] && ignored+=("$line")
-            done < .git-blame-ignore-revs
-          fi
-
-          # `git rev-list` lists newest first, so the first match is the newest.
-          # `--no-merges` because HEAD *is* a merge commit here - the one
-          # actions/checkout leaves for a pull_request event - and a merge
-          # authors no lines of its own.
-          base=HEAD^1
-          for rev in $(git rev-list --no-merges HEAD^1..HEAD); do
-            for ig in ${ignored[@]+"${ignored[@]}"}; do
-              if [[ "$rev" == "$ig" ]]; then
-                base="$rev"
-                break 2
-              fi
-            done
-          done
-
           changed=()
           while IFS= read -r file; do
             changed+=("$file")
-          done < <(git diff --name-only "$base" HEAD -- "${roots[@]}" \
+          done < <(git diff --name-only HEAD^1 HEAD -- "${roots[@]}" \
             | grep -E '\.(c|cpp|h|hpp)$' || true)
 
           # Windows cannot lint a *header* as an input, so it does not try.
@@ -735,29 +702,16 @@ jobs:
 
           # The non-empty-scan proof this repository asks of every source
           # scanning guard: name what is about to be linted, so a step that
-          # silently narrowed to nothing cannot read as a pass.
-          #
-          # What was skipped is reported rather than dropped quietly, on the
-          # repository's no-silent-caps rule: a narrowed scan that reads as a
-          # clean pass is the failure this summary exists to prevent.
-          all_changed=$(git diff --name-only HEAD^1 HEAD -- "${roots[@]}" \
-            | grep -cE '\.(c|cpp|h|hpp)$' || true)
-          skipped=$(( all_changed - ${#changed[@]} ))
-
+          # silently narrowed to nothing cannot read as a pass. The only thing
+          # that narrows the set now is the Windows header split above, and it
+          # names every file it dropped.
           if [[ ${#changed[@]} -eq 0 ]]; then
-            if [[ $skipped -gt 0 ]]; then
-              echo "- clang-tidy: nothing to lint - all **$skipped** changed engine source(s) were touched only by commits listed in \`.git-blame-ignore-revs\` (reformatting)" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "- clang-tidy: no engine sources changed, nothing to lint" >> "$GITHUB_STEP_SUMMARY"
-            fi
+            echo "- clang-tidy: no engine source to lint on this leg" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           {
-            echo "- clang-tidy linted the changed lines of **${#changed[@]}** engine source(s), against \`$(git rev-parse --short "$base")\`:"
+            echo "- clang-tidy linted the changed lines of **${#changed[@]}** engine source(s), against \`$(git rev-parse --short HEAD^1)\`:"
             printf '  - `%s`\n' "${changed[@]}"
-            if [[ $skipped -gt 0 ]]; then
-              echo "  - (**$skipped** further source(s) skipped: changed only by the reformatting commit declared in \`.git-blame-ignore-revs\`)"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           # Installed here rather than in a step of its own so a pull request
@@ -837,13 +791,24 @@ jobs:
           fi
 
           # `"${changed[@]}"`, not `"${roots[@]}"`: the roots would re-admit the
-          # sources that only a declared formatting commit touched, undoing the
-          # skip computed above.
-          git diff -U0 "$base" HEAD -- "${changed[@]}" \
+          # headers the Windows leg dropped above, which is the one narrowing
+          # this list still carries.
+          git diff -U0 HEAD^1 HEAD -- "${changed[@]}" \
             | "$python" "$tidy_diff" \
                 -clang-tidy-binary "$tidy" \
                 -p1 -path engine/build-release \
                 -quiet -allow-no-checks -j 0
+
+      # The escape says so in the job summary as well as on the pull request.
+      # Same rule as the step above: a gate that narrowed to nothing must not
+      # read as a clean pass, and "the lint step is missing" is easy to miss.
+      - name: Note the lint skip
+        if: >-
+          runner.os != 'macOS'
+          && contains(github.event.pull_request.labels.*.name, 'reformat-pr')
+        shell: bash
+        run: |
+          echo "- clang-tidy: **skipped** - this pull request carries the \`reformat-pr\` label, so it is the formatter's output and nothing else. Remove the label to lint it." >> "$GITHUB_STEP_SUMMARY"
 
       # `always()` so a suite that ran and failed is still reported - but on its
       # own that also reports a *pass* for a job that never got as far as

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -688,7 +688,7 @@ clang-tidy runs in two places, and both of them can stop a change:
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
 | `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **changed lines** of staged `.c/.cpp/.h/.hpp` files | Refuses the commit |
-| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of `engine/{src,include,tests}` sources, on Linux and Windows | Fails CI |
+| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of changed `engine/{src,include,tests}` **translation units** - not headers - on Linux and Windows | Fails CI |
 
 A finding is a failure because `engine/.clang-tidy` sets
 `WarningsAsErrors: '*'`; with that empty, clang-tidy prints every diagnostic it
@@ -756,6 +756,14 @@ Use it only for a reformat: the label excuses every engine line in the pull
 request, so anything else in the same branch goes unlinted with it. Split the
 reformat into its own pull request, which is what #886 did anyway.
 
+**Applying the label does not re-trigger CI.** This workflow runs on
+`pull_request`, whose default activity types are `opened`, `synchronize` and
+`reopened` - labelling is none of them, so the run that is already on the pull
+request keeps its old verdict. Apply the label, then **re-run the engine jobs**;
+the summary flips to the skip line. Do not add `labeled`/`unlabeled` to the
+trigger to avoid the re-run: the path labeler applies labels to every pull
+request, so that would run the whole matrix a second time on all of them.
+
 This replaced a commit walk that read the skip out of `.git-blame-ignore-revs`
 at the pull request's own HEAD (#909's bootstrap, deleted by #940). The
 declaration was an author-writable input to a gate, which needed a validator to
@@ -789,16 +797,71 @@ disables every check, and clang-tidy calls an empty check list a usage error
 rather than a clean run, so the one exempt directory would otherwise be the only
 one that fails.
 
-**A changed header is an input on Linux only.** `compile_commands.json` has one
-entry per translation unit and none for a `.hpp`, so clang-tidy synthesises a
-command for a header handed to it directly. On Linux that command still finds
-libstdc++; on Windows it does not find the MSVC STL, and the result is the whole
-standard library failing to parse - `no template named 'optional' in namespace
-'std'` - which `WarningsAsErrors: '*'` turns into a failed job. The Windows leg
-therefore lints translation units only. Little is lost, because
-`HeaderFilterRegex` reports findings *inside* a header through every translation
-unit that includes it; what is not covered there is a pull request that changes
-a header and no `.cpp`. Issue #930 carries the flags that would fix it properly.
+**The CI gate lints translation units. A header is never an input** - on every
+platform, decided in #940 (it was Windows-only, from #926). The pre-commit hook
+is the gate that lints headers.
+
+`compile_commands.json` has one entry per translation unit and none for a
+`.hpp`, so clang-tidy synthesises a command for a header handed to it directly.
+That command is a guess. On Linux it happens to find libstdc++; on Windows it
+does not find the MSVC STL and the whole standard library fails to parse - `no
+template named 'optional' in namespace 'std'` - which `WarningsAsErrors: '*'`
+turns into a failed job.
+
+What settled it is sharper than one leg failing. **A `clang-diagnostic-error` is
+not line-filtered.** Measured on clang-tidy 19.1.1: an error inside an included
+header is reported even when `-line-filter` names only the translation unit and
+only one of its lines, and clang-tidy then exits `Found compiler error(s)`. So a
+wrong synthesised command does not just fail a leg - it takes the gate out of
+changed-lines scope altogether, and handing clang-tidy a file the compilation
+database has no entry for is the only way this tree produces a compiler error at
+all. The rejected alternative was passing MSVC's include paths through
+(`--extra-arg=-imsvc...`): it buys one more leg of header-as-input coverage, in
+exchange for toolchain plumbing that breaks when a runner image moves, and it
+leaves that bypass open.
+
+**What this costs is less than #926 and #930 assumed, because the coverage they
+credited was never there.** `HeaderFilterRegex` does report diagnostics inside a
+header - but `clang-tidy-diff.py` builds one invocation per changed file, each
+with a `-line-filter` naming *only that file* (`clang-tidy-diff.py:344-351`),
+and clang-tidy drops a diagnostic in any file its filter does not list.
+Measured, same tree, same header, three filters:
+
+| Line filter passed with the `.cpp` | Header finding reported? |
+|---|---|
+| none | yes |
+| names the `.cpp` only - what CI's driver builds | **no** |
+| names the `.cpp` and the header - what the hook builds | yes |
+
+So a changed header has never reached the CI gate through its consumers. It
+reaches the **hook**, which builds one filter over every staged file for exactly
+this reason (the comment at `scripts/pre-commit:229-234` says so). What CI
+genuinely loses by this decision is a header-only change on a machine with no
+hook installed. To lint one by hand, point clang-tidy at a consumer:
+
+```bash
+clang-tidy-19 --allow-no-checks -p engine/build \
+  '-line-filter=[{"name":"engine/src/http/routes.cpp"},{"name":"engine/include/vayu/http/routes.hpp"}]' \
+  engine/src/http/routes.cpp
+```
+
+**This also answers #929's header-in-the-diff anomaly** - the one it recorded as
+observed but not explained. A header in the diff does not widen anything: the
+`.cpp`'s invocation is byte-identical whether or not a header is in the diff
+(the driver builds it from that file's hunks alone). What a header adds is *one
+more invocation, with the header as input* - and that is the invocation whose
+synthesised command can fail, spraying unfiltered `clang-diagnostic-error`s from
+files nobody touched. "The gate stops being line-scoped when a header is in the
+diff" and "the Windows leg fails on headers" were one defect seen from two
+sides, and dropping headers as inputs closes both.
+
+**`readability-function-cognitive-complexity` stays off, with no report-only
+job** (#940, closing #929). It anchors on the function declaration, which a
+line-scoped gate can never honour. A whole-tree report job would restate a list
+[#928](https://github.com/athrvk/vayu/issues/928) already holds, and #928's
+completion *is* the re-enable condition - the check becomes honourable the
+moment nothing pre-existing is left for it to anchor on. Turn it back on there.
+The reason sits beside the disable in `engine/.clang-tidy`.
 
 ### The precompiled header
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -674,7 +674,12 @@ Two other settings look like mistakes and are not; both are commented in
 raising the limit made the bulk diff two to three times worse, because a wider
 limit re-joins line breaks the code chose by hand. And `ContinuationIndentWidth:
 0` wraps arguments to the enclosing block indent, which is what the engine's
-code is written to; changing it is a 257-file rewrite and is tracked separately.
+code is written to. That one was re-measured and **kept** (#940, closing #907):
+`ContinuationIndentWidth: 4` rewrites 250 of the 288 non-vendor sources for
+23,938 lines - 3.3x #886's whole bulk-format commit - and 180 of the 191 sources
+touched in the last 60 engine commits, so it is today's code that disagrees with
+it, not legacy. The table is in `.clang-format`'s header; the question is
+closed.
 
 ### Static Analysis
 
@@ -683,7 +688,7 @@ clang-tidy runs in two places, and both of them can stop a change:
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
 | `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **changed lines** of staged `.c/.cpp/.h/.hpp` files | Refuses the commit |
-| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of `engine/{src,include,tests}` sources, on all three platforms | Fails CI |
+| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of `engine/{src,include,tests}` sources, on Linux and Windows | Fails CI |
 
 A finding is a failure because `engine/.clang-tidy` sets
 `WarningsAsErrors: '*'`; with that empty, clang-tidy prints every diagnostic it
@@ -728,20 +733,35 @@ That is for someone paying the backlog down on purpose - the one case where the
 findings CI ignores are the point. Everything else about the hook is unchanged
 by it.
 
-**Commits listed in `.git-blame-ignore-revs` are skipped.** The gate reads the
-same file `git blame` does, and for the same reason: a commit declared to be
-pure reformatting did not write new code, so re-linting it says nothing. This
-is not only a tidiness argument. Line scoping bounds the *diagnostics*
-clang-tidy reports, not the number of translation units it must parse - and a
-reformat touches a line in every file it rewrites. #886's 149-file bulk-format
-commit made the gate try to analyse 152 translation units in one run and killed
-the job at its 60-minute timeout; with the skip it analyses the 7 that actually
-changed. What was skipped is named in the job summary, never dropped silently.
+**A bulk reformat is the one change line scoping cannot help**, and the escape
+is a label. Line scoping bounds the *diagnostics* clang-tidy reports, not the
+number of translation units it must parse - and a reformat touches a line in
+every file it rewrites, so the gate parses one translation unit per reformatted
+file and widens the line filter on each to nearly the whole file, surfacing a
+backlog older than the diff. #886's 149-file bulk format made the gate ask for
+152 translation units and killed the job at its timeout.
 
-The contract runs the other way too: **do not list a commit in
-`.git-blame-ignore-revs` unless it is purely mechanical**, because doing so now
-excuses it from linting as well as from blame. That rule is written in the file
-itself.
+So a pull request that is nothing but the formatter's output carries the
+**`reformat-pr` label**, and the lint step does not run:
+
+```yaml
+if: >-
+  runner.os != 'macOS'
+  && !contains(github.event.pull_request.labels.*.name, 'reformat-pr')
+```
+
+A reviewer applies it, it is visible on the pull request, and the job summary
+says the lint was skipped rather than leaving a green check to imply it ran.
+Use it only for a reformat: the label excuses every engine line in the pull
+request, so anything else in the same branch goes unlinted with it. Split the
+reformat into its own pull request, which is what #886 did anyway.
+
+This replaced a commit walk that read the skip out of `.git-blame-ignore-revs`
+at the pull request's own HEAD (#909's bootstrap, deleted by #940). The
+declaration was an author-writable input to a gate, which needed a validator to
+guard it, which had a blind spot of its own - three mechanisms for a problem
+that happens about once a year. `.git-blame-ignore-revs` still gets the bulk
+commit's SHA, for `git blame`, which is the only thing it is for.
 
 **CI lints on Linux and Windows**, not Linux alone. clang-tidy analyses a
 translation unit, so an `#ifdef _WIN32` branch is preprocessed away before a
@@ -749,14 +769,20 @@ Linux run sees it - `platform.hpp`'s per-OS split and the Windows-only blocks in
 `client.cpp`, `event_loop_worker.cpp` and `temp_database.hpp` are code a
 Linux-only lint could never reach.
 
-**macOS is excluded**, and not by choice: clang-tidy 19.1.7 and 20.1.8 both die
-there with SIGILL - an `llvm_unreachable` trap - part way through the two
-heaviest translation units, which lint clean on both other legs. Upstream clang
-cannot parse that runner's AppleClang 21 SDK. What that loses is small and
-measured: the engine's entire macOS-conditional surface is four `#define`s in
-`platform.hpp` with no statement in them, so what is actually missed is
-`clang-analyzer-*` over shared code as compiled against libc++. Issue #906
-carries the evidence and the ways back in.
+**macOS is excluded**, and that is decided (#940) rather than pending: clang-tidy
+19.1.7 and 20.1.8 both die there with SIGILL - an `llvm_unreachable` trap - part
+way through the two heaviest translation units, which lint clean on both other
+legs. Upstream clang cannot parse that runner's AppleClang 21 SDK, and two
+consecutive majors failing the same way is not a version ladder worth climbing.
+What that loses is small and measured: the engine's entire macOS-conditional
+surface is four `#define`s in `platform.hpp` with no statement in them, so what
+is actually missed is `clang-analyzer-*` over shared code as compiled against
+libc++. Linting on two of three platforms is a common posture, and this one is
+accepted, not tolerated - there is no open issue for it.
+
+**The one condition that reopens it:** a Homebrew LLVM that survives both
+translation units on the runner's current SDK. Test it by dropping the
+`runner.os != 'macOS'` term from the step's `if`, and put it back if it traps.
 
 Both pass `--allow-no-checks`, for `engine/src/runtime/` - its `.clang-tidy`
 disables every check, and clang-tidy calls an empty check list a usage error

--- a/engine/.clang-tidy
+++ b/engine/.clang-tidy
@@ -34,9 +34,12 @@ Checks: '
 #     them fails the pull request for complexity nobody in it wrote. #926 was
 #     the first to hit this and turned the check off rather than scatter a
 #     NOLINT per function, which would have fixed the gate for exactly the
-#     functions one pull request happened to touch. **#929 owns the debt**: the
-#     numbers, the splits worth doing, and whether a function-scoped check
-#     belongs in a line-scoped gate at all or in a report-only job.
+#     functions one pull request happened to touch. **Decided in #940: it stays
+#     off, and gets no report-only job.** A whole-tree report job would restate
+#     a list #928 already holds - and #928's completion *is* the re-enable
+#     condition, because the check becomes honourable the moment nothing
+#     pre-existing is left for it to anchor on. Turn it back on there, not in a
+#     second job here. #928 owns the debt and the splits.
 #   readability-convert-member-functions-to-static
 #     Proposes making a member static whenever its body happens not to touch
 #     `this`. On a public class that is an API change decided by an

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -65,9 +65,13 @@ engine/
   preprocessed away before a Linux run sees it, so gating Linux alone left
   `platform.hpp`'s per-OS split and the Windows-only blocks in `client.cpp` /
   `event_loop_worker.cpp` / `temp_database.hpp` unlinted. macOS is excluded
-  because clang-tidy 19 *and* 20 both SIGILL there on the AppleClang 21 SDK
-  (#906); the only macOS-conditional code is four `#define`s, so what is lost is
-  `clang-analyzer-*` over shared code under libc++. **Both gate the changed
+  because clang-tidy 19 *and* 20 both SIGILL there on the AppleClang 21 SDK -
+  a settled decision (#940), not an open bug; the only macOS-conditional code is
+  four `#define`s, so what is lost is `clang-analyzer-*` over shared code under
+  libc++, and it comes back only if a Homebrew LLVM survives that SDK. A pull
+  request that is nothing but a bulk reformat carries the **`reformat-pr`**
+  label, which is the whole of the CI gate's escape hatch - line scoping cannot
+  help a change that rewrites a line in every file. **Both gate the changed
   *lines***: the tree had never been linted and most files carry findings older
   than any diff, so whole-file gating would fail a pull request for code it did
   not write. The mechanisms differ on purpose (#902) - CI runs LLVM's

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -71,7 +71,13 @@ engine/
   libc++, and it comes back only if a Homebrew LLVM survives that SDK. A pull
   request that is nothing but a bulk reformat carries the **`reformat-pr`**
   label, which is the whole of the CI gate's escape hatch - line scoping cannot
-  help a change that rewrites a line in every file. **Both gate the changed
+  help a change that rewrites a line in every file. **CI lints translation
+  units, never a header** (#940): a header has no `compile_commands.json` entry,
+  so clang-tidy guesses a command for it, and a guess that parses the wrong STL
+  emits `clang-diagnostic-error`s - which are *not* line-filtered, taking the
+  whole gate out of changed-lines scope. The hook is what lints headers, because
+  it names every staged file in one filter and CI's per-file driver does not.
+  **Both gate the changed
   *lines***: the tree had never been linted and most files carry findings older
   than any diff, so whole-file gating would fail a pull request for code it did
   not write. The mechanisms differ on purpose (#902) - CI runs LLVM's


### PR DESCRIPTION
## Description

**Plan (root cause, approach, rejected alternative).** The root cause is that the clang-tidy gate's exemption was an author-writable input: `Lint changed engine sources` walked the pull request's own commits, matched each against `.git-blame-ignore-revs` **read at the pull request's HEAD**, and moved the lint base to the newest match. That walk was built for one bootstrap event - letting #886's 149-file bulk format merge through a diff-scoped gate - and then stayed as standing mechanism, which is what spawned the validator (#933) and the validator's own blind spot (#932). The approach is the industry-standard shape the rest of this repo already has: keep the whole-tree format gate and the diff-scoped tidy gate exactly as they are, delete the walk, and replace it with a **`reformat-pr` label** checked in the step's `if` - visible on the pull request, applied by a human, nothing to attack, and needed roughly once a year. The alternative I rejected is keeping the walk and hardening it (#933's re-derivation check, or #932's per-file tightening): both add a second mechanism to guard the first, and the thing being guarded is a once-a-year event that a reviewer can see at a glance. `.git-blame-ignore-revs` goes back to being a blame file and nothing else.

**Anchors drifted, adapted.** The issue points at `pr-tests.yml:642-760` and `docs/engine/building.md:610/630-643`; on `be9be9a` the walk is at `:637-696` and the doc's platform cell is at `:686` with the skip paragraph at `:731-744`. Same code, same text.

**Blast radius traced.** The walk's only consumers are inside the one step: `$base` fed the file-selection diff, the summary line, and the `git diff -U0` piped into `clang-tidy-diff.py` - all three now read `HEAD^1`. Nothing else in the repo read `.git-blame-ignore-revs` as a lint input: the `changes` filters do not list it (that wiring was #933's, unmerged), `scripts/pre-commit` scopes itself from the staged diff and never mentions the skip, `CONTRIBUTING.md` mentions the file only for `git blame`. `fetch-depth: 0` on the engine job existed *only* for the walk and is back to 2, which is what the diff step was designed for; the stale "hence `fetch-depth: 2` above" comment at `:595` is now true again rather than deleted.

### What changed

1. **The skip machinery is gone** (`.github/workflows/pr-tests.yml`): the commit walk, the `ignored=()` parse of `.git-blame-ignore-revs`, the `all_changed`/`skipped` accounting and its two summary branches, `fetch-depth: 0`, and the comment above `git diff -U0` that described the skip.
2. **The escape is a label**: the step gains `&& !contains(github.event.pull_request.labels.*.name, 'reformat-pr')`, plus a 6-line `Note the lint skip` step that writes the skip into `$GITHUB_STEP_SUMMARY`. Without that note, a labelled pull request would show a green engine job with the lint step simply absent - the repo's no-silent-caps rule, applied to the escape itself. Documented in `docs/engine/building.md` where the old mechanism was described, and the label is added to `.github/LABELING.md` (it has to be created by hand in **Settings → Labels**, as that doc says of every non-auto label - `reformat-pr`, amber `#F39C12`).
3. **#907 settled: `ContinuationIndentWidth` stays 0.** Re-measured with #886's own method - clang-format 19, bulk-diff size over the non-vendor engine sources on `be9be9a`:

   | Config | Files rewritten | Lines | vs #886's bulk commit |
   |---|---|---|---|
   | As shipped | 0 of 288 | 0 | - |
   | `ContinuationIndentWidth: 4` | 250 | 23,938 | 3.3x |
   | `ContinuationIndentWidth: 4` + `AlignAfterOpenBracket: Align` | 250 | 28,105 | 3.8x |

   And it is not legacy code disagreeing: of the **191** engine sources touched in the last 60 engine commits, `ContinuationIndentWidth: 4` would rewrite **180**. Recorded in `.clang-format`'s header with a "do not reopen without a new measurement" line.
4. **#906 settled: the macOS tidy exclusion is a decision, not a regression.** `docs/engine/building.md`'s table cell no longer says "on all three platforms"; the workflow comment keeps naming the SIGILL; the doc, the workflow comment and `engine/CLAUDE.md` each state the one re-enable condition (a Homebrew LLVM that survives both translation units on the runner's current SDK).

### Items 5 and 6 (the scope update folded in from #929/#930)

The second commit answers both, and they turned out to be **one defect seen from two sides**. The finding that settles them, measured on clang-tidy 19.1.1:

> **A `clang-diagnostic-error` is not line-filtered.** An error inside an included header is reported even when `-line-filter` names only the translation unit and only one of its lines, and clang-tidy then exits `Found compiler error(s)`.

5. **Header policy - headers are never inputs, on any platform** (#930's option 2, adopted as one rule). A header has no `compile_commands.json` entry, so clang-tidy synthesises a command for it; when that guess is wrong (the MSVC STL on Windows) the failure is not a finding but a parse failure of the standard library - and per the finding above those errors **bypass the line filter**, taking the gate out of changed-lines scope entirely. Handing clang-tidy a file the compilation database does not know is the only way this tree produces a compiler error at all. **Rejected:** passing MSVC's include paths through (`--extra-arg=-imsvc...`) - it buys one more leg of header-as-input coverage, at the price of toolchain plumbing that breaks when a runner image moves, and it leaves the bypass open.

   **The coverage given up is smaller than #926 and #930 credited, and correcting that is half the point.** `clang-tidy-diff.py` builds one invocation per changed file with a `-line-filter` naming *only that file* (`clang-tidy-diff.py:344-351`), and clang-tidy drops a diagnostic in any file its filter does not list. Measured, same tree and header, three filters:

   | Line filter passed with the `.cpp` | Header finding reported? |
   |---|---|
   | none | yes |
   | names the `.cpp` only - what CI's driver builds | **no** |
   | names the `.cpp` and the header - what the hook builds | yes |

   So the doc's standing claim that CI lints a changed header "through the translation units that include it" was false; that only ever held in the hook, which names every staged file in one filter for exactly this reason (`scripts/pre-commit:229-234`). What CI genuinely loses is a header-only change on a machine with no hook installed, and `building.md` now carries the by-hand command for that (verified to work).

6. **`readability-function-cognitive-complexity` stays off, with no report-only job** (#929). Such a job would restate a list #928 already holds, and #928's completion *is* the re-enable condition - the check becomes honourable the moment nothing pre-existing is left to anchor on. Recorded beside the disable in `engine/.clang-tidy`.

   **#929's header-in-the-diff anomaly, answered rather than observed:** a header in the diff widens nothing. The `.cpp`'s invocation is byte-identical whether or not a header is in the diff (the driver builds each filter from that file's own hunks). What a header adds is *one more invocation with the header as input* - the one whose synthesised command can fail and spray unfiltered `clang-diagnostic-error`s from files nobody touched. "The gate stops being line-scoped when a header is in the diff" and "the Windows leg fails on headers" are the same thing; dropping headers as inputs closes both.

### Deliberate deviations from the issue spec

- **The `Note the lint skip` step is not in the issue's "~3 workflow lines".** It is 6 more, and it is the difference between a visible escape and an invisible one - the issue's own word for the mechanism is *visible*.
- **No reformat rides this pull request**, because #907's answer was "keep". The issue anticipates that branch, but it does mean the label escape is not exercised on real data here - see Testing.
- **`.git-blame-ignore-revs` is not added to the `changes` engine filter.** That was #933's wiring, and it existed because the gate read the file; it no longer does, so a change to it should not run a three-platform C++ build.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Scaled to what the diff can break, per CLAUDE.md: **no C++ and no TypeScript source changed** - the diff is workflow YAML, three Markdown docs, and comment-only edits to `.clang-format`, `.git-blame-ignore-revs` and `engine/.clang-tidy`. What ran:

- **`mkdocs build --strict -f .github/mkdocs.yml`** - clean on both commits (3.63s, 4.06s).
- **clang-format 19.1.1 over the tree after the `.clang-format` edit** - `--dry-run -Werror` clean on all **288** non-vendor sources, proving the header edit changed no formatting.
- **The `ContinuationIndentWidth` measurement**, with clang-format 19.1.1 via `--style=file:<config>` against the working tree.
- **YAML parse** of `pr-tests.yml` and an assertion on the two step conditions; **`bash -n`** clean on both step scripts, on both commits.
- **Behavioural check of the rewritten base selection, on a scratch repository** shaped like a pull request merge commit (a real code commit, a formatting commit, and a commit declaring the latter in `.git-blame-ignore-revs`, merged no-ff into a master that had moved):

  | | Base chosen | Sources linted |
  |---|---|---|
  | Old walk | the declared commit | `base.cpp` only - **`real.cpp`, the pull request's actual code, went unlinted** |
  | This pull request | `HEAD^1` | `fmt.cpp`, `real.cpp` |

  That is #932's hole reproduced concretely. **Mutation-check:** restoring the 20 deleted walk lines restores the wrong answer on the same fixture.
- **The line-filter measurements for items 5/6**, on a synthetic project with clang-tidy 19.1.1 and a real `compile_commands.json` (one entry for the `.cpp`, none for the header, mirroring the engine):
  - the three-filter table above, reproduced exactly;
  - **the error-bypass**: an error in an included header printed despite `-line-filter=[{"name":"b.cpp","lines":[[2,2]]}]`, with `Found compiler error(s)`;
  - **invocation identity**: the `.cpp` command reconstructed from both diffs (with and without a header) is byte-identical, so the header adds an invocation and widens nothing;
  - both scenarios end-to-end through the real `/usr/bin/clang-tidy-diff-19.py`.
- **The header split exercised** under `set -u` for empty / mixed / headers-only / TUs-only inputs (headers-only correctly lands in the "no engine source to lint" branch **after** naming the skipped headers, so it is not a silent narrowing). The by-hand command added to `building.md` was run and reports the header finding.
- **`cd app && pnpm test`** - **517 files, 5557 tests, 5557 passed**, 238.8s. **`pnpm type-check`** - clean on all three projects. Run for completeness at the requester's ask; neither could have changed colour on this diff.
- **Not run: `python build.py -t` and the ctest suite.** CLAUDE.md names this case directly ("if no test could possibly go from green to red, do not run tests") and no engine translation unit is touched. The engine-side check that *is* meaningful - the format gate over the edited config - ran and is above.

**The gate proves itself on this pull request.** `.clang-format` and `.github/workflows/pr-tests.yml` are both in the `changes` job's `engine` filter, so this pull request runs the full three-platform engine job through the rewritten step, with zero changed engine sources. What is **not** proven here is the label branch, which needs a labelled pull request *and a re-run* - `pull_request` does not fire on `labeled`, which `building.md` now says so the first user does not conclude the label is inert.

No pre-existing failures were encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #940
Closes #906
Closes #907
Closes #929
Closes #930

#933 was already closed unmerged, and this deletes the mechanism it guarded. #928 (the 2,835-finding paydown) is untouched and stays open - and now also carries the re-enable trigger for `readability-function-cognitive-complexity`. After this lands the clang surface is exactly #928.