### PR TITLE
test(engine): tidy paydown 1 batch 2a - clear the optional-access findings in eight test files

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -44,6 +44,20 @@ engine/
   - it names no rule, and the check reports it too, so it buys a `NOLINT` per
   site. That helper is for invariants only: an optional a client can empty is
   still handled, with its `if`, its 404 and its default.
+- **In a test the guard is `ASSERT_HAS_VALUE`** (`tests/optional_assert.hpp`,
+  #980), never `ASSERT_TRUE (opt.has_value ())`. The gtest spelling guards the
+  reads under it perfectly well at run time and the check cannot see it: the
+  condition goes through an `::testing::AssertionResult`, and the dataflow model
+  follows `has_value ()` only into a branch condition, which is where 561 of
+  `engine/tests`' findings came from. Nor can the near misses -
+  `ASSERT_TRUE (...) << "why"`, `ASSERT_NE (opt, std::nullopt)` and `.value ()`
+  are each still reported. The macro is the one `if` the model does follow, with
+  `FAIL ()`'s `return` in its failing branch, so the failure stays gtest's -
+  located at the call site, naming the expression, and streamable
+  (`ASSERT_HAS_VALUE (row) << "after the second write"`). It is a guard, not a
+  silencer: an optional the code under test may legitimately leave empty is
+  still tested over both outcomes, and `invariant_value` remains the answer for
+  a rule that lives in another function.
 - **The reentrant spelling of a C call, always** (#945). `std::localtime` and
   `std::strerror` hand back a pointer into storage the whole process shares, so
   with a worker thread per connection what comes back is a timestamp or an

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(vayu_tests
     http_client_test.cpp
     json_test.cpp
     invariant_test.cpp
+    optional_assert_test.cpp
     script_engine_test.cpp
     script_expect_message_test.cpp
     script_assertion_error_test.cpp

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -19,6 +19,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
@@ -104,12 +105,12 @@ TEST_F (ConfigRouteTest, NonIntegerReportsType) {
 
 TEST_F (ConfigRouteTest, InvalidValueDoesNotPersist) {
     auto before = db_->get_config_entry ("workers");
-    ASSERT_TRUE (before.has_value ());
+    ASSERT_HAS_VALUE (before);
 
     vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"999"}})");
 
     auto after = db_->get_config_entry ("workers");
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->value, before->value); // rejected update left the DB untouched
 }
 
@@ -120,7 +121,7 @@ TEST_F (ConfigRouteTest, ValidUpdateSucceedsAndPersists) {
     EXPECT_TRUE (body["success"].get<bool> ());
 
     auto stored = db_->get_config_entry ("workers");
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->value, "4");
 }
 
@@ -131,7 +132,7 @@ TEST_F (ConfigRouteTest, SingleUpdateFormatSucceeds) {
     EXPECT_TRUE (body["success"].get<bool> ());
 
     auto stored = db_->get_config_entry ("workers");
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->value, "8");
 }
 
@@ -192,11 +193,11 @@ TEST_F (ConfigRouteTest, EnumUpdateAcceptsValidOption) {
     EXPECT_TRUE (body["success"].get<bool> ());
 
     auto stored = db_->get_config_entry ("defaultHttpVersion");
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->value, "http2");
     // save_config_entry replaces the whole row, so a value-only update must not
     // drop the option list - without it the entry becomes unrenderable.
-    ASSERT_TRUE (stored->options.has_value ());
+    ASSERT_HAS_VALUE (stored->options);
     EXPECT_EQ (nlohmann::json::parse (*stored->options).size (),
     vayu::all_http_versions ().size ());
 }
@@ -207,7 +208,7 @@ TEST_F (ConfigRouteTest, MalformedOptionsOmitsTheKeyInsteadOfFailingTheWholeList
     // entire GET /config payload - an unguarded parse here would 500 the whole
     // settings screen.
     auto entry = db_->get_config_entry ("defaultHttpVersion");
-    ASSERT_TRUE (entry.has_value ());
+    ASSERT_HAS_VALUE (entry);
     entry->options = "{not valid json";
     db_->save_config_entry (*entry);
 
@@ -231,8 +232,8 @@ TEST_F (ConfigRouteTest, MalformedOptionsOmitsTheKeyInsteadOfFailingTheWholeList
 // domain source production is supposed to consult.
 TEST_F (ConfigRouteTest, SeededDefaultHttpVersionOptionsMatchAllHttpVersionsInOrder) {
     auto entry = db_->get_config_entry ("defaultHttpVersion");
-    ASSERT_TRUE (entry.has_value ());
-    ASSERT_TRUE (entry->options.has_value ());
+    ASSERT_HAS_VALUE (entry);
+    ASSERT_HAS_VALUE (entry->options);
 
     json options         = json::parse (*entry->options);
     const auto& versions = vayu::all_http_versions ();
@@ -537,7 +538,7 @@ TEST_F (ConfigRouteTest, SeededUnitsCoverEveryKeyWhoseNameNamesOne) {
             continue;
         }
         ++checked;
-        ASSERT_TRUE (entry.unit.has_value ())
+        ASSERT_HAS_VALUE (entry.unit)
         << "entry '" << entry.key << "' names its unit in its key and declares "
         << "none, so the input renders a bare number";
         EXPECT_EQ (*entry.unit, expected) << "entry '" << entry.key << "'";
@@ -600,11 +601,11 @@ TEST_F (ConfigRouteTest, UpdatingAValueKeepsItsMetadataFlags) {
     ASSERT_EQ (status, 200);
 
     auto stored = db_->get_config_entry ("dbBusyTimeout");
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->value, "20000");
     EXPECT_TRUE (stored->requires_restart);
     EXPECT_TRUE (stored->advanced);
-    ASSERT_TRUE (stored->unit.has_value ());
+    ASSERT_HAS_VALUE (stored->unit);
     EXPECT_EQ (*stored->unit, "ms");
 
     json entry = find_entry (body, "dbBusyTimeout");
@@ -661,7 +662,7 @@ TEST_F (ConfigRouteTest, TheRetiredDatabaseCategoryIsGoneAndItsEntriesAreInCore)
 
     for (const char* key : { "dbCacheSize", "dbBusyTimeout", "dbSynchronous" }) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         EXPECT_EQ (entry->category, "general_engine") << key;
     }
 }
@@ -697,7 +698,7 @@ TEST_F (ConfigRouteTest, TheAuditedEntriesSitOnTheShelfThatCoversThem) {
 
     for (const auto& [key, category] : placed) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         EXPECT_EQ (entry->category, category) << key;
     }
 }
