### PR TITLE
fix(engine): build nothing at namespace scope - #945 batch 2 (the whole cert-* family)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -49,13 +49,28 @@ engine/
   with a worker thread per connection what comes back is a timestamp or an
   error message describing *another* call's subject - not a crash, which is why
   it survived this long. `vayu/utils/reentrant.hpp` is the one place that
-  spells them safely (`format_local_time`, `errno_message`), and
+  spells them safely (`format_local_time`, `format_utc_time`, `errno_message`), and
   `tests/reentrant_test.cpp` scans `src` and `include` for the classic names,
   plus for the `setenv`/`putenv` that would make the single exempted `getenv`
   (`transport_policy.cpp`, no reentrant spelling to move to) unsafe. The
   daemon's force-shutdown branch is `std::_Exit` for the same family of reason:
   it runs *inside* the signal handler, and `exit` there runs every static
   destructor while the worker threads are still using what they destroy.
+- **Nothing at namespace scope is built at run time** (#945, `cert-err58-cpp`).
+  A constant is `constexpr` - `std::string_view` for text, `std::array` for a
+  list, `const char*` for a path a `std::string` parameter will take anyway -
+  and an object that cannot be one (a `std::regex`, an `nlohmann::json`, a
+  `std::mt19937`, anything holding a `std::string`) lives inside a function as
+  a `static` the accessor returns a reference to. Both spellings answer the
+  same two questions: dynamic initialisation runs before `main`, where a throw
+  has no frame to land in and terminates the process, and its order against
+  another translation unit's statics is unspecified. A function-local static is
+  built on the first caller's stack, exactly once, thread-safely, and after
+  everything it depends on. `token_pattern` in `request_composer.cpp` is the
+  shape; the same file's `PASSWORD_CHARS` is what to do when a constant was
+  *derived* from another - spell it out and pin the two together with a
+  `static_assert`, rather than concatenating before `main`. A test-only
+  constant is held to this too: the gate does not read `tests/` differently.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/include/vayu/http/event_loop/event_loop_worker.hpp
+++ b/engine/include/vayu/http/event_loop/event_loop_worker.hpp
@@ -221,8 +221,18 @@ class EventLoopWorker {
     EventLoopConfig config;
     RateLimiter rate_limiter;
 
-    // Shared DNS cache (static - shared across all workers)
-    static DnsCache dns_cache_;
+    /**
+     * The DNS cache every worker shares.
+     *
+     * A function rather than a static data member, and the difference is not
+     * cosmetic. `DnsCache`'s constructor allocates; as a data member it is
+     * constructed before `main`, where a throw has no frame to land in
+     * (`cert-err58-cpp`) and where its order against the other translation
+     * units' statics is unspecified. Constructed on the first caller's stack
+     * instead, both questions answer themselves - and C++11 guarantees the
+     * initialisation is thread-safe, which is what the workers need.
+     */
+    static DnsCache& dns_cache ();
 
     // Per-worker handle pool for reusing curl handles
     CurlHandlePool handle_pool_;

--- a/engine/include/vayu/utils/reentrant.hpp
+++ b/engine/include/vayu/utils/reentrant.hpp
@@ -41,6 +41,17 @@
 
 namespace vayu::utils {
 
+namespace detail {
+
+/// The one `std::tm` -> string rendering both public formatters below share.
+inline std::string format_tm (const std::tm& parts, const char* format) {
+    std::ostringstream out;
+    out << std::put_time (&parts, format);
+    return out.str ();
+}
+
+} // namespace detail
+
 /**
  * @brief @p time in the local zone, formatted by @p format.
  * @param time The instant to render.
@@ -48,17 +59,20 @@ namespace vayu::utils {
  * @return The formatted time, or an empty string for an instant the local zone
  *         cannot represent.
  *
- * The platform split is the same one `request_composer.cpp` uses for the UTC
- * side: POSIX spells the reentrant form `localtime_r`, taking the output
- * parameter last, and MSVC spells it `localtime_s`, taking it first. What the
- * classic call returns is a pointer into shared storage; what this one fills
- * is a `std::tm` on the caller's own stack, which is what `std::put_time` then
+ * The platform split is the one both of these functions make: POSIX spells the
+ * reentrant form `localtime_r`/`gmtime_r`, taking the output parameter last,
+ * and MSVC spells it `localtime_s`/`gmtime_s`, taking it first. What the
+ * classic call returns is a pointer into shared storage; what these fill is a
+ * `std::tm` on the caller's own stack, which is what `std::put_time` then
  * reads.
  *
  * The conversion is checked rather than assumed, because the failure is silent
- * otherwise: a `time_t` outside the zone's range leaves the zero-initialised
- * `std::tm` untouched, which formats as a confident `1899-12-31 00:00:00`. A
- * caller that gets nothing knows it got nothing.
+ * otherwise. A `time_t` outside the zone's range leaves a `std::tm` holding
+ * nothing usable - untouched on some platforms, and on glibc filled and then
+ * abandoned when the year turns out not to fit an `int` - so "failed" does not
+ * even mean "unwritten", and reading the fields anyway renders a confident
+ * `1899-12-31 00:00:00` or a year past every calendar. A caller that gets
+ * nothing knows it got nothing.
  */
 inline std::string format_local_time (std::time_t time, const char* format) {
     std::tm local{};
@@ -70,9 +84,31 @@ inline std::string format_local_time (std::time_t time, const char* format) {
     if (!converted) {
         return {};
     }
-    std::ostringstream out;
-    out << std::put_time (&local, format);
-    return out.str ();
+    return detail::format_tm (local, format);
+}
+
+/**
+ * @brief @p time in UTC, formatted by @p format.
+ * @return The formatted time, or an empty string for an instant that cannot be
+ *         converted - the same contract as {@link format_local_time}, whose
+ *         note on what a refused conversion leaves behind applies here too.
+ *
+ * The UTC sibling, which `request_composer.cpp` used to carry its own copy of -
+ * the platform split written out inline, with the return dropped
+ * (`cert-err33-c`). Sub-second precision is the caller's to append: no
+ * `std::strftime` conversion specifier covers it.
+ */
+inline std::string format_utc_time (std::time_t time, const char* format) {
+    std::tm utc{};
+#if defined(_WIN32)
+    const bool converted = gmtime_s (&utc, &time) == 0;
+#else
+    const bool converted = gmtime_r (&time, &utc) != nullptr;
+#endif
+    if (!converted) {
+        return {};
+    }
+    return detail::format_tm (utc, format);
 }
 
 /**

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -38,8 +38,11 @@
 #include <vector>
 
 namespace {
-// Default daemon URL
-const std::string DEFAULT_DAEMON_URL = vayu::core::constants::defaults::DAEMON_URL;
+// Default daemon URL. A view rather than a `std::string`, so the alias costs
+// nothing before `main` - a namespace-scope `std::string` allocates during
+// dynamic initialisation, where the allocation failure cannot be caught
+// (`cert-err58-cpp`).
+constexpr std::string_view DEFAULT_DAEMON_URL = vayu::core::constants::defaults::DAEMON_URL;
 
 void print_version () {
     std::cout << "vayu-cli " << vayu::Version::string << "\n";
@@ -296,7 +299,7 @@ int run_cli (std::span<char* const> args) {
     int verbosity       = 0; // 0=warn/error, 1=info+, 2=debug+
     bool color          = true;
     std::string filepath;
-    std::string daemon_url = DEFAULT_DAEMON_URL;
+    std::string daemon_url{ DEFAULT_DAEMON_URL };
 
     // Parse flags
     for (size_t i = 1; i < args.size (); ++i) {

--- a/engine/src/http/event_loop/event_loop_worker.cpp
+++ b/engine/src/http/event_loop/event_loop_worker.cpp
@@ -30,8 +30,11 @@ namespace vayu::http::detail {
 // DnsCache Implementation
 // ============================================================================
 
-// Static member definition
-DnsCache EventLoopWorker::dns_cache_;
+// See the declaration for why this is a function and not a data member.
+DnsCache& EventLoopWorker::dns_cache () {
+    static DnsCache cache;
+    return cache;
+}
 
 namespace {
 
@@ -404,7 +407,7 @@ void EventLoopWorker::run_loop () {
             // Acquire handle from pool (lock-free or specialized pool)
             CURL* easy = handle_pool_.acquire ();
             // Note: setup_easy_handle might take time, good to do it outside locks
-            easy = setup_easy_handle (easy, data.get (), config, &dns_cache_);
+            easy = setup_easy_handle (easy, data.get (), config, &dns_cache ());
 
             if (!easy) {
                 // Handle creation failure

--- a/engine/src/http/form_body.cpp
+++ b/engine/src/http/form_body.cpp
@@ -15,6 +15,7 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <memory>
 
 namespace vayu::http {
 
@@ -234,16 +235,24 @@ std::optional<std::string> unsendable_file_part (const Body& body) {
         // read the bytes, which permissions and a dangling symlink both answer
         // differently from mere existence. A directory opens on some platforms
         // and fails to read, so it is rejected on the read attempt below.
-        std::FILE* handle = std::fopen (field.src.c_str (), "rb");
+        //
+        // The handle owns itself, which is what removes the two findings a bare
+        // `std::FILE*` and a matching `std::fclose` carried: a close return
+        // nobody read (`cert-err33-c`) and a resource held by a plain pointer
+        // (`cppcoreguidelines-owning-memory`). There is nothing to discard and
+        // no path out of the loop that forgets to close - including the early
+        // return below, which the hand-written version reached only because the
+        // close sat above it.
+        const std::unique_ptr<std::FILE, int (*) (std::FILE*)> handle (
+        std::fopen (field.src.c_str (), "rb"), &std::fclose);
         if (!handle) {
             return "Form field '" + name + "': cannot read file '" + field.src +
             "' (" + vayu::utils::errno_message (errno) + ")";
         }
         char probe           = 0;
-        const size_t read    = std::fread (&probe, 1, 1, handle);
-        const bool readable  = read == 1 || std::feof (handle) != 0;
+        const size_t read    = std::fread (&probe, 1, 1, handle.get ());
+        const bool readable  = read == 1 || std::feof (handle.get ()) != 0;
         const int read_errno = errno;
-        std::fclose (handle);
         if (!readable) {
             return "Form field '" + name + "': cannot read file '" + field.src +
             "' (" + vayu::utils::errno_message (read_errno) + ")";

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -11,16 +11,17 @@
 #include <array>
 #include <cctype>
 #include <chrono>
-#include <cstdio>
 #include <ctime>
 #include <random>
 #include <regex>
+#include <string_view>
 #include <unordered_set>
 
 #include "vayu/http/header_text.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/json.hpp"
+#include "vayu/utils/reentrant.hpp"
 
 namespace vayu::http {
 
@@ -48,18 +49,30 @@ const std::regex& token_pattern () {
 // two `{{$guid}}` in one payload are two different ids, which is the reason to
 // write them.
 
-thread_local std::mt19937 rng{ std::random_device{}() };
+/**
+ * One generator per thread, seeded once.
+ *
+ * Function-local rather than a `thread_local` at namespace scope, for the same
+ * reason {@link token_pattern} is: seeding runs `std::random_device`, which can
+ * throw, and at namespace scope that throw happens before the thread's first
+ * statement with no frame able to catch it (`cert-err58-cpp`). Here the first
+ * caller's stack is on hand.
+ */
+std::mt19937& rng () {
+    thread_local std::mt19937 generator{ std::random_device{}() };
+    return generator;
+}
 
 int random_int (int min_inclusive, int max_inclusive) {
     std::uniform_int_distribution<int> dist (min_inclusive, max_inclusive);
-    return dist (rng);
+    return dist (rng ());
 }
 
 template <size_t N> const char* pick (const std::array<const char*, N>& items) {
     return items[static_cast<size_t> (random_int (0, static_cast<int> (N) - 1))];
 }
 
-std::string random_string (size_t length, const std::string& alphabet) {
+std::string random_string (size_t length, std::string_view alphabet) {
     std::string out;
     out.reserve (length);
     for (size_t i = 0; i < length; ++i) {
@@ -69,9 +82,16 @@ std::string random_string (size_t length, const std::string& alphabet) {
     return out;
 }
 
-const std::string ALPHANUMERIC =
+constexpr std::string_view ALPHANUMERIC =
 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-const std::string PASSWORD_CHARS = ALPHANUMERIC + "!@#$%^&*_-+=";
+// Spelled out rather than written as `ALPHANUMERIC + "!@#$%^&*_-+="`, because
+// that concatenation is dynamic initialisation of a namespace-scope object and
+// its allocation cannot be caught (`cert-err58-cpp`). The assertion below is
+// what keeps the two from drifting apart.
+constexpr std::string_view PASSWORD_CHARS =
+"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*_-+=";
+static_assert (PASSWORD_CHARS.substr (0, ALPHANUMERIC.size ()) == ALPHANUMERIC,
+"the password alphabet is the alphanumeric one plus symbols");
 
 constexpr std::array<const char*, 10> FIRST_NAMES = { "Ada", "Ravi", "Mina",
     "Jonas", "Priya", "Elena", "Omar", "Sofia", "Kenji", "Nora" };
@@ -95,19 +115,20 @@ std::string iso_timestamp () {
     const auto now = system_clock::now ();
     const auto ms = duration_cast<milliseconds> (now.time_since_epoch ()) % 1000;
     const std::time_t t = system_clock::to_time_t (now);
-    std::tm utc{};
-#if defined(_WIN32)
-    gmtime_s (&utc, &t);
-#else
-    gmtime_r (&t, &utc);
-#endif
-    // Sized for snprintf's worst case over full-range ints, so -Wformat-
-    // truncation has nothing to warn about; real output is 24 characters.
-    char buf[96];
-    std::snprintf (buf, sizeof (buf), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
-    utc.tm_year + 1900, utc.tm_mon + 1, utc.tm_mday, utc.tm_hour, utc.tm_min,
-    utc.tm_sec, static_cast<int> (ms.count ()));
-    return buf;
+    // The conversion is read rather than assumed: a refused one leaves a
+    // `std::tm` holding nothing usable, and formatting it anyway renders a
+    // confident wrong date. Unreachable for `system_clock::now()` on a 64-bit
+    // `time_t`, which is why it went unchecked - what changes is that the
+    // answer is now either right or empty, never confidently wrong.
+    const std::string seconds = vayu::utils::format_utc_time (t, "%Y-%m-%dT%H:%M:%S");
+    if (seconds.empty ()) {
+        return {};
+    }
+    // The milliseconds, which no `std::strftime` specifier covers. Always three
+    // digits, because the renderer's `toISOString` always writes three.
+    std::string millis = std::to_string (ms.count ());
+    millis.insert (0, 3 - millis.size (), '0');
+    return seconds + "." + millis + "Z";
 }
 
 struct DynamicVariable {
@@ -115,8 +136,10 @@ struct DynamicVariable {
     std::string (*generate) ();
 };
 
-// Same names, same order as the renderer table.
-const std::array<DynamicVariable, 15> DYNAMIC_VARIABLES = { {
+// Same names, same order as the renderer table. `constexpr`, so the table is
+// built by the compiler rather than before `main` - every entry is a literal
+// and a captureless lambda, both of which are constant expressions.
+constexpr std::array<DynamicVariable, 15> DYNAMIC_VARIABLES = { {
 { "$guid", [] { return vayu::utils::generate_id (""); } },
 { "$randomUUID", [] { return vayu::utils::generate_id (""); } },
 { "$timestamp",

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -336,9 +336,6 @@ namespace {
  */
 constexpr size_t MAX_IMPORT_ITEMS = 10000;
 
-/** Absent or null section - shared so `read_items` can hand out a stable empty list. */
-const nlohmann::json EMPTY_ITEMS = nlohmann::json::array ();
-
 /** A 400 about the payload as a whole. */
 RouteError body_error (const std::string& message) {
     return { 400, error_body (400, message) };
@@ -364,7 +361,13 @@ RouteError item_error (const std::string& message, const std::string& temp_id) {
  */
 RouteResult
 read_items (const nlohmann::json& body, const char* key, const nlohmann::json*& out) {
-    out = &EMPTY_ITEMS;
+    // The absent-section answer, built once on the first call rather than
+    // before `main`: a namespace-scope `nlohmann::json` allocates during
+    // dynamic initialisation, where the throw cannot be caught
+    // (`cert-err58-cpp`). Its address is what `out` hands back, so it has to
+    // outlive the call - a local would not.
+    static const nlohmann::json empty_items = nlohmann::json::array ();
+    out                                     = &empty_items;
     if (!body.contains (key) || body[key].is_null ()) {
         return {};
     }

--- a/engine/src/http/routes/spec_sync.cpp
+++ b/engine/src/http/routes/spec_sync.cpp
@@ -184,9 +184,6 @@ namespace {
  */
 constexpr size_t MAX_SYNC_ITEMS = 10000;
 
-/** Absent or null section - a stable empty list to hand out. */
-const nlohmann::json EMPTY_ITEMS = nlohmann::json::array ();
-
 RouteError body_error (const std::string& message) {
     return { 400, error_body (400, message) };
 }
@@ -207,7 +204,11 @@ RouteError item_error (int status, const std::string& message, const std::string
 /** Reads one optional top-level array; anything else that is not an array is a 400. */
 RouteResult
 read_items (const nlohmann::json& body, const char* key, const nlohmann::json*& out) {
-    out = &EMPTY_ITEMS;
+    // Built on the first call rather than before `main`, and outliving the call
+    // because `out` hands back its address - the same reasoning as
+    // `/import/apply`'s copy of this function carries.
+    static const nlohmann::json empty_items = nlohmann::json::array ();
+    out                                     = &empty_items;
     if (!body.contains (key) || body[key].is_null ()) {
         return {};
     }

--- a/engine/src/platform/platform_unix.cpp
+++ b/engine/src/platform/platform_unix.cpp
@@ -180,8 +180,14 @@ void setup_signal_handlers (ShutdownCallback callback) {
     g_shutdown_callback = std::move (callback);
     g_shutdown_requested.store (false);
 
-    std::signal (SIGINT, unix_signal_handler);
-    std::signal (SIGTERM, unix_signal_handler);
+    // Two returns discarded on purpose (`cert-err33-c`), and they are different
+    // discards. The previous handler goes because the daemon owns both signals
+    // for the process lifetime and has nothing to chain to. `SIG_ERR` goes
+    // because POSIX only produces it here for a signal that cannot be caught -
+    // `SIGKILL` and `SIGSTOP` - and neither of these is one; there is also
+    // nowhere to report it to, since this layer deliberately has no logger.
+    static_cast<void> (std::signal (SIGINT, unix_signal_handler));
+    static_cast<void> (std::signal (SIGTERM, unix_signal_handler));
 }
 
 // ============================================================================

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 #include <sqlite3.h>
 
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -21,7 +22,7 @@
 
 namespace vayu::db {
 namespace {
-const std::string TEST_DB_PATH = "test_vayu.db";
+constexpr const char* TEST_DB_PATH = "test_vayu.db";
 
 class DatabaseTest : public ::testing::Test {
     protected:
@@ -620,12 +621,14 @@ TEST_F (DatabaseTest, ImportedActiveEnvironmentAlsoDeactivatesTheStoredOne) {
 // parent_id, runs by start_time. See the comments there for which queries
 // rely on which. Named explicitly rather than counted, because sqlite also
 // creates sqlite_autoindex_* entries of its own.
-const std::vector<std::string> EXPECTED_INDEXES = { "idx_metric_ticks_run_id",
-    "idx_results_run_id", "idx_requests_collection_id", "idx_collections_parent_id",
+constexpr std::array<const char*, 8> EXPECTED_INDEXES = {
+    "idx_metric_ticks_run_id", "idx_results_run_id",
+    "idx_requests_collection_id", "idx_collections_parent_id",
     "idx_runs_start_time", "idx_result_bodies_run_id", "idx_body_blobs_run_id",
     // Examples are read only by request id - the list route and both cascades -
     // so this one backs every access the table has.
-    "idx_request_examples_request_id" };
+    "idx_request_examples_request_id"
+};
 
 // Reads index names straight out of sqlite_master on a separate connection,
 // so the assertion does not rest on anything sqlite_orm reports about itself.
@@ -780,7 +783,7 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
 
     {
         sqlite3* handle = nullptr;
-        ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
         char* err = nullptr;
         ASSERT_EQ (sqlite3_exec (handle, "ALTER TABLE requests DROP COLUMN http_version",
                    nullptr, nullptr, &err),
@@ -794,7 +797,7 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
     // assertions below would pass without proving anything.
     {
         sqlite3* handle = nullptr;
-        ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
         sqlite3_stmt* stmt = nullptr;
         ASSERT_EQ (sqlite3_prepare_v2 (handle, "PRAGMA table_info(requests)", -1, &stmt, nullptr),
         SQLITE_OK);
@@ -820,7 +823,7 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
     // with its data intact and its missing http_version backfilled to auto -
     // not silently dropped and recreated empty.
     sqlite3* handle = nullptr;
-    ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+    ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
 
     sqlite3_stmt* count_stmt = nullptr;
     ASSERT_EQ (sqlite3_prepare_v2 (handle, "SELECT COUNT(*) FROM requests", -1,
@@ -879,7 +882,7 @@ TEST_F (DatabaseTest, DropsTheLegacyMetricsTableFromAPreUpgradeDatabase) {
     // Put the pre-upgrade table back, populated, exactly as the old engine left it.
     {
         sqlite3* handle = nullptr;
-        ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
         char* err = nullptr;
         ASSERT_EQ (
         sqlite3_exec (handle,
@@ -1321,7 +1324,7 @@ TEST_F (DatabaseTest, RunsStoredBeforeTheBaselineColumnReadAsUnpinned) {
     // RequestsTable uses.
     {
         sqlite3* handle = nullptr;
-        ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
         char* err = nullptr;
         ASSERT_EQ (sqlite3_exec (handle, "ALTER TABLE runs DROP COLUMN baseline",
                    nullptr, nullptr, &err),
@@ -1335,7 +1338,7 @@ TEST_F (DatabaseTest, RunsStoredBeforeTheBaselineColumnReadAsUnpinned) {
     // assertions below passing without a pre-column database to prove them on.
     {
         sqlite3* handle = nullptr;
-        ASSERT_EQ (sqlite3_open (TEST_DB_PATH.c_str (), &handle), SQLITE_OK);
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
         sqlite3_stmt* stmt = nullptr;
         ASSERT_EQ (sqlite3_prepare_v2 (handle, "PRAGMA table_info(runs)", -1, &stmt, nullptr),
         SQLITE_OK);

--- a/engine/tests/event_loop_test.cpp
+++ b/engine/tests/event_loop_test.cpp
@@ -16,7 +16,7 @@
 #include "vayu/http/thread_pool.hpp"
 
 namespace {
-const std::string INVALID_URL = "http://127.0.0.1:1/"; // Port 1 - connection refused (fast fail)
+constexpr const char* INVALID_URL = "http://127.0.0.1:1/"; // Port 1 - connection refused (fast fail)
 
 class MockServer {
     public:

--- a/engine/tests/id_test.cpp
+++ b/engine/tests/id_test.cpp
@@ -18,8 +18,16 @@ using vayu::utils::generate_id;
 
 // Canonical RFC 4122 version-4 UUID: 8-4-4-4-12 lowercase hex, the third group
 // starts with '4' (version) and the fourth with 8/9/a/b (variant 10xx).
-static const std::regex kUuidV4 (
-"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
+//
+// Compiled on the first call rather than before `main` - a namespace-scope
+// `std::regex` allocates, and a throw during dynamic initialisation has no
+// frame to land in (`cert-err58-cpp`). The same shape `request_composer.cpp`
+// gives its own pattern.
+const std::regex& uuid_v4 () {
+    static const std::regex pattern (
+    "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
+    return pattern;
+}
 
 // A timestamp implementation fails this instantly: in a tight single-threaded
 // loop every generation lands in the same millisecond, so the old scheme
@@ -75,7 +83,7 @@ TEST (GenerateId, FormatPrefixAndUuidV4) {
         const std::string prefix_str (prefix);
         ASSERT_EQ (id.rfind (prefix_str, 0), 0U) << "prefix missing in " << id;
         const std::string suffix = id.substr (prefix_str.size ());
-        EXPECT_TRUE (std::regex_match (suffix, kUuidV4))
+        EXPECT_TRUE (std::regex_match (suffix, uuid_v4 ()))
         << "suffix is not a UUIDv4: " << suffix;
     }
 }
@@ -83,5 +91,5 @@ TEST (GenerateId, FormatPrefixAndUuidV4) {
 // An empty prefix yields a bare UUID (the app's crypto.randomUUID() shape).
 TEST (GenerateId, EmptyPrefixIsBareUuid) {
     const std::string id = generate_id ("");
-    EXPECT_TRUE (std::regex_match (id, kUuidV4)) << id;
+    EXPECT_TRUE (std::regex_match (id, uuid_v4 ())) << id;
 }

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -31,7 +31,7 @@ namespace {
 
 using vayu::tests::SlowMockServer;
 
-const std::string TEST_DB_PATH = "test_load_strategy.db";
+constexpr const char* TEST_DB_PATH = "test_load_strategy.db";
 
 class LoadStrategyTest : public ::testing::Test {
     protected:

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -44,7 +44,18 @@ using json = nlohmann::ordered_json;
 
 namespace {
 
-const ExportCollection PETSTORE{ "Petstore", "" };
+/**
+ * The collection every case exports unless it says otherwise.
+ *
+ * A function rather than a namespace-scope object: `ExportCollection` holds two
+ * `std::string`s, so building one before `main` is dynamic initialisation whose
+ * allocation cannot be caught (`cert-err58-cpp`). A reference to the
+ * function-local static is still usable as a default argument below.
+ */
+const ExportCollection& petstore () {
+    static const ExportCollection collection{ "Petstore", "" };
+    return collection;
+}
 
 std::string bound_fixture () {
     const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
@@ -99,7 +110,7 @@ struct Exported {
 
 Exported export_json (const std::vector<ExportRequest>& requests,
 const std::optional<std::string>& content = std::nullopt,
-const ExportCollection& collection        = PETSTORE) {
+const ExportCollection& collection        = petstore ()) {
     const ExportOutcome outcome =
     export_openapi (collection, requests, content, ExportFormat::Json);
     EXPECT_TRUE (outcome.ok ()) << outcome.error;
@@ -350,7 +361,7 @@ TEST (BoundExport, FailsLoudlyOnAStoredDocumentItCannotRead) {
     // drop every member of their spec Vayu does not model.
     for (const std::string content : { "{ not json: [", "[]", R"({"paths":{}})" }) {
         const ExportOutcome outcome =
-        export_openapi (PETSTORE, bound_requests (), content, ExportFormat::Json);
+        export_openapi (petstore (), bound_requests (), content, ExportFormat::Json);
         EXPECT_FALSE (outcome.ok ()) << content;
         EXPECT_TRUE (outcome.text.empty ()) << content;
     }
@@ -495,9 +506,9 @@ TEST (ExportSerialization, WritesTheSameDocumentAsJsonAndAsYaml) {
     const std::string content           = bound_fixture ();
 
     const ExportOutcome as_json =
-    export_openapi (PETSTORE, requests, content, ExportFormat::Json);
+    export_openapi (petstore (), requests, content, ExportFormat::Json);
     const ExportOutcome as_yaml =
-    export_openapi (PETSTORE, requests, content, ExportFormat::Yaml);
+    export_openapi (petstore (), requests, content, ExportFormat::Yaml);
     ASSERT_TRUE (as_yaml.ok ()) << as_yaml.error;
 
     const auto reread = vayu::core::read_document (as_yaml.text);
@@ -517,7 +528,7 @@ TEST (ExportSerialization, QuotesEveryScalarThatWouldComeBackAsSomethingElse) {
          "colon: space", "trailing ", " leading", "#hash", "line\nbreak", "" }) {
         entry.params = { row ("k", awkward) };
         const ExportOutcome outcome =
-        export_openapi (PETSTORE, { entry }, std::nullopt, ExportFormat::Yaml);
+        export_openapi (petstore (), { entry }, std::nullopt, ExportFormat::Yaml);
         ASSERT_TRUE (outcome.ok ()) << outcome.error;
         const auto reread = vayu::core::read_document (outcome.text);
         ASSERT_TRUE (reread.ok ()) << awkward << ": " << reread.error;
@@ -541,7 +552,7 @@ TEST (ExportSerialization, QuotesAMappingKeyThatWouldComeBackAsANumber) {
     entry.examples      = { example ("ok", 200, "{}", "application/json") };
 
     const ExportOutcome outcome =
-    export_openapi (PETSTORE, { entry }, std::nullopt, ExportFormat::Yaml);
+    export_openapi (petstore (), { entry }, std::nullopt, ExportFormat::Yaml);
     ASSERT_TRUE (outcome.ok ()) << outcome.error;
     EXPECT_NE (outcome.text.find ("\"200\":"), std::string::npos) << outcome.text;
 

--- a/engine/tests/reentrant_test.cpp
+++ b/engine/tests/reentrant_test.cpp
@@ -7,8 +7,9 @@
 
 /**
  * @file tests/reentrant_test.cpp
- * @brief `vayu::utils::format_local_time` and `errno_message` (issue #945), and
- *        the guard that keeps the calls they replaced out of `src`.
+ * @brief `vayu::utils::format_local_time`, `format_utc_time` and
+ *        `errno_message` (issue #945), and the guard that keeps the calls they
+ *        replaced out of `src`.
  *
  * Two halves, because the defect has two.
  *
@@ -140,6 +141,43 @@ TEST (FormatLocalTime, AnUnrepresentableInstantRendersAsNothing) {
     if (!stamped.empty ()) {
         EXPECT_NE (stamped.rfind ("1899", 0), 0u) << stamped;
         EXPECT_NE (stamped.rfind ("1900", 0), 0u) << stamped;
+    }
+}
+
+TEST (FormatUtcTime, RendersTheInstantInUtcAndNotTheLocalZone) {
+    // 2001-09-09T01:46:40Z - the epoch second every calendar agrees on, and one
+    // whose fields are all distinct, so a formatter reading the wrong ones
+    // could not pass by coincidence. Spelled in full rather than through
+    // `%F`/`%T`, since those are what the caller does not use.
+    constexpr std::time_t instant = 1'000'000'000;
+    EXPECT_EQ (format_utc_time (instant, "%Y-%m-%dT%H:%M:%S"), "2001-09-09T01:46:40");
+
+    // The two functions differ by the zone, which is the whole reason there are
+    // two. `TZ` is not set here, so on a UTC test host they agree - the
+    // assertion is on the pair being the same *shape*, which is what a caller
+    // swapping one for the other would break.
+    const std::string local = format_local_time (instant, "%Y-%m-%dT%H:%M:%S");
+    ASSERT_FALSE (local.empty ());
+    EXPECT_EQ (local.size (), std::string ("2001-09-09T01:46:40").size ());
+}
+
+TEST (FormatUtcTime, AnUnrepresentableInstantRendersAsNothing) {
+    // The epoch converts on every platform, which is what stops the second half
+    // being vacuous.
+    EXPECT_EQ (format_utc_time (0, "%Y"), "1970");
+
+    // `time_t::max()` is out of range wherever `time_t` is 64-bit and the
+    // broken-down year is an `int`, and a platform that converts it anyway is
+    // not wrong - so what is asserted is that whichever happens, the answer is
+    // honest. A formatter that ignored the conversion's verdict would render
+    // the zero-initialised 1900 as a fact; this one renders nothing at all.
+    // glibc makes that worth checking rather than obvious: it fills the fields
+    // before discovering the overflow, so there is no untouched state to detect
+    // afterwards - the return is the only thing carrying the verdict.
+    const std::string extreme =
+    format_utc_time (std::numeric_limits<std::time_t>::max (), "%Y");
+    if (!extreme.empty ()) {
+        EXPECT_NE (extreme, "1900") << extreme;
     }
 }
 

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -20,10 +20,13 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <regex>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -115,6 +118,67 @@ TEST (DynamicVariables, GuidIsAUuidV4AndDiffersPerOccurrence) {
     EXPECT_TRUE (std::regex_match (b, uuid_v4)) << b;
     // Once per occurrence: two {{$guid}} in one payload are two different ids.
     EXPECT_NE (a, b);
+}
+
+TEST (DynamicVariables, IsoTimestampIsTheShapeTheRendererProduces) {
+    // The renderer's `$isoTimestamp` is `new Date().toISOString()`, and the two
+    // tables are a contract: this is that shape, spelled out. The engine now
+    // assembles it from two pieces - a formatted `std::tm` and the
+    // milliseconds - so the assertion is on the whole string, joint included.
+    //
+    // Sampled over wall-clock time rather than in a tight loop, and that is the
+    // whole design of this test. The half a tight loop never reaches is the
+    // zero-padding: the millisecond field only needs it for one instant in ten,
+    // and 200 back-to-back calls complete inside a single millisecond, so they
+    // are 200 copies of one sample. The field visits every value once per
+    // second, so pausing between samples until a padded one turns up reaches
+    // that case instead of hoping for it - and the test says so afterwards,
+    // rather than passing on a run that never sampled it.
+    const vayu::http::VariableValues no_vars;
+    const std::regex iso_8601 (R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$)");
+    constexpr size_t kMillisAt = std::string_view ("2026-08-25T16:30:45.").size ();
+
+    bool sampled_a_padded_millisecond = false;
+    const auto deadline = std::chrono::steady_clock::now () + std::chrono::seconds (3);
+    while (std::chrono::steady_clock::now () < deadline) {
+        const std::string stamped =
+        vayu::http::resolve_template ("{{$isoTimestamp}}", no_vars);
+        ASSERT_TRUE (std::regex_match (stamped, iso_8601)) << stamped;
+        if (stamped[kMillisAt] == '0') {
+            sampled_a_padded_millisecond = true;
+            break;
+        }
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
+    }
+    EXPECT_TRUE (sampled_a_padded_millisecond)
+    << "never sampled a millisecond below 100, so the padding went unchecked";
+}
+
+TEST (DynamicVariables, TheRandomAlphabetsAreTheOnesTheCharactersComeFrom) {
+    // Both alphabets are `constexpr std::string_view` now, indexed rather than
+    // copied. A view whose length or contents went wrong reads past the literal
+    // or draws from the wrong span, and either shows up here as a character
+    // that does not belong.
+    constexpr std::string_view alphanumeric =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    constexpr std::string_view password_chars =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*_-+"
+    "=";
+    const vayu::http::VariableValues no_vars;
+
+    for (int i = 0; i < 50; ++i) {
+        const std::string one =
+        vayu::http::resolve_template ("{{$randomAlphaNumeric}}", no_vars);
+        ASSERT_EQ (one.size (), 1u) << one;
+        EXPECT_NE (alphanumeric.find (one[0]), std::string_view::npos) << one;
+
+        const std::string password =
+        vayu::http::resolve_template ("{{$randomPassword}}", no_vars);
+        ASSERT_EQ (password.size (), 15u) << password;
+        for (const char c : password) {
+            EXPECT_NE (password_chars.find (c), std::string_view::npos) << password;
+        }
+    }
 }
 
 TEST (DynamicVariables, RandomIntStaysInRange) {

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -157,7 +157,7 @@ class ScenarioMockServer {
     size_t waiting_          = 0;
 };
 
-const std::string TEST_DB_PATH = "test_scenario_load.db";
+constexpr const char* TEST_DB_PATH = "test_scenario_load.db";
 
 class ScenarioLoadTest : public ::testing::Test {
     protected:

--- a/engine/tests/spec_diff_test.cpp
+++ b/engine/tests/spec_diff_test.cpp
@@ -118,22 +118,38 @@ field_named (const vayu::core::ChangedRequest& changed, SpecField field) {
     return found == changed.fields.end () ? nullptr : &*found;
 }
 
-/** The `createPet` operation, which several cases carry unchanged. */
-const std::string CREATE_PET = R"("post":{"operationId":"createPet","summary":"Create a pet",)" +
-json_body (R"("name":{"type":"string"})") + "}";
+/**
+ * The `createPet` operation, which several cases carry unchanged.
+ *
+ * A function rather than a namespace-scope `std::string`, here and for every
+ * document below: building one runs `json_body`/`document` before `main`,
+ * where the allocation cannot be caught (`cert-err58-cpp`) and where the order
+ * against another translation unit's statics is unspecified. Built on the first
+ * case's stack instead, and still built exactly once.
+ */
+const std::string& create_pet_operation () {
+    static const std::string operation =
+    R"("post":{"operationId":"createPet","summary":"Create a pet",)" +
+    json_body (R"("name":{"type":"string"})") + "}";
+    return operation;
+}
 
 /** The bound document every case below compares against. */
-const std::string BOUND = document (
-R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
-R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})");
+const std::string& bound_document () {
+    static const std::string text =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
+    R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})");
+    return text;
+}
 
 class SpecDiffTest : public ::testing::Test {
     protected:
     void SetUp () override {
-        bound_ = drafts_of (BOUND);
+        bound_ = drafts_of (bound_document ());
     }
 
-    /** The whole collection as an import of `BOUND` left it. */
+    /** The whole collection as an import of `bound_document ()` left it. */
     [[nodiscard]] std::vector<ComparableRequest> bound_collection () const {
         std::vector<ComparableRequest> requests;
         for (size_t i = 0; i < bound_.size (); ++i) {
@@ -182,10 +198,10 @@ class SpecDiffTest : public ::testing::Test {
 class DuplicateOperationIdTest : public ::testing::Test {
     protected:
     void SetUp () override {
-        entries_ = drafts_of (DUP);
+        entries_ = drafts_of (dup ());
     }
 
-    static const std::string DUP;
+    static const std::string& dup ();
 
     /** Both requests, the second still carrying the id the first also claims. */
     [[nodiscard]] std::vector<ComparableRequest> collection () const {
@@ -206,9 +222,12 @@ class DuplicateOperationIdTest : public ::testing::Test {
     mutable std::vector<SpecRequestDraft> fetched_;
 };
 
-const std::string DuplicateOperationIdTest::DUP =
-document (R"({"/a":{"get":{"operationId":"list","summary":"List A"}},)"
-          R"("/b":{"post":{"operationId":"list","summary":"Create B"}}})");
+const std::string& DuplicateOperationIdTest::dup () {
+    static const std::string text =
+    document (R"({"/a":{"get":{"operationId":"list","summary":"List A"}},)"
+              R"("/b":{"post":{"operationId":"list","summary":"Create B"}}})");
+    return text;
+}
 
 TEST_F (DuplicateOperationIdTest, LeavesTheSecondRequestOnItsOwnOperationWhenTheFirstChanges) {
     const std::string tweaked = document (
@@ -238,7 +257,7 @@ TEST_F (DuplicateOperationIdTest, PrefersTheRequestsOwnEndpointOverAnIdNamingADi
     auto orphan = request_from ("req_b", entries_[1]);
     orphan.operation = vayu::core::DeclaredOperation{ "list", "POST", "/b", {} };
 
-    const SpecDiff diff = diff_dup (DUP, { orphan });
+    const SpecDiff diff = diff_dup (dup (), { orphan });
 
     ASSERT_EQ (diff.changed.size (), 1u);
     EXPECT_EQ (diff.changed[0].matched_by, vayu::core::IdentityMatch::Path);
@@ -271,7 +290,7 @@ TEST_F (DuplicateOperationIdTest, ReportsAMovedEndpointAsGoneRatherThanFollowing
 // ---------------------------------------------------------------------------
 
 TEST_F (SpecDiffTest, ReportsNothingChangedWhenTheDocumentIsTheSame) {
-    const SpecDiff diff = diff_against (BOUND, bound_collection ());
+    const SpecDiff diff = diff_against (bound_document (), bound_collection ());
 
     EXPECT_TRUE (diff.changed.empty ());
     EXPECT_TRUE (diff.added.empty ());
@@ -299,7 +318,7 @@ TEST_F (SpecDiffTest, CountsARequestThatCarriesNoOperationInsteadOfTreatingItAsR
     hand_written.operation.reset ();
     requests.push_back (hand_written);
 
-    const SpecDiff diff = diff_against (BOUND, requests);
+    const SpecDiff diff = diff_against (bound_document (), requests);
 
     EXPECT_EQ (diff.unmapped, 1u);
     EXPECT_TRUE (diff.removed.empty ());
@@ -307,8 +326,9 @@ TEST_F (SpecDiffTest, CountsARequestThatCarriesNoOperationInsteadOfTreatingItAsR
 }
 
 TEST_F (SpecDiffTest, FollowsAnOperationIdWhosePathMovedRatherThanReportingADeleteAndAnAdd) {
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/animals/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());
@@ -325,8 +345,9 @@ TEST_F (SpecDiffTest, FollowsAnOperationIdWhosePathMovedRatherThanReportingADele
 }
 
 TEST_F (SpecDiffTest, FollowsAPathWhoseOperationIdMovedAndReportsARenameWithNoFieldChange) {
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/pets/{petId}":{"get":{"operationId":"readPet","summary":"Get a pet"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());
@@ -343,8 +364,9 @@ TEST_F (SpecDiffTest, FollowsAPathWhoseOperationIdMovedAndReportsARenameWithNoFi
 }
 
 TEST_F (SpecDiffTest, DisclosesAnOperationWhoseIdAndPathBothMovedAsARemovalAndAnAddition) {
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/animals/{animalId}":{"get":{"operationId":"readAnimal","summary":"Get an animal"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());
@@ -382,7 +404,8 @@ TEST_F (SpecDiffTest, NamesEveryFieldTheDocumentMovedWithTheValueItWouldWrite) {
     const std::string next = document (
     R"({"/pets":{"get":{"operationId":"listPets","summary":"List all the pets",)"
     R"("parameters":[{"name":"limit","in":"query","required":true,"example":"10"}]},)" +
-    CREATE_PET + R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})");
+    create_pet_operation () +
+    R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());
     const auto* listed  = changed_with_id (diff, "listPets");
@@ -469,7 +492,7 @@ TEST_F (SpecDiffTest, ReportsARequestTheUserEditedAsDivergenceFlaggedAsTheirs) {
     auto renamed_by_user = request_from ("req_2", draft_of (bound_, "getPet"));
     renamed_by_user.name = "Fetch one pet";
 
-    const SpecDiff diff = diff_against (BOUND, { renamed_by_user });
+    const SpecDiff diff = diff_against (bound_document (), { renamed_by_user });
 
     ASSERT_EQ (diff.changed.size (), 1u);
     EXPECT_EQ (field_names (diff.changed[0]), std::vector<std::string>{ "name" });
@@ -554,10 +577,10 @@ TEST_F (SpecDiffTest, TruncatesADisplayedValueWithoutTruncatingTheComparedOne) {
 class StubParameterTest : public ::testing::Test {
     protected:
     void SetUp () override {
-        stub_ = drafts_of (STUB);
+        stub_ = drafts_of (stub ());
     }
 
-    static const std::string STUB;
+    static const std::string& stub ();
 
     /** The imported request with `verbose` ticked on, as the Params table leaves it. */
     [[nodiscard]] ComparableRequest verbose_enabled () const {
@@ -574,9 +597,12 @@ class StubParameterTest : public ::testing::Test {
     std::vector<SpecRequestDraft> stub_;
 };
 
-const std::string StubParameterTest::STUB =
-document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets",)"
-          R"("parameters":[{"name":"verbose","in":"query"}]}}})");
+const std::string& StubParameterTest::stub () {
+    static const std::string text =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets",)"
+              R"("parameters":[{"name":"verbose","in":"query"}]}}})");
+    return text;
+}
 
 TEST_F (StubParameterTest, ImportsDisabledWhichIsWhatLeavesAnythingToSurvive) {
     ASSERT_EQ (stub_[0].draft.params.size (), 1u);
@@ -643,7 +669,8 @@ TEST_F (SpecDiffTest, ReportsTheUsersMethodEditAsTheirsSoAnApplyCannotTakeItBack
     const SpecDiff diff = diff_against (
     document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets",)"
               R"("description":"Paged."},)" +
-    CREATE_PET + R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})"),
+    create_pet_operation () +
+    R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Get a pet"}}})"),
     { edited_to_head });
 
     ASSERT_EQ (diff.changed.size (), 1u);
@@ -678,8 +705,8 @@ TEST_F (SpecDiffTest, ReportsAMethodTheDocumentItselfMovedAsTheDocuments) {
 TEST_F (SpecDiffTest, LeavesARequestAloneWhenTheDocumentAgreesWithTheVerbItHolds) {
     // The other direction of the same field: comparing `method` must not make
     // every unchanged request report one.
-    const SpecDiff diff =
-    diff_against (BOUND, { request_from ("req_0", draft_of (bound_, "listPets")) });
+    const SpecDiff diff = diff_against (bound_document (),
+    { request_from ("req_0", draft_of (bound_, "listPets")) });
 
     EXPECT_TRUE (diff.changed.empty ());
     EXPECT_EQ (diff.unchanged, 1u);
@@ -717,8 +744,9 @@ TEST_F (SpecDiffTest, SafeApplyCreatesEveryAddedOperationAndDeletesNothing) {
     // The document drops `getPet` and adds `listOwners`. Creating what a contract
     // gained takes nothing away from anybody; deleting a request whose operation
     // is gone might, so it waits for a person.
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/owners":{"get":{"operationId":"listOwners","summary":"List owners"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());
@@ -740,8 +768,9 @@ TEST_F (SpecDiffTest, SafeApplyLeavesAFieldTheUserEditedAndTakesOneOnlyTheDocume
      */
     auto edited = request_from ("req_0", draft_of (bound_, "listPets"));
     edited.name = "My list call";
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/pets/{petId}":{"get":{"operationId":"getPet","summary":"Fetch one pet"}}})");
 
     const SpecDiff diff = diff_against (
@@ -800,8 +829,9 @@ TEST_F (SpecDiffTest, SafeApplyTakesARequestWhoseOnlyMovementIsItsIdentity) {
     // answers to moves, so the request is followed by its path and nothing it
     // holds is stale. Moving the *path* instead would change the url too, which
     // is a field and not this case.
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"List pets"},)" +
+    create_pet_operation () +
     R"(},"/pets/{petId}":{"get":{"operationId":"fetchPet","summary":"Get a pet"}}})");
 
     const SpecDiff diff =
@@ -818,8 +848,9 @@ TEST_F (SpecDiffTest, SafeApplyAnswersOneEntryPerBucketEntrySoNoReaderHasToAlign
     // The parallel-arrays contract every reader rests on: the marks a route
     // reports and the rows a policy sync builds are both "the entry I am holding,
     // at the index I am holding it".
-    const std::string next = document (
-    R"({"/pets":{"get":{"operationId":"listPets","summary":"Pets, listed"},)" + CREATE_PET +
+    const std::string next =
+    document (R"({"/pets":{"get":{"operationId":"listPets","summary":"Pets, listed"},)" +
+    create_pet_operation () +
     R"(},"/owners":{"get":{"operationId":"listOwners","summary":"List owners"}}})");
 
     const SpecDiff diff = diff_against (next, bound_collection ());

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -116,15 +116,30 @@ R"("/owners":{"get":{"operationId":"listOwners","responses":{"200":{}}}}}})";
 
 /// An operation neither fetched document declares - a request stamped with it is
 /// a *removal*, which a safe apply must leave standing.
-const nlohmann::json DELETE_PET = nlohmann::json{ { "operationId", "deletePet" },
-    { "method", "DELETE" }, { "path", "/pets/{petId}" } };
+///
+/// A function rather than a namespace-scope `json`, here and for the two
+/// identities below: building one allocates, and at namespace scope that runs
+/// before `main` where the throw cannot be caught (`cert-err58-cpp`). Built on
+/// the first case's stack instead, once.
+const json& delete_pet () {
+    static const json operation = json{ { "operationId", "deletePet" },
+        { "method", "DELETE" }, { "path", "/pets/{petId}" } };
+    return operation;
+}
 
 /// The identities `FETCHED_DOC` declares, as a request's stamp records them -
 /// which is how a refresh finds the responses the document documents for it.
-const json LIST_PETS =
-json{ { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" } };
-const json LIST_OWNERS =
-json{ { "operationId", "listOwners" }, { "method", "GET" }, { "path", "/owners" } };
+const json& list_pets () {
+    static const json operation =
+    json{ { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" } };
+    return operation;
+}
+
+const json& list_owners () {
+    static const json operation = json{ { "operationId", "listOwners" },
+        { "method", "GET" }, { "path", "/owners" } };
+    return operation;
+}
 
 class SpecSyncRouteTest : public ::testing::Test {
     protected:
@@ -450,7 +465,7 @@ TEST_F (SpecSyncRouteTest, RefusesAFolderParentedOutsideTheSyncedCollection) {
 
 TEST_F (SpecSyncRouteTest, WritesTheDocumentsResponsesAndKeepsTheUsersOwnExamples) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     seed_example (request, vayu::core::constants::request_example::ORIGIN_USER, 0);
     const std::string replaced =
     seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 1);
@@ -481,7 +496,7 @@ TEST_F (SpecSyncRouteTest, WritesTheDocumentsResponsesAndKeepsTheUsersOwnExample
 // is a real state, and it is the one the empty list used to spell.
 TEST_F (SpecSyncRouteTest, ADocumentedNothingRemovesTheImportedExamplesOnly) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     seed_example (request, vayu::core::constants::request_example::ORIGIN_USER, 0);
     seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 1);
 
@@ -497,7 +512,7 @@ TEST_F (SpecSyncRouteTest, ADocumentedNothingRemovesTheImportedExamplesOnly) {
 
 TEST_F (SpecSyncRouteTest, AnAbsentExamplesDecisionLeavesEveryExampleAlone) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0);
 
     auto [status, response] = routes::spec_sync_response (*db_,
@@ -513,7 +528,7 @@ TEST_F (SpecSyncRouteTest, AnAbsentExamplesDecisionLeavesEveryExampleAlone) {
 // seeded imported row is replaced by the document's two.
 TEST_F (SpecSyncRouteTest, AFalseExamplesDecisionLeavesEveryExampleAlone) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0, 500);
 
     auto [status, response] = routes::spec_sync_response (*db_,
@@ -533,7 +548,7 @@ TEST_F (SpecSyncRouteTest, AFalseExamplesDecisionLeavesEveryExampleAlone) {
 // 400 becomes a 200 with a row for a status `FETCHED_DOC` never mentions.
 TEST_F (SpecSyncRouteTest, RefusesAnExampleListWhereADecisionBelongs) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
 
     auto [status, response] = routes::spec_sync_response (*db_,
     body (json{ { "update",
@@ -571,7 +586,7 @@ TEST_F (SpecSyncRouteTest, ACreatedRequestGetsTheResponsesTheDocumentDocuments) 
     body (json{ { "create",
     json::array ({ json{ { "tempId", "t_req" }, { "collectionId", root_ },
     { "name", "list owners" }, { "method", "GET" }, { "url", "https://example.test/owners" },
-    { "specOperation", LIST_OWNERS } } }) } }));
+    { "specOperation", list_owners () } } }) } }));
     ASSERT_EQ (status, 200) << response.dump ();
 
     const auto created = response["idMap"]["t_req"].get<std::string> ();
@@ -585,8 +600,9 @@ TEST_F (SpecSyncRouteTest, ACreatedRequestGetsTheResponsesTheDocumentDocuments) 
 TEST_F (SpecSyncRouteTest, RefusesACreatedRequestThatStatesItsOwnExamples) {
     auto [status, response] = routes::spec_sync_response (*db_,
     body (json{ { "create",
-    json::array ({ json{ { "tempId", "t_req" }, { "collectionId", root_ }, { "name", "list owners" },
-    { "method", "GET" }, { "url", "https://example.test/owners" }, { "specOperation", LIST_OWNERS },
+    json::array ({ json{ { "tempId", "t_req" }, { "collectionId", root_ },
+    { "name", "list owners" }, { "method", "GET" },
+    { "url", "https://example.test/owners" }, { "specOperation", list_owners () },
     { "examples", json::array ({ json{ { "name", "418" }, { "status", 418 } } }) } } }) } }));
     ASSERT_EQ (status, 400) << response.dump ();
     EXPECT_EQ (db_->get_requests_in_collection (root_).size (), 0u);
@@ -600,7 +616,7 @@ TEST_F (SpecSyncRouteTest, RefusesACreatedRequestThatStatesItsOwnExamples) {
 // back, reddening both size assertions.
 TEST_F (SpecSyncRouteTest, ADeletedImportedExampleIsNotWrittenBackByALaterSync) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0, 200);
     const std::string unwanted = seed_example (
     request, vayu::core::constants::request_example::ORIGIN_IMPORT, 1, 404);
@@ -630,7 +646,7 @@ TEST_F (SpecSyncRouteTest, ADeletedImportedExampleIsNotWrittenBackByALaterSync) 
 // what this fix makes durable (issue #722).
 TEST_F (SpecSyncRouteTest, ARewordedDescriptionDoesNotBringADeletedExampleBack) {
     const std::string request =
-    create_request (root_, json{ { "specOperation", LIST_PETS } });
+    create_request (root_, json{ { "specOperation", list_pets () } });
     const std::string unwanted = seed_example (
     request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0, 404);
     ASSERT_EQ (routes::delete_request_example_response (*db_, request, unwanted).first, 200);
@@ -833,11 +849,12 @@ TEST_F (SpecSyncRouteTest, ASyncLeavesAnOlderRunsStoredCoverageAlone) {
 
 TEST_F (SpecSyncRouteTest, PolicyCreatesWhatTheDocumentAddedAndDeletesNothing) {
     const std::string stamped = create_request (
-    root_, json{ { "name", "listPets" }, { "specOperation", LIST_PETS } });
+    root_, json{ { "name", "listPets" }, { "specOperation", list_pets () } });
     // Stamped with an operation no fetched document declares - a removal, and the
     // one thing a safe apply may never act on.
     const std::string orphaned = create_request (root_,
-    json{ { "name", "deletePet" }, { "method", "DELETE" }, { "specOperation", DELETE_PET } });
+    json{ { "name", "deletePet" }, { "method", "DELETE" },
+    { "specOperation", delete_pet () } });
 
     auto [status, response] =
     routes::spec_sync_response (*db_, body (json{ { "policy", "safe" } }));
@@ -874,7 +891,7 @@ TEST_F (SpecSyncRouteTest, PolicyWritesAFieldOnlyTheDocumentMoved) {
     // sharper: one request, one field written and one left alone, decided field
     // by field rather than row by row.
     const std::string stamped = create_request (
-    root_, json{ { "name", "listPets" }, { "specOperation", LIST_PETS } });
+    root_, json{ { "name", "listPets" }, { "specOperation", list_pets () } });
     const std::string edited_url = db_->get_request (stamped)->url;
 
     auto [status, response] = routes::spec_sync_response (*db_,
@@ -901,8 +918,8 @@ TEST_F (SpecSyncRouteTest, PolicyLeavesAFieldSomebodyEditedExactlyAsTheyLeftIt) 
      * request. Dropping the `user_touched` guard in `safe_spec_apply` reddens
      * this: the name becomes "List all the pets" and somebody's work is gone.
      */
-    const std::string edited = create_request (
-    root_, json{ { "name", "My pets call" }, { "specOperation", LIST_PETS } });
+    const std::string edited = create_request (root_,
+    json{ { "name", "My pets call" }, { "specOperation", list_pets () } });
 
     auto [status, response] = routes::spec_sync_response (*db_,
     json{ { "collectionId", root_ },

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -84,8 +84,15 @@ R"("paths":{"/pets":{"get":{"operationId":"listPets","responses":{"200":{}}}}}})
 /// What the engine reads off {@link PETSTORE} (issue #853). Named once because
 /// several cases assert it: the index is no longer something a caller sends, so
 /// the document *is* the input and this is the whole of the output.
-const json PETSTORE_INDEX = json::array ({ json{ { "operationId", "listPets" },
-{ "method", "GET" }, { "path", "/pets" }, { "responses", json::array ({ "200" }) } } });
+/// A function rather than a namespace-scope `json`, here and for the schema
+/// index below: building one allocates, and at namespace scope that runs before
+/// `main` where the throw cannot be caught (`cert-err58-cpp`).
+const json& petstore_index () {
+    static const json index =
+    json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" },
+    { "path", "/pets" }, { "responses", json::array ({ "200" }) } } });
+    return index;
+}
 
 /// The same document with a response schema on it, for the cases that need a
 /// stored `response_schemas` index. That index is derived from the document too
@@ -97,11 +104,14 @@ R"("paths":{"/pets":{"get":{"operationId":"listPets","responses":)"
 R"({"200":{"content":{"application/json":{"schema":{"type":"array"}}}}}}}}})";
 
 /// What the engine reads off {@link PETSTORE_SCHEMAS} (issue #860).
-const json PETSTORE_SCHEMA_INDEX = json{ { "operations",
-json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" },
-{ "responses",
-json::array ({ json{ { "status", "200" }, { "contentType", "application/json" },
-{ "schema", json{ { "type", "array" } } } } }) } } }) } };
+const json& petstore_schema_index () {
+    static const json index = json{ { "operations",
+    json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" },
+    { "responses",
+    json::array ({ json{ { "status", "200" }, { "contentType", "application/json" },
+    { "schema", json{ { "type", "array" } } } } }) } } }) } };
+    return index;
+}
 
 /// A document Vayu stores happily and reads as declaring nothing - a Postman
 /// export is a perfectly good file that is not a contract. Its column stays
@@ -846,7 +856,7 @@ TEST_F (SpecsRouteTest, AStoredDocumentsIndexIsTheOneTheEngineReadOffIt) {
     auto [read_status, read] =
     routes::get_spec_document_response (*db_, body.value ("id", std::string{}));
     ASSERT_EQ (read_status, 200) << read.dump ();
-    EXPECT_EQ (read["operations"], PETSTORE_INDEX);
+    EXPECT_EQ (read["operations"], petstore_index ());
 }
 
 TEST_F (SpecsRouteTest, ADocumentThatCannotBeReadIsRefusedRatherThanStoredUnreadable) {
@@ -901,7 +911,7 @@ TEST_F (SpecsRouteTest, TheSchemaIndexIsDerivedBesideTheOperationIndexOnBothWrit
     auto [read_status, read] =
     routes::get_spec_document_response (*db_, body.value ("id", std::string{}));
     ASSERT_EQ (read_status, 200) << read.dump ();
-    EXPECT_EQ (read["responseSchemas"], PETSTORE_SCHEMA_INDEX);
+    EXPECT_EQ (read["responseSchemas"], petstore_schema_index ());
 
     auto [import_status, imported] = routes::import_apply_response (*db_,
     json{ { "specs", { { { "tempId", "s1" }, { "content", PETSTORE_SCHEMAS } } } } });
@@ -909,7 +919,7 @@ TEST_F (SpecsRouteTest, TheSchemaIndexIsDerivedBesideTheOperationIndexOnBothWrit
     auto [bulk_status, bulk] = routes::get_spec_document_response (
     *db_, imported["idMap"]["s1"].get<std::string> ());
     ASSERT_EQ (bulk_status, 200) << bulk.dump ();
-    EXPECT_EQ (bulk["responseSchemas"], PETSTORE_SCHEMA_INDEX)
+    EXPECT_EQ (bulk["responseSchemas"], petstore_schema_index ())
     << "one helper for all three writers, or a document describes different "
        "contracts depending on how it arrived";
 }
@@ -936,7 +946,7 @@ TEST_F (SpecsRouteTest, ImportDerivesTheIndexBesideTheDocumentItDescribes) {
     const auto spec_id = body["idMap"]["s1"].get<std::string> ();
     auto [read_status, read] = routes::get_spec_document_response (*db_, spec_id);
     ASSERT_EQ (read_status, 200) << read.dump ();
-    EXPECT_EQ (read["operations"], PETSTORE_INDEX);
+    EXPECT_EQ (read["operations"], petstore_index ());
 }
 
 TEST_F (SpecsRouteTest, AResolvedPlanCarriesTheBoundDocumentsOperations) {

--- a/engine/tests/version_isolation_test.cpp
+++ b/engine/tests/version_isolation_test.cpp
@@ -25,6 +25,7 @@
  * the version at all.
  */
 
+#include <array>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -40,7 +41,9 @@ using vayu::tests::read_source;
 using vayu::tests::strip_comments;
 
 /// The headers a version bump must not reach, because nearly every TU does.
-const std::vector<std::string> kHubHeaders = {
+/// `constexpr`, so the list is the compiler's and not something built before
+/// `main` where an allocation failure cannot be caught (`cert-err58-cpp`).
+constexpr std::array<const char*, 6> kHubHeaders = {
     "include/vayu/core/constants.hpp",
     "include/vayu/core/user_agent.hpp",
     "include/vayu/types.hpp",
@@ -67,7 +70,7 @@ TEST (VersionIsolationTest, TheHubHeadersDoNotNameTheVersion) {
         // the `Version` struct's initialisers alike.
         if (source.find ("vayu/version.hpp") != std::string::npos ||
         source.find ("VAYU_VERSION") != std::string::npos) {
-            offenders.push_back (relative);
+            offenders.emplace_back (relative);
         }
     }
 


### PR DESCRIPTION
## Description

Wave 3 of #928 (#945), batch 2: the whole **`cert-*`** family, cleared. Thirty findings, read rather than bulk-fixed.

**The plan.** *Root cause:* thirty findings, two families, one idea each. `cert-err58-cpp` (25) is an object with static or thread storage duration whose constructor allocates - a `std::string` from a literal, an `nlohmann::json`, a `std::regex`, a `std::mt19937`, a `DnsCache`. Its initialisation runs before `main`, where a throw has no frame to land in and terminates the process, and where its order against another translation unit's statics is unspecified. `cert-err33-c` (5) is a C call whose return carries a verdict nobody read.

*Approach:* for the first family, **remove the dynamic initialisation rather than guard it**. Ten sites became compile-time constants (`constexpr std::string_view` for text, `constexpr std::array` for a list, `constexpr const char*` for a path that a `std::string` parameter takes anyway) and now allocate nothing at any point. The other fifteen hold something that genuinely cannot be `constexpr`, and those moved inside a function as a `static` behind an accessor - built on the first caller's stack, once, thread-safely, and after everything they depend on. That is not a new idiom here: `request_composer.cpp`'s `token_pattern ()` was already the shape. For `cert-err33-c`, one return turned out to mean something and is now read (`gmtime_r`'s conversion), two calls went away entirely rather than being checked (`snprintf` and `fclose`, both below), and two returns mean nothing to their caller and are discarded explicitly with the reason at the site.

*Alternative rejected:* turning `cert-err58-cpp` off for `engine/tests/` the way `engine/tests/.clang-tidy` already turns off the cognitive-complexity check - 17 of the 25 are in test files, and the argument would have been that a throw before `main` in a test binary is loud enough on its own. Rejected on both halves: the check's *other* payload is static-initialisation order, which a test binary has as much of as the daemon does, and the fix turned out cheaper than the exemption would have been - six of those seventeen became constants the compiler builds, and the rest are three lines each.

**Category tally: 0 real defects, 30 findings cleared, 0 sites silenced with a `NOLINT`.** Unlike batch 1 this batch found nothing that reproduces, and so files no defect record: every `err58` site throws only on an allocation failure, and each `err33` return is unreachable in its failing state (`gmtime_r` on a 64-bit `time_t` from `system_clock::now()`, `snprintf` into a buffer sized for the worst case, `fclose` on a stream opened read-only, `std::signal` for two signals POSIX cannot refuse). What changes is that none of it is taken on faith any more, and that 25 objects stopped being built before `main`.

**What the batch found, all thirty:**

| Site | Check | Remedy |
|---|---|---|
| `src/cli.cpp:42` `DEFAULT_DAEMON_URL` | `err58` | `constexpr std::string_view` |
| `src/http/request_composer.cpp:72` `ALPHANUMERIC` | `err58` | `constexpr std::string_view` |
| `src/http/request_composer.cpp:74` `PASSWORD_CHARS` | `err58` | `constexpr std::string_view` + `static_assert` |
| `src/http/request_composer.cpp:119` `DYNAMIC_VARIABLES` | `err58` | `constexpr std::array` |
| `tests/db_test.cpp:24`, `load_strategy_test.cpp:34`, `scenario_load_test.cpp:160` `TEST_DB_PATH` | `err58` ×3 | `constexpr const char*` |
| `tests/event_loop_test.cpp:19` `INVALID_URL` | `err58` | `constexpr const char*` |
| `tests/db_test.cpp:623` `EXPECTED_INDEXES` | `err58` | `constexpr std::array` |
| `tests/version_isolation_test.cpp:43` `kHubHeaders` | `err58` | `constexpr std::array` |
| `src/http/event_loop/event_loop_worker.cpp:34` `dns_cache_` | `err58` | `dns_cache ()` |
| `src/http/request_composer.cpp:51` `rng` | `err58` | `rng ()`, `thread_local` inside |
| `src/http/routes/import.cpp:340`, `spec_sync.cpp:188` `EMPTY_ITEMS` | `err58` ×2 | `static` inside `read_items` |
| `tests/id_test.cpp:21` `kUuidV4` | `err58` | `uuid_v4 ()` |
| `tests/openapi_export_test.cpp:47` `PETSTORE` | `err58` | `petstore ()` |
| `tests/spec_diff_test.cpp:122`, `:126`, `:209`, `:577` | `err58` ×4 | four accessors |
| `tests/spec_sync_route_test.cpp:119`, `:124`, `:126` | `err58` ×3 | three accessors |
| `tests/specs_route_test.cpp:87`, `:100` | `err58` ×2 | two accessors |
| `src/http/request_composer.cpp:102` `gmtime_r` | `err33` | read - `utils::format_utc_time` |
| `src/http/request_composer.cpp:107` `snprintf` | `err33` | gone - no vararg call left |
| `src/http/form_body.cpp:246` `fclose` | `err33` | gone - the `FILE*` closes itself |
| `src/platform/platform_unix.cpp:183`, `:184` `signal` | `err33` ×2 | discarded, with the reason |

**Four of these are worth more than a line.**

**`gmtime_r`'s split was a hand-rolled copy of a primitive, and it is now the primitive.** `request_composer.cpp` carried its own `#if defined(_WIN32)` / `gmtime_s` / `gmtime_r` branch - the copy that `reentrant.hpp`'s own doc comment pointed at when batch 1 wrote `format_local_time`. It becomes `vayu::utils::format_utc_time`, the exact sibling of that function, with the shared `std::tm` -> string rendering factored into one `detail::format_tm` so the pair cannot drift either.

**Two things about that helper are worth recording, because both were discovered rather than designed.** The first draft was a narrower `to_utc_time (time, tm&)` whose doc said `out` is "left untouched" on refusal, which is what the local-time side reasons about. The test written for it **failed**: glibc fills the fields and only then discovers the year does not fit an `int` - `tm_year` came back as 219248568. So "failed" does not mean "unwritten", and the contract both functions document now says so - the return is the only thing carrying the verdict, which is exactly why it is read.

The second is why that narrower shape is gone. Rewriting `iso_timestamp` to read `snprintf`'s return kept the `char buf[96]` and the vararg call, and the CI lint gate - reproduced locally before pushing - **failed on those very lines**: `cppcoreguidelines-pro-type-vararg` and `pro-bounds-array-to-pointer-decay`, both in this same issue's third batch, pulled into scope by the act of editing the line they sit on. Checking a `snprintf` return was the wrong fix for a finding about unread returns. Formatting through `format_utc_time` and appending the milliseconds as a string removes the vararg call, the C array (`modernize-avoid-c-arrays`, wave 4) and the unread return together, and leaves `iso_timestamp` structurally identical to every other formatter here.

**One conversion had a consequence a changed-lines gate cannot see, which is worth more than the finding itself.** `kHubHeaders` becoming a `const char*` array made `offenders.push_back (relative)` construct a `std::string` temporary - a `modernize-use-emplace` finding on a line this diff does not touch. CI would have passed and #946's full-tree re-measure would have found it. It is `emplace_back` now, and the lesson generalises: **changing a constant's type moves work to its call sites**, so a batch like this owes its touched files a whole-file lint, not just a changed-line one. That is how it was found.

**The form part's `FILE*` closes itself now, and that was the gate's doing too.** Spelling the discard as an explicit cast of `std::fclose (handle)` to `void` put a *second*, pre-existing finding on a changed line - `cppcoreguidelines-owning-memory`, a resource held by a plain pointer - which the local gate reproduction caught in the same way it caught the `snprintf` one. A `std::unique_ptr` over the `FILE` with `std::fclose` as its deleter removes both at once and fixes something neither check names: the hand-written close sat *above* the early return that reports an unreadable file, so it closed on that path only by accident of statement order. Two findings on one line is what a batch like this is for - the pattern is the same as the `snprintf` case, and it is why the local gate run is worth its 20 minutes.

**`PASSWORD_CHARS` was derived from `ALPHANUMERIC`, and a spelled-out literal could drift from it.** `static_assert (PASSWORD_CHARS.substr (0, ALPHANUMERIC.size ()) == ALPHANUMERIC, ...)` pins the two at compile time, so the duplication cannot rot. `std::string_view`'s `substr` and `operator==` are `constexpr`, so this costs nothing at run time and fails the *build* rather than a test.

**Deliberate deviation from the issue spec.** #945's acceptance is zero findings for **three** families; this batch clears the second (`cert-*`, 30 at the wave-0 baseline and 30 on a rescan of the current tree - this one reproduced exactly). The curated `cppcoreguidelines-*` (164) is the last batch and **#945 stays open** for it, which is why there is no `Closes #945` below.

**One number for #946's re-measure.** Batch 1 found the wave-0 per-check table over-counted `concurrency-*` by counting header findings once per including TU. `cert-*` did not: 25 + 5 on a fresh scan of 206 non-vendor translation units, matching the baseline exactly. So the discrepancy #969 and batch 1 flagged is not general to the table - it is specific to checks that fire in headers.

**One thing found and deliberately left alone.** `tests/runs_route_test.cpp:158` binds `auto [__, page3]`, a reserved identifier. The first reading of this was that the alias rule had a gap - `cert-dcl37-c`/`cert-dcl51-cpp` are off in `engine/.clang-tidy` so the canonical name reports it instead, and the canonical is `bugprone-reserved-identifier`, whose family wave 2 cleared. Running the canonical check settled it the other way: it *does* report this line, so the alias rule works exactly as its comment says and what actually survived is a wave-2 finding in a test file. Out of scope for a `cert-*` batch and not something to fix inside one; filed as #978, which also asks the question this raises - whether wave 2 scoped to `src` and left other `tests/` findings standing, which #946's full-tree re-measure would otherwise discover the hard way.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Run on Linux, at `28ab5b1` as the base.

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2390 tests, 2390 passed, 0 failed** (35.1 s). Four of them are new; the base commit's suite is 2386.
- `clang-format-19 --dry-run -Werror` over every touched file - clean. Each was verified format-clean at the base commit first, so reformatting them is in policy.
- **The CI lint gate, reproduced locally** - and it was **not** clean on the first attempt, which is why the diff looks the way it does; see the `snprintf` and `fclose` notes above. The verdict is computed per translation unit (lint the whole TU with the repo config, then keep only findings whose line this branch changed) rather than through `clang-tidy-diff-19.py`, because that driver could not resolve most of these files in the compile database from this checkout and answered `clang-diagnostic-error: file not found` for them - which is #940's failure mode, not a verdict. **19 changed translation units, 449 changed lines, 0 findings on a changed line.** It is run with `-extra-arg=-Wno-ignored-gch`, the flag `scripts/pre-commit` passes for the same reason (#912): the build's precompiled header is a GCC one and clang-tidy reports it otherwise.
- **`cert-*` tree-wide**: the same scan that produced the table above, re-run over all 206 non-vendor translation units after the fixes - **zero** for every check this config enables. (`src/runtime/` is excluded: its `.clang-tidy` disables every check, a settled decision.) The scan passes `--checks='-*,cert-*'`, which re-enables the aliases `engine/.clang-tidy` turns off, so it reports one line the gate does not: the `cert-dcl37-c` on `runs_route_test.cpp:158` that is #978.

**The new tests, and what each would catch.**

- `FormatUtcTime.RendersTheInstantInUtcAndNotTheLocalZone` - 2001-09-09T01:46:40Z asserted in full, so a formatter reading the wrong fields cannot pass by coincidence, plus the shape it shares with `format_local_time`.
- `FormatUtcTime.AnUnrepresentableInstantRendersAsNothing` - the epoch renders as 1970 (which stops the second half being vacuous), and `time_t::max()` never renders as the 1900 an unconverted `std::tm` reads as. Its empty branch asserts nothing, on purpose, and the comment says why.
- `DynamicVariables.IsoTimestampIsTheShapeTheRendererProduces` - the whole `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`, which is what made the `snprintf` rewrite safe to do at all: the timestamp is now assembled from two pieces instead of one format string. The renderer's `$isoTimestamp` is `new Date().toISOString()` and the two tables are a contract. **Its first draft was a 200-round loop and the mutation check exposed it as one sample repeated**: 200 calls complete inside a single millisecond, so removing the zero-padding left it green. It now samples across wall-clock time until it sees a millisecond below 100 - the field visits every value once per second - and *asserts that it sampled one*, so a run that never reached the padded case fails rather than passing quietly. It takes 0.7 s.
- `DynamicVariables.TheRandomAlphabetsAreTheOnesTheCharactersComeFrom` - both alphabets are indexed `std::string_view`s now; a view whose length or contents went wrong draws a character that does not belong, over 50 rounds of each.

**The mutation check, run rather than reasoned about** - four mutations, each built and run:

| Mutation | Result |
|---|---|
| `iso_timestamp`'s format string to `%Y-%m-%d %H:%M:%S` | `IsoTimestampIsTheShapeTheRendererProduces` red |
| the milliseconds' `millis.insert` padding removed | red - **and green against the test's first draft, which is how that draft got rewritten** |
| `PASSWORD_CHARS` gains a trailing `~` | `TheRandomAlphabetsAreTheOnesTheCharactersComeFrom` red |
| `PASSWORD_CHARS`' prefix no longer `ALPHANUMERIC` | the **build** fails at the `static_assert`, before any test runs |

Restoring `format_utc_time`'s unchecked conversion leaves every test green, which is the honest state of an unreachable branch and is why this says 0 defects rather than 5.

**No source-scan guard this time, deliberately.** Batch 1 added one because `concurrency-*` is a fixed list of call names a scan can look for. "A namespace-scope object whose constructor may throw" has no such shape - it is a type question the compiler answers and a text scan cannot - so the CI gate on changed lines, plus the convention now written in `engine/CLAUDE.md`, is the whole of what keeps this family at zero.

**Not run, with reasons:** the app suite and `pnpm type-check` (no `app/` file is touched, and no renderer, MCP or import consumer reads any of this - the one cross-language contract in the diff, the `$isoTimestamp` shape, is asserted engine-side by a new test and unchanged on the wire); `mkdocs build --strict` (no `docs/` file is touched - `docs/engine/building.md`'s Static Analysis section already describes #943-#946 paying the families down, and nothing it states became false); the `linux-tsan` preset (no threading behaviour changes - `rng` was already per-thread and `dns_cache ()`'s initialisation is guarded by the standard's own thread-safe-statics rule, which is stronger than the unsynchronised construction it replaces).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`engine/CLAUDE.md` gains the convention this batch establishes - nothing at namespace scope is built at run time, which spelling to reach for, and where the shape already lives - and its reentrant bullet now names `format_utc_time` beside the two functions batch 1 added.

## Related Issues

Part of #945, wave 3 of #928. Refs #978.