### PR TITLE
test(engine): name the statuses the pagination test binds and drops - #978

### DIFF
--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -149,13 +149,15 @@ TEST_F (RunsRouteTest, PaginationHasMoreAndOffset) {
     for (int i = 0; i < 5; ++i)
         seed ({ .id = "run_" + std::to_string (i), .start_time = i });
 
-    auto [_, page1] = vayu::http::routes::get_runs_response (*db_, {}, 2, 0);
+    auto [page1_status, page1] = vayu::http::routes::get_runs_response (*db_, {}, 2, 0);
+    EXPECT_EQ (page1_status, 200);
     EXPECT_EQ (page1["data"].size (), 2u);
     EXPECT_EQ (page1["pagination"]["total"], 5);
     EXPECT_EQ (page1["pagination"]["hasMore"], true);
     EXPECT_EQ (page1["pagination"]["returned"], 2);
 
-    auto [__, page3] = vayu::http::routes::get_runs_response (*db_, {}, 2, 4);
+    auto [page3_status, page3] = vayu::http::routes::get_runs_response (*db_, {}, 2, 4);
+    EXPECT_EQ (page3_status, 200);
     EXPECT_EQ (page3["data"].size (), 1u);
     EXPECT_EQ (page3["pagination"]["hasMore"], false);
 }


### PR DESCRIPTION
## Description

`engine/tests/runs_route_test.cpp:158` bound a `get_runs_response` result as `auto [__, page3]`. Any identifier containing a double underscore is reserved to the implementation in every scope ([lex.name]), so that binding was undefined behaviour rather than a style preference - the name may collide with an implementation symbol, and a standard library is free to `#define` it. `bugprone-reserved-identifier` was reporting it, and `WarningsAsErrors: '*'` means it is a failure the moment those lines are ever touched again.

**The plan.** Root cause: `PaginationHasMoreAndOffset` is the one test in the file that needs two results in a single body, so the second ignored status could not reuse the `_` the file's other 20-odd tests use, and `__` was reached for. The fix is the rename the issue asks for, with one adaptation to what the code actually is: the ignored element is the **HTTP status**, not "the first page's rows" as the issue reads it, so the bindings are named `page1_status` / `page3_status` and asserted `200` - which is exactly what the file already does with a named status (line 122-123 and seven more like it). Naming a binding and then never reading it is the shape this repo keeps finding, so the assertion is what makes the name honest rather than decoration; the first binding's `_` is renamed alongside so the pair reads the same way. The alternative I rejected was renaming only `__` and leaving `_` beside it: a two-line diff that leaves a reader asking why the two statuses are spelled differently. `std::ignore` is not available - a structured binding must name every element.

**The scoping question the issue asks, answered: wave 2 did not scope to `src`, and it did not miss a translation unit.** #944's PR #976 deliberately took `engine/src` plus the three test files carrying no wave-1 finding, and parked 11 findings in 8 files for #943's `engine/tests` batch so no file would be edited twice. This was the one of those 11 that is independent of that batching rule.

**What the whole-`tests/` rescan turned up, and the gap it exposed.** The other 10 are still standing, and so is wave 1's entire tail: **571 unique `bugprone-*` findings across 54 files in `engine/tests`** - 561 `unchecked-optional-access`, 9 `implicit-widening-of-multiplication-result`, 1 `misplaced-widening-cast`. #943 was closed as completed by PR #969, which covered `engine/src` only, so nothing open tracked that remainder. Filed as **#980** (sub-issue of #928), with the per-check table, the 10 leftover sites, and a note that it must close before #946's exit re-measure. Not fixed here: those 10 live in files holding 561 wave-1 findings between them, and taking them alone is the double-edit #944 and #943 both asked to avoid.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` - green.
- `ctest --preset linux-dev --output-on-failure` - **2386/2386 passed**, 0 failed, 45.7s. `RunsRouteTest.PaginationHasMoreAndOffset` included; the two added assertions pass, so the route does answer 200 on both pages.
- `clang-format-19 --dry-run -Werror engine/tests/runs_route_test.cpp` - clean (the formatter leaves both lines unwrapped at 87 columns; `PenaltyExcessCharacter: 1` is why, and it is the formatter's own answer, not a hand choice).
- `clang-tidy-19 -p engine/build` over the changed lines on the repo config - no findings.
- **`bugprone-reserved-identifier` over all 206 non-vendor translation units the decided config lints** (93 in `engine/{src,include}`, 113 in `engine/tests`; `src/runtime/` excluded, its own `.clang-tidy` disables everything): **zero findings**, which is this issue's first acceptance criterion measured rather than asserted.
- No pre-existing failures. The 4 `unchecked-optional-access` findings this file still carries are wave 1's and belong to #980.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - two status assertions in the test the rename touches; no new test file
- [x] I have updated documentation - none applies; no documented behaviour changes

## Related Issues

Closes #978
Filed by this run: #980 (wave 1's `engine/tests` batch, orphaned when #943 closed on a `src`-only PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9a2jX7pFa8eiLmTaxcXrc)_