### PR TITLE
fix(engine): state the invariant where an optional is read - #943 batch 1 (all of engine/src)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -30,6 +30,20 @@ engine/
   reads backwards at every call site and lets a dropped return pass for "fine".
   `route_error` builds the refusal, `as_response` converts one to the pair a
   testable core answers with.
+- **An optional a guard has already proved is read through one binding**, not
+  re-derived: `const auto& shape = shapes[i]; if (!shape) { continue; }
+  use (*shape);`. `shapes[i]` written twice is two expressions, so
+  `bugprone-unchecked-optional-access` cannot connect the guard to the use - and
+  neither can a reader. Where what makes the access safe lives in *another*
+  function (a producer that sets two fields together, a validation pass that ran
+  under the same held DB mutex, a list built only from the rows that had an
+  identity), the access goes through
+  **`vayu::utils::invariant_value`** (`utils/invariant.hpp`, #943), which takes
+  the rule as a string: a broken rule throws `std::logic_error` naming it,
+  instead of reading an empty optional. `.value()` is *not* the way to say this
+  - it names no rule, and the check reports it too, so it buys a `NOLINT` per
+  site. That helper is for invariants only: an optional a client can empty is
+  still handled, with its `if`, its 404 and its default.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -670,6 +670,7 @@ if(VAYU_BUILD_TESTS)
         tests/main.cpp
         tests/http_client_test.cpp
         tests/json_test.cpp
+        tests/invariant_test.cpp
         tests/script_engine_test.cpp
         tests/script_expect_message_test.cpp
         tests/script_assertion_error_test.cpp

--- a/engine/include/vayu/utils/invariant.hpp
+++ b/engine/include/vayu/utils/invariant.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file utils/invariant.hpp
+ * @brief Reading an optional whose engagement a rule in *another* function
+ *        guarantees (issue #943).
+ *
+ * Three shapes of `std::optional` access exist in this engine. Two need
+ * nothing: an optional a local guard has already tested, and one whose
+ * emptiness is a case the code handles. The third is this one - a producer that
+ * sets two fields together, a validation pass that ran under the same held DB
+ * mutex, a list built only from the entries that had an identity. The proof is
+ * real and it is somewhere else, where neither the next reader nor
+ * `bugprone-unchecked-optional-access` can see it.
+ *
+ * Writing `*opt` there is undefined behaviour the day the rule breaks, and
+ * `.value()` is no better as documentation: it names no rule, and the check
+ * reports it too, so silencing it costs a `NOLINT` per site with the invariant
+ * in a comment nothing executes. This states the rule as an argument instead:
+ * the access is guarded here, where the check can follow it, and a broken rule
+ * throws `std::logic_error` naming the rule that broke rather than reading an
+ * empty optional.
+ *
+ * It is for invariants only. An optional that can legitimately be empty - a
+ * missing row, an absent field, anything a client can cause - is handled, never
+ * asserted: those callers keep their `if`, their 404 and their default.
+ */
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace vayu::utils {
+
+/**
+ * @brief The value of an optional an invariant says is engaged.
+ * @param value The optional to read.
+ * @param invariant The rule that makes it engaged, in the words a reader who
+ *        hits the throw would need - what holds it, and where.
+ * @throws std::logic_error naming @p invariant when the rule has broken.
+ */
+template <typename T>
+const T& invariant_value (const std::optional<T>& value, std::string_view invariant) {
+    if (!value.has_value ()) {
+        throw std::logic_error ("broken invariant: " + std::string (invariant));
+    }
+    return *value;
+}
+
+/**
+ * @brief The same, for an optional that is a temporary - a lookup's return
+ *        value read straight into a row.
+ *
+ * Returns by value rather than by reference: a reference into a temporary would
+ * dangle at the end of the full expression, which is exactly the call this
+ * overload exists to serve.
+ */
+template <typename T>
+T invariant_value (std::optional<T>&& value, std::string_view invariant) {
+    if (!value.has_value ()) {
+        throw std::logic_error ("broken invariant: " + std::string (invariant));
+    }
+    return std::move (*value);
+}
+
+} // namespace vayu::utils

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -76,13 +76,18 @@ const ResultAnnotations& annotations) {
         return;
     }
 
+    // Past the early return the result holds a Response, so it is bound once
+    // here rather than re-read per use: every branch below reads the same
+    // object, and a single binding is what says so.
+    const auto& response = result.value ();
+
     // Counted for both branches below, before either splits: a transfer that
     // connected, negotiated HTTP/1.1 against an explicit `http2`, and then
     // failed still tells the truth about the protocol the run is measuring.
     // Reading it off the Response (rather than off the request's httpVersion
     // and a string compare here) keeps the one definition in
     // http_version_downgraded - see curl_version_map.hpp.
-    if (result.value ().http_version_downgraded) {
+    if (response.http_version_downgraded) {
         context->metrics_collector->record_http_version_downgrade ();
     }
 
@@ -92,14 +97,13 @@ const ResultAnnotations& annotations) {
     // ended cleanly would read highest on the runs that failed most. Only a
     // transfer that actually streamed carries the count - see
     // `Response::stream_events` for why it is optional rather than a zero.
-    if (result.value ().stream_events) {
+    if (response.stream_events) {
         context->metrics_collector->record_stream_completion (
-        *result.value ().stream_events, result.value ().stream_capped);
+        *response.stream_events, response.stream_capped);
     }
 
-    if (result.value ().has_error ()) {
+    if (response.has_error ()) {
         // Response carrying a client-side error
-        const auto& response = result.value ();
 
         // Build detailed error trace data
         nlohmann::json error_json = { { "error_code", static_cast<int> (response.error_code) },
@@ -132,8 +136,7 @@ const ResultAnnotations& annotations) {
         response.timing.bytes_up, response.timing.bytes_down);
     } else {
         // Successful response
-        const auto& response = result.value ();
-        double latency       = response.timing.total_ms;
+        double latency = response.timing.total_ms;
 
         // Two independent reasons to keep a trace, and both are decided before
         // anything is serialised: the 1-in-N sampler (which advances its period
@@ -781,9 +784,12 @@ class CapacityLoadStrategy : public LoadStrategy {
 
         // Written before this frame returns, and read by execute_load_test
         // after it - same thread, so the summary sees a complete search.
-        context->capacity = search.finish ();
-        vayu::utils::log_info ("Capacity search stopped: " + context->capacity->stop_reason +
-        " (" + std::to_string (context->capacity->levels.size ()) + " levels measured)");
+        // emplace rather than assign: it hands back the summary it stored, so
+        // the log line below reads the engaged optional rather than asking
+        // whether the write it just made took.
+        const CapacitySummary& capacity = context->capacity.emplace (search.finish ());
+        vayu::utils::log_info ("Capacity search stopped: " + capacity.stop_reason +
+        " (" + std::to_string (capacity.levels.size ()) + " levels measured)");
     }
 };
 

--- a/engine/src/core/operation_match.cpp
+++ b/engine/src/core/operation_match.cpp
@@ -258,11 +258,11 @@ const std::vector<MatchableOperation>& operations) {
     std::vector<std::string> request_keys;
     std::unordered_map<std::string, std::vector<size_t>> requests_by_key;
     for (size_t i = 0; i < requests.size (); ++i) {
-        if (!request_shapes[i]) {
+        const std::optional<std::string>& shape = request_shapes[i];
+        if (!shape) {
             continue;
         }
-        const std::string key =
-        operation_shape_key (requests[i].method, *request_shapes[i]);
+        const std::string key = operation_shape_key (requests[i].method, *shape);
         auto [entry, inserted] = requests_by_key.try_emplace (key);
         if (inserted) {
             request_keys.push_back (key);
@@ -311,7 +311,8 @@ const std::vector<MatchableOperation>& operations) {
     std::unordered_map<size_t, std::vector<size_t>> candidates_for;
     std::unordered_map<size_t, std::vector<size_t>> claimants_of;
     for (size_t i = 0; i < requests.size (); ++i) {
-        if (request_claimed[i] || !request_shapes[i]) {
+        const std::optional<std::string>& shape = request_shapes[i];
+        if (request_claimed[i] || !shape) {
             continue;
         }
         const std::string method = upper (requests[i].method);
@@ -319,7 +320,7 @@ const std::vector<MatchableOperation>& operations) {
             if (operation_claimed[j] || upper (operations[j].method) != method) {
                 continue;
             }
-            if (!fills_template (*request_shapes[i], operation_shapes[j])) {
+            if (!fills_template (*shape, operation_shapes[j])) {
                 continue;
             }
             auto [entry, inserted] = candidates_for.try_emplace (i);

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -497,11 +497,12 @@ const std::vector<std::optional<ScriptValidationTotals>>& per_step) {
     }
     const size_t count = std::min (steps->size (), per_step.size ());
     for (size_t i = 0; i < count; ++i) {
-        if (!per_step[i]) {
+        const auto& tests = per_step[i];
+        if (!tests) {
             continue;
         }
-        (*steps)[i]["tests"] = { { "sampled", per_step[i]->sampled },
-            { "passed", per_step[i]->passed }, { "failed", per_step[i]->failed } };
+        (*steps)[i]["tests"] = { { "sampled", tests->sampled },
+            { "passed", tests->passed }, { "failed", tests->failed } };
     }
 }
 

--- a/engine/src/core/spec_coverage.cpp
+++ b/engine/src/core/spec_coverage.cpp
@@ -291,8 +291,13 @@ nlohmann::json CoverageTally::build () const {
 
     for (size_t step = 0; step < counts_.size (); ++step) {
         OperationObservation* row = nullptr;
-        if (step < step_operation_.size () && step_operation_[step]) {
-            row = &observed[*step_operation_[step]];
+        if (step < step_operation_.size ()) {
+            // Resolved against `declared_` in the constructor, so an engaged
+            // entry indexes `observed` (sized from the same list) in range.
+            const std::optional<size_t>& operation = step_operation_[step];
+            if (operation) {
+                row = &observed[*operation];
+            }
         }
         for (size_t slot = 0; slot < SLOTS; ++slot) {
             const size_t count = counts_[step][slot].load (std::memory_order_relaxed);

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -26,6 +26,7 @@
 #include "vayu/http/managed_listener.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/id.hpp"
+#include "vayu/utils/invariant.hpp"
 #include "vayu/utils/logger.hpp"
 
 #include <httplib.h>
@@ -406,6 +407,16 @@ const std::string& path) {
     return match;
 }
 
+namespace {
+
+/// `resolve_mock_route` sets `matched_route` on both of the miss kinds that
+/// name a route, which is what makes the index below safe to take. A match
+/// built by hand can still break that, and this is what it would cost.
+constexpr std::string_view MATCHED_ROUTE_INVARIANT =
+"a mock miss kind that names a route carries its index (resolve_mock_route)";
+
+} // namespace
+
 nlohmann::json mock_miss_body (const std::vector<MockRoute>& routes,
 const MockMatch& match,
 const std::string& method,
@@ -413,7 +424,8 @@ const std::string& path) {
     const std::string target = method + " " + path;
     switch (match.miss) {
     case MockMissKind::MethodMismatch: {
-        const auto& matched = routes[*match.matched_route];
+        const auto& matched =
+        routes[vayu::utils::invariant_value (match.matched_route, MATCHED_ROUTE_INVARIANT)];
         std::string methods;
         for (const auto& allowed : match.allowed_methods) {
             methods += (methods.empty () ? "" : ", ") + allowed;
@@ -424,7 +436,8 @@ const std::string& path) {
         "mock_method_mismatch");
     }
     case MockMissKind::NoExample: {
-        const auto& matched = routes[*match.matched_route];
+        const auto& matched =
+        routes[vayu::utils::invariant_value (match.matched_route, MATCHED_ROUTE_INVARIANT)];
         return routes::error_body (501,
         target + " matches request '" + matched.request_name + "', but it has no saved example to serve - import or save one, then restart the mock",
         "mock_no_example");

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/invariant.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -330,13 +331,19 @@ void normalize_scope (vayu::db::Database& db, const Scope& scope, int64_t now, W
     }
 }
 
+/// `read_move` proved every named row exists before any of them was staged, and
+/// the whole batch runs under the DB mutex `reorder_response` holds - so a row a
+/// move names is still there when it is read back.
+constexpr std::string_view ROW_EXISTS_INVARIANT =
+"a validated move names a stored row, under the DB mutex the batch holds";
+
 /** Applies one move on top of whatever the normalization pass already staged. */
 void stage_move (vayu::db::Database& db, const Move& move, int64_t now, WriteSet& out) {
     if (move.kind == Kind::Collection) {
         auto staged              = out.collections.find (move.id);
         vayu::db::Collection row = staged != out.collections.end () ?
         staged->second :
-        *db.get_collection (move.id);
+        vayu::utils::invariant_value (db.get_collection (move.id), ROW_EXISTS_INVARIANT);
         row.order                = move.order;
         if (move.states_owner) {
             row.parent_id = move.parent;
@@ -345,10 +352,11 @@ void stage_move (vayu::db::Database& db, const Move& move, int64_t now, WriteSet
         out.collections[row.id] = std::move (row);
         return;
     }
-    auto staged = out.requests.find (move.id);
-    vayu::db::Request row =
-    staged != out.requests.end () ? staged->second : *db.get_request (move.id);
-    row.order = move.order;
+    auto staged           = out.requests.find (move.id);
+    vayu::db::Request row = staged != out.requests.end () ?
+    staged->second :
+    vayu::utils::invariant_value (db.get_request (move.id), ROW_EXISTS_INVARIANT);
+    row.order             = move.order;
     if (move.states_owner) {
         row.collection_id = move.collection;
     }

--- a/engine/src/http/routes/spec_diff.cpp
+++ b/engine/src/http/routes/spec_diff.cpp
@@ -44,6 +44,7 @@
 #include "vayu/core/spec_diff.hpp"
 #include "vayu/core/openapi_document.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/invariant.hpp"
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
@@ -56,6 +57,11 @@
 namespace vayu::http::routes {
 
 namespace {
+
+/// A request the comparison put in `removed` is one it could name an operation
+/// for; one with no identity comes back as `unmapped` instead, never removed.
+constexpr std::string_view REMOVED_HAS_IDENTITY_INVARIANT =
+"a removed request carries the identity the comparison removed it by";
 
 std::pair<int, nlohmann::json> body_error (const std::string& message) {
     return { 400, error_body (400, message) };
@@ -414,9 +420,9 @@ diff_spec_response (vayu::db::Database& db, const nlohmann::json& json) {
         const size_t index = diff.removed[i];
         removed.push_back (
         { { "requestId", requests[index].id }, { "name", requests[index].name },
-        // Present by construction: a request with no identity is `unmapped`,
-        // never removed.
-        { "operation", spec_operation_json (*requests[index].operation) },
+        { "operation",
+        spec_operation_json (vayu::utils::invariant_value (
+        requests[index].operation, REMOVED_HAS_IDENTITY_INVARIANT)) },
         { "safe", safe.remove[i] } });
     }
     nlohmann::json changed = nlohmann::json::array ();

--- a/engine/tests/invariant_test.cpp
+++ b/engine/tests/invariant_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file tests/invariant_test.cpp
+ * @brief `vayu::utils::invariant_value` (issue #943) - reading an optional whose
+ *        engagement a rule in another function guarantees.
+ *
+ * The two behaviours worth locking are the two reasons it exists: an engaged
+ * optional is read without a copy the caller did not ask for, and a broken rule
+ * throws *naming the rule* rather than reading an empty optional. A message
+ * that did not carry the invariant would leave whoever hits it with a stack
+ * trace and no rule to go and check.
+ */
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "vayu/utils/invariant.hpp"
+
+namespace vayu::utils {
+namespace {
+
+TEST (InvariantValue, ReadsAnEngagedOptionalInPlace) {
+    const std::optional<std::string> value = "kept";
+    const std::string& read = invariant_value (value, "always set by its producer");
+    EXPECT_EQ (read, "kept");
+    // A reference to the stored string, not a copy of it: the callers read
+    // rows and route tables, and a copy per read would be silent cost.
+    EXPECT_EQ (&read, &*value);
+}
+
+TEST (InvariantValue, MovesOutOfATemporaryRatherThanDanglingIntoIt) {
+    // The lookup-return shape: the optional dies at the end of the full
+    // expression, so this overload has to hand back a value.
+    std::string moved = invariant_value (
+    std::optional<std::string> ("from a lookup"), "the row a validated id names");
+    EXPECT_EQ (moved, "from a lookup");
+}
+
+TEST (InvariantValue, ABrokenInvariantThrowsNamingTheRule) {
+    const std::optional<int> empty;
+    try {
+        (void)invariant_value (empty, "a decided run carries its summary");
+        FAIL () << "an empty optional must not read as a value";
+    } catch (const std::logic_error& e) {
+        // The rule itself, not just "bad optional access" - the message is the
+        // whole reason this is a helper rather than a `.value()` call.
+        EXPECT_NE (
+        std::string (e.what ()).find ("a decided run carries its summary"), std::string::npos)
+        << e.what ();
+    }
+
+    EXPECT_THROW ((void)invariant_value (std::optional<int> (), "the same, on a temporary"),
+    std::logic_error);
+}
+
+} // namespace
+} // namespace vayu::utils

--- a/engine/tests/mock_server_routes_test.cpp
+++ b/engine/tests/mock_server_routes_test.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -294,6 +295,23 @@ TEST_F (MockServerTest, ARequestWithNoExampleStaysInTheTableAsUnservable) {
     EXPECT_EQ (body["error"]["code"], "mock_no_example");
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("req_list"),
     std::string::npos);
+}
+
+TEST_F (MockServerTest, AMissKindWithNoMatchedRouteThrowsRatherThanReadingOne) {
+    seed_pet_store ();
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+
+    // `resolve_mock_route` sets `matched_route` on both of the kinds that name
+    // a route, and `mock_miss_body` reads the index on that rule alone. A match
+    // built by hand can still break it, and this is what it costs: a throw
+    // naming the rule, not an index taken from an empty optional.
+    vayu::http::MockMatch broken;
+    broken.miss = MockMissKind::MethodMismatch;
+    EXPECT_THROW (vayu::http::mock_miss_body (routes, broken, "DELETE", "/pets"),
+    std::logic_error);
+
+    broken.miss = MockMissKind::NoExample;
+    EXPECT_THROW (vayu::http::mock_miss_body (routes, broken, "GET", "/pets"), std::logic_error);
 }
 
 TEST_F (MockServerTest, DisabledExampleHeadersAreNotServedAndDuplicatesSurvive) {


### PR DESCRIPTION
## Description

Wave 1 of #928 (#943), the production half: every `bugprone-unchecked-optional-access` finding in `engine/src`, read one at a time rather than bulk-fixed. `engine/tests` carries the rest of the wave and is the next batch, so this PR does not close #943.

**The plan.** Root cause of all thirteen findings is the same: the code holds an invariant and does not state it. Two shapes. Where a local guard already proved the optional, the *use* re-derived it - `request_shapes[i]` tested and then subscripted again, `result.value ()` called four times in one function - so neither the check nor the next reader can connect the guard to the use; those now bind once. Where the rule lives in *another* function (`resolve_mock_route` setting `miss` and `matched_route` together, `read_move` validating every named row under the DB mutex the batch runs beneath, a request with no identity coming back as `unmapped` rather than `removed`), the access goes through a new `vayu::utils::invariant_value (opt, "the rule")`, which throws `std::logic_error` naming the rule instead of reading an empty optional.

**Deliberate deviation from the issue spec**, with the reason. #943's category-2 menu is "`.value()` after an early guard, a redesign, or - last resort - a NOLINT". Measured, `.value()` does **not** satisfy the check: clang-tidy 19 reports `requests[index].operation.value ()` exactly as it reported `*requests[index].operation`. So for the cross-function invariants the menu's first option is unavailable and its last would have cost three NOLINTs plus three comments nothing executes. The helper was the alternative I took instead, because it makes the invariant executable and uniform; the alternative I rejected was per-site `if (!x) throw` blocks, which is the same thing written three times with three chances to word the message uselessly. The other option considered and rejected for `mock_miss_body` was falling back to the generic "no route" body on a missing index - that silently degrades an answer on a broken invariant, which is the failure mode this repo has been bitten by.

**Yield tally** (the three categories #943 asks for): **category 1 (real latent crash) 0** · **category 2 (unexpressed invariant) 13** · **category 3 (false positive / NOLINT) 0**. No defect record sub-issues, because nothing here could crash on a reachable path today - the risk each site carried was UB the day someone builds a `MockMatch` by hand or adds a `stage_move` caller that skips `read_move`.

**Measurement note.** The #928 wave-0 inventory (2026-08-24, master `b7543e8`) lists `src/core/metrics_collector.cpp` at 24 findings; scanned now at `9bca2c2` on the decided config, that file and the rest of the load path report **zero** - the whole of `engine/src` held 13. I could not reproduce the per-file attribution of that inventory for `src`, so I am reporting what this tree measures rather than reconciling the two. The 574 total is not in doubt; it is overwhelmingly in `engine/tests`, exactly as the inventory says.

Files: `load_strategy.cpp` (3), `run_manager.cpp` (3), `operation_match.cpp` (2), `mock_server.cpp` (2), `spec_coverage.cpp` (1), `reorder.cpp` (1, plus its identical sibling two lines down), `spec_diff.cpp` (1).

Two incidental wins from the same edits, both on paths that run per completion: `handle_result` drops three `std::get` calls per response, and the capacity summary is `emplace`d so the log line reads the summary it just stored.

## Type of Change
- [x] Bug fix (latent-defect paydown - no behaviour change on any reachable path)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (`engine/CLAUDE.md` - the convention this wave settles)

## Testing

```
python build.py -e -t                                    # green
cd engine && ctest --preset linux-dev --output-on-failure # 2375/2375 passed, 0 failed (41s)
run-clang-tidy-19 -checks='-*,bugprone-unchecked-optional-access' '.*/engine/src/.*'
                                                          # 0 findings over 90 TUs (was 13)
clang-format-19 --dry-run -Werror <every touched file>    # clean
clang-tidy-19 (full repo config) over every touched file  # no finding on any changed line
```

Three new tests, +4 assertions of existing behaviour:

- `InvariantValue.{ReadsAnEngagedOptionalInPlace, MovesOutOfATemporaryRatherThanDanglingIntoIt, ABrokenInvariantThrowsNamingTheRule}` - the helper reads without a copy, moves out of a temporary rather than handing back a dangling reference, and puts the *rule* in the message.
- `MockServerTest.AMissKindWithNoMatchedRouteThrowsRatherThanReadingOne` - **mutation-checked**: with the fix reverted to `*match.matched_route`, the test fails ("it throws nothing") and passes again once restored.

No pre-existing failures were observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues

Part of #943 (batch 1 of the wave - `engine/tests` is the next batch, so this does not close it), which is wave 1 of #928.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MYpyc2rMWTxD8cjGe6pmTG)_