### PR TITLE
test(engine): clear the optional-access findings in the six largest test files (#980 batch 2b)

### DIFF
--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -504,7 +504,7 @@ TEST_F (DatabaseTest, SeedBackfillsOptionsOnUpgradeWithoutLosingUserValue) {
 
     auto after = db.get_config_entry ("defaultHttpVersion");
     ASSERT_HAS_VALUE (after);
-    EXPECT_EQ (after->value, "http2");         // user's value preserved
+    EXPECT_EQ (after->value, "http2"); // user's value preserved
     ASSERT_HAS_VALUE (after->options); // metadata backfilled
     EXPECT_EQ (*after->options, *seeded->options);
 }

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
@@ -57,7 +58,7 @@ TEST_F (DatabaseTest, CreatesAndRetrievesRun) {
     db.create_run (run);
 
     auto retrieved = db.get_run ("run_1");
-    ASSERT_TRUE (retrieved.has_value ());
+    ASSERT_HAS_VALUE (retrieved);
     EXPECT_EQ (retrieved->id, "run_1");
     EXPECT_EQ (retrieved->type, vayu::RunType::Load);
     EXPECT_EQ (retrieved->status, vayu::RunStatus::Pending);
@@ -78,7 +79,7 @@ TEST_F (DatabaseTest, UpdatesRunStatus) {
     db.update_run_status ("run_1", vayu::RunStatus::Completed);
 
     auto retrieved = db.get_run ("run_1");
-    ASSERT_TRUE (retrieved.has_value ());
+    ASSERT_HAS_VALUE (retrieved);
     EXPECT_EQ (retrieved->status, vayu::RunStatus::Completed);
 }
 
@@ -133,7 +134,7 @@ TEST_F (DatabaseTest, SavesAndRetrievesGlobals) {
     db.save_globals (globals);
 
     auto retrieved = db.get_globals ();
-    ASSERT_TRUE (retrieved.has_value ());
+    ASSERT_HAS_VALUE (retrieved);
     EXPECT_EQ (retrieved->id, "globals");
     EXPECT_EQ (retrieved->variables, globals.variables);
 }
@@ -156,7 +157,7 @@ TEST_F (DatabaseTest, UpdatesExistingGlobals) {
     db.save_globals (globals2);
 
     auto retrieved = db.get_globals ();
-    ASSERT_TRUE (retrieved.has_value ());
+    ASSERT_HAS_VALUE (retrieved);
     EXPECT_EQ (retrieved->variables, globals2.variables);
     EXPECT_EQ (retrieved->updated_at, 2000);
 }
@@ -281,7 +282,7 @@ TEST_F (DatabaseTest, SeedMovesAnEntryOutOfARetiredCategory) {
     db.init ();
 
     auto seeded = db.get_config_entry ("dbCacheSize");
-    ASSERT_TRUE (seeded.has_value ());
+    ASSERT_HAS_VALUE (seeded);
     ASSERT_EQ (seeded->category, "general_engine");
 
     ConfigEntry stale = *seeded;
@@ -290,12 +291,14 @@ TEST_F (DatabaseTest, SeedMovesAnEntryOutOfARetiredCategory) {
     stale.category = "database_performance";
     stale.value    = "33554432";
     db.save_config_entry (stale);
-    ASSERT_EQ (db.get_config_entry ("dbCacheSize")->category, "database_performance");
+    const auto chosen = db.get_config_entry ("dbCacheSize");
+    ASSERT_HAS_VALUE (chosen);
+    ASSERT_EQ (chosen->category, "database_performance");
 
     db.seed_default_config ();
 
     auto migrated = db.get_config_entry ("dbCacheSize");
-    ASSERT_TRUE (migrated.has_value ());
+    ASSERT_HAS_VALUE (migrated);
     EXPECT_EQ (migrated->category, "general_engine");
     EXPECT_EQ (migrated->value, "33554432")
     << "a category move must not reset the value the user stored";
@@ -313,7 +316,7 @@ TEST_F (DatabaseTest, SeedRehomesAnAuditedEntryWithoutResettingItsValue) {
     db.init ();
 
     auto seeded = db.get_config_entry ("oauth2RefreshLeadMs");
-    ASSERT_TRUE (seeded.has_value ());
+    ASSERT_HAS_VALUE (seeded);
     ASSERT_EQ (seeded->category, "services");
 
     ConfigEntry stale = *seeded;
@@ -324,7 +327,7 @@ TEST_F (DatabaseTest, SeedRehomesAnAuditedEntryWithoutResettingItsValue) {
     db.seed_default_config ();
 
     auto migrated = db.get_config_entry ("oauth2RefreshLeadMs");
-    ASSERT_TRUE (migrated.has_value ());
+    ASSERT_HAS_VALUE (migrated);
     EXPECT_EQ (migrated->category, "services");
     EXPECT_EQ (migrated->value, "120000")
     << "a category move must not reset the value the user stored";
@@ -381,7 +384,7 @@ TEST_F (DatabaseTest, CacheSizeConfigReachesTheConnection) {
         << "an unconfigured database opens at the compile-time default";
 
         auto entry = db.get_config_entry ("dbCacheSize");
-        ASSERT_TRUE (entry.has_value ()) << "the entry survived the sweep";
+        ASSERT_HAS_VALUE (entry) << "the entry survived the sweep";
         entry->value = std::to_string (kConfigured);
         db.save_config_entry (*entry);
 
@@ -435,7 +438,7 @@ TEST_F (DatabaseTest, SynchronousConfigStillWinsOverTheConstructorDefault) {
         Database db (TEST_DB_PATH);
         db.init ();
         auto entry = db.get_config_entry ("dbSynchronous");
-        ASSERT_TRUE (entry.has_value ());
+        ASSERT_HAS_VALUE (entry);
         entry->value = std::to_string (kConfigured);
         db.save_config_entry (*entry);
     }
@@ -461,7 +464,7 @@ TEST_F (DatabaseTest, ASeedInsideOneTransactionStillPreservesUserValues) {
     << "the seed is the many-row write this test is about";
 
     auto entry = db.get_config_entry ("dbBusyTimeout");
-    ASSERT_TRUE (entry.has_value ());
+    ASSERT_HAS_VALUE (entry);
     entry->value = "12345";
     db.save_config_entry (*entry);
 
@@ -470,7 +473,7 @@ TEST_F (DatabaseTest, ASeedInsideOneTransactionStillPreservesUserValues) {
     EXPECT_EQ (db.get_all_config_entries ().size (), seeded)
     << "a re-seed neither adds nor drops rows";
     auto preserved = db.get_config_entry ("dbBusyTimeout");
-    ASSERT_TRUE (preserved.has_value ());
+    ASSERT_HAS_VALUE (preserved);
     EXPECT_EQ (preserved->value, "12345")
     << "the seed keeps a user's value and only refreshes metadata";
 }
@@ -486,21 +489,23 @@ TEST_F (DatabaseTest, SeedBackfillsOptionsOnUpgradeWithoutLosingUserValue) {
     db.init ();
 
     auto seeded = db.get_config_entry ("defaultHttpVersion");
-    ASSERT_TRUE (seeded.has_value ());
-    ASSERT_TRUE (seeded->options.has_value ());
+    ASSERT_HAS_VALUE (seeded);
+    ASSERT_HAS_VALUE (seeded->options);
 
     ConfigEntry upgraded_row = *seeded;
     upgraded_row.value       = "http2";  // user's choice, must survive re-seed
     upgraded_row.options = std::nullopt; // pre-Task-4 row never had this column
     db.save_config_entry (upgraded_row);
-    ASSERT_FALSE (db.get_config_entry ("defaultHttpVersion")->options.has_value ());
+    const auto downgraded = db.get_config_entry ("defaultHttpVersion");
+    ASSERT_HAS_VALUE (downgraded);
+    ASSERT_FALSE (downgraded->options.has_value ());
 
     db.seed_default_config ();
 
     auto after = db.get_config_entry ("defaultHttpVersion");
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->value, "http2");         // user's value preserved
-    ASSERT_TRUE (after->options.has_value ()); // metadata backfilled
+    ASSERT_HAS_VALUE (after->options); // metadata backfilled
     EXPECT_EQ (*after->options, *seeded->options);
 }
 
@@ -910,7 +915,7 @@ TEST_F (DatabaseTest, DropsTheLegacyMetricsTableFromAPreUpgradeDatabase) {
 
         // Everything the run still owns is served normally after the drop.
         auto run = db.get_run ("run_pre_upgrade");
-        ASSERT_TRUE (run.has_value ());
+        ASSERT_HAS_VALUE (run);
         EXPECT_EQ (run->status, vayu::RunStatus::Completed);
         EXPECT_EQ (db.count_metric_ticks ("run_pre_upgrade"), 1);
     }
@@ -973,7 +978,7 @@ TEST_F (DatabaseTest, PruneRunsByCountKeepsMostRecentAndCascades) {
 
     // Five terminal runs, oldest first by start_time.
     for (int i = 1; i <= 5; ++i) {
-        seed_run_with_children (db, "run_" + std::to_string (i), i * 1000);
+        seed_run_with_children (db, "run_" + std::to_string (i), int64_t{ i } * 1000);
     }
 
     // Keep the 2 most-recent; age cap disabled.
@@ -1276,12 +1281,12 @@ TEST_F (DatabaseTest, SetRunBaselineTogglesAndPersists) {
         seed_run_with_children (db, "run_1", recent);
 
         auto stored = db.get_run ("run_1");
-        ASSERT_TRUE (stored.has_value ());
+        ASSERT_HAS_VALUE (stored);
         EXPECT_FALSE (stored->baseline)
         << "a run is not a baseline until pinned";
 
         auto pinned = db.set_run_baseline ("run_1", true);
-        ASSERT_TRUE (pinned.has_value ());
+        ASSERT_HAS_VALUE (pinned);
         EXPECT_TRUE (pinned->baseline);
         // The whole row comes back, not just the flag - the route answers with it.
         EXPECT_EQ (pinned->id, "run_1");
@@ -1291,13 +1296,15 @@ TEST_F (DatabaseTest, SetRunBaselineTogglesAndPersists) {
     Database db (TEST_DB_PATH);
     db.init ();
     auto reopened = db.get_run ("run_1");
-    ASSERT_TRUE (reopened.has_value ());
+    ASSERT_HAS_VALUE (reopened);
     EXPECT_TRUE (reopened->baseline);
 
     auto unpinned = db.set_run_baseline ("run_1", false);
-    ASSERT_TRUE (unpinned.has_value ());
+    ASSERT_HAS_VALUE (unpinned);
     EXPECT_FALSE (unpinned->baseline);
-    EXPECT_FALSE (db.get_run ("run_1")->baseline);
+    const auto unpinned_row = db.get_run ("run_1");
+    ASSERT_HAS_VALUE (unpinned_row);
+    EXPECT_FALSE (unpinned_row->baseline);
 }
 
 TEST_F (DatabaseTest, SetRunBaselineOnAMissingRunReportsNothingStored) {
@@ -1358,7 +1365,7 @@ TEST_F (DatabaseTest, RunsStoredBeforeTheBaselineColumnReadAsUnpinned) {
     Database db (TEST_DB_PATH);
     db.init ();
     auto legacy = db.get_run ("legacy");
-    ASSERT_TRUE (legacy.has_value ()) << "an older database no longer opens";
+    ASSERT_HAS_VALUE (legacy) << "an older database no longer opens";
     EXPECT_FALSE (legacy->baseline);
 }
 
@@ -1455,7 +1462,7 @@ TEST_F (DatabaseTest, ReconcileKeepsTheEndTimeTheRunAlreadyRecorded) {
     db.init ();
 
     auto run = db.get_run ("half_written");
-    ASSERT_TRUE (run.has_value ());
+    ASSERT_HAS_VALUE (run);
     EXPECT_EQ (run->status, vayu::RunStatus::Failed);
     EXPECT_EQ (run->end_time, RECORDED_END);
 }
@@ -1482,7 +1489,7 @@ TEST_F (DatabaseTest, ReconcileLeavesNoIndeterminateEndTimeOnAnUnseededRun) {
     db.init ();
 
     auto run = db.get_run ("unseeded");
-    ASSERT_TRUE (run.has_value ());
+    ASSERT_HAS_VALUE (run);
     EXPECT_EQ (run->status, vayu::RunStatus::Failed);
     // 0 is the "no end recorded" sentinel every reader guards on; anything
     // between 1 and start_time would be garbage posing as a real timestamp.
@@ -1582,13 +1589,13 @@ TEST_F (DatabaseTest, RunSummaryRoundTrips) {
     // A fresh run has no summary - that emptiness is what the report route
     // reads as "fall back to the legacy metrics rows".
     auto before = db.get_run ("run_1");
-    ASSERT_TRUE (before.has_value ());
+    ASSERT_HAS_VALUE (before);
     EXPECT_TRUE (before->summary.empty ());
 
     db.update_run_summary ("run_1", R"({"total_requests":42})");
 
     auto after = db.get_run ("run_1");
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->summary, R"({"total_requests":42})");
     // Writing the summary must not disturb the rest of the row.
     EXPECT_EQ (after->status, vayu::RunStatus::Completed);

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -37,6 +37,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -134,13 +135,15 @@ TEST_F (ImportApplyRouteTest, WiresANestedTreeThroughRealIds) {
     const std::string req_id   = response["idMap"]["r1"];
 
     auto stored_child = db_->get_collection (child_id);
-    ASSERT_TRUE (stored_child.has_value ());
-    ASSERT_TRUE (stored_child->parent_id.has_value ());
+    ASSERT_HAS_VALUE (stored_child);
+    ASSERT_HAS_VALUE (stored_child->parent_id);
     EXPECT_EQ (*stored_child->parent_id, root_id);
-    EXPECT_FALSE (db_->get_collection (root_id)->parent_id.has_value ());
+    const auto stored_collection = db_->get_collection (root_id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_FALSE (stored_collection->parent_id.has_value ());
 
     auto stored_request = db_->get_request (req_id);
-    ASSERT_TRUE (stored_request.has_value ());
+    ASSERT_HAS_VALUE (stored_request);
     EXPECT_EQ (stored_request->collection_id, child_id);
     EXPECT_EQ (db_->get_requests_in_collection (child_id).size (), 1u);
 }
@@ -159,13 +162,13 @@ TEST_F (ImportApplyRouteTest, AppliesTheSameFieldDefaultsAsPerItemCreate) {
     ASSERT_EQ (status, 200) << response.dump ();
 
     auto stored_collection = db_->get_collection (response["idMap"]["c1"]);
-    ASSERT_TRUE (stored_collection.has_value ());
+    ASSERT_HAS_VALUE (stored_collection);
     EXPECT_EQ (stored_collection->auth, R"({"mode":"none"})"); // collection default
     EXPECT_EQ (json::parse (stored_collection->variables)["base"]["value"], "1");
     EXPECT_EQ (stored_collection->description, "");
 
     auto stored_request = db_->get_request (response["idMap"]["r1"]);
-    ASSERT_TRUE (stored_request.has_value ());
+    ASSERT_HAS_VALUE (stored_request);
     EXPECT_EQ (stored_request->auth, R"({"mode":"inherit"})"); // request default
     EXPECT_EQ (stored_request->params, "[]");
     EXPECT_EQ (stored_request->headers, "[]");
@@ -184,9 +187,15 @@ TEST_F (ImportApplyRouteTest, AppendsSiblingsInPayloadOrderWhenOrderIsOmitted) {
     collection_item ("c3", "c") }) } });
     ASSERT_EQ (status, 200) << response.dump ();
 
-    EXPECT_EQ (db_->get_collection (response["idMap"]["c1"])->order, 0);
-    EXPECT_EQ (db_->get_collection (response["idMap"]["c2"])->order, 1);
-    EXPECT_EQ (db_->get_collection (response["idMap"]["c3"])->order, 2);
+    const auto first_row = db_->get_collection (response["idMap"]["c1"]);
+    ASSERT_HAS_VALUE (first_row);
+    EXPECT_EQ (first_row->order, 0);
+    const auto second_row = db_->get_collection (response["idMap"]["c2"]);
+    ASSERT_HAS_VALUE (second_row);
+    EXPECT_EQ (second_row->order, 1);
+    const auto third_row = db_->get_collection (response["idMap"]["c3"]);
+    ASSERT_HAS_VALUE (third_row);
+    EXPECT_EQ (third_row->order, 2);
 }
 
 TEST_F (ImportApplyRouteTest, AnExplicitOrderIsHonoured) {
@@ -195,19 +204,25 @@ TEST_F (ImportApplyRouteTest, AnExplicitOrderIsHonoured) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ first }) } });
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_collection (response["idMap"]["c1"])->order, 7);
+    const auto stored_collection = db_->get_collection (response["idMap"]["c1"]);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->order, 7);
 }
 
 TEST_F (ImportApplyRouteTest, AppendsAfterCollectionsThatAlreadyExist) {
     auto [existing_status, existing] =
     create_collection_response (*db_, json{ { "name", "already here" } });
     ASSERT_EQ (existing_status, 200) << existing.dump ();
-    ASSERT_EQ (db_->get_collection (existing["id"])->order, 0);
+    const auto existing_row = db_->get_collection (existing["id"]);
+    ASSERT_HAS_VALUE (existing_row);
+    ASSERT_EQ (existing_row->order, 0);
 
     auto [status, response] = import_apply_response (*db_,
     json{ { "collections", json::array ({ collection_item ("c1", "new") }) } });
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_collection (response["idMap"]["c1"])->order, 1);
+    const auto imported_row = db_->get_collection (response["idMap"]["c1"]);
+    ASSERT_HAS_VALUE (imported_row);
+    EXPECT_EQ (imported_row->order, 1);
 }
 
 TEST_F (ImportApplyRouteTest, WritesNothingWhenOneItemIsInvalid) {
@@ -441,7 +456,7 @@ TEST_F (ImportApplyRouteTest, CarriesADeclaredDataContractThroughTheSharedApplie
     import_apply_response (*db_, json{ { "collections", json::array ({ good }) } });
     ASSERT_EQ (status, 200) << response.dump ();
     auto stored = db_->get_collection (response["idMap"]["c1"]);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (json::parse (stored->data_schema)["columns"],
     json::array ({ "id", "email" }));
 

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -204,9 +204,9 @@ TEST_F (ImportApplyRouteTest, AnExplicitOrderIsHonoured) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ first }) } });
     ASSERT_EQ (status, 200) << response.dump ();
