### PR TITLE
fix(app): keep the tab strip one Tab stop, and wire its tabs to their panel

### DIFF
--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -12,6 +12,7 @@ import { Drawer } from "./Drawer";
 import { Dock } from "./Dock";
 import { ContextBar } from "./ContextBar";
 import { TabStrip } from "./TabStrip";
+import { tabElementId, tabPanelElementId } from "./tab-aria";
 import RequestBuilder from "@/modules/request-builder";
 import CollectionDetail from "@/modules/collections/CollectionDetail";
 import LoadTestDashboard from "@/modules/dashboard";
@@ -213,7 +214,22 @@ export default function Shell() {
 					<TabStrip />
 					<div className="flex flex-1 overflow-hidden relative">
 						<main className="flex-1 overflow-hidden flex flex-col min-w-0">
-							{renderTabContent(activeTab)}
+							{/*
+							 * The other half of the strip's tabs pattern: the region a tab
+							 * controls has to say so, or `aria-controls` points at nothing
+							 * and the panel claims no owner. The role goes on a child of
+							 * `main` rather than on `main` itself - `main` is a landmark and
+							 * carries only `role="main"`, so overwriting it would trade one
+							 * relationship for another.
+							 */}
+							<div
+								role="tabpanel"
+								id={activeTab ? tabPanelElementId(activeTab.id) : undefined}
+								aria-labelledby={activeTab ? tabElementId(activeTab.id) : undefined}
+								className="flex flex-1 flex-col min-w-0 overflow-hidden"
+							>
+								{renderTabContent(activeTab)}
+							</div>
 						</main>
 						<ContextBar mode={windowWidth >= 1200 ? "push" : "overlay"} />
 					</div>

--- a/app/src/components/layout/TabStrip.keyboard.test.tsx
+++ b/app/src/components/layout/TabStrip.keyboard.test.tsx
@@ -28,6 +28,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TabStrip } from "./TabStrip";
+import { tabElementId, tabPanelElementId } from "./tab-aria";
 import { useTabsStore } from "@/stores";
 
 /**
@@ -68,6 +69,42 @@ describe("TabStrip keyboard navigation", () => {
 		// Roving tabindex: exactly one reachable entry point.
 		expect(tabs.filter((t) => t.getAttribute("tabindex") === "0")).toHaveLength(1);
 		expect(tabs[0]).toHaveAttribute("tabindex", "0");
+	});
+
+	/*
+	 * The single-stop claim held only on the first render. Arrow navigation moved
+	 * focus by writing `tabIndex = 0` straight onto the destination element and
+	 * left it there: the vdom prop for that tab is still -1, so React re-renders
+	 * to nothing, and focus moves *without* activating, so there is no render to
+	 * rely on in the first place. Three arrow presses, three permanent Tab stops -
+	 * the defect roving tabindex exists to prevent, reintroduced by its own
+	 * navigation. The test above cannot see it, because it never presses a key.
+	 */
+	it("still has exactly one Tab stop after arrowing across the strip", () => {
+		renderStrip();
+		const tabs = screen.getAllByRole("tab");
+
+		tabs[0].focus();
+		press("ArrowRight");
+		press("ArrowRight");
+		press("ArrowLeft");
+
+		const stops = tabs.filter((t) => t.getAttribute("tabindex") === "0");
+		expect(stops).toHaveLength(1);
+		// And it is where focus actually is, so Tab back into the strip returns here.
+		expect(stops[0]).toBe(tabs[1]);
+		expect(document.activeElement).toBe(tabs[1]);
+	});
+
+	it("leaves one Tab stop after Home and End too", () => {
+		renderStrip();
+		const tabs = screen.getAllByRole("tab");
+
+		tabs[0].focus();
+		press("End");
+		press("Home");
+
+		expect(tabs.filter((t) => t.getAttribute("tabindex") === "0")).toHaveLength(1);
 	});
 
 	it("moves focus with Left and Right arrows", () => {
@@ -165,5 +202,40 @@ describe("TabStrip keyboard navigation", () => {
 
 		expect(useTabsStore.getState().openTabs).toHaveLength(3);
 		expect(document.activeElement).toBe(screen.getAllByRole("tab")[0]);
+	});
+});
+
+/**
+ * The strip declared `role="tablist"` and `aria-selected` and stopped there: no
+ * tab named the region it switches, and the region named no tab. A screen reader
+ * reached "tab 2 of 3" and then content with no stated relationship to it.
+ *
+ * The panel half lives in Shell, so it is asserted where the two meet
+ * (`shell-tab-identity.test.tsx`); here is the strip's end of the contract, plus
+ * the structural rule that a tablist owns only tabs.
+ */
+describe("TabStrip tabs pattern", () => {
+	it("points every tab at the panel id its content will carry", () => {
+		renderStrip();
+		const tabs = screen.getAllByRole("tab");
+		expect(tabs).toHaveLength(3);
+
+		for (const [i, tab] of tabs.entries()) {
+			expect(tab).toHaveAttribute("id", tabElementId(TABS[i].id));
+			expect(tab).toHaveAttribute("aria-controls", tabPanelElementId(TABS[i].id));
+		}
+		// Distinct ids, or `aria-labelledby` on the panel resolves to whichever
+		// element the document happens to reach first.
+		expect(new Set(tabs.map((t) => t.id)).size).toBe(tabs.length);
+	});
+
+	it("keeps the New-tab button out of the tab set", () => {
+		renderStrip();
+		const list = screen.getByRole("tablist");
+		// Inside the tablist it is announced as one of the tabs - "4 of 4", with a
+		// fourth that opens nothing. Same for the overflow trigger, which the
+		// narrow-strip case in TabStrip.overflow.test.tsx covers.
+		expect(list.contains(screen.getByLabelText("New tab"))).toBe(false);
+		for (const tab of screen.getAllByRole("tab")) expect(list.contains(tab)).toBe(true);
 	});
 });

