### PR TITLE
refactor(engine): inbox parsers return std::expected, not optional-as-error

### DIFF
--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -66,7 +66,7 @@ The HTTP server handles all API requests from the Electron UI. It runs on `127.0
 
 #### How a route says no
 
-Two shapes, and the difference between them is the point:
+Three shapes, and the difference between them is the point:
 
 - A **testable core** - `create_collection_response`, `import_apply_response` -
   returns `std::pair<int, nlohmann::json>`. Success and failure are both
@@ -78,6 +78,12 @@ Two shapes, and the difference between them is the point:
   `std::expected<void, RouteError>`: nothing on success, and on failure the
   `{status, body}` the caller should answer with. `route_error (status, message)`
   builds the refusal; `as_response` turns one into the pair a core returns.
+- A **payload parser** - `parse_mock_start`, `parse_inbox_start`,
+  `parse_inbox_response_update`, `parse_live_resume_point` - returns
+  `std::expected<Parsed, ParseError>`, where `Parsed` is the validated request
+  itself. The value *is* the return, never an out-parameter: a half-filled
+  request a caller forgot to check for is then unreachable rather than merely
+  unlikely (issues #926, #954).
 
 These used to be `std::optional<std::pair<int, nlohmann::json>>`, where an
 *empty* optional meant success (issue #901). That reads backwards at every call

--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -12,6 +12,7 @@
 #include "vayu/http/live_claim.hpp"
 
 #include <cstdint>
+#include <expected>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -119,9 +120,14 @@ bool is_loopback_bind (const std::string& bind);
  * A non-loopback `bind` additionally requires `confirmNonLoopback: true`: the
  * engine's management API has no route auth and CORS `*`, so binding wide is a
  * trust decision the caller states rather than one a default makes.
+ *
+ * The parsed request is the *value*, not an out-parameter, for the reason
+ * `parse_mock_start` gives: an empty return meaning success reads backwards,
+ * and a half-filled `InboxStartRequest` is unreachable once the request only
+ * exists when the payload was accepted (issue #954).
  */
-std::optional<InboxParseError>
-parse_inbox_start (const nlohmann::json& json, InboxStartRequest& out);
+std::expected<InboxStartRequest, InboxParseError> parse_inbox_start (
+const nlohmann::json& json);
 
 /**
  * Validate a `PUT /inbox/:id` payload against @p current.
@@ -130,10 +136,11 @@ parse_inbox_start (const nlohmann::json& json, InboxStartRequest& out);
  * so changing only the status does not silently drop the configured headers.
  * The payload may be either the canned response itself or `{"response": {...}}`
  * - the start route's shape - so a client can send back what it was given.
+ *
+ * @p current is what an absent field keeps; the merged response is the value.
  */
-std::optional<InboxParseError> parse_inbox_response_update (const nlohmann::json& json,
-const InboxCannedResponse& current,
-InboxCannedResponse& out);
+std::expected<InboxCannedResponse, InboxParseError>
+parse_inbox_response_update (const nlohmann::json& json, const InboxCannedResponse& current);
 
 /**
  * Resolve where `GET /inbox/:id/live` resumes from.
@@ -150,9 +157,8 @@ InboxCannedResponse& out);
  * and resuming from the start would replay every retained capture as though it
  * had just arrived.
  */
-std::optional<InboxParseError> parse_live_resume_point (const std::string& header_value,
-const std::string& param_value,
-int64_t& out);
+std::expected<int64_t, InboxParseError>
+parse_live_resume_point (const std::string& header_value, const std::string& param_value);
 
 /** The wire shape of an inbox, shared by start, list and update. */
 nlohmann::json inbox_info_json (const InboxInfo& info);

--- a/engine/src/http/routes/events.cpp
+++ b/engine/src/http/routes/events.cpp
@@ -80,13 +80,14 @@ void register_event_stream_routes (RouteContext& ctx) {
             return;
         }
 
-        int64_t last_seen = 0;
-        if (auto error =
-            parse_live_resume_point (req.get_header_value ("Last-Event-ID"),
-            req.get_param_value ("lastEventId"), last_seen)) {
-            send_error (res, error->http_status, error->message, error->code);
+        const auto resume_point = parse_live_resume_point (
+        req.get_header_value ("Last-Event-ID"), req.get_param_value ("lastEventId"));
+        if (!resume_point) {
+            const auto& refusal = resume_point.error ();
+            send_error (res, refusal.http_status, refusal.message, refusal.code);
             return;
         }
+        const int64_t last_seen = *resume_point;
         // Frame ids start at 0, so - unlike the inbox's capture ids - "0" is a
         // real resume point and cannot double as "absent". Presence decides,
         // and a resume starts at the frame *after* the last one seen.

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -29,6 +29,7 @@
 #include <charconv>
 #include <chrono>
 #include <cstddef>
+#include <expected>
 #include <optional>
 #include <string_view>
 #include <thread>
@@ -176,124 +177,127 @@ bool is_loopback_bind (const std::string& bind) {
 namespace {
 
 /**
- * Read the canned-response fields of @p json onto @p out, which the caller has
- * seeded with the values an absent field should keep.
+ * Read the canned-response fields of @p json onto @p merged, which the caller
+ * has seeded with the values an absent field should keep.
  */
-std::optional<InboxParseError>
-apply_response_fields (const nlohmann::json& json, InboxCannedResponse& out) {
+std::expected<InboxCannedResponse, InboxParseError>
+apply_response_fields (const nlohmann::json& json, InboxCannedResponse merged) {
     if (const auto it = json.find ("status"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || it->get<int> () < 100 || it->get<int> () > 599) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'status': must be an integer between 100 and 599" };
+            return std::unexpected (InboxParseError{ 400, "bad_request",
+            "Invalid 'status': must be an integer between 100 and 599" });
         }
-        out.status = it->get<int> ();
+        merged.status = it->get<int> ();
     }
     if (const auto it = json.find ("body"); it != json.end () && !it->is_null ()) {
         if (!it->is_string ()) {
-            return InboxParseError{ 400, "bad_request", "Invalid 'body': must be a string" };
+            return std::unexpected (InboxParseError{
+            400, "bad_request", "Invalid 'body': must be a string" });
         }
-        out.body = it->get<std::string> ();
+        merged.body = it->get<std::string> ();
     }
     if (const auto it = json.find ("delayMs"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || it->get<int> () < 0 ||
         it->get<int> () > constants::inbox::MAX_RESPONSE_DELAY_MS) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'delayMs': must be an integer between 0 and " +
-                std::to_string (constants::inbox::MAX_RESPONSE_DELAY_MS) };
+            return std::unexpected (InboxParseError{ 400, "bad_request",
+            "Invalid 'delayMs': must be an integer between 0 and " +
+            std::to_string (constants::inbox::MAX_RESPONSE_DELAY_MS) });
         }
-        out.delay_ms = it->get<int> ();
+        merged.delay_ms = it->get<int> ();
     }
     if (const auto it = json.find ("headers"); it != json.end () && !it->is_null ()) {
         if (!it->is_object ()) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'headers': must be a JSON object of string values" };
+            return std::unexpected (InboxParseError{ 400, "bad_request",
+            "Invalid 'headers': must be a JSON object of string values" });
         }
         std::map<std::string, std::string> headers;
         for (const auto& [name, value] : it->items ()) {
             if (!value.is_string ()) {
-                return InboxParseError{ 400, "bad_request",
-                    "Invalid 'headers." + name + "': must be a string" };
+                return std::unexpected (InboxParseError{ 400, "bad_request",
+                "Invalid 'headers." + name + "': must be a string" });
             }
             headers[name] = value.get<std::string> ();
         }
-        out.headers = std::move (headers);
+        merged.headers = std::move (headers);
     }
-    return std::nullopt;
+    return merged;
 }
 
 } // namespace
 
-std::optional<InboxParseError>
-parse_inbox_start (const nlohmann::json& json, InboxStartRequest& out) {
-    out = InboxStartRequest{};
+std::expected<InboxStartRequest, InboxParseError> parse_inbox_start (
+const nlohmann::json& json) {
+    InboxStartRequest parsed;
     if (json.is_null ()) {
-        return std::nullopt; // No body at all - every field is optional.
+        return parsed; // No body at all - every field is optional.
     }
     if (!json.is_object ()) {
-        return InboxParseError{ 400, "bad_request", "Request body must be a JSON object" };
+        return std::unexpected (
+        InboxParseError{ 400, "bad_request", "Request body must be a JSON object" });
     }
 
     if (const auto it = json.find ("port"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || !is_valid_port (it->get<int> ())) {
-            return InboxParseError{
-                400, "bad_request", "Invalid 'port': must be an integer between 0 and 65535 (0 picks a free port)"
-            };
+            return std::unexpected (InboxParseError{ 400, "bad_request",
+            "Invalid 'port': must be an integer between 0 and 65535 (0 picks a "
+            "free port)" });
         }
-        out.port = it->get<int> ();
+        parsed.port = it->get<int> ();
     }
 
     if (const auto it = json.find ("bind"); it != json.end () && !it->is_null ()) {
         if (!it->is_string () || it->get<std::string> ().empty ()) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'bind': must be a non-empty string" };
+            return std::unexpected (InboxParseError{
+            400, "bad_request", "Invalid 'bind': must be a non-empty string" });
         }
-        out.bind = it->get<std::string> ();
+        parsed.bind = it->get<std::string> ();
     }
 
-    if (!is_loopback_bind (out.bind)) {
+    if (!is_loopback_bind (parsed.bind)) {
         const auto confirm = json.find ("confirmNonLoopback");
         const bool confirmed =
         confirm != json.end () && confirm->is_boolean () && confirm->get<bool> ();
         if (!confirmed) {
-            return InboxParseError{ 400, "inbox_non_loopback_bind",
-                "Binding an inbox to '" + out.bind +
-                "' exposes it beyond this machine; resend with "
-                "\"confirmNonLoopback\": true to accept that" };
+            return std::unexpected (InboxParseError{ 400, "inbox_non_loopback_bind",
+            "Binding an inbox to '" + parsed.bind +
+            "' exposes it beyond this machine; resend with "
+            "\"confirmNonLoopback\": true to accept that" });
         }
     }
 
     if (const auto it = json.find ("response"); it != json.end () && !it->is_null ()) {
         if (!it->is_object ()) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'response': must be a JSON object" };
+            return std::unexpected (InboxParseError{
+            400, "bad_request", "Invalid 'response': must be a JSON object" });
         }
-        if (auto err = apply_response_fields (*it, out.response); err) {
-            return err;
+        auto response = apply_response_fields (*it, parsed.response);
+        if (!response) {
+            return std::unexpected (response.error ());
         }
+        parsed.response = std::move (*response);
     }
-    return std::nullopt;
+    return parsed;
 }
 
-std::optional<InboxParseError> parse_inbox_response_update (const nlohmann::json& json,
-const InboxCannedResponse& current,
-InboxCannedResponse& out) {
-    out = current;
+std::expected<InboxCannedResponse, InboxParseError>
+parse_inbox_response_update (const nlohmann::json& json, const InboxCannedResponse& current) {
     if (!json.is_object ()) {
-        return InboxParseError{ 400, "bad_request", "Request body must be a JSON object" };
+        return std::unexpected (
+        InboxParseError{ 400, "bad_request", "Request body must be a JSON object" });
     }
     // Accept the start route's own shape so a client can send back what it was
     // handed; `{"response": null}` means the same as an empty body (keep).
     if (const auto it = json.find ("response"); it != json.end ()) {
         if (it->is_null ()) {
-            return std::nullopt;
+            return current;
         }
         if (!it->is_object ()) {
-            return InboxParseError{ 400, "bad_request",
-                "Invalid 'response': must be a JSON object" };
+            return std::unexpected (InboxParseError{
+            400, "bad_request", "Invalid 'response': must be a JSON object" });
         }
-        return apply_response_fields (*it, out);
+        return apply_response_fields (*it, current);
     }
-    return apply_response_fields (json, out);
+    return apply_response_fields (json, current);
 }
 
 nlohmann::json inbox_info_json (const InboxInfo& info) {
@@ -318,16 +322,14 @@ nlohmann::json inbox_info_json (const InboxInfo& info) {
     return out;
 }
 
-std::optional<InboxParseError> parse_live_resume_point (const std::string& header_value,
-const std::string& param_value,
-int64_t& out) {
-    out = 0;
+std::expected<int64_t, InboxParseError>
+parse_live_resume_point (const std::string& header_value, const std::string& param_value) {
     // The header is the browser's own reconnect and therefore the more recent
     // of the two; an empty one is absent, not a resume point of "".
     const std::string& value = header_value.empty () ? param_value : header_value;
     const char* source = header_value.empty () ? "lastEventId" : "Last-Event-ID";
     if (value.empty ()) {
-        return std::nullopt;
+        return 0;
     }
 
     int64_t parsed_id = 0;
@@ -335,11 +337,10 @@ int64_t& out) {
     const char* end   = begin + value.size ();
     const auto parsed = std::from_chars (begin, end, parsed_id);
     if (parsed.ec != std::errc{} || parsed.ptr != end || parsed_id < 0) {
-        return InboxParseError{ 400, "invalid_last_event_id",
-            std::string (source) + " must be a non-negative capture id" };
+        return std::unexpected (InboxParseError{ 400, "invalid_last_event_id",
+        std::string (source) + " must be a non-negative capture id" });
     }
-    out = parsed_id;
-    return std::nullopt;
+    return parsed_id;
 }
 
 nlohmann::json inbox_capture_json (const vayu::db::InboxRequest& capture) {
@@ -769,14 +770,14 @@ void register_inbox_routes (RouteContext& ctx) {
         if (!read_json_body (req, res, body)) {
             return;
         }
-        InboxStartRequest start;
-        if (auto error = parse_inbox_start (body, start); error) {
-            vayu::utils::log_warning ("POST /inbox/start - " + error->message);
-            send_parse_error (res, *error);
+        const auto start = parse_inbox_start (body);
+        if (!start) {
+            vayu::utils::log_warning ("POST /inbox/start - " + start.error ().message);
+            send_parse_error (res, start.error ());
             return;
         }
         try {
-            auto result = ctx.inbox_manager.start (ctx.db, start);
+            auto result = ctx.inbox_manager.start (ctx.db, *start);
             if (!result.ok) {
                 vayu::utils::log_warning ("POST /inbox/start - " + result.error_message);
                 send_error (res, result.http_status, result.error_message,
@@ -869,13 +870,13 @@ void register_inbox_routes (RouteContext& ctx) {
         if (body.is_null ()) {
             body = nlohmann::json::object ();
         }
-        InboxCannedResponse updated;
-        if (auto error = parse_inbox_response_update (body, current->response, updated); error) {
-            vayu::utils::log_warning ("PUT /inbox/:id - " + error->message);
-            send_parse_error (res, *error);
+        const auto updated = parse_inbox_response_update (body, current->response);
+        if (!updated) {
+            vayu::utils::log_warning ("PUT /inbox/:id - " + updated.error ().message);
+            send_parse_error (res, updated.error ());
             return;
         }
-        auto info = ctx.inbox_manager.update_response (inbox_id, updated);
+        auto info = ctx.inbox_manager.update_response (inbox_id, *updated);
         if (!info) {
             send_error (res, 404, "Inbox not found");
             return;
@@ -944,13 +945,14 @@ void register_inbox_routes (RouteContext& ctx) {
         }
         const auto limits = ctx.inbox_manager.limits (inbox_id).value_or (InboxLimits{});
 
-        int64_t last_id = 0;
-        if (auto error =
-            parse_live_resume_point (req.get_header_value ("Last-Event-ID"),
-            req.get_param_value ("lastEventId"), last_id)) {
-            send_error (res, error->http_status, error->message, error->code);
+        const auto resume_point = parse_live_resume_point (
+        req.get_header_value ("Last-Event-ID"), req.get_param_value ("lastEventId"));
+        if (!resume_point) {
+            const auto& refusal = resume_point.error ();
+            send_error (res, refusal.http_status, refusal.message, refusal.code);
             return;
         }
+        int64_t last_id = *resume_point;
 
         const auto claim = ctx.inbox_manager.try_claim_live (inbox_id);
         if (!claim) {

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -184,37 +184,44 @@ std::expected<InboxCannedResponse, InboxParseError>
 apply_response_fields (const nlohmann::json& json, InboxCannedResponse merged) {
     if (const auto it = json.find ("status"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || it->get<int> () < 100 || it->get<int> () > 599) {
-            return std::unexpected (InboxParseError{ 400, "bad_request",
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code = "bad_request",
+            .message =
             "Invalid 'status': must be an integer between 100 and 599" });
         }
         merged.status = it->get<int> ();
     }
     if (const auto it = json.find ("body"); it != json.end () && !it->is_null ()) {
         if (!it->is_string ()) {
-            return std::unexpected (InboxParseError{
-            400, "bad_request", "Invalid 'body': must be a string" });
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "bad_request",
+            .message = "Invalid 'body': must be a string" });
         }
         merged.body = it->get<std::string> ();
     }
     if (const auto it = json.find ("delayMs"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || it->get<int> () < 0 ||
         it->get<int> () > constants::inbox::MAX_RESPONSE_DELAY_MS) {
-            return std::unexpected (InboxParseError{ 400, "bad_request",
-            "Invalid 'delayMs': must be an integer between 0 and " +
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "bad_request",
+            .message = "Invalid 'delayMs': must be an integer between 0 and " +
             std::to_string (constants::inbox::MAX_RESPONSE_DELAY_MS) });
         }
         merged.delay_ms = it->get<int> ();
     }
     if (const auto it = json.find ("headers"); it != json.end () && !it->is_null ()) {
         if (!it->is_object ()) {
-            return std::unexpected (InboxParseError{ 400, "bad_request",
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code = "bad_request",
+            .message =
             "Invalid 'headers': must be a JSON object of string values" });
         }
         std::map<std::string, std::string> headers;
         for (const auto& [name, value] : it->items ()) {
             if (!value.is_string ()) {
-                return std::unexpected (InboxParseError{ 400, "bad_request",
-                "Invalid 'headers." + name + "': must be a string" });
+                return std::unexpected (InboxParseError{ .http_status = 400,
+                .code = "bad_request",
+                .message = "Invalid 'headers." + name + "': must be a string" });
             }
             headers[name] = value.get<std::string> ();
         }
@@ -232,13 +239,16 @@ const nlohmann::json& json) {
         return parsed; // No body at all - every field is optional.
     }
     if (!json.is_object ()) {
-        return std::unexpected (
-        InboxParseError{ 400, "bad_request", "Request body must be a JSON object" });
+        return std::unexpected (InboxParseError{ .http_status = 400,
+        .code                                                 = "bad_request",
+        .message = "Request body must be a JSON object" });
     }
 
     if (const auto it = json.find ("port"); it != json.end () && !it->is_null ()) {
         if (!it->is_number_integer () || !is_valid_port (it->get<int> ())) {
-            return std::unexpected (InboxParseError{ 400, "bad_request",
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code = "bad_request",
+            .message =
             "Invalid 'port': must be an integer between 0 and 65535 (0 picks a "
             "free port)" });
         }
@@ -247,8 +257,9 @@ const nlohmann::json& json) {
 
     if (const auto it = json.find ("bind"); it != json.end () && !it->is_null ()) {
         if (!it->is_string () || it->get<std::string> ().empty ()) {
-            return std::unexpected (InboxParseError{
-            400, "bad_request", "Invalid 'bind': must be a non-empty string" });
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "bad_request",
+            .message = "Invalid 'bind': must be a non-empty string" });
         }
         parsed.bind = it->get<std::string> ();
     }
@@ -258,8 +269,9 @@ const nlohmann::json& json) {
         const bool confirmed =
         confirm != json.end () && confirm->is_boolean () && confirm->get<bool> ();
         if (!confirmed) {
-            return std::unexpected (InboxParseError{ 400, "inbox_non_loopback_bind",
-            "Binding an inbox to '" + parsed.bind +
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "inbox_non_loopback_bind",
+            .message = "Binding an inbox to '" + parsed.bind +
             "' exposes it beyond this machine; resend with "
             "\"confirmNonLoopback\": true to accept that" });
         }
@@ -267,8 +279,9 @@ const nlohmann::json& json) {
 
     if (const auto it = json.find ("response"); it != json.end () && !it->is_null ()) {
         if (!it->is_object ()) {
-            return std::unexpected (InboxParseError{
-            400, "bad_request", "Invalid 'response': must be a JSON object" });
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "bad_request",
+            .message = "Invalid 'response': must be a JSON object" });
         }
         auto response = apply_response_fields (*it, parsed.response);
         if (!response) {
@@ -282,8 +295,9 @@ const nlohmann::json& json) {
 std::expected<InboxCannedResponse, InboxParseError>
 parse_inbox_response_update (const nlohmann::json& json, const InboxCannedResponse& current) {
     if (!json.is_object ()) {
-        return std::unexpected (
-        InboxParseError{ 400, "bad_request", "Request body must be a JSON object" });
+        return std::unexpected (InboxParseError{ .http_status = 400,
+        .code                                                 = "bad_request",
+        .message = "Request body must be a JSON object" });
     }
     // Accept the start route's own shape so a client can send back what it was
     // handed; `{"response": null}` means the same as an empty body (keep).
@@ -292,8 +306,9 @@ parse_inbox_response_update (const nlohmann::json& json, const InboxCannedRespon
             return current;
         }
         if (!it->is_object ()) {
-            return std::unexpected (InboxParseError{
-            400, "bad_request", "Invalid 'response': must be a JSON object" });
+            return std::unexpected (InboxParseError{ .http_status = 400,
+            .code    = "bad_request",
+            .message = "Invalid 'response': must be a JSON object" });
         }
         return apply_response_fields (*it, current);
     }
@@ -337,8 +352,9 @@ parse_live_resume_point (const std::string& header_value, const std::string& par
     const char* end   = begin + value.size ();
     const auto parsed = std::from_chars (begin, end, parsed_id);
     if (parsed.ec != std::errc{} || parsed.ptr != end || parsed_id < 0) {
-        return std::unexpected (InboxParseError{ 400, "invalid_last_event_id",
-        std::string (source) + " must be a non-negative capture id" });
+        return std::unexpected (InboxParseError{ .http_status = 400,
+        .code = "invalid_last_event_id",
+        .message = std::string (source) + " must be a non-negative capture id" });
     }
     return parsed_id;
 }

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -45,65 +45,61 @@ namespace inbox_constants = vayu::core::constants::inbox;
 // ---------------------------------------------------------------------------
 
 TEST (InboxParseStart, EmptyBodyStartsALoopbackInboxAnswering200) {
-    InboxStartRequest out;
-    auto error = vayu::http::parse_inbox_start (json (nullptr), out);
-    ASSERT_FALSE (error.has_value ());
-    EXPECT_EQ (out.bind, "127.0.0.1");
-    EXPECT_EQ (out.port, 0);
-    EXPECT_EQ (out.response.status, 200);
-    EXPECT_EQ (out.response.delay_ms, 0);
-    EXPECT_TRUE (out.response.body.empty ());
+    const auto parsed = vayu::http::parse_inbox_start (json (nullptr));
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->bind, "127.0.0.1");
+    EXPECT_EQ (parsed->port, 0);
+    EXPECT_EQ (parsed->response.status, 200);
+    EXPECT_EQ (parsed->response.delay_ms, 0);
+    EXPECT_TRUE (parsed->response.body.empty ());
 }
 
 TEST (InboxParseStart, ReadsEveryResponseField) {
-    InboxStartRequest out;
-    const json body = { { "port", 0 }, { "bind", "127.0.0.1" },
-        { "response",
-        { { "status", 503 }, { "body", "retry later" }, { "delayMs", 25 },
-        { "headers", { { "Retry-After", "1" } } } } } };
-    ASSERT_FALSE (vayu::http::parse_inbox_start (body, out).has_value ());
-    EXPECT_EQ (out.response.status, 503);
-    EXPECT_EQ (out.response.body, "retry later");
-    EXPECT_EQ (out.response.delay_ms, 25);
-    ASSERT_EQ (out.response.headers.count ("Retry-After"), 1u);
-    EXPECT_EQ (out.response.headers.at ("Retry-After"), "1");
+    const json body   = { { "port", 0 }, { "bind", "127.0.0.1" },
+          { "response",
+          { { "status", 503 }, { "body", "retry later" }, { "delayMs", 25 },
+          { "headers", { { "Retry-After", "1" } } } } } };
+    const auto parsed = vayu::http::parse_inbox_start (body);
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->response.status, 503);
+    EXPECT_EQ (parsed->response.body, "retry later");
+    EXPECT_EQ (parsed->response.delay_ms, 25);
+    ASSERT_EQ (parsed->response.headers.count ("Retry-After"), 1u);
+    EXPECT_EQ (parsed->response.headers.at ("Retry-After"), "1");
 }
 
 TEST (InboxParseStart, RejectsRatherThanDefaultsAnUnusableValue) {
-    InboxStartRequest out;
     // A status outside the HTTP range, a negative delay, a delay past the
     // bound, a non-object headers map and a port outside the range are each a
     // 400: silently answering 200 instead is a listener doing something other
     // than what its caller asked for.
-    EXPECT_TRUE (
-    vayu::http::parse_inbox_start (json{ { "response", { { "status", 900 } } } }, out)
+    EXPECT_FALSE (
+    vayu::http::parse_inbox_start (json{ { "response", { { "status", 900 } } } })
     .has_value ());
-    EXPECT_TRUE (
-    vayu::http::parse_inbox_start (json{ { "response", { { "delayMs", -1 } } } }, out)
+    EXPECT_FALSE (
+    vayu::http::parse_inbox_start (json{ { "response", { { "delayMs", -1 } } } })
     .has_value ());
-    EXPECT_TRUE (vayu::http::parse_inbox_start (
-    json{ { "response", { { "delayMs", inbox_constants::MAX_RESPONSE_DELAY_MS + 1 } } } }, out)
+    EXPECT_FALSE (vayu::http::parse_inbox_start (
+    json{ { "response", { { "delayMs", inbox_constants::MAX_RESPONSE_DELAY_MS + 1 } } } })
     .has_value ());
-    EXPECT_TRUE (vayu::http::parse_inbox_start (
-    json{ { "response", { { "headers", "nope" } } } }, out)
+    EXPECT_FALSE (
+    vayu::http::parse_inbox_start (json{ { "response", { { "headers", "nope" } } } })
     .has_value ());
-    EXPECT_TRUE (
-    vayu::http::parse_inbox_start (json{ { "port", 70000 } }, out).has_value ());
-    EXPECT_TRUE (vayu::http::parse_inbox_start (json{ { "bind", "" } }, out).has_value ());
-    EXPECT_TRUE (vayu::http::parse_inbox_start (json ("not an object"), out).has_value ());
+    EXPECT_FALSE (vayu::http::parse_inbox_start (json{ { "port", 70000 } }).has_value ());
+    EXPECT_FALSE (vayu::http::parse_inbox_start (json{ { "bind", "" } }).has_value ());
+    EXPECT_FALSE (vayu::http::parse_inbox_start (json ("not an object")).has_value ());
 }
 
 TEST (InboxParseStart, NonLoopbackBindNeedsExplicitConfirmation) {
-    InboxStartRequest out;
-    auto refused = vayu::http::parse_inbox_start (json{ { "bind", "0.0.0.0" } }, out);
-    ASSERT_TRUE (refused.has_value ());
-    EXPECT_EQ (refused->http_status, 400);
-    EXPECT_EQ (refused->code, "inbox_non_loopback_bind");
+    const auto refused = vayu::http::parse_inbox_start (json{ { "bind", "0.0.0.0" } });
+    ASSERT_FALSE (refused.has_value ());
+    EXPECT_EQ (refused.error ().http_status, 400);
+    EXPECT_EQ (refused.error ().code, "inbox_non_loopback_bind");
 
-    auto accepted = vayu::http::parse_inbox_start (
-    json{ { "bind", "0.0.0.0" }, { "confirmNonLoopback", true } }, out);
-    EXPECT_FALSE (accepted.has_value ());
-    EXPECT_EQ (out.bind, "0.0.0.0");
+    const auto accepted = vayu::http::parse_inbox_start (
+    json{ { "bind", "0.0.0.0" }, { "confirmNonLoopback", true } });
+    ASSERT_TRUE (accepted.has_value ());
+    EXPECT_EQ (accepted->bind, "0.0.0.0");
 
     // Loopback in any of its spellings needs no confirmation.
     EXPECT_TRUE (vayu::http::is_loopback_bind ("127.0.0.1"));
@@ -127,17 +123,16 @@ TEST (InboxParseStart, ALoopbackLookingHostnameIsNotLoopback) {
     }
     // The gate follows the classification: a non-loopback bind is refused
     // without confirmation and accepted with it.
-    InboxStartRequest out;
-    auto refused =
-    vayu::http::parse_inbox_start (json{ { "bind", "127.example.com" } }, out);
-    ASSERT_TRUE (refused.has_value ())
+    const auto refused =
+    vayu::http::parse_inbox_start (json{ { "bind", "127.example.com" } });
+    ASSERT_FALSE (refused.has_value ())
     << "a hostname starting 127. was bound without confirmation";
-    EXPECT_EQ (refused->code, "inbox_non_loopback_bind");
+    EXPECT_EQ (refused.error ().code, "inbox_non_loopback_bind");
 
-    auto accepted = vayu::http::parse_inbox_start (
-    json{ { "bind", "127.example.com" }, { "confirmNonLoopback", true } }, out);
-    EXPECT_FALSE (accepted.has_value ());
-    EXPECT_EQ (out.bind, "127.example.com");
+    const auto accepted = vayu::http::parse_inbox_start (
+    json{ { "bind", "127.example.com" }, { "confirmNonLoopback", true } });
+    ASSERT_TRUE (accepted.has_value ());
+    EXPECT_EQ (accepted->bind, "127.example.com");
 
     // The whole of 127.0.0.0/8 still needs no confirmation.
     EXPECT_TRUE (vayu::http::is_loopback_bind ("127.255.255.254"));
@@ -151,26 +146,25 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
     current.delay_ms = 10;
     current.headers  = { { "X-Trace", "abc" } };
 
-    InboxCannedResponse out;
-    ASSERT_FALSE (
-    vayu::http::parse_inbox_response_update (json{ { "status", 200 } }, current, out)
-    .has_value ());
-    EXPECT_EQ (out.status, 200);
+    const auto status_only =
+    vayu::http::parse_inbox_response_update (json{ { "status", 200 } }, current);
+    ASSERT_TRUE (status_only.has_value ());
+    EXPECT_EQ (status_only->status, 200);
     // The point of the merge: changing the status must not drop the rest.
-    EXPECT_EQ (out.body, "boom");
-    EXPECT_EQ (out.delay_ms, 10);
-    ASSERT_EQ (out.headers.count ("X-Trace"), 1u);
+    EXPECT_EQ (status_only->body, "boom");
+    EXPECT_EQ (status_only->delay_ms, 10);
+    ASSERT_EQ (status_only->headers.count ("X-Trace"), 1u);
 
     // The start route's own shape is accepted too, so a client can send back
     // what it was handed.
-    ASSERT_FALSE (vayu::http::parse_inbox_response_update (
-    json{ { "response", { { "body", "ok" } } } }, current, out)
-    .has_value ());
-    EXPECT_EQ (out.body, "ok");
-    EXPECT_EQ (out.status, 500);
+    const auto wrapped = vayu::http::parse_inbox_response_update (
+    json{ { "response", { { "body", "ok" } } } }, current);
+    ASSERT_TRUE (wrapped.has_value ());
+    EXPECT_EQ (wrapped->body, "ok");
+    EXPECT_EQ (wrapped->status, 500);
 
-    EXPECT_TRUE (vayu::http::parse_inbox_response_update (json{ { "status", 12 } }, current, out)
-    .has_value ());
+    EXPECT_FALSE (
+    vayu::http::parse_inbox_response_update (json{ { "status", 12 } }, current).has_value ());
 }
 
 // ---------------------------------------------------------------------------
@@ -178,36 +172,38 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
 // ---------------------------------------------------------------------------
 
 TEST (InboxLiveResumePoint, AbsentMeansFromTheStartAndTheHeaderWinsOverTheParam) {
-    int64_t last_id = -1;
-    ASSERT_FALSE (vayu::http::parse_live_resume_point ("", "", last_id).has_value ());
-    EXPECT_EQ (last_id, 0);
+    const auto absent = vayu::http::parse_live_resume_point ("", "");
+    ASSERT_TRUE (absent.has_value ());
+    EXPECT_EQ (*absent, 0);
 
     // The query parameter is the app's own reconnect - EventSource cannot set a
     // header on a fresh connection - and is read exactly like the header.
-    ASSERT_FALSE (vayu::http::parse_live_resume_point ("", "42", last_id).has_value ());
-    EXPECT_EQ (last_id, 42);
+    const auto from_param = vayu::http::parse_live_resume_point ("", "42");
+    ASSERT_TRUE (from_param.has_value ());
+    EXPECT_EQ (*from_param, 42);
 
     // The browser's reconnect header is the more recent of the two.
-    ASSERT_FALSE (vayu::http::parse_live_resume_point ("77", "42", last_id).has_value ());
-    EXPECT_EQ (last_id, 77);
+    const auto from_header = vayu::http::parse_live_resume_point ("77", "42");
+    ASSERT_TRUE (from_header.has_value ());
+    EXPECT_EQ (*from_header, 77);
 }
 
 TEST (InboxLiveResumePoint, RejectsAValueThatIsNotACaptureId) {
-    int64_t last_id = 0;
     for (const char* bad : { "abc", "12x", "", "-1", " 7", "1.5" }) {
         const std::string value = bad;
         // Empty is absence, not a bad value - it is in this list to pin that.
-        const auto error = vayu::http::parse_live_resume_point ("", value, last_id);
+        const auto resume_point = vayu::http::parse_live_resume_point ("", value);
         if (value.empty ()) {
-            EXPECT_FALSE (error.has_value ());
+            ASSERT_TRUE (resume_point.has_value ());
+            EXPECT_EQ (*resume_point, 0);
             continue;
         }
-        ASSERT_TRUE (error.has_value ()) << bad;
-        EXPECT_EQ (error->http_status, 400) << bad;
-        EXPECT_EQ (error->code, "invalid_last_event_id") << bad;
         // Silently resuming from 0 would replay every retained capture as
-        // though it had just arrived, which is what the loud failure prevents.
-        EXPECT_EQ (last_id, 0) << bad;
+        // though it had just arrived, which is what the loud failure prevents -
+        // and there is no resume point to read at all unless the value parsed.
+        ASSERT_FALSE (resume_point.has_value ()) << bad;
+        EXPECT_EQ (resume_point.error ().http_status, 400) << bad;
+        EXPECT_EQ (resume_point.error ().code, "invalid_last_event_id") << bad;
     }
 }
 

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -64,7 +64,7 @@ TEST (InboxParseStart, ReadsEveryResponseField) {
     EXPECT_EQ (parsed->response.status, 503);
     EXPECT_EQ (parsed->response.body, "retry later");
     EXPECT_EQ (parsed->response.delay_ms, 25);
-    ASSERT_EQ (parsed->response.headers.count ("Retry-After"), 1u);
+    ASSERT_EQ (parsed->response.headers.count ("Retry-After"), 1U);
     EXPECT_EQ (parsed->response.headers.at ("Retry-After"), "1");
 }
 
@@ -153,7 +153,7 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
     // The point of the merge: changing the status must not drop the rest.
     EXPECT_EQ (status_only->body, "boom");
     EXPECT_EQ (status_only->delay_ms, 10);
-    ASSERT_EQ (status_only->headers.count ("X-Trace"), 1u);
+    ASSERT_EQ (status_only->headers.count ("X-Trace"), 1U);
 
     // The start route's own shape is accepted too, so a client can send back
     // what it was handed.


### PR DESCRIPTION
## Description

The inbox payload parsers were the last surviving members of the `optional`-as-error family that #901 removed everywhere else, and the anchors in #954 were still accurate at `e5078c2` - no drift, the four functions sat exactly where the issue named them.

**Plan (root cause, approach, rejected alternative).** The root cause is a shape, not a bug: `parse_inbox_start`, `parse_inbox_response_update`, `parse_live_resume_point` and the file-local `apply_response_fields` each returned `std::optional<InboxParseError>` with the result written through an `& out` reference, so an empty return meant success and a half-filled `InboxStartRequest`/`InboxCannedResponse` was reachable whenever a caller skipped the check - byte-for-byte the idiom #926 removed from `parse_mock_start`. The approach is the same mechanical transform: each parser returns `std::expected<Parsed, InboxParseError>` where the validated value *is* the return, and the four call sites (three in `inbox.cpp`, one in `events.cpp` - `parse_live_resume_point` is shared with the run-events stream) read `if (!r)` and reach the value only through `*r`. `apply_response_fields` takes its seed **by value** and returns the merged response, which preserves merge-patch semantics ("an absent field keeps the live value") without a reference to fill; the alternative I rejected was keeping it as a `RouteResult`-style `std::expected<void, InboxParseError>` mutating a caller-owned struct - that keeps exactly the half-filled-result hazard the issue is about, on the one function all three parsers funnel through.

Blast radius traced: the parsers are engine-internal. Their only readers are the two route files; no MCP tool, CLI path or renderer code calls them (`app/electron/mcp/tools.ts` mentions `apply_response_fields` in a comment describing engine behaviour, which is still accurate). The wire contract is untouched - every refusal keeps its status, code and message, so `POST /inbox/start`, `PUT /inbox/:id`, `GET /inbox/:id/live` and `GET /runs/:id/events` answer identically.

`curl_utils.hpp:128`/`:319` are left alone, as the issue's "not in scope" section directs.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (no behaviour change)

## Testing

- `python build.py -e -t` - engine builds clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2367/2367 passed, 0 failed** (37.1s).
- `cd app && pnpm test` - **530 files, 5676 tests passed** (290.7s).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (docs touched).
- `clang-format 19` clean on all four touched engine files; `scripts/pre-commit` passes its format check.
- **clang-tidy 19**, reproducing this repo's gate exactly (`clang-tidy-diff-19.py` over the PR diff against a `-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON` compile database, as `pr-tests.yml` does) - clean on the changed lines. Mutation check on the gate itself: revert one designated initializer and it reports `modernize-use-designated-initializers`, so the local run is genuinely exercising it rather than scanning nothing.

The second commit is that gate's doing: the first push had clang-tidy 18 as the only binary available to me locally, and CI caught two rules on lines this change introduced - `modernize-use-designated-initializers` on the 13 new `InboxParseError{...}` braces (now spelled with field names, matching `parse_mock_start`'s own refusals) and `readability-uppercase-literal-suffix` on two `1u` counts in the adapted tests. No behaviour change in either.

One flake worth recording, not fixed here: `ImportFetchStream.StopsFetchingOnceTheListenerHasGone` failed once on a local full-suite re-run and passed on re-run, and is green in CI. It is untouched by this diff (import streaming, not inbox parsing).

The inbox refusal tests are the behaviour pin, per the acceptance criteria: no assertion was weakened, only the call shape changed (`ASSERT_TRUE(parsed.has_value())` / `refused.error().code` in place of the out-param reads). Mutation check: revert any one parser to the out-param form and the file no longer compiles against the new call sites; revert a *refusal* (e.g. accept a 900 status) and `RejectsRatherThanDefaultsAnUnusableValue` fails. The one assertion that could not survive verbatim is `EXPECT_EQ (last_id, 0)` for a bad `Last-Event-ID` - there is no longer an `out` to inspect, which is the point of the change, so the test now pins that no resume point is reachable at all and says so in a comment.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - existing tests adapted; no new behaviour to cover
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/architecture.md`'s "How a route says no" listed two error shapes and now lists three, naming the payload-parser shape (`std::expected<Parsed, ParseError>`, value never an out-param) alongside the testable core and the field applier.

## Related Issues
Closes #954