### PR TITLE
fix(app): guard Enter-commit fields against IME composition

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -23,6 +23,12 @@ Renderer and Electron main process for Vayu. Apache-2.0. See the repo root
   walks a document, and it reads it through the engine
   (`POST /import/document`): inlining a `$ref` target is deterministic
   re-serialization, not an opinion about what the document declares.
+- **An Enter that acts uses `isCommitEnter`** (`@/lib/keyboard`), never a bare
+  `e.key === "Enter"` (#939). An IME commits its composition buffer with Enter,
+  and that commit reaches the handler as an ordinary keydown - so a field
+  without the guard saves, fetches or renames on a half-composed value. Seven
+  sites were missing it at once, because nothing about the bare comparison
+  looks wrong.
 - State: Zustand for UI state, TanStack Query for server state
 - Styling: Tailwind CSS v4 - all colors via CSS custom properties
 - **Design system: `docs/design-system.md`** - tokens, elevation, typography,

--- a/app/src/components/ui/variable-popover.test.tsx
+++ b/app/src/components/ui/variable-popover.test.tsx
@@ -355,3 +355,19 @@ describe("why this value won", () => {
 		expect(within(panel).getByText("••••••••")).toBeInTheDocument();
 	});
 });
+
+describe("an Enter that only commits an IME buffer", () => {
+	it("saves on a plain Enter and not on a composition commit", () => {
+		// The keystroke an IME uses to commit its composition reaches the handler
+		// as an ordinary Enter keydown, so without the guard the popover saved
+		// the half-composed value on the first one.
+		const { onValueChange } = renderPopover({ saveMode: "manual" });
+		const field = within(open()).getByLabelText("Value of merchantId");
+
+		fireEvent.keyDown(field, { key: "Enter", isComposing: true });
+		expect(onValueChange).not.toHaveBeenCalled();
+
+		fireEvent.keyDown(field, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "mrc_8813", "environment");
+	});
+});

--- a/app/src/components/ui/variable-popover.tsx
+++ b/app/src/components/ui/variable-popover.tsx
@@ -44,6 +44,7 @@ import { Kbd } from "./kbd";
 import { VariableScopeBadge, type VariableScope } from "./variable-scope-badge";
 import { VARIABLE_SCOPE_CONFIG, VARIABLE_SCOPE_DOT } from "@/constants/variables";
 import { cn } from "@/lib/utils";
+import { isCommitEnter } from "@/lib/keyboard";
 import { isDataVariableName } from "@/lib/variable-resolution";
 import { Eye, EyeOff, KeyRound } from "lucide-react";
 import type { ResolvedVariable, VariableOrigin } from "@/types";