-    const auto stored_collection = db_->get_collection (response["idMap"]["c1"]);
-    ASSERT_HAS_VALUE (stored_collection);
-    EXPECT_EQ (stored_collection->order, 7);
+    const auto row = db_->get_collection (response["idMap"]["c1"]);
+    ASSERT_HAS_VALUE (row);
+    EXPECT_EQ (row->order, 7);
 }
 
 TEST_F (ImportApplyRouteTest, AppendsAfterCollectionsThatAlreadyExist) {

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -51,6 +51,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -133,7 +134,7 @@ class ReorderRouteTest : public ::testing::Test {
      */
     void set_collection_position (const std::string& id, int order, int64_t created_at) {
         auto row = db_->get_collection (id);
-        ASSERT_TRUE (row.has_value ());
+        ASSERT_HAS_VALUE (row);
         row->order      = order;
         row->created_at = created_at;
         db_->create_collection (*row);
@@ -142,7 +143,7 @@ class ReorderRouteTest : public ::testing::Test {
     /** Forces a row to a stored `order`, bypassing the routes - the legacy shape. */
     void set_request_order (const std::string& id, int order) {
         auto row = db_->get_request (id);
-        ASSERT_TRUE (row.has_value ());
+        ASSERT_HAS_VALUE (row);
         row->order = order;
         db_->save_request (*row);
     }
@@ -242,7 +243,9 @@ TEST_F (ReorderRouteTest, RejectsAMoveIntoACollectionThatDoesNotExist) {
     EXPECT_NE (
     response["error"]["message"].get<std::string> ().find ("col_gone"), std::string::npos);
     // The row stays where it was rather than being stranded under a missing owner.
-    EXPECT_EQ (db_->get_request (a)->collection_id, col);
+    const auto stored_request = db_->get_request (a);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->collection_id, col);
 }
 
 TEST_F (ReorderRouteTest, RejectsTwoPositionsForOneRow) {
@@ -305,8 +308,12 @@ TEST_F (ReorderRouteTest, RejectsACycleFormedOnlyByTheBatchAsAWhole) {
     auto [status, response] = reorder_response (*db_, body);
 
     ASSERT_EQ (status, 400) << response.dump ();
-    EXPECT_FALSE (db_->get_collection (a)->parent_id.has_value ());
-    EXPECT_FALSE (db_->get_collection (b)->parent_id.has_value ());
+    const auto a_row = db_->get_collection (a);
+    ASSERT_HAS_VALUE (a_row);
+    EXPECT_FALSE (a_row->parent_id.has_value ());
+    const auto b_row = db_->get_collection (b);
+    ASSERT_HAS_VALUE (b_row);
+    EXPECT_FALSE (b_row->parent_id.has_value ());
 }
 
 TEST_F (ReorderRouteTest, RejectsASelfParentAndAMoveIntoOwnDescendant) {
@@ -324,7 +331,9 @@ TEST_F (ReorderRouteTest, RejectsASelfParentAndAMoveIntoOwnDescendant) {
     json::array ({ json{ { "type", "collection" }, { "id", parent },
     { "order", 0 }, { "parentId", child } } }) } });
     EXPECT_EQ (desc_status, 400) << desc_body.dump ();
-    EXPECT_FALSE (db_->get_collection (parent)->parent_id.has_value ());
+    const auto stored_collection = db_->get_collection (parent);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_FALSE (stored_collection->parent_id.has_value ());
 }
 
 TEST_F (ReorderRouteTest, AcceptsAReparentThatBreaksAnExistingChain) {
@@ -340,8 +349,14 @@ TEST_F (ReorderRouteTest, AcceptsAReparentThatBreaksAnExistingChain) {
     auto [status, response] = reorder_response (*db_, body);
 
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (*db_->get_collection (leaf)->parent_id, root);
-    EXPECT_EQ (*db_->get_collection (mid)->parent_id, leaf);
+    const auto leaf_row = db_->get_collection (leaf);
+    ASSERT_HAS_VALUE (leaf_row);
+    ASSERT_HAS_VALUE (leaf_row->parent_id);
+    EXPECT_EQ (*leaf_row->parent_id, root);
+    const auto mid_row = db_->get_collection (mid);
+    ASSERT_HAS_VALUE (mid_row);
+    ASSERT_HAS_VALUE (mid_row->parent_id);
+    EXPECT_EQ (*mid_row->parent_id, leaf);
 }
 
 // ---------------------------------------------------------------------------
@@ -424,10 +439,16 @@ TEST_F (ReorderRouteTest, NormalizesTheRootCollectionsWhenParentIdIsNull) {
     json::array ({ json{ { "type", "collection" }, { "parentId", nullptr } } }) } });
 
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_collection (a)->order, 0);
-    EXPECT_EQ (db_->get_collection (b)->order, 1);
+    const auto a_row = db_->get_collection (a);
+    ASSERT_HAS_VALUE (a_row);
+    EXPECT_EQ (a_row->order, 0);
+    const auto b_row = db_->get_collection (b);
+    ASSERT_HAS_VALUE (b_row);
+    EXPECT_EQ (b_row->order, 1);
     // A nested collection is in a different scope and must be left alone.