--- a/app/src/components/layout/TabStrip.overflow.test.tsx
+++ b/app/src/components/layout/TabStrip.overflow.test.tsx
@@ -51,12 +51,22 @@ const TABS = Array.from({ length: 8 }, (_, i) => ({
 	entityId: null,
 }));
 
+/**
+ * The strip root: the element that measures, and the one carrying the row's
+ * layout. The tablist is a child of it and holds only tabs - the overflow
+ * trigger and the New-tab button are not tabs and must not be inside a
+ * `role="tablist"`.
+ */
+function stripRoot(): HTMLElement {
+	return screen.getByRole("tablist").parentElement as HTMLElement;
+}
+
 /** jsdom lays nothing out, so the strip's width has to be supplied. */
 function stubStripWidth(px: number) {
 	Object.defineProperty(HTMLElement.prototype, "clientWidth", {
 		configurable: true,
-		get() {
-			return this.getAttribute("role") === "tablist" ? px : 0;
+		get(this: HTMLElement) {
+			return this.querySelector(':scope > [role="tablist"]') ? px : 0;
 		},
 	});
 }
@@ -94,7 +104,7 @@ describe("tab strip width", () => {
 		 * width to its content - the same loop, reintroduced by a class that
 		 * looks like the one that fixed it.
 		 */
-		expect(screen.getByRole("tablist").className).toMatch(/\bw-full\b/);
+		expect(stripRoot().className).toMatch(/\bw-full\b/);
 	});
 
 	it("takes its height from the band token the drawer header shares", () => {
@@ -103,7 +113,7 @@ describe("tab strip width", () => {
 		// A bare h-8 here would drift from the drawer's header the moment either
 		// side changed, and the two are one band across the window: the strip's
 		// left edge is the drawer's right edge.
-		expect(screen.getByRole("tablist").className).toContain("h-[var(--tabstrip-height)]");
+		expect(stripRoot().className).toContain("h-[var(--tabstrip-height)]");
 	});
 
 	it("shows every tab when there is room", () => {
@@ -120,6 +130,17 @@ describe("tab strip width", () => {
 		expect(shown).toBeGreaterThan(0);
 		expect(shown).toBeLessThan(TABS.length);
 		expect(screen.getByLabelText(`${TABS.length - shown} more tabs`)).toBeInTheDocument();
+	});
+
+	it("keeps the overflow trigger outside the tab set", () => {
+		stubStripWidth(320);
+		renderStrip();
+		const shown = screen.getAllByRole("tab").length;
+		const trigger = screen.getByLabelText(`${TABS.length - shown} more tabs`);
+		// A `role="tablist"` owns only tabs, so inside it the "+N" menu is counted
+		// and announced as one of them - "6 of 6" with a sixth that is a dropdown.
+		expect(screen.getByRole("tablist").contains(trigger)).toBe(false);
+		expect(stripRoot().contains(trigger)).toBe(true);
 	});
 
 	it("keeps the active tab on screen however narrow it gets", () => {
@@ -154,6 +175,7 @@ describe("drag regions", () => {
 		// Non-empty by construction: the strip is stubbed narrow so it renders
 		// tabs *and* the overflow control, and a scan of nothing passes anything.
 		const marked = [
+			stripRoot(),
 			screen.getByRole("tablist"),
 			...screen.getAllByRole("tab"),
 			screen.getByLabelText("New tab"),

--- a/app/src/components/layout/TabStrip.tsx
+++ b/app/src/components/layout/TabStrip.tsx
@@ -57,6 +57,9 @@ import { fitTabs, makeTextMeasurer, naturalTabWidth } from "./tab-fit";
 // the same tabs and must name them identically. See tab-descriptors.ts.
 import { useTabDescriptors, type TabDescriptor } from "./tab-descriptors";
 import { getMethodColor } from "@/utils";
+// The tab -> panel ids, shared with Shell, which renders the panel end of the
+// relationship. See tab-aria.ts.
+import { tabElementId, tabPanelElementId } from "./tab-aria";
 
 function TabItem({
 	tab,
@@ -79,7 +82,9 @@ function TabItem({
 	return (
 		<div
 			role="tab"
+			id={tabElementId(tab.id)}
 			aria-selected={isActive}
+			aria-controls={tabPanelElementId(tab.id)}
 			tabIndex={rovingTabIndex}
 			data-tab-id={tab.id}
 			title={descriptor.title}
@@ -226,8 +231,15 @@ export function TabStrip() {
 		if (e.key === "End") next = tabs.length - 1;
 
 		e.preventDefault();
-		// Roving tabindex means the destination is currently -1, which is still
-		// focusable programmatically; the render that follows activation fixes it.
+		// Reset every tab before promoting the destination, the shape `focusItem`
+		// in useRovingTreeFocus uses. Setting the destination alone leaked a tab
+		// stop per arrow press: this is a DOM mutation on top of a vdom prop that
+		// did not change, so React re-renders to nothing and the stray `0` on each
+		// tab skated past survives. There is no render to rely on either, because
+		// focus deliberately moves without activating - arrow across a dozen tabs
+		// and the strip was a dozen Tab stops again, the thing roving tabindex is
+		// here to prevent.
+		for (const el of tabs) el.tabIndex = -1;
 		tabs[next].tabIndex = 0;
 		tabs[next].focus();
 	}, []);
@@ -235,8 +247,6 @@ export function TabStrip() {
 	return (
 		<div
 			ref={listRef}
-			role="tablist"
-			onKeyDown={onKeyDown}
 			/*
 			 * `w-full` is load-bearing, not cosmetic - it is the `flex-1` this
 			 * carried while the strip was a row item in the title bar, restated for
@@ -258,15 +268,25 @@ export function TabStrip() {
 			 */
 			className="panel-clip flex h-[var(--tabstrip-height)] w-full shrink-0 items-stretch overflow-hidden border-b border-border bg-panel"
 		>
-			{visible.map((i) => (
-				<TabItem
-					key={openTabs[i].id}
-					tab={openTabs[i]}
-					isActive={openTabs[i].id === activeTabId}
-					width={widths[i]}
-					descriptor={descriptors[i]}
-				/>
-			))}
+			{/*
+			 * The tablist holds tabs and nothing else. The overflow trigger and the
+			 * New-tab button are siblings of it rather than children: a `role=tablist`
+			 * owns only `role=tab` children, and a button inside one is announced as
+			 * part of the tab set - "5 of 6" with a sixth tab that is a menu. The row
+			 * is unchanged visually, because the strip's flex layout is on the element
+			 * around all three.
+			 */}
+			<div role="tablist" onKeyDown={onKeyDown} className="flex min-w-0 items-stretch">
+				{visible.map((i) => (
+					<TabItem
+						key={openTabs[i].id}
+						tab={openTabs[i]}
+						isActive={openTabs[i].id === activeTabId}
+						width={widths[i]}
+						descriptor={descriptors[i]}
+					/>
+				))}
+			</div>
 
 			{/*
 			 * The tabs that did not fit, reachable rather than scrolled out of

--- a/app/src/components/layout/focus-containers.test.tsx
+++ b/app/src/components/layout/focus-containers.test.tsx
@@ -44,7 +44,11 @@ describe("focus containers", () => {
 	// every focusable descendant - dropping it silently clips the ring.
 	it("marks the tab row as a clipping panel", () => {
 		renderTabStrip();
-		expect(screen.getByRole("tablist")).toHaveClass("panel-clip");
+		// The row, not the tablist inside it: the tablist holds only tabs, while
+		// the clipping edge belongs to the element that also holds the overflow
+		// trigger and the New-tab button.
+		const row = screen.getByRole("tablist").parentElement;
+		expect(row).toHaveClass("panel-clip");
 	});
 
 	// Tree rows are wider than the label button inside them, so the row paints

--- a/app/src/components/layout/shell-tab-identity.test.tsx
+++ b/app/src/components/layout/shell-tab-identity.test.tsx
@@ -101,9 +101,31 @@ describe("tab content identity across the drawer", () => {
 		// same column, rather than a row spanning the window. Anything else and
 		// its left edge stops tracking the drawer's resize handle.
 		renderShell();
-		const strip = screen.getByRole("tablist");
+		// The strip row, not the tablist nested in it - the tablist holds only
+		// tabs, so the element sitting beside main is its parent.
+		const strip = screen.getByRole("tablist").parentElement as HTMLElement;
 		const main = screen.getByRole("main");
 		expect(strip.parentElement).toBe(main.parentElement?.parentElement);
 		expect(strip.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
+	/*
+	 * The tabs pattern is a round trip, and only Shell can see both ends: the
+	 * strip's `aria-controls` has to land on an element that exists, and that
+	 * element has to name the tab back. Half of it - tabs pointing at ids nothing
+	 * rendered - is indistinguishable from the whole thing in a strip-only test.
+	 */
+	it("wires the active tab to the content region in both directions", () => {
+		renderShell();
+		const tab = screen.getByRole("tab");
+		const panel = screen.getByRole("tabpanel");
+
+		expect(tab).toHaveAttribute("aria-controls", panel.id);
+		expect(panel).toHaveAttribute("aria-labelledby", tab.id);
+		expect(panel.id).not.toBe("");
+		expect(tab.id).not.toBe("");
+		// The panel is inside main, not instead of it: main is a landmark and
+		// carries only role="main".
+		expect(screen.getByRole("main").contains(panel)).toBe(true);
 	});
 });

--- a/app/src/components/layout/tab-aria.ts
+++ b/app/src/components/layout/tab-aria.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The tab -> panel relationship, as ids both ends agree on.
+ *
+ * The WAI-ARIA tabs pattern is two links, not one: the tab points at the panel
+ * with `aria-controls`, the panel names its tab with `aria-labelledby`. The two
+ * ends are rendered by different components - `TabStrip` draws the tabs, `Shell`
+ * owns the content region - so the ids are derived from the tab id here rather
+ * than spelled out in both places, where they would drift the first time either
+ * side was renamed. The strip used to declare `role="tablist"` and stop, which
+ * announces "tab 2 of 3" over content that claims no owner.
+ *
+ * A sibling module rather than an export from `TabStrip.tsx` for the same reason
+ * `tab-descriptors.ts` is one: that file exports components, and a function
+ * beside them costs it fast refresh.
+ */
+
+/** The id of a tab element in the strip. */
+export function tabElementId(tabId: string): string {
+	return `tab-${tabId}`;
+}
+
+/** The id of the panel a tab controls. Only the active tab's panel is rendered. */
+export function tabPanelElementId(tabId: string): string {
+	return `tabpanel-${tabId}`;
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -98,6 +98,8 @@ Labels and icons come from `tab-descriptors.ts`, a sibling module rather than th
 - **Middle-click closes** a tab (browser-like).
 - **No unsaved dot** - autosave ensures safety.
 - **Keyboard support:** ⌘1–9 jump to tab; displayed via dock shortcuts.
+- **The strip is one Tab stop, and stays one.** Roving tabindex: exactly one tab carries `tabIndex=0`, Left/Right/Home/End move focus within the strip, and Enter or Space activates - focus moves *without* activating, so skating past a dashboard tab mounts nothing. The arrow handler resets every tab to -1 before promoting the destination; setting the destination alone leaked a stop per press, because the DOM write sits on top of a vdom prop React never re-applies. Delete or Backspace closes the focused tab (both keys, since a Mac's "delete" reports `Backspace`). → `TabStrip.keyboard.test.tsx`
+- **The tablist holds tabs and nothing else.** The overflow "+N" trigger and the "+" button are siblings of the `role="tablist"` element, not children: inside it they are announced as part of the tab set. Each tab carries `id`/`aria-controls` (`tabElementId`, `tabPanelElementId`), and `Shell` gives the content region the matching `role="tabpanel"` + `aria-labelledby` - the WAI-ARIA relationship in both directions.
 
 ### `Shell` (`components/layout/Shell.tsx`)
 
@@ -110,6 +112,7 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Drawer-view sync:** an effect points the Drawer at the view matching the active tab - `variables`→variables, `settings`→settings, `request`/`collection`→collections - and opens it.
 - **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. It renders on the tab types the section registry has entries for - request, collection and run - and nothing on the other four. `relative` sits on the main+context row rather than on the outer one, so the overlay stops at the tab strip instead of covering the tabs it belongs to.
+- **The content region is the strip's tab panel.** A `role="tabpanel"` div inside `main` (not on `main`, which is a landmark and carries only `role="main"`), carrying the active tab's panel id and naming that tab with `aria-labelledby`. → `shell-tab-identity.test.tsx`.
 - **The restructure must not remount tab content.** Drawer state is upstream of the column the active tab renders into, so a `key` derived from it - or a wrapper mounted only while the drawer is closed - throws away an unsaved body, a scroll position, a Monaco model. → `shell-tab-identity.test.tsx`.
 - **`<ImportModal />`** and **`<CommandPalette />`** mounted once each as global overlays; visibility in a store rather than in the Shell.
 


### PR DESCRIPTION
## Description

Two defects in the top tab strip's keyboard and ARIA model (#937), plus the structural rule the second one depends on.

**Root cause, the tab-stop leak.** `TabStrip`'s arrow handler moved focus by writing `tabIndex = 0` straight onto the destination element and left every tab it had promoted that way behind it. That write is a DOM mutation on top of a vdom prop that did not change - the skated-past tab is still `tabIndex={-1}` in the render - so React re-applies nothing, and the comment's hope that "the render that follows activation fixes it" never arrives either, because focus deliberately moves *without* activating. Arrow across a dozen tabs without pressing Enter and the strip was a dozen Tab stops again: exactly what roving tabindex is in this file to prevent. The existing single-stop test read only the first render, so nothing pinned it.

**Approach.** Reset every tab to -1 before promoting the destination, the same shape `focusItem` in `useRovingTreeFocus` has used since the tree got roving focus. Three lines, no new state, and the strip keeps moving focus without activating.

**Rejected alternative:** tracking the focused tab in React state so the attribute is owned by the render. It works, but it turns every arrow press into a re-render of the whole strip (each `TabItem` re-runs its descriptor and width props) to move a caret one tab, and it puts a second source of truth beside `activeTabId` for a value that is really "where the DOM's focus is". The tree solved the identical problem the other way and this is now one shape in both places rather than two.

**Root cause, the missing relationship.** The strip declared `role="tablist"` and `aria-selected` and stopped. No tab pointed at the region it switches and the region named no tab, so a screen reader announced "tab 2 of 3" and then content with no stated relationship to it - `rg 'tabpanel|aria-controls' app/src` matched only the Radix-derived section tabs. Tabs now carry `id` + `aria-controls` and `Shell` gives the content region `role="tabpanel"` + `aria-labelledby`. The ids come from one small sibling module, `tab-aria.ts`, rather than being spelled out at both ends where they would drift the first time either side was renamed (it is a module and not an export from `TabStrip.tsx` because that file exports components, and a function beside them costs it fast refresh - the same reason `tab-descriptors.ts` is a sibling). The role sits on a child of `main`, not on `main` itself: `main` is a landmark and carries only `role="main"`, so overwriting it would have traded one relationship for another.

The minor sibling in the issue is fixed with it: the overflow "+N" trigger and the New-tab button were non-tab children of the tablist, where assistive tech counts them into the tab set. The tablist is now an element holding tabs only, with those two as siblings under the strip row. The row's flex layout is on the element around all three, so the strip is visually identical.

**Deviation to flag:** three sibling tests referenced `getByRole("tablist")` for things that belong to the strip *row* rather than to the tab set - the measured `clientWidth`, `w-full`, `h-[var(--tabstrip-height)]`, `panel-clip`, and its position beside `main`. They are repointed at that row with a comment saying why; no assertion was weakened, and `TabStrip.overflow.test.tsx` gains one that the "+N" trigger is outside the tablist.

**Docs:** `docs/app/COMPONENTS.md`'s TabStrip keyboard bullet was corrected under #931 / PR #934, so this extends rather than rewrites it - two added bullets under TabStrip (the roving-tabindex rule and the tablist-holds-only-tabs rule) and one under Shell for the panel. `mkdocs build --strict` was **not** run: mkdocs is not installed in this environment. The change adds no page, link or anchor, so there is nothing for the strict build to resolve differently.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check`

| Gate | Result |
| --- | --- |
| `pnpm test` | 517 files, 5563 tests, all passing |
| `pnpm type-check` | clean (renderer, electron, electron-tests) |
| `pnpm lint` | 0 errors, 0 warnings |
| `pnpm format:check` | all matched files clean |

One re-run of the suite hit `send-with-row.test.tsx` "opens the list on the row that step bound" at 5.25s against the default 5s timeout - the load-sensitive case class the repo guide describes, in an untouched module. It passes alone (34/34) and passed in the full run above.

New and extended cases: `TabStrip.keyboard.test.tsx` (single stop after arrowing, single stop after Home/End, tabs point at their panel ids, New-tab button outside the tab set), `TabStrip.overflow.test.tsx` (overflow trigger outside the tab set), `shell-tab-identity.test.tsx` (the round trip, which only Shell can see).

### Mutation checks

| Mutation | Cases that reddened |
| --- | --- |
| Drop `for (const el of tabs) el.tabIndex = -1;` (the old bare mutation) | 2 - "still has exactly one Tab stop after arrowing across the strip", "leaves one Tab stop after Home and End too" |
| Drop `id` + `aria-controls` from the tab | 2 - "points every tab at the panel id its content will carry", "wires the active tab to the content region in both directions" |
| Drop `role="tabpanel"` from the content region | 1 - "wires the active tab to the content region in both directions" |
| Put the overflow trigger and New-tab button back inside the tablist | 6 - "keeps the New-tab button out of the tab set", "keeps the overflow trigger outside the tab set", plus the four strip-row cases that read the row through the tablist |

Each mutation was reverted and the suite confirmed green again (37 layout files, 284 tests).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #937

Same files as #931 (landed), #935 and #938 touch `Shell.tsx` too - this one owns only the panel-role region of it and leaves the keydown map alone, so any merge order works.


---
_Generated by [Claude Code](https://claude.ai/code/session_014CWVjkN7qD2vSm6aCEK2dp)_