### PR TITLE
fix(engine): route character casts through primitives and complete the rule of five - #945 batch 3

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -71,6 +71,42 @@ engine/
   *derived* from another - spell it out and pin the two together with a
   `static_assert`, rather than concatenating before `main`. A test-only
   constant is held to this too: the gate does not read `tests/` differently.
+- **Bytes become characters in one place, never at the site** (#945,
+  `cppcoreguidelines-pro-type-reinterpret-cast`). Reinterpreting a pointer
+  between character types is defined behaviour - [basic.lval] lets any object be
+  read through a `char`, `unsigned char` or `std::byte` lvalue - so a
+  hand-rolled copy *works*, which is exactly why eight of them accumulated. Two
+  primitives own the conversion now and a third owns its inverse:
+  **`vayu::utils::byte_view`** (`utils/encoding.hpp`) for a `std::span` of bytes
+  as the `std::string_view` every encoder here takes - a `sha256` /
+  `hmac_sha256` digest, and the six sites that spelled that themselves;
+  **`vayu::db::column_text`** (`db/database.hpp`) for a sqlite TEXT column,
+  which `sqlite3_column_text` hands back as `const unsigned char*` and nothing
+  consumes as one; and **`vayu::utils::detail::sodium_bytes`**
+  (`utils/sodium_init.hpp`) going the other way, for libsodium. A SQL NULL stays
+  a null pointer through `column_text` on purpose - absent and empty are
+  different answers, and defaulting one to the other erases the distinction its
+  callers read. `tests/character_cast_test.cpp` scans `engine/{src,include,tests}`
+  and names any file spelling one itself, with a per-file exemption list, because
+  the CI gate scopes to a pull request's changed lines and so holds nothing at
+  zero once these lines stop being new. The casts that are *not* this rule - a
+  `sockaddr_in*` off an `addrinfo`, a Windows function pointer off
+  `GetProcAddress` - have no primitive to route through and the scan does not
+  look at them.
+- **A class with a destructor states all five** (#945,
+  `cppcoreguidelines-special-member-functions`). Writing one of the five and
+  leaving the rest implicit is how a fixture that owns a listener and a thread
+  stays copyable: the copy compiles, both objects stop the same server, and
+  nothing says it was not meant to. Every RAII holder here - the `Impl` behind a
+  pImpl, `Database`, and the ~20 in-process mock servers in `tests/` - deletes
+  copy *and* move beside its destructor, in the spelling `client.hpp` uses
+  (`Foo (const Foo&) = delete;` and the three that follow). Deleting is the
+  default answer, not defaulting: none of these is meaningfully movable, and a
+  move would leave a hollow object whose methods still compile. A mock server's
+  thread pool is `vayu::tests::pooled_task_queue`
+  (`tests/task_queue.hpp`) - httplib's `new_task_queue` hook takes a raw owning
+  pointer, which is its contract and not a leak, said once there rather than at
+  each fixture.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -24,6 +24,31 @@
 namespace vayu::db {
 
 /**
+ * @brief A TEXT column's bytes as the `const char*` every caller wants.
+ *
+ * `sqlite3_column_text` answers with `const unsigned char*` and nothing in this
+ * engine consumes one: the value goes straight into a `std::string`, a
+ * `std::string_view` or a parser that reads characters. Eight call sites - the
+ * enum adapters in `database.cpp` and the schema assertions in `db_test.cpp` -
+ * each spelled that conversion themselves, three of them as a C-style cast, and
+ * a copy of a primitive does not receive the primitive's fixes.
+ *
+ * Reading bytes through a character type is what [basic.lval] permits outright,
+ * which is why the cast is a NOLINT rather than a defect - written once here so
+ * nothing has to argue it again.
+ *
+ * A SQL NULL comes back as `nullptr`, exactly as the C API reports it: the
+ * distinction between an absent value and an empty string belongs to the
+ * caller, and defaulting it here would erase it silently.
+ */
+inline const char* column_text (sqlite3_stmt* stmt, int column_index) {
+    // [basic.lval] permits reading any object through a character type; see
+    // the note above for why that makes this a NOLINT and not a defect.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<const char*> (sqlite3_column_text (stmt, column_index));
+}
+
+/**
  * Optional filters for the paginated GET /runs list. An unset field is a
  * wildcard - it does not constrain the query. `q` is a case-insensitive
  * substring matched against the stored `config_snapshot` text (via SQL LIKE);
@@ -125,6 +150,16 @@ class Database {
     public:
     explicit Database (const std::string& db_path);
     ~Database ();
+
+    // Neither copyable nor movable: the handle behind the pImpl owns the open
+    // SQLite connection and the mutex every write is serialized on, and every
+    // holder in the engine keeps it in place (a stack local in `daemon.cpp`, a
+    // `unique_ptr` in the fixtures). A move would leave a hollow instance whose
+    // methods still compile.
+    Database (const Database&)            = delete;
+    Database& operator= (const Database&) = delete;
+    Database (Database&&)                 = delete;
+    Database& operator= (Database&&)      = delete;
 
     // Initialize database (create tables, etc.)
     void init ();

--- a/engine/include/vayu/http/pkce.hpp
+++ b/engine/include/vayu/http/pkce.hpp
@@ -24,8 +24,7 @@ namespace vayu::http::pkce {
  */
 inline std::string code_challenge (const std::string& verifier) {
     const auto hash = vayu::utils::sha256 (verifier);
-    return vayu::utils::base64url_encode (
-    std::string_view (reinterpret_cast<const char*> (hash.data ()), hash.size ()));
+    return vayu::utils::base64url_encode (vayu::utils::byte_view (hash));
 }
 
 /**

--- a/engine/include/vayu/utils/encoding.hpp
+++ b/engine/include/vayu/utils/encoding.hpp
@@ -14,12 +14,35 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 namespace vayu::utils {
+
+/**
+ * @brief Raw bytes as the `std::string_view` this file's encoders take.
+ *
+ * `sha256` and `hmac_sha256` answer with a `std::array<uint8_t, 32>`, and every
+ * encoder here - plus `hmac_sha256` itself, when a digest is the key - reads a
+ * `std::string_view`. Six call sites spelled that conversion themselves before
+ * this existed, which is the shape the repo's "a hand-rolled copy of a
+ * primitive does not receive the primitive's fixes" rule is about.
+ *
+ * The cast is the one reinterpretation the standard blesses outright:
+ * [basic.lval] lets any object be read through a `char`, `unsigned char` or
+ * `std::byte` lvalue, so viewing a byte array as characters is defined rather
+ * than merely customary. That is why it is a NOLINT here and not a defect -
+ * and why it is written once, so nothing has to argue it again.
+ */
+inline std::string_view byte_view (std::span<const std::uint8_t> bytes) {
+    // [basic.lval] permits reading any object through a character type; see
+    // the note above for why that makes this a NOLINT and not a defect.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return { reinterpret_cast<const char*> (bytes.data ()), bytes.size () };
+}
 
 namespace detail {
 
@@ -84,7 +107,10 @@ inline std::optional<std::string> base64_decode (std::string_view in) {
 
         // A null b64_end makes libsodium reject input it did not consume in
         // full, so trailing junk after a valid prefix is an error rather than a
-        // short decode.
+        // short decode. The cast is the writing direction of the [basic.lval]
+        // rule `byte_view` above documents - libsodium fills a byte buffer, and
+        // this string is one.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         if (sodium_base642bin (reinterpret_cast<unsigned char*> (out.data ()),
             out.size (), in.empty () ? "" : in.data (), in.size (), ignore,
             &decoded_len, nullptr, variant) != 0) {

--- a/engine/include/vayu/utils/sodium_init.hpp
+++ b/engine/include/vayu/utils/sodium_init.hpp
@@ -56,6 +56,9 @@ namespace detail {
  */
 inline const unsigned char* sodium_bytes (std::string_view s) {
     static const unsigned char empty = 0;
+    // [basic.lval] permits reading any object through a character type, and
+    // this is the one place the engine spells that direction of the conversion.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return s.empty () ? &empty : reinterpret_cast<const unsigned char*> (s.data ());
 }
 

--- a/engine/src/core/sample_capture.cpp
+++ b/engine/src/core/sample_capture.cpp
@@ -42,12 +42,11 @@ bool text_shaped (std::string_view type) {
  * cap rather than anything about the body.
  */
 bool prefix_is_utf8_text (std::string_view bytes) {
-    const auto* p = reinterpret_cast<const unsigned char*> (bytes.data ());
     const size_t inspect = std::min (bytes.size (), SNIFF_BYTES);
 
     size_t i = 0;
     while (i < inspect) {
-        const unsigned char c = p[i];
+        const auto c = static_cast<unsigned char> (bytes[i]);
         if (c == 0x00) {
             return false; // NUL never appears in text; it is the strongest signal.
         }
@@ -70,7 +69,7 @@ bool prefix_is_utf8_text (std::string_view bytes) {
             return true;
         }
         for (size_t k = 1; k <= extra; k++) {
-            if ((p[i + k] & 0xC0) != 0x80) {
+            if ((static_cast<unsigned char> (bytes[i + k]) & 0xC0) != 0x80) {
                 return false;
             }
         }
@@ -120,8 +119,7 @@ bool looks_binary (std::string_view body, std::string_view content_type) {
 
 std::string body_digest (std::string_view stored_body) {
     const auto digest = vayu::utils::sha256 (stored_body);
-    return vayu::utils::hex_encode (std::string_view (
-    reinterpret_cast<const char*> (digest.data ()), digest.size ()));
+    return vayu::utils::hex_encode (vayu::utils::byte_view (digest));
 }
 
 } // namespace vayu::core

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -83,7 +83,7 @@ template <> struct row_extractor<vayu::HttpMethod> {
         return vayu::HttpMethod::GET;
     }
     vayu::HttpMethod extract (sqlite3_stmt* stmt, int columnIndex) const {
-        const char* str = (const char*)sqlite3_column_text (stmt, columnIndex);
+        const char* str = vayu::db::column_text (stmt, columnIndex);
         return this->extract (str ? str : "");
     }
 };
@@ -112,7 +112,7 @@ template <> struct row_extractor<vayu::RunType> {
         return vayu::RunType::Design;
     }
     vayu::RunType extract (sqlite3_stmt* stmt, int columnIndex) const {
-        const char* str = (const char*)sqlite3_column_text (stmt, columnIndex);
+        const char* str = vayu::db::column_text (stmt, columnIndex);
         return this->extract (str ? str : "");
     }
 };
@@ -141,7 +141,7 @@ template <> struct row_extractor<vayu::RunStatus> {
         return vayu::RunStatus::Pending;
     }
     vayu::RunStatus extract (sqlite3_stmt* stmt, int columnIndex) const {
-        const char* str = (const char*)sqlite3_column_text (stmt, columnIndex);
+        const char* str = vayu::db::column_text (stmt, columnIndex);
         return this->extract (str ? str : "");
     }
 };

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -428,6 +428,10 @@ struct Client::Impl {
             curl_easy_cleanup (curl);
         }
     }
+    Impl (const Impl&)            = delete;
+    Impl& operator= (const Impl&) = delete;
+    Impl (Impl&&)                 = delete;
+    Impl& operator= (Impl&&)      = delete;
 
     void reset () {
         curl_easy_reset (curl);

--- a/engine/src/http/event_loop/event_loop_worker.cpp
+++ b/engine/src/http/event_loop/event_loop_worker.cpp
@@ -65,16 +65,21 @@ std::string system_resolve (const std::string& hostname) {
             }
         }
 
+        // The two casts below are the sockets API's own idiom, not a defect:
+        // `ai_addr` is a `sockaddr*` precisely so one field can carry either
+        // family, and `ai_family` - tested first, on the same record - is what
+        // says which one it is. There is no narrower spelling; POSIX defines
+        // the family structs to be reinterpretable through `sockaddr`.
         if (best->ai_family == AF_INET6) {
             char ip_str[INET6_ADDRSTRLEN];
-            struct sockaddr_in6* addr6 =
-            reinterpret_cast<struct sockaddr_in6*> (best->ai_addr);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            auto* addr6 = reinterpret_cast<sockaddr_in6*> (best->ai_addr);
             inet_ntop (AF_INET6, &(addr6->sin6_addr), ip_str, INET6_ADDRSTRLEN);
             ip = ip_str;
         } else if (best->ai_family == AF_INET) {
             char ip_str[INET_ADDRSTRLEN];
-            struct sockaddr_in* addr =
-            reinterpret_cast<struct sockaddr_in*> (best->ai_addr);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            auto* addr = reinterpret_cast<sockaddr_in*> (best->ai_addr);
             inet_ntop (AF_INET, &(addr->sin_addr), ip_str, INET_ADDRSTRLEN);
             ip = ip_str;
         }
@@ -450,7 +455,12 @@ void EventLoopWorker::run_loop () {
             did_work = true;
 
             if (msg->msg == CURLMSG_DONE) {
-                CURL* easy      = msg->easy_handle;
+                CURL* easy = msg->easy_handle;
+                // `CURLMsg::data` is a union whose active member is named by
+                // `msg`, and libcurl documents `CURLMSG_DONE` as the one that
+                // selects `result` - the branch above is that check. A variant
+                // is not on offer: the struct is libcurl's.
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
                 CURLcode result = msg->data.result;
 
                 // Named for the transfer that just finished rather than `data`,

--- a/engine/src/http/routes/mock_issuer.cpp
+++ b/engine/src/http/routes/mock_issuer.cpp
@@ -169,8 +169,7 @@ std::string mint_jwt (const std::string& key, const nlohmann::json& payload) {
     base64url_json (header) + "." + base64url_json (payload);
     const auto tag = vayu::utils::hmac_sha256 (key, signing_input);
     return signing_input + "." +
-    vayu::utils::base64url_encode (
-    std::string_view (reinterpret_cast<const char*> (tag.data ()), tag.size ()));
+    vayu::utils::base64url_encode (vayu::utils::byte_view (tag));
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -51,7 +51,10 @@ enum class Kind { Collection, Request };
  * a collection.
  */
 struct Scope {
-    Kind kind;
+    // Defaulted because `read_scope` below fills this out-parameter and can
+    // refuse the entry before it gets there: an enum left indeterminate is read
+    // as one on any path that forgets to check the refusal first.
+    Kind kind = Kind::Collection;
     std::optional<std::string> parent; // collection scope: nullopt = the roots
     std::string collection;            // request scope
 
@@ -68,7 +71,7 @@ struct Scope {
 
 /** One row's new position, and - when it changes owner - its new owner. */
 struct Move {
-    Kind kind;
+    Kind kind = Kind::Collection; // defaulted for the reason `Scope::kind` is
     std::string id;
     int order         = 0;
     bool states_owner = false; // parentId / collectionId present in the body

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -72,8 +72,7 @@ size_t spec_size_cap (vayu::db::Database& db) {
  */
 std::string spec_content_hash (const std::string& content) {
     const auto digest = vayu::utils::sha256 (content);
-    return vayu::utils::hex_encode (std::string_view (
-    reinterpret_cast<const char*> (digest.data ()), digest.size ()));
+    return vayu::utils::hex_encode (vayu::utils::byte_view (digest));
 }
 
 /**

--- a/engine/src/http/sse_parser.cpp
+++ b/engine/src/http/sse_parser.cpp
@@ -35,30 +35,44 @@ int sequence_length (unsigned char lead) {
     return 0;
 }
 
-/// True when the @p length bytes at @p begin are a well-formed, minimally
-/// encoded sequence for a scalar value UTF-8 is allowed to carry. The overlong
-/// and surrogate checks are what separate this from a length-only test: both
-/// are byte patterns a decoder must reject rather than pass through.
-bool sequence_is_valid (const unsigned char* begin, int length) {
-    for (int i = 1; i < length; ++i) {
-        if ((begin[i] & 0xC0) != 0x80) {
+/// The byte at @p index of @p text, as the unsigned value every check below
+/// compares against. `char`'s signedness is implementation-defined, so the
+/// 0x80-and-above comparisons only mean what they say once it is spelled out.
+unsigned char byte_at (std::string_view text, std::size_t index) {
+    return static_cast<unsigned char> (text[index]);
+}
+
+/// True when @p sequence is a well-formed, minimally encoded sequence for a
+/// scalar value UTF-8 is allowed to carry. The overlong and surrogate checks
+/// are what separate this from a length-only test: both are byte patterns a
+/// decoder must reject rather than pass through.
+///
+/// Takes the sequence as a view rather than a pointer and a length so the
+/// caller cannot hand it a length its buffer does not hold - the caller's own
+/// `fits` test is then the only place that bound is decided.
+bool sequence_is_valid (std::string_view sequence) {
+    for (std::size_t i = 1; i < sequence.size (); ++i) {
+        if ((byte_at (sequence, i) & 0xC0) != 0x80) {
             return false;
         }
     }
-    switch (length) {
+    switch (sequence.size ()) {
     case 1: return true;
-    case 2: return begin[0] >= 0xC2; // C0/C1 encode 7-bit values overlong
+    case 2:
+        return byte_at (sequence, 0) >= 0xC2; // C0/C1 encode 7-bit values overlong
     case 3: {
-        const uint32_t code = (static_cast<uint32_t> (begin[0] & 0x0F) << 12) |
-        (static_cast<uint32_t> (begin[1] & 0x3F) << 6) |
-        static_cast<uint32_t> (begin[2] & 0x3F);
+        const uint32_t code =
+        (static_cast<uint32_t> (byte_at (sequence, 0) & 0x0F) << 12) |
+        (static_cast<uint32_t> (byte_at (sequence, 1) & 0x3F) << 6) |
+        static_cast<uint32_t> (byte_at (sequence, 2) & 0x3F);
         return code >= 0x800 && (code < 0xD800 || code > 0xDFFF);
     }
     case 4: {
-        const uint32_t code = (static_cast<uint32_t> (begin[0] & 0x07) << 18) |
-        (static_cast<uint32_t> (begin[1] & 0x3F) << 12) |
-        (static_cast<uint32_t> (begin[2] & 0x3F) << 6) |
-        static_cast<uint32_t> (begin[3] & 0x3F);
+        const uint32_t code =
+        (static_cast<uint32_t> (byte_at (sequence, 0) & 0x07) << 18) |
+        (static_cast<uint32_t> (byte_at (sequence, 1) & 0x3F) << 12) |
+        (static_cast<uint32_t> (byte_at (sequence, 2) & 0x3F) << 6) |
+        static_cast<uint32_t> (byte_at (sequence, 3) & 0x3F);
         return code >= 0x10000 && code <= 0x10FFFF;
     }
     default: return false;
@@ -70,13 +84,12 @@ bool sequence_is_valid (const unsigned char* begin, int length) {
 std::string sanitize_utf8 (std::string_view text) {
     std::string out;
     out.reserve (text.size ());
-    const auto* bytes = reinterpret_cast<const unsigned char*> (text.data ());
-    std::size_t i     = 0;
+    std::size_t i = 0;
     while (i < text.size ()) {
-        const int length = sequence_length (bytes[i]);
+        const int length = sequence_length (byte_at (text, i));
         const bool fits =
         length > 0 && i + static_cast<std::size_t> (length) <= text.size ();
-        if (fits && sequence_is_valid (bytes + i, length)) {
+        if (fits && sequence_is_valid (text.substr (i, static_cast<std::size_t> (length)))) {
             out.append (text.substr (i, static_cast<std::size_t> (length)));
             i += static_cast<std::size_t> (length);
             continue;

--- a/engine/src/http/thread_pool.cpp
+++ b/engine/src/http/thread_pool.cpp
@@ -56,6 +56,10 @@ struct ThreadPool::Impl {
             }
         }
     }
+    Impl (const Impl&)            = delete;
+    Impl& operator= (const Impl&) = delete;
+    Impl (Impl&&)                 = delete;
+    Impl& operator= (Impl&&)      = delete;
 
     void worker_loop () {
         while (true) {

--- a/engine/src/platform/platform_unix.cpp
+++ b/engine/src/platform/platform_unix.cpp
@@ -57,6 +57,11 @@ bool acquire_file_lock (const std::string& path, LockHandle& handle) {
     // Open or create the lock file
     // Note: On Unix, file locks (flock) are automatically released when the process terminates
     // (even if it crashes or is killed), so stale locks are not a concern.
+    // POSIX declares `open` variadic so the mode argument can be omitted when
+    // O_CREAT is not passed; with O_CREAT it is required. There is no
+    // non-variadic spelling to move to - `std::fopen` cannot express the flags
+    // `flock` below needs a descriptor for.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     handle = open (path.c_str (), O_RDWR | O_CREAT, 0666);
     if (handle < 0) {
         return false;
@@ -126,7 +131,7 @@ void release_file_lock (LockHandle& handle) {
 // ============================================================================
 
 bool is_directory (const std::string& path) {
-    struct stat st;
+    struct stat st{};
     if (stat (path.c_str (), &st) != 0) {
         return false;
     }
@@ -145,7 +150,7 @@ bool create_directory (const std::string& path) {
 }
 
 void ensure_directory (const std::string& path) {
-    struct stat st;
+    struct stat st{};
     if (stat (path.c_str (), &st) != 0) {
         // Directory doesn't exist, create it
         if (mkdir (path.c_str (), 0755) != 0 && errno != EEXIST) {

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -2034,8 +2034,7 @@ bool read_crypto_bytes (JSContext* ctx, JSValueConst value, const char* what, st
 JSValue encode_digest (JSContext* ctx,
 const std::array<uint8_t, 32>& digest,
 const std::string& encoding) {
-    const std::string_view raw (
-    reinterpret_cast<const char*> (digest.data ()), digest.size ());
+    const std::string_view raw = vayu::utils::byte_view (digest);
 
     if (encoding == "bytes") {
         // Constructed through the global Uint8Array rather than a helper, for

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(vayu_tests
     script_types_test.cpp
     event_loop_test.cpp
     db_test.cpp
+    character_cast_test.cpp
     db_concurrency_test.cpp
     db_recovery_test.cpp
     rate_limit_test.cpp
@@ -284,6 +285,7 @@ set(vayu_scratch_database_suites
     AuthRefreshTuningTest
     ClientCertificateDbTest
     CollectMetrics
+    ColumnTextFixture
     CollectionsRouteTest
     ConfigRouteTest
     CustomCaVerificationTest

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -22,6 +22,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "task_queue.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/auth_refresh.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -59,7 +60,7 @@ int64_t now_ms () {
 class MockTarget {
     public:
     MockTarget () {
-        svr_.new_task_queue = [] { return new httplib::ThreadPool (16); };
+        svr_.new_task_queue = vayu::tests::pooled_task_queue (16);
 
         svr_.Get ("/api", [this] (const httplib::Request& req, httplib::Response& res) {
             const std::string auth = req.get_header_value ("Authorization");
@@ -82,9 +83,10 @@ class MockTarget {
         if (thread_.joinable ())
             thread_.join ();
     }
-
     MockTarget (const MockTarget&)            = delete;
     MockTarget& operator= (const MockTarget&) = delete;
+    MockTarget (MockTarget&&)                 = delete;
+    MockTarget& operator= (MockTarget&&)      = delete;
 
     std::string api_url () const {
         return "http://127.0.0.1:" + std::to_string (port_) + "/api";

--- a/engine/tests/character_cast_test.cpp
+++ b/engine/tests/character_cast_test.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/character_cast_test.cpp
+ * @brief `vayu::utils::byte_view` and `vayu::db::column_text` (issue #945), and
+ *        the guard that keeps hand-rolled copies of them out of the tree.
+ *
+ * Two halves, because the defect has two.
+ *
+ * The behavioural half is what each primitive promises. `byte_view` must hand
+ * back the same bytes in the same order and must survive an empty span, which
+ * is where a `data()`-plus-`size()` conversion written by hand goes wrong.
+ * `column_text` must answer `nullptr` for a SQL NULL and the text otherwise -
+ * a wrapper that defaulted NULL to the empty string would erase the one
+ * distinction its callers read.
+ *
+ * The scanning half is for what no behavioural test can reach. Reinterpreting a
+ * pointer between character types is defined behaviour ([basic.lval] lets any
+ * object be read through `char`, `unsigned char` or `std::byte`), so a
+ * hand-rolled copy *works* - it is simply a copy, and a copy of a primitive
+ * does not receive the primitive's fixes. Eight of them had accumulated by the
+ * time #945's batch 3 counted: six spelling a digest as a `string_view`, and
+ * three more spelling a sqlite TEXT column as `const char*`. The CI tidy gate
+ * scopes to a pull request's changed lines, so nothing holds the count at zero
+ * once these lines stop being new; the scan is what does. Reverting any one of
+ * the rewrites fails it.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <sqlite3.h>
+
+#include "source_scan.hpp"
+#include "temp_database.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/utils/encoding.hpp"
+#include "vayu/utils/sha256.hpp"
+
+namespace vayu {
+namespace {
+
+// ---------------------------------------------------------------------------
+// byte_view
+// ---------------------------------------------------------------------------
+
+TEST (ByteView, PresentsTheSameBytesInTheSameOrder) {
+    // Values chosen so a sign-extending or byte-swapping conversion could not
+    // pass: 0x00 terminates a C string, 0x80 and 0xFF are negative as `char`.
+    const std::array<std::uint8_t, 5> bytes = { 0x00, 0x7F, 0x80, 0xFF, 0x41 };
+    const std::string_view view             = utils::byte_view (bytes);
+
+    ASSERT_EQ (view.size (), bytes.size ());
+    for (std::size_t i = 0; i < bytes.size (); ++i) {
+        EXPECT_EQ (static_cast<std::uint8_t> (view[i]), bytes.at (i)) << "at " << i;
+    }
+}
+
+TEST (ByteView, CarriesTheWholeDigestPastAnInteriorZeroByte) {
+    // The reason the length travels with the pointer. This input is picked for
+    // a digest that has an interior `\0` (byte 22 of
+    // ba2f...8f99) - a zero is an ordinary digest byte, and a NUL-terminated
+    // reading of the same pointer would cut the encoding short there.
+    const auto digest = utils::sha256 ("vayu-15");
+    ASSERT_NE (std::find (digest.begin (), digest.end (), 0), digest.end ())
+    << "the fixture input no longer digests to a value with a zero byte";
+
+    const std::string encoded = utils::hex_encode (utils::byte_view (digest));
+    EXPECT_EQ (encoded, "ba2f3c08a44c40eb55c74df28784328123620907190a003929d4b519f4c28f99");
+}
+
+TEST (ByteView, AnEmptySpanIsAnEmptyView) {
+    const std::array<std::uint8_t, 0> nothing{};
+    EXPECT_TRUE (utils::byte_view (nothing).empty ());
+}
+
+// ---------------------------------------------------------------------------
+// column_text
+// ---------------------------------------------------------------------------
+
+/// A scratch database with one row: a TEXT value and a SQL NULL beside it.
+class ColumnTextFixture : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        tests::remove_database_files (DB_PATH);
+        ASSERT_EQ (sqlite3_open (DB_PATH, &handle_), SQLITE_OK);
+        ASSERT_EQ (sqlite3_exec (handle_,
+                   "CREATE TABLE t (present TEXT, absent TEXT);"
+                   "INSERT INTO t VALUES ('caf\xC3\xA9', NULL);",
+                   nullptr, nullptr, nullptr),
+        SQLITE_OK);
+    }
+
+    void TearDown () override {
+        sqlite3_close (handle_);
+        tests::remove_database_files (DB_PATH);
+    }
+
+    static constexpr const char* DB_PATH = "test_column_text.db";
+    sqlite3* handle_                     = nullptr;
+};
+
+TEST_F (ColumnTextFixture, ReadsATextColumnAsCharacters) {
+    sqlite3_stmt* stmt = nullptr;
+    ASSERT_EQ (sqlite3_prepare_v2 (handle_, "SELECT present, absent FROM t", -1, &stmt, nullptr),
+    SQLITE_OK);
+    ASSERT_EQ (sqlite3_step (stmt), SQLITE_ROW);
+
+    const char* present = db::column_text (stmt, 0);
+    ASSERT_NE (present, nullptr);
+    // Multi-byte, so a conversion that went through a signed character type and
+    // truncated would be visible rather than merely suspected.
+    EXPECT_EQ (std::string (present), "caf\xC3\xA9");
+
+    // A SQL NULL stays a null pointer: the caller decides what absent means.
+    EXPECT_EQ (db::column_text (stmt, 1), nullptr);
+
+    sqlite3_finalize (stmt);
+}
+
+// ---------------------------------------------------------------------------
+// The guard
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Whether @p code reinterpret_casts a pointer to a character type.
+ *
+ * Matches `reinterpret_cast<` followed by an optional `const`, then `char`,
+ * `signed char` or `unsigned char`, then `*`. Deliberately narrow: the casts
+ * this rule is about are the character-type ones, and the tree's other
+ * `reinterpret_cast`s (a `sockaddr_in*` off an `addrinfo`, a Windows function
+ * pointer off `GetProcAddress`, a `uintptr_t` for a unique path) are answering
+ * different questions with no primitive to route through.
+ */
+bool names_character_reinterpret_cast (const std::string& code) {
+    constexpr std::string_view kOpen = "reinterpret_cast<";
+    for (std::size_t at = code.find (kOpen); at != std::string::npos;
+    at                  = code.find (kOpen, at + 1)) {
+        std::string_view rest (code);
+        rest.remove_prefix (at + kOpen.size ());
+
+        const auto skip_spaces = [&rest] () {
+            while (!rest.empty () &&
+            (std::isspace (static_cast<unsigned char> (rest.front ())) != 0)) {
+                rest.remove_prefix (1);
+            }
+        };
+        const auto eat = [&rest, &skip_spaces] (std::string_view word) {
+            if (rest.substr (0, word.size ()) != word) {
+                return false;
+            }
+            rest.remove_prefix (word.size ());
+            skip_spaces ();
+            return true;
+        };
+
+        skip_spaces ();
+        eat ("const");
+        // `signed`/`unsigned` are optional; `char` is not.
+        if (!eat ("unsigned")) {
+            eat ("signed");
+        }
+        if (!eat ("char")) {
+            continue;
+        }
+        if (!rest.empty () && rest.front () == '*') {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// The files allowed to spell one, and why. Per file rather than per line: a
+/// file on this list is one whose whole job is the conversion (or, for the two
+/// at the bottom, one where no primitive can stand in), and a new cast added to
+/// any file *not* here is what the guard exists to name.
+struct ExemptFile {
+    std::string_view file;
+    std::string_view reason;
+};
+
+/// `cert-err58-cpp` is why this is a `constexpr std::array` of views rather
+/// than the `std::vector<std::string>` it reads more naturally as - a
+/// namespace-scope container with a throwing constructor is a finding of this
+/// same paydown.
+constexpr std::array<ExemptFile, 5> kExempt = { {
+{ "include/vayu/utils/encoding.hpp", "byte_view, and the base64 decoder's output buffer" },
+{ "include/vayu/utils/sodium_init.hpp", "sodium_bytes - byte_view's inverse" },
+{ "include/vayu/db/database.hpp", "column_text" },
+{ "tests/tls_server.hpp", "OpenSSL's C API takes const unsigned char* directly, with no string_view seam" },
+{ "src/runtime/script_engine.cpp", "a JS ArrayBuffer's bytes arrive as uint8_t* from QuickJS, not as a span" },
+} };
+
+bool is_exempt (std::string_view file) {
+    return std::any_of (kExempt.begin (), kExempt.end (),
+    [&] (const ExemptFile& entry) { return entry.file == file; });
+}
+
+TEST (CharacterCasts, TheEngineSourcesGoThroughThePrimitives) {
+    const std::filesystem::path root{ VAYU_ENGINE_SOURCE_DIR };
+    std::size_t scanned_files = 0;
+    std::size_t scanned_bytes = 0;
+    std::vector<std::string> offenders;
+
+    for (const auto* directory : { "src", "include", "tests" }) {
+        const auto tree = root / directory;
+        ASSERT_TRUE (std::filesystem::is_directory (tree))
+        << tree.string () << " is not where the guard looks";
+
+        for (const auto& entry : std::filesystem::recursive_directory_iterator (tree)) {
+            const auto& path            = entry.path ();
+            const std::string extension = path.extension ().string ();
+            if (!entry.is_regular_file () || (extension != ".cpp" && extension != ".hpp")) {
+                continue;
+            }
+            const std::string relative =
+            std::filesystem::relative (path, root).generic_string ();
+            // This file's own planted positives live in string literals, which
+            // `strip_comments` does not blank.
+            if (relative == "tests/character_cast_test.cpp") {
+                continue;
+            }
+
+            const std::string code = tests::strip_comments (tests::read_source (path));
+            ASSERT_FALSE (code.empty ()) << relative << " read as empty";
+            ++scanned_files;
+            scanned_bytes += code.size ();
+
+            if (!is_exempt (relative) && names_character_reinterpret_cast (code)) {
+                offenders.push_back (relative);
+            }
+        }
+    }
+
+    // A scan that read nothing passes forever, so it says what it read.
+    ASSERT_GT (scanned_files, 200u) << "the guard found almost no sources";
+    ASSERT_GT (scanned_bytes, 100'000u) << "the guard read empty sources";
+
+    std::string joined;
+    for (const auto& offender : offenders) {
+        if (!joined.empty ()) {
+            joined += "\n  ";
+        }
+        joined += offender;
+    }
+    EXPECT_TRUE (offenders.empty ())
+    << "a character-type reinterpret_cast written here is a copy of a "
+       "primitive, and a copy does not receive the primitive's fixes. Use "
+       "vayu::utils::byte_view for bytes-as-text, vayu::db::column_text for a "
+       "sqlite TEXT column, or add the file to kExempt with its reason. "
+       "Offenders:\n  "
+    << joined;
+}
+
+TEST (CharacterCasts, TheGuardSeesACharacterCastAndNotTheOthers) {
+    // The planted positives. Without these, a broken matcher would leave the
+    // guard above passing on a tree that had brought every copy back.
+    EXPECT_TRUE (names_character_reinterpret_cast (
+    "reinterpret_cast<const char*> (digest.data ())"));
+    EXPECT_TRUE (names_character_reinterpret_cast (
+    "reinterpret_cast<unsigned char*> (out.data ())"));
+    EXPECT_TRUE (names_character_reinterpret_cast (
+    "reinterpret_cast<const unsigned char*> (s.data ())"));
+    EXPECT_TRUE (
+    names_character_reinterpret_cast ("reinterpret_cast<char*>(p)"));
+
+    // And the casts this rule is not about.
+    EXPECT_FALSE (names_character_reinterpret_cast (
+    "reinterpret_cast<sockaddr_in6*> (best->ai_addr)"));
+    EXPECT_FALSE (
+    names_character_reinterpret_cast ("reinterpret_cast<uintptr_t> (this)"));
+    EXPECT_FALSE (names_character_reinterpret_cast (
+    "reinterpret_cast<RtlVerifyVersionInfoFn> (address)"));
+    EXPECT_FALSE (
+    names_character_reinterpret_cast ("static_cast<const char*> (p)"));
+    // `char_traits` starts with `char` and is not a character type.
+    EXPECT_FALSE (
+    names_character_reinterpret_cast ("reinterpret_cast<char_traits*> (p)"));
+
+    // And the stripper really does blank prose, which is what keeps the
+    // exemption list to files that spell one in code.
+    EXPECT_FALSE (names_character_reinterpret_cast (tests::strip_comments (
+    "// never write reinterpret_cast<const char*> (p) here\n")));
+    EXPECT_TRUE (names_character_reinterpret_cast (tests::strip_comments (
+    "/* see below */ reinterpret_cast<const char*> (p);\n")));
+}
+
+} // namespace
+} // namespace vayu

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -84,6 +84,8 @@ class ScratchFile {
     }
     ScratchFile (const ScratchFile&)            = delete;
     ScratchFile& operator= (const ScratchFile&) = delete;
+    ScratchFile (ScratchFile&&)                 = delete;
+    ScratchFile& operator= (ScratchFile&&)      = delete;
 
     const std::string& path () const {
         return path_;
@@ -114,6 +116,10 @@ class MockUpstream {
         if (thread.joinable ())
             thread.join ();
     }
+    MockUpstream (const MockUpstream&)            = delete;
+    MockUpstream& operator= (const MockUpstream&) = delete;
+    MockUpstream (MockUpstream&&)                 = delete;
+    MockUpstream& operator= (MockUpstream&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -25,6 +25,7 @@
 
 #include <httplib.h>
 
+#include "task_queue.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/cookie_jar.hpp"
 #include "vayu/runtime/script_engine.hpp"
@@ -70,7 +71,7 @@ constexpr int64_t NOW        = 1700000000; // 2023-11-14
 class CookieServer {
     public:
     CookieServer () {
-        svr.new_task_queue = [] { return new httplib::ThreadPool (8); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (8);
 
         // Sets a session cookie, the way a login endpoint does.
         svr.Get ("/login", [] (const httplib::Request&, httplib::Response& res) {
@@ -100,6 +101,10 @@ class CookieServer {
             thread.join ();
         }
     }
+    CookieServer (const CookieServer&)            = delete;
+    CookieServer& operator= (const CookieServer&) = delete;
+    CookieServer (CookieServer&&)                 = delete;
+    CookieServer& operator= (CookieServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/curl_transfer_test.cpp
+++ b/engine/tests/curl_transfer_test.cpp
@@ -75,6 +75,10 @@ class MethodEchoServer {
         if (thread.joinable ())
             thread.join ();
     }
+    MethodEchoServer (const MethodEchoServer&)            = delete;
+    MethodEchoServer& operator= (const MethodEchoServer&) = delete;
+    MethodEchoServer (MethodEchoServer&&)                 = delete;
+    MethodEchoServer& operator= (MethodEchoServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -653,9 +653,9 @@ std::set<std::string> read_index_names (const std::string& path) {
     }
 
     while (sqlite3_step (stmt) == SQLITE_ROW) {
-        const auto* name = sqlite3_column_text (stmt, 0);
+        const auto* name = vayu::db::column_text (stmt, 0);
         if (name != nullptr) {
-            names.emplace (reinterpret_cast<const char*> (name));
+            names.emplace (name);
         }
     }
 
@@ -803,9 +803,8 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
         SQLITE_OK);
         bool has_column = false;
         while (sqlite3_step (stmt) == SQLITE_ROW) {
-            const auto* col_name = sqlite3_column_text (stmt, 1);
-            if (col_name != nullptr &&
-            std::string (reinterpret_cast<const char*> (col_name)) == "http_version") {
+            const auto* col_name = vayu::db::column_text (stmt, 1);
+            if (col_name != nullptr && std::string (col_name) == "http_version") {
                 has_column = true;
             }
         }
@@ -839,11 +838,8 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
                -1, &row_stmt, nullptr),
     SQLITE_OK);
     ASSERT_EQ (sqlite3_step (row_stmt), SQLITE_ROW);
-    EXPECT_EQ (
-    std::string (reinterpret_cast<const char*> (sqlite3_column_text (row_stmt, 0))),
-    "Pre-migration request");
-    EXPECT_EQ (
-    std::string (reinterpret_cast<const char*> (sqlite3_column_text (row_stmt, 1))), "auto");
+    EXPECT_EQ (std::string (vayu::db::column_text (row_stmt, 0)), "Pre-migration request");
+    EXPECT_EQ (std::string (vayu::db::column_text (row_stmt, 1)), "auto");
     sqlite3_finalize (row_stmt);
     sqlite3_close (handle);
 }
@@ -1344,9 +1340,8 @@ TEST_F (DatabaseTest, RunsStoredBeforeTheBaselineColumnReadAsUnpinned) {
         SQLITE_OK);
         bool has_column = false;
         while (sqlite3_step (stmt) == SQLITE_ROW) {
-            const auto* col_name = sqlite3_column_text (stmt, 1);
-            if (col_name != nullptr &&
-            std::string (reinterpret_cast<const char*> (col_name)) == "baseline") {
+            const auto* col_name = vayu::db::column_text (stmt, 1);
+            if (col_name != nullptr && std::string (col_name) == "baseline") {
                 has_column = true;
             }
         }

--- a/engine/tests/diagnostics_route_test.cpp
+++ b/engine/tests/diagnostics_route_test.cpp
@@ -52,6 +52,10 @@ class MockTarget {
         if (thread_.joinable ())
             thread_.join ();
     }
+    MockTarget (const MockTarget&)            = delete;
+    MockTarget& operator= (const MockTarget&) = delete;
+    MockTarget (MockTarget&&)                 = delete;
+    MockTarget& operator= (MockTarget&&)      = delete;
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port_) + path;
     }

--- a/engine/tests/event_loop_test.cpp
+++ b/engine/tests/event_loop_test.cpp
@@ -41,6 +41,10 @@ class MockServer {
         if (thread.joinable ())
             thread.join ();
     }
+    MockServer (const MockServer&)            = delete;
+    MockServer& operator= (const MockServer&) = delete;
+    MockServer (MockServer&&)                 = delete;
+    MockServer& operator= (MockServer&&)      = delete;
 
     std::string base_url () const {
         return "http://127.0.0.1:" + std::to_string (port);

--- a/engine/tests/form_body_test.cpp
+++ b/engine/tests/form_body_test.cpp
@@ -77,9 +77,10 @@ class TempFile {
         std::error_code ignored;
         std::filesystem::remove (path_, ignored);
     }
-
     TempFile (const TempFile&)            = delete;
     TempFile& operator= (const TempFile&) = delete;
+    TempFile (TempFile&&)                 = delete;
+    TempFile& operator= (TempFile&&)      = delete;
 
     std::string path () const {
         return path_.string ();

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -160,6 +160,10 @@ class MockHttpBin {
         if (thread_.joinable ())
             thread_.join ();
     }
+    MockHttpBin (const MockHttpBin&)            = delete;
+    MockHttpBin& operator= (const MockHttpBin&) = delete;
+    MockHttpBin (MockHttpBin&&)                 = delete;
+    MockHttpBin& operator= (MockHttpBin&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port_) + path;

--- a/engine/tests/import_route_test.cpp
+++ b/engine/tests/import_route_test.cpp
@@ -92,6 +92,10 @@ class MockSpecServer {
         if (thread_.joinable ())
             thread_.join ();
     }
+    MockSpecServer (const MockSpecServer&)            = delete;
+    MockSpecServer& operator= (const MockSpecServer&) = delete;
+    MockSpecServer (MockSpecServer&&)                 = delete;
+    MockSpecServer& operator= (MockSpecServer&&)      = delete;
     int port () const {
         return port_;
     }

--- a/engine/tests/mock_issuer_test.cpp
+++ b/engine/tests/mock_issuer_test.cpp
@@ -56,9 +56,7 @@ bool signature_verifies (const std::string& jwt, const std::string& key) {
         return false;
     }
     const auto tag = vayu::utils::hmac_sha256 (key, parts[0] + "." + parts[1]);
-    return parts[2] ==
-    vayu::utils::base64url_encode (
-    std::string_view (reinterpret_cast<const char*> (tag.data ()), tag.size ()));
+    return parts[2] == vayu::utils::base64url_encode (vayu::utils::byte_view (tag));
 }
 
 json decode_jwt_payload (const std::string& jwt) {

--- a/engine/tests/mock_server.hpp
+++ b/engine/tests/mock_server.hpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <thread>
 
+#include "task_queue.hpp"
+
 namespace vayu::tests {
 
 class SlowMockServer {
@@ -25,7 +27,7 @@ class SlowMockServer {
         // concurrent /slow requests, and the worker drains active transfers on
         // stop(). A thread-starved mock would serialize them and make teardown
         // take tens of seconds (a harness artifact, not engine behavior).
-        svr.new_task_queue = [] { return new httplib::ThreadPool (128); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (128);
 
         svr.Get ("/slow", [] (const httplib::Request&, httplib::Response& res) {
             std::this_thread::sleep_for (std::chrono::milliseconds (500));
@@ -103,6 +105,10 @@ class SlowMockServer {
         if (thread.joinable ())
             thread.join ();
     }
+    SlowMockServer (const SlowMockServer&)            = delete;
+    SlowMockServer& operator= (const SlowMockServer&) = delete;
+    SlowMockServer (SlowMockServer&&)                 = delete;
+    SlowMockServer& operator= (SlowMockServer&&)      = delete;
 
     std::string slow_url () const {
         return "http://127.0.0.1:" + std::to_string (port) + "/slow";

--- a/engine/tests/oauth_authorize_test.cpp
+++ b/engine/tests/oauth_authorize_test.cpp
@@ -39,6 +39,10 @@ class MockTokenServer {
         if (thread_.joinable ())
             thread_.join ();
     }
+    MockTokenServer (const MockTokenServer&)            = delete;
+    MockTokenServer& operator= (const MockTokenServer&) = delete;
+    MockTokenServer (MockTokenServer&&)                 = delete;
+    MockTokenServer& operator= (MockTokenServer&&)      = delete;
     std::string token_url () const {
         return "http://127.0.0.1:" + std::to_string (port_) + "/token";
     }

--- a/engine/tests/oauth_client_test.cpp
+++ b/engine/tests/oauth_client_test.cpp
@@ -104,6 +104,10 @@ class MockTokenServer {
         if (thread_.joinable ())
             thread_.join ();
     }
+    MockTokenServer (const MockTokenServer&)            = delete;
+    MockTokenServer& operator= (const MockTokenServer&) = delete;
+    MockTokenServer (MockTokenServer&&)                 = delete;
+    MockTokenServer& operator= (MockTokenServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port_) + path;

--- a/engine/tests/pkce_test.cpp
+++ b/engine/tests/pkce_test.cpp
@@ -16,8 +16,7 @@ namespace {
 // Delegates rather than repeating the table: vayu::utils::hex_encode is the one
 // hex encoder, and a second copy here would not receive its fixes.
 std::string hex (const std::array<uint8_t, 32>& d) {
-    return vayu::utils::hex_encode (
-    std::string_view (reinterpret_cast<const char*> (d.data ()), d.size ()));
+    return vayu::utils::hex_encode (vayu::utils::byte_view (d));
 }
 
 TEST (Sha256, Fips180Vectors) {
@@ -80,9 +79,8 @@ TEST (HmacSha256, KeyLengthsAroundTheBlockBoundary) {
     // construction. So the equality below is the specification, not an
     // accident: pass the digest of an over-long key and you get the same MAC.
     const auto digest = vayu::utils::sha256 (std::string (65, 'k'));
-    const std::string_view digest_bytes (
-    reinterpret_cast<const char*> (digest.data ()), digest.size ());
-    EXPECT_EQ (hex (over), hex (vayu::utils::hmac_sha256 (digest_bytes, "payload")));
+    EXPECT_EQ (hex (over),
+    hex (vayu::utils::hmac_sha256 (vayu::utils::byte_view (digest), "payload")));
 }
 
 TEST (Base64Url, NoPaddingUrlSafeAlphabet) {

--- a/engine/tests/proxy_server.hpp
+++ b/engine/tests/proxy_server.hpp
@@ -33,12 +33,14 @@
 #include <thread>
 #include <vector>
 
+#include "task_queue.hpp"
+
 namespace vayu::tests {
 
 class MockProxy {
     public:
     MockProxy () {
-        svr.new_task_queue = [] { return new httplib::ThreadPool (16); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (16);
 
         // CONNECT never reaches the routing table - httplib dispatches only the
         // body-carrying methods - so the tunnel case is answered here, before
@@ -75,6 +77,10 @@ class MockProxy {
         if (thread.joinable ())
             thread.join ();
     }
+    MockProxy (const MockProxy&)            = delete;
+    MockProxy& operator= (const MockProxy&) = delete;
+    MockProxy (MockProxy&&)                 = delete;
+    MockProxy& operator= (MockProxy&&)      = delete;
 
     /// What to put in `TransportPolicy::proxy_url`.
     std::string url () const {

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -569,6 +569,8 @@ class CompetingWriter {
     }
     CompetingWriter (const CompetingWriter&)            = delete;
     CompetingWriter& operator= (const CompetingWriter&) = delete;
+    CompetingWriter (CompetingWriter&&)                 = delete;
+    CompetingWriter& operator= (CompetingWriter&&)      = delete;
 
     /** The `before_write` probe: starts the writer, then waits out the window. */
     std::function<void ()> probe () {

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -26,6 +26,7 @@
 
 #include <httplib.h>
 
+#include "task_queue.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/scenario_data.hpp"
@@ -61,7 +62,7 @@ class ScenarioMockServer {
 
     explicit ScenarioMockServer (size_t login_rendezvous = 0)
     : login_rendezvous_ (login_rendezvous) {
-        svr.new_task_queue = [] { return new httplib::ThreadPool (64); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (64);
 
         svr.Get ("/login", [this] (const httplib::Request& req, httplib::Response& res) {
             record (req, "/login");
@@ -117,6 +118,10 @@ class ScenarioMockServer {
         if (thread.joinable ())
             thread.join ();
     }
+    ScenarioMockServer (const ScenarioMockServer&)            = delete;
+    ScenarioMockServer& operator= (const ScenarioMockServer&) = delete;
+    ScenarioMockServer (ScenarioMockServer&&)                 = delete;
+    ScenarioMockServer& operator= (ScenarioMockServer&&)      = delete;
 
     [[nodiscard]] std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -34,6 +34,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "task_queue.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -73,7 +74,7 @@ struct SeenRequest {
 class ScenarioMockServer {
     public:
     ScenarioMockServer () {
-        svr.new_task_queue = [] { return new httplib::ThreadPool (8); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (8);
 
         const auto record = [this] (const httplib::Request& req) {
             std::lock_guard<std::mutex> lock (mtx);
@@ -134,6 +135,10 @@ class ScenarioMockServer {
             thread.join ();
         }
     }
+    ScenarioMockServer (const ScenarioMockServer&)            = delete;
+    ScenarioMockServer& operator= (const ScenarioMockServer&) = delete;
+    ScenarioMockServer (ScenarioMockServer&&)                 = delete;
+    ScenarioMockServer& operator= (ScenarioMockServer&&)      = delete;
 
     [[nodiscard]] std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -27,6 +27,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "task_queue.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
@@ -47,7 +48,7 @@ constexpr int SLOW_MS = 3000;
 class SendRequestServer {
     public:
     SendRequestServer () {
-        svr.new_task_queue = [] { return new httplib::ThreadPool (16); };
+        svr.new_task_queue = vayu::tests::pooled_task_queue (16);
 
         svr.Get ("/token", [this] (const httplib::Request&, httplib::Response& res) {
             hits.fetch_add (1, std::memory_order_relaxed);
@@ -91,6 +92,10 @@ class SendRequestServer {
         if (thread.joinable ())
             thread.join ();
     }
+    SendRequestServer (const SendRequestServer&)            = delete;
+    SendRequestServer& operator= (const SendRequestServer&) = delete;
+    SendRequestServer (SendRequestServer&&)                 = delete;
+    SendRequestServer& operator= (SendRequestServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;

--- a/engine/tests/sse_load_stream_test.cpp
+++ b/engine/tests/sse_load_stream_test.cpp
@@ -113,6 +113,10 @@ class LoadStreamServer {
             thread_.join ();
         }
     }
+    LoadStreamServer (const LoadStreamServer&)            = delete;
+    LoadStreamServer& operator= (const LoadStreamServer&) = delete;
+    LoadStreamServer (LoadStreamServer&&)                 = delete;
+    LoadStreamServer& operator= (LoadStreamServer&&)      = delete;
 
     [[nodiscard]] std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port_) + path;

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -140,6 +140,10 @@ class StreamServer {
             thread_.join ();
         }
     }
+    StreamServer (const StreamServer&)            = delete;
+    StreamServer& operator= (const StreamServer&) = delete;
+    StreamServer (StreamServer&&)                 = delete;
+    StreamServer& operator= (StreamServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port_) + path;

--- a/engine/tests/task_queue.hpp
+++ b/engine/tests/task_queue.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+/**
+ * @file task_queue.hpp
+ * @brief The one place a test says how big its mock server's thread pool is.
+ *
+ * Every in-process mock here overrides httplib's default task queue, because
+ * the default is sized for a demo and these tests hold tens of concurrent
+ * transfers open at once - a thread-starved mock serializes them and makes
+ * teardown take tens of seconds, which reads as engine latency and is a harness
+ * artifact. Seven fixtures wrote that override themselves before this existed,
+ * and a copy of a primitive does not receive the primitive's fixes.
+ *
+ * The `new` is httplib's contract, not a leak: `Server::new_task_queue` is a
+ * factory the server calls once per `listen()`, and the server deletes what it
+ * gets back (`httplib::Server::stop`/`~Server`). A `unique_ptr` cannot be
+ * returned here - the hook's signature is `std::function<TaskQueue*()>` - which
+ * is why `cppcoreguidelines-owning-memory` is silenced with that reason once,
+ * here, rather than at each fixture that used to spell the `new` itself.
+ */
+
+#include <httplib.h>
+
+#include <cstddef>
+#include <functional>
+
+namespace vayu::tests {
+
+/**
+ * @brief An httplib `new_task_queue` factory for a pool of @p threads workers.
+ *
+ * Assign it: `svr.new_task_queue = vayu::tests::pooled_task_queue (16);`
+ */
+inline std::function<httplib::TaskQueue*()> pooled_task_queue (std::size_t threads) {
+    return [threads] () -> httplib::TaskQueue* {
+        // httplib owns and deletes what this factory returns; see the file
+        // comment above.
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        return new httplib::ThreadPool (threads);
+    };
+}
+
+} // namespace vayu::tests

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -84,6 +84,10 @@ class MockUpstream {
         if (thread.joinable ())
             thread.join ();
     }
+    MockUpstream (const MockUpstream&)            = delete;
+    MockUpstream& operator= (const MockUpstream&) = delete;
+    MockUpstream (MockUpstream&&)                 = delete;
+    MockUpstream& operator= (MockUpstream&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string (port) + path;
@@ -116,6 +120,8 @@ class ScopedEnv {
     }
     ScopedEnv (const ScopedEnv&)            = delete;
     ScopedEnv& operator= (const ScopedEnv&) = delete;
+    ScopedEnv (ScopedEnv&&)                 = delete;
+    ScopedEnv& operator= (ScopedEnv&&)      = delete;
 
     private:
     /**


### PR DESCRIPTION
## Description

Wave 3's batch 3: the curated `cppcoreguidelines-*` subset **except** the `pro-bounds-*` family, cleared. **51 findings, rescanned to zero** over the 207 non-vendor translation units. `pro-bounds-*` (93 still standing) stays on #945 as batch 4.

**The plan.** The rescan turned up 157 findings across 56 files - too much for one reviewable diff, and two unrelated kinds of change - so it splits where the family splits: the type-and-ownership half here, the bounds half next. Reading the 51 showed most were not 51 separate decisions but **eight hand-rolled copies of three primitives that did not exist**, plus a rule-of-five omission repeated across every RAII fixture in `tests/`. So the fix is three primitives and one convention rather than 51 local edits; the alternative - a `NOLINT` per site, which the discipline permits for a false positive - was rejected because none of these *is* a false positive. Reinterpreting between character types is defined behaviour ([basic.lval]), which is precisely why a copy works and why eight of them accumulated unnoticed. The NOLINT and its reason now live once per direction, in the primitive.

### Three primitives replace eight copies

- **`vayu::utils::byte_view`** (`utils/encoding.hpp`) - a `std::span` of bytes as the `std::string_view` this file's encoders take. `sha256`/`hmac_sha256` answer with `std::array<uint8_t, 32>`, and seven sites spelled the conversion themselves: `sample_capture.cpp`, `specs.cpp`, `mock_issuer.cpp`, `http/pkce.hpp`, `pkce_test.cpp` (×2), `mock_issuer_test.cpp` - and an eighth in `src/runtime/script_engine.cpp`, which lints nothing and so had never been counted. `pkce_test.cpp` is the tell: its own comment says a second copy of `hex_encode` "would not receive its fixes" while it hand-rolled this one two lines up.
- **`vayu::db::column_text`** (`db/database.hpp`) - a sqlite TEXT column as the `const char*` every caller wants. `sqlite3_column_text` answers `const unsigned char*` and nothing here consumes one. Eight sites: three C-style casts in `database.cpp`'s enum adapters, five `reinterpret_cast` in `db_test.cpp`. **A SQL NULL stays a null pointer** - absent and empty are different answers, and defaulting one to the other would erase the distinction three of those callers read.
- **`vayu::tests::pooled_task_queue`** (`tests/task_queue.hpp`) - httplib's `new_task_queue` factory. The raw owning `new` is that library's contract (the server deletes what the factory returns) and a `unique_ptr` cannot be returned through a `std::function<TaskQueue*()>`, so `cppcoreguidelines-owning-memory` is silenced once there with that reason instead of at each of seven fixtures.

### Rule of five on 24 RAII holders

`Client::Impl`, `ThreadPool::Impl`, `Database`, and the ~20 in-process mock servers and scratch-file fixtures in `tests/` each declared a destructor and left the other four implicit. That is how a fixture owning a listener and a thread stays copyable: the copy compiles, both objects stop the same server, and nothing says it was not meant to. All four are now `= delete` beside the destructor, in the spelling `client.hpp` already used. Deleting rather than defaulting is deliberate - none is meaningfully movable, and `Database` in particular is held as a stack local or a `unique_ptr` everywhere, never moved.

### The rest, read on their merits

- `struct stat st{}` in `platform_unix.cpp` (×2) - zeroed before `stat` fills it.
- `reorder.cpp`'s `Scope::kind` / `Move::kind` get a default: `read_scope` and `read_move` fill these out-parameters and can refuse the entry first, and an indeterminate enum is read as one by any path that forgets to check the refusal.
- `sse_parser.cpp`'s `sequence_is_valid` takes a `std::string_view` instead of a pointer and a length, so the caller cannot hand it a length its buffer does not hold. That removed a pointer-arithmetic finding too, which is batch 4's - noted rather than hidden.
- Four API-shaped constructs silenced with their reason: POSIX `open`'s varargs, `CURLMsg`'s union (whose active member `msg->msg` names, checked on the line above), and the two `sockaddr` casts the sockets API is built around.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
```

**2396 tests pass, 0 fail** (2390 on the base commit - six new).

**The rescan.** Batch 3's ten checks report **zero** over the 207 non-vendor translation units. `src/runtime/` is excluded by `engine/src/runtime/.clang-tidy`, which declines every check there with its reason; a check-list override surfaces 261 findings in `script_engine.cpp` and every one of them is that decision working rather than a backlog.

**The changed-lines gate, reproduced locally.** Every touched translation unit linted in full against the whole config and filtered to this branch's changed lines, per #979's warning that `clang-tidy-diff-19.py` cannot resolve files from this checkout. It found exactly one finding, in the new test file - `pro-bounds-constant-array-index` on a `std::array` subscript, batch 4's family pulled into scope by adding the line - and it is fixed here rather than left for CI. That is #979's lesson repeating: every line you touch is a line the next family already had an opinion about.

**The guard is mutation-checked.** Reverting `specs.cpp`'s rewrite to the hand-rolled cast made `CharacterCasts.TheEngineSourcesGoThroughThePrimitives` fail, naming `src/http/routes/specs.cpp`; restoring it passed.

`clang-format-19 --dry-run -Werror` clean over every touched file.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`tests/character_cast_test.cpp` is new, in the shape batch 1's `reentrant_test.cpp` set. Two halves: the primitives' own contracts (bytes survive a `0x00` and an interior zero byte; an empty span is an empty view; a SQL NULL is a null pointer and a multi-byte value is not truncated), and a source scan of `engine/{src,include,tests}` naming any file that spells a character-type `reinterpret_cast` itself. The scan asserts it read something (>200 files, >100KB) and carries planted positives *and* negatives, so an over-eager matcher cannot pass a tree that had brought every copy back. The exemption list is per file with a reason each. It exists because the CI gate scopes to changed lines and so holds nothing at zero once these lines stop being new - #975's argument, unchanged.

`engine/CLAUDE.md` gains the two rules this establishes, beside batch 1's and batch 2's.

## Deliberate deviations from the issue

- **The batch is a split, not the whole family.** #945's acceptance criterion is zero for all three families; this clears two of the three checks-groups and leaves `pro-bounds-*` on the issue, as batches 1 and 2 did for their families. #945 stays open.
- **No defect record sub-issue.** Category tally: **0 confirmed races, 0 reproducible defects, 51 findings cleared, 5 sites silenced with a reason.** The nearest thing to a defect is the copyable RAII fixture - a real double-stop waiting for someone to write `auto server = other_server;` - but nothing does, so there is nothing to record retroactively under #928's yield-ledger rule.
- **No TSan pass.** #945 asks for one on any fix in the threaded core. Nothing here changes threaded-core behaviour: the `event_loop_worker.cpp` edits are two comments and a `NOLINT`, and the deleted special members are compile-time declarations. Stated rather than skipped silently.

One thing found and filed rather than fixed: **#1013** - the paydown's numbers have all been translation-unit counts, and headers carry 50 findings for these families that no measurement has reported, because `HeaderFilterRegex` in the config does not reach a scan that omits `-header-filter` on the command line. Batch 3 cleared the headers it edited, per #975's rule, and stopped there. It matters to #946's final re-measure, which is why it is a sibling issue rather than a line in this description.

## Related Issues
Part of #945 (batch 3 of 4); sub-issue of #928. Filed from this work: #1013.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126GN9DBeFsfcVA8PAYkuxk)_