-    EXPECT_EQ (db_->get_collection (child)->order, 0);
+    const auto child_row = db_->get_collection (child);
+    ASSERT_HAS_VALUE (child_row);
+    EXPECT_EQ (child_row->order, 0);
 }
 
 /**
@@ -453,8 +474,12 @@ TEST_F (ReorderRouteTest, NormalizesTiedRootsInStoredOrderNotCreationOrder) {
     json::array ({ json{ { "type", "collection" }, { "parentId", nullptr } } }) } });
 
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_collection (b)->order, 0);
-    EXPECT_EQ (db_->get_collection (a)->order, 1);
+    const auto b_row = db_->get_collection (b);
+    ASSERT_HAS_VALUE (b_row);
+    EXPECT_EQ (b_row->order, 0);
+    const auto a_row = db_->get_collection (a);
+    ASSERT_HAS_VALUE (a_row);
+    EXPECT_EQ (a_row->order, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -505,8 +530,10 @@ TEST_F (ReorderRouteTest, AMoveWithoutAnOwnerKeepsTheOneItHas) {
     *db_, json{ { "moves", json::array ({ move_request (a, 7) }) } });
 
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_request (a)->collection_id, col);
-    EXPECT_EQ (db_->get_request (a)->order, 7);
+    const auto a_row = db_->get_request (a);
+    ASSERT_HAS_VALUE (a_row);
+    EXPECT_EQ (a_row->collection_id, col);
+    EXPECT_EQ (a_row->order, 7);
 }
 
 TEST_F (ReorderRouteTest, AnEmptyBatchIsANoOp) {
@@ -535,7 +562,9 @@ TEST_F (ReorderRouteTest, TheResponseCarriesTheRowsAsWritten) {
     for (const auto& row : response["requests"]) {
         ASSERT_TRUE (row.contains ("id")) << row.dump ();
         EXPECT_EQ (row["collectionId"].get<std::string> (), col);
-        EXPECT_EQ (row["order"].get<int> (), db_->get_request (row["id"])->order);
+        const auto stored_request = db_->get_request (row["id"]);
+        ASSERT_HAS_VALUE (stored_request);
+        EXPECT_EQ (row["order"].get<int> (), stored_request->order);
     }
 }
 
@@ -622,8 +651,12 @@ TEST_F (ReorderRouteTest, AConflictingBatchWaitsAndIsRejectedAgainstTheCommitted
     other.join ();
 
     EXPECT_EQ (other_status, 400) << other_body.dump ();
-    EXPECT_EQ (db_->get_collection (a)->parent_id, std::optional<std::string> (b));
-    EXPECT_FALSE (db_->get_collection (b)->parent_id.has_value ());
+    const auto a_row = db_->get_collection (a);
+    ASSERT_HAS_VALUE (a_row);
+    EXPECT_EQ (a_row->parent_id, std::optional<std::string> (b));
+    const auto b_row = db_->get_collection (b);
+    ASSERT_HAS_VALUE (b_row);
+    EXPECT_FALSE (b_row->parent_id.has_value ());
 }
 
 TEST_F (ReorderRouteTest, ACreateDuringABatchWaitsAndAppendsPastTheRenumberedRange) {
@@ -644,7 +677,9 @@ TEST_F (ReorderRouteTest, ACreateDuringABatchWaitsAndAppendsPastTheRenumberedRan
     // The create's append scan reads `max_order + 1`. Let it run inside the
     // batch's window and it reads the pre-renumber rows - every one at 0 - and
     // takes slot 1, tying with the row the batch is renumbering to 1.
-    EXPECT_EQ (db_->get_request (late)->order, 3);
+    const auto stored_request = db_->get_request (late);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->order, 3);
     EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2, 3 }));
     EXPECT_EQ (request_ids (col).back (), late);
 }
@@ -669,7 +704,9 @@ TEST_F (ReorderRouteTest, ARowDeletedAfterStagingFailsTheBatchRatherThanBeingRes
     // `replace` would have written the staged row straight back.
     EXPECT_FALSE (db_->get_request (b).has_value ());
     // And the rows the batch had already updated roll back with it.
-    EXPECT_EQ (db_->get_request (a)->order, 0);
+    const auto stored_request = db_->get_request (a);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->order, 0);
 }
 
 } // namespace

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -48,6 +48,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
@@ -194,7 +195,7 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateOnExistingIdIsRejected) {
     EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
 
     auto stored = db_->get_collection (id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->name, "Original");
 }
 
@@ -206,7 +207,9 @@ TEST_F (ResourceWriteRouteTest, CollectionUpdateRejectsMismatchedBodyId) {
     EXPECT_EQ (status, 400);
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
     std::string::npos);
-    EXPECT_EQ (db_->get_collection (id)->name, "Original")
+    const auto stored_collection = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->name, "Original")
     << "a body id naming another record must not write through the path id";
 }
 
@@ -219,7 +222,9 @@ TEST_F (ResourceWriteRouteTest, CollectionUpdateAcceptsMatchingBodyId) {
     *db_, id, json{ { "id", id }, { "name", "Renamed" } });
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["name"], "Renamed");
-    EXPECT_EQ (db_->get_collection (id)->name, "Renamed");
+    const auto stored_collection = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->name, "Renamed");
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionUpdateRejectsNullBodyId) {
@@ -230,7 +235,9 @@ TEST_F (ResourceWriteRouteTest, CollectionUpdateRejectsNullBodyId) {
     EXPECT_EQ (status, 400);
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
     std::string::npos);
-    EXPECT_EQ (db_->get_collection (id)->name, "Original");
+    const auto stored_collection = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->name, "Original");
 }
 
 TEST_F (ResourceWriteRouteTest, UpdateRejectsBodyIdBeforeLookingTheRecordUp) {
@@ -300,7 +307,9 @@ TEST_F (ResourceWriteRouteTest, CollectionNullNameIsRejected) {
     update_collection_response (*db_, id, json{ { "name", nullptr } });
     EXPECT_EQ (status, 400);
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("name"), std::string::npos);
-    EXPECT_EQ (db_->get_collection (id)->name, "Keep me");
+    const auto stored_collection = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->name, "Keep me");
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionCreateNullMeansDefault) {
@@ -321,7 +330,9 @@ TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
     { "auth", { { "mode", "bearer" }, { "token", "t" } } } })
     .first,
     200);
-    const auto before = *db_->get_collection (id);
+    const auto before_row = db_->get_collection (id);
+    ASSERT_HAS_VALUE (before_row);
+    const auto before = *before_row;
 
     for (const char* field : { "variables", "auth", "dataSchema" }) {
         for (const json& bad : wrong_shapes ()) {
@@ -336,7 +347,9 @@ TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
 
     // The stored blobs are what matters: the old helper returned 200 and wrote
     // the junk, so asserting only the response would pass either way.
-    const auto after = *db_->get_collection (id);
+    const auto after_row = db_->get_collection (id);
+    ASSERT_HAS_VALUE (after_row);
+    const auto after = *after_row;
     EXPECT_EQ (after.variables, before.variables);
     EXPECT_EQ (after.auth, before.auth);
     EXPECT_EQ (after.data_schema, before.data_schema);
@@ -389,7 +402,9 @@ TEST_F (ResourceWriteRouteTest, CollectionDataSchemaRoundTripsAndFollowsTheNullR
     ASSERT_EQ (clear_status, 200);
     EXPECT_TRUE (cleared["dataSchema"].is_object ());
     EXPECT_TRUE (cleared["dataSchema"].empty ());
-    EXPECT_EQ (db_->get_collection (id)->data_schema, "{}");
+    const auto stored_collection = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored_collection);
+    EXPECT_EQ (stored_collection->data_schema, "{}");
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionDataSchemaContentsAreValidated) {
@@ -414,7 +429,9 @@ TEST_F (ResourceWriteRouteTest, CollectionDataSchemaContentsAreValidated) {
         EXPECT_EQ (status, 400) << schema.dump ();
         EXPECT_NE (body["error"]["message"].get<std::string> ().find (names), std::string::npos)
         << body["error"]["message"];
-        EXPECT_EQ (db_->get_collection (id)->data_schema, "{}")
+        const auto stored_collection = db_->get_collection (id);
+        ASSERT_HAS_VALUE (stored_collection);
+        EXPECT_EQ (stored_collection->data_schema, "{}")
         << "a rejected write must store nothing - " << schema.dump ();
     }
 
@@ -474,7 +491,9 @@ TEST_F (ResourceWriteRouteTest, RequestCreateRejectsClientId) {
     { "method", "POST" }, { "url", "https://evil.example" } });
     EXPECT_EQ (status, 400);
     EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
-    EXPECT_EQ (db_->get_request (id)->name, "R");
+    const auto stored_request = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->name, "R");
     EXPECT_EQ (db_->get_requests_in_collection (collection).size (), 1U)
     << "a rejected create must not persist a second row under a generated id";
 }
@@ -488,7 +507,9 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateRejectsMismatchedBodyId) {
     EXPECT_EQ (status, 400);
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
     std::string::npos);
-    EXPECT_EQ (db_->get_request (id)->name, "R");
+    const auto stored_request = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->name, "R");
 }
 
 TEST_F (ResourceWriteRouteTest, RequestCreateRequiresItsNoDefaultFields) {
@@ -595,7 +616,9 @@ TEST_F (ResourceWriteRouteTest, RequestNullNoDefaultFieldIsRejected) {
         EXPECT_NE (body["error"]["message"].get<std::string> ().find (field),
         std::string::npos);
     }
-    EXPECT_EQ (db_->get_request (id)->url, "https://example.com");
+    const auto stored_request = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->url, "https://example.com");
 }
 
 TEST_F (ResourceWriteRouteTest, RequestInvalidMethodIsRejected) {
@@ -627,7 +650,9 @@ TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
                { "auth", { { "mode", "bearer" }, { "token", "t" } } } })
                .first,
     200);
-    const auto before = *db_->get_request (id);
+    const auto before_row = db_->get_request (id);
+    ASSERT_HAS_VALUE (before_row);
+    const auto before = *before_row;
 
     for (const char* field : { "body", "auth" }) {
         for (const json& bad : wrong_shapes ()) {
@@ -639,7 +664,9 @@ TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
         }
     }
 
-    const auto after = *db_->get_request (id);
+    const auto after_row = db_->get_request (id);
+    ASSERT_HAS_VALUE (after_row);
+    const auto after = *after_row;
     EXPECT_EQ (after.body, before.body);
     EXPECT_EQ (after.auth, before.auth)
     << "a stored non-object auth reads back as no auth, and the request goes "
@@ -688,7 +715,9 @@ TEST_F (ResourceWriteRouteTest, RequestCreateAbsentVerifySSLVerifies) {
     ASSERT_EQ (status, 200);
     ASSERT_TRUE (body.contains ("verifySSL"));
     EXPECT_EQ (body["verifySSL"], true);
-    EXPECT_TRUE (db_->get_request (body["id"].get<std::string> ())->verify_ssl);
+    const auto stored_request = db_->get_request (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_TRUE (stored_request->verify_ssl);
 }
 
 TEST_F (ResourceWriteRouteTest, RequestCreateStoresVerifySSLFalse) {
@@ -698,7 +727,9 @@ TEST_F (ResourceWriteRouteTest, RequestCreateStoresVerifySSLFalse) {
              { "url", "https://example.com" }, { "verifySSL", false } });
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["verifySSL"], false);
-    EXPECT_FALSE (db_->get_request (body["id"].get<std::string> ())->verify_ssl);
+    const auto stored_request = db_->get_request (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_FALSE (stored_request->verify_ssl);
 }
 
 TEST_F (ResourceWriteRouteTest, RequestUpdateKeepsVerifySSLWhenAbsent) {
@@ -802,7 +833,9 @@ TEST_F (ResourceWriteRouteTest, RequestCreateValidHttpVersionIsStored) {
              { "url", "https://example.com" }, { "httpVersion", "http1.1" } });
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["httpVersion"], "http1.1");
-    EXPECT_EQ (db_->get_request (body["id"].get<std::string> ())->http_version, "http1.1");
+    const auto stored_request = db_->get_request (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->http_version, "http1.1");
 }
 
 TEST_F (ResourceWriteRouteTest, RequestCreateInvalidHttpVersionIsRejectedAndNotStored) {
@@ -864,7 +897,9 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateNullHttpVersionReReadsGlobalAtWrite
     // vayu::DEFAULT_HTTP_VERSION) produces "http2" here.
     const std::string collection = make_collection ();
     const std::string id         = make_request (collection);
-    ASSERT_EQ (db_->get_request (id)->http_version, "auto");
+    const auto seeded_row = db_->get_request (id);
+    ASSERT_HAS_VALUE (seeded_row);
+    ASSERT_EQ (seeded_row->http_version, "auto");
 
     ASSERT_EQ (
     apply_config_update (*db_, R"({"entries":{"defaultHttpVersion":"http2"}})").first, 200);
@@ -873,7 +908,9 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateNullHttpVersionReReadsGlobalAtWrite
     update_request_response (*db_, id, json{ { "httpVersion", nullptr } });
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["httpVersion"], "http2");
-    EXPECT_EQ (db_->get_request (id)->http_version, "http2");
+    const auto reset_row = db_->get_request (id);
+    ASSERT_HAS_VALUE (reset_row);
+    EXPECT_EQ (reset_row->http_version, "http2");
 }
 
 TEST_F (ResourceWriteRouteTest, RequestUpdateValidHttpVersionIsStored) {
@@ -897,7 +934,9 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateInvalidHttpVersionIsRejectedAndUnch
     const auto message = body["error"]["message"].get<std::string> ();
     EXPECT_NE (message.find ("httpVersion"), std::string::npos);
     EXPECT_NE (message.find ("spdy"), std::string::npos);
-    EXPECT_EQ (db_->get_request (id)->http_version, "http2")
+    const auto stored_request = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->http_version, "http2")
     << "a rejected update must leave the stored value untouched";
 }
 
@@ -931,7 +970,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentCreateRejectsClientId) {
     create_environment_response (*db_, json{ { "id", id }, { "name", "Impostor" } });
     EXPECT_EQ (status, 400);
     EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
-    EXPECT_EQ (db_->get_environment (id)->name, "Original");
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->name, "Original");
     EXPECT_EQ (db_->get_environments ().size (), 1U)
     << "a rejected create must not persist a second row under a generated id";
 }
@@ -947,7 +988,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentUpdateRejectsMismatchedBodyId) {
     EXPECT_EQ (status, 400);
     EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
     std::string::npos);
-    EXPECT_EQ (db_->get_environment (id)->name, "Original");
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->name, "Original");
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentUpdateMissingIsNotFound) {
@@ -974,14 +1017,18 @@ TEST_F (ResourceWriteRouteTest, EnvironmentNullVariablesResetsToEmptyObject) {
     EXPECT_TRUE (body["variables"].empty ());
 
     // The stored blob is `{}`, not the string "null".
-    EXPECT_EQ (db_->get_environment (id)->variables, "{}");
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->variables, "{}");
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentCreateNullVariablesIsEmptyObject) {
     auto [status, body] = create_environment_response (
     *db_, json{ { "name", "Env" }, { "variables", nullptr } });
     ASSERT_EQ (status, 200);
-    EXPECT_EQ (db_->get_environment (body["id"].get<std::string> ())->variables, "{}");
+    const auto stored_environment = db_->get_environment (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->variables, "{}");
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentUpdateHonoursIsActive) {
@@ -997,7 +1044,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentUpdateHonoursIsActive) {
     update_environment_response (*db_, id, json{ { "isActive", false } });
     ASSERT_EQ (status, 200);
     EXPECT_FALSE (body["isActive"].get<bool> ());
-    EXPECT_FALSE (db_->get_environment (id)->is_active);
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_FALSE (stored_environment->is_active);
 }
 
 TEST_F (ResourceWriteRouteTest, ActivatingOverTheRouteDeactivatesThePrevious) {
@@ -1018,8 +1067,12 @@ TEST_F (ResourceWriteRouteTest, ActivatingOverTheRouteDeactivatesThePrevious) {
     update_environment_response (*db_, prod, json{ { "isActive", true } });
     ASSERT_EQ (status, 200);
     EXPECT_TRUE (body["isActive"].get<bool> ());
-    EXPECT_TRUE (db_->get_environment (prod)->is_active);
-    EXPECT_FALSE (db_->get_environment (dev)->is_active);
+    const auto prod_row = db_->get_environment (prod);
+    ASSERT_HAS_VALUE (prod_row);
+    EXPECT_TRUE (prod_row->is_active);
+    const auto dev_row = db_->get_environment (dev);
+    ASSERT_HAS_VALUE (dev_row);
+    EXPECT_FALSE (dev_row->is_active);
 }
 
 TEST_F (ResourceWriteRouteTest, CreatingAnActiveEnvironmentDeactivatesThePrevious) {
@@ -1031,8 +1084,12 @@ TEST_F (ResourceWriteRouteTest, CreatingAnActiveEnvironmentDeactivatesThePreviou
     auto [status, body] = create_environment_response (
     *db_, json{ { "name", "Prod" }, { "isActive", true } });
     ASSERT_EQ (status, 200);
-    EXPECT_TRUE (db_->get_environment (body["id"].get<std::string> ())->is_active);
-    EXPECT_FALSE (db_->get_environment (dev)->is_active);
+    const auto stored_environment = db_->get_environment (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_TRUE (stored_environment->is_active);
+    const auto dev_row = db_->get_environment (dev);
+    ASSERT_HAS_VALUE (dev_row);
+    EXPECT_FALSE (dev_row->is_active);
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentUpdateAbsentKeepsVariables) {
@@ -1055,7 +1112,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentWrongShapeVariablesIsRejected) {
     { "variables", { { "token", { { "value", "abc" }, { "enabled", true } } } } } });
     ASSERT_EQ (created_status, 200);
     const std::string id     = created["id"].get<std::string> ();
-    const std::string before = db_->get_environment (id)->variables;
+    const auto before_row = db_->get_environment (id);
+    ASSERT_HAS_VALUE (before_row);
+    const std::string before = before_row->variables;
 
     for (const json& bad : wrong_shapes ()) {
         auto [status, body] =
@@ -1064,7 +1123,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentWrongShapeVariablesIsRejected) {
         EXPECT_NE (
         body["error"]["message"].get<std::string> ().find ("variables"), std::string::npos);
     }
-    EXPECT_EQ (db_->get_environment (id)->variables, before)
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->variables, before)
     << "a rejected write must not reach the column";
 }
 
@@ -1087,7 +1148,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentNullNameIsRejected) {
     auto [status, body] =
     update_environment_response (*db_, id, json{ { "name", nullptr } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (db_->get_environment (id)->name, "Keep me");
+    const auto stored_environment = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored_environment);
+    EXPECT_EQ (stored_environment->name, "Keep me");
 }
 
 } // namespace

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -897,7 +897,7 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateNullHttpVersionReReadsGlobalAtWrite
     // vayu::DEFAULT_HTTP_VERSION) produces "http2" here.
     const std::string collection = make_collection ();
     const std::string id         = make_request (collection);
-    const auto seeded_row = db_->get_request (id);
+    const auto seeded_row        = db_->get_request (id);
     ASSERT_HAS_VALUE (seeded_row);
     ASSERT_EQ (seeded_row->http_version, "auto");
 
@@ -1026,9 +1026,9 @@ TEST_F (ResourceWriteRouteTest, EnvironmentCreateNullVariablesIsEmptyObject) {
     auto [status, body] = create_environment_response (
     *db_, json{ { "name", "Env" }, { "variables", nullptr } });
     ASSERT_EQ (status, 200);
-    const auto stored_environment = db_->get_environment (body["id"].get<std::string> ());
-    ASSERT_HAS_VALUE (stored_environment);
-    EXPECT_EQ (stored_environment->variables, "{}");
+    const auto row = db_->get_environment (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (row);
+    EXPECT_EQ (row->variables, "{}");
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentUpdateHonoursIsActive) {
@@ -1084,9 +1084,9 @@ TEST_F (ResourceWriteRouteTest, CreatingAnActiveEnvironmentDeactivatesThePreviou
     auto [status, body] = create_environment_response (
     *db_, json{ { "name", "Prod" }, { "isActive", true } });
     ASSERT_EQ (status, 200);
-    const auto stored_environment = db_->get_environment (body["id"].get<std::string> ());
-    ASSERT_HAS_VALUE (stored_environment);
-    EXPECT_TRUE (stored_environment->is_active);
+    const auto row = db_->get_environment (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (row);
+    EXPECT_TRUE (row->is_active);
     const auto dev_row = db_->get_environment (dev);
     ASSERT_HAS_VALUE (dev_row);
     EXPECT_FALSE (dev_row->is_active);
@@ -1111,7 +1111,7 @@ TEST_F (ResourceWriteRouteTest, EnvironmentWrongShapeVariablesIsRejected) {
     json{ { "name", "Env" },
     { "variables", { { "token", { { "value", "abc" }, { "enabled", true } } } } } });
     ASSERT_EQ (created_status, 200);
-    const std::string id     = created["id"].get<std::string> ();
+    const std::string id  = created["id"].get<std::string> ();
     const auto before_row = db_->get_environment (id);
     ASSERT_HAS_VALUE (before_row);
     const std::string before = before_row->variables;

--- a/engine/tests/schema_validation_test.cpp
+++ b/engine/tests/schema_validation_test.cpp
@@ -16,6 +16,7 @@
  * guarding line is removed.
  */
 