@@ -214,14 +215,14 @@ export function VariablePopover({
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (saveMode === "manual") {
-			if (e.key === "Enter") {
+			if (isCommitEnter(e)) {
 				handleSave();
 			} else if (e.key === "Escape") {
 				handleCancel();
 			}
 		} else {
 			// Auto mode: Enter saves, Escape cancels
-			if (e.key === "Enter") {
+			if (isCommitEnter(e)) {
 				handleOpenChange(false);
 			} else if (e.key === "Escape") {
 				// Mark as cancelled before Radix fires its own onOpenChange for Escape

--- a/app/src/lib/keyboard.test.ts
+++ b/app/src/lib/keyboard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The guard has to hold on the event the IME actually sends: same `key`, same
+ * handler, `isComposing` the only thing separating "commit the buffer" from
+ * "do the thing". Both halves are asserted, because a helper that returned
+ * `false` for every Enter would satisfy the composition case alone.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { KeyboardEvent } from "react";
+import { isCommitEnter } from "./keyboard";
+
+/** The two fields the guard reads, in the shape React hands a handler. */
+const keyEvent = (key: string, isComposing: boolean): KeyboardEvent =>
+	({ key, nativeEvent: { isComposing } }) as KeyboardEvent;
+
+describe("isCommitEnter", () => {
+	it("accepts a plain Enter", () => {
+		expect(isCommitEnter(keyEvent("Enter", false))).toBe(true);
+	});
+
+	it("refuses the Enter that commits an IME composition", () => {
+		expect(isCommitEnter(keyEvent("Enter", true))).toBe(false);
+	});
+
+	it("refuses any other key, composing or not", () => {
+		expect(isCommitEnter(keyEvent("Escape", false))).toBe(false);
+		expect(isCommitEnter(keyEvent(" ", true))).toBe(false);
+	});
+});

--- a/app/src/lib/keyboard.ts
+++ b/app/src/lib/keyboard.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Enter that means "do it", told apart from the Enter that means
+ * "that's the word I meant".
+ *
+ * An IME (Chinese, Japanese, Korean) commits its composition buffer with
+ * Enter, and that commit arrives as an ordinary `keydown` the handler cannot
+ * distinguish from a submit. A field that acts on every Enter therefore fires
+ * on the first one - saving an example named by a half-composed romaji buffer,
+ * fetching a URL that is still being spelled. `isComposing` is the browser's
+ * own answer: it is true for exactly the keystrokes the IME owns.
+ *
+ * It lives here as one definition rather than seven copies because the guard
+ * is invisible when absent - nothing about a plain `e.key === "Enter"` looks
+ * wrong, which is how all seven sites came to be missing it at once.
+ */
+
+import type { KeyboardEvent } from "react";
+
+/** True for an Enter that should act - not one committing an IME buffer. */
+export function isCommitEnter(e: KeyboardEvent): boolean {
+	return e.key === "Enter" && !e.nativeEvent.isComposing;
+}

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -58,6 +58,7 @@ import {
 import { useSpecDocumentLimit } from "@/hooks/useSpecDocumentLimit";
 import { ImportProgressView, type ImportProgress } from "./ImportProgressView";
 import { MethodBadge } from "@/components/shared";
+import { isCommitEnter } from "@/lib/keyboard";
 
 type Tab = "file" | "url" | "paste";
 type Phase = "idle" | "detecting" | "preview" | "error";
@@ -737,7 +738,7 @@ export function ImportModal() {
 								value={url}
 								onChange={(e) => setUrl(e.target.value)}
 								onKeyDown={(e) => {
-									if (e.key === "Enter" && url) handleFetchUrl();
+									if (isCommitEnter(e) && url) handleFetchUrl();
 								}}
 								placeholder="https://petstore.swagger.io/v2/swagger.json"
 								className="flex-1"

--- a/app/src/modules/request-builder/components/ResponseViewer/SaveAsExampleDialog.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/SaveAsExampleDialog.tsx
@@ -37,6 +37,7 @@ import {
 import { Callout } from "@/components/shared";
 import { formatSize } from "@/components/shared/response-viewer";
 import { useCreateRequestExampleMutation } from "@/queries";
+import { isCommitEnter } from "@/lib/keyboard";
 import { defaultExampleName, exampleFromResponse } from "./save-as-example";
 import type { ResponseState } from "../../types";
 
@@ -94,7 +95,7 @@ export function SaveAsExampleDialog({ requestId, response, onClose }: SaveAsExam
 							value={name}
 							onChange={(e) => setName(e.target.value)}
 							onKeyDown={(e) => {
-								if (e.key === "Enter") onSave();
+								if (isCommitEnter(e)) onSave();
 							}}
 							aria-invalid={trimmed.length === 0}
 							autoFocus

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -64,6 +64,7 @@ import type {
 } from "@/types";
 import { useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
+import { isCommitEnter } from "@/lib/keyboard";
 import { Callout } from "@/components/shared";
 import { LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
 import { appSetting } from "../app-settings";
@@ -796,7 +797,7 @@ export default function McpSettingsPanel() {
 								value={newHost}
 								onChange={(e) => setNewHost(e.target.value)}
 								onKeyDown={(e) => {
-									if (e.key === "Enter") {
+									if (isCommitEnter(e)) {
 										e.preventDefault();
 										addHost();
 									}

--- a/app/src/modules/settings/main/panels/SettingControls.tsx
+++ b/app/src/modules/settings/main/panels/SettingControls.tsx
@@ -27,6 +27,7 @@ import {
 	Label,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { isCommitEnter } from "@/lib/keyboard";
 
 export interface OptionButtonItem<T> {
 	value: T;
@@ -481,7 +482,7 @@ export function NumberSettingRow({
 							handleBlur();
 						}}
 						onKeyDown={(e) => {
-							if (e.key === "Enter") e.currentTarget.blur();
+							if (isCommitEnter(e)) e.currentTarget.blur();
 						}}
 						className={cn(
 							"max-w-[12rem]",

--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
@@ -45,6 +45,7 @@ import {
 	Copy,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isCommitEnter } from "@/lib/keyboard";
 import { Badge, Input, DeleteConfirmDialog, TooltipIconButton } from "@/components/ui";
 import { DEFAULT_ENVIRONMENT_NAME } from "@/constants/environment";
 
@@ -261,7 +262,7 @@ export default function VariablesCategoryTree() {
 											value={newEnvName}
 											onChange={(e) => setNewEnvName(e.target.value)}
 											onKeyDown={(e) => {
-												if (e.key === "Enter") handleCreateEnvironment();
+												if (isCommitEnter(e)) handleCreateEnvironment();
 												if (e.key === "Escape") {
 													setCreatingEnvironment(false);
 													setNewEnvName(DEFAULT_ENVIRONMENT_NAME);
@@ -354,7 +355,7 @@ export default function VariablesCategoryTree() {
 														}
 														onKeyDown={(e) => {
 															e.stopPropagation();
-															if (e.key === "Enter")
+															if (isCommitEnter(e))
 																submitRenameEnvironment(
 																	environment.id
 																);


### PR DESCRIPTION
## Description

**Root cause.** An IME (Chinese, Japanese, Korean) commits its composition buffer with Enter, and that commit reaches the renderer as an ordinary `keydown` whose `key` is `"Enter"`. Nothing in `app/src` consulted `nativeEvent.isComposing` - `rg isComposing app/src` matched nothing outside `node_modules` - so every Enter-to-act field acted on the keystroke that was only meant to accept a candidate word. In practice: an example saved under a half-composed romaji name, a URL fetched while it was still being spelled, an allowlist host added half-typed, an environment created or renamed mid-word.

**Approach.** One definition, `isCommitEnter` in `app/src/lib/keyboard.ts`, returning `e.key === "Enter" && !e.nativeEvent.isComposing`, adopted mechanically at the seven sites the keyboard review named:

| Site | Enter did |
| --- | --- |
| `SaveAsExampleDialog.tsx` | save the example |
| `ImportModal.tsx` | start the URL fetch |
| `McpSettingsPanel.tsx` | add the allowlist host |
| `SettingControls.tsx` (`NumberSettingRow`) | blur, which commits |
| `VariablesCategoryTree.tsx` x2 | create / rename an environment |
| `variable-popover.tsx` | save (manual mode) / close-and-save (auto mode) |

The diff per site is the single condition plus the import; no handler changed shape.

**Rejected alternative.** Writing the two-term condition inline at each site. That is exactly how the defect arose: a bare `e.key === "Enter"` looks complete, so a missing composition check is invisible at the call site and all seven were missing it at once. A named helper makes its absence something a reader can notice, and gives the convention a place to point at.

The 229-keyCode fallback for engines predating `isComposing` is deliberately left out - Electron's Chromium has supported the property throughout, and the issue asks for it only if older-engine support is demonstrated necessary.

**Deviations from the spec:** none. Only the seven listed sites were touched; other Enter handlers in the tree (`CollectionTree`, `CollectionItem`, `RequestItem`, `ServicesPanel`, `SpecTab`, `VariableRow`, and the popover's create-value field) are outside this issue's scope and were left alone rather than widened into.

**Stacking note:** #935 (open) touches two of the same handlers - `SaveAsExampleDialog` and `ImportModal` - on these exact `if (e.key === "Enter")` lines. Its PR will stack on this one and rebase over the changed condition.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Full gates from `app/`:

| Gate | Result |
| --- | --- |
| `pnpm test` | 518 files, 5561 tests, all passing |
| `pnpm type-check` | clean (renderer, electron, electron-tests) |
| `pnpm lint` | clean, zero warnings |
| `pnpm format:check` | clean |

New coverage: `src/lib/keyboard.test.ts` (plain Enter accepted, composition-commit Enter refused, other keys refused either way) and one wired case in `src/components/ui/variable-popover.test.tsx` driving the real handler through the rendered field.

Mutation check - guard removed (`return e.key === "Enter"`), suite re-run, guard restored:

| Case | With guard | Guard removed |
| --- | --- | --- |
| `isCommitEnter` refuses the Enter that commits an IME composition | pass | **fail** |
| variable popover: saves on a plain Enter and not on a composition commit | pass | **fail** |
| the other 25 cases in the two files | pass | pass |

2 of 27 red on the mutation, both of them the named cases; green again after restoring.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: the issue names none beyond a possible convention line, and there was a natural home - a bullet in `app/CLAUDE.md`'s Conventions section, so a new Enter handler reaches for the helper. Nothing under `docs/` changed, so `mkdocs build --strict` was not applicable.

## Related Issues
Closes #939


---
_Generated by [Claude Code](https://claude.ai/code/session_014CWVjkN7qD2vSm6aCEK2dp)_