### PR TITLE
test(engine): finish the optional-access wave and gate the spelling it replaced (#980 final batch)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -57,7 +57,14 @@ engine/
   (`ASSERT_HAS_VALUE (row) << "after the second write"`). It is a guard, not a
   silencer: an optional the code under test may legitimately leave empty is
   still tested over both outcomes, and `invariant_value` remains the answer for
-  a rule that lives in another function.
+  a rule that lives in another function. Two shapes the macro does not cover:
+  an optional read *through* a guarded row (`row->parent_id`, a reassigned
+  `verdict.reason`) needs its own guard, since the outer one says nothing about
+  it, and a non-void test helper cannot use the macro at all - `FAIL ()`
+  returns - so it states the absent case as an `if` that `ADD_FAILURE ()`s and
+  returns something harmless. `optional_assert_test.cpp` scans `tests/` for the
+  spelling this replaced and fails naming the file, because CI lints a pull
+  request's changed lines only and nothing else holds the family at zero.
 - **The reentrant spelling of a C call, always** (#945). `std::localtime` and
   `std::strerror` hand back a pointer into storage the whole process shares, so
   with a worker thread per connection what comes back is a timestamp or an

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -22,6 +22,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/auth_refresh.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -237,7 +238,7 @@ TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
     for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
          "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs", "oauth2RefreshPollIntervalMs" }) {
         const auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not offered in Settings";
+        ASSERT_HAS_VALUE (entry) << key << " is not offered in Settings";
         EXPECT_EQ (entry->type, "integer") << key;
         EXPECT_FALSE (entry->label.empty ()) << key;
         EXPECT_FALSE (entry->description.empty ()) << key;
@@ -266,7 +267,7 @@ TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
         { "oauth2RefreshRetryMaxMs", 99'000 }, { "oauth2RefreshPollIntervalMs", 42 } };
     for (const auto& [key, value] : edits) {
         auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = std::to_string (value);
         db->save_config_entry (*entry);
     }
@@ -286,7 +287,7 @@ TEST_F (AuthRefreshTuningTest, ANonPositiveStoredValueFallsBackToTheDefault) {
     for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
          "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs", "oauth2RefreshPollIntervalMs" }) {
         auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = "0";
         db->save_config_entry (*entry);
     }
@@ -354,7 +355,7 @@ TEST_F (PlanAuthRefreshTest, PlansForAHeaderPlacedExpiringToken) {
     const auto plan =
     vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ());
 
-    ASSERT_TRUE (plan.has_value ());
+    ASSERT_HAS_VALUE (plan);
     EXPECT_EQ (plan->header_name, "Authorization");
     EXPECT_EQ (plan->header_value, "Bearer AT1");
     EXPECT_GT (plan->expires_at_ms, now_ms ());
@@ -370,7 +371,7 @@ TEST_F (PlanAuthRefreshTest, HonoursACustomHeaderPrefix) {
     const auto plan =
     vayu::http::plan_auth_refresh (request_with ("Token AT1"), auth, db.get ());
 
-    ASSERT_TRUE (plan.has_value ());
+    ASSERT_HAS_VALUE (plan);
     EXPECT_EQ (plan->header_value, "Token AT1");
 }
 
@@ -481,7 +482,7 @@ class MidRunRefreshTest : public ::testing::Test {
     /// UI offers rather than inventing a row beside it.
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        ASSERT_HAS_VALUE (entry) << key << " is not seeded";
         entry->value = value;
         db->save_config_entry (*entry);
     }
@@ -605,7 +606,7 @@ TEST_F (MidRunRefreshTest, AFailedRefreshIsRecordedAndTheRunStillCompletes) {
     manager.shutdown (std::chrono::milliseconds (15000));
 
     const auto stored = db->get_run ("run-auth-refresh-fails");
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->status, vayu::RunStatus::Completed)
     << "a refusal to refresh must not fail the run";
 

--- a/engine/tests/capacity_controller_test.cpp
+++ b/engine/tests/capacity_controller_test.cpp
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "optional_assert.hpp"
 #include "vayu/core/capacity_controller.hpp"
 #include "vayu/core/constants.hpp"
 
@@ -166,12 +167,12 @@ TEST (CapacityControllerTest, KneeIsTheLevelThatGaveOutAndHeadlineIsTheLastThatH
         window (48, 23400, 41.2), window (64, 23000, 300.0), window (64, 22800, 312.0) };
     const auto summary = summarize_capacity (search (), history, stop::SLO_EXCEEDED);
 
-    ASSERT_TRUE (summary.max_healthy.has_value ());
+    ASSERT_HAS_VALUE (summary.max_healthy);
     EXPECT_EQ (summary.max_healthy->concurrency, 48u);
     EXPECT_DOUBLE_EQ (summary.max_healthy->rps, 23400.0);
     EXPECT_DOUBLE_EQ (summary.max_healthy->p99_ms, 41.2);
 
-    ASSERT_TRUE (summary.knee.has_value ());
+    ASSERT_HAS_VALUE (summary.knee);
     EXPECT_EQ (summary.knee->concurrency, 64u);
     EXPECT_DOUBLE_EQ (summary.knee->p99_ms, 312.0);
     EXPECT_GT (summary.knee->p99_ms, summary.slo_ms);
@@ -185,7 +186,7 @@ TEST (CapacityControllerTest, NoKneeWhenTheSearchNeverSawTheServiceGiveOut) {
         window (100, 9000, 40.0) };
     const auto summary = summarize_capacity (search (), history, stop::CAP_REACHED);
 
-    ASSERT_TRUE (summary.max_healthy.has_value ());
+    ASSERT_HAS_VALUE (summary.max_healthy);
     EXPECT_EQ (summary.max_healthy->concurrency, 100u);
     EXPECT_FALSE (summary.knee.has_value ());
 }
@@ -196,7 +197,7 @@ TEST (CapacityControllerTest, NoHeadlineWhenTheFirstLevelAlreadyBreached) {
     const auto summary = summarize_capacity (search (), history, stop::SLO_EXCEEDED);
 
     EXPECT_FALSE (summary.max_healthy.has_value ());
-    ASSERT_TRUE (summary.knee.has_value ());
+    ASSERT_HAS_VALUE (summary.knee);
     EXPECT_EQ (summary.knee->concurrency, 10u);
 }
 

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -31,6 +31,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -474,14 +475,14 @@ TEST (ClientCertValidation, RejectsAFileThatIsNotThere) {
 
     const auto missing_cert = client_cert_rejection ("api.example.com",
     std::nullopt, ClientCertFormat::Pem, "/nope/client.pem", key.path ());
-    ASSERT_TRUE (missing_cert.has_value ());
+    ASSERT_HAS_VALUE (missing_cert);
     // The message has to name the file, or the user is left with "invalid
     // certificate" and two paths to check by hand.
     EXPECT_NE (missing_cert->find ("/nope/client.pem"), std::string::npos);
 
     const auto missing_key = client_cert_rejection ("api.example.com",
     std::nullopt, ClientCertFormat::Pem, cert.path (), "/nope/client.key");
-    ASSERT_TRUE (missing_key.has_value ());
+    ASSERT_HAS_VALUE (missing_key);
     EXPECT_NE (missing_key->find ("/nope/client.key"), std::string::npos);
 
     // A directory is not a file, and opening one succeeds on some platforms -
@@ -548,14 +549,14 @@ TEST (ClientCertValidation, APkcs12EntryCarriesItsOwnKeyAndMayNotNameOne) {
     // card would keep asking for a file nothing ever opens.
     const auto with_key = client_cert_rejection ("api.example.com",
     std::nullopt, ClientCertFormat::Pkcs12, bundle.path (), key.path ());
-    ASSERT_TRUE (with_key.has_value ());
+    ASSERT_HAS_VALUE (with_key);
     EXPECT_NE (with_key->find ("PKCS#12"), std::string::npos) << *with_key;
 
     // And the mirror: a PEM entry without a key names what is missing rather
     // than failing later against the endpoint.
     const auto without_key = client_cert_rejection (
     "api.example.com", std::nullopt, ClientCertFormat::Pem, bundle.path (), "");
-    ASSERT_TRUE (without_key.has_value ());
+    ASSERT_HAS_VALUE (without_key);
     EXPECT_NE (without_key->find ("key file"), std::string::npos) << *without_key;
 }
 
@@ -569,13 +570,13 @@ TEST (ClientCertValidation, RefusesAFileThatContradictsItsDeclaredFormat) {
     // endpoint, which is the misdiagnosis this registry exists to end.
     const auto bundle_as_pem = client_cert_rejection ("api.example.com",
     std::nullopt, ClientCertFormat::Pem, der.path (), key.path ());
-    ASSERT_TRUE (bundle_as_pem.has_value ());
+    ASSERT_HAS_VALUE (bundle_as_pem);
     EXPECT_NE (bundle_as_pem->find ("p12"), std::string::npos) << *bundle_as_pem;
     EXPECT_NE (bundle_as_pem->find (der.path ()), std::string::npos) << *bundle_as_pem;
 
     const auto pem_as_bundle = client_cert_rejection (
     "api.example.com", std::nullopt, ClientCertFormat::Pkcs12, pem.path (), "");
-    ASSERT_TRUE (pem_as_bundle.has_value ());
+    ASSERT_HAS_VALUE (pem_as_bundle);
     EXPECT_NE (pem_as_bundle->find ("pem"), std::string::npos) << *pem_as_bundle;
 }
 
@@ -612,9 +613,10 @@ TEST_F (ClientCertificateDbTest, CreatesAndListsAnEntry) {
 
     const auto rows = db_->get_client_certificates ();
     ASSERT_EQ (rows.size (), 1u);
-    EXPECT_EQ (rows.front ().host, "api.example.com");
-    ASSERT_TRUE (rows.front ().port.has_value ());
-    EXPECT_EQ (*rows.front ().port, 8443);
+    const auto& only = rows.front ();
+    EXPECT_EQ (only.host, "api.example.com");
+    ASSERT_HAS_VALUE (only.port);
+    EXPECT_EQ (*only.port, 8443);
 }
 
 TEST_F (ClientCertificateDbTest, RegistersAPkcs12EntryWithNoKeyPath) {

--- a/engine/tests/curl_utils_test.cpp
+++ b/engine/tests/curl_utils_test.cpp
@@ -13,6 +13,7 @@
 #include <climits>
 #include <string>
 
+#include "optional_assert.hpp"
 #include "vayu/http/event_loop/curl_utils.hpp"
 
 using vayu::http::detail::apply_phase_timings;
@@ -155,7 +156,7 @@ TEST (ValidateTransferable, HeadWithABodyIsRefusedWithAReason) {
     request.body.content = R"({"q":1})";
 
     auto error = validate_transferable (request);
-    ASSERT_TRUE (error.has_value ());
+    ASSERT_HAS_VALUE (error);
     EXPECT_EQ (error->code, vayu::ErrorCode::InvalidMethod);
     EXPECT_NE (error->message.find ("HEAD"), std::string::npos)
     << "the error must name what is wrong: " << error->message;
@@ -207,7 +208,7 @@ TEST (ValidateTransferable, AHeaderCarryingALineBreakIsRefused) {
     { "ok\r\nX-Admin: true", "ok\nX-Admin: true", "ok\rX-Admin: true" }) {
         request.headers = { { "X-Note", forged } };
         auto error      = validate_transferable (request);
-        ASSERT_TRUE (error.has_value ()) << forged;
+        ASSERT_HAS_VALUE (error) << forged;
         EXPECT_NE (error->message.find ("X-Note"), std::string::npos)
         << "the refusal must name the header: " << error->message;
         EXPECT_NE (error->message.find ("CR or LF"), std::string::npos) << error->message;
@@ -217,7 +218,7 @@ TEST (ValidateTransferable, AHeaderCarryingALineBreakIsRefused) {
     // quoted - quoting it would break the message the same way.
     request.headers = { { "X-A\r\nX-Admin: true", "v" } };
     auto error      = validate_transferable (request);
-    ASSERT_TRUE (error.has_value ());
+    ASSERT_HAS_VALUE (error);
     EXPECT_NE (error->message.find ("header name"), std::string::npos) << error->message;
     EXPECT_EQ (error->message.find ('\n'), std::string::npos)
     << "the message must not carry the injected line break: " << error->message;
@@ -232,7 +233,7 @@ TEST (ValidateTransferable, AHeaderCarryingANulIsRefused) {
     request.headers = { { "X-Note", std::string ("ok\0dropped", 10) } };
 
     auto error = validate_transferable (request);
-    ASSERT_TRUE (error.has_value ());
+    ASSERT_HAS_VALUE (error);
     EXPECT_NE (error->message.find ("NUL"), std::string::npos) << error->message;
 }
 

--- a/engine/tests/db_recovery_test.cpp
+++ b/engine/tests/db_recovery_test.cpp
@@ -21,6 +21,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/db/recovery.hpp"
@@ -98,7 +99,7 @@ TEST_F (DbRecoveryTest, DeletingACorruptDatabaseWithNoBackupIsRecorded) {
 
     auto db = std::make_unique<vayu::db::Database> (DB_PATH);
 
-    ASSERT_TRUE (db->recovery ().has_value ());
+    ASSERT_HAS_VALUE (db->recovery ());
     EXPECT_TRUE (recorded_outcome (*db) == RecoveryOutcome::DeletedCorrupt);
     EXPECT_GT (recorded_at (*db), 0);
 
@@ -128,7 +129,7 @@ TEST_F (DbRecoveryTest, RestoringFromABackupIsADifferentOutcome) {
     write_corrupt_database ();
     auto db = std::make_unique<vayu::db::Database> (DB_PATH);
 
-    ASSERT_TRUE (db->recovery ().has_value ());
+    ASSERT_HAS_VALUE (db->recovery ());
     EXPECT_TRUE (recorded_outcome (*db) == RecoveryOutcome::RestoredFromBackup);
     EXPECT_EQ (
     vayu::http::routes::build_health_response (*db)["recovery"]["outcome"],
@@ -146,7 +147,7 @@ TEST_F (DbRecoveryTest, TheRecordOutlivesTheEngineRunThatWroteIt) {
     }
 
     vayu::db::Database second (DB_PATH);
-    ASSERT_TRUE (second.recovery ().has_value ());
+    ASSERT_HAS_VALUE (second.recovery ());
     EXPECT_TRUE (recorded_outcome (second) == RecoveryOutcome::DeletedCorrupt);
 }
 

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -229,7 +229,7 @@ TEST_F (DatabaseTest, SeedRemovesRetiredRequestBatchSizeEntry) {
     stale.default_value = "5";
     stale.updated_at    = 1;
     db.save_config_entry (stale);
-    ASSERT_TRUE (db.get_config_entry ("requestBatchSize").has_value ());
+    ASSERT_HAS_VALUE (db.get_config_entry ("requestBatchSize"));
 
     db.seed_default_config ();
 
@@ -258,7 +258,7 @@ TEST_F (DatabaseTest, SeedRemovesRetiredContextPoolSizeEntry) {
     stale.default_value = "64";
     stale.updated_at    = 1;
     db.save_config_entry (stale);
-    ASSERT_TRUE (db.get_config_entry ("contextPoolSize").has_value ());
+    ASSERT_HAS_VALUE (db.get_config_entry ("contextPoolSize"));
 
     db.seed_default_config ();
 
@@ -356,7 +356,7 @@ TEST_F (DatabaseTest, SeedRemovesTheSweepRetiredEntries) {
         stale.default_value = "1";
         stale.updated_at    = 1;
         db.save_config_entry (stale);
-        ASSERT_TRUE (db.get_config_entry (key).has_value ());
+        ASSERT_HAS_VALUE (db.get_config_entry (key));
     }
 
     db.seed_default_config ();
@@ -524,7 +524,7 @@ TEST_F (DatabaseTest, DeletesEnvironment) {
     db.save_environment (env);
 
     auto retrieved = db.get_environment ("env_1");
-    ASSERT_TRUE (retrieved.has_value ());
+    ASSERT_HAS_VALUE (retrieved);
 
     db.delete_environment ("env_1");
 
@@ -1049,7 +1049,7 @@ TEST_F (DatabaseTest, PruneRunsNeverDeletesABaselineRun) {
     seed_run_with_children (db, "pinned", 1000);
     seed_run_with_children (db, "old", 2000);
     seed_run_with_children (db, "recent", 3000);
-    ASSERT_TRUE (db.set_run_baseline ("pinned", true).has_value ());
+    ASSERT_HAS_VALUE (db.set_run_baseline ("pinned", true));
 
 
     // Cap of one: without the exemption "pinned" is the oldest and the first
@@ -1079,7 +1079,7 @@ TEST_F (DatabaseTest, PruneRunsByAgeSparesABaselineRun) {
     const int64_t ninety_days_ago = now - 90 * day;
     seed_run_with_children (db, "pinned_stale", ninety_days_ago);
     seed_run_with_children (db, "stale", ninety_days_ago);
-    ASSERT_TRUE (db.set_run_baseline ("pinned_stale", true).has_value ());
+    ASSERT_HAS_VALUE (db.set_run_baseline ("pinned_stale", true));
 
     db.prune_runs (0, 30);
 

--- a/engine/tests/encoding_test.cpp
+++ b/engine/tests/encoding_test.cpp
@@ -5,6 +5,10 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
+#include <string>
+#include <string_view>
+
 #include "vayu/utils/encoding.hpp"
 
 using vayu::utils::base64_decode;
@@ -13,6 +17,20 @@ using vayu::utils::form_encode;
 using vayu::utils::hex_encode;
 using vayu::utils::url_decode;
 using vayu::utils::url_encode;
+
+namespace {
+
+/// The bytes @p encoded decodes to, or an empty string after a failure naming
+/// it. A vector table stays one line per vector this way, and an input that
+/// failed to decode is that line's failure rather than a read of an empty
+/// optional.
+std::string decoded (std::string_view encoded) {
+    const std::optional<std::string> bytes = base64_decode (encoded);
+    EXPECT_TRUE (bytes.has_value ()) << "expected \"" << encoded << "\" to decode";
+    return bytes.value_or (std::string{});
+}
+
+} // namespace
 
 // RFC 4648 §10 test vectors.
 TEST (Encoding, Base64Rfc4648Vectors) {
@@ -93,23 +111,23 @@ TEST (Encoding, FormEncodeOrdersAndEscapes) {
 // its author never encoded.
 
 TEST (Encoding, Base64DecodeRfc4648Vectors) {
-    EXPECT_EQ (base64_decode ("").value (), "");
-    EXPECT_EQ (base64_decode ("Zg==").value (), "f");
-    EXPECT_EQ (base64_decode ("Zm8=").value (), "fo");
-    EXPECT_EQ (base64_decode ("Zm9v").value (), "foo");
-    EXPECT_EQ (base64_decode ("Zm9vYg==").value (), "foob");
-    EXPECT_EQ (base64_decode ("Zm9vYmE=").value (), "fooba");
-    EXPECT_EQ (base64_decode ("Zm9vYmFy").value (), "foobar");
+    EXPECT_EQ (decoded (""), "");
+    EXPECT_EQ (decoded ("Zg=="), "f");
+    EXPECT_EQ (decoded ("Zm8="), "fo");
+    EXPECT_EQ (decoded ("Zm9v"), "foo");
+    EXPECT_EQ (decoded ("Zm9vYg=="), "foob");
+    EXPECT_EQ (decoded ("Zm9vYmE="), "fooba");
+    EXPECT_EQ (decoded ("Zm9vYmFy"), "foobar");
 }
 
 TEST (Encoding, Base64DecodeAcceptsUnpaddedAndWrappedInput) {
     // Padding is optional as long as the trailing bits are zero, and wrapped
     // base64 (a PEM-ish blob, a value pasted out of a config file) is common
     // enough that rejecting the newline would be its own bug.
-    EXPECT_EQ (base64_decode ("Zg").value (), "f");
-    EXPECT_EQ (base64_decode ("Zm8").value (), "fo");
-    EXPECT_EQ (base64_decode ("Zm9v\nYmFy").value (), "foobar");
-    EXPECT_EQ (base64_decode ("Zm9v YmFy").value (), "foobar");
+    EXPECT_EQ (decoded ("Zg"), "f");
+    EXPECT_EQ (decoded ("Zm8"), "fo");
+    EXPECT_EQ (decoded ("Zm9v\nYmFy"), "foobar");
+    EXPECT_EQ (decoded ("Zm9v YmFy"), "foobar");
 }
 
 TEST (Encoding, Base64DecodeRejectsMalformedInput) {
@@ -122,11 +140,11 @@ TEST (Encoding, Base64DecodeRejectsMalformedInput) {
 }
 
 TEST (Encoding, Base64DecodeCarriesHighBytesAndNul) {
-    const std::string decoded = base64_decode ("AP8Q").value ();
-    ASSERT_EQ (decoded.size (), 3U);
-    EXPECT_EQ (static_cast<unsigned char> (decoded[0]), 0x00);
-    EXPECT_EQ (static_cast<unsigned char> (decoded[1]), 0xFF);
-    EXPECT_EQ (static_cast<unsigned char> (decoded[2]), 0x10);
+    const std::string bytes = decoded ("AP8Q");
+    ASSERT_EQ (bytes.size (), 3U);
+    EXPECT_EQ (static_cast<unsigned char> (bytes[0]), 0x00);
+    EXPECT_EQ (static_cast<unsigned char> (bytes[1]), 0xFF);
+    EXPECT_EQ (static_cast<unsigned char> (bytes[2]), 0x10);
 }
 
 TEST (Encoding, Base64RoundTripsEveryByteValue) {
@@ -134,7 +152,7 @@ TEST (Encoding, Base64RoundTripsEveryByteValue) {
     for (int i = 0; i < 256; ++i) {
         all.push_back (static_cast<char> (i));
     }
-    EXPECT_EQ (base64_decode (base64_encode (all)).value (), all);
+    EXPECT_EQ (decoded (base64_encode (all)), all);
 }
 
 TEST (Encoding, HexEncodeIsLowercaseAndZeroPadded) {

--- a/engine/tests/examples_route_test.cpp
+++ b/engine/tests/examples_route_test.cpp
@@ -23,6 +23,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
@@ -210,13 +211,17 @@ TEST_F (ExamplesRouteTest, CreateDefaultsOriginToImportAndKeepsAClaimedUser) {
     *db_, "req_1", json{ { "name", "Bare" } });
     ASSERT_EQ (status, 200) << body.dump ();
     EXPECT_EQ (body["origin"], "import");
-    EXPECT_EQ (db_->get_request_example (body["id"])->origin, "import");
+    const auto stored_example7 = db_->get_request_example (body["id"]);
+    ASSERT_HAS_VALUE (stored_example7);
+    EXPECT_EQ (stored_example7->origin, "import");
 
     auto [saved_status, saved] = routes::create_request_example_response (*db_,
     "req_1", json{ { "name", "Saved from a response" }, { "origin", "user" } });
     ASSERT_EQ (saved_status, 200) << saved.dump ();
     EXPECT_EQ (saved["origin"], "user");
-    EXPECT_EQ (db_->get_request_example (saved["id"])->origin, "user");
+    const auto stored_example6 = db_->get_request_example (saved["id"]);
+    ASSERT_HAS_VALUE (stored_example6);
+    EXPECT_EQ (stored_example6->origin, "user");
 }
 
 // A 400, not a silent fall back to `import`: an absorbed typo would hand a
@@ -255,7 +260,9 @@ TEST_F (ExamplesRouteTest, UpdateOriginFollowsTheNullVsAbsentRule) {
     auto [bad_status, bad_body] = routes::update_request_example_response (
     *db_, "req_1", id, json{ { "origin", "elsewhere" } });
     EXPECT_EQ (bad_status, 400);
-    EXPECT_EQ (db_->get_request_example (id)->origin, "import");
+    const auto stored_example5 = db_->get_request_example (id);
+    ASSERT_HAS_VALUE (stored_example5);
+    EXPECT_EQ (stored_example5->origin, "import");
 }
 
 // ---------------------------------------------------------------------------
@@ -271,14 +278,18 @@ TEST_F (ExamplesRouteTest, CreateDefaultsBodyTruncatedToFalseAndKeepsAClaimedTru
     *db_, "req_1", json{ { "name", "Whole" } });
     ASSERT_EQ (status, 200) << body.dump ();
     EXPECT_EQ (body["bodyTruncated"], false);
-    EXPECT_FALSE (db_->get_request_example (body["id"])->body_truncated);
+    const auto stored_example4 = db_->get_request_example (body["id"]);
+    ASSERT_HAS_VALUE (stored_example4);
+    EXPECT_FALSE (stored_example4->body_truncated);
 
     auto [cut_status, cut] = routes::create_request_example_response (*db_, "req_1",
     json{ { "name", "First slice only" }, { "body", "{\"items\":[" },
     { "bodyTruncated", true } });
     ASSERT_EQ (cut_status, 200) << cut.dump ();
     EXPECT_EQ (cut["bodyTruncated"], true);
-    EXPECT_TRUE (db_->get_request_example (cut["id"])->body_truncated);
+    const auto stored_example3 = db_->get_request_example (cut["id"]);
+    ASSERT_HAS_VALUE (stored_example3);
+    EXPECT_TRUE (stored_example3->body_truncated);
 }
 
 // The list read is what the Examples panel paints its chip from, so the flag
@@ -312,7 +323,9 @@ TEST_F (ExamplesRouteTest, UpdateBodyTruncatedFollowsTheNullVsAbsentRule) {
     *db_, "req_1", id, json{ { "bodyTruncated", nullptr } });
     ASSERT_EQ (reset_status, 200) << reset_body.dump ();
     EXPECT_EQ (reset_body["bodyTruncated"], false);
-    EXPECT_FALSE (db_->get_request_example (id)->body_truncated);
+    const auto stored_example2 = db_->get_request_example (id);
+    ASSERT_HAS_VALUE (stored_example2);
+    EXPECT_FALSE (stored_example2->body_truncated);
 }
 
 // ---------------------------------------------------------------------------
@@ -406,7 +419,7 @@ TEST_F (ExamplesRouteTest, ExampleOfAnotherRequestIsInvisible) {
 
     // Still stored, still named what its owner called it.
     auto stored = db_->get_request_example (id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->name, "theirs");
 }
 
@@ -415,7 +428,9 @@ TEST_F (ExamplesRouteTest, UpdateRejectsMismatchedBodyId) {
     auto [status, body]  = routes::update_request_example_response (
     *db_, "req_1", id, json{ { "id", "exa_other" }, { "name", "y" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (db_->get_request_example (id)->name, "x");
+    const auto stored_example = db_->get_request_example (id);
+    ASSERT_HAS_VALUE (stored_example);
+    EXPECT_EQ (stored_example->name, "x");
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/tests/form_body_test.cpp
+++ b/engine/tests/form_body_test.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "echo_server.hpp"
+#include "optional_assert.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/form_body.hpp"
@@ -589,7 +590,7 @@ TEST (FormBodyRules, UnsendableFilePartNamesTheFieldAndThePath) {
     body.fields = { file };
 
     const auto missing = unsendable_file_part (body);
-    ASSERT_TRUE (missing.has_value ());
+    ASSERT_HAS_VALUE (missing);
     EXPECT_NE (missing->find ("avatar"), std::string::npos) << *missing;
     EXPECT_NE (missing->find ("/nonexistent/vayu/avatar.png"), std::string::npos)
     << *missing;
@@ -598,7 +599,7 @@ TEST (FormBodyRules, UnsendableFilePartNamesTheFieldAndThePath) {
     // the user at a path that does not exist because they never named one.
     body.fields[0].src = "";
     const auto unset   = unsendable_file_part (body);
-    ASSERT_TRUE (unset.has_value ());
+    ASSERT_HAS_VALUE (unset);
     EXPECT_NE (unset->find ("avatar"), std::string::npos) << *unset;
     EXPECT_NE (unset->find ("no file selected"), std::string::npos) << *unset;
 }

--- a/engine/tests/http_version_test.cpp
+++ b/engine/tests/http_version_test.cpp
@@ -1,3 +1,4 @@
+#include "optional_assert.hpp"
 #include "vayu/http/curl_version_map.hpp"
 #include "vayu/types.hpp"
 #include <gtest/gtest.h>
@@ -19,7 +20,7 @@ TEST (HttpVersionDomain, EnumerationCoversTheWholeEnum) {
 TEST (HttpVersionDomain, RoundTripsEveryMember) {
     for (auto v : vayu::all_http_versions ()) {
         auto parsed = vayu::http_version_from_string (vayu::to_string (v));
-        ASSERT_TRUE (parsed.has_value ()) << vayu::to_string (v);
+        ASSERT_HAS_VALUE (parsed) << vayu::to_string (v);
         EXPECT_EQ (*parsed, v);
     }
 }

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -113,7 +113,7 @@ TEST_F (ImportApplyRouteTest, MapsEveryTempIdToAPrefixedEngineId) {
     EXPECT_EQ (id_map["e1"].get<std::string> ().rfind ("env_", 0), 0u);
 
     // The temp ids are opaque client strings and must not be stored anywhere.
-    ASSERT_TRUE (db_->get_collection (id_map["c1"].get<std::string> ()).has_value ());
+    ASSERT_HAS_VALUE (db_->get_collection (id_map["c1"].get<std::string> ()));
     EXPECT_FALSE (db_->get_collection ("c1").has_value ());
     EXPECT_FALSE (db_->get_request ("r1").has_value ());
     EXPECT_FALSE (db_->get_environment ("e1").has_value ());

--- a/engine/tests/import_parse_test.cpp
+++ b/engine/tests/import_parse_test.cpp
@@ -41,6 +41,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/import_document.hpp"
 #include "vayu/db/database.hpp"
@@ -302,7 +303,7 @@ TEST_F (ImportParseRoute, RefusesADocumentOverTheStoredCap) {
     // document is read into memory whatever format claims it, and an OpenAPI
     // import stores exactly these bytes.
     auto entry = db_->get_config_entry ("maxSpecDocumentBytes");
-    ASSERT_TRUE (entry.has_value ());
+    ASSERT_HAS_VALUE (entry);
     entry->value = "64";
     db_->save_config_entry (*entry);
     auto [status, body] = vayu::http::routes::import_parse_response (

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -47,7 +47,7 @@ namespace inbox_constants = vayu::core::constants::inbox;
 
 TEST (InboxParseStart, EmptyBodyStartsALoopbackInboxAnswering200) {
     const auto parsed = vayu::http::parse_inbox_start (json (nullptr));
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->bind, "127.0.0.1");
     EXPECT_EQ (parsed->port, 0);
     EXPECT_EQ (parsed->response.status, 200);
@@ -61,7 +61,7 @@ TEST (InboxParseStart, ReadsEveryResponseField) {
           { { "status", 503 }, { "body", "retry later" }, { "delayMs", 25 },
           { "headers", { { "Retry-After", "1" } } } } } };
     const auto parsed = vayu::http::parse_inbox_start (body);
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->response.status, 503);
     EXPECT_EQ (parsed->response.body, "retry later");
     EXPECT_EQ (parsed->response.delay_ms, 25);
@@ -99,7 +99,7 @@ TEST (InboxParseStart, NonLoopbackBindNeedsExplicitConfirmation) {
 
     const auto accepted = vayu::http::parse_inbox_start (
     json{ { "bind", "0.0.0.0" }, { "confirmNonLoopback", true } });
-    ASSERT_TRUE (accepted.has_value ());
+    ASSERT_HAS_VALUE (accepted);
     EXPECT_EQ (accepted->bind, "0.0.0.0");
 
     // Loopback in any of its spellings needs no confirmation.
@@ -132,7 +132,7 @@ TEST (InboxParseStart, ALoopbackLookingHostnameIsNotLoopback) {
 
     const auto accepted = vayu::http::parse_inbox_start (
     json{ { "bind", "127.example.com" }, { "confirmNonLoopback", true } });
-    ASSERT_TRUE (accepted.has_value ());
+    ASSERT_HAS_VALUE (accepted);
     EXPECT_EQ (accepted->bind, "127.example.com");
 
     // The whole of 127.0.0.0/8 still needs no confirmation.
@@ -149,7 +149,7 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
 
     const auto status_only =
     vayu::http::parse_inbox_response_update (json{ { "status", 200 } }, current);
-    ASSERT_TRUE (status_only.has_value ());
+    ASSERT_HAS_VALUE (status_only);
     EXPECT_EQ (status_only->status, 200);
     // The point of the merge: changing the status must not drop the rest.
     EXPECT_EQ (status_only->body, "boom");
@@ -160,7 +160,7 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
     // what it was handed.
     const auto wrapped = vayu::http::parse_inbox_response_update (
     json{ { "response", { { "body", "ok" } } } }, current);
-    ASSERT_TRUE (wrapped.has_value ());
+    ASSERT_HAS_VALUE (wrapped);
     EXPECT_EQ (wrapped->body, "ok");
     EXPECT_EQ (wrapped->status, 500);
 
@@ -174,18 +174,18 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
 
 TEST (InboxLiveResumePoint, AbsentMeansFromTheStartAndTheHeaderWinsOverTheParam) {
     const auto absent = vayu::http::parse_live_resume_point ("", "");
-    ASSERT_TRUE (absent.has_value ());
+    ASSERT_HAS_VALUE (absent);
     EXPECT_EQ (*absent, 0);
 
     // The query parameter is the app's own reconnect - EventSource cannot set a
     // header on a fresh connection - and is read exactly like the header.
     const auto from_param = vayu::http::parse_live_resume_point ("", "42");
-    ASSERT_TRUE (from_param.has_value ());
+    ASSERT_HAS_VALUE (from_param);
     EXPECT_EQ (*from_param, 42);
 
     // The browser's reconnect header is the more recent of the two.
     const auto from_header = vayu::http::parse_live_resume_point ("77", "42");
-    ASSERT_TRUE (from_header.has_value ());
+    ASSERT_HAS_VALUE (from_header);
     EXPECT_EQ (*from_header, 77);
 }
 
@@ -195,7 +195,7 @@ TEST (InboxLiveResumePoint, RejectsAValueThatIsNotACaptureId) {
         // Empty is absence, not a bad value - it is in this list to pin that.
         const auto resume_point = vayu::http::parse_live_resume_point ("", value);
         if (value.empty ()) {
-            ASSERT_TRUE (resume_point.has_value ());
+            ASSERT_HAS_VALUE (resume_point);
             EXPECT_EQ (*resume_point, 0);
             continue;
         }
@@ -319,7 +319,7 @@ TEST_F (InboxListenerTest, UpdatingTheCannedResponseTakesEffectOnTheNextCall) {
     InboxCannedResponse updated;
     updated.status = 202;
     updated.body   = "queued";
-    ASSERT_TRUE (manager_->update_response (started.info.inbox_id, updated).has_value ());
+    ASSERT_HAS_VALUE (manager_->update_response (started.info.inbox_id, updated));
 
     auto response = client.Post ("/hook", "", "text/plain");
     ASSERT_TRUE (response);
@@ -426,7 +426,7 @@ TEST_F (InboxListenerTest, DeleteLeavesAnAttachedLiveStreamNothingToStrand) {
     const auto claim = manager_->try_claim_live (started.info.inbox_id);
     ASSERT_HAS_VALUE (claim);
 
-    ASSERT_TRUE (manager_->remove (*db_, started.info.inbox_id).has_value ());
+    ASSERT_HAS_VALUE (manager_->remove (*db_, started.info.inbox_id));
 
     // What the stream's own loop checks: the inbox is gone, so it breaks out.
     EXPECT_FALSE (manager_->get (started.info.inbox_id).has_value ());

--- a/engine/tests/json_test.cpp
+++ b/engine/tests/json_test.cpp
@@ -3,6 +3,7 @@
  * @brief Tests for JSON utilities
  */
 
+#include "optional_assert.hpp"
 #include "vayu/utils/json.hpp"
 
 #include <gtest/gtest.h>
@@ -192,7 +193,7 @@ TEST (JsonTest, TryParseBodyReturnsNulloptForInvalidJson) {
 TEST (JsonTest, TryParseBodyReturnsJsonForValidInput) {
     auto result = try_parse_body (R"({"key": "value"})");
 
-    ASSERT_TRUE (result.has_value ());
+    ASSERT_HAS_VALUE (result);
     EXPECT_EQ ((*result)["key"], "value");
 }
 

--- a/engine/tests/load_script_scopes_test.cpp
+++ b/engine/tests/load_script_scopes_test.cpp
@@ -27,6 +27,7 @@
 #include <optional>
 #include <string>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -195,7 +196,7 @@ TEST_F (LoadScriptScopesTest, ATestPassingOnSendPassesUnderLoad) {
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->sampled, 1u);
     EXPECT_EQ (validation.run->passed, 1u);
     EXPECT_EQ (validation.run->failed, 0u)
@@ -223,7 +224,7 @@ TEST_F (LoadScriptScopesTest, GlobalsAndTheWholeCollectionChainAreBoundToo) {
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->passed, 3u);
     EXPECT_EQ (validation.run->failed, 0u);
 }
@@ -247,9 +248,10 @@ TEST_F (LoadScriptScopesTest, AScenarioStepReplayReadsTheRunningCollectionsScope
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
     ASSERT_EQ (validation.steps.size (), 1u);
-    ASSERT_TRUE (validation.steps[0].has_value ());
-    EXPECT_EQ (validation.steps[0]->passed, 1u);
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 1u);
+    EXPECT_EQ (first_step->failed, 0u);
 }
 
 // The write rule, half one: a replay's `set()` is never persisted. A reservoir
@@ -269,7 +271,7 @@ TEST_F (LoadScriptScopesTest, AReplayWriteIsNeverPersisted) {
     context->metrics_collector->record_response_sample (response_with ("{}"));
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->passed, 1u)
     << "the write was not even visible in-memory";
 
@@ -277,10 +279,10 @@ TEST_F (LoadScriptScopesTest, AReplayWriteIsNeverPersisted) {
     << "a deferred replay persisted a variable; only design mode may write "
        "back";
     auto globals = db_->get_globals ();
-    ASSERT_TRUE (globals.has_value ());
+    ASSERT_HAS_VALUE (globals);
     EXPECT_EQ (globals->variables, GLOBALS_BLOB);
     auto leaf = db_->get_collection ("col_leaf");
-    ASSERT_TRUE (leaf.has_value ());
+    ASSERT_HAS_VALUE (leaf);
     EXPECT_EQ (leaf->variables, LEAF_BLOB);
 }
 
@@ -302,7 +304,7 @@ TEST_F (LoadScriptScopesTest, AWriteIsVisibleToTheSamplesReplayedAfterIt) {
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->sampled, 2u);
     EXPECT_EQ (validation.run->passed, 1u);
     EXPECT_EQ (validation.run->failed, 1u);
@@ -325,7 +327,7 @@ TEST_F (LoadScriptScopesTest, ARunWithNoEnvironmentStillBindsTheOtherScopes) {
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->passed, 2u);
     EXPECT_EQ (validation.run->failed, 0u);
 }

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -11,6 +11,7 @@
  * a pending_count()-based cap never fires.
  */
 
+#include "optional_assert.hpp"
 #include "vayu/core/load_strategy.hpp"
 
 #include <gtest/gtest.h>
@@ -829,8 +830,7 @@ TEST_F (LoadStrategyTest, OutliersAndExemplarsCaptureBodiesButPlainSamplesDoNot)
     const auto& slow = context->metrics_collector->slow_results ();
     ASSERT_EQ (slow.size (), 1u)
     << "the outlier was rerouted out of the slow store by the exemplar bucket";
-    ASSERT_TRUE (slow[0].capture.has_value ())
-    << "an outlier must carry its body";
+    ASSERT_HAS_VALUE (slow[0].capture) << "an outlier must carry its body";
 
     // Every sampled fast completion is stored; the first `quota` of them
     // claimed an exemplar and kept a body, the one past the quota did not.
@@ -952,7 +952,7 @@ TEST_F (LoadStrategyTest, CapacityStopsOnTheSloAgainstASlowEndpoint) {
     run_capacity_search (config, mock_server->slow_url (), "test-capacity-slo", db);
 
     EXPECT_EQ (summary.stop_reason, "slo_exceeded");
-    ASSERT_TRUE (summary.knee.has_value ());
+    ASSERT_HAS_VALUE (summary.knee);
     EXPECT_GT (summary.knee->p99_ms, summary.slo_ms);
     EXPECT_EQ (summary.knee->concurrency, 4u)
     << "the search should not have climbed";
@@ -978,7 +978,7 @@ TEST_F (LoadStrategyTest, CapacityStopsAtTheCapAgainstAFastEndpoint) {
     run_capacity_search (config, mock_server->fast_url (), "test-capacity-cap", db);
 
     EXPECT_EQ (summary.stop_reason, "cap_reached");
-    ASSERT_TRUE (summary.max_healthy.has_value ());
+    ASSERT_HAS_VALUE (summary.max_healthy);
     EXPECT_EQ (summary.max_healthy->concurrency, 3u);
     EXPECT_GT (summary.max_healthy->rps, 0.0);
     EXPECT_FALSE (summary.knee.has_value ());
@@ -1005,7 +1005,7 @@ TEST_F (LoadStrategyTest, CapacityStopsOnItsDeadline) {
     // One window closed before the clock ran out; the partial second one is not
     // in the audit trail, because it was never judged.
     EXPECT_EQ (summary.levels.size (), 1u);
-    ASSERT_TRUE (summary.max_healthy.has_value ());
+    ASSERT_HAS_VALUE (summary.max_healthy);
     EXPECT_EQ (summary.max_healthy->concurrency, 2u);
 }
 
@@ -1053,7 +1053,7 @@ TEST_F (LoadStrategyTest, PhaseHistogramsEscapeTheRetentionSample) {
     EXPECT_EQ (context->metrics_collector->success_results ().size (), 50u);
 
     auto phases = context->metrics_collector->phase_percentiles ();
-    ASSERT_TRUE (phases.has_value ());
+    ASSERT_HAS_VALUE (phases);
     const auto& ttfb =
     (*phases)[static_cast<size_t> (vayu::core::TimingPhase::FirstByte)];
     EXPECT_EQ (ttfb.count, 500u);

--- a/engine/tests/load_stream_events_test.cpp
+++ b/engine/tests/load_stream_events_test.cpp
@@ -31,6 +31,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -222,7 +223,7 @@ class LoadReplayEventsTest : public ::testing::Test {
     /// Write a config value through the catalogue, as POST /config does.
     void set_config (const char* key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = value;
         db_->save_config_entry (*entry);
     }
@@ -260,7 +261,7 @@ TEST_F (LoadReplayEventsTest, AStreamedSampleReplaysWithItsEvents) {
     streamed_response (THREE_EVENTS, 3));
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->failed, 0u);
     EXPECT_EQ (validation.run->passed, 1u);
 }
@@ -281,7 +282,7 @@ TEST_F (LoadReplayEventsTest, ANonStreamSampleLeavesTheFieldUndefined) {
     context->metrics_collector->record_response_sample (plain);
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->passed, 1u);
     EXPECT_EQ (validation.run->failed, 0u);
 }
@@ -302,7 +303,7 @@ TEST_F (LoadReplayEventsTest, TheStoredEventsSettingBoundsWhatAReplayedScriptSee
     streamed_response (event_body (6), 6));
 
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->failed, 0u);
     EXPECT_EQ (validation.run->passed, 1u);
 }

--- a/engine/tests/mock_server_routes_test.cpp
+++ b/engine/tests/mock_server_routes_test.cpp
@@ -25,6 +25,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -53,7 +54,7 @@ int64_t now_ms () {
 TEST (MockParseStart, RequiresACollectionAndDefaultsTheRest) {
     const auto parsed =
     vayu::http::parse_mock_start (json{ { "collectionId", "col_1" } });
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->collection_id, "col_1");
     EXPECT_EQ (parsed->port, 0);
     EXPECT_EQ (parsed->latency_ms, 0);
@@ -79,7 +80,7 @@ TEST (MockParseStart, RequiresACollectionAndDefaultsTheRest) {
 TEST (MockParseStart, ReadsAndBoundsEveryTuningField) {
     const auto parsed = vayu::http::parse_mock_start (json{ { "collectionId", "col_1" },
     { "port", 41234 }, { "latencyMs", 25 }, { "errorRatePct", 10 } });
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->port, 41234);
     EXPECT_EQ (parsed->latency_ms, 25);
     EXPECT_EQ (parsed->error_rate_pct, 10);
@@ -358,11 +359,11 @@ TEST_F (MockServerTest, ALiteralRouteBeatsATemplatedOneWhateverOrderTheyWereWrit
     ASSERT_EQ (routes[0].path_template, "/pets/{{petId}}")
     << "the wildcard must come first";
     const auto mine = vayu::http::resolve_mock_route (routes, "GET", "/pets/mine");
-    ASSERT_TRUE (mine.route_index.has_value ());
+    ASSERT_HAS_VALUE (mine.route_index);
     EXPECT_EQ (routes[*mine.route_index].response.body, "literal");
 
     const auto other = vayu::http::resolve_mock_route (routes, "GET", "/pets/42");
-    ASSERT_TRUE (other.route_index.has_value ());
+    ASSERT_HAS_VALUE (other.route_index);
     EXPECT_EQ (routes[*other.route_index].response.body, "wildcard");
 }
 
@@ -486,7 +487,7 @@ TEST_F (MockServerTest, AStartedMockServesItsExamplesAndReportsItsTable) {
     EXPECT_EQ (json::parse (bare->body)["error"]["code"], "mock_no_example");
 
     const auto table = manager.routes (started.info.mock_id);
-    ASSERT_TRUE (table.has_value ());
+    ASSERT_HAS_VALUE (table);
     EXPECT_EQ (table->size (), 4u);
     EXPECT_FALSE (manager.routes ("mock_nope").has_value ());
 }
@@ -550,7 +551,7 @@ TEST_F (MockServerTest, StopEndsTheListenerAndDropsTheRecord) {
     const int port = started.info.port;
 
     ASSERT_EQ (manager.list ().size (), 1u);
-    ASSERT_TRUE (manager.get (started.info.mock_id).has_value ());
+    ASSERT_HAS_VALUE (manager.get (started.info.mock_id));
 
     EXPECT_TRUE (manager.stop (started.info.mock_id));
     // A stop is a delete: a mock holds nothing that outlives its listener, so
@@ -648,7 +649,7 @@ TEST_F (MockServerTest, ALoadRunCanTargetAMockEndToEnd) {
     run_manager.shutdown (std::chrono::milliseconds (15000));
 
     const auto stored = db_->get_run (row.id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     ASSERT_FALSE (stored->summary.empty ()) << "the run produced no summary";
     const json summary = json::parse (stored->summary);
     // The point of the workflow: a realistic, zero-cost upstream that actually

--- a/engine/tests/monitor_test.cpp
+++ b/engine/tests/monitor_test.cpp
@@ -20,6 +20,7 @@
 #include <nlohmann/json.hpp>
 
 #include "mock_server.hpp"
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/monitor.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -61,7 +62,7 @@ TEST (MonitorConfigValidation, AMinimalBlockIsAcceptedAndDefaulted) {
     ASSERT_FALSE (validate_monitor_config (config).has_value ());
 
     auto parsed = monitor_config_from (config);
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->url, "http://localhost:9100/metrics");
     EXPECT_EQ (parsed->interval_ms, vayu::core::monitor_limits::DEFAULT_INTERVAL_MS);
     EXPECT_EQ (parsed->format, MonitorFormat::Prometheus);
@@ -139,7 +140,7 @@ class MonitorLimitsTest : public ::testing::Test {
 
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << "seed_default_config did not seed " << key;
+        ASSERT_HAS_VALUE (entry) << "seed_default_config did not seed " << key;
         entry->value = value;
         db->save_config_entry (*entry);
     }
@@ -166,7 +167,7 @@ TEST_F (MonitorLimitsTest, TheConfiguredScrapeTimeoutReachesTheBlockTheRunExecut
     auto config = monitor_config (json{ { "url", "http://localhost:9100/metrics" },
     { "series", json::array ({ "up" }) } });
     auto parsed = monitor_config_from (config, limits);
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->scrape_timeout_ms, 1800);
 }
 
@@ -225,12 +226,14 @@ TEST_F (MonitorLimitsTest, TheConfiguredIntervalIsWhatABlockWithoutOneScrapesAt)
     auto config = monitor_config (json{ { "url", "http://localhost:9100/metrics" },
     { "series", json::array ({ "up" }) } });
     auto parsed = monitor_config_from (config, limits);
-    ASSERT_TRUE (parsed.has_value ());
+    ASSERT_HAS_VALUE (parsed);
     EXPECT_EQ (parsed->interval_ms, 5000);
 
     // ...and a block that states its own still wins.
     config["monitor"]["intervalMs"] = 250;
-    EXPECT_EQ (monitor_config_from (config, limits)->interval_ms, 250);
+    const auto stated               = monitor_config_from (config, limits);
+    ASSERT_HAS_VALUE (stated);
+    EXPECT_EQ (stated->interval_ms, 250);
 }
 
 TEST_F (MonitorLimitsTest, TheConfiguredCapIsWhatTheSeriesListIsJudgedAgainst) {
@@ -417,7 +420,7 @@ class MonitorRunTest : public ::testing::Test {
 
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << "seed_default_config did not seed " << key;
+        ASSERT_HAS_VALUE (entry) << "seed_default_config did not seed " << key;
         entry->value = value;
         db->save_config_entry (*entry);
     }
@@ -479,7 +482,7 @@ TEST_F (MonitorRunTest, AConfiguredRunRecordsSamplesForItsWholeDuration) {
 
     // The report's section, from the same scrape.
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     auto summary = json::parse (stored->summary);
     ASSERT_TRUE (summary.contains ("monitor")) << stored->summary;
     EXPECT_GE (summary["monitor"]["samples"].get<size_t> (), 4u);
@@ -550,7 +553,7 @@ TEST_F (MonitorRunTest, AHangingEndpointStallsNeitherTheRunNorTheTicks) {
     // The gaps are counted, so the report says the scrape found nothing rather
     // than silently showing an empty chart.
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     auto summary = json::parse (stored->summary);
     ASSERT_TRUE (summary.contains ("monitor"));
     EXPECT_EQ (summary["monitor"]["samples"].get<size_t> (), 0u);
@@ -605,7 +608,7 @@ TEST_F (MonitorRunTest, ASlowExpositionScrapesOnceTheBudgetIsRaisedAtTheSameCade
     // The cadence is the one the run asked for either way: the setting buys a
     // longer scrape, not a slower one.
     auto stored = db->get_run (raised_run);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     auto summary = json::parse (stored->summary);
     ASSERT_TRUE (summary.contains ("monitor")) << stored->summary;
     EXPECT_GE (summary["monitor"]["samples"].get<size_t> (), 1u);
@@ -626,7 +629,7 @@ TEST_F (MonitorRunTest, ARunWithoutAMonitorScrapesNothingAndReportsNoSection) {
 
     EXPECT_EQ (db->count_monitor_samples (run_id), 0);
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     auto summary = json::parse (stored->summary);
     EXPECT_FALSE (summary.contains ("monitor"))
     << "a run that configured no monitor reported one";

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -66,6 +66,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "tls_backend.hpp"
 #include "tls_server.hpp"
@@ -221,7 +222,7 @@ class MutualTlsTest : public ::testing::TestWithParam<ClientIdentityFormat> {
 
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        ASSERT_HAS_VALUE (entry) << key << " is not seeded";
         entry->value = value;
         db_->save_config_entry (*entry);
     }

--- a/engine/tests/oauth_client_test.cpp
+++ b/engine/tests/oauth_client_test.cpp
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/http/oauth_client.hpp"
 
@@ -309,7 +310,9 @@ TEST_F (OAuthClientTest, ExpiredTokenRefreshesAndKeepsOldRefreshToken) {
     EXPECT_EQ (form["grant_type"], "refresh_token");
     EXPECT_EQ (form["refresh_token"], "RT_OLD");
     // Persisted rotation is durable
-    EXPECT_EQ (db_->get_oauth_token (stale.cache_key)->refresh_token, "RT_OLD");
+    const auto stored_token = db_->get_oauth_token (stale.cache_key);
+    ASSERT_HAS_VALUE (stored_token);
+    EXPECT_EQ (stored_token->refresh_token, "RT_OLD");
 }
 
 TEST_F (OAuthClientTest, RejectedRefreshFallsBackToFreshGrant) {
@@ -402,7 +405,7 @@ TEST_F (OAuthClientTest, DbRoundTrip) {
     t.raw_response  = "{}";
     db_->save_oauth_token (t);
     auto got = db_->get_oauth_token ("k1");
-    ASSERT_TRUE (got.has_value ());
+    ASSERT_HAS_VALUE (got);
     EXPECT_EQ (got->access_token, "a");
     EXPECT_EQ (got->created_at, 42);
     db_->delete_oauth_token ("k1");

--- a/engine/tests/optional_assert_test.cpp
+++ b/engine/tests/optional_assert_test.cpp
@@ -7,7 +7,8 @@
 
 /**
  * @file tests/optional_assert_test.cpp
- * @brief What `ASSERT_HAS_VALUE` promises a test that uses it (issue #980).
+ * @brief What `ASSERT_HAS_VALUE` promises a test that uses it (issue #980),
+ *        and the guard that keeps the spelling it replaced out of the suite.
  *
  * The property that made the macro necessary - that
  * `bugprone-unchecked-optional-access` accepts the guard it writes - is a lint
@@ -17,15 +18,26 @@
  * the failure names the expression it was given, and that a caller's own
  * message survives. Those are what a future rewrite of the macro would break
  * silently.
+ *
+ * The scan at the bottom is the other half of the wave. CI lints a pull
+ * request's *changed* lines, so once these conversions stop being new nothing
+ * holds the family at zero - the same argument #945 made for `concurrency-*`.
+ * It could not be turned on until every test file was converted, which is what
+ * #980's last batch did; reverting any one conversion fails it.
  */
 
+#include <algorithm>
+#include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 #include "optional_assert.hpp"
+#include "source_scan.hpp"
 
 namespace {
 
@@ -65,4 +77,128 @@ TEST (OptionalAssert, AnEngagedOptionalRaisesNothing) {
         ADD_FAILURE () << "the body continued";
     },
     "the body continued");
+}
+
+namespace {
+
+/**
+ * @brief Whether @p code guards an optional with `ASSERT_TRUE (x.has_value ())`.
+ *
+ * The whole argument has to be the `has_value ()` call, not merely contain
+ * one: `ASSERT_TRUE (a.has_value () && b)` is a different assertion, and the
+ * rule this scan states is about the guard spelling alone. `EXPECT_TRUE` is
+ * left out for the same reason - it asserts something about an optional rather
+ * than guarding a read below it, and it is the right call when a test says an
+ * optional is engaged and stops there.
+ */
+bool guards_with_assert_true (const std::string& code) {
+    constexpr std::string_view kOpen = "ASSERT_TRUE (";
+    constexpr std::string_view kEnd  = ".has_value ()";
+
+    for (size_t at = code.find (kOpen); at != std::string::npos;
+    at             = code.find (kOpen, at + 1)) {
+        size_t depth          = 1;
+        size_t i              = at + kOpen.size ();
+        const size_t argument = i;
+        for (; i < code.size () && depth > 0; ++i) {
+            if (code[i] == '(') {
+                ++depth;
+            } else if (code[i] == ')') {
+                --depth;
+            }
+        }
+        if (depth != 0) {
+            continue; // unbalanced, so not an assertion this scan can read
+        }
+        std::string_view inside (code.data () + argument, i - argument - 1);
+        while (!inside.empty () && (inside.back () == ' ' || inside.back () == '\n')) {
+            inside.remove_suffix (1);
+        }
+        if (inside.size () >= kEnd.size () && inside.ends_with (kEnd)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// This file plants the spelling in string literals to pin the matcher below,
+/// and `strip_comments` does not model literals - so the file carrying the
+/// guard is the one file the guard cannot read.
+constexpr std::string_view kScanExempt = "tests/optional_assert_test.cpp";
+
+} // namespace
+
+/**
+ * Every test file guards an engaged optional with `ASSERT_HAS_VALUE`. The
+ * gtest spelling reads the same at run time and the optional check cannot
+ * follow it, which is where 561 findings came from (#980); a file that brings
+ * it back would pass CI, because the gate lints changed lines only.
+ */
+TEST (OptionalAssertGuard, NoTestFileGuardsWithAssertTrue) {
+    const std::filesystem::path tests =
+    std::filesystem::path{ VAYU_ENGINE_SOURCE_DIR } / "tests";
+    ASSERT_TRUE (std::filesystem::is_directory (tests))
+    << tests.string () << " is not where the guard looks";
+
+    size_t scanned_files = 0;
+    size_t scanned_bytes = 0;
+    std::vector<std::string> offenders;
+
+    for (const auto& entry : std::filesystem::recursive_directory_iterator (tests)) {
+        const std::string extension = entry.path ().extension ().string ();
+        if (!entry.is_regular_file () || (extension != ".cpp" && extension != ".hpp")) {
+            continue;
+        }
+        const std::string relative =
+        std::filesystem::relative (entry.path (), VAYU_ENGINE_SOURCE_DIR).generic_string ();
+
+        const std::string code =
+        vayu::tests::strip_comments (vayu::tests::read_source (entry.path ()));
+        ASSERT_FALSE (code.empty ()) << relative << " read as empty";
+        ++scanned_files;
+        scanned_bytes += code.size ();
+
+        if (relative != kScanExempt && guards_with_assert_true (code)) {
+            offenders.push_back (relative);
+        }
+    }
+
+    // A scan that read nothing passes forever, so it says what it read.
+    ASSERT_GT (scanned_files, 100u) << "the guard found almost no test sources";
+    ASSERT_GT (scanned_bytes, 100'000u) << "the guard read empty sources";
+
+    std::string joined;
+    for (const auto& offender : offenders) {
+        if (!joined.empty ()) {
+            joined += "\n  ";
+        }
+        joined += offender;
+    }
+    EXPECT_TRUE (offenders.empty ())
+    << "ASSERT_TRUE (opt.has_value ()) guards the reads under it at run time "
+       "and "
+       "bugprone-unchecked-optional-access cannot see that it does. Use "
+       "ASSERT_HAS_VALUE (opt) from tests/optional_assert.hpp. Offenders:\n  "
+    << joined;
+}
+
+/**
+ * The matcher still finds the spelling it is looking for, and still ignores
+ * the assertions that are not it. Without this, a stripper that blanked too
+ * much would leave the guard above passing on a suite that had brought every
+ * one of them back.
+ */
+TEST (OptionalAssertGuard, TheGuardSeesTheSpellingAndNotItsNeighbours) {
+    EXPECT_TRUE (guards_with_assert_true ("ASSERT_TRUE (row.has_value ());"));
+    EXPECT_TRUE (
+    guards_with_assert_true ("ASSERT_TRUE (db.get_run (id).has_value ());"));
+
+    EXPECT_FALSE (guards_with_assert_true ("ASSERT_HAS_VALUE (row);"));
+    EXPECT_FALSE (guards_with_assert_true ("EXPECT_TRUE (row.has_value ());"));
+    EXPECT_FALSE (guards_with_assert_true ("ASSERT_FALSE (row.has_value ());"));
+    EXPECT_FALSE (
+    guards_with_assert_true ("ASSERT_TRUE (row.has_value () && row->ok);"));
+
+    EXPECT_FALSE (guards_with_assert_true (vayu::tests::strip_comments (
+    "// never ASSERT_TRUE (row.has_value ()) here\n")));
 }

--- a/engine/tests/optional_assert_test.cpp
+++ b/engine/tests/optional_assert_test.cpp
@@ -95,26 +95,27 @@ bool guards_with_assert_true (const std::string& code) {
     constexpr std::string_view kOpen = "ASSERT_TRUE (";
     constexpr std::string_view kEnd  = ".has_value ()";
 
-    for (size_t at = code.find (kOpen); at != std::string::npos;
-    at             = code.find (kOpen, at + 1)) {
+    const std::string_view source (code);
+    for (size_t at = source.find (kOpen); at != std::string_view::npos;
+    at             = source.find (kOpen, at + 1)) {
         size_t depth          = 1;
         size_t i              = at + kOpen.size ();
         const size_t argument = i;
-        for (; i < code.size () && depth > 0; ++i) {
-            if (code[i] == '(') {
+        for (; i < source.size () && depth > 0; ++i) {
+            if (source[i] == '(') {
                 ++depth;
-            } else if (code[i] == ')') {
+            } else if (source[i] == ')') {
                 --depth;
             }
         }
         if (depth != 0) {
             continue; // unbalanced, so not an assertion this scan can read
         }
-        std::string_view inside (code.data () + argument, i - argument - 1);
+        std::string_view inside = source.substr (argument, i - argument - 1);
         while (!inside.empty () && (inside.back () == ' ' || inside.back () == '\n')) {
             inside.remove_suffix (1);
         }
-        if (inside.size () >= kEnd.size () && inside.ends_with (kEnd)) {
+        if (inside.ends_with (kEnd)) {
             return true;
         }
     }

--- a/engine/tests/response_capture_test.cpp
+++ b/engine/tests/response_capture_test.cpp
@@ -28,6 +28,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/db/database.hpp"
@@ -120,7 +121,7 @@ TEST_F (ResponseCaptureTest, EveryStoredErrorCarriesItsExchange) {
 
     ASSERT_EQ (collector.errors ().size (), 5u);
     for (const auto& record : collector.errors ()) {
-        ASSERT_TRUE (record.capture.has_value ());
+        ASSERT_HAS_VALUE (record.capture);
         EXPECT_EQ (record.capture->body, R"({"err":true})");
     }
     // Past the cap the record is dropped, so no body was copied for it either.
@@ -158,7 +159,7 @@ TEST_F (ResponseCaptureTest, ExemplarStoreKeepsOnePerStatusUpToTheLimit) {
     2 * constants::metrics_collector::EXEMPLARS_PER_STATUS);
     std::set<int> statuses;
     for (const auto& record : collector.exemplar_results ()) {
-        ASSERT_TRUE (record.capture.has_value ());
+        ASSERT_HAS_VALUE (record.capture);
         statuses.insert (record.status_code);
     }
     EXPECT_EQ (statuses, (std::set<int>{ 200, 500 }));
@@ -182,8 +183,9 @@ TEST_F (ResponseCaptureTest, CaptureFollowsTheCallerNotTheStore) {
     collector.record_success (200, 9000.0, 0.0, "{}", SuccessTraceReason::Slow, nullptr);
 
     ASSERT_EQ (collector.success_results ().size (), 1u);
-    ASSERT_TRUE (collector.success_results ()[0].capture.has_value ());
-    EXPECT_EQ (collector.success_results ()[0].capture->body, "hello");
+    const auto& capture = collector.success_results ()[0].capture;
+    ASSERT_HAS_VALUE (capture);
+    EXPECT_EQ (capture->body, "hello");
     ASSERT_EQ (collector.slow_results ().size (), 1u);
     EXPECT_FALSE (collector.slow_results ()[0].capture.has_value ());
 }
@@ -224,7 +226,7 @@ TEST_F (ResponseCaptureTest, BodyOverThePerBodyCapIsTruncatedAndSaysSo) {
 
     ASSERT_EQ (collector.errors ().size (), 1u);
     const auto& captured = collector.errors ()[0].capture;
-    ASSERT_TRUE (captured.has_value ());
+    ASSERT_HAS_VALUE (captured);
     EXPECT_EQ (captured->body.size (), 16u);
     EXPECT_TRUE (captured->truncated);
     EXPECT_EQ (captured->body_bytes, 100);
@@ -247,7 +249,7 @@ TEST_F (ResponseCaptureTest, SpentBudgetKeepsMetadataAndCountsDroppedBodies) {
     ASSERT_EQ (collector.errors ().size (), 10u);
     size_t with_body = 0;
     for (const auto& record : collector.errors ()) {
-        ASSERT_TRUE (record.capture.has_value ())
+        ASSERT_HAS_VALUE (record.capture)
         << "metadata must survive a spent budget";
         EXPECT_EQ (record.capture->headers.size (), 2u);
         EXPECT_EQ (record.capture->body_bytes, 100);

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -27,6 +27,7 @@
 #include <optional>
 #include <string>
 
+#include "optional_assert.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/monitor.hpp"
@@ -56,7 +57,7 @@ nlohmann::json valid_config () {
 // body does not say which field is wrong is barely better than a crash.
 void expect_rejected (const nlohmann::json& config, const std::string& key) {
     auto reason = validate_run_config (config);
-    ASSERT_TRUE (reason.has_value ())
+    ASSERT_HAS_VALUE (reason)
     << "expected rejection for " << key << " in " << config.dump ();
     EXPECT_NE (reason->find (key), std::string::npos)
     << "message should name '" << key << "', got: " << *reason;

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -1,3 +1,4 @@
+#include "optional_assert.hpp"
 #include "vayu/core/run_manager.hpp"
 #include <gtest/gtest.h>
 
@@ -353,13 +354,12 @@ TEST (CollectMetrics, SizesTheReplayRingFromTheConfiguredWindow) {
     // 20s of history at a 20ms cadence = 1000 ticks - deliberately neither the
     // default window nor the default cadence, so a hardcoded 3000 fails here.
     auto entry = db.get_config_entry ("liveReplayWindowMs");
-    ASSERT_TRUE (entry.has_value ())
-    << "seed_default_config did not seed the key";
+    ASSERT_HAS_VALUE (entry) << "seed_default_config did not seed the key";
     entry->value = "20000";
     db.save_config_entry (*entry);
 
     auto tick = db.get_config_entry ("liveTickIntervalMs");
-    ASSERT_TRUE (tick.has_value ());
+    ASSERT_HAS_VALUE (tick);
     tick->value = "20";
     db.save_config_entry (*tick);
 

--- a/engine/tests/run_shutdown_test.cpp
+++ b/engine/tests/run_shutdown_test.cpp
@@ -25,6 +25,7 @@
 #include <nlohmann/json.hpp>
 
 #include "mock_server.hpp"
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
@@ -131,7 +132,7 @@ TEST_F (RunShutdownTest, ShutdownStopsAndJoinsAWorkerMidRun) {
     // A joined worker has finished its writes; the status cannot still be
     // in-flight once shutdown has returned.
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_NE (stored->status, vayu::RunStatus::Running);
     EXPECT_NE (stored->status, vayu::RunStatus::Pending);
     EXPECT_FALSE (context->is_running.load ());
@@ -159,7 +160,7 @@ TEST_F (RunShutdownTest, DestructorDrainsAnActiveRun) {
     EXPECT_LT (elapsed, 20000) << "the destructor took " << elapsed << "ms to drain";
 
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_NE (stored->status, vayu::RunStatus::Running)
     << "~RunManager returned while the run was still executing - its worker "
        "outlives the manager and the database";

--- a/engine/tests/run_stop_test.cpp
+++ b/engine/tests/run_stop_test.cpp
@@ -29,6 +29,7 @@
 #include <nlohmann/json.hpp>
 
 #include "mock_server.hpp"
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/load_strategy.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -312,7 +313,7 @@ TEST_F (RunStopAccountingTest, StoppedRunReachesTerminalStatusPromptly) {
     << "ms to reach a terminal status against a hung upstream";
 
     auto stored = db->get_run (run_id);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->status, vayu::RunStatus::Stopped);
 
     EXPECT_LE (context->requests_sent.load () - sent_at_stop, 10u)

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -21,6 +21,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/spec_coverage.hpp"
@@ -1297,13 +1298,17 @@ TEST_F (RunsRouteTest, BaselinePutPinsTheRunAndAnswersTheUpdatedRow) {
     // than re-listing - the compact summary travels with it.
     EXPECT_TRUE (body.contains ("summary"));
 
-    EXPECT_TRUE (db_->get_run ("run_a")->baseline);
+    const auto stored_run3 = db_->get_run ("run_a");
+    ASSERT_HAS_VALUE (stored_run3);
+    EXPECT_TRUE (stored_run3->baseline);
 
     auto [unpin_status, unpin_body] = vayu::http::routes::set_run_baseline_response (
     *db_, "run_a", R"({"baseline":false})");
     ASSERT_EQ (unpin_status, 200);
     EXPECT_FALSE (unpin_body["baseline"].get<bool> ());
-    EXPECT_FALSE (db_->get_run ("run_a")->baseline);
+    const auto stored_run2 = db_->get_run ("run_a");
+    ASSERT_HAS_VALUE (stored_run2);
+    EXPECT_FALSE (stored_run2->baseline);
 }
 
 TEST_F (RunsRouteTest, BaselinePutOnAMissingRunIs404) {
@@ -1325,8 +1330,9 @@ TEST_F (RunsRouteTest, BaselinePutRejectsABodyWithoutABoolean) {
         vayu::http::routes::set_run_baseline_response (*db_, "run_a", body);
         EXPECT_EQ (status, 400) << "accepted: " << body;
     }
-    EXPECT_FALSE (db_->get_run ("run_a")->baseline)
-    << "a rejected body still wrote";
+    const auto stored_run = db_->get_run ("run_a");
+    ASSERT_HAS_VALUE (stored_run);
+    EXPECT_FALSE (stored_run->baseline) << "a rejected body still wrote";
 }
 
 TEST_F (RunsRouteTest, ListRowsCarryTheBaselineFlag) {
@@ -1369,7 +1375,7 @@ TEST_F (RunsRouteTest, SingleRunPayloadCarriesTheBaselineFlag) {
     vayu::http::routes::set_run_baseline_response (*db_, "run_a", R"({"baseline":true})");
 
     auto run = db_->get_run ("run_a");
-    ASSERT_TRUE (run.has_value ());
+    ASSERT_HAS_VALUE (run);
     EXPECT_TRUE (vayu::json::serialize (*run)["baseline"].get<bool> ());
 }
 

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -11,6 +11,7 @@
  * visible in any aggregate.
  */
 
+#include "optional_assert.hpp"
 #include "vayu/core/scenario_load.hpp"
 
 #include <gtest/gtest.h>
@@ -269,7 +270,7 @@ TEST (ScenarioLoadConfig, ConstantRpsIsRefusedForAScenario) {
 
     ASSERT_TRUE (vayu::core::is_scenario_load_run (config));
     const auto refusal = vayu::core::validate_scenario_load_config (config);
-    ASSERT_TRUE (refusal.has_value ())
+    ASSERT_HAS_VALUE (refusal)
     << "constant_rps with a scenario must be refused, not silently run "
        "closed-loop";
     EXPECT_NE (refusal->find ("constant_rps"), std::string::npos)
@@ -282,7 +283,7 @@ TEST (ScenarioLoadConfig, CapacityIsRefusedForAScenario) {
 
     ASSERT_TRUE (vayu::core::is_scenario_load_run (config));
     const auto refusal = vayu::core::validate_scenario_load_config (config);
-    ASSERT_TRUE (refusal.has_value ())
+    ASSERT_HAS_VALUE (refusal)
     << "capacity with a scenario must be refused: the search judges one "
        "windowed p99 and a sequence has one per step";
     EXPECT_NE (refusal->find ("capacity"), std::string::npos)
@@ -689,16 +690,17 @@ TEST_F (ScenarioLoadTest, EachStepsScriptIsReplayedAgainstItsOwnSamples) {
     const auto validation = vayu::core::validate_scripts (context_, *db_, false);
 
     ASSERT_EQ (validation.steps.size (), 2u);
-    ASSERT_TRUE (validation.steps[0].has_value ())
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step)
     << "the scripted step reported no tallies, so its assertions went "
        "unchecked";
-    EXPECT_EQ (validation.steps[0]->sampled, 3u);
-    EXPECT_EQ (validation.steps[0]->passed, 3u);
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    EXPECT_EQ (first_step->sampled, 3u);
+    EXPECT_EQ (first_step->passed, 3u);
+    EXPECT_EQ (first_step->failed, 0u);
     EXPECT_FALSE (validation.steps[1].has_value ())
     << "a step with no script must report nothing rather than a row of zeros";
 
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->sampled, 3u);
     EXPECT_EQ (validation.run->passed, 3u);
 }
@@ -723,17 +725,19 @@ TEST_F (ScenarioLoadTest, AFailingAssertionIsAttributedToItsOwnStep) {
     const auto validation = vayu::core::validate_scripts (context_, *db_, false);
 
     ASSERT_EQ (validation.steps.size (), 3u);
-    ASSERT_TRUE (validation.steps[0].has_value ());
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
-    EXPECT_EQ (validation.steps[0]->passed, 2u);
-    ASSERT_TRUE (validation.steps[1].has_value ());
-    EXPECT_EQ (validation.steps[1]->failed, 2u)
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->failed, 0u);
+    EXPECT_EQ (first_step->passed, 2u);
+    const auto& second_step = validation.steps[1];
+    ASSERT_HAS_VALUE (second_step);
+    EXPECT_EQ (second_step->failed, 2u)
     << "step 2's failing assertion was not attributed to step 2";
-    EXPECT_EQ (validation.steps[1]->passed, 0u);
+    EXPECT_EQ (second_step->passed, 0u);
     EXPECT_FALSE (validation.steps[2].has_value ());
 
     // The run's headline still says something failed; the breakdown says where.
-    ASSERT_TRUE (validation.run.has_value ());
+    ASSERT_HAS_VALUE (validation.run);
     EXPECT_EQ (validation.run->failed, 2u);
     EXPECT_EQ (validation.run->passed, 2u);
 }
@@ -761,9 +765,10 @@ TEST_F (ScenarioLoadTest, ADeferredStepScriptReadsItsIterationAndDataRow) {
 
     const auto validation = vayu::core::validate_scripts (context_, *db_, false);
     ASSERT_EQ (validation.steps.size (), 1u);
-    ASSERT_TRUE (validation.steps[0].has_value ());
-    EXPECT_EQ (validation.steps[0]->passed, 2u);
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 2u);
+    EXPECT_EQ (first_step->failed, 0u);
 }
 
 // `pm.execution` still throws, naming itself: a script that has already run
@@ -790,9 +795,10 @@ TEST_F (ScenarioLoadTest, PmExecutionStillThrowsInADeferredStepScript) {
 
     const auto validation = vayu::core::validate_scripts (context_, *db_, false);
     ASSERT_EQ (validation.steps.size (), 1u);
-    ASSERT_TRUE (validation.steps[0].has_value ());
-    EXPECT_EQ (validation.steps[0]->passed, 1u);
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 1u);
+    EXPECT_EQ (first_step->failed, 0u);
 }
 
 // The tallies land on the step they belong to in the stored summary, which is

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -38,6 +38,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -281,7 +282,7 @@ TEST_F (ScenarioPlanTest, TiedOrdersRunInTheSameSequenceTheSidebarShows) {
     seed_request ("earlier", "root", /*order=*/0);
     auto make_older = [&] (const std::string& id, int64_t created_at) {
         auto row = db_->get_request (id);
-        ASSERT_TRUE (row.has_value ());
+        ASSERT_HAS_VALUE (row);
         row->created_at = created_at;
         db_->save_request (*row);
     };

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -34,6 +34,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -188,7 +189,7 @@ class ScenarioRunnerTest : public ::testing::Test {
     /// Override a seeded config value, keeping the rest of its row intact.
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not a seeded config key";
+        ASSERT_HAS_VALUE (entry) << key << " is not a seeded config key";
         entry->value = value;
         db_->save_config_entry (*entry);
     }
@@ -240,7 +241,7 @@ class ScenarioRunnerTest : public ::testing::Test {
     /// validation resolve by.
     void stamp_spec_operation (const std::string& request_id, const json& identity) {
         auto row = db_->get_request (request_id);
-        ASSERT_TRUE (row.has_value ()) << request_id;
+        ASSERT_HAS_VALUE (row) << request_id;
         row->spec_operation = identity.dump ();
         db_->save_request (*row);
     }
@@ -257,7 +258,7 @@ class ScenarioRunnerTest : public ::testing::Test {
         db_->save_spec_document (spec);
 
         auto col = db_->get_collection ("col_1");
-        ASSERT_TRUE (col.has_value ());
+        ASSERT_HAS_VALUE (col);
         col->openapi =
         json{ { "specId", "spec_1" }, { "specHash", hash }, { "syncedAt", 1 } }.dump ();
         db_->create_collection (*col); // a replace, keyed on the id
@@ -389,7 +390,10 @@ class ScenarioRunnerTest : public ::testing::Test {
 
     [[nodiscard]] json summary_of (const std::string& run_id) {
         auto run = db_->get_run (run_id);
-        EXPECT_TRUE (run.has_value ());
+        if (!run.has_value ()) {
+            ADD_FAILURE () << "no run is stored under " << run_id;
+            return json::object ();
+        }
         return json::parse (run->summary);
     }
 
@@ -447,7 +451,7 @@ TEST_F (ScenarioRunnerTest, ADesignRunsSingleResultContractIsUntouched) {
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 
     auto run = db_->get_run (run_id);
-    ASSERT_TRUE (run.has_value ());
+    ASSERT_HAS_VALUE (run);
     EXPECT_EQ (run->type, vayu::RunType::Scenario);
 
     // `GET /runs/:id` serves `result` from the first row *only* for a design
@@ -491,7 +495,7 @@ TEST_F (ScenarioRunnerTest, AVariableSetByAStepIsReadableByTheNextAndPersistedOn
     EXPECT_EQ (mid_run_value.find ("from-step-1"), std::string::npos);
 
     auto env = db_->get_environment ("env_1");
-    ASSERT_TRUE (env.has_value ());
+    ASSERT_HAS_VALUE (env);
     EXPECT_NE (env->variables.find ("from-step-1"), std::string::npos);
 }
 
@@ -1188,7 +1192,7 @@ TEST_F (ScenarioRunnerTest, ABoundDocumentWithNoSchemaIndexIsSaidSoRatherThanSil
     spec.fetched_at = 1;
     db_->save_spec_document (spec);
     auto col = db_->get_collection ("col_1");
-    ASSERT_TRUE (col.has_value ());
+    ASSERT_HAS_VALUE (col);
     col->openapi = json{ { "specId", "spec_1" }, { "specHash", "hash-1" } }.dump ();
     db_->create_collection (*col);
 

--- a/engine/tests/script_info_test.cpp
+++ b/engine/tests/script_info_test.cpp
@@ -22,6 +22,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
@@ -88,7 +89,7 @@ TEST_F (ScriptRequestNameTest, PayloadNameWinsOverTheStoredRow) {
     json{ { "requestName", "Renamed in the editor" } }, std::string ("req_1"));
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    ASSERT_TRUE (resolved.name.has_value ());
+    ASSERT_HAS_VALUE (resolved.name);
     EXPECT_EQ (*resolved.name, "Renamed in the editor");
 }
 
@@ -99,7 +100,7 @@ TEST_F (ScriptRequestNameTest, PayloadNameIsUsedWithNoRequestIdAtAll) {
     *db_, json{ { "requestName", "Untitled" } }, std::nullopt);
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    ASSERT_TRUE (resolved.name.has_value ());
+    ASSERT_HAS_VALUE (resolved.name);
     EXPECT_EQ (*resolved.name, "Untitled");
 }
 
@@ -111,7 +112,7 @@ TEST_F (ScriptRequestNameTest, FallsBackToTheStoredRowWhenOnlyAnIdIsSent) {
     resolve_script_request_name (*db_, json::object (), std::string ("req_1"));
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    ASSERT_TRUE (resolved.name.has_value ());
+    ASSERT_HAS_VALUE (resolved.name);
     EXPECT_EQ (*resolved.name, "Fetch users");
 }
 
@@ -140,7 +141,7 @@ TEST_F (ScriptRequestNameTest, EmptyPayloadNameDoesNotShadowTheStoredRow) {
     *db_, json{ { "requestName", "" } }, std::string ("req_1"));
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    ASSERT_TRUE (resolved.name.has_value ());
+    ASSERT_HAS_VALUE (resolved.name);
     EXPECT_EQ (*resolved.name, "Fetch users");
 }
 

--- a/engine/tests/script_variables_test.cpp
+++ b/engine/tests/script_variables_test.cpp
@@ -27,6 +27,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
@@ -502,7 +503,7 @@ TEST_F (ScriptVariableScopesTest, AScriptThatReadsAnAncestorAndWritesPersistsOnl
     // blob and `updated_at` both.
     EXPECT_EQ (stored_variables ("col_root"), root_before);
     auto root = db_->get_collection ("col_root");
-    ASSERT_TRUE (root.has_value ());
+    ASSERT_HAS_VALUE (root);
     EXPECT_EQ (root->updated_at, 1);
 }
 

--- a/engine/tests/spec_bind_route_test.cpp
+++ b/engine/tests/spec_bind_route_test.cpp
@@ -31,6 +31,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/spec_coverage.hpp"
 #include "vayu/db/database.hpp"
@@ -170,7 +171,7 @@ TEST_F (SpecBindRouteTest, StoresTheDocumentMovesTheBindingAndStampsWhatMatched)
     // The document is stored verbatim, and the hash the binding names is the
     // one the row carries - a run stamps that, so the two must be one value.
     auto document = db_->get_spec_document (body["specId"].get<std::string> ());
-    ASSERT_TRUE (document.has_value ());
+    ASSERT_HAS_VALUE (document);
     EXPECT_EQ (document->content, pets_document ());
     EXPECT_EQ (document->hash, body["specHash"].get<std::string> ());
 
@@ -188,14 +189,14 @@ TEST_F (SpecBindRouteTest, DerivesBothIndexesFromTheDocumentItStores) {
     const auto body        = bind_ok (pets_document ());
 
     auto document = db_->get_spec_document (body["specId"].get<std::string> ());
-    ASSERT_TRUE (document.has_value ());
+    ASSERT_HAS_VALUE (document);
     auto declared = vayu::core::parse_declared_operations (document->operations);
-    ASSERT_TRUE (declared.has_value ());
+    ASSERT_HAS_VALUE (declared);
     EXPECT_EQ (declared->size (), 2u);
 
     const vayu::core::OperationIndex index (*declared);
     const auto resolved = index.resolve (stamp_of (list));
-    ASSERT_TRUE (resolved.has_value ());
+    ASSERT_HAS_VALUE (resolved);
     EXPECT_EQ ((*declared)[*resolved].operation_id, "listPets");
 }
 
@@ -369,14 +370,14 @@ TEST_F (SpecBindRouteTest, DoesNotRewriteARequestItNeitherStampedNorCleared) {
     // carried nothing is not part of the write.
     const std::string spare = create_request (root_, "POST", "{{baseUrl}}/unrelated");
     auto before = db_->get_request (spare);
-    ASSERT_TRUE (before.has_value ());
+    ASSERT_HAS_VALUE (before);
 
     const auto body = bind_ok (pets_document ());
     EXPECT_EQ (body["stamped"], 0u);
     EXPECT_EQ (body["cleared"], 0u);
 
     auto after = db_->get_request (spare);
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->updated_at, before->updated_at);
 }
 

--- a/engine/tests/spec_coverage_test.cpp
+++ b/engine/tests/spec_coverage_test.cpp
@@ -18,6 +18,7 @@
  * runs_route_test.cpp.
  */
 
+#include "optional_assert.hpp"
 #include "vayu/core/spec_coverage.hpp"
 
 #include "vayu/core/constants.hpp"
@@ -83,8 +84,9 @@ TEST (SpecCoverageIndex, AnAbsentOrUnreadableIndexIsNotMeasuredRatherThanEmpty) 
     EXPECT_FALSE (parse_declared_operations ("{\"operations\": []}").has_value ());
     // An array that *is* empty parses - the document declared nothing, which is
     // a different answer from having no index at all.
-    ASSERT_TRUE (parse_declared_operations ("[]").has_value ());
-    EXPECT_TRUE (parse_declared_operations ("[]")->empty ());
+    const auto empty_index = parse_declared_operations ("[]");
+    ASSERT_HAS_VALUE (empty_index);
+    EXPECT_TRUE (empty_index->empty ());
 }
 
 TEST (SpecCoverageIndex, OneUnusableRowIsSkippedRatherThanCostingTheWholeIndex) {
@@ -94,7 +96,7 @@ TEST (SpecCoverageIndex, OneUnusableRowIsSkippedRatherThanCostingTheWholeIndex) 
         "not an object",
         {"operationId": "createPet", "method": "post", "path": "/pets", "responses": ["201"]}
     ])");
-    ASSERT_TRUE (declared.has_value ());
+    ASSERT_HAS_VALUE (declared);
     ASSERT_EQ (declared->size (), 2u);
     // Methods are upper-cased on the way in, so a document that wrote `get`
     // matches a request stamped `GET`.

--- a/engine/tests/spec_describe_route_test.cpp
+++ b/engine/tests/spec_describe_route_test.cpp
@@ -31,6 +31,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -153,7 +154,7 @@ TEST_F (SpecDescribeRouteTest, RefusesADocumentOverTheConfiguredCap) {
     // The live config entry, not the compiled default, exactly as a store of the
     // same bytes reads it.
     auto entry = db_->get_config_entry ("maxSpecDocumentBytes");
-    ASSERT_TRUE (entry.has_value ());
+    ASSERT_HAS_VALUE (entry);
     entry->value = "64";
     db_->save_config_entry (*entry);
 

--- a/engine/tests/spec_diff_route_test.cpp
+++ b/engine/tests/spec_diff_route_test.cpp
@@ -38,6 +38,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -242,21 +243,21 @@ TEST_F (SpecDiffRouteTest, LeavesTheCollectionExactlyAsItFoundIt) {
     // read: no new document, no moved binding, and no stamp on any request.
     const std::string listed = create_listed_request (root_);
     const auto before        = db_->get_collection (root_);
-    ASSERT_TRUE (before.has_value ());
+    ASSERT_HAS_VALUE (before);
 
     diff ();
 
     const auto after = db_->get_collection (root_);
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->openapi, before->openapi);
     const auto request = db_->get_request (listed);
-    ASSERT_TRUE (request.has_value ());
-    ASSERT_TRUE (request->spec_operation.has_value ());
+    ASSERT_HAS_VALUE (request);
+    ASSERT_HAS_VALUE (request->spec_operation);
     EXPECT_EQ (json::parse (*request->spec_operation)["operationId"], "listPets");
     EXPECT_EQ (request->name, "List pets");
     // The bound document is still the bound document, byte for byte.
     const auto stored = db_->get_spec_document (bound_spec_);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->content, BOUND_DOC);
 }
 
@@ -285,7 +286,7 @@ TEST_F (SpecDiffRouteTest, RefusesABindingNamingADocumentTheStoreNoLongerHolds) 
      * and reporting every request as changed.
      */
     auto row = db_->get_collection (root_);
-    ASSERT_TRUE (row.has_value ());
+    ASSERT_HAS_VALUE (row);
     row->openapi = R"({"specId":"spec_missing","specHash":"seed","syncedAt":1})";
     db_->create_collection (*row);
 

--- a/engine/tests/spec_export_route_test.cpp
+++ b/engine/tests/spec_export_route_test.cpp
@@ -29,6 +29,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -282,11 +283,11 @@ TEST_F (SpecExportRouteTest, LeavesTheCollectionExactlyAsItFoundIt) {
     export_collection ();
 
     const auto stored = db_->get_spec_document (spec);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->content, PETS_DOC);
     const auto request = db_->get_request (listed);
-    ASSERT_TRUE (request.has_value ());
-    ASSERT_TRUE (request->spec_operation.has_value ());
+    ASSERT_HAS_VALUE (request);
+    ASSERT_HAS_VALUE (request->spec_operation);
     EXPECT_NE (request->spec_operation->find ("listPets"), std::string::npos);
 }
 

--- a/engine/tests/spec_match_route_test.cpp
+++ b/engine/tests/spec_match_route_test.cpp
@@ -28,6 +28,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
@@ -124,10 +125,10 @@ TEST_F (SpecMatchRouteTest, LeavesTheCollectionExactlyAsItFoundIt) {
     { "operationId", "listPets" } } }));
 
     const auto stored = db_->get_request (list);
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_FALSE (stored->spec_operation.has_value ());
     const auto collection = db_->get_collection (root_);
-    ASSERT_TRUE (collection.has_value ());
+    ASSERT_HAS_VALUE (collection);
     EXPECT_TRUE (collection->openapi.empty () || collection->openapi == "{}");
 }
 

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -39,6 +39,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/run_manager.hpp"
@@ -191,7 +192,10 @@ class SpecSyncRouteTest : public ::testing::Test {
     /** The `openapi` binding the collection holds right now. */
     json binding () {
         auto collection = db_->get_collection (root_);
-        EXPECT_TRUE (collection.has_value ());
+        if (!collection.has_value ()) {
+            ADD_FAILURE () << "the fixture's root collection is gone";
+            return json::object ();
+        }
         return json::parse (collection->openapi);
     }
 
@@ -256,11 +260,11 @@ TEST_F (SpecSyncRouteTest, AppliesCreateUpdateAndDeleteInOneCall) {
     EXPECT_TRUE (created_id.starts_with ("req_"));
 
     auto created = db_->get_request (created_id);
-    ASSERT_TRUE (created.has_value ());
+    ASSERT_HAS_VALUE (created);
     EXPECT_EQ (created->collection_id, folder_id);
 
     auto updated = db_->get_request (stayed);
-    ASSERT_TRUE (updated.has_value ());
+    ASSERT_HAS_VALUE (updated);
     EXPECT_EQ (updated->name, "list every pet");
     EXPECT_FALSE (db_->get_request (gone).has_value ());
 
@@ -269,7 +273,7 @@ TEST_F (SpecSyncRouteTest, AppliesCreateUpdateAndDeleteInOneCall) {
     const auto moved = binding ();
     EXPECT_NE (moved["specId"].get<std::string> (), bound_spec_);
     auto stored = db_->get_spec_document (moved["specId"].get<std::string> ());
-    ASSERT_TRUE (stored.has_value ());
+    ASSERT_HAS_VALUE (stored);
     EXPECT_EQ (stored->content, FETCHED_DOC);
     EXPECT_EQ (moved["specHash"].get<std::string> (), stored->hash);
     EXPECT_EQ (response["specId"].get<std::string> (), stored->id);
@@ -296,7 +300,7 @@ TEST_F (SpecSyncRouteTest, SyncingReclaimsTheDocumentTheBindingLeftBehind) {
     // Age the seeded document past the sweep's grace window: it was stored a
     // moment ago, and a document that new is treated as a bind in flight.
     auto seeded = db_->get_spec_document (bound_spec_);
-    ASSERT_TRUE (seeded.has_value ());
+    ASSERT_HAS_VALUE (seeded);
     seeded->fetched_at -=
     vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS + 1000;
     db_->save_spec_document (*seeded);
@@ -318,7 +322,7 @@ TEST_F (SpecSyncRouteTest, SyncingReclaimsTheDocumentTheBindingLeftBehind) {
 // by exactly the run's own retention.
 TEST_F (SpecSyncRouteTest, SyncingKeepsASupersededDocumentARunStillNames) {
     auto seeded = db_->get_spec_document (bound_spec_);
-    ASSERT_TRUE (seeded.has_value ());
+    ASSERT_HAS_VALUE (seeded);
     seeded->fetched_at -=
     vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS + 1000;
     db_->save_spec_document (*seeded);
@@ -417,7 +421,7 @@ TEST_F (SpecSyncRouteTest, RefusesToUpdateARequestOutsideTheSyncedCollection) {
     EXPECT_EQ (response["error"]["item"].get<std::string> (), stranger);
 
     auto untouched = db_->get_request (stranger);
-    ASSERT_TRUE (untouched.has_value ());
+    ASSERT_HAS_VALUE (untouched);
     EXPECT_EQ (untouched->name, "not yours");
 }
 
@@ -441,7 +445,9 @@ TEST_F (SpecSyncRouteTest, ReachesARequestInANestedTagFolder) {
     body (json{ { "update",
     json::array ({ json{ { "id", nested }, { "name", "renamed" } } }) } }));
     ASSERT_EQ (status, 200) << response.dump ();
-    EXPECT_EQ (db_->get_request (nested)->name, "renamed");
+    const auto stored_request2 = db_->get_request (nested);
+    ASSERT_HAS_VALUE (stored_request2);
+    EXPECT_EQ (stored_request2->name, "renamed");
 }
 
 TEST_F (SpecSyncRouteTest, RefusesAFolderParentedOutsideTheSyncedCollection) {
@@ -698,7 +704,9 @@ TEST_F (SpecSyncRouteTest, RefusesToMoveARequestWhileUpdatingIt) {
     body (json{ { "update",
     json::array ({ json{ { "id", request }, { "collectionId", folder } } }) } }));
     ASSERT_EQ (status, 400) << response.dump ();
-    EXPECT_EQ (db_->get_request (request)->collection_id, root_);
+    const auto stored_request = db_->get_request (request);
+    ASSERT_HAS_VALUE (stored_request);
+    EXPECT_EQ (stored_request->collection_id, root_);
 }
 
 TEST_F (SpecSyncRouteTest, RefusesTheSameRequestTwiceInOnePayload) {
@@ -878,8 +886,9 @@ TEST_F (SpecSyncRouteTest, PolicyCreatesWhatTheDocumentAddedAndDeletesNothing) {
     ASSERT_EQ (owners->parent_id.value_or (""), root_);
     const auto filed = db_->get_requests_in_collection (owners->id);
     ASSERT_EQ (filed.size (), 1u);
-    EXPECT_TRUE (filed[0].spec_operation.has_value ());
-    EXPECT_EQ (json::parse (*filed[0].spec_operation)["operationId"], "listOwners");
+    const auto& identity = filed[0].spec_operation;
+    ASSERT_HAS_VALUE (identity);
+    EXPECT_EQ (json::parse (*identity)["operationId"], "listOwners");
     // The untouched request is left where it was - nothing about it moved.
     EXPECT_TRUE (db_->get_request (stamped).has_value ());
 }
@@ -892,7 +901,9 @@ TEST_F (SpecSyncRouteTest, PolicyWritesAFieldOnlyTheDocumentMoved) {
     // by field rather than row by row.
     const std::string stamped = create_request (
     root_, json{ { "name", "listPets" }, { "specOperation", list_pets () } });
-    const std::string edited_url = db_->get_request (stamped)->url;
+    const auto stamped_row = db_->get_request (stamped);
+    ASSERT_HAS_VALUE (stamped_row);
+    const std::string edited_url = stamped_row->url;
 
     auto [status, response] = routes::spec_sync_response (*db_,
     json{ { "collectionId", root_ },
@@ -901,7 +912,7 @@ TEST_F (SpecSyncRouteTest, PolicyWritesAFieldOnlyTheDocumentMoved) {
 
     EXPECT_EQ (response["updated"].get<size_t> (), 1u);
     auto updated = db_->get_request (stamped);
-    ASSERT_TRUE (updated.has_value ());
+    ASSERT_HAS_VALUE (updated);
     EXPECT_EQ (updated->name, "List all the pets");
     // The url the fixture typed is neither document's, so it is somebody's edit
     // and this apply writes around it - counted, not dropped.
@@ -927,7 +938,7 @@ TEST_F (SpecSyncRouteTest, PolicyLeavesAFieldSomebodyEditedExactlyAsTheyLeftIt) 
     ASSERT_EQ (status, 200) << response.dump ();
 
     auto after = db_->get_request (edited);
-    ASSERT_TRUE (after.has_value ());
+    ASSERT_HAS_VALUE (after);
     EXPECT_EQ (after->name, "My pets call");
     EXPECT_EQ (response["updated"].get<size_t> (), 0u);
     // Counted rather than dropped: a caller that stated no ticks cannot see what

--- a/engine/tests/sse_load_stream_test.cpp
+++ b/engine/tests/sse_load_stream_test.cpp
@@ -35,6 +35,7 @@
 #include <thread>
 #include <vector>
 
+#include "optional_assert.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/types.hpp"
@@ -169,7 +170,7 @@ TEST (SseLoadStreamTest, EventCapEndsAnEndlessStreamAsASuccess) {
     // reports a 200. A stream that ended exactly as asked is not a failure.
     EXPECT_FALSE (response.has_error ()) << response.error_message;
     EXPECT_EQ (response.status_code, 200);
-    ASSERT_TRUE (response.stream_events.has_value ());
+    ASSERT_HAS_VALUE (response.stream_events);
     EXPECT_GE (*response.stream_events, 5u);
     EXPECT_TRUE (response.stream_capped);
 
@@ -193,7 +194,7 @@ TEST (SseLoadStreamTest, DurationCapEndsASilentStreamAsASuccess) {
     EXPECT_FALSE (response.has_error ()) << response.error_message;
     EXPECT_EQ (response.status_code, 200);
     EXPECT_TRUE (response.stream_capped);
-    ASSERT_TRUE (response.stream_events.has_value ());
+    ASSERT_HAS_VALUE (response.stream_events);
     EXPECT_EQ (*response.stream_events, 0u)
     << "a silent stream delivered nothing, and says so";
     // Ended by the cap, well before the backstop timeout that sits
@@ -214,7 +215,7 @@ TEST (SseLoadStreamTest, AServerClosedStreamCompletesUncappedWithItsEvents) {
     const auto& response = result.value ();
     EXPECT_FALSE (response.has_error ()) << response.error_message;
     EXPECT_EQ (response.status_code, 200);
-    ASSERT_TRUE (response.stream_events.has_value ());
+    ASSERT_HAS_VALUE (response.stream_events);
     // Three `data` frames and one comment-only keep-alive: the keep-alive is
     // not an event, here as on the design path.
     EXPECT_EQ (*response.stream_events, 3u);

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -30,6 +30,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/http/routes.hpp"
@@ -288,9 +289,9 @@ TEST (StreamFlag, ReadsPerRequestCaps) {
     const auto flag = read_stream_flag (json{ { "stream", true },
     { "maxStreamDurationMs", 5000 }, { "maxStreamEvents", 12 } });
     ASSERT_TRUE (flag.ok);
-    ASSERT_TRUE (flag.max_duration_ms.has_value ());
+    ASSERT_HAS_VALUE (flag.max_duration_ms);
     EXPECT_EQ (*flag.max_duration_ms, 5000);
-    ASSERT_TRUE (flag.max_events.has_value ());
+    ASSERT_HAS_VALUE (flag.max_events);
     EXPECT_EQ (*flag.max_events, 12);
 }
 
@@ -330,7 +331,7 @@ class SseLimitsTest : public ::testing::Test {
 
     void set_config (const char* key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = value;
         db_->save_config_entry (*entry);
     }
@@ -773,7 +774,7 @@ class RelayTest : public ::testing::Test {
 
     void set_config (const char* key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = value;
         db_->save_config_entry (*entry);
     }
@@ -858,7 +859,7 @@ TEST_F (RelayTest, ASecondConcurrentWatcherIsRefused) {
     auto context = streamed (1);
     ASSERT_NE (context, nullptr);
     const auto held = context->try_claim ();
-    ASSERT_TRUE (held.has_value ());
+    ASSERT_HAS_VALUE (held);
 
     auto response = client ().Get ("/runs/run_test/events");
     ASSERT_TRUE (response);
@@ -1015,7 +1016,7 @@ class StreamExecuteTest : public ::testing::Test {
 
     void set_config (const char* key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key;
+        ASSERT_HAS_VALUE (entry) << key;
         entry->value = value;
         db_->save_config_entry (*entry);
     }

--- a/engine/tests/threshold_eval_test.cpp
+++ b/engine/tests/threshold_eval_test.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/threshold_eval.hpp"
 
@@ -52,9 +53,14 @@ nlohmann::json config_with (const nlohmann::json& thresholds) {
     return nlohmann::json{ { "url", "http://localhost/" }, { "thresholds", thresholds } };
 }
 
-/// The one check in an outcome that declared exactly one budget.
-const vayu::core::ThresholdCheck& only_check (const std::optional<ThresholdOutcome>& outcome) {
-    EXPECT_TRUE (outcome.has_value ());
+/// The one check in an outcome that declared exactly one budget. By value
+/// rather than by reference, so an outcome that never arrived is a named
+/// failure and a default check rather than a read of an empty optional.
+vayu::core::ThresholdCheck only_check (const std::optional<ThresholdOutcome>& outcome) {
+    if (!outcome.has_value ()) {
+        ADD_FAILURE () << "the evaluation reported no outcome at all";
+        return {};
+    }
     EXPECT_EQ (outcome->checks.size (), 1u);
     return outcome->checks.at (0);
 }
@@ -63,7 +69,7 @@ const vayu::core::ThresholdCheck& only_check (const std::optional<ThresholdOutco
 /// body does not say which budget is wrong is barely better than silence.
 void expect_rejected (const nlohmann::json& thresholds, const std::string& key) {
     auto reason = validate_thresholds (config_with (thresholds));
-    ASSERT_TRUE (reason.has_value ())
+    ASSERT_HAS_VALUE (reason)
     << "expected rejection for " << key << " in " << thresholds.dump ();
     EXPECT_NE (reason->find (key), std::string::npos)
     << "message should name '" << key << "', got: " << *reason;
@@ -83,7 +89,7 @@ TEST (ThresholdEval, AnEmptyThresholdsObjectIsRejectedRatherThanStored) {
     // Accepting it would complete the run with no verdict, which is precisely
     // what the caller believed it was asking for.
     auto reason = validate_thresholds (config_with (nlohmann::json::object ()));
-    ASSERT_TRUE (reason.has_value ());
+    ASSERT_HAS_VALUE (reason);
     EXPECT_NE (reason->find ("no budget"), std::string::npos) << *reason;
 }
 
@@ -150,7 +156,7 @@ TEST (ThresholdEval, EveryKnownBudgetIsAcceptedTogether) {
         { "latencyP99Ms", 50 }, { "maxErrorRatePct", 0.1 }, { "minThroughputRps", 10000 } };
     EXPECT_FALSE (validate_thresholds (config_with (thresholds)).has_value ());
     auto outcome = evaluate_thresholds (config_with (thresholds), measured_run ());
-    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_HAS_VALUE (outcome);
     EXPECT_EQ (outcome->checks.size (), 5u);
 }
 
@@ -176,7 +182,7 @@ TEST (ThresholdEval, EachPercentileReadsItsOwnMeasurement) {
     auto config = config_with (
     { { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 }, { "latencyP99Ms", 50 } });
     auto outcome = evaluate_thresholds (config, measured_run ());
-    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_HAS_VALUE (outcome);
     ASSERT_EQ (outcome->checks.size (), 3u);
     EXPECT_EQ (outcome->checks[0].metric, "latencyP50Ms");
     EXPECT_DOUBLE_EQ (outcome->checks[0].actual, 10.0);
@@ -216,7 +222,7 @@ TEST (ThresholdEval, TalliesSplitPassedFromFailed) {
     config_with ({ { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 },
     { "latencyP99Ms", 46 }, { "maxErrorRatePct", 0.5 }, { "minThroughputRps", 100 } }),
     measured_run ());
-    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_HAS_VALUE (outcome);
     EXPECT_EQ (outcome->passed, 3u); // p50, p95, throughput
     EXPECT_EQ (outcome->failed, 2u); // p99 (47 > 46), error rate (1% > 0.5%)
     EXPECT_EQ (outcome->checks.size (), 5u);
@@ -239,7 +245,7 @@ TEST (ThresholdEval, AStoredBudgetOfTheWrongTypeIsSkippedRatherThanGuessed) {
     auto outcome = evaluate_thresholds (
     config_with ({ { "latencyP99Ms", "fast" }, { "minThroughputRps", 100 } }),
     measured_run ());
-    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_HAS_VALUE (outcome);
     ASSERT_EQ (outcome->checks.size (), 1u);
     EXPECT_EQ (outcome->checks[0].metric, "minThroughputRps");
 }

--- a/engine/tests/tls_verification_test.cpp
+++ b/engine/tests/tls_verification_test.cpp
@@ -58,6 +58,7 @@
 #include <string>
 #include <system_error>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "tls_server.hpp"
 #include "vayu/db/database.hpp"
@@ -126,7 +127,7 @@ class CustomCaVerificationTest : public ::testing::Test {
 
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        ASSERT_HAS_VALUE (entry) << key << " is not seeded";
         entry->value = value;
         db_->save_config_entry (*entry);
     }

--- a/engine/tests/transient_execute_test.cpp
+++ b/engine/tests/transient_execute_test.cpp
@@ -45,6 +45,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/routes.hpp"
@@ -167,7 +168,7 @@ TEST_F (RecordDesignResultTest, ATransientExecutionWritesNoResultRow) {
     // Untouched, not merely un-inserted: a transient execution must not move
     // some other run's status either.
     auto row = db_->get_run (existing);
-    ASSERT_TRUE (row.has_value ());
+    ASSERT_HAS_VALUE (row);
     EXPECT_EQ (row->status, vayu::RunStatus::Running);
 }
 
@@ -201,7 +202,7 @@ TEST_F (RecordDesignResultTest, ARecordedExecutionStoresTheTraceAndCompletesTheR
     EXPECT_EQ (trace["request"]["headers"]["Authorization"], "Bearer sk_live_secret");
 
     auto row = db_->get_run (id);
-    ASSERT_TRUE (row.has_value ());
+    ASSERT_HAS_VALUE (row);
     EXPECT_EQ (row->status, vayu::RunStatus::Completed);
 }
 
@@ -243,7 +244,7 @@ TEST_F (RecordDesignResultTest, AStreamRecordCarriesItsEventsAndItsOwnStatus) {
     EXPECT_EQ (trace["events"]["items"].size (), 1u);
 
     auto row = db_->get_run (id);
-    ASSERT_TRUE (row.has_value ());
+    ASSERT_HAS_VALUE (row);
     EXPECT_EQ (row->status, vayu::RunStatus::Stopped);
 }
 
@@ -261,7 +262,7 @@ TEST_F (RecordDesignResultTest, ARecordedFailureMarksTheRunFailed) {
     record_design_result (*db_, id, sent_request (), failed);
 
     auto row = db_->get_run (id);
-    ASSERT_TRUE (row.has_value ());
+    ASSERT_HAS_VALUE (row);
     EXPECT_EQ (row->status, vayu::RunStatus::Failed);
     ASSERT_EQ (db_->get_results (id).size (), 1u);
     EXPECT_EQ (db_->get_results (id)[0].error, "connection refused");

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -33,6 +33,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "proxy_server.hpp"
 #include "temp_database.hpp"
 #include "tls_backend.hpp"
@@ -226,7 +227,7 @@ class TransportPolicyDbTest : public ::testing::Test {
 
     void set_config (const std::string& key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
-        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        ASSERT_HAS_VALUE (entry) << key << " is not seeded";
         entry->value = value;
         db_->save_config_entry (*entry);
     }
@@ -343,8 +344,8 @@ TEST_F (TransportPolicyDbTest, EveryModeIsOfferedBySettings) {
     // mode is ever added to the enum without reaching the settings row - which
     // would make it a value the engine honours and POST /config rejects.
     const auto entry = db_->get_config_entry ("proxyMode");
-    ASSERT_TRUE (entry.has_value ());
-    ASSERT_TRUE (entry->options.has_value ());
+    ASSERT_HAS_VALUE (entry);
+    ASSERT_HAS_VALUE (entry->options);
     const auto options = nlohmann::json::parse (*entry->options);
     ASSERT_EQ (options.size (), all_proxy_modes ().size ());
     for (const auto mode : all_proxy_modes ()) {
@@ -418,7 +419,7 @@ TEST (CaPemValidation, NamesAPastedPrivateKeyForWhatItIs) {
     // a formatting problem instead of telling them what they pasted.
     const auto rejection = ca_pem_rejection (
     "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n");
-    ASSERT_TRUE (rejection.has_value ());
+    ASSERT_HAS_VALUE (rejection);
     EXPECT_NE (rejection->find ("private key"), std::string::npos) << *rejection;
 }
 
@@ -564,7 +565,7 @@ TEST (TlsBackend, IsTheBackendEveryTrustStatementHereAssumes) {
 
     const std::optional<bool> bundle_file_backend =
     verifies_through_a_bundle_file (backend);
-    ASSERT_TRUE (bundle_file_backend.has_value ())
+    ASSERT_HAS_VALUE (bundle_file_backend)
     << "TLS backend '" << backend
     << "' is one no statement in this repo covers - decide which trust model "
        "it "
@@ -636,7 +637,7 @@ TEST (TlsBackend, FindsTheSystemAnchorsTheMergeExtends) {
     ASSERT_FALSE (backend.empty ());
     const std::optional<bool> bundle_file_backend =
     verifies_through_a_bundle_file (backend);
-    ASSERT_TRUE (bundle_file_backend.has_value ()) << backend;
+    ASSERT_HAS_VALUE (bundle_file_backend) << backend;
     ASSERT_TRUE (*bundle_file_backend)
     << "TLS backend '" << backend << "' does not verify through a bundle file";
 


### PR DESCRIPTION
## Description

The last batch of #980: the 295 `bugprone-unchecked-optional-access` findings still standing in `engine/tests` after batch 2b (#1012), across 40 files, plus the gate the wave asked its final batch to carry.

**The check now reports zero over the whole engine** - all 113 test translation units and all 93 under `src`, re-scanned on this branch. That is wave 1's acceptance criterion, unmet since #943 was closed on `engine/src` alone and the reason #980 exists.

**Plan (root cause, approach, rejected alternative).** 257 of the 295 were the wave's one shape - `ASSERT_TRUE (opt.has_value ())`, a guard that works at run time and that the check's dataflow model cannot follow through gtest's `AssertionResult` - and they became `ASSERT_HAS_VALUE` (`tests/optional_assert.hpp`, from #982). The 38 that were not are the interesting half, and they are why this was not a bulk `sed`:

- **An optional re-derived rather than bound** (19). `ASSERT_HAS_VALUE (validation.steps[0])` followed by `validation.steps[0]->passed` is two expressions to the check and to a reader alike, which `engine/CLAUDE.md` already says for `src`. These bind the optional once and read through the binding.
- **An optional reached *through* a guarded row** (7): a reassigned `verdict.reason`, a `parent_id` inside a collection row, a `capture` inside a result record. The outer guard says nothing about the inner optional, so each got its own.
- **Three non-void test helpers**, where `ASSERT_HAS_VALUE` cannot be used at all because `FAIL ()` returns void. They state the absent case as the `if` the check does follow, with `ADD_FAILURE ()` naming what was missing and a harmless value returned - so a fixture whose row has gone reports *that*, instead of reading an empty optional on the way to a confusing comparison failure. `only_check` in `threshold_eval_test.cpp` returns by value for this; `ThresholdCheck` is four scalars.
- **Thirteen `.value ()` reads** in `encoding_test.cpp`'s base64 vector table. A file-local `decoded ()` keeps it one line per vector, names the input that failed, and reads through `value_or`.

The alternative I rejected for the third kind was `vayu::utils::invariant_value` from #969: it satisfies the check and reads well, but it throws, and a test helper that throws reports "C++ exception in the test body" instead of a gtest failure naming the fixture state that was missing. `invariant_value` stays what it is documented as - for an invariant proved in another function, not for a test's own setup.

**The gate.** CI lints a pull request's *changed* lines, so once these conversions stop being new nothing holds the family at zero - the same argument #945 made for `concurrency-*`, and recorded on #980 by batch 2a as work for the last batch. `optional_assert_test.cpp` now scans `tests/` for `ASSERT_TRUE (x.has_value ())` and fails naming the file. It reads code and not prose (`strip_comments` from `tests/source_scan.hpp`), proves it read something (>100 files, >100k bytes), and pins its matcher with a planted positive; the one file it cannot read is the one carrying that planted positive, exempted by name with the reason, exactly as `reentrant_test.cpp` exempts its one `getenv`. It could not be turned on before every file was converted, which is why the **28 remaining guards that preceded no unchecked read were converted too** - a rule with exceptions scattered through the tree is not worth enforcing, and the spelling is what `engine/CLAUDE.md` already tells contributors not to write.

## Type of Change
- [x] Bug fix (test failure paths that were undefined behaviour; no engine behaviour changes)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2396 / 2396 passed, 0 failed** (39s). 2394 before, plus the gate's two.
- `clang-tidy-19` over **all 113 `engine/tests` translation units**, deduplicated by (file, line, column, check): **0 findings**, down from 295. Over all 93 `engine/src` translation units: **0**. The whole `bugprone-*` family is now zero in `engine/tests`.
- `clang-format-19 --style=file --dry-run -Werror` over every `engine/{src,include,tests}` source, the Engine formatting gate's own command: exit 0.
- **Mutation check on the gate**, which is the new test and so the one that owes it: reverting a single conversion in `db_test.cpp` fails `OptionalAssertGuard.NoTestFileGuardsWithAssertTrue` with `Offenders: tests/db_test.cpp`; restoring it passes. The matcher's own test pins the boundaries - `EXPECT_TRUE`, `ASSERT_FALSE`, `ASSERT_HAS_VALUE`, `ASSERT_TRUE (x.has_value () && y)` and the spelling inside a comment are each *not* offenders.
- App suite not run: this diff touches no file under `app/`, so no app test could change colour (repo `CLAUDE.md`, "scale the verification to what the change could actually break").

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the source-scan gate and its matcher test, both mutation-checked.
- [x] I have updated documentation - `engine/CLAUDE.md`'s `ASSERT_HAS_VALUE` entry now names the two shapes the macro does not cover (an optional inside a guarded row; a non-void helper) and the gate that keeps the old spelling out.

## On #980's acceptance criteria

- **Zero findings over `engine/tests`, re-scanned** - yes, and zero over `src` with it.
- **The 10 wave-2 leftovers** - cleared, nine in #982 and the last in #1012.
- **Category 1 gets a defect record and a mutation-checked regression test** - as #982 and #1012 both found, category 1 in a test file is not a latent engine crash: the code under these tests is correct, and what was wrong was the *test's* failure path. No defect record is owed under #928 by this batch either. The record is here and in the two PR bodies before it.
- **Nothing silenced without its reason at the site** - **zero `NOLINT`s across the entire wave**.
- **#943's close reconciled** - a comment on #943 points at #980 and the three PRs that finished the wave, so the ledger on #928 no longer reads as though `engine/src` alone completed it.

## Related Issues

Closes #980.

Refs #1012, #982, #943, #944, #928, #946 - whose closing re-measure will now find `bugprone-unchecked-optional-access` at zero rather than the 571 it would have reported.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaNmUGNKtCFgPXNCGcVwut)_