+#include "optional_assert.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/schema_validation.hpp"
 
@@ -94,7 +95,7 @@ TEST (SchemaValidationPayloadTest, CheckedAlwaysCarriesTheTotal) {
 
 TEST (ResponseSchemaIndexTest, ValidBodyPasses) {
     const auto index = ResponseSchemaIndex::parse (one_operation_index (pet_schema ()));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict =
     index->check (GET_PET, 200, "application/json", R"({"id":1,"name":"Rex"})");
@@ -107,7 +108,7 @@ TEST (ResponseSchemaIndexTest, ValidBodyPasses) {
 
 TEST (ResponseSchemaIndexTest, InvalidBodyFailsAndNamesWhere) {
     const auto index = ResponseSchemaIndex::parse (one_operation_index (pet_schema ()));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict = index->check (GET_PET, 200, "application/json", R"({"id":"one"})");
     EXPECT_TRUE (verdict.checked);
@@ -127,7 +128,7 @@ TEST (ResponseSchemaIndexTest, InvalidBodyFailsAndNamesWhere) {
 
 TEST (ResponseSchemaIndexTest, ContentTypeParametersAreIgnored) {
     const auto index = ResponseSchemaIndex::parse (one_operation_index (pet_schema ()));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict = index->check (
     GET_PET, 200, "application/json; charset=utf-8", R"({"id":1,"name":"Rex"})");
@@ -146,7 +147,7 @@ TEST (ResponseSchemaIndexTest, ExactStatusWinsOverARange) {
     { "schema", json{ { "type", "object" } } } } }) } } });
 
     const auto parsed = ResponseSchemaIndex::parse (index.dump ());
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
 
     // The object passes only if the `200` schema was chosen; the `2XX` one
     // demands a string. Two distinct promises, and 200 answers the specific one.
