### PR TITLE
perf(engine): tidy paydown 4 - clear performance-* and avoid-c-arrays, promote the gates to whole-file scope - #946

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -579,43 +579,43 @@ jobs:
       # that survives both translation units on the runner's current SDK - try
       # it by dropping this `if`, and put it back if it traps.
       #
-      # **It lints the changed lines, not the changed files.** The engine had
-      # never been linted, so most files carry findings that predate the diff -
-      # `openapi_drafts.cpp` alone answered with nine on a tree nobody had
-      # touched. Gating on whole files would fail a pull request for code it did
-      # not write, in every file it happened to open, which ends one of two ways:
-      # unrelated refactors smuggled into every diff, or the gate turned off. New
-      # code is held to the config from its first line, and the backlog is paid
-      # down by whoever edits it. `clang-tidy-diff.py` is LLVM's own driver for
-      # exactly this - the line ranges come out of the diff and go in as
-      # `--line-filter`, so nothing here reimplements them.
+      # **It lints the whole of every changed file** (#946, the promotion that
+      # closed the #928 backlog paydown). The gate opened at changed-*lines*
+      # scope (#885), because the engine had never been linted and most files
+      # carried findings older than any diff - whole-file gating then would have
+      # failed pull requests for code they did not write. That quarantine was
+      # the scoping's only job, and #928 paid the backlog to zero tree-wide -
+      # while measuring what the scoping cost: a retyped constant created a
+      # finding on a line its diff never touched (#979), and one branch's
+      # whole-file lint of its own 30 changed files found 98 findings where the
+      # changed-lines gate, correctly, reported 0 (#946). With nothing
+      # pre-existing left to surface, every edited file is fully re-checked.
+      # This also retired `clang-tidy-diff.py` and the Python interpreter it
+      # needed - clang-tidy is invoked directly on each changed translation
+      # unit.
       #
       # `HEAD^1` is the base side of the pull request's merge commit, which is
       # what actions/checkout leaves at HEAD for a `pull_request` event; hence
       # `fetch-depth: 2` above, and the check below rather than a silent empty
       # diff if that ever stops being true.
       #
-      # **A bulk reformat is the one change line scoping cannot help**, because
-      # it rewrites a line in every file it touches: clang-tidy would parse a
-      # whole translation unit per reformatted file and, for the ones it does
-      # lint, widen the line filter to almost the whole file, so the backlog
-      # older than the diff surfaces as failures. #886's 149-file bulk format
-      # asked for 152 translation units and hit this job's timeout. The escape
-      # is the `reformat-pr` label in the `if` below: a reviewer applies it to a
-      # pull request that is nothing but the formatter's output, sees it on the
-      # pull request, and the lint step does not run. It is deliberately not
+      # **A bulk reformat is the one change this gate cannot price fairly**: it
+      # touches a line in every file, so the gate would parse one translation
+      # unit per reformatted file - #886's 149-file bulk format asked for 152
+      # translation units and hit this job's timeout. The escape is the
+      # `reformat-pr` label in the `if` below: a reviewer applies it to a pull
+      # request that is nothing but the formatter's output, sees it on the pull
+      # request, and the lint step does not run. It is deliberately not
       # machinery - a commit walk that read the skip out of a file in the diff
       # was tried (#909's bootstrap) and deleted (#940), because a gate whose
       # exemption is an author-writable input needs a second gate to guard it.
       # `.git-blame-ignore-revs` still gets the reformat's SHA, for blame, which
       # is the only thing it is for.
       #
-      # `-allow-no-checks` is for `engine/src/runtime/`, whose `.clang-tidy` sets
-      # `Checks: '-*'`: without it clang-tidy calls an empty check list a usage
-      # error and exits 1, so the directory that is meant to be exempt would be
-      # the one that fails. `-clang-tidy-binary` because the driver otherwise
-      # calls whatever plain `clang-tidy` resolves to, which on the Linux image
-      # is 18 - old enough to reject `engine/.clang-tidy` outright.
+      # `--allow-no-checks` is for `engine/src/runtime/`, whose `.clang-tidy`
+      # sets `Checks: '-*'`: without it clang-tidy calls an empty check list a
+      # usage error and exits 1, so the directory that is meant to be exempt
+      # would be the one that fails.
       #
       # The two legs run different clang-tidy versions, and neither is a free
       # choice. Linux pins 19 from apt, which is what CONTRIBUTING.md tells
@@ -630,9 +630,6 @@ jobs:
       # leg alone may be a version difference rather than a platform one - worth
       # knowing when you read a failure, and much cheaper than having no
       # coverage of the per-OS branches at all.
-      #
-      # `-j 0` rather than a CPU count: the driver reads 0 as
-      # `multiprocessing.cpu_count()`, and `nproc` does not exist on macOS.
       - name: Lint changed engine sources
         if: >-
           runner.os != 'macOS'
@@ -670,31 +667,21 @@ jobs:
           # the standard library - `no template named 'optional' in namespace
           # 'std'`, twenty errors deep, in files no diff line touched (#926 on
           # Windows, where the same run linted every changed `.cpp` cleanly).
-          #
-          # It is worse than one leg failing, and this is the part that decided
-          # it: **a `clang-diagnostic-error` is not line-filtered**. Measured on
-          # clang-tidy 19.1.1 - an error in an included header is reported even
-          # when `-line-filter` names only the translation unit and only one of
-          # its lines. So a bad synthesised command does not merely fail, it
-          # takes the gate out of changed-lines scope entirely, which is the one
-          # property the whole design rests on. Feeding clang-tidy a file the
-          # compilation database has no entry for is the only way this tree
-          # produces a compiler error at all.
+          # Feeding clang-tidy a file the compilation database has no entry for
+          # is the only way this tree produces a compiler error at all, so
+          # headers stay out of the input list.
           #
           # The MSVC include paths could be passed through instead
           # (`--extra-arg=-imsvc...`, re-derived per image). Rejected: it buys
           # header-as-input coverage on one more leg, at the price of toolchain
-          # plumbing that breaks when an image moves, and it leaves the
-          # error-bypass above wide open.
+          # plumbing that breaks when an image moves.
           #
-          # What this costs is **not** what #926 assumed. `HeaderFilterRegex`
-          # does report diagnostics inside a header, but `clang-tidy-diff.py`
-          # builds one invocation per changed file with a `-line-filter` naming
-          # *only that file* (`clang-tidy-diff.py:344-351`), and clang-tidy
-          # drops a diagnostic in any file its filter does not list - so a
-          # changed header was never reaching this gate through its consumers
-          # either. The hook is the gate that does lint headers: it builds one
-          # filter naming every staged file, which is why it can.
+          # What the promotion changed here (#946): with no line filter on the
+          # invocation, the config's `HeaderFilterRegex` applies, so a header's
+          # findings now surface through every *changed* translation unit that
+          # includes it. What a header-only pull request still needs is the
+          # hook, which lints a staged header directly against the
+          # contributor's own build tree - the summary note below says so.
           headers=()
           translation_units=()
           for file in ${changed[@]+"${changed[@]}"}; do
