### PR TITLE
fix(engine): count the headers the tidy paydown never measured, and clear them - #1013

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -995,6 +995,40 @@ down by whoever edits those lines - and, since #928, by its waves on purpose:
 findings down family by family, with promotion from changed-lines to whole-file
 gating decided in #946 once nothing pre-existing is left to surface.
 
+**"Clean" means the whole tree, headers included - and a scan has to be asked
+for that** (#1013). `run-clang-tidy` reports nothing found in a header unless
+`-header-filter` is passed **on the command line**: the `HeaderFilterRegex` in
+`engine/.clang-tidy` does not supply it. Every number the #928 paydown worked
+from before this was measured without it, so 50 findings sat in headers that no
+report had ever counted - the same seam as "CI lints translation units, never a
+header" (#940), reaching the measurement rather than the gate.
+
+That is a gap in the *measurement*, not in the standard. A header is part of the
+tree, the pre-commit hook lints one whenever a commit stages it, and #946's
+"zero findings tree-wide" is not true of a tree whose headers were never read.
+So the re-measure command is:
+
+```bash
+run-clang-tidy-19 -p engine/build -quiet \
+  -header-filter='.*/(src|include|tests)/.*' \
+  -extra-arg=-Wno-ignored-gch <every non-vendor translation unit>
+```
+
+and its output is **deduplicated by (file, line, column, check)** before it is
+counted, because a header finding is reported once per translation unit that
+includes it - which is what made the wave-0 table read 11 `concurrency-mt-unsafe`
+where 8 sites existed. `-extra-arg=-Wno-ignored-gch` is needed because the
+build's precompiled header is GCC's (#912).
+
+Two things this does **not** change. The gate still lints translation units,
+because a header has no `compile_commands.json` entry and a guessed command
+emits `clang-diagnostic-error`s that escape line filtering (#940) - so a
+promotion from changed-lines to whole-*file* scope, which #946 decides, still
+would not read a header; the hook is what does. And `engine/src/runtime/` stays
+out of scope in every count: its own `.clang-tidy` declines every check with a
+written reason, so the findings a check-list override surfaces there are that
+decision working, not a backlog.
+
 **What the config enables is a decision, not a default** (#928): the families
 that catch real defects - `bugprone-*`, `clang-analyzer-*`, `concurrency-*`,
 `cert-*`, a curated `cppcoreguidelines-*` safety subset, `performance-*` - plus

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -96,8 +96,11 @@ engine/
   `hmac_sha256` digest, and the six sites that spelled that themselves;
   **`vayu::db::column_text`** (`db/database.hpp`) for a sqlite TEXT column,
   which `sqlite3_column_text` hands back as `const unsigned char*` and nothing
-  consumes as one; and **`vayu::utils::detail::sodium_bytes`**
-  (`utils/sodium_init.hpp`) going the other way, for libsodium. A SQL NULL stays
+  consumes as one; **`vayu::utils::detail::sodium_bytes`**
+  (`utils/sodium_init.hpp`) going the other way, for libsodium; and
+  **`tls_detail::openssl_bytes`** (`tests/tls_server.hpp`, #1013) going the same
+  way for OpenSSL, whose parameters are `const unsigned char*` with no
+  `string_view` seam. A SQL NULL stays
   a null pointer through `column_text` on purpose - absent and empty are
   different answers, and defaulting one to the other erases the distinction its
   callers read. `tests/character_cast_test.cpp` scans `engine/{src,include,tests}`
@@ -112,15 +115,41 @@ engine/
   leaving the rest implicit is how a fixture that owns a listener and a thread
   stays copyable: the copy compiles, both objects stop the same server, and
   nothing says it was not meant to. Every RAII holder here - the `Impl` behind a
-  pImpl, `Database`, and the ~20 in-process mock servers in `tests/` - deletes
-  copy *and* move beside its destructor, in the spelling `client.hpp` uses
-  (`Foo (const Foo&) = delete;` and the three that follow). Deleting is the
+  pImpl, `Database`, the ~20 in-process mock servers in `tests/`, and (#1013)
+  every manager and listener in `include/`: `Server`, `ManagedListener`,
+  `SseStreamManager`, `InboxManager`, `RunManager`, `EventLoopWorker`, `Logger`
+  and their kin - deletes copy *and* move beside its destructor, in the spelling
+  `client.hpp` uses (`Foo (const Foo&) = delete;` and the three that follow).
+  Deleting is the
   default answer, not defaulting: none of these is meaningfully movable, and a
-  move would leave a hollow object whose methods still compile. A mock server's
+  move would leave a hollow object whose methods still compile. **Declaring the
+  four suppresses the implicit default constructor**, so a class that had no
+  other constructor gains `Foo () = default;` beside them - `TransferData`,
+  `RunManager` and the `LoadStrategy` interface each needed it, and the build is
+  what says so. A mock server's
   thread pool is `vayu::tests::pooled_task_queue`
   (`tests/task_queue.hpp`) - httplib's `new_task_queue` hook takes a raw owning
   pointer, which is its contract and not a leak, said once there rather than at
   each fixture.
+- **A row struct's scalars all carry a default** (#1013,
+  `cppcoreguidelines-pro-type-member-init`). The `vayu::db` structs in
+  `types.hpp` are aggregates an insert site fills field by field, so one it
+  forgets is *indeterminate* rather than zero - and sqlite_orm binds and stores
+  whatever that was. `Run::end_time` had already made the argument for itself;
+  it now holds for every scalar in the namespace. The three enums
+  (`Request::method`, `Run::type`, `Run::status`) default to what
+  `database.cpp`'s `row_extractor` already falls back to for a stored value it
+  cannot parse, so the struct and the reader agree about an unset field rather
+  than each picking an answer. A default is not a substitute for setting the
+  field: it bounds what a wrong insert can persist, and stops an indeterminate
+  `bool` or enum being read at all.
+- **A whole-tree tidy measurement passes `-header-filter` itself** (#1013). The
+  `HeaderFilterRegex` in `engine/.clang-tidy` is *not* read by a
+  `run-clang-tidy` invocation that omits the command-line flag, so a scan
+  without it reports nothing found in a header - which is how 50 findings went
+  uncounted through four measurement rounds. Deduplicate the result by
+  (file, line, column, check): a header finding is reported once per including
+  translation unit. `docs/engine/building.md` carries the command.
 - Formatter: clang-format, **19 exactly** (`.clang-format` at repo root; the
   version is pinned because 39 of the 285 engine sources format differently
   under 18). **A difference is a failure now** (#886): the `Engine formatting`

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -110,7 +110,15 @@ const ResultAnnotations& annotations = {});
  */
 class LoadStrategy {
     public:
+    LoadStrategy ()          = default;
     virtual ~LoadStrategy () = default;
+    // Deleted rather than protected: nothing copies a strategy - they are held
+    // by pointer and run in place - and deleting is what stops a derived one
+    // being sliced back to this interface.
+    LoadStrategy (const LoadStrategy&)            = delete;
+    LoadStrategy& operator= (const LoadStrategy&) = delete;
+    LoadStrategy (LoadStrategy&&)                 = delete;
+    LoadStrategy& operator= (LoadStrategy&&)      = delete;
 
     /**
      * @brief Execute the load test strategy

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -46,12 +46,12 @@ namespace vayu::core {
  * Stores minimal data needed to run test scripts after load test completes
  */
 struct ResponseSample {
-    int status_code;
+    int status_code = 0;
     std::string status_text;
     std::string body;
     Headers headers;
-    double latency_ms;
-    int64_t timestamp;
+    double latency_ms = 0.0;
+    int64_t timestamp = 0;
     /**
      * Scenario load runs only: the virtual user's iteration this response was
      * sent in, and the data row that iteration was bound to.
@@ -120,10 +120,10 @@ struct CapturedExchange {
  * @brief Record for a single request result (lighter than db::Result)
  */
 struct ResultRecord {
-    int64_t timestamp;
-    int status_code;
-    double latency_ms;
-    ErrorCode error_code;
+    int64_t timestamp    = 0;
+    int status_code      = 0;
+    double latency_ms    = 0.0;
+    ErrorCode error_code = ErrorCode::None;
     std::string error_message;
     std::string trace_data;
     /// Present only for the three captured buckets (errors, slow outliers,

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -513,6 +513,10 @@ struct RunContext {
     size_t max_errors = constants::metrics_collector::DEFAULT_MAX_ERRORS,
     EngineDefaults engine_defaults = {});
     ~RunContext ();
+    RunContext (const RunContext&)            = delete;
+    RunContext& operator= (const RunContext&) = delete;
+    RunContext (RunContext&&)                 = delete;
+    RunContext& operator= (RunContext&&)      = delete;
 
     /**
      * @brief Join the run's auxiliary threads (metrics tick, auth refresh).
@@ -840,7 +844,12 @@ class RunManager {
     const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn);
 
     public:
+    RunManager () = default;
     ~RunManager ();
+    RunManager (const RunManager&)            = delete;
+    RunManager& operator= (const RunManager&) = delete;
+    RunManager (RunManager&&)                 = delete;
+    RunManager& operator= (RunManager&&)      = delete;
 
     void register_run (const std::string& run_id, std::shared_ptr<RunContext> context);
     std::shared_ptr<RunContext> get_run (const std::string& run_id);

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -166,6 +166,8 @@ class StepHistograms {
 
     StepHistograms (const StepHistograms&)            = delete;
     StepHistograms& operator= (const StepHistograms&) = delete;
+    StepHistograms (StepHistograms&&)                 = delete;
+    StepHistograms& operator= (StepHistograms&&)      = delete;
 
     /// A completed step: its latency, and whether it counted as an error.
     void record (size_t step, double latency_ms);

--- a/engine/include/vayu/http/cookie_jar.hpp
+++ b/engine/include/vayu/http/cookie_jar.hpp
@@ -225,13 +225,16 @@ struct CookieScopeView {
  */
 class CookieJar {
     public:
-    CookieJar () = default;
+    CookieJar ()  = default;
+    ~CookieJar () = default;
 
     // Non-copyable, non-movable: it is held by reference (RouteContext, and
     // ClientConfig for the duration of a send), so a copy would silently
     // become a second jar that no reader ever sees again.
     CookieJar (const CookieJar&)            = delete;
     CookieJar& operator= (const CookieJar&) = delete;
+    CookieJar (CookieJar&&)                 = delete;
+    CookieJar& operator= (CookieJar&&)      = delete;
 
     /**
      * @brief The scope's stored lines, ready for `CURLOPT_COOKIELIST`.

--- a/engine/include/vayu/http/event_loop.hpp
+++ b/engine/include/vayu/http/event_loop.hpp
@@ -93,7 +93,7 @@ struct EventLoopConfig {
  * @brief Request handle for tracking/cancellation
  */
 struct RequestHandle {
-    size_t id;
+    size_t id = 0;
     std::future<Result<Response>> future;
 };
 

--- a/engine/include/vayu/http/event_loop/event_loop_impl.hpp
+++ b/engine/include/vayu/http/event_loop/event_loop_impl.hpp
@@ -47,6 +47,10 @@ class EventLoopImpl {
     public:
     explicit EventLoopImpl (EventLoopConfig cfg);
     ~EventLoopImpl ();
+    EventLoopImpl (const EventLoopImpl&)            = delete;
+    EventLoopImpl& operator= (const EventLoopImpl&) = delete;
+    EventLoopImpl (EventLoopImpl&&)                 = delete;
+    EventLoopImpl& operator= (EventLoopImpl&&)      = delete;
 
     void start ();
     void stop (bool wait_for_pending,

--- a/engine/include/vayu/http/event_loop/event_loop_worker.hpp
+++ b/engine/include/vayu/http/event_loop/event_loop_worker.hpp
@@ -118,6 +118,8 @@ class CurlHandlePool {
     // Prevent copying
     CurlHandlePool (const CurlHandlePool&)            = delete;
     CurlHandlePool& operator= (const CurlHandlePool&) = delete;
+    CurlHandlePool (CurlHandlePool&&)                 = delete;
+    CurlHandlePool& operator= (CurlHandlePool&&)      = delete;
 
     /// Acquire a handle from the pool (or create new if empty)
     /// The handle is reset and ready for configuration
@@ -163,6 +165,8 @@ class EventLoopWorker {
     // Prevent copying
     EventLoopWorker (const EventLoopWorker&)            = delete;
     EventLoopWorker& operator= (const EventLoopWorker&) = delete;
+    EventLoopWorker (EventLoopWorker&&)                 = delete;
+    EventLoopWorker& operator= (EventLoopWorker&&)      = delete;
 
     void start ();
     /// See EventLoop::stop. `drain_timeout` bounds the drain when

--- a/engine/include/vayu/http/event_loop/transfer_context.hpp
+++ b/engine/include/vayu/http/event_loop/transfer_context.hpp
@@ -74,7 +74,12 @@ struct TransferData {
     /// transfer's curl state. Only a `form-data` body has one.
     curl_mime* mime = nullptr;
 
+    TransferData () = default;
     ~TransferData ();
+    TransferData (const TransferData&)            = delete;
+    TransferData& operator= (const TransferData&) = delete;
+    TransferData (TransferData&&)                 = delete;
+    TransferData& operator= (TransferData&&)      = delete;
 };
 
 } // namespace detail

--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -188,6 +188,8 @@ class InboxManager {
 
     InboxManager (const InboxManager&)            = delete;
     InboxManager& operator= (const InboxManager&) = delete;
+    InboxManager (InboxManager&&)                 = delete;
+    InboxManager& operator= (InboxManager&&)      = delete;
 
     struct StartResult {
         bool ok         = true;

--- a/engine/include/vayu/http/managed_listener.hpp
+++ b/engine/include/vayu/http/managed_listener.hpp
@@ -60,6 +60,8 @@ class ManagedListener {
 
     ManagedListener (const ManagedListener&)            = delete;
     ManagedListener& operator= (const ManagedListener&) = delete;
+    ManagedListener (ManagedListener&&)                 = delete;
+    ManagedListener& operator= (ManagedListener&&)      = delete;
 
     /**
      * The server to register routes and options on, before `start()`.

--- a/engine/include/vayu/http/mock_issuer.hpp
+++ b/engine/include/vayu/http/mock_issuer.hpp
@@ -118,6 +118,8 @@ class MockIssuerManager {
 
     MockIssuerManager (const MockIssuerManager&)            = delete;
     MockIssuerManager& operator= (const MockIssuerManager&) = delete;
+    MockIssuerManager (MockIssuerManager&&)                 = delete;
+    MockIssuerManager& operator= (MockIssuerManager&&)      = delete;
 
     MockIssuerStart start (const nlohmann::json& body);
 

--- a/engine/include/vayu/http/mock_server.hpp
+++ b/engine/include/vayu/http/mock_server.hpp
@@ -231,6 +231,8 @@ class MockServerManager {
 
     MockServerManager (const MockServerManager&)            = delete;
     MockServerManager& operator= (const MockServerManager&) = delete;
+    MockServerManager (MockServerManager&&)                 = delete;
+    MockServerManager& operator= (MockServerManager&&)      = delete;
 
     struct StartResult {
         bool ok         = true;

--- a/engine/include/vayu/http/oauth_authorize.hpp
+++ b/engine/include/vayu/http/oauth_authorize.hpp
@@ -60,6 +60,8 @@ class OAuth2AuthorizeManager {
 
     OAuth2AuthorizeManager (const OAuth2AuthorizeManager&)            = delete;
     OAuth2AuthorizeManager& operator= (const OAuth2AuthorizeManager&) = delete;
+    OAuth2AuthorizeManager (OAuth2AuthorizeManager&&)                 = delete;
+    OAuth2AuthorizeManager& operator= (OAuth2AuthorizeManager&&)      = delete;
 
     // mode: "loopback" (default) or "embedded".
     AuthorizeStart

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -28,6 +28,10 @@ class Server {
     public:
     Server (vayu::db::Database& db, vayu::core::RunManager& run_manager, int port, bool verbose = false);
     ~Server ();
+    Server (const Server&)            = delete;
+    Server& operator= (const Server&) = delete;
+    Server (Server&&)                 = delete;
+    Server& operator= (Server&&)      = delete;
 
     void start ();
     void stop ();

--- a/engine/include/vayu/http/sse_stream.hpp
+++ b/engine/include/vayu/http/sse_stream.hpp
@@ -349,6 +349,8 @@ class SseStreamManager {
 
     SseStreamManager (const SseStreamManager&)            = delete;
     SseStreamManager& operator= (const SseStreamManager&) = delete;
+    SseStreamManager (SseStreamManager&&)                 = delete;
+    SseStreamManager& operator= (SseStreamManager&&)      = delete;
 
     /**
      * Start consuming @p request on a worker thread.

--- a/engine/include/vayu/http/thread_pool.hpp
+++ b/engine/include/vayu/http/thread_pool.hpp
@@ -27,6 +27,10 @@ class ThreadPool {
     public:
     explicit ThreadPool (size_t num_threads = 0);
     ~ThreadPool ();
+    ThreadPool (const ThreadPool&)            = delete;
+    ThreadPool& operator= (const ThreadPool&) = delete;
+    ThreadPool (ThreadPool&&)                 = delete;
+    ThreadPool& operator= (ThreadPool&&)      = delete;
 
     /**
      * @brief Submit a task that returns a value

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -923,6 +923,21 @@ inline std::optional<RunStatus> parse_run_status (const std::string& str) {
 // Database Types
 // ============================================================================
 
+/**
+ * Every scalar member of a row struct below carries a default (#1013,
+ * `cppcoreguidelines-pro-type-member-init`), and the argument is the one
+ * `Run::end_time` already made for itself: these are aggregates, an insert site
+ * builds one field by field, and a field it forgets is *indeterminate* rather
+ * than zero - which sqlite_orm then binds and stores. A default cannot make an
+ * insert correct, but it bounds what a wrong one can persist, and reading an
+ * indeterminate `bool` or enum is undefined behaviour before it ever reaches
+ * the database.
+ *
+ * The three enums (`Request::method`, `Run::type`, `Run::status`) default to
+ * what `database.cpp`'s `row_extractor` already falls back to for a stored
+ * value it cannot parse, so the struct and the reader agree about what an
+ * unset field means rather than each picking its own answer.
+ */
 namespace db {
 struct Collection {
     std::string id;
@@ -945,9 +960,9 @@ struct Collection {
     // only the edge, so two collections may bind the same spec and unbinding
     // one leaves the document alone.
     std::string openapi{ "{}" };
-    int order;
-    int64_t created_at;
-    int64_t updated_at;
+    int order          = 0;
+    int64_t created_at = 0;
+    int64_t updated_at = 0;
 };
 
 struct Request {
@@ -955,7 +970,7 @@ struct Request {
     std::string collection_id;
     std::string name;
     std::string description; // TEXT NOT NULL DEFAULT ''
-    HttpMethod method;
+    HttpMethod method = HttpMethod::GET;
     std::string url;
     std::string params; // JSON array of KeyValueEntry: [{key,value,enabled,description?}]
     std::string headers; // JSON array of KeyValueEntry
@@ -964,7 +979,7 @@ struct Request {
     std::string auth; // JSON - RequestAuth (mode + fields, may be 'inherit')
     std::string pre_request_script;  // JS Code
     std::string post_request_script; // JS Code (Tests)
-    int order; // INTEGER NOT NULL DEFAULT 0 - position within collection
+    int order = 0; // INTEGER NOT NULL DEFAULT 0 - position within collection
     // Execution options. Mirror the fields of the executable vayu::Request so a
     // saved request keeps the redirect policy the user chose. The in-struct
     // defaults match the column defaults, so a default-constructed row and a row
@@ -997,8 +1012,8 @@ struct Request {
     // it is the identity a re-fetched spec is diffed against (#627) and the key
     // coverage counts by (#629). Two requests may name the same operation.
     std::optional<std::string> spec_operation;
-    int64_t created_at;
-    int64_t updated_at;
+    int64_t created_at = 0;
+    int64_t updated_at = 0;
 };
 
 /**
@@ -1080,9 +1095,9 @@ struct RequestExample {
      * `false` for every row that predates the column, which is what they all
      * are - a row a delete had reached was gone.
      */
-    bool suppressed = false;
-    int64_t created_at;
-    int64_t updated_at;
+    bool suppressed    = false;
+    int64_t created_at = 0;
+    int64_t updated_at = 0;
 };
 
 /**
@@ -1173,19 +1188,19 @@ struct Environment {
     // environmentId - but the choice is stored here rather than in client-local
     // state, so it survives a reinstall and is shared by every client on the
     // same database. See docs/engine/db-schema.md.
-    bool is_active = false;
-    int64_t created_at;
-    int64_t updated_at;
+    bool is_active     = false;
+    int64_t created_at = 0;
+    int64_t updated_at = 0;
 };
 
 struct Run {
     std::string id;
     std::optional<std::string> request_id; // Linked request (if design mode)
     std::optional<std::string> environment_id; // Environment used
-    RunType type;                              // "design", "load" or "scenario"
-    RunStatus status;            // "pending", "running", "completed", "failed"
+    RunType type = RunType::Design;            // "design", "load" or "scenario"
+    RunStatus status = RunStatus::Pending; // "pending", "running", "completed", "failed"
     std::string config_snapshot; // JSON string (Full copy of request/env)
-    int64_t start_time;
+    int64_t start_time = 0;
     // 0 means "no end recorded"; readers guard on `> 0` (the report route
     // substitutes now_ms(), the app's dashboard falls back to its own clock).
     // Defaulted rather than left bare so an insert site that forgets to stamp
@@ -1224,10 +1239,10 @@ struct Run {
  * makes that endpoint's pagination tick-aligned.
  */
 struct MetricTick {
-    int id;
+    int id = 0;
     std::string run_id;
-    int64_t timestamp;   // Unix ms - the tick's single wall-clock sample
-    std::string payload; // JSON object (see build_metric_tick_payload)
+    int64_t timestamp = 0; // Unix ms - the tick's single wall-clock sample
+    std::string payload;   // JSON object (see build_metric_tick_payload)
 };
 
 /**
@@ -1278,7 +1293,7 @@ struct Result {
  * deleting a run deletes its blobs without any cross-run refcount to maintain.
  */
 struct BodyBlob {
-    int id;
+    int id = 0;
     std::string run_id;
     std::string hash; // lowercase hex SHA-256 of `content` (vayu::core::body_digest)
     std::string content; // the stored bytes, already truncated to the per-body cap
@@ -1292,15 +1307,15 @@ struct BodyBlob {
  * `trace_data` - never reads a body it does not use.
  */
 struct ResultBody {
-    int result_id; // PK, and the `results.id` this exchange belongs to
+    int result_id = 0; // PK, and the `results.id` this exchange belongs to
     std::string run_id;
     std::string headers; // JSON object of response headers
     // 0 when no body was stored: the response had none, it was binary, or the
     // run's capture budget was spent. `body_bytes` and the flags say which.
-    int blob_id;
-    int64_t body_bytes; // size of the body as received, before truncation
-    bool truncated;     // stored bytes are a prefix of `body_bytes`
-    bool is_binary;     // stored as a descriptor; `blob_id` is 0
+    int blob_id        = 0;
+    int64_t body_bytes = 0; // size of the body as received, before truncation
+    bool truncated     = false; // stored bytes are a prefix of `body_bytes`
+    bool is_binary     = false; // stored as a descriptor; `blob_id` is 0
     std::string content_type;
     /**
      * Events the transfer delivered, when it was a bounded stream
@@ -1379,7 +1394,7 @@ struct ConfigEntry {
     std::optional<std::string> min_value; // Optional minimum (for numbers)
     std::optional<std::string> max_value; // Optional maximum (for numbers)
     std::optional<std::string> options; // JSON array of {value,label}, enum types only
-    int64_t updated_at;                 // Last update timestamp
+    int64_t updated_at = 0;             // Last update timestamp
     // Whether the running engine keeps the old value until it is restarted.
     // Serialized as `requiresRestart`; the app and the MCP `update_config` tool
     // both read it. It used to be spelled as a "(Requires Restart)" suffix in
@@ -1424,7 +1439,7 @@ struct ConfigEntry {
 struct Globals {
     std::string id;        // Always "globals" - singleton
     std::string variables; // JSON - Global variables
-    int64_t updated_at;
+    int64_t updated_at = 0;
 };
 
 /**
@@ -1439,8 +1454,8 @@ struct OAuthToken {
     std::string token_type;    // "Bearer" when the provider omits it
     std::string refresh_token; // "" = none
     std::string scope;
-    int64_t expires_in; // seconds; 0 = non-expiring
-    int64_t created_at; // ms epoch
+    int64_t expires_in = 0; // seconds; 0 = non-expiring
+    int64_t created_at = 0; // ms epoch
     std::string raw_response; // provider JSON (truncated); debugging only, never logged
 };
 

--- a/engine/include/vayu/utils/logger.hpp
+++ b/engine/include/vayu/utils/logger.hpp
@@ -60,6 +60,10 @@ class Logger {
     private:
     Logger () = default;
     ~Logger ();
+    Logger (const Logger&)            = delete;
+    Logger& operator= (const Logger&) = delete;
+    Logger (Logger&&)                 = delete;
+    Logger& operator= (Logger&&)      = delete;
 
     std::string level_to_string (Level level) const;
     std::string get_timestamp () const;

--- a/engine/include/vayu/utils/logger.hpp
+++ b/engine/include/vayu/utils/logger.hpp
@@ -32,6 +32,16 @@ class Logger {
 
     static Logger& instance ();
 
+    // Public although the constructor and destructor below are not: a deleted
+    // member that is also private reports as inaccessible rather than as
+    // deleted, which says nothing about why (`modernize-use-equals-delete`).
+    // The singleton is enforced by the private constructor; these say that even
+    // `instance()`'s reference cannot be copied out of it.
+    Logger (const Logger&)            = delete;
+    Logger& operator= (const Logger&) = delete;
+    Logger (Logger&&)                 = delete;
+    Logger& operator= (Logger&&)      = delete;
+
     void init (const std::string& log_dir = vayu::core::constants::logging::DIR);
     void log (Level level, const std::string& message);
     void debug (const std::string& message);
@@ -60,10 +70,6 @@ class Logger {
     private:
     Logger () = default;
     ~Logger ();
-    Logger (const Logger&)            = delete;
-    Logger& operator= (const Logger&) = delete;
-    Logger (Logger&&)                 = delete;
-    Logger& operator= (Logger&&)      = delete;
 
     std::string level_to_string (Level level) const;
     std::string get_timestamp () const;

--- a/engine/src/core/js_json.hpp
+++ b/engine/src/core/js_json.hpp
@@ -34,7 +34,7 @@
 #include <cctype>
 #include <charconv>
 #include <cmath>
-#include <cstdio>
+#include <format>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
@@ -122,13 +122,15 @@ inline std::string js_number_text (const json& value) {
         return "null"; // What `JSON.stringify` writes for NaN and Infinity.
     }
     if (std::trunc (real) == real && std::abs (real) < 1e21) {
-        std::array<char, 64> buffer{};
-        const int written = std::snprintf (buffer.data (), buffer.size (), "%.0f", real);
-        if (written > 0) {
-            std::string text (buffer.data (), static_cast<size_t> (written));
-            // `%.0f` writes "-0" for negative zero; JavaScript writes "0".
-            return text == "-0" ? "0" : text;
-        }
+        // `std::format` rather than `snprintf ("%.0f")`: the same fixed
+        // notation with no fractional digits, without the vararg call
+        // (`cppcoreguidelines-pro-type-vararg`), the fixed buffer, or the
+        // short-write branch that a value bounded by 1e21 could never take.
+        // Rounding cannot differ between the two here - the guard above admits
+        // only values that are already whole.
+        const std::string text = std::format ("{:.0f}", real);
+        // A negative zero formats as "-0"; JavaScript writes "0".
+        return text == "-0" ? "0" : text;
     }
     std::array<char, 64> buffer{};
     const auto result =
@@ -182,10 +184,10 @@ inline void append_json_string (const std::string& value, std::string& out) {
         case '\t': out += "\\t"; break;
         default:
             if (static_cast<unsigned char> (ch) < 0x20) {
-                std::array<char, 8> escape{};
-                std::snprintf (escape.data (), escape.size (), "\\u%04x",
+                // Same four lowercase hex digits `\\u%04x` wrote, without the
+                // vararg call or the fixed buffer.
+                out += std::format ("\\u{:04x}",
                 static_cast<unsigned int> (static_cast<unsigned char> (ch)));
-                out += escape.data ();
             } else {
                 out += ch;
             }

--- a/engine/tests/character_cast_test.cpp
+++ b/engine/tests/character_cast_test.cpp
@@ -199,7 +199,7 @@ constexpr std::array<ExemptFile, 5> kExempt = { {
 { "include/vayu/utils/encoding.hpp", "byte_view, and the base64 decoder's output buffer" },
 { "include/vayu/utils/sodium_init.hpp", "sodium_bytes - byte_view's inverse" },
 { "include/vayu/db/database.hpp", "column_text" },
-{ "tests/tls_server.hpp", "OpenSSL's C API takes const unsigned char* directly, with no string_view seam" },
+{ "tests/tls_server.hpp", "tls_detail::openssl_bytes - OpenSSL's C API takes const unsigned char* directly, with no string_view seam" },
 { "src/runtime/script_engine.cpp", "a JS ArrayBuffer's bytes arrive as uint8_t* from QuickJS, not as a span" },
 } };
 

--- a/engine/tests/echo_server.hpp
+++ b/engine/tests/echo_server.hpp
@@ -90,6 +90,10 @@ class EchoServer {
             thread_.join ();
         }
     }
+    EchoServer (const EchoServer&)            = delete;
+    EchoServer& operator= (const EchoServer&) = delete;
+    EchoServer (EchoServer&&)                 = delete;
+    EchoServer& operator= (EchoServer&&)      = delete;
 
     std::string url () const {
         return "http://127.0.0.1:" + std::to_string (port_) + "/echo";

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -62,6 +62,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
 
 namespace vayu::tests {
@@ -116,6 +117,25 @@ using Pkcs12Ptr   = std::unique_ptr<PKCS12, Pkcs12Deleter>;
     }
     throw std::runtime_error ("tls_server.hpp: " + what +
     (reason != 0 ? std::string (": ") + detail : std::string ()));
+}
+
+/**
+ * @brief A string's bytes as the `const unsigned char*` OpenSSL parameters take.
+ *
+ * `vayu::utils::byte_view` goes the other way (bytes to text) and
+ * `utils::detail::sodium_bytes` is libsodium's own, so this is the third
+ * direction rather than a fourth copy: three call sites here hand a
+ * passphrase, a DER blob and a common name to a C API whose parameter is
+ * `const unsigned char*` and which offers no `string_view` seam.
+ *
+ * [basic.lval] permits reading any object through a character type, which is
+ * why the cast is a NOLINT rather than a defect - written once, per the rule
+ * `tests/character_cast_test.cpp` enforces (this file is that guard's one
+ * exemption, and this is now the only cast the exemption covers).
+ */
+inline const unsigned char* openssl_bytes (std::string_view s) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<const unsigned char*> (s.data ());
 }
 
 inline std::string read_bio (const BioPtr& bio, const char* what) {
@@ -209,7 +229,7 @@ struct CertificateAndKey {
         // terminal, which a test process does not have.
         if (!bio ||
         PEM_write_bio_PrivateKey (bio.get (), key.get (), EVP_aes_256_cbc (),
-        reinterpret_cast<const unsigned char*> (passphrase.data ()),
+        tls_detail::openssl_bytes (passphrase),
         static_cast<int> (passphrase.size ()), nullptr, nullptr) != 1) {
             tls_detail::fail ("could not serialize an encrypted private key");
         }
@@ -361,7 +381,7 @@ class TestCertificateAuthority {
         if (der.empty ()) {
             return "nothing was served";
         }
-        const auto* data = reinterpret_cast<const unsigned char*> (der.data ());
+        const auto* data = tls_detail::openssl_bytes (der);
         tls_detail::CrlPtr crl (
         d2i_X509_CRL (nullptr, &data, static_cast<long> (der.size ())));
         if (!crl) {
@@ -399,6 +419,10 @@ class TestCertificateAuthority {
         ASN1_INTEGER* serial = X509_get_serialNumber (certificate);
         if (serial == nullptr ||
         ASN1_INTEGER_set_uint64 (serial,
+        // The pointer is the serial: unique for as long as this process runs,
+        // which is all these certificates live. Not a character-type cast, so
+        // no primitive stands in for it.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         static_cast<uint64_t> (reinterpret_cast<uintptr_t> (certificate))) != 1) {
             tls_detail::fail ("could not set a serial number");
         }
@@ -406,7 +430,7 @@ class TestCertificateAuthority {
 
     static void set_name (X509_NAME* name, const std::string& common_name) {
         if (X509_NAME_add_entry_by_txt (name, "CN", MBSTRING_ASC,
-            reinterpret_cast<const unsigned char*> (common_name.c_str ()), -1, -1, 0) != 1) {
+            tls_detail::openssl_bytes (common_name), -1, -1, 0) != 1) {
             tls_detail::fail ("could not set a subject name");
         }
     }
@@ -558,6 +582,8 @@ class CrlServer {
 
     CrlServer (const CrlServer&)            = delete;
     CrlServer& operator= (const CrlServer&) = delete;
+    CrlServer (CrlServer&&)                 = delete;
+    CrlServer& operator= (CrlServer&&)      = delete;
 
     /// What a leaf's distribution point names, and where the guard fetches.
     std::string url () const {
@@ -569,6 +595,9 @@ class CrlServer {
     /// regular expression, and a literal here reads as one.
     std::string path () const {
         std::ostringstream token;
+        // The address distinguishes one CrlServer's route from another's; see
+        // set_serial above for why a pointer is spelled as a number here.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         token << "/crl-" << std::hex << reinterpret_cast<uintptr_t> (this);
         return token.str ();
     }
@@ -619,6 +648,8 @@ class TlsServer {
 
     TlsServer (const TlsServer&)            = delete;
     TlsServer& operator= (const TlsServer&) = delete;
+    TlsServer (TlsServer&&)                 = delete;
+    TlsServer& operator= (TlsServer&&)      = delete;
 
     std::string url (const std::string& path) const {
         return "https://127.0.0.1:" + std::to_string (port_) + path;


### PR DESCRIPTION
> **Stacked on #1014.** Base is `claude/bold-keller-8rn0i1`, not `master` - the two diffs overlap in `engine/CLAUDE.md`, `tests/character_cast_test.cpp` and `tests/tls_server.hpp`. Merge #1014 first; this retargets to `master` on its own. Review it as the ~230 lines below, not as #1014's 631 plus these.

## Description

**The plan.** #1013 is a measurement bug before it is a backlog. Every number #928's paydown has worked from - #942's baseline, #969's re-check, #975's and #979's tallies, #945 batch 3's rescan - is a **translation-unit** count, and `run-clang-tidy` reports nothing found in a header unless `-header-filter` is passed **on the command line**. The `HeaderFilterRegex` in `engine/.clang-tidy` does not supply it. So 50 findings for wave 3's families were standing in headers that four rounds of measurement had never read, and #946's closing "zero findings tree-wide" would either have missed them or discovered them at the worst possible moment.

Root cause: the same seam #940 settled for CI ("CI lints translation units, never a header") reaching the *measurement* as well as the gate. The fix is therefore two halves, and the first outlasts the second - a basis recorded in `docs/engine/building.md`, then the findings. The alternative I rejected was flipping `AllowMissingMoveFunctionsWhenCopyIsDeleted` in the tidy config, which would have silenced ~13 of the 21 `special-member-functions` findings without a line of code changing. It is defensible in isolation - a class with deleted copy has no implicitly declared move, so the defect the rule guards cannot occur - but it would have made #1014's 24 explicit deletions redundant the week they landed, and traded a stated convention for a config flag nobody reads.

This clears the **42** that belong to batch 3's checks. The other 8 are `pro-bounds-*` and go with #945 batch 4, as the issue says.

### The basis (`docs/engine/building.md`)

"Clean" means the whole tree, headers included. The section now carries the re-measure command with its `-header-filter` and `-extra-arg=-Wno-ignored-gch` (#912), and says the output must be **deduplicated by (file, line, column, check)** - a header finding is reported once per including translation unit, which is exactly what made the wave-0 table read 11 `concurrency-mt-unsafe` where 8 sites existed. #975 and #979 both flagged that over-count from the other side; this is the same seam, and neither dedupe nor `-header-filter` alone gives an honest number.

It also records what this does **not** change: the gate still lints translation units, so the changed-lines-to-whole-**file** promotion #946 decides still would not read a header - the pre-commit hook is what does - and `engine/src/runtime/` stays out of every count by its own config's written decision.

### Rule of five, the remaining 21

`Server`, `ManagedListener`, `SseStreamManager`, `InboxManager`, `MockServerManager`, `MockIssuerManager`, `OAuth2AuthorizeManager`, `RunManager`, `RunContext`, `EventLoopImpl`, `EventLoopWorker`, `CurlHandlePool`, `TransferData`, `LoadStrategy`, `StepHistograms`, `ThreadPool`, `Logger`, `CookieJar`, and `EchoServer` / `CrlServer` / `TlsServer` in `tests/`. Most already deleted copy and were missing only the two move declarations.

- **`CookieJar` is the one the issue said to read rather than pattern-match.** Its comment already said "Non-copyable, **non-movable**" and only the copy half was written; the code now says what the comment did. It also needed `~CookieJar () = default;` - with no destructor declared, the check is not satisfied by the other four.
- **Declaring the four suppresses the implicit default constructor**, and the build caught it: `TransferData` (built by `std::make_unique<TransferData>()`), `RunManager` and the `LoadStrategy` interface each gained `= default` beside them. Nothing else in the tree copies or moves any of these - a clean build is the proof.
- `LoadStrategy` is a polymorphic base, where C.67 offers protected copy/move as an alternative. Deleted instead, with the reason at the site: nothing copies a strategy, and deleting is what stops a derived one being sliced back to the interface.

### Every `vayu::db` row-struct scalar carries a default

The argument is one the file had already made for itself. `Run::end_time` carries a comment explaining that it is defaulted "so an insert site that forgets to stamp it cannot store an indeterminate value"; that reasoning holds for every scalar in the namespace, and 11 of them did not have it. These are aggregates an insert fills field by field, and a field it forgets is *indeterminate* rather than zero - which sqlite_orm then binds and stores.

The three enums (`Request::method`, `Run::type`, `Run::status`) are the decision rather than the mechanics. They default to what `database.cpp`'s `row_extractor` **already falls back to** for a stored value it cannot parse - `GET`, `Design`, `Pending` - so the struct and the reader agree about what an unset field means instead of each picking its own answer. A default is not a substitute for setting the field: it bounds what a wrong insert can persist, and stops an indeterminate `bool` or enum being read at all.

### The tail

- **`tls_detail::openssl_bytes`** (`tests/tls_server.hpp`) is the third direction of #1014's character-cast rule: OpenSSL's parameters are `const unsigned char*` with no `string_view` seam, so a passphrase, a DER blob and a common name go through one cast instead of three. The file stays `character_cast_test.cpp`'s single exemption, and the exemption's reason now names the function it covers.
- The two `uintptr_t` casts in the same file are **not** that rule - a pointer used as a certificate serial, and as a unique route path - and carry their reason at the line.
- **`js_json.hpp`'s two `snprintf` calls become `std::format`**, which the engine already uses on all three platforms (`routes.hpp`, `mock_server.cpp`). Same output, without the vararg call, the fixed buffer, or a short-write branch that a value bounded by 1e21 could never take. Rounding cannot differ: the guard above admits only values that are already whole. This deletes the construct rather than annotating it, which is #979's lesson applied.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
mkdocs build --strict -f .github/mkdocs.yml
```

**2400 tests pass, 0 fail** - the same count as this PR's base, since nothing here adds a test. `mkdocs build --strict` clean.

**The rescan, on the basis this PR records.** The ten checks report **zero** over the 207 non-vendor translation units with `-header-filter='.*/(src|include|tests)/.*'` - the measurement the issue exists to fix, run the way `building.md` now documents. `src/runtime/` reports 136 and every one is its own config's decision working.

**The build is the proof for the special members.** A deleted copy or move that something actually used would not compile, and the first pass did not: `TransferData` failed at `std::make_unique`, which is how the suppressed-default-constructor case was found rather than guessed at.

`clang-format-19 --dry-run -Werror` clean over every touched file.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

**No new test, deliberately.** Both halves are compile-time: a deleted special member is checked by the build, and a default member initialiser has no runtime behaviour to lock that the existing db and route suites do not already exercise. The `js_json.hpp` rewrite is the one behavioural change, and it is covered - `import_parse_test.cpp` and `openapi_document_test.cpp` pin that number formatting against a recorded corpus (#877's conformance fixture), which is a stronger check than anything written for this diff would be. #1014's `character_cast_test.cpp` guard already covers the new `openssl_bytes`.

`engine/CLAUDE.md` gains the row-struct-defaults rule and the measurement rule, and #1014's two bullets are extended rather than duplicated (the third cast direction; the manager classes and the suppressed default constructor).

## Deliberate deviations from the issue

- **The 8 `pro-bounds-*` header findings are not here.** The issue assigns them to #945 batch 4 and this PR honours that rather than widening.
- **No change to the gate's scope.** The issue asks the basis to be decided and recorded, not the gate to be moved; the whole-file promotion remains #946's call, and `building.md` now says why that promotion still would not read a header.

## Related Issues
Closes #1013. Sibling of #945 (whose batch 4 keeps the `pro-bounds-*` remainder); sub-issue of #928.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126GN9DBeFsfcVA8PAYkuxk)_