@@ -159,14 +160,14 @@ TEST (ResponseSchemaIndexTest, ExactStatusWinsOverARange) {
 TEST (ResponseSchemaIndexTest, RangeAndDefaultAnswerWhenNothingExactDoes) {
     const auto ranged =
     ResponseSchemaIndex::parse (one_operation_index (pet_schema (), "2XX"));
-    ASSERT_TRUE (ranged.has_value ());
+    ASSERT_HAS_VALUE (ranged);
     EXPECT_EQ (
     ranged->check (GET_PET, 201, "application/json", R"({"id":1,"name":"a"})").matched_status,
     "2XX");
 
     const auto fallback =
     ResponseSchemaIndex::parse (one_operation_index (pet_schema (), "default"));
-    ASSERT_TRUE (fallback.has_value ());
+    ASSERT_HAS_VALUE (fallback);
     EXPECT_EQ (
     fallback->check (GET_PET, 503, "application/json", R"({"id":1,"name":"a"})").matched_status,
     "default");
@@ -175,7 +176,7 @@ TEST (ResponseSchemaIndexTest, RangeAndDefaultAnswerWhenNothingExactDoes) {
 TEST (ResponseSchemaIndexTest, AWildcardMediaTypeAnswersWhenNothingExactDoes) {
     const auto index =
     ResponseSchemaIndex::parse (one_operation_index (pet_schema (), "200", "*/*"));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict =
     index->check (GET_PET, 200, "application/hal+json", R"({"id":1,"name":"Rex"})");
@@ -185,34 +186,39 @@ TEST (ResponseSchemaIndexTest, AWildcardMediaTypeAnswersWhenNothingExactDoes) {
 
 TEST (ResponseSchemaIndexTest, EveryUncheckableCaseNamesItself) {
     const auto index = ResponseSchemaIndex::parse (one_operation_index (pet_schema ()));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
     const std::string body = R"({"id":1,"name":"Rex"})";
 
     // Not an operation at all.
     auto verdict = index->check ("", 200, "application/json", body);
     EXPECT_FALSE (verdict.checked);
-    ASSERT_TRUE (verdict.reason.has_value ());
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoOperation);
 
     // An identity the document does not declare.
     verdict = index->check (
     R"({"method":"GET","path":"/ghosts"})", 200, "application/json", body);
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::OperationNotDeclared);
 
     // A status nothing covers.
     verdict = index->check (GET_PET, 404, "application/json", body);
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoSchemaForStatus);
 
     // A media type nothing declares.
     verdict = index->check (GET_PET, 200, "text/html", body);
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoSchemaForContentType);
 
     // A transport error is not a status the contract failed to declare.
     verdict = index->check (GET_PET, 0, "", "");
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoResponse);
 
     // A body no JSON Schema can speak about.
     verdict = index->check (GET_PET, 200, "application/json", "<html></html>");
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::BodyNotJson);
 }
 
@@ -220,7 +226,7 @@ TEST (ResponseSchemaIndexTest, IdentityResolvesByOperationIdBeforeMethodAndPath)
     // The path moved and the operationId did not: the document still describes
     // this request, and following the operationId is what says so.
     const auto index = ResponseSchemaIndex::parse (one_operation_index (pet_schema ()));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict =
     index->check (R"({"operationId":"getPet","method":"GET","path":"/v2/pets/{petId}"})",
@@ -245,7 +251,7 @@ TEST (ResponseSchemaIndexTest, OneUnusableRowDoesNotCostTheDocumentItsIndex) {
     { "contentType", "application/json" }, { "schema", pet_schema () } } }) } } });
 
     const auto parsed = ResponseSchemaIndex::parse (index.dump ());
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->size (), 1u);
     EXPECT_TRUE (
     parsed->check (GET_PET, 200, "application/json", R"({"id":1,"name":"a"})").checked);
@@ -263,7 +269,7 @@ TEST (ResponseSchemaRefTest, RefsResolveThroughTheSharedRoots) {
     const auto index     = ResponseSchemaIndex::parse (
     one_operation_index (json::parse (R"({"$ref":"#/components/schemas/Pet"})"),
         "200", "application/json", ref_roots));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     // Nested through two refs - the assertion that reddens if the shared roots
     // stop being merged in, because an unresolvable `$ref` validates nothing.
@@ -286,7 +292,7 @@ TEST (ResponseSchemaRefTest, ARecursiveSchemaTerminates) {
     const auto index     = ResponseSchemaIndex::parse (
     one_operation_index (json::parse (R"({"$ref":"#/components/schemas/Node"})"),
         "200", "application/json", ref_roots));
-    ASSERT_TRUE (index.has_value ());
+    ASSERT_HAS_VALUE (index);
 
     const auto verdict = index->check (GET_PET, 200, "application/json",
     R"({"name":"a","child":{"name":"b","child":{"name":"c"}}})");
@@ -413,7 +419,7 @@ TEST (SchemaValidationBoundsTest, ASchemaTheValidatorRefusesIsUncheckedNotInvali
     schema, json::object (), json::parse (R"({"a":1})"));
 
     EXPECT_FALSE (verdict.checked);
-    ASSERT_TRUE (verdict.reason.has_value ());
+    ASSERT_HAS_VALUE (verdict.reason);
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoIndex);
 }
 

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -31,6 +31,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -235,7 +236,7 @@ TEST_F (SpecsRouteTest, RefusesADocumentOverTheConfiguredCapNamingBothNumbers) {
     // Below the compiled default, so this proves the *live* config entry is what
     // the write reads - not the constant.
     auto entry = db_->get_config_entry ("maxSpecDocumentBytes");
-    ASSERT_TRUE (entry.has_value ())
+    ASSERT_HAS_VALUE (entry)
     << "the cap must be a seeded, user-visible knob";
     entry->value = "64";
     db_->save_config_entry (*entry);
@@ -372,7 +373,7 @@ TEST_F (SpecsRouteTest, DeleteSucceedsOnceTheCollectionUnbinds) {
 TEST_F (SpecsRouteTest, AnUnboundCollectionSerializesAnEmptyBinding) {
     const std::string col_id = create_collection (json{ { "name", "Plain" } });
     auto stored              = db_->get_collection (col_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     const auto serialized = vayu::json::serialize (*stored);
     ASSERT_TRUE (serialized.contains ("openapi"));
     EXPECT_TRUE (serialized["openapi"].is_object ());
@@ -438,8 +439,9 @@ TEST_F (SpecsRouteTest, ABindingWrittenWithoutAVersionIsStampedFromTheStoredDocu
     routes::spec_content_hash (PETSTORE));
     EXPECT_GT (body["openapi"].value ("syncedAt", int64_t{ 0 }), 0);
 
-    const json stored =
-    json::parse (db_->get_collection (body["id"].get<std::string> ())->openapi);
+    const auto row = db_->get_collection (body["id"].get<std::string> ());
+    ASSERT_HAS_VALUE (row) << "the create must have stored the collection it just returned";
+    const json stored = json::parse (row->openapi);
     EXPECT_EQ (stored.value ("specHash", std::string{}), routes::spec_content_hash (PETSTORE))
     << "the response must be the row, not a dressed-up copy of it";
 }
@@ -463,7 +465,9 @@ TEST_F (SpecsRouteTest, AStampFillsWhatIsMissingAndOverwritesNothing) {
     // not quietly "repair" it into agreement with whatever is stored today.
     const std::string col_id = create_collection (json{ { "name", "Pets" },
     { "openapi", { { "specId", spec_id }, { "specHash", "stale-hash" }, { "syncedAt", 42 } } } });
-    const json stored = json::parse (db_->get_collection (col_id)->openapi);
+    const auto row = db_->get_collection (col_id);
+    ASSERT_HAS_VALUE (row);
+    const json stored = json::parse (row->openapi);
     EXPECT_EQ (stored.value ("specHash", std::string{}), "stale-hash");
     EXPECT_EQ (stored.value ("syncedAt", int64_t{ 0 }), 42);
 }
@@ -488,8 +492,10 @@ TEST_F (SpecsRouteTest, StartupStampsAnUnstampedBindingFromTheDocumentItNames) {
     db_->init (); // idempotent, and where the repair pass runs
 
     const auto document = db_->get_spec_document (spec_id);
-    ASSERT_TRUE (document.has_value ());
-    const json stored = json::parse (db_->get_collection ("col_legacy")->openapi);
+    ASSERT_HAS_VALUE (document);
+    const auto legacy_row = db_->get_collection ("col_legacy");
+    ASSERT_HAS_VALUE (legacy_row);
+    const json stored = json::parse (legacy_row->openapi);
     EXPECT_EQ (stored.value ("specHash", std::string{}), document->hash);
     EXPECT_EQ (stored.value ("syncedAt", int64_t{ 0 }), document->fetched_at)
     << "the binding was made when the document was stored, not on this restart";
@@ -497,8 +503,9 @@ TEST_F (SpecsRouteTest, StartupStampsAnUnstampedBindingFromTheDocumentItNames) {
     // And a second start leaves it alone - a repair pass that re-stamped would
     // move `syncedAt` forward on every launch.
     db_->init ();
-    EXPECT_EQ (
-    json::parse (db_->get_collection ("col_legacy")->openapi).value ("syncedAt", int64_t{ 0 }),
+    const auto restarted_row = db_->get_collection ("col_legacy");
+    ASSERT_HAS_VALUE (restarted_row);
+    EXPECT_EQ (json::parse (restarted_row->openapi).value ("syncedAt", int64_t{ 0 }),
     document->fetched_at);
 }
 
@@ -514,7 +521,9 @@ TEST_F (SpecsRouteTest, StartupLeavesABindingWhoseDocumentIsGoneUntouched) {
 
     db_->init ();
 
-    const json stored = json::parse (db_->get_collection ("col_orphan")->openapi);
+    const auto orphan_row = db_->get_collection ("col_orphan");
+    ASSERT_HAS_VALUE (orphan_row);
+    const json stored = json::parse (orphan_row->openapi);
     EXPECT_EQ (stored["specId"].get<std::string> (), "spec_ghost");
     EXPECT_FALSE (stored.contains ("specHash"))
     << "there is nothing to stamp it from, and a run says so already";
@@ -581,7 +590,9 @@ TEST_F (SpecsRouteTest, OperationIdentityIsUnsetByAnExplicitNullOnUpdate) {
     *db_, req_id, json{ { "specOperation", nullptr } });
     ASSERT_EQ (reset, 200) << reset_body.dump ();
     EXPECT_TRUE (reset_body["specOperation"].is_null ());
-    EXPECT_FALSE (db_->get_request (req_id)->spec_operation.has_value ())
+    const auto reset_row = db_->get_request (req_id);
+    ASSERT_HAS_VALUE (reset_row);
+    EXPECT_FALSE (reset_row->spec_operation.has_value ())
     << "the column must be NULL, not the string \"{}\"";
 }
 
@@ -628,14 +639,14 @@ TEST_F (SpecsRouteTest, ImportWritesSpecsAndResolvesABindingThroughTheTempIdMap)
     const auto spec_id = body["idMap"]["s1"].get<std::string> ();
     EXPECT_TRUE (spec_id.starts_with ("spec_"));
     auto stored_spec = db_->get_spec_document (spec_id);
-    ASSERT_TRUE (stored_spec.has_value ());
+    ASSERT_HAS_VALUE (stored_spec);
     EXPECT_EQ (stored_spec->content, PETSTORE);
     // Computed on the import path too, never carried on the payload.
     EXPECT_EQ (stored_spec->hash, routes::spec_content_hash (PETSTORE));
     EXPECT_EQ (stored_spec->source_url.value_or (""), "https://example.test/openapi.json");
 
     auto stored_col = db_->get_collection (body["idMap"]["c1"].get<std::string> ());
-    ASSERT_TRUE (stored_col.has_value ());
+    ASSERT_HAS_VALUE (stored_col);
     const json binding = json::parse (stored_col->openapi);
     EXPECT_EQ (binding["specId"].get<std::string> (), spec_id)
     << "the temp id must have been rewritten to the engine's real id";
@@ -648,8 +659,8 @@ TEST_F (SpecsRouteTest, ImportWritesSpecsAndResolvesABindingThroughTheTempIdMap)
 
     // Operation identity rides the shared applier, so it arrives free.
     auto stored_req = db_->get_request (body["idMap"]["r1"].get<std::string> ());
-    ASSERT_TRUE (stored_req.has_value ());
-    ASSERT_TRUE (stored_req->spec_operation.has_value ());
+    ASSERT_HAS_VALUE (stored_req);
+    ASSERT_HAS_VALUE (stored_req->spec_operation);
     EXPECT_EQ (
     json::parse (*stored_req->spec_operation)["operationId"].get<std::string> (), "listPets");
 }
@@ -662,7 +673,7 @@ TEST_F (SpecsRouteTest, ImportMayBindASpecThatIsAlreadyStored) {
     auto [status, body] = routes::import_apply_response (*db_, payload);
     ASSERT_EQ (status, 200) << body.dump ();
     auto stored = db_->get_collection (body["idMap"]["c1"].get<std::string> ());
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     const json binding = json::parse (stored->openapi);
     EXPECT_EQ (binding["specId"].get<std::string> (), spec_id);
     // Stamped from the stored document, the same as the payload-local case -
@@ -729,7 +740,7 @@ TEST_F (SpecsRouteTest, ABindingWithNoVersionIsNamedRatherThanBlamedOnTheDocumen
 
     const auto resolved = resolve ("col_unstamped");
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    ASSERT_TRUE (resolved.spec.schema_reason.has_value ());
+    ASSERT_HAS_VALUE (resolved.spec.schema_reason);
     EXPECT_EQ (vayu::core::to_string (*resolved.spec.schema_reason), "never_stamped");
 }
 
@@ -1124,7 +1135,7 @@ TEST_F (SpecsRouteTest, TheDesignPathAndTheScenarioPathResolveOneBinding) {
     ASSERT_TRUE (resolved.ok) << resolved.error;
     EXPECT_EQ (resolved.spec.spec_id, nearer_spec)
     << "nearest bound ancestor wins";
-    ASSERT_TRUE (resolved.spec.schema_reason.has_value ());
+    ASSERT_HAS_VALUE (resolved.spec.schema_reason);
     EXPECT_EQ (*resolved.spec.schema_reason, vayu::core::UncheckedReason::HashMismatch);
     EXPECT_TRUE (resolved.spec.declared_operations.empty ())
     << "the root's operations would mean the scenario walk took the wrong "
@@ -1132,7 +1143,7 @@ TEST_F (SpecsRouteTest, TheDesignPathAndTheScenarioPathResolveOneBinding) {
 
     const auto design = routes::resolve_design_schema_index (*db_, req_id);
     EXPECT_TRUE (design.bound);
-    ASSERT_TRUE (design.reason.has_value ())
+    ASSERT_HAS_VALUE (design.reason)
     << "a clean index here means the design walk took the root's binding";
     EXPECT_EQ (*design.reason, *resolved.spec.schema_reason)
     << "the two paths must resolve one binding, or a Send and a run of the "

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -236,8 +236,7 @@ TEST_F (SpecsRouteTest, RefusesADocumentOverTheConfiguredCapNamingBothNumbers) {
     // Below the compiled default, so this proves the *live* config entry is what
     // the write reads - not the constant.
     auto entry = db_->get_config_entry ("maxSpecDocumentBytes");
-    ASSERT_HAS_VALUE (entry)
-    << "the cap must be a seeded, user-visible knob";
+    ASSERT_HAS_VALUE (entry) << "the cap must be a seeded, user-visible knob";
     entry->value = "64";
     db_->save_config_entry (*entry);
     const std::string oversized (128, 'x');
@@ -440,7 +439,8 @@ TEST_F (SpecsRouteTest, ABindingWrittenWithoutAVersionIsStampedFromTheStoredDocu
     EXPECT_GT (body["openapi"].value ("syncedAt", int64_t{ 0 }), 0);
 
     const auto row = db_->get_collection (body["id"].get<std::string> ());
-    ASSERT_HAS_VALUE (row) << "the create must have stored the collection it just returned";
+    ASSERT_HAS_VALUE (row)
+    << "the create must have stored the collection it just returned";
     const json stored = json::parse (row->openapi);
     EXPECT_EQ (stored.value ("specHash", std::string{}), routes::spec_content_hash (PETSTORE))
     << "the response must be the row, not a dressed-up copy of it";
@@ -465,7 +465,7 @@ TEST_F (SpecsRouteTest, AStampFillsWhatIsMissingAndOverwritesNothing) {
     // not quietly "repair" it into agreement with whatever is stored today.
     const std::string col_id = create_collection (json{ { "name", "Pets" },
     { "openapi", { { "specId", spec_id }, { "specHash", "stale-hash" }, { "syncedAt", 42 } } } });
-    const auto row = db_->get_collection (col_id);
+    const auto row           = db_->get_collection (col_id);
     ASSERT_HAS_VALUE (row);
     const json stored = json::parse (row->openapi);
     EXPECT_EQ (stored.value ("specHash", std::string{}), "stale-hash");


### PR DESCRIPTION
## Description

Wave 1 batch 2b of the clang-tidy paydown (#980), picking up exactly where #982 (batch 2a) left off. It takes the six largest files off the post-2a table - `db_test.cpp`, `resource_write_route_test.cpp`, `schema_validation_test.cpp`, `specs_route_test.cpp`, `reorder_route_test.cpp`, `import_apply_route_test.cpp` - and with them the last of the ten wave-2 widening leftovers, which lives in `db_test.cpp` and so came free with its file, as #944 and #943 both asked for.

**Plan (root cause, approach, rejected alternative).** The root cause is not 561 unsafe reads: `ASSERT_TRUE (opt.has_value ())` guards the reads under it perfectly well at run time, and `bugprone-unchecked-optional-access` cannot see it, because gtest routes the condition through an `::testing::AssertionResult` while the dataflow model follows `has_value ()` only into a branch condition. Batch 2a measured that and wrote the answer down as `tests/optional_assert.hpp`'s `ASSERT_HAS_VALUE`, the one `if` the model does follow. So the approach here is the one the wave already established, applied to the next six files, with each finding read rather than swept: 60 guards converted, 64 reads off an unchecked lookup bound and guarded, 7 inner or reassigned optionals given the guard their outer row never covered, zero `NOLINT`s. The alternative I rejected was a value-yielding test helper - something like `stored_row (db_->get_collection (id)).name` - which would have collapsed the 64 binding sites to one line each. It fails loudly only by `ADD_FAILURE` and a default-constructed row, so a missing row would produce a second, confusing comparison failure instead of stopping the test; and it would put a second spelling of "guard an optional in a test" next to the one `engine/CLAUDE.md` documents. Two extra lines per site is the cheaper price.

**The measurement reproduced exactly, per file.** 47, 32, 26, 23, 23, 20 measured against the 47, 32, 26, 23, 23, 20 this issue's batch-2a comment predicted - no ±1 drift this time. `engine/tests` goes 466 -> 295, and all 295 remaining are the single optional check: **`bugprone-implicit-widening-of-multiplication-result` reaches zero tree-wide here**, as `bugprone-misplaced-widening-cast` did in 2a. All ten wave-2 leftovers are now cleared.

**The three shapes, and what "category 1" means in a test file.** 64 of these were reads off a lookup nothing had checked - `db_->get_collection (id)->name` and its kin, almost always reading a row back to prove that a rejected write did not reach the column. Each now binds the lookup and guards the binding, so a vanished row is a named failure at that line rather than undefined behaviour taking the suite process out. Following 2a's finding: **none of these gets a defect record under #928**, because the engine code they exercise is correct and what was wrong was the test's own failure path. The 7 remaining were optionals reached *through* a row that was itself guarded - five reads of `verdict.reason` after `verdict` had been reassigned, two of `parent_id` inside a collection row - where the outer guard says nothing about the inner optional.

Two lookups of the same row a line apart in `reorder_route_test.cpp` collapse into one binding rather than two, and bindings are named for what they hold (`leaf_row`, `existing_row`, `imported_row`), since a numbered `stored_collection2` carries no more than the expression it replaced.

Anchors held: every line the issue named was where it said, and the wave-2 leftover had moved only from `db_test.cpp:973` to `:976`, exactly as the batch-2a comment recorded.

## Type of Change
- [x] Bug fix (test failure paths that were undefined behaviour; no engine behaviour changes)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

All figures below are from the current head, after the formatting commit.

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2394 / 2394 passed, 0 failed** (40s).
- `clang-tidy-19 -p engine/build --checks='-*,bugprone-*,-bugprone-easily-swappable-parameters'` over each of the six files: **0 findings**, from 171 optional-access plus 1 implicit-widening before.
- Tree-wide rescan of all 113 `engine/tests` translation units, deduplicated by (file, line, column, check): **295 findings, every one `bugprone-unchecked-optional-access`** - down from 466, with both widening families at zero.
- `clang-format-19 --style=file --dry-run -Werror` over every `engine/{src,include,tests}` source, which is the command the Engine formatting gate runs: exit 0.
- `pnpm test` (app): **5698 passed, 1 failed** - `src/modules/request-builder/components/UrlBar/send-with-row.test.tsx > opens the list on the row that step bound, without a click`, which timed out at 6.3s under full-suite load and **passes 41/41 when its file is run alone**. This diff touches no file under `app/`, so it is a pre-existing flake rather than anything this branch caused; noted here rather than fixed, per the batch's scope.

The first push (`22f4af5`) failed the Engine formatting gate on nine lines: the new bindings joined existing alignment groups and three crossed the 80-column limit. `b01a134` is `clang-format` over the six files, plus three shorter binding names where the alternative was a wrapped continuation. The miss was a bad local check on my side - it counted lines matching "warning", and `clang-format --dry-run -Werror` says "error" - so the run above is the gate's own command and exit code instead.

Mutation check: reverting any single conversion puts its finding straight back (that is what the per-file re-scan measures), and reverting any of the 64 bindings restores a read of an unchecked optional at that exact line.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no new tests: the macro's own promises are pinned by `optional_assert_test.cpp` from #982, and this batch adds no behaviour to cover. The 2394-test suite is the regression check.
- [x] I have updated documentation - none was owed: `engine/CLAUDE.md` and `tests/optional_assert.hpp` already carry this convention and its measurements from #982, and nothing in `docs/`'s table describes what changed here.

## Deviations from the issue spec

- Measured with the `bugprone-*` family on the decided config as the issue specifies, but this environment ships `clang-tidy-19.1.1` only after an explicit install; the plain `clang-tidy` here is 18, which cannot parse the engine's C++23 (`std::expected`) at all. Numbers above are all 19.1.1, the same version 2a used.

## Related Issues

Refs #980 - deliberately **not** `Closes`. This is batch 2b of the wave, and #980's first acceptance criterion is zero findings over `engine/tests`, re-scanned; 295 remain across 40 files. Auto-closing it here would leave that remainder untracked, which is the exact situation #980 was filed to correct after #943 was closed by a `src`-only PR. #980 stays open and now carries a measured per-file table for batch 2c.

Also refs #982, #943, #944, #928.