@@ -705,7 +692,7 @@ jobs:
           done
           if [[ ${#headers[@]} -gt 0 ]]; then
             {
-              echo "- clang-tidy: **${#headers[@]}** changed header(s) are not linted here - this gate lints translation units only (#940). \`scripts/pre-commit\` lints them through the sources that include them:"
+              echo "- clang-tidy: **${#headers[@]}** changed header(s) are not direct inputs here - this gate lints translation units only (#940). Their findings surface through any changed source that includes them (#946); \`scripts/pre-commit\` lints them directly:"
               printf '  - `%s`\n' "${headers[@]}"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -721,29 +708,22 @@ jobs:
             exit 0
           fi
           {
-            echo "- clang-tidy linted the changed lines of **${#changed[@]}** engine source(s), against \`$(git rev-parse --short HEAD^1)\`:"
+            echo "- clang-tidy linted **${#changed[@]}** whole engine source(s) changed against \`$(git rev-parse --short HEAD^1)\` (#946):"
             printf '  - `%s`\n' "${changed[@]}"
           } >> "$GITHUB_STEP_SUMMARY"
 
           # Installed here rather than in a step of its own so a pull request
-          # that changed no engine source pays for none of it. Each package
-          # brings LLVM's own `clang-tidy-diff.py` with the binary, at a path
-          # that differs per packager - which is the whole of the per-platform
-          # difference below.
+          # that changed no engine source pays for none of it.
           case "$RUNNER_OS" in
             Linux)
               sudo apt-get install -y --no-install-recommends clang-tidy-19
               tidy=clang-tidy-19
-              tidy_diff=/usr/bin/clang-tidy-diff-19.py
-              python=python3
               ;;
             Windows)
               # Nothing to install: the image ships LLVM 20.1.8, and asking
               # chocolatey for 19.1.1 failed outright rather than downgrading
               # ("A newer version of llvm is already installed").
               tidy="/c/Program Files/LLVM/bin/clang-tidy.exe"
-              tidy_diff="/c/Program Files/LLVM/share/clang/clang-tidy-diff.py"
-              python=python
               ;;
             *)
               echo "::error::No clang-tidy 19 recipe for $RUNNER_OS"
@@ -796,18 +776,15 @@ jobs:
             exit 1
           fi
 
-          if [[ ! -f "$tidy_diff" ]]; then
-            echo "::error::clang-tidy-diff.py not found at $tidy_diff"
-            exit 1
-          fi
-
-          # `"${changed[@]}"`, not `"${roots[@]}"`: the roots would re-admit the
-          # headers dropped above, which is the one narrowing this list carries.
-          git diff -U0 HEAD^1 HEAD -- "${changed[@]}" \
-            | "$python" "$tidy_diff" \
-                -clang-tidy-binary "$tidy" \
-                -p1 -path engine/build-release \
-                -quiet -allow-no-checks -j 0
+          # Whole files, one clang-tidy invocation per changed translation
+          # unit, in parallel. GNU xargs (both remaining legs have it; macOS is
+          # excluded above) exits non-zero when any invocation fails, which
+          # `WarningsAsErrors: '*'` makes every finding do. Header findings
+          # surface through the translation units that include them, per the
+          # config's `HeaderFilterRegex` - headers are still never inputs.
+          printf '%s\0' "${changed[@]}" \
+            | xargs -0 -n 1 -P "$(nproc)" \
+                "$tidy" -p engine/build-release --quiet --allow-no-checks
 
       # The escape says so in the job summary as well as on the pull request.
       # Same rule as the step above: a gate that narrowed to nothing must not
@@ -851,12 +828,13 @@ jobs:
   # then run it three times for one answer. Out here it reports in under a
   # minute, beside the suites.
   #
-  # **Whole tree, not changed lines** - the opposite of the clang-tidy gate one
-  # job up, and for the opposite reason. That gate is line-scoped because the
-  # engine carries a lint backlog older than any current diff. Formatting has no
-  # backlog: the bulk-format commit in `.git-blame-ignore-revs` left all 285
-  # non-vendor sources clean at the pinned version, so the strict check is the
-  # cheap one and it cannot fail a pull request for code it did not write.
+  # **Whole tree** - wider still than the clang-tidy gate one job up, which
+  # since #946 lints the whole of every changed file but never parses an
+  # unchanged one (a lint costs a translation-unit parse; a format check does
+  # not). Formatting never had a backlog: the bulk-format commit in
+  # `.git-blame-ignore-revs` left all 285 non-vendor sources clean at the
+  # pinned version, so the strict check is the cheap one and it cannot fail a
+  # pull request for code it did not write.
   #
   # `engine/vendor/` is excluded by the roots below, and carries
   # `DisableFormat: true` of its own besides.

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -579,20 +579,21 @@ jobs:
       # that survives both translation units on the runner's current SDK - try
       # it by dropping this `if`, and put it back if it traps.
       #
-      # **It lints the whole of every changed file** (#946, the promotion that
-      # closed the #928 backlog paydown). The gate opened at changed-*lines*
-      # scope (#885), because the engine had never been linted and most files
-      # carried findings older than any diff - whole-file gating then would have
-      # failed pull requests for code they did not write. That quarantine was
-      # the scoping's only job, and #928 paid the backlog to zero tree-wide -
-      # while measuring what the scoping cost: a retyped constant created a
-      # finding on a line its diff never touched (#979), and one branch's
-      # whole-file lint of its own 30 changed files found 98 findings where the
-      # changed-lines gate, correctly, reported 0 (#946). With nothing
-      # pre-existing left to surface, every edited file is fully re-checked.
-      # This also retired `clang-tidy-diff.py` and the Python interpreter it
-      # needed - clang-tidy is invoked directly on each changed translation
-      # unit.
+      # **Linux lints the whole of every changed file; Windows lints its
+      # changed lines** (#946, which promoted the scope where the measurement
+      # supports it; #1023 owns the rest). The gate opened at changed-*lines*
+      # scope on both legs (#885), because the engine had never been linted
+      # and most files carried findings older than any diff - whole-file
+      # gating then would have failed pull requests for code they did not
+      # write. #928 paid that backlog to zero tree-wide *as measured on the
+      # Linux toolchain* - while measuring what the scoping cost: a retyped
+      # constant created a finding on a line its diff never touched (#979),
+      # and one branch's whole-file lint of its own 30 changed files found 98
+      # findings where the changed-lines gate, correctly, reported 0 (#946).
+      # So the Linux leg is fully re-checked per edited file, invoking
+      # clang-tidy directly; the Windows leg keeps `clang-tidy-diff.py` until
+      # #1023 measures and zeroes what only it can see (the scope note at the
+      # invocation carries the evidence).
       #
       # `HEAD^1` is the base side of the pull request's merge commit, which is
       # what actions/checkout leaves at HEAD for a `pull_request` event; hence
@@ -692,7 +693,7 @@ jobs:
           done
           if [[ ${#headers[@]} -gt 0 ]]; then
             {
-              echo "- clang-tidy: **${#headers[@]}** changed header(s) are not direct inputs here - this gate lints translation units only (#940). Their findings surface through any changed source that includes them (#946); \`scripts/pre-commit\` lints them directly:"
+              echo "- clang-tidy: **${#headers[@]}** changed header(s) are not direct inputs here - this gate lints translation units only (#940). On the whole-file leg their findings surface through any changed source that includes them (#946); \`scripts/pre-commit\` lints them directly:"
               printf '  - `%s`\n' "${headers[@]}"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -708,12 +709,19 @@ jobs:
             exit 0
           fi
           {
-            echo "- clang-tidy linted **${#changed[@]}** whole engine source(s) changed against \`$(git rev-parse --short HEAD^1)\` (#946):"
+            if [[ "$RUNNER_OS" == "Linux" ]]; then
+              echo "- clang-tidy linted **${#changed[@]}** whole engine source(s) changed against \`$(git rev-parse --short HEAD^1)\` (#946):"
+            else
+              echo "- clang-tidy linted the changed lines of **${#changed[@]}** engine source(s) against \`$(git rev-parse --short HEAD^1)\` (whole-file on this leg is #1023):"
+            fi
             printf '  - `%s`\n' "${changed[@]}"
           } >> "$GITHUB_STEP_SUMMARY"
 
           # Installed here rather than in a step of its own so a pull request
-          # that changed no engine source pays for none of it.
+          # that changed no engine source pays for none of it. Windows also
+          # names `clang-tidy-diff.py` and a Python: that leg still lints
+          # changed lines (see the scope note below), and the driver ships
+          # beside the binary at a per-packager path.
           case "$RUNNER_OS" in
             Linux)
               sudo apt-get install -y --no-install-recommends clang-tidy-19
@@ -724,6 +732,8 @@ jobs:
               # chocolatey for 19.1.1 failed outright rather than downgrading
               # ("A newer version of llvm is already installed").
               tidy="/c/Program Files/LLVM/bin/clang-tidy.exe"
+              tidy_diff="/c/Program Files/LLVM/share/clang/clang-tidy-diff.py"
+              python=python
               ;;
             *)
               echo "::error::No clang-tidy 19 recipe for $RUNNER_OS"
@@ -776,15 +786,46 @@ jobs:
             exit 1
           fi
 
-          # Whole files, one clang-tidy invocation per changed translation
-          # unit, in parallel. GNU xargs (both remaining legs have it; macOS is
-          # excluded above) exits non-zero when any invocation fails, which
-          # `WarningsAsErrors: '*'` makes every finding do. Header findings
-          # surface through the translation units that include them, per the
-          # config's `HeaderFilterRegex` - headers are still never inputs.
-          printf '%s\0' "${changed[@]}" \
-            | xargs -0 -n 1 -P "$(nproc)" \
-                "$tidy" -p engine/build-release --quiet --allow-no-checks
+          # **The scope differs per leg, and that is measured, not preference**
+          # (#946, which shipped the promotion; #1023 owns the remainder).
+          # Linux lints whole changed files: the #928 paydown's "zero findings
+          # tree-wide" was measured on this leg's toolchain (clang-tidy 19,
+          # GCC compile commands), so nothing pre-existing is left for a
+          # whole-file lint to surface. Windows stays at changed-lines scope,
+          # because the same zero was never measured there and does not hold:
+          # the first whole-file lint on this leg (#1022's run) reported ~85
+          # findings in the touched files alone, none on a line the diff wrote
+          # - `pro-type-vararg` on every `curl_easy_setopt` (curl's GCC
+          # typecheck macro hides them from Linux), checks that exist only in
+          # this leg's clang-tidy 20, and findings in Windows-only code Linux
+          # never compiles. Promoting a leg ahead of its measured zero fails
+          # pull requests for code they did not write - the exact failure
+          # line scoping existed to prevent. #1023 measures and pays that
+          # backlog down, then this branch collapses to the Linux one.
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            # Whole files, one clang-tidy invocation per changed translation
+            # unit, in parallel. GNU xargs exits non-zero when any invocation
+            # fails, which `WarningsAsErrors: '*'` makes every finding do.
+            # Header findings surface through the translation units that
+            # include them, per the config's `HeaderFilterRegex` - headers are
+            # still never inputs.
+            printf '%s\0' "${changed[@]}" \
+              | xargs -0 -n 1 -P "$(nproc)" \
+                  "$tidy" -p engine/build-release --quiet --allow-no-checks
+          else
+            if [[ ! -f "$tidy_diff" ]]; then
+              echo "::error::clang-tidy-diff.py not found at $tidy_diff"
+              exit 1
+            fi
+            # `"${changed[@]}"`, not `"${roots[@]}"`: the roots would re-admit
+            # the headers dropped above. `-j 0` is the driver's spelling for
+            # one worker per CPU.
+            git diff -U0 HEAD^1 HEAD -- "${changed[@]}" \
+              | "$python" "$tidy_diff" \
+                  -clang-tidy-binary "$tidy" \
+                  -p1 -path engine/build-release \
+                  -quiet -allow-no-checks -j 0
+          fi
 
       # The escape says so in the job summary as well as on the pull request.
       # Same rule as the step above: a gate that narrowed to nothing must not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,9 +138,11 @@ vayu/
   apart again.
 
   A finding fails in both places - the hook refuses the commit, CI fails the
-  engine job - and both gate the **whole of every file** you touch (#946; the
-  tree is clean, so every finding in a file you edit is yours to fix or to
-  NOLINT with a reason). A hook refusal is therefore a merge blocker you are
+  engine job - and the hook and CI's Linux leg gate the **whole of every
+  file** you touch (#946; the tree is clean on that toolchain, so every
+  finding in a file you edit is yours to fix or to NOLINT with a reason).
+  CI's Windows leg still gates changed lines until #1023 zeroes what only
+  its toolchain sees. A hook refusal is therefore a merge blocker you are
   seeing early. See
   [Static Analysis](docs/engine/building.md#static-analysis).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,10 @@ vayu/
   apart again.
 
   A finding fails in both places - the hook refuses the commit, CI fails the
-  engine job - and both gate the **lines** you changed, not the whole file, so
-  a finding older than your diff stops neither (#902). A hook refusal is
-  therefore a merge blocker you are seeing early. To lint whole staged files
-  instead, backlog and all, commit once with `VAYU_TIDY_FULL=1`. See
+  engine job - and both gate the **whole of every file** you touch (#946; the
+  tree is clean, so every finding in a file you edit is yours to fix or to
+  NOLINT with a reason). A hook refusal is therefore a merge blocker you are
+  seeing early. See
   [Static Analysis](docs/engine/building.md#static-analysis).
 
 #### Naming Conventions

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -978,7 +978,7 @@ clang-tidy runs in two places, and both of them can stop a change:
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
 | `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **whole** of every staged `.c/.cpp/.h/.hpp` file | Refuses the commit |
-| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **whole** of every changed `engine/{src,include,tests}` **translation unit** - headers are never direct inputs - on Linux and Windows | Fails CI |
+| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | On Linux, the **whole** of every changed `engine/{src,include,tests}` **translation unit**; on Windows, the **changed lines** of those units until #1023 zeroes that leg's own backlog. Headers are never direct inputs | Fails CI |
 
 A finding is a failure because `engine/.clang-tidy` sets
 `WarningsAsErrors: '*'`; with that empty, clang-tidy prints every diagnostic it
@@ -1010,6 +1010,19 @@ scan-guard tests (`reentrant_test.cpp`, `character_cast_test.cpp`,
 `bounds_primitives_test.cpp`, `optional_assert_test.cpp`) keep their job of
 holding *unedited* files to the spellings they pin.
 
+**One leg is deliberately not promoted yet.** The zero above was measured on
+the Linux toolchain - clang-tidy 19 over GCC compile commands, the only
+toolchain any #928 wave scanned with - and the promotion's own PR proved the
+zero does not transfer: the first whole-file lint ever run on the Windows leg
+reported ~85 findings in the touched files alone, none on a line the diff
+wrote (`pro-type-vararg` on every `curl_easy_setopt`, which curl's GCC
+typecheck macro hides from Linux; checks that exist only in that leg's
+clang-tidy 20; findings in Windows-only code a Linux lint never compiles).
+Promoting a leg ahead of its measured zero is the original failure back
+again, so the Windows leg keeps changed-lines scope - the `clang-tidy-diff.py`
+mechanism, unchanged - until #1023 measures its real backlog, zeroes it, and
+collapses the branch.
+
 **"Clean" means the whole tree, headers included - and a scan has to be asked
 for that** (#1013). `run-clang-tidy` reports nothing found in a header unless
 `-header-filter` is passed **on the command line**: the `HeaderFilterRegex` in
@@ -1025,7 +1038,7 @@ So the re-measure command is:
 
 ```bash
 run-clang-tidy-19 -p engine/build -quiet \
-  -header-filter='.*/(src|include|tests)/.*' \
+  -header-filter='.*[/\\]engine[/\\](src|include|tests)[/\\].*' \
   -extra-arg=-Wno-ignored-gch <every non-vendor translation unit>
 ```
 
@@ -1072,12 +1085,15 @@ whole staged files against a tree full of backlog, so a one-line edit to a
 legacy file was refused a commit over findings CI would let through, and
 `--no-verify` was the only way past it. #902 brought it down to CI's
 changed-lines scope, because a hook that has to be bypassed to commit is
-advisory in practice. #946 brought *both* up to whole files, because the
-backlog whose existence was the whole argument for line scoping was gone. The
-`VAYU_TIDY_FULL=1` escape hatch went with it - whole-file linting is simply
-what the hook does now - as did CI's `clang-tidy-diff.py` driver and the Python
-interpreter it needed: both gates invoke clang-tidy directly on each file, with
-no line filter to compute.
+advisory in practice. #946 brought the hook and CI's Linux leg up to whole
+files, because the backlog whose existence was the whole argument for line
+scoping was gone there. The `VAYU_TIDY_FULL=1` escape hatch went with it -
+whole-file linting is simply what the hook does now - and those two invoke
+clang-tidy directly on each file, with no line filter to compute; only CI's
+Windows leg still carries `clang-tidy-diff.py`, for the reason above, until
+#1023 retires it. A Windows contributor's hook may therefore surface
+findings CI's Windows leg does not yet gate - `git commit --no-verify` is
+the escape while #1023 is open, and CI remains the gate of record.
 
 **A bulk reformat is the one change this gate cannot price fairly**, and the
 escape is a label. The gate's unit of cost is the translation-unit parse, and a

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -937,8 +937,9 @@ rather than a missing one. That two-name lookup is
 it formats the changed lines, and a staged file it called clean could still fail
 this whole-file check.
 
-The gate checks the **whole tree**, not the changed lines - the opposite of the
-clang-tidy gate below, because formatting has no backlog to grandfather. Issue
+The gate checks the **whole tree** - wider still than the clang-tidy gate
+below, which lints the whole of every changed file but never parses an
+unchanged one, because formatting never had a backlog to grandfather. Issue
 #886 replaced an imported 2015 template with a config derived by measurement,
 and bulk-formatted all 285 sources in one commit; that commit's SHA is in
 `.git-blame-ignore-revs`, so `git blame` on a formatted file still attributes
@@ -976,8 +977,8 @@ clang-tidy runs in two places, and both of them can stop a change:
 
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
-| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **changed lines** of staged `.c/.cpp/.h/.hpp` files | Refuses the commit |
-| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **changed lines** of changed `engine/{src,include,tests}` **translation units** - not headers - on Linux and Windows | Fails CI |
+| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **whole** of every staged `.c/.cpp/.h/.hpp` file | Refuses the commit |
+| `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **whole** of every changed `engine/{src,include,tests}` **translation unit** - headers are never direct inputs - on Linux and Windows | Fails CI |
 
 A finding is a failure because `engine/.clang-tidy` sets
 `WarningsAsErrors: '*'`; with that empty, clang-tidy prints every diagnostic it
@@ -985,15 +986,29 @@ found and still exits 0. That single setting is what both places read their
 verdict from - do not re-state it as a `--warnings-as-errors` flag at a call
 site, or the two can disagree about what counts.
 
-**Both gate the changed lines, not the changed files.** The engine had never
-been linted, so most files carry findings older than any current diff -
-`openapi_drafts.cpp` answered with nine on an untouched tree. Gating whole files
-would fail a pull request for code it did not write, in every file it happened
-to open. New code is held to the config from its first line; the backlog is paid
-down by whoever edits those lines - and, since #928, by its waves on purpose:
-#942 measured the whole tree against the decided config and #943-#946 pay the
-findings down family by family, with promotion from changed-lines to whole-file
-gating decided in #946 once nothing pre-existing is left to surface.
+**Both gate whole files - the promotion decided in #946.** The gates opened at
+changed-*lines* scope (#885, aligned across the two in #902), and that scoping
+had exactly one job: the engine had never been linted, most files carried
+findings older than any current diff (`openapi_drafts.cpp` answered with nine
+on an untouched tree), and whole-file gating then would have failed pull
+requests for code they did not write. #928 paid that backlog down family by
+family (#942-#946) to zero findings tree-wide, which removed the only argument
+for scoping - and its waves measured what the scoping cost while it lasted:
+
+- #979 found that retyping a constant created a finding on a line its diff
+  never touched, which a changed-lines gate structurally cannot see.
+- #946's batch-4 measurement made the gap concrete: a whole-file lint of one
+  branch's 30 changed translation units reported **98** findings; the same lint
+  filtered to the branch's changed lines reported **0**. CI passed, correctly,
+  with 98 findings standing in the very files the pull request opened.
+
+So every edited file is fully re-checked, forever: a finding anywhere in a file
+a pull request touches is that pull request's to fix, or to `NOLINT` with the
+reason at the site. A file nobody edits is still not re-parsed - the gate's
+unit of cost stays the translation-unit parse - which is why the tree-wide
+scan-guard tests (`reentrant_test.cpp`, `character_cast_test.cpp`,
+`bounds_primitives_test.cpp`, `optional_assert_test.cpp`) keep their job of
+holding *unedited* files to the spellings they pin.
 
 **"Clean" means the whole tree, headers included - and a scan has to be asked
 for that** (#1013). `run-clang-tidy` reports nothing found in a header unless
@@ -1021,10 +1036,12 @@ where 8 sites existed. `-extra-arg=-Wno-ignored-gch` is needed because the
 build's precompiled header is GCC's (#912).
 
 Two things this does **not** change. The gate still lints translation units,
-because a header has no `compile_commands.json` entry and a guessed command
-emits `clang-diagnostic-error`s that escape line filtering (#940) - so a
-promotion from changed-lines to whole-*file* scope, which #946 decides, still
-would not read a header; the hook is what does. And `engine/src/runtime/` stays
+never a header as an input, because a header has no `compile_commands.json`
+entry and a guessed command emits `clang-diagnostic-error`s (#940) - though
+since the #946 promotion removed the line filter, a header's findings do
+surface through every changed translation unit that includes it
+(`HeaderFilterRegex` applies); a header-only pull request still relies on the
+hook, which lints a staged header directly. And `engine/src/runtime/` stays
 out of scope in every count: its own `.clang-tidy` declines every check with a
 written reason, so the findings a check-list override surfaces there are that
 decision working, not a backlog.
@@ -1036,9 +1053,8 @@ the `readability-*`/`modernize-*` remainder after the style-motivated checks
 were declined with a written reason each. `engine/.clang-tidy` is the single
 source of truth for both lists and the reasons; it also documents the alias
 rule (one name per defect - a `cert-*` alias of an enabled check is off so
-nothing reports twice). The gate holds new code to the newly enabled families
-immediately, on changed lines, while their backlog is paid down - the same
-posture every enabled check has always had.
+nothing reports twice). Every enabled family is at zero tree-wide since #946's
+close-out, and the whole-file gates are what hold an edited file there.
 
 **An empty `catch` says so in words** (#944). `bugprone-empty-catch` is enabled,
 and a comment does not satisfy it: the check reads only the keywords in its
@@ -1050,43 +1066,24 @@ a `NOLINT` per site, which records nothing. The keyword is not an argument on it
 own: a `catch` that cannot state a reason is swallowing an error, and the answer
 there is to fix it or to log it, not to name it deliberate.
 
-The hook used to be the stricter of the two - it gated whole staged files, so a
-one-line edit to a legacy file was refused a commit over findings CI would let
-through, and `--no-verify` was the only way past it. #902 aligned them: a hook
-that has to be bypassed to commit is advisory in practice, which is the state
-#885 set out to end.
+The scope has been aligned across the two gates twice, in opposite directions,
+and the second one is where it settled. The hook opened stricter than CI -
+whole staged files against a tree full of backlog, so a one-line edit to a
+legacy file was refused a commit over findings CI would let through, and
+`--no-verify` was the only way past it. #902 brought it down to CI's
+changed-lines scope, because a hook that has to be bypassed to commit is
+advisory in practice. #946 brought *both* up to whole files, because the
+backlog whose existence was the whole argument for line scoping was gone. The
+`VAYU_TIDY_FULL=1` escape hatch went with it - whole-file linting is simply
+what the hook does now - as did CI's `clang-tidy-diff.py` driver and the Python
+interpreter it needed: both gates invoke clang-tidy directly on each file, with
+no line filter to compute.
 
-**The two compute those lines differently, and that is deliberate.** CI runs
-LLVM's own `clang-tidy-diff.py`. The hook parses the staged diff's hunk headers
-itself and passes clang-tidy `--line-filter` directly, because the driver is a
-Python script whose version has to match the binary - an 18-era copy rejects the
-`-allow-no-checks` that `engine/src/runtime/` needs - and it is packaged
-differently on each platform (`/usr/bin/clang-tidy-diff-19.py` from apt,
-`share/clang/clang-tidy-diff.py` beside the binary under Homebrew and the
-Windows LLVM installer). A CI image pins all of that; a contributor's machine
-does not, and a hook that fell back to whole-file linting whenever it could not
-find a driver or an interpreter would put the asymmetry back for exactly the
-people it hurts. `git diff --cached -U0` is always available, and with no
-context lines a hunk header's new-side range *is* the set of lines the commit
-adds, so the hook reads the headers and never the diff body.
-
-**`VAYU_TIDY_FULL=1` restores whole-file linting** for one commit:
-
-```bash
-VAYU_TIDY_FULL=1 git commit
-```
-
-That is for someone paying the backlog down on purpose - the one case where the
-findings CI ignores are the point. Everything else about the hook is unchanged
-by it.
-
-**A bulk reformat is the one change line scoping cannot help**, and the escape
-is a label. Line scoping bounds the *diagnostics* clang-tidy reports, not the
-number of translation units it must parse - and a reformat touches a line in
-every file it rewrites, so the gate parses one translation unit per reformatted
-file and widens the line filter on each to nearly the whole file, surfacing a
-backlog older than the diff. #886's 149-file bulk format made the gate ask for
-152 translation units and killed the job at its timeout.
+**A bulk reformat is the one change this gate cannot price fairly**, and the
+escape is a label. The gate's unit of cost is the translation-unit parse, and a
+reformat touches a line in every file it rewrites, so the gate would parse one
+translation unit per reformatted file - #886's 149-file bulk format made the
+gate ask for 152 translation units and killed the job at its timeout.
 
 So a pull request that is nothing but the formatter's output carries the
 **`reformat-pr` label**, and the lint step does not run:
@@ -1155,60 +1152,38 @@ does not find the MSVC STL and the whole standard library fails to parse - `no
 template named 'optional' in namespace 'std'` - which `WarningsAsErrors: '*'`
 turns into a failed job.
 
-What settled it is sharper than one leg failing. **A `clang-diagnostic-error` is
-not line-filtered.** Measured on clang-tidy 19.1.1: an error inside an included
-header is reported even when `-line-filter` names only the translation unit and
-only one of its lines, and clang-tidy then exits `Found compiler error(s)`. So a
-wrong synthesised command does not just fail a leg - it takes the gate out of
-changed-lines scope altogether, and handing clang-tidy a file the compilation
-database has no entry for is the only way this tree produces a compiler error at
-all. The rejected alternative was passing MSVC's include paths through
-(`--extra-arg=-imsvc...`): it buys one more leg of header-as-input coverage, in
-exchange for toolchain plumbing that breaks when a runner image moves, and it
-leaves that bypass open.
+A wrong synthesised command is worse than one leg failing: a
+`clang-diagnostic-error` sprays from files nobody touched, and handing
+clang-tidy a file the compilation database has no entry for is the only way
+this tree produces a compiler error at all. The rejected alternative was
+passing MSVC's include paths through (`--extra-arg=-imsvc...`): it buys one
+more leg of header-as-input coverage, in exchange for toolchain plumbing that
+breaks when a runner image moves.
 
-**What this costs is less than #926 and #930 assumed, because the coverage they
-credited was never there.** `HeaderFilterRegex` does report diagnostics inside a
-header - but `clang-tidy-diff.py` builds one invocation per changed file, each
-with a `-line-filter` naming *only that file* (`clang-tidy-diff.py:344-351`),
-and clang-tidy drops a diagnostic in any file its filter does not list.
-Measured, same tree, same header, three filters:
-
-| Line filter passed with the `.cpp` | Header finding reported? |
-|---|---|
-| none | yes |
-| names the `.cpp` only - what CI's driver builds | **no** |
-| names the `.cpp` and the header - what the hook builds | yes |
-
-So a changed header has never reached the CI gate through its consumers. It
-reaches the **hook**, which builds one filter over every staged file for exactly
-this reason (the comment at `scripts/pre-commit:229-234` says so). What CI
-genuinely loses by this decision is a header-only change on a machine with no
-hook installed. To lint one by hand, point clang-tidy at a consumer:
+**What this costs shrank with the #946 promotion.** Under the changed-lines
+gate, `clang-tidy-diff.py` built one invocation per changed file with a
+`-line-filter` naming only that file, and clang-tidy drops a diagnostic in any
+file its filter does not list - so a changed header never reached the CI gate
+through its consumers at all. With no line filter on the invocation, the
+config's `HeaderFilterRegex` applies, and a header's findings surface through
+every **changed** translation unit that includes it. What CI still loses is a
+header-only pull request from a machine with no hook installed - the hook
+lints a staged header directly, against the contributor's own build tree. To
+lint one by hand, point clang-tidy at a consumer:
 
 ```bash
-clang-tidy-19 --allow-no-checks -p engine/build \
-  '-line-filter=[{"name":"engine/src/http/routes.cpp"},{"name":"engine/include/vayu/http/routes.hpp"}]' \
-  engine/src/http/routes.cpp
+clang-tidy-19 --allow-no-checks -p engine/build engine/src/http/routes.cpp
 ```
 
-**This also answers #929's header-in-the-diff anomaly** - the one it recorded as
-observed but not explained. A header in the diff does not widen anything: the
-`.cpp`'s invocation is byte-identical whether or not a header is in the diff
-(the driver builds it from that file's hunks alone). What a header adds is *one
-more invocation, with the header as input* - and that is the invocation whose
-synthesised command can fail, spraying unfiltered `clang-diagnostic-error`s from
-files nobody touched. "The gate stops being line-scoped when a header is in the
-diff" and "the Windows leg fails on headers" were one defect seen from two
-sides, and dropping headers as inputs closes both.
-
 **`readability-function-cognitive-complexity` stays off, with no report-only
-job** (#940, closing #929). It anchors on the function declaration, which a
-line-scoped gate can never honour. A whole-tree report job would restate a list
-[#928](https://github.com/athrvk/vayu/issues/928) already holds, and #928's
-completion *is* the re-enable condition - the check becomes honourable the
-moment nothing pre-existing is left for it to anchor on. Turn it back on there.
-The reason sits beside the disable in `engine/.clang-tidy`.
+job** (#940, closing #929; declined while it could not be honoured by a
+line-scoped gate, since it anchors on the function declaration). #928's
+completion met the re-enable condition that decision attached - nothing
+pre-existing is left for the check to anchor on except the over-threshold
+functions themselves - so whether to pay that refactor, NOLINT it, or decline
+the check permanently is now
+[#1021](https://github.com/athrvk/vayu/issues/1021)'s decision. The reason
+sits beside the disable in `engine/.clang-tidy`.
 
 ### The precompiled header
 
@@ -1283,10 +1258,10 @@ To lint by hand, point clang-tidy at a configured build tree:
 python build.py -e                       # writes engine/build/compile_commands.json
 clang-tidy-19 --allow-no-checks -p engine/build engine/src/http/routes.cpp
 
-# Or exactly what CI does, against your own changes:
-git diff -U0 master... -- engine/src engine/include engine/tests \
-  | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 \
-      -p1 -path engine/build -quiet -allow-no-checks -j "$(nproc)"
+# Or exactly what CI does, against your own changes (#946: whole changed files):
+git diff --name-only master... -- engine/src engine/include engine/tests \
+  | grep -E '\.(c|cpp)$' \
+  | xargs -n 1 -P "$(nproc)" clang-tidy-19 --allow-no-checks -p engine/build
 ```
 
 clang-tidy is deliberately **not** wired into the build itself. A

--- a/engine/.clang-tidy
+++ b/engine/.clang-tidy
@@ -234,7 +234,12 @@ CheckOptions:
 # which could stop anything. Set here rather than as a `--warnings-as-errors`
 # flag at each call site so the two cannot disagree about what counts.
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*/(?:src|include|tests)/.*'
+# Anchored to `engine/` deliberately (#946): the unanchored spelling
+# `.*/(src|include|tests)/.*` matched every toolchain's own `include`
+# directory, and the first whole-file lint on Windows reported a finding
+# inside MSVC's `xfilesystem_abi.h`. Both separators, because MSVC paths
+# arrive with backslashes.
+HeaderFilterRegex: '.*[/\\]engine[/\\](?:src|include|tests)[/\\].*'
 ExcludeHeaderFilterRegex: '.*/vendor/.*'
 FormatStyle: file
 ...

--- a/engine/.clang-tidy
+++ b/engine/.clang-tidy
@@ -116,11 +116,11 @@ Checks: '
 #     the first to hit this and turned the check off rather than scatter a
 #     NOLINT per function, which would have fixed the gate for exactly the
 #     functions one pull request happened to touch. **Decided in #940: it stays
-#     off, and gets no report-only job.** A whole-tree report job would restate
-#     a list #928 already holds - and #928's completion *is* the re-enable
-#     condition, because the check becomes honourable the moment nothing
-#     pre-existing is left for it to anchor on. Turn it back on there, not in a
-#     second job here. #928 owns the debt and the splits.
+#     off, and gets no report-only job.** #928's completion (#946) met the
+#     re-enable condition that decision attached - the gates are whole-file now
+#     and nothing pre-existing is left for the check to anchor on except the
+#     over-threshold functions themselves - so whether to refactor those,
+#     NOLINT them, or decline the check permanently is #1021's decision.
 #   readability-convert-member-functions-to-static
 #     Proposes making a member static whenever its body happens not to touch
 #     `this`. On a public class that is an API change decided by an

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -231,13 +231,17 @@ engine/
   surface through every changed translation unit that includes it (#946); a
   header-only change relies on the hook, which lints a staged header directly
   against the local build tree.
-  **Both gate whole files** (#946, the promotion that closed the #928 backlog
-  paydown; #902 is why the two scopes match). Changed-lines scoping existed
-  only to quarantine a backlog older than any diff, and went with the backlog:
-  a finding anywhere in a file a commit stages or a pull request changes is
-  that change's to fix, or to NOLINT with the reason at the site. Both gates
-  invoke clang-tidy directly per file - the `clang-tidy-diff.py` driver, the
-  `VAYU_TIDY_FULL` opt-in and the line-filter machinery are gone. Nothing
+  **The hook and CI's Linux leg gate whole files** (#946, the promotion that
+  closed the #928 backlog paydown). Changed-lines scoping existed only to
+  quarantine a backlog older than any diff, and went with the backlog *where
+  the zero was measured* - the Linux toolchain: a finding anywhere in a file a
+  commit stages or a Linux-visible pull request change is that change's to
+  fix, or to NOLINT with the reason at the site; the `VAYU_TIDY_FULL` opt-in
+  and the hook's line-filter machinery are gone. **CI's Windows leg stays at
+  changed lines** (#1023): its clang-tidy 20 over MSVC sees a backlog no
+  Linux scan could (`pro-type-vararg` on every `curl_easy_setopt`, 20-only
+  checks, Windows-only code), measured at ~85 findings by the promotion's own
+  PR - it promotes when #1023 zeroes that. Nothing
   lints at *build*
   time: the commented-out `CMAKE_CXX_CLANG_TIDY` block went with #885, because a
   lint that runs when someone uncomments it never runs. See

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -63,8 +63,9 @@ engine/
   it, and a non-void test helper cannot use the macro at all - `FAIL ()`
   returns - so it states the absent case as an `if` that `ADD_FAILURE ()`s and
   returns something harmless. `optional_assert_test.cpp` scans `tests/` for the
-  spelling this replaced and fails naming the file, because CI lints a pull
-  request's changed lines only and nothing else holds the family at zero.
+  spelling this replaced and fails naming the file, because the gates lint only
+  the files a change touches (#946) and nothing else holds an *untouched* file
+  at zero.
 - **The reentrant spelling of a C call, always** (#945). `std::localtime` and
   `std::strerror` hand back a pointer into storage the whole process shares, so
   with a worker thread per connection what comes back is a timestamp or an
@@ -112,8 +113,8 @@ engine/
   different answers, and defaulting one to the other erases the distinction its
   callers read. `tests/character_cast_test.cpp` scans `engine/{src,include,tests}`
   and names any file spelling one itself, with a per-file exemption list, because
-  the CI gate scopes to a pull request's changed lines and so holds nothing at
-  zero once these lines stop being new. The casts that are *not* this rule - a
+  the gates lint only the files a change touches (#946) and so hold an
+  *untouched* file at nothing. The casts that are *not* this rule - a
   `sockaddr_in*` off an `addrinfo`, a Windows function pointer off
   `GetProcAddress` - have no primitive to route through and the scan does not
   look at them.
@@ -157,10 +158,11 @@ engine/
   on failure so a reused handle must be cleared between transfers) a bare
   `char[CURL_ERROR_SIZE]` states none of. `tests/bounds_primitives_test.cpp`
   scans `engine/{src,include,tests}` for both spellings with a per-(file, token)
-  exemption list, on batch 1's reasoning: the CI gate scopes to a pull request's
-  changed lines and so holds nothing at zero once these lines stop being new.
+  exemption list, on batch 1's reasoning: the gates lint only the files a
+  change touches (#946) and so hold an *untouched* file at nothing.
   The rest of the family is a subscript, which is not a token - there the gate
-  is the whole of the guard, decided rather than omitted.
+  is the whole of the guard, decided rather than omitted, and since #946 the
+  gate re-checks the whole of every file an edit opens.
 - **A row struct's scalars all carry a default** (#1013,
   `cppcoreguidelines-pro-type-member-init`). The `vayu::db` structs in
   `types.hpp` are aggregates an insert site fills field by field, so one it
@@ -220,23 +222,23 @@ engine/
   four `#define`s, so what is lost is `clang-analyzer-*` over shared code under
   libc++, and it comes back only if a Homebrew LLVM survives that SDK. A pull
   request that is nothing but a bulk reformat carries the **`reformat-pr`**
-  label, which is the whole of the CI gate's escape hatch - line scoping cannot
-  help a change that rewrites a line in every file. **CI lints translation
-  units, never a header** (#940): a header has no `compile_commands.json` entry,
-  so clang-tidy guesses a command for it, and a guess that parses the wrong STL
-  emits `clang-diagnostic-error`s - which are *not* line-filtered, taking the
-  whole gate out of changed-lines scope. The hook is what lints headers, because
-  it names every staged file in one filter and CI's per-file driver does not.
-  **Both gate the changed
-  *lines***: the tree had never been linted and most files carry findings older
-  than any diff, so whole-file gating would fail a pull request for code it did
-  not write. The mechanisms differ on purpose (#902) - CI runs LLVM's
-  `clang-tidy-diff.py`, the hook parses `git diff --cached -U0` hunk headers and
-  passes `--line-filter` itself, because the driver needs Python and a
-  version-matched copy that is packaged differently on each platform, and a
-  fallback to whole-file linting would restore the asymmetry it removes.
-  `VAYU_TIDY_FULL=1` opts one commit back into whole staged files, for paying
-  the backlog down on purpose. Nothing lints at *build*
+  label, which is the whole of the CI gate's escape hatch - the gate's unit of
+  cost is the translation-unit parse, and a reformat asks for one per file it
+  rewrites. **CI lints translation units, never a header as an input** (#940):
+  a header has no `compile_commands.json` entry, so clang-tidy guesses a
+  command for it, and a guess that parses the wrong STL emits
+  `clang-diagnostic-error`s from files nobody touched. A header's findings
+  surface through every changed translation unit that includes it (#946); a
+  header-only change relies on the hook, which lints a staged header directly
+  against the local build tree.
+  **Both gate whole files** (#946, the promotion that closed the #928 backlog
+  paydown; #902 is why the two scopes match). Changed-lines scoping existed
+  only to quarantine a backlog older than any diff, and went with the backlog:
+  a finding anywhere in a file a commit stages or a pull request changes is
+  that change's to fix, or to NOLINT with the reason at the site. Both gates
+  invoke clang-tidy directly per file - the `clang-tidy-diff.py` driver, the
+  `VAYU_TIDY_FULL` opt-in and the line-filter machinery are gone. Nothing
+  lints at *build*
   time: the commented-out `CMAKE_CXX_CLANG_TIDY` block went with #885, because a
   lint that runs when someone uncomments it never runs. See
   `docs/engine/building.md`.

--- a/engine/include/vayu/core/capacity_controller.hpp
+++ b/engine/include/vayu/core/capacity_controller.hpp
@@ -70,7 +70,7 @@ struct CapacityConfig {
     size_t slo_breach_windows = 2;
 };
 
-enum class CapacityAction { Hold, StepUp, Stop };
+enum class CapacityAction : std::uint8_t { Hold, StepUp, Stop };
 
 /// Stop reasons, as they appear in the report's `capacity.stopReason`. Named
 /// constants rather than string literals at each `return`, so the report, the

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -303,11 +303,11 @@ constexpr int MIN_DERIVED_SCRAPE_TIMEOUT_MS = 100;
  */
 namespace script_engine {
 /// Memory limit for the script engine in bytes (64MB)
-constexpr size_t MEMORY_LIMIT = 64 * 1024 * 1024;
+constexpr size_t MEMORY_LIMIT = size_t{ 64 } * 1024 * 1024;
 /// Script execution timeout in milliseconds
 constexpr uint64_t TIMEOUT_MS = 5000;
 /// Stack size for the script engine in bytes (256KB)
-constexpr size_t STACK_SIZE = 256 * 1024;
+constexpr size_t STACK_SIZE = size_t{ 256 } * 1024;
 /// Whether to enable console output from scripts
 constexpr bool ENABLE_CONSOLE = true;
 /**
@@ -331,10 +331,10 @@ namespace json {
 /// Default indentation level for JSON serialization
 constexpr int DEFAULT_INDENT = 2;
 /// Maximum size for JSON field parsing to prevent OOM (10MB)
-constexpr size_t MAX_FIELD_SIZE = 10 * 1024 * 1024;
+constexpr size_t MAX_FIELD_SIZE = size_t{ 10 } * 1024 * 1024;
 /// Maximum request/response body bytes stored per design-run trace (5MB).
 /// Larger bodies are truncated in results.trace_data with bodyTruncated set.
-constexpr size_t MAX_TRACE_BODY_BYTES = 5 * 1024 * 1024;
+constexpr size_t MAX_TRACE_BODY_BYTES = size_t{ 5 } * 1024 * 1024;
 } // namespace json
 
 /**
@@ -357,7 +357,7 @@ constexpr size_t MAX_DATA_ROWS = 1000;
 /// ceiling is cpp-httplib's 100MB body cap, which would surface as a reset
 /// connection rather than as a message naming what was wrong. This is the
 /// engine-authored bound that answers first.
-constexpr size_t MAX_DATA_BYTES = 16 * 1024 * 1024;
+constexpr size_t MAX_DATA_BYTES = size_t{ 16 } * 1024 * 1024;
 /// Largest number of per-step `results` rows one scenario run stores (config
 /// key `maxScenarioStoredSteps`; 0 = unlimited). `Database::get_results` loads
 /// every row of a run with no limit and the report parses each `trace_data`,
@@ -446,7 +446,7 @@ constexpr size_t DEFAULT_MAX_SAMPLE_BODY_BYTES = 32768;
 /// only the bodies are dropped - counted by
 /// MetricsCollector::sample_bodies_dropped so the UI can say the set is
 /// incomplete rather than showing a silently biased subset.
-constexpr size_t DEFAULT_MAX_SAMPLE_BYTES = 2 * 1024 * 1024;
+constexpr size_t DEFAULT_MAX_SAMPLE_BYTES = size_t{ 2 } * 1024 * 1024;
 /// How many exemplars of each distinct status code a run guarantees to retain.
 /// Small on purpose: exemplars answer "what does a 503 from this target look
 /// like", which the first few answer as well as the first few hundred.
@@ -503,7 +503,7 @@ constexpr std::size_t RETAINED_EVENTS_CEILING = 200000;
 
 /// Bytes of one event's `data` kept, seeding `sseMaxEventBytes`. Also the cap
 /// on any single unterminated line, which is what bounds the parser itself.
-constexpr std::size_t MAX_EVENT_BYTES     = 64 * 1024;
+constexpr std::size_t MAX_EVENT_BYTES     = std::size_t{ 64 } * 1024;
 constexpr std::size_t MIN_EVENT_BYTES     = 256;
 constexpr std::size_t EVENT_BYTES_CEILING = 8UL * 1024 * 1024;
 
@@ -560,7 +560,7 @@ constexpr int RELAY_CLAIM_STALE_INTERVALS = 2;
 namespace inbox {
 /// Stored bytes per capture, seeding the `inboxMaxBodyBytes` setting. A larger
 /// body is truncated with the flag set.
-constexpr int64_t MAX_BODY_BYTES = 64 * 1024;
+constexpr int64_t MAX_BODY_BYTES = int64_t{ 64 } * 1024;
 /// Bounds on that setting. The floor keeps a capture from being all flag and no
 /// payload; the ceiling is the transport limit below, past which nothing is
 /// read at all.
@@ -648,7 +648,7 @@ constexpr size_t MAX_REFRESH_TOKENS = 256;
 /// How long an authorization code stays exchangeable. RFC 6749 §4.1.2 asks for
 /// a short lifetime; this matches the interactive attempt TTL in
 /// oauth_authorize.cpp so the two halves of one flow expire together.
-constexpr int64_t CODE_TTL_MS = 5 * 60 * 1000;
+constexpr int64_t CODE_TTL_MS = int64_t{ 5 } * 60 * 1000;
 /// Ceiling on the `slow` failure mode's delay. Past a minute the caller is
 /// testing its own timeout, and the sleep holds a cpp-httplib pool thread.
 constexpr int64_t MAX_SLOW_MS = 60000;
@@ -669,7 +669,7 @@ namespace request_example {
 /// Body bytes per stored example. A larger body is a 400, never a silent
 /// truncation: an example whose body is not what the caller sent would be
 /// served as if it were (phase 2), and a half-body is worse than a refusal.
-constexpr size_t MAX_BODY_BYTES = 1024 * 1024;
+constexpr size_t MAX_BODY_BYTES = size_t{ 1024 } * 1024;
 /// Examples one request may hold. Bounds the list read and the per-request
 /// slice of a bulk import.
 constexpr size_t MAX_PER_REQUEST = 100;
@@ -701,7 +701,7 @@ namespace spec_document {
 /// parse path already carries. Engine-authored so an oversized document is
 /// refused with a message naming the count and the cap, the way `MAX_DATA_BYTES`
 /// is - cpp-httplib's own body cap would drop the connection instead.
-constexpr size_t MAX_BYTES = 10 * 1024 * 1024;
+constexpr size_t MAX_BYTES = size_t{ 10 } * 1024 * 1024;
 
 /// Operation rows one stored `spec_documents.operations` index may declare, and
 /// the same number of rows a coverage block reports (issue #629).
@@ -735,7 +735,7 @@ constexpr size_t READ_NODES_FLOOR = 4096;
 /// The absolute ceiling on that budget, whatever `maxSpecDocumentBytes` is
 /// raised to. The DOM is held whole while the index is extracted, so this is
 /// the memory bound of a single write.
-constexpr size_t MAX_READ_NODES = 4 * 1000 * 1000;
+constexpr size_t MAX_READ_NODES = size_t{ 4 } * 1000 * 1000;
 
 /// Status codes one coverage row may list under `statusesSeen`/`undeclaredSeen`.
 /// A misconfigured target can answer one operation with hundreds of distinct

--- a/engine/include/vayu/core/load_pacing.hpp
+++ b/engine/include/vayu/core/load_pacing.hpp
@@ -141,7 +141,7 @@ ramp_target_concurrency (size_t start, size_t target, int64_t ramp_ms, int64_t e
     const double progress =
     static_cast<double> (elapsed_ms) / static_cast<double> (ramp_ms);
     const double value = static_cast<double> (start) +
-    (static_cast<double> (target) - static_cast<double> (start)) * progress;
+    ((static_cast<double> (target) - static_cast<double> (start)) * progress);
     if (value <= 0.0)
         return 0;
     return static_cast<size_t> (value);

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -100,9 +100,9 @@ struct ResultAnnotations {
  * @param annotations Reaches the stored record only where one is stored: an
  *           unsampled success keeps no trace, so there is nothing to annotate.
  */
-void handle_result (std::shared_ptr<RunContext> context,
+void handle_result (const std::shared_ptr<RunContext>& context,
 vayu::db::Database& db,
-vayu::Result<vayu::Response> result,
+const vayu::Result<vayu::Response>& result,
 const ResultAnnotations& annotations = {});
 
 /**

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -134,13 +134,11 @@ struct ResultRecord {
 
     ResultRecord () = default;
     ResultRecord (int64_t ts, int status, double latency)
-    : timestamp (ts), status_code (status), latency_ms (latency),
-      error_code (ErrorCode::None) {
+    : timestamp (ts), status_code (status), latency_ms (latency) {
     }
 
     ResultRecord (int64_t ts, ErrorCode code, std::string msg)
-    : timestamp (ts), status_code (0), latency_ms (0.0), error_code (code),
-      error_message (std::move (msg)) {
+    : timestamp (ts), error_code (code), error_message (std::move (msg)) {
     }
 
     [[nodiscard]] bool is_error () const {
@@ -269,8 +267,7 @@ enum class SuccessTraceReason : std::uint8_t {
  */
 class MetricsCollector {
     public:
-    explicit MetricsCollector (const std::string& run_id,
-    MetricsCollectorConfig config = {});
+    explicit MetricsCollector (std::string run_id, MetricsCollectorConfig config = {});
     ~MetricsCollector ();
 
     // Non-copyable, non-movable (due to atomics and mutex)

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -220,7 +221,7 @@ struct MetricsCollectorConfig {
  * returns; `TIMING_PHASE_KEYS` gives the wire name of each, so the enum and
  * the JSON cannot drift apart.
  */
-enum class TimingPhase : size_t {
+enum class TimingPhase : std::uint8_t {
     Dns       = 0,
     Connect   = 1,
     Tls       = 2,
@@ -253,7 +254,7 @@ inline constexpr std::array<const char*, TIMING_PHASE_COUNT> TIMING_PHASE_KEYS =
  * passed to record_success - a record can sit in the sampled budget and still
  * deserve a body, which no ordering of these three could express.
  */
-enum class SuccessTraceReason {
+enum class SuccessTraceReason : std::uint8_t {
     None,    ///< no trace was built for this completion
     Sampled, ///< the 1-in-N sampler selected it
     Slow,    ///< it crossed slow_threshold_ms

--- a/engine/include/vayu/core/monitor.hpp
+++ b/engine/include/vayu/core/monitor.hpp
@@ -26,6 +26,7 @@
  * engine or hand-edited.
  */
 
+#include <cstdint>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -44,7 +45,7 @@ class Database;
 namespace vayu::core {
 
 /** Which exposition format the scraped endpoint speaks. */
-enum class MonitorFormat {
+enum class MonitorFormat : std::uint8_t {
     /// Prometheus text exposition: `name{labels} value [timestamp]` lines.
     Prometheus,
     /// A flat JSON object of numbers, keyed by the requested series names.

--- a/engine/include/vayu/core/openapi_export.hpp
+++ b/engine/include/vayu/core/openapi_export.hpp
@@ -42,6 +42,7 @@
 
 #include "vayu/core/openapi_document.hpp"
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -50,7 +51,7 @@
 namespace vayu::core {
 
 /** The serialization the caller asked for. */
-enum class ExportFormat { Json, Yaml };
+enum class ExportFormat : std::uint8_t { Json, Yaml };
 
 /** One Params or Headers row, as the exporter reads it. */
 struct ExportKeyValue {

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -947,7 +947,7 @@ class RunManager {
 };
 
 // Worker functions
-void execute_load_test (std::shared_ptr<RunContext> context,
+void execute_load_test (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
 bool verbose,
 RunManager& manager);
@@ -971,9 +971,9 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
  * Declared here so a test can drive the loop against a mock endpoint without an
  * HTTP server in front of it; the production caller is `RunManager::start_run`.
  */
-void collect_monitor (std::shared_ptr<RunContext> context,
+void collect_monitor (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
-MonitorConfig config);
+const MonitorConfig& config);
 
 /**
  * @brief Keep a run's OAuth 2.0 credential valid for as long as the run lasts.
@@ -991,7 +991,7 @@ MonitorConfig config);
  * Returns as soon as the run stops, or once the published token no longer
  * expires. Inert (returns immediately) when the run has no `auth_refresh`.
  */
-void run_auth_refresh (std::shared_ptr<RunContext> context,
+void run_auth_refresh (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
 const AuthRefreshTuning& tuning);
 

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -89,11 +89,9 @@ size_t max_ticks = constants::server::DEFAULT_MAX_LIVE_TICKS) {
     if (window_ms < 0) {
         window_ms = constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS;
     }
-    auto ticks = static_cast<size_t> (window_ms / tick_interval_ms);
-    if (ticks < 1) {
-        ticks = 1;
-    }
-    return ticks > max_ticks ? max_ticks : ticks;
+    const auto ticks =
+    std::max<size_t> (static_cast<size_t> (window_ms / tick_interval_ms), 1);
+    return std::min (ticks, max_ticks);
 }
 
 /**
@@ -245,7 +243,7 @@ struct RunContext {
     std::atomic<bool> should_stop{ false };
     std::atomic<bool> is_running{ false };
     nlohmann::json config;
-    int64_t start_time_ms;
+    int64_t start_time_ms = 0;
 
     // Test script for deferred validation
     std::string test_script;

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -82,12 +82,12 @@ struct ScenarioStep {
     /// The step's parsed auth, kept **only** when its credentials carry a
     /// `{{data.column}}`. `NoAuth` for every other step, whose auth is already
     /// resolved into `request` above.
-    vayu::http::Auth auth{};
+    vayu::http::Auth auth;
     /// The stored `requests.spec_operation` text, "" for a step whose request
     /// names no operation. Carried on the step so contract coverage (#629) can
     /// resolve each step's identity **once**, when the tally is built, rather
     /// than parsing it per completion on the load path.
-    std::string spec_operation{};
+    std::string spec_operation;
     /// `auth`'s tokens, split once here like `data_template`.
     ///
     /// **Non-empty means this step's auth was deferred**: `request` carries no

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -81,13 +81,19 @@ struct ScenarioStep {
     StepDataTemplate data_template{};
     /// The step's parsed auth, kept **only** when its credentials carry a
     /// `{{data.column}}`. `NoAuth` for every other step, whose auth is already
-    /// resolved into `request` above.
-    vayu::http::Auth auth;
+    /// resolved into `request` above. The `{}` here and below is load-bearing:
+    /// aggregate initializations of a step that stop short of these trailing
+    /// fields are each a -Wmissing-field-initializers error under clang
+    /// otherwise (#946 measured the removal) - redundant to the default
+    /// constructor, not to that warning.
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    vayu::http::Auth auth{};
     /// The stored `requests.spec_operation` text, "" for a step whose request
     /// names no operation. Carried on the step so contract coverage (#629) can
     /// resolve each step's identity **once**, when the tally is built, rather
     /// than parsing it per completion on the load path.
-    std::string spec_operation;
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    std::string spec_operation{};
     /// `auth`'s tokens, split once here like `data_template`.
     ///
     /// **Non-empty means this step's auth was deferred**: `request` carries no

--- a/engine/include/vayu/core/scenario_runner.hpp
+++ b/engine/include/vayu/core/scenario_runner.hpp
@@ -26,6 +26,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -54,7 +55,7 @@ namespace vayu::core {
  * the iteration continues. `Errored` is the step not completing at all (a
  * transport failure, a timeout, a script that threw), and ends its iteration.
  */
-enum class StepOutcome { Passed, Failed, Skipped, Errored };
+enum class StepOutcome : std::uint8_t { Passed, Failed, Skipped, Errored };
 
 [[nodiscard]] const char* to_string (StepOutcome outcome);
 
@@ -320,8 +321,8 @@ const ScenarioSummaryInputs& inputs);
  * persisted once at the end: per-step persistence would be N x M diff-and-write
  * cycles against the DB mutex for a value only this run's later steps read.
  */
-void execute_scenario_run (std::shared_ptr<RunContext> context,
-std::shared_ptr<const ScenarioExecution> execution,
+void execute_scenario_run (const std::shared_ptr<RunContext>& context,
+const std::shared_ptr<const ScenarioExecution>& execution,
 vayu::db::Database* db_ptr,
 vayu::http::CookieJar* cookie_jar,
 bool verbose,

--- a/engine/include/vayu/core/schema_validation.hpp
+++ b/engine/include/vayu/core/schema_validation.hpp
@@ -81,6 +81,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -101,7 +102,7 @@ namespace vayu::core {
  * did not fail one. Every reason below describes a run that *is* bound and
  * still could not be judged.
  */
-enum class UncheckedReason {
+enum class UncheckedReason : std::uint8_t {
     /// The request carries no `spec_operation` - it is not an operation.
     NoOperation,
     /// The bound document carries no response-schema index (stored before the

--- a/engine/include/vayu/core/spec_diff.hpp
+++ b/engine/include/vayu/core/spec_diff.hpp
@@ -63,6 +63,7 @@
 #include "vayu/core/spec_coverage.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -78,7 +79,15 @@ namespace vayu::core {
  * `inherit` and both scripts to empty for every operation, so a difference
  * there is always the user's and never the document's.
  */
-enum class SpecField { Name, Description, Method, Url, Params, Headers, Body };
+enum class SpecField : std::uint8_t {
+    Name,
+    Description,
+    Method,
+    Url,
+    Params,
+    Headers,
+    Body
+};
 
 /// The wire spelling of @p field - what a tick names and what an apply reads.
 [[nodiscard]] std::string_view spec_field_name (SpecField field);
@@ -100,7 +109,7 @@ struct SpecFieldDiff {
 };
 
 /** How a request was followed from its recorded identity into the new document. */
-enum class IdentityMatch { OperationId, Path };
+enum class IdentityMatch : std::uint8_t { OperationId, Path };
 
 /**
  * A stored request, as the comparison reads it.

--- a/engine/include/vayu/db/recovery.hpp
+++ b/engine/include/vayu/db/recovery.hpp
@@ -92,8 +92,8 @@ std::optional<RecoveryOutcome> recovery_outcome_from_string (const std::string& 
  * (`created_at` on every row), so a reader formats it the way it formats those.
  */
 struct RecoveryRecord {
-    RecoveryOutcome outcome;
-    int64_t at;
+    RecoveryOutcome outcome{};
+    int64_t at = 0;
     /**
      * Where the corrupt database was moved to, when it was moved rather than
      * deleted (issue #984).

--- a/engine/include/vayu/http/client.hpp
+++ b/engine/include/vayu/http/client.hpp
@@ -212,7 +212,7 @@ class Client {
 /// that includes this one. `NOMINMAX` is deliberately PRIVATE to `vayu_core`
 /// (`CMakeLists.txt`), so `vayu-engine` does not get it and `daemon.cpp` is
 /// where that lands - which is exactly how this was found.
-enum class TlsBackendSelection {
+enum class TlsBackendSelection : std::uint8_t {
     /// OpenSSL is the backend every transfer will use, because we said so.
     Selected,
     /// This build has no OpenSSL to select - so whatever it does verify with,

--- a/engine/include/vayu/http/cookie_jar.hpp
+++ b/engine/include/vayu/http/cookie_jar.hpp
@@ -90,7 +90,7 @@ namespace vayu::http {
  * empty, so the empty key cannot collide with one, and naming it keeps the
  * "no environment" jar findable by grep.
  */
-inline constexpr std::string_view NO_ENVIRONMENT_SCOPE = "";
+inline constexpr std::string_view NO_ENVIRONMENT_SCOPE{};
 
 /**
  * @brief One cookie, as read back out of the jar for a *view*.

--- a/engine/include/vayu/http/cookie_jar.hpp
+++ b/engine/include/vayu/http/cookie_jar.hpp
@@ -176,7 +176,7 @@ cookie_for_url (const std::string& url, JarCookie cookie);
  * land in the live map beside a transfer.
  */
 struct CookieWrite {
-    enum class Kind {
+    enum class Kind : std::uint8_t {
         /// Merge `line` in, replacing a cookie of the same name/domain/path.
         Set,
         /// Drop the cookies named `name` that would be sent to `url`.

--- a/engine/include/vayu/http/event_loop/event_loop_worker.hpp
+++ b/engine/include/vayu/http/event_loop/event_loop_worker.hpp
@@ -157,6 +157,12 @@ class CurlHandlePool {
  * - Active transfers map for in-flight requests
  * - Rate limiter for controlling throughput
  */
+// The analyzer would reorder the fields to save 84 padding bytes. Declaration
+// order here follows the lifecycle (queue, loop state, transfers, limiter,
+// flags) and is what the constructor's initialization order hangs off; one
+// worker exists per thread, so the bytes saved would be a few hundred per
+// process for a reordering that costs the reader the grouping.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class EventLoopWorker {
     public:
     explicit EventLoopWorker (const EventLoopConfig& cfg);

--- a/engine/include/vayu/http/event_loop/transfer_context.hpp
+++ b/engine/include/vayu/http/event_loop/transfer_context.hpp
@@ -36,7 +36,7 @@ namespace detail {
  */
 struct TransferData {
     size_t request_id = 0;
-    std::chrono::steady_clock::time_point submitted_at{};
+    std::chrono::steady_clock::time_point submitted_at;
     Request request;
     Response response;
     std::string response_body;
@@ -61,7 +61,7 @@ struct TransferData {
     /// When the duration cap expires. Computed at configure time from
     /// `stream_bounds->max_duration_ms`, so the clock is read once per transfer
     /// rather than once per callback.
-    std::chrono::steady_clock::time_point stream_deadline{};
+    std::chrono::steady_clock::time_point stream_deadline;
     /// Set by whichever cap ended the transfer, so the completion can report a
     /// **success** where curl reports an aborted write. Distinct from
     /// `body_limit_exceeded`, which stays an error: the byte cap is a refusal

--- a/engine/include/vayu/http/live_claim.hpp
+++ b/engine/include/vayu/http/live_claim.hpp
@@ -103,7 +103,7 @@ class LiveClaimSlot {
     /// at least a keep-alive every interval, so a long gap here is the only
     /// evidence available that its socket is gone: cpp-httplib reports that
     /// only through the next failing write.
-    std::chrono::steady_clock::time_point last_write_{};
+    std::chrono::steady_clock::time_point last_write_;
 };
 
 } // namespace vayu::http

--- a/engine/include/vayu/http/mock_server.hpp
+++ b/engine/include/vayu/http/mock_server.hpp
@@ -72,7 +72,7 @@ struct MockRoute {
 };
 
 /** Why a request did not match, so the 404 body can say which near-miss it was. */
-enum class MockMissKind {
+enum class MockMissKind : std::uint8_t {
     /// Nothing in the table has this path shape at all.
     NoPath,
     /// The path matches a route, but none of them is registered for this method.

--- a/engine/include/vayu/http/oauth_client.hpp
+++ b/engine/include/vayu/http/oauth_client.hpp
@@ -33,9 +33,14 @@ struct TokenError {
     // `{}` rather than bare declarations: every construction here is a
     // three-field aggregate init for a failure that carries no provider body,
     // and without the default member initializer each of those eight sites is
-    // a -Wmissing-field-initializers warning. Empty is the intended value.
+    // a -Wmissing-field-initializers warning. Empty is the intended value -
+    // which is why the redundant-member-init finding on each is suppressed:
+    // the initializer is redundant to the default constructor but not to the
+    // aggregate-init warning.
+    // NOLINTBEGIN(readability-redundant-member-init)
     std::string provider_error{};             // RFC 6749 "error"
     std::string provider_error_description{}; // RFC 6749 "error_description"
+    // NOLINTEND(readability-redundant-member-init)
 };
 
 /**

--- a/engine/include/vayu/http/rate_limiter.hpp
+++ b/engine/include/vayu/http/rate_limiter.hpp
@@ -121,7 +121,7 @@ class RateLimiter {
     RateLimiterConfig config_;
     mutable std::mutex mutex_;
 
-    double tokens_;
+    double tokens_ = 0.0;
     std::chrono::steady_clock::time_point last_refill_;
 };
 

--- a/engine/include/vayu/http/sse_parser.hpp
+++ b/engine/include/vayu/http/sse_parser.hpp
@@ -119,10 +119,10 @@ class SseParser {
 
     std::string event_type_;
     std::string data_;
-    std::size_t data_bytes_    = 0;
-    bool data_truncated_       = false;
-    bool has_data_             = false;
-    std::string last_event_id_ = {};
+    std::size_t data_bytes_ = 0;
+    bool data_truncated_    = false;
+    bool has_data_          = false;
+    std::string last_event_id_;
 };
 
 /**

--- a/engine/include/vayu/http/sse_stream.hpp
+++ b/engine/include/vayu/http/sse_stream.hpp
@@ -62,7 +62,7 @@ namespace vayu::http {
  * Why a stream ended. Always one of these - a stream that simply stopped
  * producing is `Idle`, not an unexplained silence.
  */
-enum class SseEndReason {
+enum class SseEndReason : std::uint8_t {
     /// The server closed the stream. The ordinary end of a finite stream.
     Completed,
     /// `POST /runs/:id/stop`.
@@ -204,7 +204,7 @@ class SseStreamContext {
     /// The initial response's status line and headers, recorded as soon as they
     /// arrive so the relay can report what the stream is even before its first
     /// event. Zero status means nothing has been received yet.
-    void note_response_open (int status_code, std::string status_text, Headers headers);
+    void note_response_open (int status_code, std::string status_text, const Headers& headers);
 
     /// The single-watcher slot. Guarded by `claim_mutex_` rather than the ring
     /// lock: a relay claiming or releasing must not contend with the producer.

--- a/engine/include/vayu/http/thread_pool.hpp
+++ b/engine/include/vayu/http/thread_pool.hpp
@@ -40,7 +40,8 @@ class ThreadPool {
         using return_type = decltype (f (args...));
 
         auto task = std::make_shared<std::packaged_task<return_type ()>> (
-        std::bind (std::forward<F> (f), std::forward<Args> (args)...));
+        [f = std::forward<F> (f),
+        ... args = std::forward<Args> (args)] () mutable { return f (args...); });
 
         std::future<return_type> result = task->get_future ();
         submit_impl ([task] () { (*task) (); });

--- a/engine/include/vayu/http/transport_policy.hpp
+++ b/engine/include/vayu/http/transport_policy.hpp
@@ -22,6 +22,7 @@
  */
 
 #include <array>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -36,7 +37,7 @@ namespace vayu::http {
 /**
  * @brief Where a transfer's proxy comes from.
  */
-enum class ProxyMode {
+enum class ProxyMode : std::uint8_t {
     /**
      * libcurl's own `http_proxy` / `https_proxy` / `no_proxy` environment
      * pickup - the default, because it is the behaviour every shell and CI
@@ -111,7 +112,7 @@ std::optional<std::string> proxy_url_rejection (std::string_view url);
  * same answer thousands of times - and an answer nothing stored is one the
  * Settings card cannot print. It is written once, when the entry is registered.
  */
-enum class ClientCertFormat {
+enum class ClientCertFormat : std::uint8_t {
     /// A PEM certificate with its key in a second file - libcurl's default.
     Pem,
     /// A PKCS#12 file carrying certificate *and* key, which libcurl reads only

--- a/engine/include/vayu/platform/platform.hpp
+++ b/engine/include/vayu/platform/platform.hpp
@@ -22,6 +22,9 @@
 #include <string>
 
 // Platform detection macros
+// Macros, not an enum: every consumer is a preprocessor conditional
+// (`#if VAYU_PLATFORM_WINDOWS`), which an enum cannot serve.
+// NOLINTBEGIN(modernize-macro-to-enum)
 #ifdef _WIN32
 #define VAYU_PLATFORM_WINDOWS 1
 #define VAYU_PLATFORM_UNIX 0
@@ -43,6 +46,7 @@
 #define VAYU_PLATFORM_MACOS 0
 #define VAYU_PLATFORM_LINUX 0
 #endif
+// NOLINTEND(modernize-macro-to-enum)
 
 namespace vayu::platform {
 

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -15,6 +15,7 @@
  * and access to request/response data.
  */
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -64,7 +65,7 @@ struct ScriptConfig {
 /**
  * @brief Which hook a script is running as, reported to it as `pm.info.eventName`.
  */
-enum class ScriptEvent {
+enum class ScriptEvent : std::uint8_t {
     PreRequest,
     Test,
 };

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -817,7 +817,11 @@ struct Variable {
     // `{}` rather than a bare declaration so the ~43 aggregate initializations
     // that stop short of this trailing field are not each a
     // -Wmissing-field-initializers warning; absent still means "unknown age".
-    std::optional<int64_t> created_at;
+    // Redundant to the default constructor, not to that warning - hence the
+    // suppression rather than the removal (#946 measured the removal: clang
+    // fails the macOS and Windows legs on every one of those sites).
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    std::optional<int64_t> created_at{};
 
     bool operator== (const Variable&) const = default;
 };
@@ -1445,7 +1449,10 @@ struct ConfigEntry {
     // load-bearing for the same reason: without a default member initializer,
     // every one of those 53 positional seeds is a `-Wmissing-field-initializers`
     // warning, and the cure belongs on the field rather than at each site.
-    std::optional<std::string> unit;
+    // Redundant to the default constructor, not to that warning - hence the
+    // suppression rather than the removal (#946 measured the removal).
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    std::optional<std::string> unit{};
 };
 
 /**

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -817,7 +817,7 @@ struct Variable {
     // `{}` rather than a bare declaration so the ~43 aggregate initializations
     // that stop short of this trailing field are not each a
     // -Wmissing-field-initializers warning; absent still means "unknown age".
-    std::optional<int64_t> created_at{};
+    std::optional<int64_t> created_at;
 
     bool operator== (const Variable&) const = default;
 };
@@ -1445,7 +1445,7 @@ struct ConfigEntry {
     // load-bearing for the same reason: without a default member initializer,
     // every one of those 53 positional seeds is a `-Wmissing-field-initializers`
     // warning, and the cure belongs on the field rather than at each site.
-    std::optional<std::string> unit{};
+    std::optional<std::string> unit;
 };
 
 /**

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <string>
@@ -50,7 +51,15 @@ using Duration  = std::chrono::milliseconds;
 #endif
 #endif
 
-enum class HttpMethod { GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS };
+enum class HttpMethod : std::uint8_t {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    PATCH,
+    HEAD,
+    OPTIONS
+};
 
 /**
  * @brief Convert HttpMethod enum to string
@@ -125,7 +134,7 @@ using Headers = std::map<std::string, std::string, CaseInsensitiveLess>;
  * Both carry their content as `Body::fields`, never as `Body::content` - see
  * `vayu/http/form_body.hpp` for the wire encoding of each.
  */
-enum class BodyMode {
+enum class BodyMode : std::uint8_t {
     None,
     Json,
     Text,
@@ -144,7 +153,7 @@ enum class BodyMode {
  * pairs - so a `File` part is only ever valid under `BodyMode::FormData`, and
  * `parse_form_fields` refuses it anywhere else.
  */
-enum class FormFieldType { Text, File };
+enum class FormFieldType : std::uint8_t { Text, File };
 
 /**
  * @brief One entry of a form body.
@@ -199,7 +208,7 @@ struct Body {
  * validation and the seeded config `options` list both derive their allowed
  * values from it rather than writing a literal list, so the two cannot drift.
  */
-enum class HttpVersion { Auto, Http1_1, Http2 };
+enum class HttpVersion : std::uint8_t { Auto, Http1_1, Http2 };
 
 inline std::string to_string (HttpVersion version) {
     switch (version) {
@@ -331,7 +340,7 @@ struct Timing {
 // Error Types (defined early so Response can use ErrorCode)
 // ============================================================================
 
-enum class ErrorCode {
+enum class ErrorCode : std::uint8_t {
     None,
     Timeout,
     ConnectionFailed,
@@ -712,7 +721,7 @@ struct TestResult {
  * dropped entirely until now, which is why every line reached the app's Console
  * tab looking the same whether the script called `log` or `error`.
  */
-enum class ConsoleLevel { Log, Info, Warn, Error };
+enum class ConsoleLevel : std::uint8_t { Log, Info, Warn, Error };
 
 /** Wire spelling of a level. The app matches on these exact strings. */
 [[nodiscard]] constexpr const char* to_string (ConsoleLevel level) noexcept {
@@ -754,7 +763,7 @@ struct ConsoleEntry {
  * caller an instruction it would silently drop.
  */
 struct ScriptControl {
-    enum class Kind {
+    enum class Kind : std::uint8_t {
         None,        ///< The script asked for nothing; run the next step.
         Next,        ///< `setNextRequest(name)` - jump to `target`.
         Skip,        ///< `skipRequest()` - do not send this step.
@@ -830,7 +839,7 @@ using Environment = std::map<std::string, Variable>;
  * (`attach_design_result`, `utils/json.cpp`), while a scenario run writes one
  * row per step execution. Overloading `design` would break that reader.
  */
-enum class RunType { Design, Load, Scenario };
+enum class RunType : std::uint8_t { Design, Load, Scenario };
 
 inline const char* to_string (RunType type) {
     switch (type) {
@@ -859,7 +868,7 @@ inline std::optional<RunType> parse_run_type (const std::string& str) {
  * published metric tick and stops itself. Every other member's target is a
  * pure function of elapsed time.
  */
-enum class LoadTestType {
+enum class LoadTestType : std::uint8_t {
     ConstantRps,
     ConstantConcurrency,
     RampUp,
@@ -892,7 +901,13 @@ inline std::optional<LoadTestType> parse_load_test_type (const std::string& str)
     return std::nullopt;
 }
 
-enum class RunStatus { Pending, Running, Completed, Failed, Stopped };
+enum class RunStatus : std::uint8_t {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Stopped
+};
 
 inline const char* to_string (RunStatus status) {
     switch (status) {

--- a/engine/include/vayu/utils/encoding.hpp
+++ b/engine/include/vayu/utils/encoding.hpp
@@ -114,10 +114,12 @@ inline std::optional<std::string> base64_decode (std::string_view in) {
         // callee never assumes a terminator - the suspicious-stringview-data
         // check cannot see that through the ternary, which only exists to keep
         // the pointer non-null for an empty input.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,bugprone-suspicious-stringview-data-usage)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         if (sodium_base642bin (reinterpret_cast<unsigned char*> (out.data ()),
-            out.size (), in.empty () ? "" : in.data (), in.size (),
-            ignore.data (), &decoded_len, nullptr, variant) != 0) {
+            out.size (),
+            // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+            in.empty () ? "" : in.data (), in.size (), ignore.data (),
+            &decoded_len, nullptr, variant) != 0) {
             return std::nullopt;
         }
 

--- a/engine/include/vayu/utils/encoding.hpp
+++ b/engine/include/vayu/utils/encoding.hpp
@@ -110,7 +110,11 @@ inline std::optional<std::string> base64_decode (std::string_view in) {
         // short decode. The cast is the writing direction of the [basic.lval]
         // rule `byte_view` above documents - libsodium fills a byte buffer, and
         // this string is one.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        // The data () below travels with in.size () one argument over, so the
+        // callee never assumes a terminator - the suspicious-stringview-data
+        // check cannot see that through the ternary, which only exists to keep
+        // the pointer non-null for an empty input.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,bugprone-suspicious-stringview-data-usage)
         if (sodium_base642bin (reinterpret_cast<unsigned char*> (out.data ()),
             out.size (), in.empty () ? "" : in.data (), in.size (),
             ignore.data (), &decoded_len, nullptr, variant) != 0) {
@@ -141,7 +145,7 @@ inline std::string hex_encode (std::string_view in) {
     ensure_sodium_initialized ();
 
     // sodium_bin2hex needs room for the terminating NUL and aborts without it.
-    std::string out (in.size () * 2 + 1, '\0');
+    std::string out ((in.size () * 2) + 1, '\0');
     sodium_bin2hex (out.data (), out.size (), detail::sodium_bytes (in), in.size ());
     out.resize (in.size () * 2);
     return out;
@@ -208,16 +212,20 @@ inline std::string url_decode (std::string_view in) {
     out.reserve (in.size ());
     for (size_t i = 0; i < in.size (); ++i) {
         const char ch = in[i];
-        int hi = -1, lo = -1;
         if (ch == '+') {
             out.push_back (' ');
-        } else if (ch == '%' && i + 2 < in.size () &&
-        (hi = unhex (in[i + 1])) >= 0 && (lo = unhex (in[i + 2])) >= 0) {
-            out.push_back (static_cast<char> ((hi << 4) | lo));
-            i += 2;
-        } else {
-            out.push_back (ch);
+            continue;
         }
+        if (ch == '%' && i + 2 < in.size ()) {
+            const int hi = unhex (in[i + 1]);
+            const int lo = unhex (in[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                out.push_back (static_cast<char> ((hi << 4) | lo));
+                i += 2;
+                continue;
+            }
+        }
+        out.push_back (ch);
     }
     return out;
 }

--- a/engine/include/vayu/utils/logger.hpp
+++ b/engine/include/vayu/utils/logger.hpp
@@ -7,6 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -28,7 +29,12 @@
 namespace vayu::utils {
 class Logger {
     public:
-    enum class Level { DEBUG = 0, INFO = 1, WARNING = 2, ERROR = 3 };
+    enum class Level : std::uint8_t {
+        DEBUG   = 0,
+        INFO    = 1,
+        WARNING = 2,
+        ERROR   = 3
+    };
 
     static Logger& instance ();
 

--- a/engine/include/vayu/version.hpp
+++ b/engine/include/vayu/version.hpp
@@ -12,9 +12,15 @@
  * @brief Vayu Engine version information
  */
 
+// Macros, not an enum: build.py's version bump rewrites these exact
+// `#define` lines by regex, and VAYU_VERSION_STRING must stay a macro for
+// the string literal pasting in user_agent.cpp - the parts stay in the same
+// spelling beside it.
+// NOLINTBEGIN(modernize-macro-to-enum)
 #define VAYU_VERSION_MAJOR 0
 #define VAYU_VERSION_MINOR 23
 #define VAYU_VERSION_PATCH 0
+// NOLINTEND(modernize-macro-to-enum)
 
 #define VAYU_VERSION_STRING "0.23.0"
 

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -177,7 +177,7 @@ const AuthRefreshTuning& tuning) {
         0.0;
         state->publish (
         vayu::http::oauth2_header_value (state->config (), token.access_token), at_seconds,
-        token.expires_in > 0 ? token.created_at + token.expires_in * 1000 : 0);
+        token.expires_in > 0 ? token.created_at + (token.expires_in * 1000) : 0);
         vayu::utils::log_info ("OAuth2: refreshed the token for run " + context->run_id);
     }
 }

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -131,7 +131,7 @@ int64_t auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, const Auth
     return std::max (tuning.min_interval_ms, expires_at_ms - tuning.lead_ms - now_ms);
 }
 
-void run_auth_refresh (std::shared_ptr<RunContext> context,
+void run_auth_refresh (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
 const AuthRefreshTuning& tuning) {
     const auto state = context->auth_refresh;

--- a/engine/src/core/capacity_controller.cpp
+++ b/engine/src/core/capacity_controller.cpp
@@ -50,7 +50,7 @@ bool plateaued (const CapacityConfig& config, const std::vector<CapacityWindow>&
     const auto& base = levels[levels.size () - 3];
     const auto& mid  = levels[levels.size () - 2];
     const auto& top  = levels[levels.size () - 1];
-    if (!(base.concurrency < mid.concurrency && mid.concurrency < top.concurrency)) {
+    if (base.concurrency >= mid.concurrency || mid.concurrency >= top.concurrency) {
         return false;
     }
     if (!(base.rps > 0.0)) {

--- a/engine/src/core/import_document.cpp
+++ b/engine/src/core/import_document.cpp
@@ -111,8 +111,8 @@ json map_key_values (const json* rows) {
         entry["key"]   = as_string (prop (record, "key"));
         entry["value"] = normalize_vars (as_string (prop (record, "value")));
         const json* disabled = prop (record, "disabled");
-        entry["enabled"] =
-        !(disabled != nullptr && disabled->is_boolean () && disabled->get<bool> ());
+        entry["enabled"] = disabled == nullptr || !disabled->is_boolean () ||
+        !disabled->get<bool> ();
         if (const json* description = prop (record, "description"); truthy (description)) {
             entry["description"] = as_string (description);
         }
@@ -597,8 +597,7 @@ json map_postman_auth (const json* auth) {
         // A `type` that is not a string names no scheme, so nothing can be sent.
         return json{ { "mode", "none" } };
     }
-    const std::map<std::string, std::string> detail =
-    auth_detail (prop (node, type->c_str ()));
+    const std::map<std::string, std::string> detail = auth_detail (prop (node, *type));
 
     if (*type == "bearer") {
         return json{ { "mode", "bearer" }, { "token", detail_text (detail, "token") } };
@@ -710,7 +709,7 @@ json formdata_fields (const json* rows, PostmanCounts& counts) {
         const json single = json::array ({ row });
         const json mapped = map_key_values (&single);
         const json* type  = prop (&row, "type");
-        if (!(type != nullptr && *type == "file")) {
+        if (type == nullptr || *type != "file") {
             for (const json& entry : mapped) {
                 out.push_back (entry);
             }
@@ -992,6 +991,18 @@ json pm_examples (const json* item, PostmanCounts& counts) {
     return out;
 }
 
+/// Postman's `description` is either a string or `{ content: "..." }` - the
+/// declared text, "" when neither shape carries one.
+std::string pm_description_text (const std::string* text, const std::string* nested) {
+    if (text != nullptr) {
+        return *text;
+    }
+    if (nested != nullptr) {
+        return *nested;
+    }
+    return {};
+}
+
 json pm_request (const json* item, PostmanCounts& counts) {
     const json* declared   = as_record (prop (item, "request"));
     const json empty       = json::object ();
@@ -1013,11 +1024,10 @@ json pm_request (const json* item, PostmanCounts& counts) {
 
     json request;
     request["name"] = name == nullptr || name->is_null () ? "Untitled" : as_string (name);
-    request["description"] =
-    description != nullptr ? *description : (nested != nullptr ? *nested : "");
-    request["method"] = to_method (prop (rq, "method"));
-    request["url"]    = url;
-    request["params"] = params;
+    request["description"] = pm_description_text (description, nested);
+    request["method"]      = to_method (prop (rq, "method"));
+    request["url"]         = url;
+    request["params"]      = params;
     request["headers"] =
     with_required_content_type (map_key_values (prop (rq, "header")), body);
     request["body"] = std::move (body);
@@ -1087,10 +1097,9 @@ json pm_folder (const json* node, PostmanCounts& counts) {
     json collection;
     collection["name"] =
     name == nullptr || name->is_null () ? "Imported Collection" : as_string (name);
-    collection["description"] =
-    text != nullptr ? *text : (nested != nullptr ? *nested : "");
-    collection["variables"] = to_var_record (prop (node, "variable"));
-    collection["auth"]      = collection_auth (prop (node, "auth"));
+    collection["description"] = pm_description_text (text, nested);
+    collection["variables"]   = to_var_record (prop (node, "variable"));
+    collection["auth"]        = collection_auth (prop (node, "auth"));
     collection["preRequestScript"] =
     counts.options.import_scripts ? join_exec (pm_event (events, "prerequest")) : "";
     collection["postRequestScript"] =
@@ -1335,7 +1344,7 @@ json multipart_fields (const json* rows, InsomniaCounts& counts) {
         const json single = json::array ({ kv_row (row) });
         const json mapped = map_key_values (&single);
         const json* type  = prop (&row, "type");
-        if (!(type != nullptr && *type == "file")) {
+        if (type == nullptr || *type != "file") {
             for (const json& entry : mapped) {
                 out.push_back (entry);
             }
@@ -2068,7 +2077,8 @@ class OperationFolders {
             folder["children"]          = json::array ();
             folder["requests"]          = json::array ();
             folders_.emplace (name, std::move (folder));
-        } else if (from_tag && folders_.at (name).at ("description") == "") {
+        } else if (from_tag &&
+        folders_.at (name).at ("description").get_ref<const std::string&> ().empty ()) {
             // A path segment can be spelled exactly like a tag, in which case
             // the folder already exists with no description. The tag's
             // description still describes what is in it.

--- a/engine/src/core/import_document.cpp
+++ b/engine/src/core/import_document.cpp
@@ -1366,7 +1366,7 @@ std::string to_graphql_envelope (const std::string& body) {
     if (begin == std::string::npos) {
         return js_json_compact (json{ { "query", "" } });
     }
-    const std::string trimmed =
+    std::string trimmed =
     body.substr (begin, body.find_last_not_of (" \t\n\r\f\v") - begin + 1);
     const json parsed = json::parse (trimmed, nullptr, false);
     if (!parsed.is_discarded () && parsed.is_object () &&

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -173,9 +173,13 @@ const ResultAnnotations& annotations) {
             // whichever budget claims it, the record is stored, and the
             // exemplar's real job (capturing a body for it) is decided
             // separately below.
-            trace_reason = is_slow ?
-            SuccessTraceReason::Slow :
-            (sampled ? SuccessTraceReason::Sampled : SuccessTraceReason::Exemplar);
+            if (is_slow) {
+                trace_reason = SuccessTraceReason::Slow;
+            } else if (sampled) {
+                trace_reason = SuccessTraceReason::Sampled;
+            } else {
+                trace_reason = SuccessTraceReason::Exemplar;
+            }
 
             nlohmann::json timing_json = { { "totalMs", response.timing.total_ms },
                 { "wireMs", response.timing.wire_ms },
@@ -281,8 +285,8 @@ inline void update_peak (const std::shared_ptr<RunContext>& context) {
 // a null state.
 class SubmissionRequest {
     public:
-    SubmissionRequest (const std::shared_ptr<RunContext>& context, const vayu::Request& request)
-    : state_ (context->auth_refresh), request_ (request) {
+    SubmissionRequest (const std::shared_ptr<RunContext>& context, vayu::Request request)
+    : state_ (context->auth_refresh), request_ (std::move (request)) {
     }
 
     const vayu::Request& current () {
@@ -434,7 +438,7 @@ class ConstantLoadStrategy : public LoadStrategy {
 
                     for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
                         context->event_loop->submit (live.current (),
-                        [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+                        [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
                             handle_result (context, db, result);
                         });
                         submitted++;
@@ -484,7 +488,7 @@ class ConstantLoadStrategy : public LoadStrategy {
 
             auto submit_one = [&context, &db, &live] () {
                 context->event_loop->submit (live.current (),
-                [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+                [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
                     handle_result (context, db, result);
                 });
                 context->requests_sent++;
@@ -520,7 +524,7 @@ class IterationsLoadStrategy : public LoadStrategy {
 
         auto submit_one = [&context, &db, &live] () {
             context->event_loop->submit (live.current (),
-            [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
                 handle_result (context, db, result);
             });
             context->requests_sent++;
@@ -570,7 +574,7 @@ class RampUpLoadStrategy : public LoadStrategy {
 
         auto submit_one = [&context, &db, &live] () {
             context->event_loop->submit (live.current (),
-            [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
                 handle_result (context, db, result);
             });
             context->requests_sent++;
@@ -769,7 +773,7 @@ class CapacityLoadStrategy : public LoadStrategy {
 
         auto submit_one = [&context, &db, &request] () {
             context->event_loop->submit (request,
-            [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
                 handle_result (context, db, result);
             });
             context->requests_sent++;

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -50,9 +50,9 @@ void annotate (nlohmann::json& record, const ResultAnnotations& annotations) {
 
 } // namespace
 
-void handle_result (std::shared_ptr<RunContext> context,
+void handle_result (const std::shared_ptr<RunContext>& context,
 vayu::db::Database& /* db - unused, kept for API compat */,
-vayu::Result<vayu::Response> result,
+const vayu::Result<vayu::Response>& result,
 const ResultAnnotations& annotations) {
     // A transfer usually completes as a Response carrying error_code, but two
     // paths still produce a real Error: curl-handle creation failure, and the
@@ -435,7 +435,7 @@ class ConstantLoadStrategy : public LoadStrategy {
                     for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
                         context->event_loop->submit (live.current (),
                         [context, &db] (size_t, vayu::Result<vayu::Response> result) {
-                            handle_result (context, db, std::move (result));
+                            handle_result (context, db, result);
                         });
                         submitted++;
                         context->requests_sent++;
@@ -485,7 +485,7 @@ class ConstantLoadStrategy : public LoadStrategy {
             auto submit_one = [&context, &db, &live] () {
                 context->event_loop->submit (live.current (),
                 [context, &db] (size_t, vayu::Result<vayu::Response> result) {
-                    handle_result (context, db, std::move (result));
+                    handle_result (context, db, result);
                 });
                 context->requests_sent++;
             };
@@ -521,7 +521,7 @@ class IterationsLoadStrategy : public LoadStrategy {
         auto submit_one = [&context, &db, &live] () {
             context->event_loop->submit (live.current (),
             [context, &db] (size_t, vayu::Result<vayu::Response> result) {
-                handle_result (context, db, std::move (result));
+                handle_result (context, db, result);
             });
             context->requests_sent++;
         };
@@ -571,7 +571,7 @@ class RampUpLoadStrategy : public LoadStrategy {
         auto submit_one = [&context, &db, &live] () {
             context->event_loop->submit (live.current (),
             [context, &db] (size_t, vayu::Result<vayu::Response> result) {
-                handle_result (context, db, std::move (result));
+                handle_result (context, db, result);
             });
             context->requests_sent++;
         };
@@ -770,7 +770,7 @@ class CapacityLoadStrategy : public LoadStrategy {
         auto submit_one = [&context, &db, &request] () {
             context->event_loop->submit (request,
             [context, &db] (size_t, vayu::Result<vayu::Response> result) {
-                handle_result (context, db, std::move (result));
+                handle_result (context, db, result);
             });
             context->requests_sent++;
         };

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -72,8 +72,8 @@ bool insert_at_slot (std::vector<T>& store, size_t capacity, const ReservoirSlot
 }
 } // namespace
 
-MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorConfig config)
-: run_id_ (run_id), config_ (config) {
+MetricsCollector::MetricsCollector (std::string run_id, MetricsCollectorConfig config)
+: run_id_ (std::move (run_id)), config_ (config) {
     // Both sample rates are sampling *periods* - "keep 1 in N" - used as the
     // right-hand side of a `%` in the hot record path and as a divisor in the
     // reserve below. A 0 there is integer division by zero: a SIGFPE that takes
@@ -301,9 +301,8 @@ const Timing* phases) {
     // non-atomic `counts[i] += 1; total_count += 1`, which loses increments and
     // tears min/max under concurrent writers.
     // Convert milliseconds to microseconds for histogram precision
-    int64_t latency_us = static_cast<int64_t> (latency_ms * 1000.0);
-    if (latency_us < 1)
-        latency_us = 1; // Minimum 1 microsecond
+    const int64_t latency_us =
+    std::max<int64_t> (static_cast<int64_t> (latency_ms * 1000.0), 1);
     hdr_record_value_atomic (latency_histogram_, latency_us);
     // Also feed the rolling-window recorder for the live per-tick percentiles.
     hdr_interval_recorder_record_value_atomic (&interval_recorder_, latency_us);

--- a/engine/src/core/openapi_document.cpp
+++ b/engine/src/core/openapi_document.cpp
@@ -161,7 +161,11 @@ nlohmann::ordered_json plain_scalar (const std::string& text) {
         base = 10;
     } else if (digits.size () > 2 && digits[0] == '0' &&
     (digits[1] == 'x' || digits[1] == 'o' || digits[1] == 'b')) {
-        base = digits[1] == 'x' ? 16 : (digits[1] == 'o' ? 8 : 2);
+        switch (digits[1]) {
+        case 'x': base = 16; break;
+        case 'o': base = 8; break;
+        default: base = 2; break;
+        }
     }
     if (base != 0) {
         const std::string body{ base == 10 ? digits : digits.substr (2) };
@@ -456,6 +460,18 @@ std::string scalar_text (const nlohmann::ordered_json& value) {
     return is_plain_safe (text) ? text : dump (value);
 }
 
+/// The one-line spelling of a leaf: an empty container as its brackets, a
+/// scalar as `scalar_text`.
+std::string leaf_text (const nlohmann::ordered_json& value) {
+    if (value.is_object ()) {
+        return "{}";
+    }
+    if (value.is_array ()) {
+        return "[]";
+    }
+    return scalar_text (value);
+}
+
 void emit_map (const nlohmann::ordered_json& node, size_t indent, std::string& out);
 void emit_seq (const nlohmann::ordered_json& node, size_t indent, std::string& out);
 
@@ -474,7 +490,7 @@ void emit_after_marker (const nlohmann::ordered_json& value, size_t indent, std:
         return;
     }
     out += ' ';
-    out += value.is_object () ? "{}" : (value.is_array () ? "[]" : scalar_text (value));
+    out += leaf_text (value);
     out += '\n';
 }
 
@@ -509,7 +525,7 @@ void emit_seq (const nlohmann::ordered_json& node, size_t indent, std::string& o
         }
         out.append (indent, ' ');
         out += "- ";
-        out += item.is_object () ? "{}" : (item.is_array () ? "[]" : scalar_text (item));
+        out += leaf_text (item);
         out += '\n';
     }
 }
@@ -841,9 +857,7 @@ std::string emit_yaml (const nlohmann::ordered_json& document) {
         emit_seq (document, 0, out);
         return out;
     }
-    out += document.is_object () ?
-    "{}" :
-    (document.is_array () ? "[]" : scalar_text (document));
+    out += leaf_text (document);
     out += '\n';
     return out;
 }

--- a/engine/src/core/openapi_drafts.cpp
+++ b/engine/src/core/openapi_drafts.cpp
@@ -786,9 +786,15 @@ ImportTally* tally) {
         const json* response = sampler.deref (&entry.value ());
         auto example         = response_example (entry.key (), response, tally,
                 [&] (const json& node) -> std::optional<ExamplePayload> {
-            const std::string content_type = json_produced ?
-                    *json_produced :
-                    (produces.empty () ? std::string ("application/json") : produces.front ());
+            const std::string content_type = [&] {
+                if (json_produced) {
+                    return *json_produced;
+                }
+                if (produces.empty ()) {
+                    return std::string ("application/json");
+                }
+                return produces.front ();
+            }();
             if (const json* documented = as_record (prop (&node, "examples"))) {
                 // `declared[contentType] ?? declared["application/json"]`, then
                 // `!== undefined` - so an explicitly documented `null` is a body

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <format>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -791,7 +792,7 @@ const std::vector<ExportRequest>& requests) {
         }
         const std::string templated = path_template (*parts.path);
         const std::string method    = lower (entry.method);
-        if (!claimed.insert (method + " " + templated).second) {
+        if (!claimed.insert (std::format ("{} {}", method, templated)).second) {
             // Two requests on the same method and path are one operation in a
             // document, and the second would silently replace the first.
             assembly.notes.duplicate_operations += 1;

--- a/engine/src/core/openapi_walk.hpp
+++ b/engine/src/core/openapi_walk.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_set>
@@ -67,7 +68,7 @@ inline std::string lower (std::string value) {
 /// Which of the two formats Vayu imports a document claims to be. `None` is
 /// not an error - the document may be a perfectly good file that simply is not
 /// a contract, which is `NotASpecError` on the renderer side.
-enum class Dialect { None, V2, V3 };
+enum class Dialect : std::uint8_t { None, V2, V3 };
 
 /**
  * @brief The dialect @p document declares, by the renderer's detection order.

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -618,7 +618,7 @@ void RunContext::join_aux_threads () {
 
 void RunManager::register_run (const std::string& run_id, std::shared_ptr<RunContext> context) {
     std::lock_guard<std::mutex> lock (mutex_);
-    active_runs_[run_id] = context;
+    active_runs_[run_id] = std::move (context);
 }
 
 std::shared_ptr<RunContext> RunManager::get_run (const std::string& run_id) {
@@ -831,6 +831,7 @@ void RunManager::shutdown (std::chrono::milliseconds grace) {
 std::vector<std::shared_ptr<RunContext>> RunManager::get_all_active_runs () const {
     std::lock_guard<std::mutex> lock (mutex_);
     std::vector<std::shared_ptr<RunContext>> runs;
+    runs.reserve (active_runs_.size ());
     for (const auto& [id, context] : active_runs_) {
         runs.push_back (context);
     }
@@ -935,7 +936,7 @@ std::shared_ptr<const ScenarioExecution> scenario) {
             context->monitor_totals = std::make_unique<MonitorTotals> ();
             context->monitor_thread =
             std::thread ([context, &db, cfg = std::move (*monitor)] () mutable {
-                collect_monitor (context, &db, std::move (cfg));
+                collect_monitor (context, &db, cfg);
             });
         }
         return std::thread ([context, &db, verbose, this] () {
@@ -958,7 +959,7 @@ bool verbose) {
     });
 }
 
-void execute_load_test (std::shared_ptr<RunContext> context,
+void execute_load_test (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
 bool verbose,
 RunManager& manager) {
@@ -1815,9 +1816,9 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     context->closed.store (true, std::memory_order_release);
 }
 
-void collect_monitor (std::shared_ptr<RunContext> context,
+void collect_monitor (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
-MonitorConfig config) {
+const MonitorConfig& config) {
     auto& db = *db_ptr;
 
     // A scrape must not outlive its own cadence: the sample a late answer

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -508,8 +508,7 @@ const std::vector<std::optional<ScriptValidationTotals>>& per_step) {
 
 RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_errors, EngineDefaults engine_defaults)
 : run_id (id),
-  config (cfg.is_object () ? std::move (cfg) : nlohmann::json::object ()),
-  start_time_ms (0) {
+  config (cfg.is_object () ? std::move (cfg) : nlohmann::json::object ()) {
     // Initialize MetricsCollector with configuration from test config
     MetricsCollectorConfig mc_config;
     mc_config.max_errors = max_errors;
@@ -561,11 +560,11 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
     // between the caller's number and the engine setting's.
     if (config.value ("stream", false)) {
         vayu::StreamBounds bounds;
-        bounds.max_duration_ms = config.value ("maxStreamDurationMs",
-        static_cast<int64_t> (engine_defaults.stream_max_duration_ms));
-        bounds.max_events      = config.value ("maxStreamEvents",
-             static_cast<int64_t> (engine_defaults.stream_max_events));
-        stream_bounds          = bounds;
+        bounds.max_duration_ms =
+        config.value ("maxStreamDurationMs", engine_defaults.stream_max_duration_ms);
+        bounds.max_events =
+        config.value ("maxStreamEvents", engine_defaults.stream_max_events);
+        stream_bounds = bounds;
     }
     mc_config.max_exemplar_results =
     static_cast<size_t> (config.value ("max_exemplar_results",

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -8,6 +8,7 @@
 #include "vayu/core/scenario_data.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -305,11 +306,11 @@ struct XmlOpener {
 /// The three things a `<` in character data can open. Anything else it opens is
 /// a tag, and every tag is @ref XmlPosition::Markup - a `<!DOCTYPE` included,
 /// which ends at its `>` like a tag and carries nothing a row would bind into.
-constexpr XmlOpener XML_OPENERS[] = {
-    { "<!--", XmlPosition::Comment },
-    { "<![CDATA[", XmlPosition::Cdata },
-    { "<?", XmlPosition::ProcessingInstruction },
-};
+constexpr auto XML_OPENERS = std::to_array<XmlOpener> ({
+{ "<!--", XmlPosition::Comment },
+{ "<![CDATA[", XmlPosition::Cdata },
+{ "<?", XmlPosition::ProcessingInstruction },
+});
 
 /// Where @p c leaves a scan that is inside a tag but not inside an attribute
 /// value. Asked twice - once per ordinary character, once for the character

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -564,7 +564,7 @@ std::string escape_xml_cdata (const std::string& text) {
         out += SPLIT;
         cursor = found + CLOSER.size ();
     }
-    out.append (text, cursor, std::string::npos);
+    out.append (text, cursor);
     return out;
 }
 

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -440,7 +440,7 @@ const ScenarioExecution& execution) {
 
         context->event_loop->submit (request,
         [context, &db, state, vu, step_index, iteration, row, finish_step] (
-        size_t, vayu::Result<vayu::Response> result) {
+        size_t, const vayu::Result<vayu::Response>& result) {
             const bool errored = result.is_error () || result.value ().has_error ();
             if (!errored) {
                 state->steps.record (step_index, result.value ().timing.total_ms);

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -455,7 +455,7 @@ const ScenarioExecution& execution) {
             step_index, result.is_error () ? 0 : result.value ().status_code);
             finish_step (vu, step_index, errored,
             errored ? nullptr : &result.value ().cookie_lines);
-            handle_result (context, db, std::move (result),
+            handle_result (context, db, result,
             ResultAnnotations{ row, step_index, iteration });
         });
         context->requests_sent++;

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -8,6 +8,7 @@
 #include "vayu/core/scenario_plan.hpp"
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <unordered_map>
@@ -120,7 +121,7 @@ collect_requests (vayu::db::Database& db, const std::string& root_id, bool recur
     // renders `childCollections` above `requests` at every depth
     // (`CollectionItem.tsx`), and a recursive run has to execute in the order
     // the user is looking at (issue #431, the #360 rule one level up).
-    enum class Step { Descend, Emit };
+    enum class Step : std::uint8_t { Descend, Emit };
     struct Entry {
         Step step;
         std::string id;

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -433,8 +433,8 @@ nlohmann::json build_scenario_summary_payload (const ScenarioSummaryInputs& inpu
     return summary;
 }
 
-void execute_scenario_run (std::shared_ptr<RunContext> context,
-std::shared_ptr<const ScenarioExecution> execution,
+void execute_scenario_run (const std::shared_ptr<RunContext>& context,
+const std::shared_ptr<const ScenarioExecution>& execution,
 vayu::db::Database* db_ptr,
 vayu::http::CookieJar* cookie_jar,
 bool verbose,

--- a/engine/src/core/threshold_eval.cpp
+++ b/engine/src/core/threshold_eval.cpp
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <string_view>
 
 #include "vayu/core/run_manager.hpp"
@@ -19,7 +20,7 @@ namespace vayu::core {
 namespace {
 
 /// Which way a budget is breached.
-enum class Direction {
+enum class Direction : std::uint8_t {
     AtMost,  ///< passes while `actual <= limit` (a ceiling)
     AtLeast, ///< passes while `actual >= limit` (a floor)
 };

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1897,8 +1897,9 @@ void Database::prune_runs (int max_runs, int max_age_days) {
         std::chrono::system_clock::now ().time_since_epoch ())
                             .count ();
         // 0 disables the age cap; guard the multiply against overflow.
-        const int64_t age_cutoff =
-        max_age_days > 0 ? now - static_cast<int64_t> (max_age_days) * 86'400'000LL : 0;
+        const int64_t age_cutoff = max_age_days > 0 ?
+        now - (static_cast<int64_t> (max_age_days) * 86'400'000LL) :
+        0;
 
         int kept = 0;
         for (const auto& run : runs) {
@@ -2056,7 +2057,7 @@ int Database::add_inbox_request (const InboxRequest& capture, int64_t max_captur
     int assigned_id = 0;
     retry_on_busy ("append inbox capture", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
-            assigned_id = static_cast<int> (impl_->storage.insert (capture));
+            assigned_id = impl_->storage.insert (capture);
 
             if (max_captures > 0) {
                 const int64_t stored = impl_->storage.count<InboxRequest> (
@@ -2142,7 +2143,7 @@ const std::vector<PendingResultBody>& bodies) {
             std::vector<int> result_ids;
             result_ids.reserve (results.size ());
             for (const auto& result : results) {
-                result_ids.push_back (static_cast<int> (impl_->storage.insert (result)));
+                result_ids.push_back (impl_->storage.insert (result));
             }
 
             // Dedup within the run: identical bodies (the norm for a load test)
@@ -2164,7 +2165,7 @@ const std::vector<PendingResultBody>& bodies) {
                         blob.run_id  = results[pending.result_index].run_id;
                         blob.hash    = pending.body_hash;
                         blob.content = pending.body;
-                        blob_id = static_cast<int> (impl_->storage.insert (blob));
+                        blob_id      = impl_->storage.insert (blob);
                         blob_ids.emplace (pending.body_hash, blob_id);
                     }
                 }

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -308,7 +308,7 @@ curl_mime* apply_method_and_body (CURL* curl, const Request& request) {
 }
 
 std::string body_content_type_value (const Request& request) {
-    const std::string implied = vayu::http::implied_content_type (request.body);
+    std::string implied = vayu::http::implied_content_type (request.body);
     if (implied.empty ()) {
         return {};
     }

--- a/engine/src/http/managed_listener.cpp
+++ b/engine/src/http/managed_listener.cpp
@@ -98,8 +98,11 @@ const std::string& owner_label) {
 
         // bind_to_any_port answers -1 on failure, bind_to_port a bool; both
         // become 0 here so every caller has one "nothing is listening" check.
-        bound = port > 0 ? (server_->bind_to_port (bind_address, port) ? port : 0) :
-                           server_->bind_to_any_port (bind_address);
+        if (port > 0) {
+            bound = server_->bind_to_port (bind_address, port) ? port : 0;
+        } else {
+            bound = server_->bind_to_any_port (bind_address);
+        }
         if (bound <= 0) {
             return out;
         }

--- a/engine/src/http/oauth_client.cpp
+++ b/engine/src/http/oauth_client.cpp
@@ -315,7 +315,7 @@ nlohmann::json serialize_token (const vayu::db::OAuthToken& t) {
     out["expiresIn"]       = t.expires_in;
     out["createdAt"]       = t.created_at;
     out["expiresAt"]       = t.expires_in > 0 ?
-          nlohmann::json (t.created_at + t.expires_in * 1000) :
+          nlohmann::json (t.created_at + (t.expires_in * 1000)) :
           nlohmann::json (nullptr);
     out["hasRefreshToken"] = !t.refresh_token.empty ();
     return out;

--- a/engine/src/http/rate_limiter.cpp
+++ b/engine/src/http/rate_limiter.cpp
@@ -14,8 +14,7 @@
 
 namespace vayu::http {
 RateLimiter::RateLimiter (RateLimiterConfig config)
-: config_ (std::move (config)), tokens_ (0.0),
-  last_refill_ (std::chrono::steady_clock::now ()) {
+: config_ (config), tokens_ (0.0), last_refill_ (std::chrono::steady_clock::now ()) {
     // Set default burst size if not specified
     if (config_.burst_size == 0.0 && config_.target_rps > 0.0) {
         config_.burst_size = config_.target_rps * vayu::core::constants::http::BURST_MULTIPLIER;

--- a/engine/src/http/rate_limiter.cpp
+++ b/engine/src/http/rate_limiter.cpp
@@ -14,7 +14,7 @@
 
 namespace vayu::http {
 RateLimiter::RateLimiter (RateLimiterConfig config)
-: config_ (config), tokens_ (0.0), last_refill_ (std::chrono::steady_clock::now ()) {
+: config_ (config), last_refill_ (std::chrono::steady_clock::now ()) {
     // Set default burst size if not specified
     if (config_.burst_size == 0.0 && config_.target_rps > 0.0) {
         config_.burst_size = config_.target_rps * vayu::core::constants::http::BURST_MULTIPLIER;

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -481,7 +481,7 @@ nlohmann::json parse_auth_blob (const std::string& blob) {
 
 nlohmann::json resolve_inherited_auth (const std::vector<vayu::db::Collection>& chain) {
     for (auto it = chain.rbegin (); it != chain.rend (); ++it) {
-        const nlohmann::json auth = parse_auth_blob (it->auth);
+        nlohmann::json auth = parse_auth_blob (it->auth);
         if (auth_mode (auth) == "noauth") {
             return nlohmann::json (); // explicit "send nothing" ends the walk
         }

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <format>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -188,32 +189,33 @@ apply_config_update (vayu::db::Database& db, const std::string& body) {
             try {
                 int int_val = std::stoi (value);
                 if (existing->min_value && int_val < std::stoi (*existing->min_value)) {
-                    reason = "'" + key + "' must be at least " +
-                    *existing->min_value + " (got " + value + ")";
+                    reason = std::format ("'{}' must be at least {} (got {})",
+                    key, *existing->min_value, value);
                 } else if (existing->max_value && int_val > std::stoi (*existing->max_value)) {
-                    reason = "'" + key + "' must be at most " +
-                    *existing->max_value + " (got " + value + ")";
+                    reason = std::format ("'{}' must be at most {} (got {})",
+                    key, *existing->max_value, value);
                 }
             } catch (...) {
-                reason = "'" + key + "' must be an integer (got '" + value + "')";
+                reason = std::format ("'{}' must be an integer (got '{}')", key, value);
             }
         } else if (existing->type == "number") {
             try {
                 double double_val = std::stod (value);
                 if (existing->min_value && double_val < std::stod (*existing->min_value)) {
-                    reason = "'" + key + "' must be at least " +
-                    *existing->min_value + " (got " + value + ")";
+                    reason = std::format ("'{}' must be at least {} (got {})",
+                    key, *existing->min_value, value);
                 } else if (existing->max_value &&
                 double_val > std::stod (*existing->max_value)) {
-                    reason = "'" + key + "' must be at most " +
-                    *existing->max_value + " (got " + value + ")";
+                    reason = std::format ("'{}' must be at most {} (got {})",
+                    key, *existing->max_value, value);
                 }
             } catch (...) {
-                reason = "'" + key + "' must be a number (got '" + value + "')";
+                reason = std::format ("'{}' must be a number (got '{}')", key, value);
             }
         } else if (existing->type == "boolean") {
             if (value != "true" && value != "false") {
-                reason = "'" + key + "' must be 'true' or 'false' (got '" + value + "')";
+                reason =
+                std::format ("'{}' must be 'true' or 'false' (got '{}')", key, value);
             }
         } else if (existing->type == "enum") {
             std::vector<std::string> allowed;
@@ -232,8 +234,8 @@ apply_config_update (vayu::db::Database& db, const std::string& body) {
                 }
             }
             if (std::find (allowed.begin (), allowed.end (), value) == allowed.end ()) {
-                reason = "'" + key + "' must be one of [" + allowed_list +
-                "] (got '" + value + "')";
+                reason = std::format (
+                "'{}' must be one of [{}] (got '{}')", key, allowed_list, value);
             }
         }
 

--- a/engine/src/http/routes/cookies.cpp
+++ b/engine/src/http/routes/cookies.cpp
@@ -102,8 +102,15 @@ void register_cookie_routes (RouteContext& ctx) {
         std::optional<std::string> (req.get_param_value ("environmentId")) :
         std::nullopt;
         auto response = clear_cookies_response (ctx.cookie_jar, scope);
-        vayu::utils::log_info ("DELETE /cookies - scope=" +
-        (scope ? (scope->empty () ? std::string ("none") : *scope) : std::string ("all")) +
+        std::string scope_label;
+        if (!scope) {
+            scope_label = "all";
+        } else if (scope->empty ()) {
+            scope_label = "none";
+        } else {
+            scope_label = *scope;
+        }
+        vayu::utils::log_info ("DELETE /cookies - scope=" + scope_label +
         ", cleared=" + std::to_string (response["cleared"].get<size_t> ()));
         res.set_content (response.dump (), "application/json");
     });

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -16,6 +16,7 @@
  * - Server's HTTP status code is always in the response body, never translated to engine status
  */
 
+#include <array>
 #include <cmath>
 #include <optional>
 #include <regex>
@@ -752,50 +753,48 @@ const vayu::core::MonitorLimits& monitor_limits) {
         }
     }
 
-    namespace limits               = vayu::core::constants::run_config;
-    const NumericRunField fields[] = {
-        { "success_sample_rate", 1, 100000,
-        "It is a sampling period (keep 1 in N), and 0 is a division by zero." },
-        { "response_sample_rate", 1, 100000,
-        "It is a sampling period (keep 1 in N), and 0 is a division by zero." },
-        { "max_response_samples", 0, limits::MAX_RESPONSE_SAMPLES,
-        "Each retained sample holds a full response body." },
-        { "max_success_results", 0, limits::MAX_RETAINED_RESULTS,
-        "Each retained record holds a serialised timing breakdown, and the "
-        "store is reserved up front." },
-        { "max_slow_results", 0, limits::MAX_RETAINED_RESULTS,
-        "Each retained record holds a serialised timing breakdown, and the "
-        "store is reserved up front." },
-        { "slow_threshold_ms", 0, limits::MAX_SLOW_THRESHOLD_MS,
-        "0 disables outlier capture; a negative threshold would mark every "
-        "completion an outlier." },
-        { "max_sample_body_bytes", 0, limits::MAX_SAMPLE_BODY_BYTES,
-        "A captured body is copied on the completion callback, so the cap "
-        "bounds hot-path work; 0 keeps headers and metadata and no body." },
-        { "max_sample_bytes", 0, limits::MAX_SAMPLE_BYTES,
-        "It is the whole-run capture budget, and every byte under it is held "
-        "in memory until the run flushes." },
-        { "max_exemplar_results", 0, limits::MAX_EXEMPLAR_RESULTS,
-        "Each retained exemplar holds a captured exchange." },
-        { "concurrency", 1, limits::MAX_CONCURRENCY,
-        "Connections are pre-allocated per worker before any traffic flows." },
-        { "startConcurrency", 1, limits::MAX_CONCURRENCY,
-        "A ramp is seeded with this many in-flight requests before the first "
-        "duration check, and it is read as a size_t, so a negative start is "
-        "~1.8e19 of them." },
-        { "maxInFlight", 1, limits::MAX_IN_FLIGHT,
-        "It is a pending-request ceiling read as a size_t, so a negative value "
-        "is ~1.8e19 - it removes the backpressure the field exists to provide "
-        "rather than tightening it." },
-        { "sloMs", 1, limits::MAX_SLO_MS,
-        "It is the latency budget a capacity search looks for the edge of; a "
-        "non-positive budget has no edge, and one past a minute is longer than "
-        "the transfers any realistic run measures." },
-        { "timeout", 1, 86400000,
-        "A transfer with no timeout never completes, so the run can never "
-        "reach "
-        "a terminal status." },
-    };
+    namespace limits  = vayu::core::constants::run_config;
+    const auto fields = std::to_array<NumericRunField> ({
+    { "success_sample_rate", 1, 100000, "It is a sampling period (keep 1 in N), and 0 is a division by zero." },
+    { "response_sample_rate", 1, 100000, "It is a sampling period (keep 1 in N), and 0 is a division by zero." },
+    { "max_response_samples", 0, limits::MAX_RESPONSE_SAMPLES,
+    "Each retained sample holds a full response body." },
+    { "max_success_results", 0, limits::MAX_RETAINED_RESULTS,
+    "Each retained record holds a serialised timing breakdown, and the "
+    "store is reserved up front." },
+    { "max_slow_results", 0, limits::MAX_RETAINED_RESULTS,
+    "Each retained record holds a serialised timing breakdown, and the "
+    "store is reserved up front." },
+    { "slow_threshold_ms", 0, limits::MAX_SLOW_THRESHOLD_MS,
+    "0 disables outlier capture; a negative threshold would mark every "
+    "completion an outlier." },
+    { "max_sample_body_bytes", 0, limits::MAX_SAMPLE_BODY_BYTES,
+    "A captured body is copied on the completion callback, so the cap "
+    "bounds hot-path work; 0 keeps headers and metadata and no body." },
+    { "max_sample_bytes", 0, limits::MAX_SAMPLE_BYTES,
+    "It is the whole-run capture budget, and every byte under it is held "
+    "in memory until the run flushes." },
+    { "max_exemplar_results", 0, limits::MAX_EXEMPLAR_RESULTS,
+    "Each retained exemplar holds a captured exchange." },
+    { "concurrency", 1, limits::MAX_CONCURRENCY,
+    "Connections are pre-allocated per worker before any traffic flows." },
+    { "startConcurrency", 1, limits::MAX_CONCURRENCY,
+    "A ramp is seeded with this many in-flight requests before the first "
+    "duration check, and it is read as a size_t, so a negative start is "
+    "~1.8e19 of them." },
+    { "maxInFlight", 1, limits::MAX_IN_FLIGHT,
+    "It is a pending-request ceiling read as a size_t, so a negative value "
+    "is ~1.8e19 - it removes the backpressure the field exists to provide "
+    "rather than tightening it." },
+    { "sloMs", 1, limits::MAX_SLO_MS,
+    "It is the latency budget a capacity search looks for the edge of; a "
+    "non-positive budget has no edge, and one past a minute is longer than "
+    "the transfers any realistic run measures." },
+    { "timeout", 1, 86400000,
+    "A transfer with no timeout never completes, so the run can never "
+    "reach "
+    "a terminal status." },
+    });
     for (const auto& field : fields) {
         if (auto reason = check_numeric_field (config, field)) {
             return reason;

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -671,9 +671,12 @@ const nlohmann::json& scripts) {
 
         // A stream names its own terminal status: one the user stopped is
         // `Stopped`, which neither the response nor the error flag can say.
-        auto status = stream ?
-        stream->status :
-        (has_error ? vayu::RunStatus::Failed : vayu::RunStatus::Completed);
+        vayu::RunStatus status = vayu::RunStatus::Completed;
+        if (stream) {
+            status = stream->status;
+        } else if (has_error) {
+            status = vayu::RunStatus::Failed;
+        }
         db.update_run_status_with_retry (*run_id, status);
 
         // A design run reached a terminal status - trim the run history so
@@ -1143,9 +1146,13 @@ void register_execution_routes (RouteContext& ctx) {
                 StreamRecord record;
                 nlohmann::json scripts = nlohmann::json::object ();
                 record.events = vayu::http::stream_trace_node (context);
-                record.status = context.end_reason () == vayu::http::SseEndReason::Stopped ?
-                vayu::RunStatus::Stopped :
-                (response.has_error () ? vayu::RunStatus::Failed : vayu::RunStatus::Completed);
+                if (context.end_reason () == vayu::http::SseEndReason::Stopped) {
+                    record.status = vayu::RunStatus::Stopped;
+                } else if (response.has_error ()) {
+                    record.status = vayu::RunStatus::Failed;
+                } else {
+                    record.status = vayu::RunStatus::Completed;
+                }
 
                 const bool has_script_output = !post_request_script.empty () ||
                 !pre_script_result.tests.empty () ||
@@ -1549,11 +1556,15 @@ void register_execution_routes (RouteContext& ctx) {
         }
 
         nlohmann::json response;
-        response["runId"]   = run_id;
-        response["status"]  = to_string (vayu::RunStatus::Pending);
-        response["message"] = is_scenario_load ?
-        "Scenario load test started" :
-        (is_scenario ? "Collection run started" : "Load test started");
+        response["runId"]  = run_id;
+        response["status"] = to_string (vayu::RunStatus::Pending);
+        if (is_scenario_load) {
+            response["message"] = "Scenario load test started";
+        } else if (is_scenario) {
+            response["message"] = "Collection run started";
+        } else {
+            response["message"] = "Load test started";
+        }
 
         res.status = 202;
         res.set_content (response.dump (), "application/json");

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -748,17 +748,15 @@ parse_capture_pagination (const httplib::Request& req, int64_t retained) {
             limit = std::stoll (req.get_param_value ("limit"));
             if (limit <= 0)
                 limit = constants::inbox::DEFAULT_PAGE_LIMIT;
-            if (limit > retained)
-                limit = retained;
+            limit = std::min (limit, retained);
         } catch (...) {
             limit = constants::inbox::DEFAULT_PAGE_LIMIT;
         }
     }
     if (req.has_param ("offset")) {
         try {
-            offset = std::stoll (req.get_param_value ("offset"));
-            if (offset < 0)
-                offset = 0;
+            offset =
+            std::max<int64_t> (std::stoll (req.get_param_value ("offset")), 0);
         } catch (...) {
             offset = 0;
         }

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -10,6 +10,7 @@
  * @brief Metrics streaming routes (SSE endpoints for real-time stats)
  */
 
+#include <algorithm>
 #include <thread>
 
 #include "vayu/http/routes.hpp"
@@ -192,17 +193,15 @@ std::pair<int64_t, int64_t> parse_time_series_pagination (const httplib::Request
             limit = std::stoll (req.get_param_value ("limit"));
             if (limit <= 0)
                 limit = 5000;
-            if (limit > 50000)
-                limit = 50000; // Cap at 50k for safety
+            limit = std::min<int64_t> (limit, 50000); // Cap at 50k for safety
         } catch (...) {
             limit = 5000;
         }
     }
     if (req.has_param ("offset")) {
         try {
-            offset = std::stoll (req.get_param_value ("offset"));
-            if (offset < 0)
-                offset = 0;
+            offset =
+            std::max<int64_t> (std::stoll (req.get_param_value ("offset")), 0);
         } catch (...) {
             offset = 0;
         }

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -16,6 +16,7 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <optional>
@@ -43,7 +44,7 @@ RouteError body_error (const std::string& message) {
 }
 
 /** The two entity kinds this endpoint moves. */
-enum class Kind { Collection, Request };
+enum class Kind : std::uint8_t { Collection, Request };
 
 /**
  * One scope whose children are renumbered dense before the moves apply: the

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -1246,8 +1246,7 @@ void register_run_routes (RouteContext& ctx) {
             } catch (...) {
                 offset = 0;
             }
-            if (offset < 0)
-                offset = 0;
+            offset = std::max<int64_t> (offset, 0);
         }
 
         vayu::db::RunFilter filter;
@@ -1549,8 +1548,7 @@ void register_run_routes (RouteContext& ctx) {
             } catch (...) {
                 offset = 0;
             }
-            if (offset < 0)
-                offset = 0;
+            offset = std::max<int64_t> (offset, 0);
         }
 
         try {

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -35,6 +35,7 @@
 // file is built on all three.
 #include <cctype>
 #include <cstddef>
+#include <format>
 #include <map>
 #include <string>
 #include <string_view>
@@ -75,7 +76,7 @@ constexpr const char* ANY_OBJECT = "{ [key: string]: any }";
  * table, so removing or renaming one fails loudly instead of silently degrading
  * that member to `void` and breaking every `.to.not.` completion downstream.
  */
-constexpr const char* CHAIN_CONTINUATIONS[] = { "not", "and" };
+constexpr auto CHAIN_CONTINUATIONS = std::to_array<const char*> ({ "not", "and" });
 
 /**
  * @brief Host globals a browser or Node would have and this sandbox does not.
@@ -361,7 +362,7 @@ Signature parse_signature (const std::string& detail, const std::string& name) {
     sig.params = params_ok ? trim (raw_params) : "...args: any[]";
 
     const auto rest = trim (detail.substr (close + 1));
-    if (rest.rfind (":", 0) == 0) {
+    if (rest.rfind (':', 0) == 0) {
         sig.return_type = trim (rest.substr (1));
     }
     return sig;
@@ -470,7 +471,10 @@ void append_doc (std::string& out, const TypeNode& node, const std::string& inde
     std::string line;
     for (char c : body) {
         if (c == '\n') {
-            out += indent + " * " + line + "\n";
+            out += indent;
+            out += " * ";
+            out += line;
+            out += '\n';
             line.clear ();
         } else {
             line += c;
@@ -652,7 +656,7 @@ std::string generate_script_typedefs () {
             const Signature sig = parse_signature (child.detail, name);
             const std::string params = sig.parsed ? sig.params : "...args: any[]";
             const std::string ret = sig.return_type.empty () ? "void" : sig.return_type;
-            out += "declare function " + name + "(" + params + "): " + ret + ";\n";
+            out += std::format ("declare function {}({}): {};\n", name, params, ret);
         } else {
             out += "declare const " + name + ": " + field_type (child.detail) + ";\n";
         }

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <array>
+#include <format>
 #include <string>
 
 #include "vayu/http/routes.hpp"
@@ -692,9 +693,10 @@ nlohmann::json get_script_completions () {
         { "insertTextRules", INSERT_AS_SNIPPET },
         { "detail", accessor + ".has(name: string): boolean" },
         { "documentation",
-        "True when the " + noun + " exists and is enabled - the same rows " +
-        accessor + ".get() can read.\n\nExample:\nif (" + accessor + ".has('" +
-        scope.example + "')) { /* ... */ }" },
+        std::format ("True when the {} exists and is enabled - the same rows "
+                     "{}.get() can read.\n\nExample:\nif ({}.has('{}')) {{ /* "
+                     "... */ }}",
+        noun, accessor, accessor, scope.example) },
         { "sortText", sort + "has" } });
 
         completions.push_back ({ { "label", accessor + ".unset" },
@@ -702,11 +704,11 @@ nlohmann::json get_script_completions () {
         { "insertTextRules", INSERT_AS_SNIPPET },
         { "detail", accessor + ".unset(name: string): void" },
         { "documentation",
-        "Remove the " + noun +
-        " entirely. Not the same as setting it to \"\", which leaves an "
-        "enabled empty variable behind for {{template}} resolution to "
-        "find.\n\nExample:\n" +
-        accessor + ".unset('" + scope.example + "');" },
+        std::format (
+        "Remove the {} entirely. Not the same as setting it to \"\", "
+        "which leaves an enabled empty variable behind for "
+        "{{{{template}}}} resolution to find.\n\nExample:\n{}.unset('{}');",
+        noun, accessor, scope.example) },
         { "sortText", sort + "unset" } });
 
         completions.push_back ({ { "label", accessor + ".clear" },
@@ -719,8 +721,10 @@ nlohmann::json get_script_completions () {
         { "kind", KIND_FUNCTION }, { "insertText", accessor + ".toObject()" },
         { "detail", accessor + ".toObject(): Record<string, any>" },
         { "documentation",
-        "A plain object of every enabled " + noun + ", each value cast by its declared type.\n\nExample:\nconsole.log(" +
-        accessor + ".toObject());" },
+        std::format ("A plain object of every enabled {}, each value cast "
+                     "by its declared "
+                     "type.\n\nExample:\nconsole.log({}.toObject());",
+        noun, accessor) },
         { "sortText", sort + "toObject" } });
     }
 

--- a/engine/src/http/sse_stream.cpp
+++ b/engine/src/http/sse_stream.cpp
@@ -168,11 +168,13 @@ std::vector<nlohmann::json> SseStreamContext::stored_events () const {
     return stored_;
 }
 
-void SseStreamContext::note_response_open (int status_code, std::string status_text, Headers headers) {
+void SseStreamContext::note_response_open (int status_code,
+std::string status_text,
+const Headers& headers) {
     nlohmann::json open;
     open["statusCode"] = status_code;
     open["statusText"] = std::move (status_text);
-    open["headers"]    = std::move (headers);
+    open["headers"]    = headers;
     append ("open", open);
 }
 

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -509,35 +509,35 @@ Json serialize (const vayu::db::Request& r) {
     return json;
 }
 
-Json serialize (const vayu::db::RequestExample& x) {
+Json serialize (const vayu::db::RequestExample& example) {
     Json json;
-    json["id"]        = x.id;
-    json["requestId"] = x.request_id;
-    json["name"]      = x.name;
-    json["status"]    = x.status;
+    json["id"]        = example.id;
+    json["requestId"] = example.request_id;
+    json["name"]      = example.name;
+    json["status"]    = example.status;
 
     // Headers - stored as JSON array of KeyValueEntry, same as a request's.
     // An unparseable blob degrades to `[]` exactly as the request serializer
     // does: one bad row must not fail the list read it sits in.
-    if (x.headers.empty ()) {
+    if (example.headers.empty ()) {
         json["headers"] = Json::array ();
     } else {
         try {
-            json["headers"] = Json::parse (x.headers);
+            json["headers"] = Json::parse (example.headers);
         } catch (const std::exception&) {
             json["headers"] = Json::array ();
         }
     }
 
-    json["body"]        = x.body;
-    json["contentType"] = x.content_type;
-    json["order"]       = x.order;
-    json["origin"]      = x.origin;
+    json["body"]        = example.body;
+    json["contentType"] = example.content_type;
+    json["order"]       = example.order;
+    json["origin"]      = example.origin;
     // Always present, never inferred from the body's length: only the writer
     // knew the response was cut (issue #659).
-    json["bodyTruncated"] = x.body_truncated;
-    json["createdAt"]     = x.created_at;
-    json["updatedAt"]     = x.updated_at;
+    json["bodyTruncated"] = example.body_truncated;
+    json["createdAt"]     = example.created_at;
+    json["updatedAt"]     = example.updated_at;
     return json;
 }
 

--- a/engine/tests/bounds_primitives_test.cpp
+++ b/engine/tests/bounds_primitives_test.cpp
@@ -26,9 +26,9 @@
  * libcurl only ever writes on failure - so a buffer that is not cleared answers
  * a later success with an earlier failure's message.
  *
- * The scanning half is for what no behavioural test can reach. The CI tidy gate
- * scopes to a pull request's changed lines, so nothing holds either count at
- * zero once these lines stop being new; the scan is what does. Unlike a
+ * The scanning half is for what no behavioural test can reach. The tidy gates
+ * lint only the files a change touches (#946), so nothing holds either count
+ * at zero in a file nobody edits; the scan is what does. Unlike a
  * subscript, both spellings are tokens - `from_chars` and `CURLOPT_ERRORBUFFER`
  * - so this family is scannable after all, for the two shapes that had copies.
  */

--- a/engine/tests/character_cast_test.cpp
+++ b/engine/tests/character_cast_test.cpp
@@ -25,9 +25,9 @@
  * hand-rolled copy *works* - it is simply a copy, and a copy of a primitive
  * does not receive the primitive's fixes. Eight of them had accumulated by the
  * time #945's batch 3 counted: six spelling a digest as a `string_view`, and
- * three more spelling a sqlite TEXT column as `const char*`. The CI tidy gate
- * scopes to a pull request's changed lines, so nothing holds the count at zero
- * once these lines stop being new; the scan is what does. Reverting any one of
+ * three more spelling a sqlite TEXT column as `const char*`. The tidy gates
+ * lint only the files a change touches (#946), so nothing holds the count at
+ * zero in a file nobody edits; the scan is what does. Reverting any one of
  * the rewrites fails it.
  */
 

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -1087,6 +1087,7 @@ TEST (ClientCertificatePaths, ALoadRunCarriesTheRegistryAndStillTransfers) {
     EventLoop loop (config);
     loop.start ();
     std::vector<Request> requests;
+    requests.reserve (3);
     for (int i = 0; i < 3; ++i) {
         requests.push_back (get_request (upstream.url ("/hello")));
     }

--- a/engine/tests/curl_transfer_test.cpp
+++ b/engine/tests/curl_transfer_test.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "optional_assert.hpp"
@@ -116,7 +117,7 @@ class CurlTransferTest : public ::testing::Test {
     /// Run one request through the event loop with the given config.
     vayu::Result<vayu::Response> run_once (const vayu::Request& request,
     vayu::http::EventLoopConfig config = {}) {
-        vayu::http::EventLoop loop (config);
+        vayu::http::EventLoop loop (std::move (config));
         loop.start ();
         auto handle = loop.submit_async (request);
         auto result = handle.future.get ();

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1003,8 +1003,8 @@ TEST_F (DatabaseTest, PruneRunsByAgeDeletesOldOnly) {
                         .count ();
     const int64_t day = 86'400'000LL;
 
-    seed_run_with_children (db, "fresh", now - 1 * day);
-    seed_run_with_children (db, "stale", now - 40 * day);
+    seed_run_with_children (db, "fresh", now - (1 * day));
+    seed_run_with_children (db, "stale", now - (40 * day));
 
     // Count cap disabled; drop anything older than 30 days.
     db.prune_runs (0, 30);
@@ -1073,7 +1073,7 @@ TEST_F (DatabaseTest, PruneRunsByAgeSparesABaselineRun) {
     std::chrono::system_clock::now ().time_since_epoch ())
                         .count ();
     const int64_t day             = 86'400'000LL;
-    const int64_t ninety_days_ago = now - 90 * day;
+    const int64_t ninety_days_ago = now - (90 * day);
     seed_run_with_children (db, "pinned_stale", ninety_days_ago);
     seed_run_with_children (db, "stale", ninety_days_ago);
     ASSERT_HAS_VALUE (db.set_run_baseline ("pinned_stale", true));

--- a/engine/tests/event_loop_test.cpp
+++ b/engine/tests/event_loop_test.cpp
@@ -216,7 +216,7 @@ TEST_F (EventLoopTest, ConcurrentRequests) {
         request.method = vayu::HttpMethod::GET;
         request.url    = test_url;
 
-        loop.submit (request, [&] (size_t, vayu::Result<vayu::Response> result) {
+        loop.submit (request, [&] (size_t, const vayu::Result<vayu::Response>& result) {
             if (result.is_ok ()) {
                 completed_count++;
             }
@@ -295,7 +295,7 @@ TEST_F (EventLoopTest, CancelPendingRequest) {
     std::atomic<bool> was_error{ false };
 
     size_t request_id =
-    loop.submit (request, [&] (size_t, vayu::Result<vayu::Response> result) {
+    loop.submit (request, [&] (size_t, const vayu::Result<vayu::Response>& result) {
         callback_called = true;
         was_error       = result.is_error ();
     });
@@ -365,6 +365,7 @@ TEST_F (ThreadPoolTest, SubmitMultipleTasks) {
 
     std::atomic<int> counter{ 0 };
     std::vector<std::future<int>> futures;
+    futures.reserve (10);
 
     for (int i = 0; i < 10; ++i) {
         futures.push_back (pool.submit ([&counter, i] () {
@@ -510,7 +511,8 @@ TEST_F (EventLoopTest, ProgressCallback) {
     std::atomic<bool> completed{ false };
 
     loop.submit (
-    request, [&] (size_t, vayu::Result<vayu::Response>) { completed = true; },
+    request,
+    [&] (size_t, const vayu::Result<vayu::Response>&) { completed = true; },
     [&] (size_t, size_t downloaded, size_t total) {
         progress_calls++;
         // Progress callback should report download progress

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -75,7 +75,11 @@ class MockHttpBin {
             for (const auto& [k, v] : req.headers) {
                 if (!first)
                     body += ",";
-                body += "\"" + k + "\":\"" + v + "\"";
+                body += '"';
+                body += k;
+                body += "\":\"";
+                body += v;
+                body += '"';
                 first = false;
             }
             body += "}";

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -231,7 +231,7 @@ class InboxListenerTest : public ::testing::Test {
         vayu::tests::remove_database_files (DB_PATH);
     }
 
-    InboxManager::StartResult start (InboxStartRequest request = {}) {
+    InboxManager::StartResult start (const InboxStartRequest& request = {}) {
         auto result = manager_->start (*db_, request);
         EXPECT_TRUE (result.ok) << result.error_message;
         return result;

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -341,6 +341,7 @@ TEST_F (MetricsCollectorTest, ThreadSafePerCodeCounts) {
     // Codes spanning every class plus one out-of-range overflow code.
     const std::vector<int> codes = { 200, 201, 301, 404, 500, 503, 999 };
     std::vector<std::thread> threads;
+    threads.reserve (num_threads);
 
     for (int t = 0; t < num_threads; ++t) {
         threads.emplace_back ([this, &codes] () {
@@ -376,6 +377,7 @@ TEST_F (MetricsCollectorTest, ThreadSafeRecording) {
     const int num_threads         = 8;
     const int requests_per_thread = 1000;
     std::vector<std::thread> threads;
+    threads.reserve (num_threads);
 
     for (int t = 0; t < num_threads; ++t) {
         threads.emplace_back ([this] () {

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -398,7 +398,7 @@ TEST_F (MetricsCollectorTest, ThreadSafeRecording) {
     EXPECT_EQ (collector->total_requests (), num_threads * requests_per_thread);
     EXPECT_EQ (collector->total_errors (), num_threads * (requests_per_thread / 10));
     EXPECT_EQ (collector->success_count (),
-    num_threads * requests_per_thread - num_threads * (requests_per_thread / 10));
+    (num_threads * requests_per_thread) - (num_threads * (requests_per_thread / 10)));
 }
 
 // The std::atomic counters above are not the interesting part - the histogram

--- a/engine/tests/mock_issuer_test.cpp
+++ b/engine/tests/mock_issuer_test.cpp
@@ -66,7 +66,11 @@ json decode_jwt_payload (const std::string& jwt) {
     }
     std::string standard = parts[1];
     for (char& c : standard) {
-        c = c == '-' ? '+' : (c == '_' ? '/' : c);
+        if (c == '-') {
+            c = '+';
+        } else if (c == '_') {
+            c = '/';
+        }
     }
     const auto decoded = vayu::utils::base64_decode (standard);
     if (!decoded) {

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -436,6 +436,7 @@ TEST_P (MutualTlsTest, ALoadRunPresentsTheCertificate) {
     EventLoop loop (config);
     loop.start ();
     std::vector<Request> requests;
+    requests.reserve (3);
     for (int i = 0; i < 3; ++i) {
         requests.push_back (get_request (server.url ("/hello")));
     }

--- a/engine/tests/operation_match_test.cpp
+++ b/engine/tests/operation_match_test.cpp
@@ -75,6 +75,7 @@ const std::string& operation_id = "") {
 std::vector<std::string> matched_ids (const vayu::core::MatchResult& result,
 const std::vector<MatchableRequest>& requests) {
     std::vector<std::string> ids;
+    ids.reserve (result.matched.size ());
     for (const auto& pair : result.matched) {
         ids.push_back (requests[pair.request].id);
     }
@@ -85,6 +86,7 @@ const std::vector<MatchableRequest>& requests) {
 std::vector<std::string> matched_operations (const vayu::core::MatchResult& result,
 const std::vector<MatchableOperation>& operations) {
     std::vector<std::string> ids;
+    ids.reserve (result.matched.size ());
     for (const auto& pair : result.matched) {
         ids.push_back (operations[pair.operation].operation_id);
     }
@@ -94,6 +96,7 @@ const std::vector<MatchableOperation>& operations) {
 std::vector<std::string> unmatched_request_ids (const vayu::core::MatchResult& result,
 const std::vector<MatchableRequest>& requests) {
     std::vector<std::string> ids;
+    ids.reserve (result.unmatched_requests.size ());
     for (const size_t index : result.unmatched_requests) {
         ids.push_back (requests[index].id);
     }
@@ -103,6 +106,7 @@ const std::vector<MatchableRequest>& requests) {
 std::vector<std::string> unmatched_operation_ids (const vayu::core::MatchResult& result,
 const std::vector<MatchableOperation>& operations) {
     std::vector<std::string> ids;
+    ids.reserve (result.unmatched_operations.size ());
     for (const size_t index : result.unmatched_operations) {
         ids.push_back (operations[index].operation_id);
     }

--- a/engine/tests/optional_assert_test.cpp
+++ b/engine/tests/optional_assert_test.cpp
@@ -132,8 +132,8 @@ constexpr std::string_view kScanExempt = "tests/optional_assert_test.cpp";
 /**
  * Every test file guards an engaged optional with `ASSERT_HAS_VALUE`. The
  * gtest spelling reads the same at run time and the optional check cannot
- * follow it, which is where 561 findings came from (#980); a file that brings
- * it back would pass CI, because the gate lints changed lines only.
+ * follow it, which is where 561 findings came from (#980); an untouched file
+ * that carries it would pass CI, because the gate lints only changed files.
  */
 TEST (OptionalAssertGuard, NoTestFileGuardsWithAssertTrue) {
     const std::filesystem::path tests =

--- a/engine/tests/rate_limit_test.cpp
+++ b/engine/tests/rate_limit_test.cpp
@@ -59,6 +59,7 @@ TEST_F (RateLimiterTest, EnforcesTargetRPS) {
 
     // Submit all requests quickly - rate limiter will pace them
     std::vector<RequestHandle> handles;
+    handles.reserve (200);
     for (int i = 0; i < 200; ++i) {
         handles.push_back (loop.submit_async (req));
     }
@@ -166,6 +167,7 @@ TEST_F (RateLimiterTest, EnforcesTargetRPSAcrossMultipleWorkers) {
     auto submission_start = std::chrono::steady_clock::now ();
 
     std::vector<RequestHandle> handles;
+    handles.reserve (200);
     for (int i = 0; i < 200; ++i) {
         handles.push_back (loop.submit_async (req));
     }

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -332,7 +332,7 @@ TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
     200);
     const auto before_row = db_->get_collection (id);
     ASSERT_HAS_VALUE (before_row);
-    const auto before = *before_row;
+    const auto& before = *before_row;
 
     for (const char* field : { "variables", "auth", "dataSchema" }) {
         for (const json& bad : wrong_shapes ()) {
@@ -349,7 +349,7 @@ TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
     // the junk, so asserting only the response would pass either way.
     const auto after_row = db_->get_collection (id);
     ASSERT_HAS_VALUE (after_row);
-    const auto after = *after_row;
+    const auto& after = *after_row;
     EXPECT_EQ (after.variables, before.variables);
     EXPECT_EQ (after.auth, before.auth);
     EXPECT_EQ (after.data_schema, before.data_schema);
@@ -652,7 +652,7 @@ TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
     200);
     const auto before_row = db_->get_request (id);
     ASSERT_HAS_VALUE (before_row);
-    const auto before = *before_row;
+    const auto& before = *before_row;
 
     for (const char* field : { "body", "auth" }) {
         for (const json& bad : wrong_shapes ()) {
@@ -666,7 +666,7 @@ TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
 
     const auto after_row = db_->get_request (id);
     ASSERT_HAS_VALUE (after_row);
-    const auto after = *after_row;
+    const auto& after = *after_row;
     EXPECT_EQ (after.body, before.body);
     EXPECT_EQ (after.auth, before.auth)
     << "a stored non-object auth reads back as no auth, and the request goes "

--- a/engine/tests/run_stop_test.cpp
+++ b/engine/tests/run_stop_test.cpp
@@ -106,7 +106,8 @@ TEST_F (EventLoopStopTest, StopCancelsInFlightAgainstAHungUpstream) {
     std::atomic<size_t> completed{ 0 };
     std::atomic<size_t> errored{ 0 };
     for (size_t i = 0; i < TOTAL; ++i) {
-        loop.submit (hang_request (), [&] (size_t, vayu::Result<vayu::Response> result) {
+        loop.submit (hang_request (),
+        [&] (size_t, const vayu::Result<vayu::Response>& result) {
             if (result.is_error ())
                 errored++;
             completed++;
@@ -147,7 +148,7 @@ TEST_F (EventLoopStopTest, StopDiscardsTheQueuedBacklog) {
     std::atomic<size_t> completed{ 0 };
     for (size_t i = 0; i < TOTAL; ++i) {
         loop.submit (hang_request (),
-        [&] (size_t, vayu::Result<vayu::Response>) { completed++; });
+        [&] (size_t, const vayu::Result<vayu::Response>&) { completed++; });
     }
 
     auto stop_start = Clock::now ();
@@ -172,7 +173,7 @@ TEST_F (EventLoopStopTest, DrainingStopHonoursItsDeadline) {
     std::atomic<size_t> completed{ 0 };
     for (size_t i = 0; i < TOTAL; ++i) {
         loop.submit (hang_request (),
-        [&] (size_t, vayu::Result<vayu::Response>) { completed++; });
+        [&] (size_t, const vayu::Result<vayu::Response>&) { completed++; });
     }
 
     auto wait_start = Clock::now ();

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -162,6 +162,7 @@ class ScenarioPlanTest : public ::testing::Test {
 
     std::vector<std::string> step_ids (const vayu::core::ScenarioPlan& plan) {
         std::vector<std::string> ids;
+        ids.reserve (plan.steps.size ());
         for (const auto& step : plan.steps) {
             ids.push_back (step.request_id);
         }
@@ -561,7 +562,7 @@ TEST_F (ScenarioPlanTest, PlanOverMaxStepsIsRejectedWithCountAndCap) {
     vayu::core::resolve_scenario (*db_, block ("col"), options (/*max_steps=*/2));
     EXPECT_FALSE (resolved.ok);
     EXPECT_NE (resolved.error.find ("3 steps"), std::string::npos) << resolved.error;
-    EXPECT_NE (resolved.error.find ("2"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ('2'), std::string::npos) << resolved.error;
     EXPECT_NE (resolved.error.find ("maxScenarioSteps"), std::string::npos)
     << resolved.error;
 }
@@ -1025,7 +1026,7 @@ TEST_F (ScenarioPlanTest, MalformedBlockFieldsAreRejected) {
     seed_collection ("col", "");
     seed_request ("req", "col");
 
-    const auto rejected = [&] (json scenario) {
+    const auto rejected = [&] (const json& scenario) {
         const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
         EXPECT_FALSE (resolved.ok) << scenario.dump ();
         EXPECT_FALSE (resolved.error.empty ());

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -12,6 +12,7 @@
 // its `${1:...}` placeholders as literal text, which looks like a typo rather
 // than a feature.
 
+#include <format>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
@@ -308,7 +309,8 @@ TEST (ScriptCompletions, TheOfferedVariableScopeMethodsAreExactlyWhatTheRuntimeH
                 continue;
             }
             offered++;
-            probe += "if (typeof " + label + " !== 'function') missing.push('" + label + "');\n";
+            probe += std::format (
+            "if (typeof {} !== 'function') missing.push('{}');\n", label, label);
         }
     }
     ASSERT_GT (offered, 0)
@@ -397,10 +399,12 @@ TEST (ScriptCompletions, EveryOfferedExpectMatcherExistsInTheRuntime) {
         // A function must be callable; a chainer or terminal getter only has to
         // be a declared own property of the object it hangs off.
         const std::string check = item.value ("kind", 0) == KIND_FUNCTION ?
-        "if (typeof " + target + "[\"" + member +
-        "\"] !== \"function\") { throw new Error(\"missing\"); }" :
-        "if (!Object.getOwnPropertyDescriptor(" + target + ", \"" + member +
-        "\")) { throw new Error(\"missing\"); }";
+        std::format ("if (typeof {}[\"{}\"] !== \"function\") "
+                     "{{ throw new Error(\"missing\"); }}",
+        target, member) :
+        std::format ("if (!Object.getOwnPropertyDescriptor({}, \"{}\")) "
+                     "{{ throw new Error(\"missing\"); }}",
+        target, member);
 
         const std::string script = "pm.test(\"t\", function() { " + check + " });";
         auto result = engine.execute_test (script, request, response, env);

--- a/engine/tests/script_variables_test.cpp
+++ b/engine/tests/script_variables_test.cpp
@@ -31,6 +31,7 @@
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
+#include "vayu/http/request_exchange.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
@@ -39,16 +40,6 @@
 using nlohmann::json;
 using vayu::json::parse_variables;
 using vayu::json::serialize_variables;
-
-namespace vayu::http::routes {
-// Defined in execution.cpp. The tail of POST /execute: writes back whatever the
-// pre/post-request scripts left in the three variable scopes.
-void persist_script_variables (vayu::db::Database& db,
-const vayu::db::Run& run,
-const vayu::Environment& env,
-const vayu::Environment& globals,
-const vayu::Environment& collectionVariables);
-} // namespace vayu::http::routes
 
 namespace {
 

--- a/engine/tests/spec_diff_test.cpp
+++ b/engine/tests/spec_diff_test.cpp
@@ -104,6 +104,7 @@ ComparableRequest request_from (const std::string& id, const SpecRequestDraft& e
 /** The compared field names of one changed request, sorted for comparison. */
 std::vector<std::string> field_names (const vayu::core::ChangedRequest& changed) {
     std::vector<std::string> names;
+    names.reserve (changed.fields.size ());
     for (const auto& field : changed.fields) {
         names.emplace_back (vayu::core::spec_field_name (field.field));
     }
@@ -152,6 +153,7 @@ class SpecDiffTest : public ::testing::Test {
     /** The whole collection as an import of `bound_document ()` left it. */
     [[nodiscard]] std::vector<ComparableRequest> bound_collection () const {
         std::vector<ComparableRequest> requests;
+        requests.reserve (bound_.size ());
         for (size_t i = 0; i < bound_.size (); ++i) {
             requests.push_back (request_from ("req_" + std::to_string (i), bound_[i]));
         }
@@ -733,6 +735,7 @@ TEST_F (SpecDiffTest, LeavesARequestAloneWhenTheDocumentAgreesWithTheVerbItHolds
 /** The ticked field names of one changed entry, sorted. */
 std::vector<std::string> safe_field_names (const vayu::core::SafeChangedApply& entry) {
     std::vector<std::string> names;
+    names.reserve (entry.fields.size ());
     for (const SpecField field : entry.fields) {
         names.emplace_back (vayu::core::spec_field_name (field));
     }

--- a/engine/tests/spec_match_route_test.cpp
+++ b/engine/tests/spec_match_route_test.cpp
@@ -20,6 +20,7 @@
  * extracted core is exercised directly, no in-process HTTP server.
  */
 
+#include <array>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -176,18 +177,17 @@ TEST_F (SpecMatchRouteTest, RefusesAPayloadTheStoreWouldRefuse) {
         json body;
         const char* what;
     };
-    const Case cases[] = {
-        { json::object (), "no collectionId" },
-        { json{ { "collectionId", "" }, { "operations", json::array () } }, "empty collectionId" },
-        { json{ { "collectionId", "col_x" } }, "no operations" },
-        { json{ { "collectionId", "col_x" }, { "operations", "nope" } }, "operations not an array" },
-        { json{ { "collectionId", "col_x" },
-          { "operations", json::array ({ json::object () }) } },
-        "an operation with no method or path" },
-        { json{ { "collectionId", "col_x" },
-          { "operations", json::array ({ json{ { "method", "GET" }, { "path", "" } } }) } },
-        "an operation with an empty path" },
-    };
+    const auto cases = std::to_array<Case> ({
+    { json::object (), "no collectionId" },
+    { json{ { "collectionId", "" }, { "operations", json::array () } }, "empty collectionId" },
+    { json{ { "collectionId", "col_x" } }, "no operations" },
+    { json{ { "collectionId", "col_x" }, { "operations", "nope" } }, "operations not an array" },
+    { json{ { "collectionId", "col_x" }, { "operations", json::array ({ json::object () }) } },
+    "an operation with no method or path" },
+    { json{ { "collectionId", "col_x" },
+      { "operations", json::array ({ json{ { "method", "GET" }, { "path", "" } } }) } },
+    "an operation with an empty path" },
+    });
     for (const auto& one : cases) {
         auto [status, body] = routes::match_spec_operations_response (*db_, one.body);
         EXPECT_EQ (status, 400) << one.what << ": " << body.dump ();

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -21,6 +21,7 @@
  * route tests (no in-process HTTP server).
  */
 
+#include <array>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -598,16 +599,16 @@ TEST_F (SpecsRouteTest, OperationIdentityIsUnsetByAnExplicitNullOnUpdate) {
 
 TEST_F (SpecsRouteTest, RejectsAnOperationIdentityThatIsNotOne) {
     const std::string col_id = create_collection (json{ { "name", "Pets" } });
-    const json bad[]         = {
-        json ("GET /pets"),                            // not an object
-        json{ { "operationId", "listPets" } },         // no method/path
-        json{ { "method", "GET" } },                   // no path
-        json{ { "path", "/pets" } },                   // no method
-        json{ { "method", "" }, { "path", "/pets" } }, // empty method
-        json{ { "method", "GET" }, { "path", "pets" } }, // not a template path
-        json{ { "method", "GET" }, { "path", "https://x/p" } }, // a concrete URL
-        json{ { "method", "GET" }, { "path", "/pets" }, { "operationId", 7 } },
-    };
+    const auto bad           = std::to_array<json> ({
+    json ("GET /pets"),                            // not an object
+    json{ { "operationId", "listPets" } },         // no method/path
+    json{ { "method", "GET" } },                   // no path
+    json{ { "path", "/pets" } },                   // no method
+    json{ { "method", "" }, { "path", "/pets" } }, // empty method
+    json{ { "method", "GET" }, { "path", "pets" } }, // not a template path
+    json{ { "method", "GET" }, { "path", "https://x/p" } }, // a concrete URL
+    json{ { "method", "GET" }, { "path", "/pets" }, { "operationId", 7 } },
+    });
     for (const auto& operation : bad) {
         json body = { { "collectionId", col_id }, { "name", "r" }, { "method", "GET" },
             { "url", "https://example.test/pets" }, { "specOperation", operation } };

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -55,7 +55,6 @@ std::pair<int, nlohmann::json>
 get_spec_document_meta_response (vayu::db::Database& db, const std::string& id);
 std::pair<int, nlohmann::json>
 delete_spec_document_response (vayu::db::Database& db, const std::string& id);
-std::string spec_content_hash (const std::string& content);
 // Defined in collections.cpp / requests.cpp / import.cpp.
 std::pair<int, nlohmann::json>
 create_collection_response (vayu::db::Database& db, const nlohmann::json& json);

--- a/engine/tests/sse_load_stream_test.cpp
+++ b/engine/tests/sse_load_stream_test.cpp
@@ -276,7 +276,7 @@ TEST (SseLoadStreamTest, BalancedAccountingUnderConcurrency) {
 
     for (size_t i = 0; i < STREAMS; ++i) {
         loop.submit (stream_request (server.url ("/endless"), 3, 20000),
-        [&] (size_t, vayu::Result<vayu::Response> result) {
+        [&] (size_t, const vayu::Result<vayu::Response>& result) {
             completed.fetch_add (1);
             if (result.is_ok ()) {
                 if (!result.value ().has_error ()) {

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -771,7 +771,7 @@ class RelayTest : public ::testing::Test {
         return context;
     }
 
-    httplib::Client client () {
+    httplib::Client client () const {
         httplib::Client client ("127.0.0.1", port_);
         client.set_read_timeout (20, 0);
         return client;

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -756,6 +756,7 @@ class RelayTest : public ::testing::Test {
     /// so the relay replays what a transfer actually produced.
     std::shared_ptr<SseStreamContext> streamed (int count) {
         std::vector<std::string> chunks;
+        chunks.reserve (static_cast<size_t> (count));
         for (int i = 0; i < count; ++i) {
             chunks.push_back ("data: " + std::to_string (i) + "\n\n");
         }
@@ -941,6 +942,7 @@ class StreamExecuteTest : public ::testing::Test {
     /// consumer really does assemble them over time.
     void serve (int count) {
         std::vector<std::string> chunks;
+        chunks.reserve (static_cast<size_t> (count));
         for (int i = 0; i < count; ++i) {
             chunks.push_back ("id: e" + std::to_string (i) +
             "\nevent: tick\ndata: {\"n\": " + std::to_string (i) + "}\n\n");

--- a/engine/tests/stats_route_test.cpp
+++ b/engine/tests/stats_route_test.cpp
@@ -208,7 +208,7 @@ TEST_F (StatsRouteTest, StoredTickPayloadKeysAndTypesArePinned) {
 TEST_F (StatsRouteTest, TickPaginationNeverSplitsATick) {
     const std::string id = seed_run ();
     for (int i = 0; i < 3; ++i) {
-        auto sample = sample_at (1000 + i * 1000, static_cast<double> (i));
+        auto sample = sample_at (1000 + (i * 1000), static_cast<double> (i));
         add_tick (id, sample.timestamp, vayu::core::build_metric_tick_payload (sample));
     }
 

--- a/engine/tests/tls_backend.hpp
+++ b/engine/tests/tls_backend.hpp
@@ -12,6 +12,7 @@
  * when a build's backend changes. It lives here so there is one.
  */
 
+#include <cstdint>
 #include <curl/curl.h>
 
 #include <string>
@@ -31,7 +32,7 @@ inline std::string tls_backend_name () {
 }
 
 /// The shape a client identity is stored in.
-enum class ClientIdentityFormat {
+enum class ClientIdentityFormat : std::uint8_t {
     /// A PEM certificate and a PEM key, the pair libcurl reads by default.
     PemPair,
     /// A PKCS#12 file, which libcurl reads only when told the type is `P12`.

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -781,6 +781,7 @@ TEST (TransportPolicyPaths, LoadRunTraversesManualProxy) {
     loop.start ();
 
     std::vector<Request> requests;
+    requests.reserve (3);
     for (int i = 0; i < 3; ++i) {
         requests.push_back (get_request (upstream.url ("/hello")));
     }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,8 +2,8 @@
 
 # Two checks over the staged C++ changes, each mirroring a CI gate that can fail
 # a pull request: clang-format over whole staged engine sources (issue #908),
-# then clang-tidy over the lines this commit changes - or whole files under
-# VAYU_TIDY_FULL, announced below once the staged set is known.
+# then clang-tidy over whole staged files (#946 - the gate promotion that closed
+# the #928 backlog paydown).
 #
 # Neither is stricter than the gate it mirrors, which is the property that keeps
 # `--no-verify` from becoming a reflex: a refusal here is a merge blocker seen
@@ -94,10 +94,11 @@ fi
 # of work that used to be reachable only after a push and a CI round trip; this
 # runs the same check, on the same major, over the sources this commit stages.
 #
-# **Whole files, not changed lines** - the opposite of the clang-tidy pass below
-# and for the opposite reason. The bulk-format commit in `.git-blame-ignore-revs`
-# left the tree clean at the pinned version, so formatting has no backlog to
-# grandfather and file scope already agrees with CI's tree scope.
+# **Whole files, not changed lines** - as the clang-tidy pass below is too,
+# since #946. Formatting got there first: the bulk-format commit in
+# `.git-blame-ignore-revs` left the tree clean at the pinned version, so it
+# never had a backlog to grandfather, where the tidy pass had to pay one down
+# (#928) before its scope could match.
 #
 # `git clang-format --staged` ships beside clang-format and was the primitive to
 # reuse here; it is the wrong one, because it formats the *changed lines*. A
@@ -156,9 +157,9 @@ fi
 
 # The one way out of this hook, so that a verdict is reported where it will be
 # read - last, under whatever else ran - and so that no exit can lose one. The
-# clang-tidy pass below has three legitimate early exits (no clang-tidy, one too
-# old to read the config, a deletions-only change); none of them is a reason to
-# forget that clang-format already refused this commit.
+# clang-tidy pass below has two legitimate early exits (no clang-tidy, one too
+# old to read the config); neither is a reason to forget that clang-format
+# already refused this commit.
 STATUS=0
 end_hook() {
     if [ "$FORMAT_STATUS" -ne 0 ]; then
@@ -183,9 +184,9 @@ end_hook() {
 # (issue #918).
 #
 # The `Lint changed engine sources` step in .github/workflows/pr-tests.yml lints
-# the same lines on clang-tidy 19 before a pull request can merge, so this stays
-# a skip rather than a refusal to commit - a missing or old local toolchain costs
-# a contributor nothing but the early warning.
+# the same files whole on clang-tidy 19 before a pull request can merge, so this
+# stays a skip rather than a refusal to commit - a missing or old local toolchain
+# costs a contributor nothing but the early warning.
 find_llvm_tool clang-tidy "$MIN_CLANG_TIDY_MAJOR" minimum
 CLANG_TIDY="$LLVM_TOOL"
 if [ -z "$CLANG_TIDY" ]; then
@@ -194,44 +195,15 @@ if [ -z "$CLANG_TIDY" ]; then
     echo "         >= ${MIN_CLANG_TIDY_MAJOR}; an older binary rejects the whole config and lints nothing."
     echo "         NOTHING WAS LINTED. Install it ('apt install clang-tidy-${MIN_CLANG_TIDY_MAJOR}',"
     echo "         'brew install llvm@${MIN_CLANG_TIDY_MAJOR}') or rely on CI, which lints the same"
-    echo "         lines on clang-tidy ${MIN_CLANG_TIDY_MAJOR}."
+    echo "         files on clang-tidy ${MIN_CLANG_TIDY_MAJOR}."
     end_hook
 fi
 
-# What it looks at - the lines this commit changes, or whole files under
-# VAYU_TIDY_FULL - is announced below, once the staged set is known. The binary
-# is named because it need not be the plain one.
+# The binary is named because it need not be the plain one.
 echo "Running ${CLANG_TIDY} on staged C++ changes..."
 
-# Turns one file's staged hunk headers into clang-tidy `--line-filter` ranges.
-#
-# `-U0` is what makes this exact: with no context lines, a hunk's new-side range
-# `@@ -a,b +c,d @@` *is* the set of lines this commit adds or rewrites, so the
-# header alone answers the question and the body never has to be read. A hunk
-# with `d` of 0 is a pure deletion and contributes no range - there is no new
-# line there to hold to the config.
-#
-# `h[1] + 0` drops the leading `+` by arithmetic conversion, and a header with
-# no comma (`@@ -3 +3 @@`) means a count of one, which is git's own shorthand.
-staged_line_ranges() {
-    git diff --cached -U0 -- "$1" | awk '
-        /^@@ / {
-            split($3, h, ",")
-            start = h[1] + 0
-            count = (2 in h) ? h[2] + 0 : 1
-            if (count > 0) {
-                printf "%s[%d,%d]", (n++ ? "," : ""), start, start + count - 1
-            }
-        }
-    '
-}
-
-# The files to lint, in the order they were staged, minus the two the loop below
-# used to skip inline (vendored code, and a path that no longer exists on disk).
-# Computed before the line filter because that filter has to name every file in
-# one argument, and clang-tidy drops a diagnostic in any file the filter does not
-# list - so a header's findings would vanish from the translation unit that
-# includes it if the filter were built per invocation.
+# The files to lint, in the order they were staged, minus vendored code and
+# paths that no longer exist on disk (a staged deletion has no file to lint).
 LINT_FILES=
 for FILE in $FILES; do
     if [[ "$FILE" == *"vendor/"* ]]; then
@@ -243,57 +215,20 @@ for FILE in $FILES; do
     LINT_FILES="$LINT_FILES $FILE"
 done
 
-# What this hook looks at, and why it is not the whole file (issue #902).
+# Whole staged files, not changed lines (#946 - the promotion that closed the
+# #928 backlog paydown; #902 aligned the two gates and they stay aligned, so CI
+# gates whole changed files too).
 #
-# The engine had never been linted when the gates went in, so most files carry
-# findings older than any current diff. CI gates the *changed lines* for that
-# reason, and this hook used to gate whole staged files - so a contributor who
-# edited one line of a legacy file was refused a commit over findings CI would
-# let through. The predictable end of that is `--no-verify` as a reflex, which
-# costs the hook its whole value: advisory in practice, arrived at from the
-# stricter direction.
-#
-# So the two gates now look at the same lines. The mechanism differs and that is
-# deliberate: CI runs LLVM's `clang-tidy-diff.py`, which needs a Python
-# interpreter and a copy of the driver whose version matches the binary (an
-# 18-era driver rejects the `-allow-no-checks` that `engine/src/runtime/`
-# requires) - dependencies a CI image can pin and a contributor's machine
-# cannot. Falling back to whole-file linting whenever one of them is missing
-# would put the asymmetry back for exactly the people it hurts, so the ranges
-# are computed here instead, from the one thing that is always present: git.
-# `-U0` makes that a header parse rather than a diff implementation.
-#
-# `VAYU_TIDY_FULL=1` restores whole-file linting, for someone paying the backlog
-# down on purpose - that is the one case where the findings CI ignores are the
-# point.
-LINE_FILTER_ARG=()
-if [ -n "${VAYU_TIDY_FULL:-}" ]; then
-    echo "VAYU_TIDY_FULL is set: linting whole staged files, pre-existing findings included."
-else
-    SCOPED_FILES=
-    LINE_FILTER=
-    for FILE in $LINT_FILES; do
-        RANGES=$(staged_line_ranges "$FILE")
-        # Only deletions staged for this file. Parsing the translation unit
-        # would report the backlog alone, and the filter would then drop all of
-        # it - the same answer, minus the parse.
-        if [ -z "$RANGES" ]; then
-            continue
-        fi
-        SCOPED_FILES="$SCOPED_FILES $FILE"
-        [ -n "$LINE_FILTER" ] && LINE_FILTER="$LINE_FILTER,"
-        LINE_FILTER="$LINE_FILTER{\"name\":\"$FILE\",\"lines\":[$RANGES]}"
-    done
-
-    if [ -z "$SCOPED_FILES" ]; then
-        echo "Staged C++ changes add no lines (deletions only); nothing to lint."
-        end_hook
-    fi
-
-    LINT_FILES="$SCOPED_FILES"
-    LINE_FILTER_ARG=("--line-filter=[$LINE_FILTER]")
-    echo "Scoped to the lines this commit changes, as CI is. Whole files: VAYU_TIDY_FULL=1"
-fi
+# Line scoping existed to quarantine a backlog: the engine had never been
+# linted, so most files carried findings older than any diff, and a whole-file
+# hook refused commits over code the committer did not write - `--no-verify` as
+# a reflex, the hook advisory in practice. #928 paid that backlog to zero
+# tree-wide, which removed the only argument for scoping - and the waves
+# measured what scoping cost while it lasted: a retyped constant created a
+# finding on a line its diff never touched (#979), and one branch's whole-file
+# lint of its own 30 changed files found 98 findings where the changed-lines
+# gate, correctly, reported 0 (#946). A finding anywhere in a staged file is
+# yours to fix now, or to NOLINT with the reason at the site.
 
 # What makes this hook a gate rather than a report. clang-tidy is invoked once
 # per file and each invocation's status is kept, so one bad file does not stop
@@ -350,11 +285,11 @@ for FILE in $LINT_FILES; do
     # nothing and say it had linted.
     if [ -f "engine/build/compile_commands.json" ]; then
         "$CLANG_TIDY" --allow-no-checks --extra-arg=-Wno-ignored-gch \
-            "${LINE_FILTER_ARG[@]}" -p engine/build "$FILE" || STATUS=1
+            -p engine/build "$FILE" || STATUS=1
     else
         echo "Warning: compile_commands.json not found in engine/build. clang-tidy might report false positives."
         # Fallback: try to include common directories
-        "$CLANG_TIDY" --allow-no-checks "${LINE_FILTER_ARG[@]}" "$FILE" \
+        "$CLANG_TIDY" --allow-no-checks "$FILE" \
             -- -Iengine/include -Iengine/vendor/quickjs-ng || STATUS=1
     fi
 done
@@ -364,16 +299,8 @@ if [ "$STATUS" -ne 0 ]; then
     echo "clang-tidy reported findings in the staged files above; the commit was refused."
     echo "Fix them, or mark a deliberate exception with a NOLINT comment naming the check."
     echo
-    if [ -n "${VAYU_TIDY_FULL:-}" ]; then
-        echo "VAYU_TIDY_FULL was set, so this run linted whole staged files and the"
-        echo "findings above may include ones that predate your change. Unset it and the"
-        echo "hook reports only the lines you touched, which is what CI gates."
-    else
-        echo "Every finding above is on a line this commit changes - the same lines CI"
-        echo "gates, so this is a merge blocker you are seeing early. To lint whole"
-        echo "staged files instead, backlog included: VAYU_TIDY_FULL=1 git commit"
-    fi
-    echo "To commit anyway: git commit --no-verify"
+    echo "CI lints the same files whole (#946), so this is a merge blocker you are"
+    echo "seeing early. To commit anyway: git commit --no-verify"
 fi
 
 end_hook

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -216,8 +216,9 @@ for FILE in $FILES; do
 done
 
 # Whole staged files, not changed lines (#946 - the promotion that closed the
-# #928 backlog paydown; #902 aligned the two gates and they stay aligned, so CI
-# gates whole changed files too).
+# #928 backlog paydown; CI's Linux leg gates whole changed files too, its
+# Windows leg still changed lines until #1023 zeroes what only that
+# toolchain sees).
 #
 # Line scoping existed to quarantine a backlog: the engine had never been
 # linted, so most files carried findings older than any diff, and a whole-file

--- a/scripts/test/pre-commit_test.sh
+++ b/scripts/test/pre-commit_test.sh
@@ -16,11 +16,11 @@
 # the `|| STATUS=1` on the two invocations, or the `exit 1` at the end - reddens
 # the cases below.
 #
-# The third is what it looks at. The hook gated whole staged files while CI gated
-# the changed lines, so it refused commits over findings CI would let through and
-# `--no-verify` was the way past it. It now passes clang-tidy a `--line-filter`
-# built from the staged hunk headers; dropping that argument, or widening it past
-# the staged range, reddens the line-scope cases.
+# The third is what it looks at: whole staged files (issue #946, the gate
+# promotion that closed the #928 backlog paydown). The hook briefly gated the
+# changed lines instead (#902), while a backlog older than any diff had to be
+# quarantined; with that backlog at zero the scope is the whole of every staged
+# file, and reintroducing a `--line-filter` reddens the scope cases below.
 #
 # The fourth is the formatting check (issue #908). The hook linted but never
 # format-checked, so the whole-tree `Engine formatting` gate - two seconds of
@@ -256,7 +256,7 @@ EOF
 # files matching $2, at line $3 (default 1), in a repo built by $4 (default
 # make_repo). Sets HOOK_OUTPUT and HOOK_STATUS - a global rather than a printed
 # value, because the status has to survive the call and a command substitution
-# would run this in a subshell. TIDY_FULL is the `VAYU_TIDY_FULL` the hook sees.
+# would run this in a subshell.
 #
 # FORMAT_STUB_VERSION, when set, puts a clang-format stub of that version on
 # PATH under FORMAT_STUB_NAME, reporting files matching FORMAT_STUB_DIRTY as
@@ -264,7 +264,6 @@ EOF
 # above, so no real clang-format can answer.
 HOOK_OUTPUT=""
 HOOK_STATUS=0
-TIDY_FULL=""
 FORMAT_STUB_NAME="clang-format"
 FORMAT_STUB_VERSION=""
 FORMAT_STUB_DIRTY=""
@@ -285,7 +284,7 @@ run_hook() {
         tail="$fstub:$tail"
     fi
     set +e
-    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$tail" VAYU_TIDY_FULL="$TIDY_FULL" bash "$HOOK" 2>&1)"
+    HOOK_OUTPUT="$(cd "$repo" && PATH="$stub:$tail" bash "$HOOK" 2>&1)"
     HOOK_STATUS=$?
     set -e
     rm -rf "$repo" "$stub" ${fstub:+"$fstub"} ${sandbox:+"$sandbox"}
@@ -464,57 +463,46 @@ else
     fail "clang-tidy 18 still skips" "exit $HOOK_STATUS: $HOOK_OUTPUT"
 fi
 
-# --- What the hook looks at (issue #902) -------------------------------------
+# --- What the hook looks at (issue #946) -------------------------------------
 echo
-echo "pre-commit line scope"
+echo "pre-commit whole-file scope"
 
-# The defect: the hook gated whole staged files while CI gated the changed
-# lines, so a one-line edit to a legacy file was refused a commit over findings
-# CI would let through - and `--no-verify` became the way out. `legacy.cpp` has
-# a finding on line 1, which this commit does not touch.
+# The promotion: with the #928 backlog at zero tree-wide, the hook gates whole
+# staged files - a finding anywhere in a file this commit stages refuses the
+# commit, whether or not the diff touched its line. `legacy.cpp` has a finding
+# on line 1, which this commit does not touch.
 #
-# Mutation-check: drop `LINE_FILTER_ARG` from the clang-tidy invocations in
-# scripts/pre-commit and the stub, seeing no filter, reports every line - this
-# case reddens.
+# Mutation-check: reintroduce a `--line-filter` built from the staged hunks in
+# scripts/pre-commit and the stub, honouring it, reports nothing on line 1 -
+# this case reddens.
 run_hook 19.1.0 legacy.cpp 1 make_repo_with_history
-if [[ "$HOOK_STATUS" -eq 0 ]]; then
-    pass "a finding on a line this commit did not touch lets the commit through"
+if [[ "$HOOK_STATUS" -ne 0 ]]; then
+    pass "a finding on a line this commit did not touch still refuses the commit"
 else
-    fail "a pre-existing finding lets the commit through" "exit $HOOK_STATUS: $HOOK_OUTPUT"
+    fail "a whole-file finding refuses the commit" "the hook exited 0: $HOOK_OUTPUT"
 fi
 
-# The other half. Without it, "filter everything out" would pass the case above
-# - and the hook would be a gate over nothing.
+# No filter is passed at all - asserted on the invocation rather than inferred
+# from the verdict, so a filter that happened to cover line 1 could not pass
+# the case above while narrowing the scope.
+if [[ "$HOOK_OUTPUT" != *"--line-filter"* ]]; then
+    pass "the invocation carries no line filter"
+else
+    fail "the invocation carries no line filter" "got: $HOOK_OUTPUT"
+fi
+
+# A finding on a changed line, for completeness of the promotion: whole-file
+# scope is a superset of the old changed-lines scope.
 run_hook 19.1.0 legacy.cpp 3 make_repo_with_history
 if [[ "$HOOK_STATUS" -ne 0 ]]; then
-    pass "a finding on a line this commit changes still refuses the commit"
+    pass "a finding on a line this commit changes refuses the commit"
 else
     fail "a finding on a changed line refuses the commit" "the hook exited 0: $HOOK_OUTPUT"
 fi
 
-# The ranges themselves, named rather than inferred from the verdict: line 3 is
-# the only line staged, so the filter must say exactly that. A filter naming the
-# whole file would satisfy both cases above and gate nothing.
-if [[ "$HOOK_OUTPUT" == *'--line-filter=[{"name":"legacy.cpp","lines":[[3,3]]}]'* ]]; then
-    pass "the filter carries the staged hunk's range and nothing wider"
-else
-    fail "the filter is the staged hunk's range" "got: $HOOK_OUTPUT"
-fi
-
-# The opt-in for someone paying the backlog down on purpose, which is the one
-# case where a pre-existing finding is the point.
-TIDY_FULL=1
-run_hook 19.1.0 legacy.cpp 1 make_repo_with_history
-TIDY_FULL=""
-if [[ "$HOOK_STATUS" -ne 0 && "$HOOK_OUTPUT" != *"--line-filter"* ]]; then
-    pass "VAYU_TIDY_FULL=1 lints whole staged files again, with no line filter"
-else
-    fail "VAYU_TIDY_FULL=1 lints whole files" "exit $HOOK_STATUS: $HOOK_OUTPUT"
-fi
-
-# A deletion-only staged change has no new line to hold to the config, so there
-# is nothing to lint - and the hook must say so rather than parsing the
-# translation unit to have every finding filtered back out.
+# A deletion-only staged change still lints the whole file: removing a line can
+# create a finding on the lines that remain, and whole-file scope has no
+# nothing-new-to-lint case.
 repo="$(make_repo_with_history)"
 printf 'int a() { return 0; }\nint b() { return 0; }\n' > "$repo/legacy.cpp"
 git -C "$repo" add legacy.cpp
@@ -524,10 +512,10 @@ out="$(cd "$repo" && PATH="$stub:$PATH" bash "$HOOK" 2>&1)"
 status=$?
 set -e
 rm -rf "$repo" "$stub"
-if [[ "$status" -eq 0 && "$out" != *"STUB_LINTED"* && "$out" == *"deletions only"* ]]; then
-    pass "a deletion-only staged change lints nothing and says so"
+if [[ "$status" -ne 0 && "$out" == *"STUB_LINTED"*"legacy.cpp"* ]]; then
+    pass "a deletion-only staged change still lints the whole file"
 else
-    fail "a deletion-only change lints nothing" "exit $status: $out"
+    fail "a deletion-only change lints the whole file" "exit $status: $out"
 fi
 
 # --- Where the PCH flag lives (issue #912) -----------------------------------


### PR DESCRIPTION
## Description

Wave 4 of #928 - the closing wave.

**Plan.** Root cause: the last two enabled-family backlogs (`performance-*`, `modernize-avoid-c-arrays`) were still standing, and the CI/hook tidy gates were still changed-lines scoped - a shape that existed only to quarantine a backlog that no longer exists. Approach: re-measure the batch honestly first (the wave-0 "70 + 25" predates #1013's `-header-filter` lesson, so it never counted headers - the true figure on the current head is **107 unique findings over 205 non-vendor translation units**, deduped by (file, line, column, check), with `performance-enum-size` hiding 32 of them in 22 headers), fix all 107 per the established per-check disciplines, then promote the gates to whole-file scope and record the decision in `docs/engine/building.md`. Alternative rejected: keeping the changed-lines gate with the backlog at zero - declined because the waves measured exactly what it cannot see (#979's retyped constant created a finding on a line its diff never touched, and #946's batch-4 measurement found 98 findings standing in the very files a green PR opened), and the only argument for line scoping - not failing PRs for code they did not write - expired with the backlog. **This PR's own CI then sharpened that scoping rule into a per-leg one** - see the last section below.

**Part 1 (`99ebec5`)** - the findings, by check:
- `performance-enum-size` (32): every enum takes the `std::uint8_t` base its value set fits.
- `performance-inefficient-string-concatenation` (21): message-building `operator+` chains become `std::format` (already in engine use), or sequential appends where a loop builds a line.
- `performance-unnecessary-value-param` (20): the owner's "CPU related" ask landing - `shared_ptr<RunContext>` and result/config parameters on the load path (`handle_result`, `execute_load_test`, `execute_scenario_run`, `run_auth_refresh`, `collect_monitor`) and per-completion callbacks become const references; a `shared_ptr` copy is an atomic refcount round-trip per completion. `register_run` keeps its by-value parameter and moves it into the map.
- `performance-inefficient-vector-operation` (19): `reserve` before every `push_back` loop.
- `modernize-avoid-c-arrays` (5): fixed tables become `std::to_array`, so the count is not restated (most of the baseline's 25 had already gone with #1020's bounds work).
- `performance-unnecessary-copy-initialization` (4), `performance-no-automatic-move` (3), `performance-faster-string-find` (2), `performance-move-const-arg` (1): mechanical.

**Part 2 close-out (`942d6a0`, `574fc96`, `cc8d86b`)** - the exit-proof re-measure over the whole compile database found the acceptance criterion was not yet true: **100 findings still standing** that no wave had ever owned - the non-declined `readability-*`/`modernize-*` remainder, headers no wave ever counted, and six knock-ons from part 1's own const-ref change. All cleared: nested ternaries restructured (shared helpers `pm_description_text`, `leaf_text`), `constants.hpp` widening given typed first factors, math parens, member-init reconciliation, `std::min/max`, DeMorgan, `thread_pool`'s `std::bind` replaced with a pack-capture lambda (also retiring its `std::result_of` deprecation), and three suppressions with written reasons (version/platform macros, `oauth_client`'s aggregate-init `{}`s, `EventLoopWorker` field order). `574fc96` restores four `{}` member inits the close-out wrongly removed - their comments said they were load-bearing for `-Wmissing-field-initializers`, GCC stays silent for that shape, and the macOS leg (clang) failed on all of them; reproduced and re-verified with clang 18 across every TU.

**Part 2 promotion (`1a36b29`, `ac98959`)** - taken, scoped to where the zero was measured:
- **CI's Linux leg** lints the **whole** of every changed translation unit, invoking clang-tidy directly. **The hook** lints whole staged files on every platform - `VAYU_TIDY_FULL` and the hunk-header line-filter machinery are retired; `scripts/test/pre-commit_test.sh` pins the new scope (33/33).
- **CI's Windows leg stays at changed-lines scope** (`ac98959`): this PR's own run was the first whole-file lint that leg has ever executed, and it reported **~85 findings in the touched files alone, none on a line the diff wrote** - `pro-type-vararg` on every `curl_easy_setopt` (curl's GCC typecheck macro hides these from Linux), checks that exist only in that leg's clang-tidy 20, and findings in Windows-only code a Linux lint never compiles. #928's zero was measured on the Linux toolchain and nowhere else; promoting a leg ahead of its measured zero fails PRs for code they did not write - the exact failure line scoping existed to prevent. #1023 owns measuring and zeroing that leg, then collapsing the branch.
- `HeaderFilterRegex` is now anchored to `engine/` - the unanchored spelling matched MSVC's own `include` directory, and the whole-file run surfaced a finding inside `xfilesystem_abi.h`.
- Recorded in `docs/engine/building.md`'s Static Analysis section, `engine/CLAUDE.md`'s linter bullet, `CONTRIBUTING.md` and the `engine/.clang-tidy` comments. #928's completion also meets the re-enable condition #940 attached to `readability-function-cognitive-complexity`; that decision is deliberately **not** taken here - it is filed as #1021.

**Exit proof.** The definitive full-tree scan (205 unique non-vendor TUs - the honest denominator; the old "256/256" counted database entries - `run-clang-tidy-19`, `-header-filter` passed, deduped by (file, line, column, check)) on the final tree: numbers land as a comment here and on #928 when the run completes (the previous full pass reported exactly one residual finding - a misplaced NOLINT, fixed in `cc8d86b` and re-verified through an including TU).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- Engine: `python build.py -e -t`, then `ctest --preset linux-dev --output-on-failure` - **2412/2412 pass** locally (2413/2413 on CI's Windows leg); re-run after every batch.
- App: `pnpm test` - **5702/5702 pass (531 files)**; `pnpm type-check`, `pnpm lint`, `pnpm format:check` clean; `python build.py -a` builds.
- Hook: `bash scripts/test/pre-commit_test.sh` - **33/33 pass** (the line-scope cases inverted to whole-file cases, mutation-checked against a reintroduced line filter).
- Cross-compiler: every TU swept with clang 18 `-Werror=missing-field-initializers` after the macOS failure (2 TUs affected before the fix, 0 after).
- Docs: `mkdocs build --strict` clean. Formatting: `clang-format-19 --dry-run -Werror` clean over every touched C++ file.

No pre-existing failures were observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #946