### PR TITLE
fix(engine): keep the length instead of re-deriving it - #945 batch 4 (the pro-bounds-* family)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -131,6 +131,29 @@ engine/
   (`tests/task_queue.hpp`) - httplib's `new_task_queue` hook takes a raw owning
   pointer, which is its contract and not a leak, said once there rather than at
   each fixture.
+- **A length is kept, never re-derived** (#945, `cppcoreguidelines-pro-bounds-*`).
+  Every finding in this family is a place where a bound was thrown away and then
+  written out again by hand, and the answer is almost never a `NOLINT`: a
+  subrange of a string is `substr` on a view, not `data () + offset`; a fixed
+  table is a `constexpr std::array` (`std::to_array` so the count is not
+  restated) or a `std::string_view`, not a C array; `argv` is a
+  `std::span<char* const>` built from `argc`; and an index a caller computed
+  goes through **`.at ()`**, which costs one predictable compare and turns a
+  wrong index into a throw instead of a read past the end. Two shapes had grown
+  hand-rolled copies and now have primitives: **`vayu::utils::parse_number`**
+  (`utils/parse.hpp`) is a whole `std::string_view` as an integer or nothing -
+  the five sites that spelled `from_chars`'s pointer range themselves each had
+  to remember the `ptr != end` half that separates "42abc is 42" from "42abc is
+  not a number" - and **`vayu::http::CurlErrorBuffer`**
+  (`http/curl_error_buffer.hpp`) owns `CURLOPT_ERRORBUFFER`, whose three rules
+  (at least `CURL_ERROR_SIZE` bytes, alive for the whole transfer, written only
+  on failure so a reused handle must be cleared between transfers) a bare
+  `char[CURL_ERROR_SIZE]` states none of. `tests/bounds_primitives_test.cpp`
+  scans `engine/{src,include,tests}` for both spellings with a per-(file, token)
+  exemption list, on batch 1's reasoning: the CI gate scopes to a pull request's
+  changed lines and so holds nothing at zero once these lines stop being new.
+  The rest of the family is a subscript, which is not a token - there the gate
+  is the whole of the guard, decided rather than omitted.
 - **A row struct's scalars all carry a default** (#1013,
   `cppcoreguidelines-pro-type-member-init`). The `vayu::db` structs in
   `types.hpp` are aggregates an insert site fills field by field, so one it

--- a/engine/include/vayu/http/curl_error_buffer.hpp
+++ b/engine/include/vayu/http/curl_error_buffer.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/curl_error_buffer.hpp
+ * @brief The buffer libcurl writes a transfer's error text into (issue #945).
+ *
+ * `CURLOPT_ERRORBUFFER` has three rules and no way to state them: the buffer
+ * must hold at least `CURL_ERROR_SIZE` bytes, it must outlive the transfer, and
+ * libcurl leaves it *untouched* when nothing goes wrong - so a handle reused
+ * across transfers reports the previous failure unless something clears it in
+ * between. All three drivers here (the single-request client, the event loop,
+ * the SSE stream) spelled it as a bare `char[CURL_ERROR_SIZE]`, which decays to
+ * a pointer at every use and carries none of that with it; the size then had to
+ * be restated, and "empty means no message" was re-derived at each read as
+ * `error_buffer[0]`.
+ *
+ * This keeps the length attached to the storage and says the contract once. It
+ * is deliberately not a `std::string`: libcurl needs somewhere fixed to write
+ * into for the whole transfer, and a string that reallocates is exactly what
+ * that option cannot be given.
+ */
+
+#include <curl/curl.h>
+
+#include <array>
+#include <string_view>
+
+namespace vayu::http {
+
+class CurlErrorBuffer {
+    public:
+    /**
+     * @brief Clear the buffer and give @p curl somewhere to write its next
+     *        failure.
+     *
+     * Clearing is the point of doing both together: libcurl only ever writes on
+     * failure, so a handle that is reused would otherwise answer a later
+     * transfer's success with an earlier transfer's message.
+     */
+    void attach (CURL* curl) {
+        clear ();
+        curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, storage_.data ());
+    }
+
+    /// Forget any message, leaving the buffer attached where it already is.
+    void clear () {
+        storage_.fill ('\0');
+    }
+
+    /// What libcurl wrote, empty when it wrote nothing.
+    [[nodiscard]] std::string_view message () const {
+        return { storage_.data () };
+    }
+
+    private:
+    /// NUL-terminated by libcurl, which never writes more than
+    /// `CURL_ERROR_SIZE` bytes including the terminator.
+    std::array<char, CURL_ERROR_SIZE> storage_{};
+};
+
+} // namespace vayu::http

--- a/engine/include/vayu/http/event_loop/curl_utils.hpp
+++ b/engine/include/vayu/http/event_loop/curl_utils.hpp
@@ -14,6 +14,7 @@
 #include <string_view>
 
 #include "vayu/http/cookie_jar.hpp"
+#include "vayu/http/curl_error_buffer.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/transport_policy.hpp"
 #include "vayu/types.hpp"
@@ -34,7 +35,7 @@ class DnsCache;
  *             where no handle is available; the mapping then falls back to the
  *             code alone.
  */