@@ -742,7 +743,7 @@ TEST_F (ConfigRouteTest, MovedEntriesStayFindableByTheWordsTheyAreSoughtWith) {
 
     for (const auto& [key, terms] : sought) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
 
         std::string haystack =
         lowered (entry->key + " " + entry->label + " " + entry->description);

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -25,6 +25,7 @@
 
 #include <httplib.h>
 
+#include "optional_assert.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/cookie_jar.hpp"
 #include "vayu/runtime/script_engine.hpp"
@@ -144,7 +145,7 @@ std::string send_in_scope (CookieJar& jar, const std::string& scope, const std::
 TEST (CookieJarParse, ReadsEveryFieldOfALine) {
     auto cookie = parse_cookie_line (netscape_line (
     ".example.com", "TRUE", "/app", "TRUE", "1700000001", "session", "abc"));
-    ASSERT_TRUE (cookie.has_value ());
+    ASSERT_HAS_VALUE (cookie);
     EXPECT_EQ (cookie->domain, ".example.com");
     EXPECT_TRUE (cookie->include_subdomains);
     EXPECT_EQ (cookie->path, "/app");
@@ -158,7 +159,7 @@ TEST (CookieJarParse, ReadsEveryFieldOfALine) {
 TEST (CookieJarParse, TheHttpOnlyPrefixIsAFlagAndNotPartOfTheDomain) {
     auto cookie = parse_cookie_line ("#HttpOnly_" +
     netscape_line ("example.com", "FALSE", "/", "FALSE", "0", "session", "abc"));
-    ASSERT_TRUE (cookie.has_value ());
+    ASSERT_HAS_VALUE (cookie);
     EXPECT_TRUE (cookie->http_only);
     EXPECT_EQ (cookie->domain, "example.com")
     << "the marker leaked into the domain";
@@ -169,12 +170,12 @@ TEST (CookieJarParse, KeepsAnEmptyValueAndAValueWithAnEquals) {
     // value is what a server writes to delete one.
     auto padded = parse_cookie_line (
     netscape_line ("example.com", "FALSE", "/", "FALSE", "0", "t", "YWJj=="));
-    ASSERT_TRUE (padded.has_value ());
+    ASSERT_HAS_VALUE (padded);
     EXPECT_EQ (padded->value, "YWJj==");
 
     auto empty = parse_cookie_line (
     netscape_line ("example.com", "FALSE", "/", "FALSE", "0", "t", ""));
-    ASSERT_TRUE (empty.has_value ());
+    ASSERT_HAS_VALUE (empty);
     EXPECT_EQ (empty->value, "");
 }
 
@@ -287,8 +288,9 @@ TEST (CookieJarStore, SnapshotNamesTheScopeAndSkipsEmptyOnes) {
     ASSERT_EQ (scopes.size (), 2u);
     // Ordered by scope key, so the no-environment jar (empty key) comes first.
     EXPECT_FALSE (scopes[0].environment_id.has_value ());
-    ASSERT_TRUE (scopes[1].environment_id.has_value ());
-    EXPECT_EQ (*scopes[1].environment_id, "env_a");
+    const auto& scoped = scopes[1].environment_id;
+    ASSERT_HAS_VALUE (scoped);
+    EXPECT_EQ (*scoped, "env_a");
     EXPECT_EQ (scopes[1].cookies.size (), 1u);
 }
 
@@ -817,8 +819,9 @@ TEST (CookieJarWrite, ClearEmptiesOnlyThisEnvironmentsJar) {
     const auto scopes = jar.snapshot ();
     ASSERT_EQ (scopes.size (), 1u)
     << "clear() reached beyond its own environment";
-    ASSERT_TRUE (scopes[0].environment_id.has_value ());
-    EXPECT_EQ (*scopes[0].environment_id, "env_b");
+    const auto& survivor = scopes[0].environment_id;
+    ASSERT_HAS_VALUE (survivor);
+    EXPECT_EQ (*survivor, "env_b");
 }
 
 TEST (CookieJarWrite, AWrittenCookieDoesNotCrossAnEnvironmentBoundary) {
@@ -966,7 +969,7 @@ TEST (CookieJarWriteValue, ADefaultedCookieTakesItsDomainAndPathFromTheUrl) {
     const auto defaulted =
     vayu::http::cookie_for_url ("https://api.example.com/v1/orders/42",
     JarCookie{ "", false, "", false, false, 0, "session", "abc" });
-    ASSERT_TRUE (defaulted.has_value ());
+    ASSERT_HAS_VALUE (defaulted);
     EXPECT_EQ (defaulted->domain, "api.example.com");
     EXPECT_FALSE (defaulted->include_subdomains)
     << "a defaulted domain is host-only, as a Set-Cookie without Domain is";
@@ -977,14 +980,14 @@ TEST (CookieJarWriteValue, ADefaultedCookieTakesItsDomainAndPathFromTheUrl) {
     const auto explicit_domain =
     vayu::http::cookie_for_url ("https://api.example.com/",
     JarCookie{ ".example.com", false, "/", false, false, 0, "session", "abc" });
-    ASSERT_TRUE (explicit_domain.has_value ());
+    ASSERT_HAS_VALUE (explicit_domain);
     EXPECT_TRUE (explicit_domain->include_subdomains);
 
     // A round trip through the line is the point of formatting one: a written
     // cookie and a received one must be the same kind of thing.
     const auto round_tripped =
     parse_cookie_line (vayu::http::format_cookie_line (*defaulted));
-    ASSERT_TRUE (round_tripped.has_value ());
+    ASSERT_HAS_VALUE (round_tripped);
     EXPECT_EQ (round_tripped->domain, "api.example.com");
     EXPECT_EQ (round_tripped->path, "/v1/orders");
     EXPECT_EQ (round_tripped->value, "abc");
@@ -1057,8 +1060,16 @@ TEST (CookieJarRoute, AbsentScopeClearsEverythingAndAnEmptyOneClearsOnlyTheNoEnv
     auto cleared = vayu::http::routes::clear_cookies_response (
     jar, std::optional<std::string> (std::string (NO_ENVIRONMENT_SCOPE)));
     EXPECT_EQ (cleared["cleared"], 1u);
-    ASSERT_EQ (jar.snapshot ().size (), 1u) << "the environment's jar went too";
-    EXPECT_EQ (*jar.snapshot ()[0].environment_id, "env_a");
+    const auto remaining = jar.snapshot ();
+    ASSERT_EQ (remaining.size (), 1u) << "the environment's jar went too";
+    // Guarded rather than read straight through: were the wrong jar cleared,
+    // the surviving scope would be the no-environment one and this read would
+    // be undefined, so the regression would crash the suite instead of naming
+    // itself here.
+    const auto& kept = remaining[0].environment_id;
+    ASSERT_HAS_VALUE (kept)
+    << "the no-environment jar survived instead of env_a's";
+    EXPECT_EQ (*kept, "env_a");
 
     cleared = vayu::http::routes::clear_cookies_response (jar, std::nullopt);
     EXPECT_EQ (cleared["cleared"], 1u);

--- a/engine/tests/curl_transfer_test.cpp
+++ b/engine/tests/curl_transfer_test.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <vector>
 
+#include "optional_assert.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/event_loop/curl_utils.hpp"
@@ -80,7 +81,7 @@ class MethodEchoServer {
         return "http://127.0.0.1:" + std::to_string (port) + path;
     }
 
-    static constexpr size_t kBigBodyBytes = 256 * 1024;
+    static constexpr size_t kBigBodyBytes = size_t{ 256 } * 1024;
 
     httplib::Server svr;
     std::thread thread;
@@ -467,8 +468,7 @@ TEST (AddToMulti, RejectedHandleIsReportedRatherThanDiscarded) {
     EXPECT_FALSE (vayu::http::detail::add_to_multi (multi, easy).has_value ());
 
     auto rejected = vayu::http::detail::add_to_multi (multi, easy);
-    ASSERT_TRUE (rejected.has_value ())
-    << "a rejected add must not look like success";
+    ASSERT_HAS_VALUE (rejected) << "a rejected add must not look like success";
     EXPECT_EQ (rejected->code, vayu::ErrorCode::InternalError);
     EXPECT_NE (rejected->message.find ("Failed to submit transfer"), std::string::npos);
 

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "optional_assert.hpp"
 #include "vayu/http/client.hpp"
 
 namespace vayu::http {
@@ -30,14 +31,14 @@ namespace {
 /// Larger than curl's 16 KiB write buffer so a progress report has to be made
 /// of several calls rather than one - a single-call report would pass a test
 /// that only checked the final count.
-constexpr size_t SIZED_BYTES = 256 * 1024;
-constexpr size_t CHUNK_BYTES = 8 * 1024;
+constexpr size_t SIZED_BYTES = size_t{ 256 } * 1024;
+constexpr size_t CHUNK_BYTES = size_t{ 8 } * 1024;
 
 /// `/dribbles` sends this much, in these pieces, ~120ms apart - so the whole
 /// transfer runs well past any stall window short enough to test with, while
 /// never actually stalling.
-constexpr size_t DRIBBLE_CHUNK = 4 * 1024;
-constexpr size_t DRIBBLE_BYTES = 40 * 1024;
+constexpr size_t DRIBBLE_CHUNK = size_t{ 4 } * 1024;
+constexpr size_t DRIBBLE_BYTES = size_t{ 40 } * 1024;
 static_assert ((DRIBBLE_BYTES / DRIBBLE_CHUNK) * 120 > 300,
 "the dribble must outlast the 300ms total bound the tests set, or they prove "
 "nothing");
@@ -514,7 +515,7 @@ TEST_F (HttpClientTest, ReportsTheDeclaredTotalWhenTheServerDeclaresOne) {
     ASSERT_FALSE (ticks.empty ());
     // Content-Length arrives before the first body byte, so every tick has it.
     for (const auto& tick : ticks) {
-        ASSERT_TRUE (tick.total.has_value ());
+        ASSERT_HAS_VALUE (tick.total);
         EXPECT_EQ (*tick.total, SIZED_BYTES);
     }
 }

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
@@ -243,7 +244,7 @@ class InboxListenerTest : public ::testing::Test {
     /// Edit a seeded config row the way a user would through POST /config.
     void set_config (const char* key, int64_t value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = std::to_string (value);
         db_->save_config_entry (*entry);
     }
@@ -355,7 +356,7 @@ TEST_F (InboxListenerTest, StopFreesTheListenerAndKeepsTheHistory) {
     EXPECT_FALSE (manager_->stop ("inbox_nope"));
 
     auto after = manager_->get (started.info.inbox_id);
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_FALSE (after->running);
     // Stopping is not deleting: the captures are still listable.
     EXPECT_EQ (db_->count_inbox_requests (started.info.inbox_id), 1);
@@ -382,7 +383,7 @@ TEST_F (InboxListenerTest, DeleteFreesTheListenerAndTakesTheCapturesWithIt) {
     // A running inbox is stopped rather than refused: one call, because the
     // caller's intent is "make it gone".
     const auto deleted = manager_->remove (*db_, started.info.inbox_id);
-    ASSERT_TRUE (deleted.has_value ());
+    ASSERT_HAS_VALUE (deleted);
     EXPECT_EQ (*deleted, 2);
 
     EXPECT_FALSE (manager_->get (started.info.inbox_id).has_value ());
@@ -423,7 +424,7 @@ TEST_F (InboxListenerTest, DeleteTakesOnlyItsOwnInboxsCaptures) {
 TEST_F (InboxListenerTest, DeleteLeavesAnAttachedLiveStreamNothingToStrand) {
     auto started     = start ();
     const auto claim = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (claim.has_value ());
+    ASSERT_HAS_VALUE (claim);
 
     ASSERT_TRUE (manager_->remove (*db_, started.info.inbox_id).has_value ());
 
@@ -482,12 +483,12 @@ TEST_F (InboxListenerTest, TearsDownCleanlyWithAListenerStillRunning) {
 TEST_F (InboxListenerTest, OneLiveStreamPerInbox) {
     auto started     = start ();
     const auto claim = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (claim.has_value ());
+    ASSERT_HAS_VALUE (claim);
     EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ())
     << "a second watcher would park a second pool thread on the same inbox";
     manager_->release_live (started.info.inbox_id, *claim);
     const auto second = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (second.has_value ());
+    ASSERT_HAS_VALUE (second);
     EXPECT_NE (*second, *claim)
     << "a reused token would let a stale holder act on it";
     EXPECT_FALSE (manager_->try_claim_live ("inbox_nope").has_value ());
@@ -501,7 +502,7 @@ TEST_F (InboxListenerTest, AWritingStreamKeepsItsClaimPastTheStaleWindow) {
     // must not read as a dead holder here or the test is flaky by design.
     auto started     = start ();
     const auto claim = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (claim.has_value ());
+    ASSERT_HAS_VALUE (claim);
 
     const auto deadline = std::chrono::steady_clock::now () +
     std::chrono::milliseconds (inbox_constants::LIVE_POLL_INTERVAL_MS * 4);
@@ -520,7 +521,7 @@ TEST_F (InboxListenerTest, AReconnectTakesOverAClaimThatStoppedWriting) {
     set_config ("inboxLivePollIntervalMs", inbox_constants::MIN_LIVE_POLL_INTERVAL_MS);
     auto started    = start ();
     const auto dead = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (dead.has_value ());
+    ASSERT_HAS_VALUE (dead);
 
     // Immediately after the last write the holder is presumed alive.
     EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ());
@@ -528,7 +529,7 @@ TEST_F (InboxListenerTest, AReconnectTakesOverAClaimThatStoppedWriting) {
     std::this_thread::sleep_for (
     std::chrono::milliseconds (inbox_constants::MIN_LIVE_CLAIM_STALE_MS + 50));
     const auto reconnect = manager_->try_claim_live (started.info.inbox_id);
-    ASSERT_TRUE (reconnect.has_value ())
+    ASSERT_HAS_VALUE (reconnect)
     << "a reconnect met a 409 it cannot recover from";
 
     // The evicted holder learns it lost the slot the next time it writes, and
@@ -555,7 +556,7 @@ TEST_F (InboxListenerTest, SeedsTheThreeLimitsFromTheConstants) {
     for (const char* key :
     { "inboxMaxBodyBytes", "inboxMaxCaptures", "inboxLivePollIntervalMs" }) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         // Services, not Observability: the Dock's word for inboxes, mock
         // servers and issuers, so the settings tree and the drawer name
         // the same group the same way (#586).
@@ -603,17 +604,20 @@ TEST_F (InboxListenerTest, AConfiguredRetentionIsWhatBoundsTheCaptureRing) {
 // a set truncated by a single rule rather than by whatever the setting was at
 // each arrival.
 TEST_F (InboxListenerTest, ARunningInboxKeepsTheLimitsItStartedWith) {
-    auto started = start ();
-    ASSERT_TRUE (manager_->limits (started.info.inbox_id).has_value ());
-    EXPECT_EQ (manager_->limits (started.info.inbox_id)->max_captures,
-    inbox_constants::MAX_CAPTURES);
+    auto started        = start ();
+    const auto at_start = manager_->limits (started.info.inbox_id);
+    ASSERT_HAS_VALUE (at_start);
+    EXPECT_EQ (at_start->max_captures, inbox_constants::MAX_CAPTURES);
 
     set_config ("inboxMaxCaptures", 3);
-    EXPECT_EQ (manager_->limits (started.info.inbox_id)->max_captures,
-    inbox_constants::MAX_CAPTURES);
+    const auto after_the_edit = manager_->limits (started.info.inbox_id);
+    ASSERT_HAS_VALUE (after_the_edit);
+    EXPECT_EQ (after_the_edit->max_captures, inbox_constants::MAX_CAPTURES);
 
-    auto restarted = start ();
-    EXPECT_EQ (manager_->limits (restarted.info.inbox_id)->max_captures, 3);
+    auto restarted           = start ();
+    const auto after_restart = manager_->limits (restarted.info.inbox_id);
+    ASSERT_HAS_VALUE (after_restart);
+    EXPECT_EQ (after_restart->max_captures, 3);
     EXPECT_FALSE (manager_->limits ("inbox_nope").has_value ());
 }
 
@@ -623,7 +627,8 @@ TEST_F (InboxListenerTest, ARunningInboxKeepsTheLimitsItStartedWith) {
 TEST_F (InboxListenerTest, AnOutOfRangeStoredValueFallsBackToItsSeed) {
     set_config ("inboxMaxBodyBytes", 0);
     set_config ("inboxMaxCaptures", -1);
-    set_config ("inboxLivePollIntervalMs", 10 * inbox_constants::MAX_LIVE_POLL_INTERVAL_MS);
+    set_config ("inboxLivePollIntervalMs",
+    int64_t{ 10 } * inbox_constants::MAX_LIVE_POLL_INTERVAL_MS);
 
     const auto limits = vayu::http::read_inbox_limits (*db_);
     EXPECT_EQ (limits.max_body_bytes, inbox_constants::MAX_BODY_BYTES);
@@ -762,7 +767,7 @@ TEST_F (InboxStorageTest, TheWireShapeCarriesWhatTheInboxIsHolding) {
     // Read back from the manager, as every route does: the count is filled in
     // from the database rather than carried on the record.
     auto info = manager.get (inbox_id);
-    ASSERT_TRUE (info.has_value ());
+    ASSERT_HAS_VALUE (info);
     EXPECT_EQ (vayu::http::routes::inbox_json (*db_, *info)["captureCount"], 3);
 }
 

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -11,6 +11,8 @@
 #include <thread>
 #include <vector>
 
+#include "optional_assert.hpp"
+
 using namespace vayu::core;
 
 class MetricsCollectorTest : public ::testing::Test {
@@ -237,8 +239,8 @@ TEST_F (MetricsCollectorTest, SampleWindowSafeUnderConcurrentWriters) {
     // Sample repeatedly from this (single reader) thread while writers run.
     while (!stop.load ()) {
         (void)collector->sample_window_percentiles ();
-        bool all_done = collector->total_requests () >=
-        static_cast<size_t> (kThreads * kPerThread);
+        bool all_done =
+        collector->total_requests () >= static_cast<size_t> (kThreads) * kPerThread;
         if (all_done)
             stop.store (true);
     }
@@ -1033,7 +1035,7 @@ TEST_F (MetricsCollectorTest, PhaseValuesLandInTheirOwnHistogram) {
     }
 
     auto phases = collector->phase_percentiles ();
-    ASSERT_TRUE (phases.has_value ());
+    ASSERT_HAS_VALUE (phases);
 
     constexpr double tolerance = 1.0;
     EXPECT_NEAR ((*phases)[kDns].p50, 1.0, tolerance);
@@ -1068,7 +1070,7 @@ TEST_F (MetricsCollectorTest, PhasePercentilesSeparateTailFromBody) {
     }
 
     auto phases = collector->phase_percentiles ();
-    ASSERT_TRUE (phases.has_value ());
+    ASSERT_HAS_VALUE (phases);
 
     // A zero p50 is the truthful reading of "most requests did no handshake" -
     // it must not be mistaken for a dropped record, which is why zeros are
@@ -1130,9 +1132,9 @@ TEST_F (MetricsCollectorTest, PhaseHistogramsSafeUnderConcurrentWriters) {
     }
 
     auto phases = collector->phase_percentiles ();
-    ASSERT_TRUE (phases.has_value ());
+    ASSERT_HAS_VALUE (phases);
     for (const auto& phase : *phases) {
-        EXPECT_EQ (phase.count, static_cast<size_t> (kThreads * kPerThread));
+        EXPECT_EQ (phase.count, static_cast<size_t> (kThreads) * kPerThread);
     }
 }
 
@@ -1153,7 +1155,7 @@ TEST_F (MetricsCollectorTest, StreamTotalsSumEventsAndCountCappedSeparately) {
     collector->record_stream_completion (30, false);
 
     auto totals = collector->stream_totals ();
-    ASSERT_TRUE (totals.has_value ());
+    ASSERT_HAS_VALUE (totals);
     EXPECT_EQ (totals->completions, 3u);
     EXPECT_EQ (totals->total_events, 60u);
     // The server ended one of them, so it is not among the capped - which is
@@ -1172,7 +1174,7 @@ TEST_F (MetricsCollectorTest, StreamTotalsCountAnEmptyStreamAsACompletion) {
     collector->record_stream_completion (0, false);
 
     auto totals = collector->stream_totals ();
-    ASSERT_TRUE (totals.has_value ());
+    ASSERT_HAS_VALUE (totals);
     EXPECT_EQ (totals->completions, 1u);
     EXPECT_EQ (totals->total_events, 0u);
 }

--- a/engine/tests/openapi_document_test.cpp
+++ b/engine/tests/openapi_document_test.cpp
@@ -40,6 +40,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/openapi_document.hpp"
 #include "vayu/core/schema_validation.hpp"
@@ -55,7 +56,7 @@ using vayu::core::read_document;
 
 /// A cap no case here is trying to reach - the schema index's own limit is
 /// exercised by the one case that names it.
-constexpr size_t INDEX_CAP = 1024 * 1024;
+constexpr size_t INDEX_CAP = size_t{ 1024 } * 1024;
 
 nlohmann::ordered_json read_ok (const std::string& text) {
     const auto result = read_document (text);
@@ -364,7 +365,7 @@ TEST (DeriveSpecIndexes, StoresWhatTheDocumentDeclares) {
     // And what is stored reads back as what a run measures against - the two
     // halves of the column, held to each other.
     const auto parsed = vayu::core::parse_declared_operations (index.operations);
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     ASSERT_EQ (parsed->size (), 1U);
     EXPECT_EQ ((*parsed)[0].operation_id, "listPets");
     EXPECT_EQ ((*parsed)[0].responses, (std::vector<std::string>{ "200" }));
@@ -799,8 +800,7 @@ TEST (DeriveSpecIndexes, TheDerivedIndexIsWhatValidationThenReads) {
     ASSERT_TRUE (index.ok ()) << index.error;
 
     const auto parsed = vayu::core::ResponseSchemaIndex::parse (index.response_schemas);
-    ASSERT_TRUE (parsed.has_value ())
-    << "the engine's own index must parse back";
+    ASSERT_HAS_VALUE (parsed) << "the engine's own index must parse back";
     const auto verdict =
     parsed->check (R"({"operationId":"getPet","method":"GET","path":"/pets/{petId}"})",
     200, "application/json", R"({"name":null})");

--- a/engine/tests/optional_assert.hpp
+++ b/engine/tests/optional_assert.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/optional_assert.hpp
+ * @brief `ASSERT_HAS_VALUE` - the engaged-optional assertion that
+ *        `bugprone-unchecked-optional-access` can follow (issue #980).
+ *
+ * `ASSERT_TRUE (opt.has_value ())` guards the reads after it perfectly well at
+ * run time: the macro returns from the test body when it fails, so nothing
+ * below it executes on an empty optional. The check cannot see that. gtest
+ * routes the condition through an `::testing::AssertionResult`, and the
+ * dataflow model behind the check follows `has_value ()` only into a branch
+ * condition - so every read guarded that way is reported as unchecked, which
+ * is where 561 of `engine/tests`' findings came from (#980).
+ *
+ * The three spellings that look like they would fix it do not. Measured on
+ * clang-tidy 19.1.1 - the version floor `engine/.clang-tidy` sets - each of
+ * `ASSERT_TRUE (opt.has_value ()) << "why"`, `ASSERT_NE (opt, std::nullopt)`
+ * and `.value ()` still reports the read below it. (`.value ()` throws rather
+ * than reading an empty optional, so it is not *unsafe*; it is simply not a
+ * guard the check accepts, and `utils/invariant.hpp` says the same.)
+ *
+ * What the model does follow is a plain `if` whose failing branch cannot fall
+ * through - which `FAIL ()` is, because it expands to a `return`. This macro
+ * is that `if`, written once so a test body stays one line per assertion. The
+ * guard stays gtest's: the failure is reported at the call site, names the
+ * expression, and stops the test body the way a fatal assertion must.
+ *
+ * Reach for it wherever a test reads an optional it has just asserted engaged.
+ * It is not a way past the check. An optional the code under test may
+ * legitimately leave empty is still *tested* - `EXPECT_FALSE (opt.has_value
+ * ())`, or an `if` over both outcomes - and a read with no guard at all is the
+ * defect the check exists to find, not a site for this.
+ */
+
+#include <gtest/gtest.h>
+
+/**
+ * @brief Fail the current test unless @p optional_expression holds a value,
+ *        and leave the reads after it visible to the optional check as guarded.
+ *
+ * Streams like any gtest assertion:
+ * `ASSERT_HAS_VALUE (row) << "after the second write";`.
+ *
+ * @p optional_expression is evaluated once, so the guarded reads below must
+ * name the same expression - and, per `engine/CLAUDE.md`, should name a
+ * *binding* rather than re-derive a subscript or a call, since two spellings of
+ * one value are two expressions to the check and to the next reader alike.
+ *
+ * `GTEST_AMBIGUOUS_ELSE_BLOCKER_` is gtest's own guard against
+ * `if (x) ASSERT_HAS_VALUE (o); else ...` binding that `else` to this macro's
+ * `if`; it is used here rather than copied so this assertion keeps whatever
+ * gtest's does. The empty then-branch is `{}` rather than gtest's `;` because
+ * `bugprone-suspicious-semicolon` reads the latter as a mistake.
+ */
+#define ASSERT_HAS_VALUE(optional_expression) \
+    GTEST_AMBIGUOUS_ELSE_BLOCKER_             \
+    if ((optional_expression).has_value ()) { \
+    } else                                    \
+        FAIL () << "expected " #optional_expression " to hold a value. "

--- a/engine/tests/optional_assert_test.cpp
+++ b/engine/tests/optional_assert_test.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/optional_assert_test.cpp
+ * @brief What `ASSERT_HAS_VALUE` promises a test that uses it (issue #980).
+ *
+ * The property that made the macro necessary - that
+ * `bugprone-unchecked-optional-access` accepts the guard it writes - is a lint
+ * result and cannot be asserted from inside the suite; `optional_assert.hpp`
+ * records how it was measured. What a running test *can* pin is the half a
+ * caller depends on: that an empty optional stops the test body fatally, that
+ * the failure names the expression it was given, and that a caller's own
+ * message survives. Those are what a future rewrite of the macro would break
+ * silently.
+ */
+
+#include <optional>
+#include <string>
+
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+
+#include "optional_assert.hpp"
+
+namespace {
+
+// Free functions rather than locals: `EXPECT_FATAL_FAILURE` runs its statement
+// in a class of its own, which cannot reach the enclosing test body's variables.
+
+std::optional<std::string> empty_row () {
+    return std::nullopt;
+}
+
+std::optional<std::string> filled_row () {
+    return std::string ("row");
+}
+
+} // namespace
+
+TEST (OptionalAssert, LetsTheTestReadTheValueItAsserted) {
+    const std::optional<std::string> row = filled_row ();
+    ASSERT_HAS_VALUE (row);
+    EXPECT_EQ (*row, "row");
+}
+
+TEST (OptionalAssert, AnEmptyOptionalIsAFatalFailureNamingTheExpression) {
+    EXPECT_FATAL_FAILURE (
+    ASSERT_HAS_VALUE (empty_row ()), "expected empty_row () to hold a value");
+}
+
+TEST (OptionalAssert, TheCallersOwnMessageReachesTheFailure) {
+    EXPECT_FATAL_FAILURE (
+    ASSERT_HAS_VALUE (empty_row ()) << "after the second write", "after the second write");
+}
+
+TEST (OptionalAssert, AnEngagedOptionalRaisesNothing) {
+    EXPECT_NONFATAL_FAILURE (
+    {
+        ASSERT_HAS_VALUE (filled_row ());
+        ADD_FAILURE () << "the body continued";
+    },
+    "the body continued");
+}

--- a/engine/tests/send_with_row_test.cpp
+++ b/engine/tests/send_with_row_test.cpp
@@ -51,6 +51,7 @@
 #include <nlohmann/json.hpp>
 
 #include "echo_server.hpp"
+#include "optional_assert.hpp"
 #include "vayu/core/scenario_data.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/cookie_jar.hpp"
@@ -72,7 +73,7 @@ using vayu::http::routes::read_stream_flag;
 using vayu::http::routes::read_transient_flag;
 
 /// The engine's seeded `maxScenarioDataBytes`, as the route resolves it.
-constexpr size_t kDataBytes = 16 * 1024 * 1024;
+constexpr size_t kDataBytes = size_t{ 16 } * 1024 * 1024;
 
 // --- read_data_row -----------------------------------------------------------
 
@@ -92,7 +93,7 @@ TEST (ReadDataRow, ObjectIsTheRow) {
     auto row = read_data_row (
     json{ { "data", { { "id", "7" }, { "email", "a@b.c" } } } }, kDataBytes);
     ASSERT_TRUE (row.ok);
-    ASSERT_TRUE (row.value.has_value ());
+    ASSERT_HAS_VALUE (row.value);
     EXPECT_EQ ((*row.value)["id"], "7");
     EXPECT_EQ ((*row.value)["email"], "a@b.c");
 }
@@ -400,7 +401,7 @@ TEST_F (SendWithRowTest, BasicCredentialsBindBeforeTheyAreEncoded) {
     const std::string header = server_->header ("Authorization");
     ASSERT_EQ (header.rfind ("Basic ", 0), 0u) << header;
     const auto decoded = vayu::utils::base64_decode (header.substr (6));
-    ASSERT_TRUE (decoded.has_value ()) << header;
+    ASSERT_HAS_VALUE (decoded) << header;
     // A colon in the password is why this decodes rather than string-matches:
     // the base64 is of `user:pass` joined, and the row is allowed to contain
     // the separator.


### PR DESCRIPTION
## Description

Wave 1 batch 2 of #928's paydown, first slice: the `engine/tests` half of
`bugprone-unchecked-optional-access` that #943 left standing when it closed on
`engine/src` alone. **95 findings across eight files**, plus **nine of the ten
wave-2 widening leftovers** #944 parked - all nine happen to live in files this
batch opens anyway, which is what #944 and #943 both asked for.

**The plan.** The root cause is not 561 unsafe reads: it is one blind spot.
`ASSERT_TRUE (opt.has_value ())` guards the reads under it perfectly well at run
time - the macro returns from the test body on failure - and the check cannot
see it, because gtest routes the condition through an
`::testing::AssertionResult` and the dataflow model follows `has_value ()` only
into a branch condition. So the approach is to re-express that guard in the one
form the model does follow - a plain `if` whose failing branch cannot fall
through, which `FAIL ()` is - written once as `ASSERT_HAS_VALUE`
(`tests/optional_assert.hpp`), so a test body stays one line per assertion and
the failure stays gtest's: located at the call site, naming the expression,
streamable. **The alternative I rejected** was turning the check off for
`engine/tests` in `tests/.clang-tidy`, the way `readability-function-cognitive-complexity`
is turned off there. It would have been one line and it is wrong: two of these
95 findings are reads nothing had guarded at all, and those are exactly what the
check exists to find. Silencing the family would have taken the false negatives
with the false positives. Per-site `NOLINT` was rejected for the reason
`utils/invariant.hpp` already records - it records nothing about why.

**Three spellings that look like they would fix this do not**, measured on
clang-tidy 19.1.1 (the floor `engine/.clang-tidy` sets): `ASSERT_TRUE (...) << "why"`,
`ASSERT_NE (opt, std::nullopt)` and `.value ()` are each still reported on the
read below them. That measurement is in the header, next to the macro, so the
next person does not redo it.

### Category tally

| | Count |
|---|---|
| Guard the check cannot read (gtest's fatal assertion) | 89 |
| Guard and use written as two expressions | 4 |
| **Read with no guard at all** - undefined on the test's own failure path | **2** |
| Silenced with a `NOLINT` | 0 |
| **Total** | **95** |

The two unguarded reads are the wave-1 discipline's category 1, in the form it
takes inside a test: not a crash a user can reach, but a *regression that would
be undefined behaviour instead of a named failure*.

- `cookie_jar_test.cpp` read `*jar.snapshot ()[0].environment_id` off a
  temporary nothing had checked. Had `clear_cookies_response` cleared the wrong
  jar, the surviving scope would be the no-environment one and this read would
  be undefined - so the regression the test exists to catch would have taken the
  suite process out rather than named itself.
- `inbox_test.cpp` read a *second* inbox's limits through
  `manager_->limits (restarted...)->max_captures`, a call nothing asserted; the
  `ASSERT_TRUE` above it covered a different inbox's call.

Both now bind and guard. **Neither gets a defect record under #928**: the engine
code they exercise is correct, and what was wrong was the test's failure path.
That distinction is worth carrying into the remaining batches - in `engine/src` a
category-1 finding is a latent crash in production; in `engine/tests` it is a
test that crashes instead of failing.

The four two-expression sites (`cookie_jar_test.cpp` ×2, `inbox_test.cpp` ×2)
read through one binding now, per `engine/CLAUDE.md`'s existing rule.

### The measurement

`bugprone-*` on the decided config over all 113 `engine/tests` translation units,
before and after:

| Check | Before | After |
|---|---|---|
| `bugprone-unchecked-optional-access` | 561 | **466** |
| `bugprone-implicit-widening-of-multiplication-result` | 9 | **1** |
| `bugprone-misplaced-widening-cast` | 1 | **0** |

**The 561 reproduced exactly** - so unlike batch 1 of #945, this family's total
is trustworthy. Its *per-file* column is not, by ±1: `inbox_test.cpp` measured
21 against the issue's 22 and `metrics_collector_test.cpp` 19 against 20, while
the total still landed on 561. Worth knowing before #946's closing re-measure.

Per file cleared:

| File | optional-access | wave-2 leftover |
|---|---|---|
| `cookie_jar_test.cpp` | 23 | - |
| `config_route_test.cpp` | 22 | - |
| `inbox_test.cpp` | 21 | 1 implicit-widening |
| `metrics_collector_test.cpp` | 19 | 1 misplaced-widening-cast |
| `openapi_document_test.cpp` | 4 | 1 implicit-widening |
| `send_with_row_test.cpp` | 3 | 1 implicit-widening |
| `curl_transfer_test.cpp` | 2 | 1 implicit-widening |
| `http_client_test.cpp` | 1 | 4 implicit-widening |
| **Total** | **95** | **9** |

`bugprone-misplaced-widening-cast` reaches **zero tree-wide** with this. The one
implicit-widening leftover still standing is `db_test.cpp:976` (was `:973`),
whose 47 optional findings put that file in a later batch - taking it here would
have meant opening the largest file in the wave for one line.

### Two deliberate deviations, both small

- `metrics_collector_test.cpp:1134` casts `kThreads * kPerThread` to `size_t`
  the same way the flagged leftover at :241 did, and is *not* reported, because
  it sits inside an `EXPECT_EQ` rather than a comparison the check inspects.
  Fixed alongside its twin rather than leaving one file with two spellings of
  the same thing.
- `config_route_test.cpp:540` is an `ASSERT_TRUE (entry.unit.has_value ())` the
  check does not report (the read is inside a loop the model gives up on).
  Converted too, so the file does not keep one instance of the idiom this batch
  is retiring.

### Still open on #980 after this

466 findings across 46 files, and one wave-2 leftover in `db_test.cpp`. The
per-file table above is now measured rather than inherited, and I have posted it
to the issue for whoever takes batch 2b.

One item for the **last** batch of this wave, noted on the issue: a source scan
in the shape of `tests/reentrant_test.cpp`, naming any test file that brings
the `ASSERT_TRUE (o.has_value ())` spelling back. It cannot be turned on until
every file is converted - the CI gate scopes to changed lines, so nothing holds
this at zero once these lines stop being new - which is exactly the argument
#945 batch 1 made for its own family.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
```

**2394 tests, 2394 passed, 0 failed** (2390 before; the four new ones are
`optional_assert_test.cpp`).

Lint, reproduced the way #945 batch 2 said to - each changed translation unit
linted in full under the repo config, not through `clang-tidy-diff`:

- **Zero `bugprone-*` findings** in all nine changed TUs.
- The other findings those files still carry (`cppcoreguidelines-special-member-functions`,
  `-owning-memory`, `-pro-bounds-array-to-pointer-decay`, `performance-*`,
  `modernize-avoid-c-arrays`, `readability-math-missing-parentheses`) belong to
  #945 batch 3 and #946 and sit on lines this diff does not touch, so the
  changed-lines gate is clean. They are pre-existing on the base commit and are
  not touched here.
- `tests/optional_assert.hpp` was linted **directly**, since CI lints translation
  units and never a header: no findings.
- `clang-format-19 --dry-run -Werror` clean over `engine/{src,include,tests}`.

The macro's runtime promises are mutation-checked: changing the `FAIL ()` message
so it no longer names the expression makes
`OptionalAssert.AnEmptyOptionalIsAFatalFailureNamingTheExpression` fail, and only
that one; restoring it returns 4/4. The guard property itself is a lint result
and cannot be asserted from inside the suite - it is the 95 → 0 measurement
above, and the header records how it was taken.

Environment note: this run installed `clang-tidy-19` / `clang-format-19`, which
were not present (only 18, which rejects `engine/.clang-tidy` outright).

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`engine/CLAUDE.md`'s optional bullet gains the test-side rule beside the
`invariant_value` one, because a contributor who writes
`ASSERT_TRUE (opt.has_value ())` in a new test will be failed by CI and needs to
find the answer where the existing optional rules live.

## Related Issues

Part of #980 (batch 2a of the `engine/tests` half); does not close it - 466
findings remain. Under #928.