-Error curl_to_error (CURL* curl, CURLcode code, const char* error_buffer);
+Error curl_to_error (CURL* curl, CURLcode code, const CurlErrorBuffer& errors);
 
 /**
  * @brief Put the transport policy on a handle: TLS verification and the proxy.

--- a/engine/include/vayu/http/event_loop/transfer_context.hpp
+++ b/engine/include/vayu/http/event_loop/transfer_context.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <string>
 
+#include "vayu/http/curl_error_buffer.hpp"
 #include "vayu/http/sse_frame_counter.hpp"
 #include "vayu/types.hpp"
 
@@ -67,9 +68,9 @@ struct TransferData {
     /// to buffer, the stream caps are the stream's intended end.
     bool stream_cap_reached = false;
 
-    char error_buffer[CURL_ERROR_SIZE] = { 0 };
-    struct curl_slist* headers_list    = nullptr;
-    struct curl_slist* resolve_list    = nullptr; // DNS pre-resolution list
+    CurlErrorBuffer errors;
+    struct curl_slist* headers_list = nullptr;
+    struct curl_slist* resolve_list = nullptr; // DNS pre-resolution list
     /// Multipart body attached to the handle, freed with the rest of this
     /// transfer's curl state. Only a `form-data` body has one.
     curl_mime* mime = nullptr;

--- a/engine/include/vayu/http/sse_frame_counter.hpp
+++ b/engine/include/vayu/http/sse_frame_counter.hpp
@@ -113,8 +113,7 @@ class SseFrameCounter {
     enum class FieldMatch : std::uint8_t { Matching, MatchedName, Decided };
 
     void advance_field_match (char c) {
-        static constexpr char FIELD[]          = "data";
-        static constexpr std::size_t FIELD_LEN = 4;
+        static constexpr std::string_view FIELD = "data";
 
         if (field_match_ == FieldMatch::MatchedName) {
             // `data:` is the field; `database:` is a different one whose name
@@ -123,9 +122,9 @@ class SseFrameCounter {
             field_match_  = FieldMatch::Decided;
             return;
         }
-        if (matched_ < FIELD_LEN && c == FIELD[matched_]) {
+        if (matched_ < FIELD.size () && c == FIELD[matched_]) {
             ++matched_;
-            if (matched_ == FIELD_LEN) {
+            if (matched_ == FIELD.size ()) {
                 // A colonless line is a field with an empty value, so a line
                 // that is exactly `data` is one - resolved here in case the
                 // line ends before another byte arrives.

--- a/engine/include/vayu/utils/encoding.hpp
+++ b/engine/include/vayu/utils/encoding.hpp
@@ -96,7 +96,7 @@ inline std::optional<std::string> base64_decode (std::string_view in) {
 
     // ASCII whitespace is skipped wherever it appears, so wrapped base64 (a
     // PEM-ish blob, a value pasted out of a config file) decodes.
-    static constexpr char ignore[] = " \t\n\r\f";
+    static constexpr std::string_view ignore = " \t\n\r\f";
 
     const auto attempt = [&in] (int variant) -> std::optional<std::string> {
         // Base64 never shrinks by less than a quarter, so the input length is
@@ -112,8 +112,8 @@ inline std::optional<std::string> base64_decode (std::string_view in) {
         // this string is one.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         if (sodium_base642bin (reinterpret_cast<unsigned char*> (out.data ()),
-            out.size (), in.empty () ? "" : in.data (), in.size (), ignore,
-            &decoded_len, nullptr, variant) != 0) {
+            out.size (), in.empty () ? "" : in.data (), in.size (),
+            ignore.data (), &decoded_len, nullptr, variant) != 0) {
             return std::nullopt;
         }
 
@@ -165,7 +165,7 @@ inline std::string base64url_encode (std::string_view in) {
  * application/x-www-form-urlencoded values.
  */
 inline std::string url_encode (std::string_view in) {
-    static constexpr char hex[] = "0123456789ABCDEF";
+    static constexpr std::string_view hex = "0123456789ABCDEF";
 
     std::string out;
     out.reserve (in.size () * 3);

--- a/engine/include/vayu/utils/parse.hpp
+++ b/engine/include/vayu/utils/parse.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file utils/parse.hpp
+ * @brief A whole `std::string_view` as a number, or nothing (issue #945).
+ *
+ * Five call sites had each written the same eight lines: name the view's two
+ * ends, hand them to `std::from_chars`, reject unless the conversion both
+ * succeeded and consumed to the end. `std::from_chars` is the right primitive
+ * to build on - it is the one integer parse that neither throws on the event
+ * loop's handler-less worker threads nor guesses at a base - but it takes a
+ * pointer range, and every copy spelled that range as `text.data ()` plus
+ * `text.size ()` arithmetic on it. That is two findings per site
+ * (`bugprone-suspicious-stringview-data-usage` on the `data ()`,
+ * `cppcoreguidelines-pro-bounds-pointer-arithmetic` on the `+`) and, more to
+ * the point, five chances to forget the `ptr != end` half - which is what
+ * separates "42abc is 42" from "42abc is not a number".
+ *
+ * `std::to_address` over the view's own iterators is the same two addresses
+ * with the bound still attached to them (the spelling settled in the fix that
+ * preceded this one), and it belongs in one place rather than at each call.
+ *
+ * Whole-view is the contract, deliberately: a caller that wants a prefix has a
+ * prefix to pass, and every caller here already had to reject a partial parse.
+ * Range is *not* part of the contract - a port's 1..65535 and a capture id's
+ * "not negative" are the caller's rules, checked on the value this returns.
+ */
+
+#include <charconv>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+namespace vayu::utils {
+
+/**
+ * @brief @p text as a `T`, or `std::nullopt` unless the whole of it is one.
+ *
+ * Empty input, leading whitespace, a leading `+`, a trailing unit and a value
+ * too large for `T` are all "not a number" - `std::from_chars` accepts none of
+ * them, and the end-of-input check refuses what it accepted only a prefix of.
+ * Never throws: this runs on the event loop workers, which have no handler.
+ */
+template <typename T> std::optional<T> parse_number (std::string_view text) {
+    T value                 = T{};
+    const auto* const begin = std::to_address (text.begin ());
+    const auto* const end   = std::to_address (text.end ());
+
+    const auto [ptr, ec] = std::from_chars (begin, end, value);
+    if (ec != std::errc{} || ptr != end) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+} // namespace vayu::utils

--- a/engine/src/core/js_json.hpp
+++ b/engine/src/core/js_json.hpp
@@ -300,7 +300,8 @@ inline bool contains_variable_token (const std::string& text) {
             return false;
         }
         // `[^{}]+` between the braces: a `{` inside is not this token's close.
-        const std::string_view inner (text.data () + at + 2, close - at - 2);
+        const std::string_view inner =
+        std::string_view (text).substr (at + 2, close - at - 2);
         if (!inner.empty () && inner.find_first_of ("{}") == std::string_view::npos) {
             return true;
         }

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -113,13 +113,14 @@ MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorC
     // leaves the bank null: the run is still fully measurable without phase
     // percentiles, which is not true of the two histograms above.
     if (config_.phase_histograms) {
-        for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
+        for (auto*& histogram : phase_histograms_) {
             if (hdr_init (1, constants::metrics_collector::HISTOGRAM_MAX_LATENCY_US,
-                constants::metrics_collector::HISTOGRAM_SIGNIFICANT_FIGURES,
-                &phase_histograms_[i]) != 0 ||
-            phase_histograms_[i] == nullptr) {
-                for (size_t j = 0; j < i; ++j) {
-                    hdr_close (phase_histograms_[j]);
+                constants::metrics_collector::HISTOGRAM_SIGNIFICANT_FIGURES, &histogram) != 0 ||
+            histogram == nullptr) {
+                // The bank is null-initialised and filled in order, so closing
+                // every non-null slot closes exactly the ones already built.
+                for (auto* built : phase_histograms_) {
+                    hdr_close (built);
                 }
                 phase_histograms_.fill (nullptr);
                 vayu::utils::log_warning ("Run " + run_id_ +
@@ -231,8 +232,8 @@ bool MetricsCollector::claim_status_exemplar (int status_code) {
     const int slot = (status_code >= 0 && status_code < STATUS_CODE_SLOTS - 1) ?
     status_code :
     STATUS_CODE_SLOTS - 1;
-    const size_t claimed = exemplar_claims_[static_cast<size_t> (slot)].fetch_add (
-    1, std::memory_order_relaxed);
+    const size_t claimed =
+    exemplar_claims_.at (static_cast<size_t> (slot)).fetch_add (1, std::memory_order_relaxed);
     return claimed < constants::metrics_collector::EXEMPLARS_PER_STATUS;
 }
 
@@ -324,8 +325,8 @@ const Timing* phases) {
             // a 0ms phase is the common case (a reused connection does no DNS
             // and no handshake), so flooring it to 1us would inflate every
             // percentile of the phases that legitimately did not run.
-            hdr_record_value_atomic (phase_histograms_[i],
-            static_cast<int64_t> (std::max (0.0, values[i]) * 1000.0));
+            hdr_record_value_atomic (phase_histograms_.at (i),
+            static_cast<int64_t> (std::max (0.0, values.at (i)) * 1000.0));
         }
     }
 
@@ -633,16 +634,17 @@ MetricsCollector::phase_percentiles () const {
 
     std::array<Percentiles, TIMING_PHASE_COUNT> result;
     for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
-        auto* histogram = phase_histograms_[i];
-        result[i].count = static_cast<size_t> (histogram->total_count);
-        result[i].min   = us_to_ms (hdr_min (histogram));
-        result[i].max   = us_to_ms (hdr_max (histogram));
-        result[i].p50   = us_to_ms (hdr_value_at_percentile (histogram, 50.0));
-        result[i].p75   = us_to_ms (hdr_value_at_percentile (histogram, 75.0));
-        result[i].p90   = us_to_ms (hdr_value_at_percentile (histogram, 90.0));
-        result[i].p95   = us_to_ms (hdr_value_at_percentile (histogram, 95.0));
-        result[i].p99   = us_to_ms (hdr_value_at_percentile (histogram, 99.0));
-        result[i].p999  = us_to_ms (hdr_value_at_percentile (histogram, 99.9));
+        auto* histogram    = phase_histograms_.at (i);
+        Percentiles& phase = result.at (i);
+        phase.count        = static_cast<size_t> (histogram->total_count);
+        phase.min          = us_to_ms (hdr_min (histogram));
+        phase.max          = us_to_ms (hdr_max (histogram));
+        phase.p50  = us_to_ms (hdr_value_at_percentile (histogram, 50.0));
+        phase.p75  = us_to_ms (hdr_value_at_percentile (histogram, 75.0));
+        phase.p90  = us_to_ms (hdr_value_at_percentile (histogram, 90.0));
+        phase.p95  = us_to_ms (hdr_value_at_percentile (histogram, 95.0));
+        phase.p99  = us_to_ms (hdr_value_at_percentile (histogram, 99.0));
+        phase.p999 = us_to_ms (hdr_value_at_percentile (histogram, 99.9));
     }
     return result;
 }
@@ -737,8 +739,7 @@ MetricsCollector::Percentiles MetricsCollector::sample_window_percentiles () {
 void MetricsCollector::record_status_code (int status_code) {
     if (status_code >= 0 && status_code < STATUS_CODE_SLOTS) {
         // Hot path: single relaxed atomic increment, no lock.
-        status_code_counts_[static_cast<size_t> (status_code)].fetch_add (
-        1, std::memory_order_relaxed);
+        status_code_counts_.at (static_cast<size_t> (status_code)).fetch_add (1, std::memory_order_relaxed);
         return;
     }
     // Out-of-range (non-standard) code: dead path for real HTTP traffic.
@@ -749,8 +750,8 @@ void MetricsCollector::record_status_code (int status_code) {
 std::map<int, size_t> MetricsCollector::status_code_distribution () const {
     std::map<int, size_t> result;
     for (int code = 0; code < STATUS_CODE_SLOTS; ++code) {
-        size_t count = status_code_counts_[static_cast<size_t> (code)].load (
-        std::memory_order_relaxed);
+        size_t count =
+        status_code_counts_.at (static_cast<size_t> (code)).load (std::memory_order_relaxed);
         if (count > 0) {
             result[code] = count;
         }

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -206,7 +206,8 @@ const std::vector<std::string>& series) {
         if (line_end == std::string::npos) {
             line_end = body.size ();
         }
-        std::string_view line (body.data () + line_start, line_end - line_start);
+        std::string_view line =
+        std::string_view (body).substr (line_start, line_end - line_start);
         line_start = line_end + 1;
 
         // Trim both ends: exposition files are frequently CRLF, and a trailing

--- a/engine/src/core/openapi_document.cpp
+++ b/engine/src/core/openapi_document.cpp
@@ -150,8 +150,8 @@ nlohmann::ordered_json plain_scalar (const std::string& text) {
 
     const bool negative     = text[0] == '-';
     const bool signed_token = negative || text[0] == '+';
-    const std::string_view digits (text.data () + (signed_token ? 1 : 0),
-    text.size () - (signed_token ? 1 : 0));
+    const std::string_view digits =
+    std::string_view (text).substr (signed_token ? 1 : 0);
     if (digits.empty ()) {
         return text;
     }

--- a/engine/src/core/path_template.cpp
+++ b/engine/src/core/path_template.cpp
@@ -79,7 +79,8 @@ std::string normalize (const std::string& path, bool path_templates) {
             const bool doubled = close != std::string::npos &&
             close + 1 < path.size () && path[close + 1] == '}';
             if (close != std::string::npos && close > i + 1 && !doubled) {
-                const std::string_view name (path.data () + i + 1, close - i - 1);
+                const std::string_view name =
+                std::string_view (path).substr (i + 1, close - i - 1);
                 if (std::all_of (name.begin (), name.end (), is_path_template_char)) {
                     out += "{{" + std::string (name) + "}}";
                     i = close + 1;

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1474,10 +1474,11 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     // reader that finds no `phases` key is looking at a run whose phase data
     // was never collected, not at a target with a free TLS handshake.
     if (inputs.phases.has_value ()) {
-        nlohmann::json phases = nlohmann::json::object ();
+        nlohmann::json phases      = nlohmann::json::object ();
+        const auto& phase_measured = *inputs.phases;
         for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
-            const auto& p                = (*inputs.phases)[i];
-            phases[TIMING_PHASE_KEYS[i]] = { { "p50", p.p50 }, { "p95", p.p95 },
+            const auto& p = phase_measured.at (i);
+            phases[TIMING_PHASE_KEYS.at (i)] = { { "p50", p.p50 }, { "p95", p.p95 },
                 { "p99", p.p99 }, { "max", p.max }, { "count", p.count } };
         }
         summary["phases"] = phases;

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -502,7 +502,7 @@ std::string escape_json_string_content (const std::string& text) {
         case '\t': out += "\\t"; break;
         default:
             if (static_cast<unsigned char> (c) < 0x20) {
-                constexpr const char* kHex = "0123456789abcdef";
+                constexpr std::string_view kHex = "0123456789abcdef";
                 out += "\\u00";
                 out += kHex[(static_cast<unsigned char> (c) >> 4U) & 0x0FU];
                 out += kHex[static_cast<unsigned char> (c) & 0x0FU];

--- a/engine/src/core/spec_diff.cpp
+++ b/engine/src/core/spec_diff.cpp
@@ -325,15 +325,15 @@ const DraftRequest* previous) {
 
     std::vector<SpecFieldDiff> out;
     for (size_t i = 0; i < FIELDS.size (); ++i) {
-        if (current[i].compare == fetched[i].compare) {
+        if (current.at (i).compare == fetched.at (i).compare) {
             continue;
         }
         SpecFieldDiff field;
-        field.field   = FIELDS[i];
-        field.current = current[i].display;
-        field.next    = fetched[i].display;
+        field.field   = FIELDS.at (i);
+        field.current = current.at (i).display;
+        field.next    = fetched.at (i).display;
         field.user_touched =
-        bound.has_value () && current[i].compare != (*bound)[i].compare;
+        bound.has_value () && current.at (i).compare != bound->at (i).compare;
         out.push_back (std::move (field));
     }
     return out;

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
+#include <span>
 #include <thread>
 
 #include "vayu/core/constants.hpp"
@@ -63,22 +64,27 @@ int main (int argc, char* argv[]) {
     int verbosity        = 0; // 0=warn/error, 1=info+, 2=debug+
     std::string data_dir = get_default_data_dir ();
 
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
+    // The argument vector as the bounded range it is: `argv[i]` is arithmetic
+    // on a pointer that carries no length, and the count is right there.
+    const std::span<char* const> args (argv, static_cast<size_t> (argc));
+
+    for (size_t i = 1; i < args.size (); ++i) {
+        std::string arg = args[i];
 
         if (arg == vayu::core::constants::cli::ARG_PORT_SHORT ||
         arg == vayu::core::constants::cli::ARG_PORT_LONG) {
-            if (i + 1 < argc) {
-                port = std::stoi (argv[++i]);
+            if (i + 1 < args.size ()) {
+                port = std::stoi (args[++i]);
             }
         } else if (arg == "-d" || arg == "--data-dir") {
-            if (i + 1 < argc) {
-                data_dir = argv[++i];
+            if (i + 1 < args.size ()) {
+                data_dir = args[++i];
             }
         } else if (arg == "-v" || arg == "--verbose") {
             // Check if next arg is a number (verbosity level)
-            if (i + 1 < argc && std::isdigit (argv[i + 1][0])) {
-                verbosity = std::stoi (argv[++i]);
+            if (i + 1 < args.size () &&
+            std::isdigit (static_cast<unsigned char> (*args[i + 1])) != 0) {
+                verbosity = std::stoi (args[++i]);
                 // Clamp to valid range [0, 2]
                 verbosity = std::max (0, std::min (2, verbosity));
             } else {

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -21,6 +21,7 @@
 
 #include "vayu/core/constants.hpp"
 #include "vayu/http/client.hpp"
+#include "vayu/http/curl_error_buffer.hpp"
 #include "vayu/http/curl_version_map.hpp"
 #include "vayu/http/debug_redact.hpp"
 #include "vayu/http/event_loop/curl_utils.hpp"
@@ -32,7 +33,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <cstring>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -414,7 +414,7 @@ std::string synthesize_raw_request (const Request& request, const Response& resp
 struct Client::Impl {
     CURL* curl = nullptr;
     ClientConfig config;
-    char error_buffer[CURL_ERROR_SIZE] = { 0 };
+    CurlErrorBuffer errors;
 
     explicit Impl (ClientConfig cfg) : config (std::move (cfg)) {
         curl = curl_easy_init ();
@@ -435,7 +435,7 @@ struct Client::Impl {
 
     void reset () {
         curl_easy_reset (curl);
-        std::memset (error_buffer, 0, sizeof (error_buffer));
+        errors.clear ();
     }
 };
 
@@ -474,8 +474,7 @@ Result<Response> Client::send (const Request& request) {
     // build_request_header_list below, from the very appends that build the
     // slist - see its contract for why it is not snapshotted here.
 
-    // Set error buffer
-    curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, impl_->error_buffer);
+    impl_->errors.attach (curl);
 
     // Set URL
     curl_easy_setopt (curl, CURLOPT_URL, request.url.c_str ());
@@ -643,7 +642,7 @@ Result<Response> Client::send (const Request& request) {
         Error error = sink.limit_exceeded ?
         Error{ ErrorCode::ResponseTooLarge,
             too_large_message (response.headers, sink.max_bytes) } :
-        detail::curl_to_error (curl, res, impl_->error_buffer);
+        detail::curl_to_error (curl, res, impl_->errors);
 
         // Return Response object with error details (Postman-compatible approach)
         response.status_code = 0; // 0 indicates client-side error (no server response)
@@ -696,7 +695,7 @@ Client::post (const std::string& url, const std::string& body, const Headers& he
 }
 
 std::string Client::last_error () const {
-    return impl_->error_buffer;
+    return std::string (impl_->errors.message ());
 }
 
 // ============================================================================

--- a/engine/src/http/cookie_jar.cpp
+++ b/engine/src/http/cookie_jar.cpp
@@ -18,9 +18,10 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <charconv>
 #include <ctime>
 #include <utility>
+
+#include "vayu/utils/parse.hpp"
 
 namespace vayu::http {
 
@@ -86,11 +87,11 @@ std::optional<JarCookie> parse_cookie_line (std::string_view line) {
         // The value (last field) may itself be empty and may contain no tab;
         // every earlier field must be tab-terminated.
         if (tab == std::string_view::npos) {
-            fields[count++] = line.substr (start);
+            fields.at (count++) = line.substr (start);
             break;
         }
-        fields[count++] = line.substr (start, tab - start);
-        start           = tab + 1;
+        fields.at (count++) = line.substr (start, tab - start);
+        start               = tab + 1;
     }
     if (count != NETSCAPE_FIELDS) {
         return std::nullopt;
@@ -108,12 +109,12 @@ std::optional<JarCookie> parse_cookie_line (std::string_view line) {
     // An expiry libcurl did not write as a number is not a cookie we can
     // reason about; refuse the line rather than treat it as a session cookie
     // that never expires.
-    const auto* first     = fields[4].data ();
-    const auto* last      = first + fields[4].size ();
-    const auto conversion = std::from_chars (first, last, cookie.expires);
-    if (conversion.ec != std::errc{} || conversion.ptr != last) {
+    const auto expires =
+    vayu::utils::parse_number<decltype (cookie.expires)> (fields[4]);
+    if (!expires.has_value ()) {
         return std::nullopt;
     }
+    cookie.expires = *expires;
 
     // A cookie with no name is not addressable by any reader (`pm.cookies.get`
     // takes a name), so it is dropped here for the same reason parse_set_cookie

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -12,12 +12,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
-#include <charconv>
 #include <chrono>
 #include <mutex>
 #include <optional>
 #include <string_view>
-#include <system_error>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/http/curl_version_map.hpp"
@@ -28,6 +26,7 @@
 #include "vayu/http/header_text.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/utils/logger.hpp"
+#include "vayu/utils/parse.hpp"
 
 namespace vayu::http::detail {
 
@@ -47,15 +46,12 @@ int scheme_default_port (const std::string& url) {
 }
 
 /// A digit run from a user-supplied URL can exceed any integer type.
-/// std::from_chars reports that in its return value where std::stoi would
+/// `parse_number` reports that as an empty optional where std::stoi would
 /// throw - and this runs on the event loop worker thread, which has no
 /// handler, so an escaping exception terminates the whole daemon.
 std::optional<int> parse_port (std::string_view digits) {
-    int port             = 0;
-    const char* first    = digits.data ();
-    const char* last     = first + digits.size ();
-    const auto [ptr, ec] = std::from_chars (first, last, port);
-    if (ec == std::errc () && ptr == last && port >= kMinPort && port <= kMaxPort) {
+    const std::optional<int> port = vayu::utils::parse_number<int> (digits);
+    if (port.has_value () && *port >= kMinPort && *port <= kMaxPort) {
         return port;
     }
     // Out of range for a port (or for int): the caller falls back to the scheme
@@ -530,9 +526,10 @@ bool tls_connection_never_answered (CURL* curl) {
 
 } // namespace
 
-Error curl_to_error (CURL* curl, CURLcode code, const char* error_buffer) {
+Error curl_to_error (CURL* curl, CURLcode code, const CurlErrorBuffer& errors) {
     Error error;
-    error.message = error_buffer[0] ? error_buffer : curl_easy_strerror (code);
+    const std::string_view message = errors.message ();
+    error.message = message.empty () ? curl_easy_strerror (code) : std::string (message);
 
     // Checked before the code, not as a fallback under it: a proxy that
     // answered the CONNECT with a 4xx is a proxy failure whatever CURLcode
@@ -763,8 +760,7 @@ CURL* setup_easy_handle (CURL* curl, TransferData* data, const EventLoopConfig& 
 
     const Request& request = data->request;
 
-    // Set error buffer
-    curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, data->error_buffer);
+    data->errors.attach (curl);
 
     // Set URL
     curl_easy_setopt (curl, CURLOPT_URL, request.url.c_str ());
@@ -1059,7 +1055,7 @@ Result<Response> extract_response (CURL* curl, TransferData* data, CURLcode resu
              Error{ ErrorCode::InternalError,
             "Response body exceeded the " + std::to_string (data->max_response_bytes) +
             " byte cap (maxResponseBodyBytes)" } :
-             curl_to_error (curl, result, data->error_buffer);
+             curl_to_error (curl, result, data->errors);
         response.error_code    = error.code;
         response.error_message = error.message;
         response.status_code   = 0;

--- a/engine/src/http/event_loop/event_loop_worker.cpp
+++ b/engine/src/http/event_loop/event_loop_worker.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <utility>
 
@@ -71,17 +72,17 @@ std::string system_resolve (const std::string& hostname) {
         // says which one it is. There is no narrower spelling; POSIX defines
         // the family structs to be reinterpretable through `sockaddr`.
         if (best->ai_family == AF_INET6) {
-            char ip_str[INET6_ADDRSTRLEN];
+            std::array<char, INET6_ADDRSTRLEN> ip_str{};
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             auto* addr6 = reinterpret_cast<sockaddr_in6*> (best->ai_addr);
-            inet_ntop (AF_INET6, &(addr6->sin6_addr), ip_str, INET6_ADDRSTRLEN);
-            ip = ip_str;
+            inet_ntop (AF_INET6, &(addr6->sin6_addr), ip_str.data (), ip_str.size ());
+            ip = ip_str.data ();
         } else if (best->ai_family == AF_INET) {
-            char ip_str[INET_ADDRSTRLEN];
+            std::array<char, INET_ADDRSTRLEN> ip_str{};
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             auto* addr = reinterpret_cast<sockaddr_in*> (best->ai_addr);
-            inet_ntop (AF_INET, &(addr->sin_addr), ip_str, INET_ADDRSTRLEN);
-            ip = ip_str;
+            inet_ntop (AF_INET, &(addr->sin_addr), ip_str.data (), ip_str.size ());
+            ip = ip_str.data ();
         }
         freeaddrinfo (result);
     }

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -69,7 +69,7 @@ int random_int (int min_inclusive, int max_inclusive) {
 }
 
 template <size_t N> const char* pick (const std::array<const char*, N>& items) {
-    return items[static_cast<size_t> (random_int (0, static_cast<int> (N) - 1))];
+    return items.at (static_cast<size_t> (random_int (0, static_cast<int> (N) - 1)));
 }
 
 std::string random_string (size_t length, std::string_view alphabet) {

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -21,12 +21,12 @@
 #include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
+#include "vayu/utils/parse.hpp"
 
 #include <httplib.h>
 
 #include <algorithm>
 #include <cctype>
-#include <charconv>
 #include <chrono>
 #include <cstddef>
 #include <expected>
@@ -146,21 +146,12 @@ std::optional<unsigned> ipv4_first_octet (std::string_view bind) {
         if (part.empty () || part.size () > 3) {
             return std::nullopt;
         }
-        // The view's two ends, taken as pointers from its own iterators.
-        // `from_chars` wants a range and `part` is one; spelling that as
-        // `part.data ()` plus arithmetic on it says neither - the `.data ()`
-        // reads as a pointer handed to something that will look for a
-        // terminator, and the `+` is unbounded pointer arithmetic. `to_address`
-        // is the same two addresses with the bound still attached to them.
-        unsigned value          = 0;
-        const auto* const begin = std::to_address (part.begin ());
-        const auto* const end   = std::to_address (part.end ());
-        const auto [ptr, ec]    = std::from_chars (begin, end, value);
-        if (ec != std::errc () || ptr != end || value > 255) {
+        const std::optional<unsigned> value = vayu::utils::parse_number<unsigned> (part);
+        if (!value.has_value () || *value > 255) {
             return std::nullopt;
         }
         if (octet == 0) {
-            first = value;
+            first = *value;
         }
         start = dot + 1;
     }
@@ -355,16 +346,13 @@ parse_live_resume_point (const std::string& header_value, const std::string& par
         return 0;
     }
 
-    int64_t parsed_id = 0;
-    const char* begin = value.data ();
-    const char* end   = begin + value.size ();
-    const auto parsed = std::from_chars (begin, end, parsed_id);
-    if (parsed.ec != std::errc{} || parsed.ptr != end || parsed_id < 0) {
+    const std::optional<int64_t> parsed_id = vayu::utils::parse_number<int64_t> (value);
+    if (!parsed_id.has_value () || *parsed_id < 0) {
         return std::unexpected (InboxParseError{ .http_status = 400,
         .code = "invalid_last_event_id",
         .message = std::string (source) + " must be a non-negative capture id" });
     }
-    return parsed_id;
+    return *parsed_id;
 }
 
 nlohmann::json inbox_capture_json (const vayu::db::InboxRequest& capture) {

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -84,7 +84,7 @@ std::string normalize_colon_segment (const std::string& segment) {
     if (segment.size () < 2 || segment[0] != ':') {
         return segment;
     }
-    const std::string_view name (segment.data () + 1, segment.size () - 1);
+    const std::string_view name = std::string_view (segment).substr (1);
     if (!std::all_of (name.begin (), name.end (), is_path_template_char)) {
         return segment;
     }

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <algorithm>
+#include <array>
 // <cctype> for isalpha/isalnum and <cstddef> for size_t: libstdc++ pulls both
 // in transitively through <string>, MSVC and libc++ do not promise to, and this
 // file is built on all three.
@@ -97,39 +98,39 @@ struct AbsentGlobal {
     const char* name;
     const char* reason;
 };
-constexpr AbsentGlobal ABSENT_GLOBALS[] = {
-    { "setTimeout",
-    "The sandbox is synchronous - a script runs to completion "
-    "before the request is sent, so there is no later to defer to." },
-    { "setInterval",
-    "The sandbox is synchronous and a script has a wall-clock "
-    "deadline (scriptTimeout)." },
-    { "clearTimeout", "There is no setTimeout to cancel." },
-    { "clearInterval", "There is no setInterval to cancel." },
-    { "fetch",
-    "Scripts cannot make network calls. The request being built is "
-    "the only one sent; edit it through pm.request." },
-    { "XMLHttpRequest", "Scripts cannot make network calls." },
-    { "require",
-    "No module system - QuickJS here has no loader, and there is "
-    "no filesystem to load from." },
-    { "process", "Not Node. There is no process, no argv and no env." },
-    { "Buffer", "Not Node. Use btoa/atob, or pm.crypto for hashing." },
-    { "URL", "No URL parser in the sandbox. pm.request.url is a plain string." },
-    { "URLSearchParams", "No URL parser in the sandbox." },
-    { "TextEncoder", "Absent. pm.crypto accepts strings directly." },
-    { "TextDecoder", "Absent. pm.crypto accepts strings directly." },
-    { "structuredClone", "Absent. Use JSON.parse(JSON.stringify(value))." },
-    { "localStorage",
-    "No browser storage. Persist through pm.environment or "
-    "pm.globals, which outlive the script." },
-    { "sessionStorage", "No browser storage. Use pm.variables instead." },
-    { "window", "Not a browser." },
-    { "document", "Not a browser." },
-    { "alert",
-    "Not a browser. Use console.log, shown in the response pane's "
-    "Console tab." },
-};
+constexpr auto ABSENT_GLOBALS = std::to_array<AbsentGlobal> ({
+{ "setTimeout",
+"The sandbox is synchronous - a script runs to completion "
+"before the request is sent, so there is no later to defer to." },
+{ "setInterval",
+"The sandbox is synchronous and a script has a wall-clock "
+"deadline (scriptTimeout)." },
+{ "clearTimeout", "There is no setTimeout to cancel." },
+{ "clearInterval", "There is no setInterval to cancel." },
+{ "fetch",
+"Scripts cannot make network calls. The request being built is "
+"the only one sent; edit it through pm.request." },
+{ "XMLHttpRequest", "Scripts cannot make network calls." },
+{ "require",
+"No module system - QuickJS here has no loader, and there is "
+"no filesystem to load from." },
+{ "process", "Not Node. There is no process, no argv and no env." },
+{ "Buffer", "Not Node. Use btoa/atob, or pm.crypto for hashing." },
+{ "URL", "No URL parser in the sandbox. pm.request.url is a plain string." },
+{ "URLSearchParams", "No URL parser in the sandbox." },
+{ "TextEncoder", "Absent. pm.crypto accepts strings directly." },
+{ "TextDecoder", "Absent. pm.crypto accepts strings directly." },
+{ "structuredClone", "Absent. Use JSON.parse(JSON.stringify(value))." },
+{ "localStorage",
+"No browser storage. Persist through pm.environment or "
+"pm.globals, which outlive the script." },
+{ "sessionStorage", "No browser storage. Use pm.variables instead." },
+{ "window", "Not a browser." },
+{ "document", "Not a browser." },
+{ "alert",
+"Not a browser. Use console.log, shown in the response pane's "
+"Console tab." },
+});
 
 bool is_chain_continuation (const std::string& name) {
     return std::find (std::begin (CHAIN_CONTINUATIONS),

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -10,6 +10,7 @@
  * @brief Scripting API routes - provides script engine capabilities for UI autocomplete
  */
 
+#include <array>
 #include <string>
 
 #include "vayu/http/routes.hpp"
@@ -300,23 +301,23 @@ nlohmann::json get_script_completions () {
         const char* name;
         const char* condition;
     };
-    constexpr StatusClassCompletion status_classes[] = {
-        { "ok", "a 2xx status code" },
-        { "success", "a 2xx status code" },
-        { "info", "a 1xx status code" },
-        { "redirection", "a 3xx status code" },
-        { "clientError", "a 4xx status code" },
-        { "serverError", "a 5xx status code" },
-        { "error", "a 4xx or 5xx status code" },
-        { "accepted", "status 202" },
-        { "badRequest", "status 400" },
-        { "unauthorized", "status 401" },
-        { "forbidden", "status 403" },
-        { "notFound", "status 404" },
-        { "rateLimited", "status 429" },
-        { "json", "a body that parses as JSON" },
-        { "withBody", "a non-empty body" },
-    };
+    constexpr auto status_classes = std::to_array<StatusClassCompletion> ({
+    { "ok", "a 2xx status code" },
+    { "success", "a 2xx status code" },
+    { "info", "a 1xx status code" },
+    { "redirection", "a 3xx status code" },
+    { "clientError", "a 4xx status code" },
+    { "serverError", "a 5xx status code" },
+    { "error", "a 4xx or 5xx status code" },
+    { "accepted", "status 202" },
+    { "badRequest", "status 400" },
+    { "unauthorized", "status 401" },
+    { "forbidden", "status 403" },
+    { "notFound", "status 404" },
+    { "rateLimited", "status 429" },
+    { "json", "a body that parses as JSON" },
+    { "withBody", "a non-empty body" },
+    });
 
     for (const auto& status_class : status_classes) {
         const std::string label =
@@ -675,11 +676,11 @@ nlohmann::json get_script_completions () {
         const char* noun;     // what its variables are called in prose
         const char* example;  // a variable name that reads naturally for it
     };
-    constexpr VariableScopeCompletion variable_scopes[] = {
-        { "environment", "environment variable", "auth_token" },
-        { "globals", "global variable", "api_key" },
-        { "collectionVariables", "collection variable", "base_url" },
-    };
+    constexpr auto variable_scopes = std::to_array<VariableScopeCompletion> ({
+    { "environment", "environment variable", "auth_token" },
+    { "globals", "global variable", "api_key" },
+    { "collectionVariables", "collection variable", "base_url" },
+    });
 
     for (const auto& scope : variable_scopes) {
         const std::string accessor = std::string ("pm.") + scope.accessor;

--- a/engine/src/http/sse_stream.cpp
+++ b/engine/src/http/sse_stream.cpp
@@ -15,17 +15,20 @@
 #include <curl/curl.h>
 
 #include <algorithm>
-#include <charconv>
 #include <chrono>
+#include <optional>
+#include <string_view>
 #include <utility>
 
 #include "vayu/core/run_manager.hpp"
+#include "vayu/http/curl_error_buffer.hpp"
 #include "vayu/http/curl_version_map.hpp"
 #include "vayu/http/event_loop/curl_utils.hpp"
 #include "vayu/http/form_body.hpp"
 #include "vayu/http/sse_parser.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/utils/logger.hpp"
+#include "vayu/utils/parse.hpp"
 
 namespace vayu::http {
 
@@ -342,11 +345,14 @@ size_t stream_header_callback (char* buffer, size_t size, size_t nitems, void* u
             // as the status of a perfectly healthy 200.
             const auto code_end =
             second_space == std::string::npos ? line.size () : second_space;
-            int parsed        = 0;
-            const auto result = std::from_chars (
-            line.data () + first_space + 1, line.data () + code_end, parsed);
-            if (result.ec == std::errc{}) {
-                response->status_code = parsed;
+            // Whole-token, so a code with a tail glued to it ("200OK") leaves
+            // the status unread rather than reporting the digits it starts
+            // with - a malformed status line is not a 200.
+            const std::string_view code = std::string_view (line).substr (
+            first_space + 1, code_end - first_space - 1);
+            const std::optional<int> parsed = vayu::utils::parse_number<int> (code);
+            if (parsed.has_value ()) {
+                response->status_code = *parsed;
             }
         }
         // Headers are cleared between redirect hops so the final hop's set is
@@ -407,7 +413,7 @@ vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamCon
         return failed;
     }
 
-    char error_buffer[CURL_ERROR_SIZE] = { 0 };
+    CurlErrorBuffer errors;
     SseParser parser (request.limits.max_event_bytes);
 
     TransferState state;
@@ -420,7 +426,7 @@ vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamCon
     request.max_duration_ms.value_or (request.limits.max_stream_duration_ms);
     state.started_at = std::chrono::steady_clock::now ();
 
-    curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, error_buffer);
+    errors.attach (curl);
     curl_easy_setopt (curl, CURLOPT_URL, request.request.url.c_str ());
     curl_mime* mime = detail::apply_method_and_body (curl, request.request);
 
@@ -522,8 +528,8 @@ vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamCon
         // rather than a deadline on a healthy stream.
         reason = SseEndReason::Idle;
     } else if (result != CURLE_OK) {
-        reason            = SseEndReason::Error;
-        const Error error = detail::curl_to_error (curl, result, error_buffer);
+        reason                 = SseEndReason::Error;
+        const Error error      = detail::curl_to_error (curl, result, errors);
         response.status_code   = 0;
         response.status_text   = vayu::http::status_text (0);
         response.error_code    = error.code;

--- a/engine/src/http/transport_policy.cpp
+++ b/engine/src/http/transport_policy.cpp
@@ -139,8 +139,7 @@ std::filesystem::path system_ca_bundle_path () {
         // process, so a `CURL_CA_BUNDLE` exported for a later run would go
         // unread with nothing to say why.
         // NOLINTNEXTLINE(concurrency-mt-unsafe)
-        if (const char* value = std::getenv (variable);
-        value != nullptr && value[0] != '\0') {
+        if (const char* value = std::getenv (variable); value != nullptr && *value != '\0') {
             std::error_code ec;
             if (std::filesystem::is_regular_file (value, ec)) {
                 return { value };
@@ -150,7 +149,7 @@ std::filesystem::path system_ca_bundle_path () {
 
     const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
     if (info != nullptr && info->age >= CURLVERSION_SEVENTH &&
-    info->cainfo != nullptr && info->cainfo[0] != '\0') {
+    info->cainfo != nullptr && *info->cainfo != '\0') {
         std::error_code ec;
         if (std::filesystem::is_regular_file (info->cainfo, ec)) {
             return { info->cainfo };

--- a/engine/src/utils/id.cpp
+++ b/engine/src/utils/id.cpp
@@ -66,8 +66,8 @@ std::string generate_id (const char* prefix) {
     // 128 bits land big-endian: hi fills bytes 0-7, lo fills bytes 8-15.
     std::array<uint8_t, 16> bytes{};
     for (size_t i = 8; i-- > 0;) {
-        bytes[i]     = static_cast<uint8_t> (hi & 0xFF);
-        bytes[i + 8] = static_cast<uint8_t> (lo & 0xFF);
+        bytes.at (i)     = static_cast<uint8_t> (hi & 0xFF);
+        bytes.at (i + 8) = static_cast<uint8_t> (lo & 0xFF);
         hi >>= 8;
         lo >>= 8;
     }
@@ -86,8 +86,9 @@ std::string generate_id (const char* prefix) {
         if (i == 4 || i == 6 || i == 8 || i == 10) {
             out.push_back ('-');
         }
-        out.push_back (hex[static_cast<size_t> (bytes[i] >> 4)]);
-        out.push_back (hex[static_cast<size_t> (bytes[i] & 0x0F)]);
+        const uint8_t byte = bytes.at (i);
+        out.push_back (hex[static_cast<size_t> (byte >> 4)]);
+        out.push_back (hex[static_cast<size_t> (byte & 0x0F)]);
     }
     return out;
 }

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(vayu_tests
     event_loop_test.cpp
     db_test.cpp
     character_cast_test.cpp
+    bounds_primitives_test.cpp
     db_concurrency_test.cpp
     db_recovery_test.cpp
     rate_limit_test.cpp

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -13,11 +13,13 @@
 #include <gtest/gtest.h>
 #include <httplib.h>
 
+#include <array>
 #include <chrono>
 #include <memory>
 #include <set>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -263,9 +265,10 @@ TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
 // Mutation check for the reader: revert any one key to its constant and the
 // value the user stored stops reaching the run.
 TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
-    const std::pair<const char*, int> edits[] = { { "oauth2RefreshLeadMs", 12'345 },
-        { "oauth2RefreshMinIntervalMs", 321 }, { "oauth2RefreshRetryMs", 777 },
-        { "oauth2RefreshRetryMaxMs", 99'000 }, { "oauth2RefreshPollIntervalMs", 42 } };
+    const auto edits =
+    std::to_array<std::pair<const char*, int>> ({ { "oauth2RefreshLeadMs", 12'345 },
+    { "oauth2RefreshMinIntervalMs", 321 }, { "oauth2RefreshRetryMs", 777 },
+    { "oauth2RefreshRetryMaxMs", 99'000 }, { "oauth2RefreshPollIntervalMs", 42 } });
     for (const auto& [key, value] : edits) {
         auto entry = db->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key;

--- a/engine/tests/bounds_primitives_test.cpp
+++ b/engine/tests/bounds_primitives_test.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/bounds_primitives_test.cpp
+ * @brief `vayu::utils::parse_number` and `vayu::http::CurlErrorBuffer` (issue
+ *        #945 batch 4), and the guard that keeps hand-rolled copies of them
+ *        out of the tree.
+ *
+ * The `cppcoreguidelines-pro-bounds-*` family is mostly not N decisions: it is
+ * a handful of places where a length was thrown away and then re-derived by
+ * hand. Two of those had grown copies - five sites naming a `string_view`'s two
+ * ends for `std::from_chars`, three declaring a bare `char[CURL_ERROR_SIZE]`
+ * for libcurl - and both are the kind of copy that *works*, which is why they
+ * accumulated: the arithmetic is correct at every site, right up until one of
+ * them forgets the half that is not.
+ *
+ * The behavioural half is what each primitive promises. `parse_number` must
+ * refuse a partial parse, because "42abc is 42" is exactly the mistake a copy
+ * makes by leaving out the `ptr != end` check. `CurlErrorBuffer` must be empty
+ * when libcurl wrote nothing, because a handle is reused across transfers and
+ * libcurl only ever writes on failure - so a buffer that is not cleared answers
+ * a later success with an earlier failure's message.
+ *
+ * The scanning half is for what no behavioural test can reach. The CI tidy gate
+ * scopes to a pull request's changed lines, so nothing holds either count at
+ * zero once these lines stop being new; the scan is what does. Unlike a
+ * subscript, both spellings are tokens - `from_chars` and `CURLOPT_ERRORBUFFER`
+ * - so this family is scannable after all, for the two shapes that had copies.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+#include "source_scan.hpp"
+#include "vayu/http/curl_error_buffer.hpp"
+#include "vayu/utils/parse.hpp"
+
+namespace vayu {
+namespace {
+
+// ---------------------------------------------------------------------------
+// parse_number
+// ---------------------------------------------------------------------------
+
+TEST (ParseNumber, ReadsTheWholeViewAndNothingLess) {
+    EXPECT_EQ (utils::parse_number<int> ("0"), 0);
+    EXPECT_EQ (utils::parse_number<int> ("65535"), 65535);
+    EXPECT_EQ (utils::parse_number<int> ("-7"), -7);
+    EXPECT_EQ (utils::parse_number<std::int64_t> ("9007199254740993"), 9007199254740993);
+
+    // The view's bound is what says where the number ends: a longer buffer
+    // behind it must not be read past.
+    const std::string_view padded = std::string_view ("12345").substr (0, 3);
+    EXPECT_EQ (utils::parse_number<int> (padded), 123);
+}
+
+TEST (ParseNumber, RefusesEverythingThatIsNotAWholeNumber) {
+    // The one a hand-rolled copy gets wrong by dropping the end-of-input check.
+    EXPECT_EQ (utils::parse_number<int> ("42abc"), std::nullopt);
+    EXPECT_EQ (utils::parse_number<int> ("200 OK"), std::nullopt);
+
+    EXPECT_EQ (utils::parse_number<int> (""), std::nullopt);
+    EXPECT_EQ (utils::parse_number<int> (" 1"), std::nullopt);
+    EXPECT_EQ (utils::parse_number<int> ("+1"), std::nullopt);
+    EXPECT_EQ (utils::parse_number<int> ("0x10"), std::nullopt);
+    EXPECT_EQ (utils::parse_number<unsigned> ("-1"), std::nullopt);
+
+    // Out of range is a refusal, not a wrap or a throw: this runs on the event
+    // loop workers, which have no handler.
+    EXPECT_EQ (utils::parse_number<std::int32_t> ("99999999999999999999"), std::nullopt);
+}
+
+// ---------------------------------------------------------------------------
+// CurlErrorBuffer
+// ---------------------------------------------------------------------------
+
+TEST (CurlErrorBuffer, IsEmptyUntilLibcurlWritesSomething) {
+    http::CurlErrorBuffer errors;
+    EXPECT_TRUE (errors.message ().empty ());
+
+    CURL* curl = curl_easy_init ();
+    ASSERT_NE (curl, nullptr);
+    errors.attach (curl);
+
+    // Attaching does not manufacture a message, and a transfer that never ran
+    // has none to report.
+    EXPECT_TRUE (errors.message ().empty ());
+    curl_easy_cleanup (curl);
+}
+
+TEST (CurlErrorBuffer, ReportsWhatAFailedTransferWroteAndForgetsItOnTheNext) {
+    http::CurlErrorBuffer errors;
+    CURL* curl = curl_easy_init ();
+    ASSERT_NE (curl, nullptr);
+    errors.attach (curl);
+
+    // A scheme libcurl does not support fails before any socket is opened, so
+    // this is a message with no network behind it.
+    curl_easy_setopt (curl, CURLOPT_URL, "not-a-scheme://vayu.invalid/");
+    ASSERT_NE (curl_easy_perform (curl), CURLE_OK);
+    EXPECT_FALSE (errors.message ().empty ())
+    << "libcurl reported a failure and the buffer did not carry its text";
+
+    // The whole point of attach clearing: libcurl writes only on failure, so a
+    // reused handle would otherwise answer the next transfer with this one's
+    // message.
+    errors.attach (curl);
+    EXPECT_TRUE (errors.message ().empty ())
+    << "the previous transfer's error survived into the next one";
+
+    curl_easy_cleanup (curl);
+}
+
+// ---------------------------------------------------------------------------
+// The guard
+// ---------------------------------------------------------------------------
+
+/// The files allowed to spell one, and why - per (file, token), because a file
+/// that owns one primitive has no standing to hand-roll the other.
+struct ExemptSpelling {
+    std::string_view file;
+    std::string_view token;
+};
+
+/// A `constexpr std::array` rather than the `std::vector<std::string>` this
+/// reads more naturally as: a namespace-scope container with a throwing
+/// constructor is `cert-err58-cpp`, a finding of this same paydown.
+constexpr std::array<ExemptSpelling, 2> kExempt = { {
+{ "include/vayu/utils/parse.hpp", "from_chars" },
+{ "include/vayu/http/curl_error_buffer.hpp", "CURLOPT_ERRORBUFFER" },
+} };
+
+bool is_exempt (std::string_view file, std::string_view token) {
+    return std::any_of (kExempt.begin (), kExempt.end (), [&] (const ExemptSpelling& entry) {
+        return entry.file == file && entry.token == token;
+    });
+}
+
+TEST (BoundsPrimitives, TheEngineSourcesGoThroughThePrimitives) {
+    const std::filesystem::path root{ VAYU_ENGINE_SOURCE_DIR };
+    std::size_t scanned_files = 0;
+    std::size_t scanned_bytes = 0;
+    std::vector<std::string> offenders;
+
+    for (const auto* directory : { "src", "include", "tests" }) {
+        const auto tree = root / directory;
+        ASSERT_TRUE (std::filesystem::is_directory (tree))
+        << tree.string () << " is not where the guard looks";
+
+        for (const auto& entry : std::filesystem::recursive_directory_iterator (tree)) {
+            const auto& path            = entry.path ();
+            const std::string extension = path.extension ().string ();
+            if (!entry.is_regular_file () || (extension != ".cpp" && extension != ".hpp")) {
+                continue;
+            }
+            const std::string relative =
+            std::filesystem::relative (path, root).generic_string ();
+            // This file's own planted positives live in string literals, which
+            // `strip_comments` does not blank.
+            if (relative == "tests/bounds_primitives_test.cpp") {
+                continue;
+            }
+
+            const std::string code = tests::strip_comments (tests::read_source (path));
+            ASSERT_FALSE (code.empty ()) << relative << " read as empty";
+            ++scanned_files;
+            scanned_bytes += code.size ();
+
+            if (!is_exempt (relative, "from_chars") && tests::names_call (code, "from_chars")) {
+                offenders.push_back (relative + ": std::from_chars");
+            }
+            // A plain substring: the option name is one token and appears
+            // nowhere else, so there is nothing narrower to match.
+            if (!is_exempt (relative, "CURLOPT_ERRORBUFFER") &&
+            code.find ("CURLOPT_ERRORBUFFER") != std::string::npos) {
+                offenders.push_back (relative + ": CURLOPT_ERRORBUFFER");
+            }
+        }
+    }
+
+    // A scan that read nothing passes forever, so it says what it read.
+    ASSERT_GT (scanned_files, 200u) << "the guard found almost no sources";
+    ASSERT_GT (scanned_bytes, 100'000u) << "the guard read empty sources";
+
+    std::string joined;
+    for (const auto& offender : offenders) {
+        if (!joined.empty ()) {
+            joined += "\n  ";
+        }
+        joined += offender;
+    }
+    EXPECT_TRUE (offenders.empty ())
+    << "each of these is a copy of a primitive, and a copy does not receive "
+       "the primitive's fixes. Parse an integer with vayu::utils::parse_number "
+       "and give libcurl a vayu::http::CurlErrorBuffer, or add the file to "
+       "kExempt with the token it is allowed to spell. Offenders:\n  "
+    << joined;
+}
+
+TEST (BoundsPrimitives, TheGuardSeesTheSpellingsAndNotTheirNeighbours) {
+    // The planted positives. Without these, a broken matcher would leave the
+    // guard above passing on a tree that had brought every copy back.
+    EXPECT_TRUE (tests::names_call ("std::from_chars (begin, end, value)", "from_chars"));
+    EXPECT_TRUE (tests::names_call ("const auto r = from_chars(a, b, c);", "from_chars"));
+
+    // And the calls this rule is not about. `to_chars` is the writing
+    // direction and has no bound to lose; a name that merely ends in the same
+    // letters is a different function.
+    EXPECT_FALSE (tests::names_call ("std::to_chars (first, last, value)", "from_chars"));
+    EXPECT_FALSE (tests::names_call ("legacy_from_chars (begin, end, value)", "from_chars"));
+
+    // And the stripper really does blank prose, which is what keeps the
+    // exemption list to files that spell one in code.
+    EXPECT_FALSE (tests::names_call (
+    tests::strip_comments ("// never call std::from_chars (a, b, c) here\n"), "from_chars"));
+    EXPECT_TRUE (tests::names_call (
+    tests::strip_comments ("/* see below */ std::from_chars (a, b, c);\n"), "from_chars"));
+}
+
+} // namespace
+} // namespace vayu

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
 #include <string>
 #include <thread>
@@ -872,27 +873,27 @@ TEST (CookieJarWrite, BadInputIsRefusedLoudlyRatherThanStoredWrong) {
         const char* script;
         const char* expected;
     };
-    const Case cases[] = {
-        { "pm.cookies.jar().set('http://example.com/', { value: 'v' });", "name" },
-        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 1 "
-          "});",
-        "value" },
-        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
-          "'v', secure: 'yes' });",
-        "true or false" },
-        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
-          "'v', expires: '2030' });",
-        "seconds since the epoch" },
-        // A tab is the Netscape line's own separator: stored, the cookie would
-        // be unreadable on the next parse and would simply vanish.
-        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
-          "'a\\tb' });",
-        "tab or newline" },
-        { "pm.cookies.jar().set('not a url', { name: 'n', value: 'v' });", "parseable" },
-        { "pm.cookies.jar().set();", "URL string" },
-        { "pm.cookies.jar().unset('http://example.com/');", "cookie name string" },
-        { "pm.cookies.jar().clear('nope');", "callback must be a function" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { "pm.cookies.jar().set('http://example.com/', { value: 'v' });", "name" },
+    { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 1 "
+      "});",
+    "value" },
+    { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+      "'v', secure: 'yes' });",
+    "true or false" },
+    { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+      "'v', expires: '2030' });",
+    "seconds since the epoch" },
+    // A tab is the Netscape line's own separator: stored, the cookie would
+    // be unreadable on the next parse and would simply vanish.
+    { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+      "'a\\tb' });",
+    "tab or newline" },
+    { "pm.cookies.jar().set('not a url', { name: 'n', value: 'v' });", "parseable" },
+    { "pm.cookies.jar().set();", "URL string" },
+    { "pm.cookies.jar().unset('http://example.com/');", "cookie name string" },
+    { "pm.cookies.jar().clear('nope');", "callback must be a function" },
+    });
 
     for (const auto& one : cases) {
         vayu::Environment scratch = env;

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -418,8 +418,9 @@ TEST_F (DatabaseTest, TheFirstConnectionCarriesTheEnginesDurabilitySettings) {
     // journal, 2 for WAL - and it persists, which is the point of the check.
     std::ifstream header (TEST_DB_PATH, std::ios::binary);
     ASSERT_TRUE (header.is_open ());
-    char format[20] = {};
-    ASSERT_TRUE (header.read (format, sizeof (format)))
+    std::array<char, 20> format{};
+    ASSERT_TRUE (
+    header.read (format.data (), static_cast<std::streamsize> (format.size ())))
     << "a database this engine created is longer than its own header";
     EXPECT_EQ (static_cast<int> (format[18]), 2)
     << "the schema was written under a rollback journal, before init() set WAL";

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -31,6 +31,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <memory>
 #include <string>
 #include <utility>
@@ -412,13 +413,13 @@ TEST_F (ImportApplyRouteTest, RejectsAnObjectFieldGivenANonObject) {
     json request    = request_item ("r1", "c1", "get users");
     json environment{ { "tempId", "e1" }, { "name", "Prod" } };
 
-    const Case cases[] = {
-        { "collections", collection, "variables" },
-        { "collections", collection, "auth" },
-        { "requests", request, "body" },
-        { "requests", request, "auth" },
-        { "environments", environment, "variables" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { "collections", collection, "variables" },
+    { "collections", collection, "auth" },
+    { "requests", request, "body" },
+    { "requests", request, "auth" },
+    { "environments", environment, "variables" },
+    });
 
     for (const auto& c : cases) {
         for (const json& bad_shape :

--- a/engine/tests/monitor_test.cpp
+++ b/engine/tests/monitor_test.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -74,30 +75,25 @@ TEST (MonitorConfigValidation, RejectsAnUnusableBlock) {
         json monitor;
         const char* what;
     };
-    const Case cases[] = {
-        { json::array (), "not an object" },
-        { json{ { "series", json::array ({ "up" }) } }, "no url" },
-        { json{ { "url", "ftp://localhost/metrics" }, { "series", json::array ({ "up" }) } },
-        "not http(s)" },
-        { json{ { "url", "http://x/m" } }, "no series" },
-        { json{ { "url", "http://x/m" }, { "series", json::array () } }, "empty series" },
-        { json{ { "url", "http://x/m" }, { "series", json::array ({ "" }) } }, "empty series name" },
-        { json{ { "url", "http://x/m" },
-          { "series", json::array ({ "a", "b", "c", "d", "e", "f", "g", "h", "i" }) } },
-        "too many series" },
-        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
-          { "intervalMs", 10 } },
-        "interval below the floor" },
-        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
-          { "intervalMs", 90000 } },
-        "interval above the ceiling" },
-        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
-          { "intervalMs", "1s" } },
-        "interval not a number" },
-        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
-          { "format", "influx" } },
-        "unknown format" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { json::array (), "not an object" },
+    { json{ { "series", json::array ({ "up" }) } }, "no url" },
+    { json{ { "url", "ftp://localhost/metrics" }, { "series", json::array ({ "up" }) } }, "not http(s)" },
+    { json{ { "url", "http://x/m" } }, "no series" },
+    { json{ { "url", "http://x/m" }, { "series", json::array () } }, "empty series" },
+    { json{ { "url", "http://x/m" }, { "series", json::array ({ "" }) } }, "empty series name" },
+    { json{ { "url", "http://x/m" },
+      { "series", json::array ({ "a", "b", "c", "d", "e", "f", "g", "h", "i" }) } },
+    "too many series" },
+    { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) }, { "intervalMs", 10 } },
+    "interval below the floor" },
+    { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) }, { "intervalMs", 90000 } },
+    "interval above the ceiling" },
+    { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) }, { "intervalMs", "1s" } },
+    "interval not a number" },
+    { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) }, { "format", "influx" } },
+    "unknown format" },
+    });
     for (const auto& c : cases) {
         auto config = monitor_config (c.monitor);
         EXPECT_TRUE (validate_monitor_config (config).has_value ())

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 #include <utility>
 
@@ -1192,14 +1193,15 @@ TEST_F (RunsRouteTest, ReportCarriesPerPhasePercentiles) {
 
     std::array<vayu::core::MetricsCollector::Percentiles, vayu::core::TIMING_PHASE_COUNT> phases{};
     // Five distinct magnitudes, so a phase written into the wrong key fails here.
-    const double p50s[] = { 0.1, 0.3, 0.0, 2.9, 0.1 };
-    const double p99s[] = { 1.4, 8.2, 22.0, 6.1, 0.9 };
+    const auto p50s = std::to_array<double> ({ 0.1, 0.3, 0.0, 2.9, 0.1 });
+    const auto p99s = std::to_array<double> ({ 1.4, 8.2, 22.0, 6.1, 0.9 });
     for (size_t i = 0; i < vayu::core::TIMING_PHASE_COUNT; ++i) {
-        phases[i].count = 4321;
-        phases[i].p50   = p50s[i];
-        phases[i].p95   = p50s[i] * 2.0;
-        phases[i].p99   = p99s[i];
-        phases[i].max   = p99s[i] * 3.0;
+        auto& phase = phases.at (i);
+        phase.count = 4321;
+        phase.p50   = p50s.at (i);
+        phase.p95   = p50s.at (i) * 2.0;
+        phase.p99   = p99s.at (i);
+        phase.max   = p99s.at (i) * 3.0;
     }
     inputs.phases = phases;
     db_->update_run_summary (

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <regex>
@@ -1000,20 +1001,20 @@ TEST_F (ScriptEngineTest, ResponseToBeStatusClassMatchersAssertOnBothSides) {
         const char* matches;
         const char* does_not_match;
     };
-    const Case cases[] = {
-        { 100, "info", "ok" },
-        { 202, "accepted", "notFound" },
-        { 301, "redirection", "success" },
-        { 400, "badRequest", "serverError" },
-        { 401, "unauthorized", "forbidden" },
-        { 403, "forbidden", "unauthorized" },
-        { 404, "notFound", "badRequest" },
-        { 429, "rateLimited", "serverError" },
-        { 404, "clientError", "serverError" },
-        { 503, "serverError", "clientError" },
-        { 503, "error", "redirection" },
-        { 404, "error", "info" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { 100, "info", "ok" },
+    { 202, "accepted", "notFound" },
+    { 301, "redirection", "success" },
+    { 400, "badRequest", "serverError" },
+    { 401, "unauthorized", "forbidden" },
+    { 403, "forbidden", "unauthorized" },
+    { 404, "notFound", "badRequest" },
+    { 429, "rateLimited", "serverError" },
+    { 404, "clientError", "serverError" },
+    { 503, "serverError", "clientError" },
+    { 503, "error", "redirection" },
+    { 404, "error", "info" },
+    });
 
     for (const auto& c : cases) {
         response.status_code = c.status;
@@ -1067,13 +1068,13 @@ TEST_F (ScriptEngineTest, ResponseToBeJsonAndWithBody) {
 // A name nothing implements must fail loudly. Silently returning undefined is
 // the whole defect - a misspelled matcher would otherwise report PASS.
 TEST_F (ScriptEngineTest, ResponseToChainRejectsUnknownAssertions) {
-    const char* scripts[] = {
-        R"(pm.test("t", function() { pm.response.to.be.definitelyNotAMatcher; });)",
-        R"(pm.test("t", function() { pm.response.to.have.definitelyNotAMatcher; });)",
-        R"(pm.test("t", function() { pm.response.to.definitelyNotAMatcher; });)",
-        // The negated form is not implemented; it must throw, not pass.
-        R"(pm.test("t", function() { pm.response.to.not.be.ok; });)",
-    };
+    const auto scripts = std::to_array<const char*> ({
+    R"(pm.test("t", function() { pm.response.to.be.definitelyNotAMatcher; });)",
+    R"(pm.test("t", function() { pm.response.to.have.definitelyNotAMatcher; });)",
+    R"(pm.test("t", function() { pm.response.to.definitelyNotAMatcher; });)",
+    // The negated form is not implemented; it must throw, not pass.
+    R"(pm.test("t", function() { pm.response.to.not.be.ok; });)",
+    });
 
     for (const char* script : scripts) {
         auto result = engine.execute_test (script, request, response, env);
@@ -3466,17 +3467,16 @@ TEST_F (ScriptEngineTest, DocExampleSetsAQueryParamAcrossItsThreeCases) {
         const char* url;
         const char* expected;
     };
-    const Case cases[] = {
-        // No query at all.
-        { "https://api.example.com/users", "https://api.example.com/users?traceId=t1" },
-        // Query present, parameter absent.
-        { "https://api.example.com/users?page=2", "https://api.example.com/users?page=2&traceId=t1" },
-        // Parameter already present - replaced, not duplicated.
-        { "https://api.example.com/users?traceId=old&page=2",
-        "https://api.example.com/users?traceId=t1&page=2" },
-        // Fragment is preserved and never searched for the parameter.
-        { "https://api.example.com/users#section", "https://api.example.com/users?traceId=t1#section" },
-    };
+    const auto cases = std::to_array<Case> ({
+    // No query at all.
+    { "https://api.example.com/users", "https://api.example.com/users?traceId=t1" },
+    // Query present, parameter absent.
+    { "https://api.example.com/users?page=2", "https://api.example.com/users?page=2&traceId=t1" },
+    // Parameter already present - replaced, not duplicated.
+    { "https://api.example.com/users?traceId=old&page=2", "https://api.example.com/users?traceId=t1&page=2" },
+    // Fragment is preserved and never searched for the parameter.
+    { "https://api.example.com/users#section", "https://api.example.com/users?traceId=t1#section" },
+    });
 
     for (const auto& c : cases) {
         Request req;
@@ -3912,12 +3912,12 @@ TEST_F (ScriptEngineTest, SetNextRequestRejectsEveryArgumentThatNamesNothing) {
     // Omitting the argument is not a synonym for null: "end the iteration" and
     // "I forgot the name" are different intents, and guessing between them
     // would silently end runs.
-    const Case cases[] = {
-        { "pm.execution.setNextRequest();", "no argument" },
-        { "pm.execution.setNextRequest(3);", "number" },
-        { "pm.execution.setNextRequest(undefined);", "undefined" },
-        { "pm.execution.setNextRequest('');", "empty name" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { "pm.execution.setNextRequest();", "no argument" },
+    { "pm.execution.setNextRequest(3);", "number" },
+    { "pm.execution.setNextRequest(undefined);", "undefined" },
+    { "pm.execution.setNextRequest('');", "empty name" },
+    });
 
     for (const auto& test_case : cases) {
         auto ctx    = scenario_test (request, response, env);

--- a/engine/tests/script_expect_message_test.cpp
+++ b/engine/tests/script_expect_message_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 
 #include "vayu/runtime/script_engine.hpp"
@@ -89,34 +90,34 @@ TEST_F (ExpectMessageTest, EveryMatcherCarriesTheMessage) {
         const char* generic; // a fragment of the matcher's own failure text
     };
 
-    const Case cases[] = {
-        { R"(pm.expect(1, "M").to.equal(2))", "to equal" },
-        { R"(pm.expect({ a: 1 }, "M").to.eql({ a: 2 }))", "deeply equal" },
-        { R"(pm.expect(undefined, "M").to.exist)", "to exist" },
-        { R"(pm.expect(false, "M").to.be.true)", "truthy" },
-        { R"(pm.expect(true, "M").to.be.false)", "to be false" },
-        { R"(pm.expect(1, "M").to.be.above(2))", "to be above" },
-        { R"(pm.expect(2, "M").to.be.below(1))", "to be below" },
-        { R"(pm.expect([1], "M").to.include(2))", "to include" },
-        { R"(pm.expect({}, "M").to.have.property("a"))", "to have property" },
-        { R"(pm.expect(1, "M").to.be.null)", "to be null" },
-        { R"(pm.expect(1, "M").to.be.undefined)", "to be undefined" },
-        { R"(pm.expect(0, "M").to.be.ok)", "truthy" },
-        { R"(pm.expect([1], "M").to.be.empty)", "to be empty" },
-        { R"(pm.expect(1, "M").to.be.at.least(2))", "at least" },
-        { R"(pm.expect(3, "M").to.be.at.most(2))", "at most" },
-        { R"(pm.expect([1], "M").to.have.length(2))", "Expected length" },
-        { R"(pm.expect(1, "M").to.be.a("string"))", "Expected type" },
-        { R"(pm.expect("abc", "M").to.match(/z/))", "to match the pattern" },
-        { R"(pm.expect(1, "M").to.be.oneOf([2, 3]))", "to be one of" },
-        { R"(pm.expect({ a: 1 }, "M").to.have.keys("b"))", "exactly the keys" },
-        { R"(pm.expect([1], "M").to.have.members([2]))", "to have members" },
-        { R"(pm.expect(function () {}, "M").to.throw())", "to throw" },
-        { R"(pm.expect({}, "M").to.be.instanceOf(Array))", "instance of" },
-        { R"(pm.expect(1, "M").to.be.closeTo(5, 0.1))", "to be within" },
-        { R"(pm.expect(1, "M").to.satisfy(function (v) { return v > 2; }))", "satisfy the predicate" },
-        { R"(pm.expect("abc", "M").to.have.string("z"))", "to contain" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { R"(pm.expect(1, "M").to.equal(2))", "to equal" },
+    { R"(pm.expect({ a: 1 }, "M").to.eql({ a: 2 }))", "deeply equal" },
+    { R"(pm.expect(undefined, "M").to.exist)", "to exist" },
+    { R"(pm.expect(false, "M").to.be.true)", "truthy" },
+    { R"(pm.expect(true, "M").to.be.false)", "to be false" },
+    { R"(pm.expect(1, "M").to.be.above(2))", "to be above" },
+    { R"(pm.expect(2, "M").to.be.below(1))", "to be below" },
+    { R"(pm.expect([1], "M").to.include(2))", "to include" },
+    { R"(pm.expect({}, "M").to.have.property("a"))", "to have property" },
+    { R"(pm.expect(1, "M").to.be.null)", "to be null" },
+    { R"(pm.expect(1, "M").to.be.undefined)", "to be undefined" },
+    { R"(pm.expect(0, "M").to.be.ok)", "truthy" },
+    { R"(pm.expect([1], "M").to.be.empty)", "to be empty" },
+    { R"(pm.expect(1, "M").to.be.at.least(2))", "at least" },
+    { R"(pm.expect(3, "M").to.be.at.most(2))", "at most" },
+    { R"(pm.expect([1], "M").to.have.length(2))", "Expected length" },
+    { R"(pm.expect(1, "M").to.be.a("string"))", "Expected type" },
+    { R"(pm.expect("abc", "M").to.match(/z/))", "to match the pattern" },
+    { R"(pm.expect(1, "M").to.be.oneOf([2, 3]))", "to be one of" },
+    { R"(pm.expect({ a: 1 }, "M").to.have.keys("b"))", "exactly the keys" },
+    { R"(pm.expect([1], "M").to.have.members([2]))", "to have members" },
+    { R"(pm.expect(function () {}, "M").to.throw())", "to throw" },
+    { R"(pm.expect({}, "M").to.be.instanceOf(Array))", "instance of" },
+    { R"(pm.expect(1, "M").to.be.closeTo(5, 0.1))", "to be within" },
+    { R"(pm.expect(1, "M").to.satisfy(function (v) { return v > 2; }))", "satisfy the predicate" },
+    { R"(pm.expect("abc", "M").to.have.string("z"))", "to contain" },
+    });
 
     for (const auto& c : cases) {
         const std::string reported = failure_of (c.assertion);

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -57,6 +57,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <sstream>
@@ -111,12 +112,12 @@ using Pkcs12Ptr   = std::unique_ptr<PKCS12, Pkcs12Deleter>;
 /// silently degraded fixture would leave the tests below asserting nothing.
 [[noreturn]] inline void fail (const std::string& what) {
     const unsigned long reason = ERR_get_error ();
-    char detail[256]           = { 0 };
+    std::array<char, 256> detail{};
     if (reason != 0) {
-        ERR_error_string_n (reason, detail, sizeof (detail));
+        ERR_error_string_n (reason, detail.data (), detail.size ());
     }
     throw std::runtime_error ("tls_server.hpp: " + what +
-    (reason != 0 ? std::string (": ") + detail : std::string ()));
+    (reason != 0 ? std::string (": ") + detail.data () : std::string ()));
 }
 
 /**

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -167,7 +167,7 @@ class ScopedEnv {
         // restore path wants when there was nothing to restore.
         _putenv_s (name, value);
 #else
-        if (value[0] == '\0') {
+        if (*value == '\0') {
             // NOLINTNEXTLINE(concurrency-mt-unsafe)
             unsetenv (name);
         } else {
@@ -612,9 +612,11 @@ TEST (TlsBackend, IsTheBackendEveryTrustStatementHereAssumes) {
     ASSERT_NE (available, nullptr)
     << "libcurl enumerates no TLS backend at all, so nothing here is checked";
     std::vector<std::string> compiled_in;
-    for (int i = 0; available[i] != nullptr; ++i) {
-        compiled_in.emplace_back (
-        available[i]->name != nullptr ? available[i]->name : "unnamed");
+    // libcurl hands back a null-terminated array of pointers and no count, so
+    // walking it is the only way to read it - there is no bound to keep.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    for (const curl_ssl_backend* const* it = available; *it != nullptr; ++it) {
+        compiled_in.emplace_back ((*it)->name != nullptr ? (*it)->name : "unnamed");
     }
     EXPECT_EQ (vayu::http::pin_tls_backend (), vayu::http::TlsBackendSelection::Selected)
     << "this process never selected its TLS backend, so on the MultiSSL build "


### PR DESCRIPTION
## Description

Wave 3's last family: `cppcoreguidelines-pro-bounds-*`, cleared. **Re-scanned to zero** over all 206 non-vendor translation units.

**Plan (root cause, approach, the alternative rejected).** The 93 translation-unit findings batch 3 left here, plus the 8 `pro-bounds-*` findings [#1013](https://github.com/athrvk/vayu/issues/1013) found standing in headers, are one root cause repeated: a place where a length was thrown away and then written out again by hand. `data () + offset` re-derives a subrange a view already bounds; `char[CURL_ERROR_SIZE]` decays and the size gets restated at the call; `argv[i]` is arithmetic on a pointer whose count is sitting right there in `argc`; a `std::array` subscript with a computed index reads past the end the day the computation is wrong. So the approach was batch 3's lesson applied again: read for the missing primitive before writing the first fix. Two shapes had grown hand-rolled copies and now have one - `vayu::utils::parse_number` (five sites) and `vayu::http::CurlErrorBuffer` (three) - and the rest is spelling what the code meant with `substr`, `std::to_array`, `std::span` and `.at ()`. **The alternative rejected was a `NOLINT` per site**, and rejected on the same evidence batch 3 gave: these copies are all *correct*, which is exactly why they accumulated unnoticed, and a suppression records nothing about why. It survives at only two sites, where there genuinely is no bound to keep. A second alternative, a `gsl::at`-style `vayu::utils::at` helper, was rejected because `std::array::at` already is that primitive and a copy of a primitive does not receive its fixes.

**Rescan first.** 101 unique findings across 33 files - batch 3's 93 TU findings plus the 8 in headers, exactly. Deduplicated by (file, line, column, check) with `-header-filter` on the command line, per `docs/engine/building.md`. `engine/src/runtime/` stays out of the count by its own config's decision (its 124 surface only because a `-checks` override defeats that config).

**The two primitives.**

- **`vayu::utils::parse_number`** (`engine/include/vayu/utils/parse.hpp`) - a whole `std::string_view` as an integer, or nothing. Five sites named `from_chars`'s pointer range themselves and each had to remember the `ptr != end` half that separates "42abc is 42" from "42abc is not a number". **One of them did not**: the SSE status-line parse checked only `ec`, so `HTTP/1.1 200OK` reported 200. It now leaves the status unread. That is the one behaviour change in this diff, deliberate and commented at the site - a malformed status line is not a 200, and `status_code` staying 0 is the answer that says so.
- **`vayu::http::CurlErrorBuffer`** (`engine/include/vayu/http/curl_error_buffer.hpp`) - `CURLOPT_ERRORBUFFER` has three rules (at least `CURL_ERROR_SIZE` bytes, alive for the whole transfer, written *only* on failure so a reused handle must be cleared between transfers) and a bare `char[CURL_ERROR_SIZE]` states none of them. All three drivers had their own copy. `curl_to_error` now takes the buffer rather than a decayed `const char*`, so "empty means no message" is read in one place instead of re-derived as `error_buffer[0]`.

**The rest**, by shape: `substr` on a view for a subrange (5 sites, one of them two lines below an existing `substr` in the same function); `constexpr std::array` via `std::to_array`, or a `std::string_view` for a character table (11); `std::span<char* const>` over `argv` (1 loop, 5 findings); `.at ()` where a caller's index genuinely indexes (26). Two loops lost their index entirely.

**Category tally: 0 real defects, 99 findings cleared, 2 sites silenced with a reason.** The two are libcurl's null-terminated TLS-backend list, which comes with no count at all, and `sodium_base642bin`'s `ignore` set. No defect record: nothing here was reachable as a wrong answer, the SSE status-line leniency included - it needed a malformed status line to show at all.

**Anchor drift:** none. Every finding was where the rescan put it.

**Three things worth carrying to [#946](https://github.com/athrvk/vayu/issues/946).**

**The changed-lines gate is not the whole check when a batch retypes constants,** and batch 2 was right to say so. This one retyped five (`ignore`, two hex tables, `FIELD`, eleven C arrays). Linting all 30 changed translation units *whole-file* under the real config found 82 findings in the touched files and **0 on any changed line** - so CI passes - but the whole-file numbers are what proves none of the retypes pushed work to a call site. All 82 belong to other families' waves (`performance-enum-size`, `modernize-*`, `readability-*`) on lines this diff never touched.

**The new files were linted before pushing, and this time they were clean.** Batch 1 found four findings in the guard it was adding and batch 3 found one; `parse.hpp`, `curl_error_buffer.hpp` and `bounds_primitives_test.cpp` report zero between them. What made the difference is that the shapes to avoid were already written down in `engine/CLAUDE.md` by the three batches before this one.

**A guard is possible here after all, for the half that is tokens.** Batch 3 expected this family to rest on the gate alone because "a subscript is not a token". True of the subscripts - and false of the two shapes that had copies. `std::from_chars` and `CURLOPT_ERRORBUFFER` are both single tokens, so `tests/bounds_primitives_test.cpp` scans for them. The subscript half does rest on the gate, which is now recorded as a decision in `engine/CLAUDE.md` rather than left as an omission.

## Type of Change

- [x] Bug fix (a lint-family paydown; one deliberate behaviour tightening, called out above)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` - green.
- `ctest --preset linux-dev --output-on-failure` - **2412 passed, 0 failed** on the current head (2410 before the peer merge below; 2404 before this branch, so 6 new here, all in `bounds_primitives_test.cpp`).
- `cd app && pnpm test` - **5701 passed, 1 failed of 5702**. The failure is `src/modules/request-builder/components/UrlBar/send-with-row.test.tsx > arriving from a failed step > opens the list on the row that step bound, without a click`. **Not this PR's**: the diff touches zero files under `app/`, and the file passes 41/41 when run alone. It failed under a full-suite run that shared four CPUs with a concurrent clang-tidy scan. Reported, not fixed or hidden.
- `cd app && pnpm type-check` - green on all three projects.
- `clang-format-19 --dry-run -Werror` over every touched file - clean.
- Tree-wide re-scan of the three checks over 206 translation units, `-header-filter` on the command line, deduplicated by (file, line, column, check): **0 findings** outside `src/runtime/`, **0 `clang-diagnostic-error`**.
- Whole-file lint of all 30 changed translation units under the real `engine/.clang-tidy`, filtered to this branch's changed lines: **0 findings**.
- Mutation-checked: reverting `cookie_jar.cpp`'s parse makes the guard name `src/http/cookie_jar.cpp: std::from_chars`; reverting `sse_stream.cpp`'s `attach` makes it name `src/http/sse_stream.cpp: CURLOPT_ERRORBUFFER`. Both restored.
- **After merging master** (see the peer note below): rebuilt, **2412/2412 green**, `clang-format-19 --dry-run -Werror` clean over the 47 files that arrived, and the three checks re-scanned over all **46 translation units master changed** - **0 findings**, 0 `clang-diagnostic-error`. So "zero tree-wide" still holds on the merged head, including for the guard file [#1016](https://github.com/athrvk/vayu/pull/1016) brought with it.
- **No TSan pass**: nothing here is in the threaded core's synchronisation. The three touched files that run on worker threads (`curl_utils.cpp`, `event_loop_worker.cpp`, `sse_stream.cpp`) changed only how a buffer's length is spelled and how an integer is parsed - no shared state, no lifetime, no ordering. `CurlErrorBuffer` is per-transfer storage owned exactly where the `char[]` it replaces was.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (6 in `engine/tests/bounds_primitives_test.cpp`: two per primitive, plus the source scan and its planted positives/negatives)
- [x] I have updated documentation (`engine/CLAUDE.md` gains the family's rule and names both primitives, in the same commit)

## Related Issues

Closes #945

Peer note: [#980](https://github.com/athrvk/vayu/issues/980)'s final batch, [#1016](https://github.com/athrvk/vayu/pull/1016), **has merged**, and master is merged into this branch (a merge commit, not a rebase, as that note said it would want). It touched seven of the same test files but no overlapping lines - that one converted `ASSERT_TRUE (opt.has_value ())` guards, this one converts C arrays and subscripts - and the merge was clean. Its own `pro-bounds-pointer-arithmetic` fix in the guard it added (`b1b17e5`) is consistent with this batch and re-scans clean here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019cRe3aq4wBHhC13btuqqME)_