### PR TITLE
fix(engine): report a taken port instead of exiting 0 - #983

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,12 @@ one app instance may drive it:
   refuses to start an engine, and a restart already in flight is waited out
   rather than raced - otherwise a freshly spawned engine outlives the process
   that was supposed to kill it.
+- **A taken port is a loud failure, not a silent one.** The engine binds 9876
+  before it serves, so anything already holding the port makes it print
+  `Could not bind 127.0.0.1:9876 - ...` to stderr and exit **1** rather than
+  report itself listening. It never falls back to another port: the app and CLI
+  both address the engine at a fixed one, so an engine on a different port would
+  be a quieter failure than no engine at all.
 - **A startup that cannot succeed fails immediately.** The readiness poll allows
   45 seconds, but it watches the spawned child as well as the port: an engine
   that exits first - a missing shared library, a lock it could not acquire -

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -166,6 +166,15 @@ connections across both accept loops - two inboxes on one port, each capturing a
 webhooks and neither list showing the rest. An ephemeral request needs no check, since the kernel
 does not hand out a port it is already using.
 
+The management API answers that same `SO_REUSEPORT` problem the other way round, because it is the
+one listener whose port is a *contract* rather than a detail: it clears the option (Windows, which
+has no `SO_REUSEPORT` and lets `SO_REUSEADDR` step over a live listener, gets `SO_EXCLUSIVEADDRUSE`
+instead), so a port anything else holds fails the bind rather than splitting the engine's own
+traffic. `Server::start()` binds before it serves and returns that outcome, and the daemon prints
+the reason to stderr and exits **1** (#983). It was `listen()` before, which folds the bind into the
+serve loop and reports failure only through a `return false` on a detached thread - so a taken port
+printed the listening banner, unwound through the graceful-shutdown path and exited 0.
+
 ### Event Loop (`curl_multi`)
 
 The event loop manages concurrent HTTP request execution using libcurl's multi interface.

--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -159,6 +159,10 @@ The Vayu Engine daemon must be running before using the CLI:
 vayu-cli run request.json
 ```
 
+The daemon exits **1** if it cannot take its port, naming the address on
+stderr - another process is listening there. Use `--port` to pick a different
+one, and `--daemon` to point the CLI at it. An ordinary shutdown exits **0**.
+
 ## Error Handling
 
 The CLI returns non-zero exit codes on errors:

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string>
 #include <thread>
 
 #include "vayu/core/run_manager.hpp"
@@ -33,9 +34,30 @@ class Server {
     Server (Server&&)                 = delete;
     Server& operator= (Server&&)      = delete;
 
-    void start ();
+    /**
+     * @brief Bind the listener, then serve on it from a background thread.
+     *
+     * The bind happens on the caller's thread so its failure is *returned*
+     * rather than logged from a thread nobody is reading (#983): a taken port
+     * used to leave `is_running_` false a moment after `start()` had already
+     * printed the listening banner, and the daemon read that as a shutdown
+     * request and exited 0.
+     *
+     * @return true once the accept loop owns the port; false when the bind
+     * failed, in which case `bind_error()` names the reason and nothing is
+     * listening.
+     */
+    [[nodiscard]] bool start ();
     void stop ();
     bool is_running () const;
+
+    /**
+     * @brief Why `start()` could not take the port, empty when it did.
+     *
+     * Names the host, the port and the likely cause, so the daemon can print
+     * one line that explains an exit rather than a bare code.
+     */
+    const std::string& bind_error () const;
 
     /**
      * @brief Set a callback to be invoked when /shutdown endpoint is called
@@ -51,6 +73,7 @@ class Server {
     vayu::core::RunManager& run_manager_;
     int port_;
     bool verbose_;
+    std::string bind_error_;
     // Everything from here down to server_ is declared *before* it so it is
     // destroyed *after* it (reverse member order): the httplib lambdas that
     // reference these members are gone with server_, and db_ - external, so

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -199,7 +199,21 @@ int main (int argc, char* argv[]) {
         g_running.store (false);
     });
 
-    server.start ();
+    // A listener that never came up and one that was asked to stop both leave
+    // the wait loop below with `is_running()` false, and telling them apart is
+    // the whole of #983: a taken port used to print the listening banner, fall
+    // into the graceful path and exit 0, so the app saw an engine that had
+    // simply died. The teardown is shared - the lock file and curl's global
+    // state must be released either way - and only the exit code differs.
+    int exit_code = 0;
+    if (!server.start ()) {
+        // `start()` has already logged the reason, which puts it on stderr and
+        // in the log file; what it cannot say is what to do about it.
+        std::cerr << "vayu-engine: exiting 1 - stop the process holding that "
+                     "port, or pass --port, then start the engine again.\n";
+        std::cerr.flush ();
+        exit_code = 1;
+    }
 
     // Wait for shutdown signal (either from OS signal or /shutdown endpoint)
     while (g_running && server.is_running ()) {
@@ -243,5 +257,7 @@ int main (int argc, char* argv[]) {
     // Force flush logs
     vayu::utils::Logger::instance ().flush ();
 
-    return 0;
+    // 1 = the listener never took its port (see the start() check above); 0 =
+    // an ordinary shutdown. Documented in docs/engine/cli.md.
+    return exit_code;
 }

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -15,9 +15,11 @@
 #include <chrono>
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <string>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/platform/platform.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/version.hpp"
 
@@ -32,27 +34,67 @@ Server::~Server () {
     stop ();
 }
 
-void Server::start () {
+bool Server::start () {
     if (is_running_)
-        return;
+        return true;
+
+    bind_error_.clear ();
+
+    vayu::utils::log_info ("Vayu Engine " + std::string (vayu::Version::string));
+
+    // Load and display config
+    auto entries = db_.get_all_config_entries ();
+    nlohmann::json config;
+    for (const auto& entry : entries) {
+        config[entry.key] = entry.value;
+    }
+    config["verbose"] = verbose_;
+    vayu::utils::log_info ("Configuration: " + config.dump ());
+
+    // The engine's port is fixed by contract (docs/architecture.md), so this
+    // listener must never *share* it - a second binder is a collision to
+    // report, not a peer to split traffic with. cpp-httplib's default socket
+    // options say the opposite: they set SO_REUSEPORT where it exists, and the
+    // kernel then hands each accept loop a random half of the connections
+    // (the #512 defect, one layer down). SO_REUSEADDR alone still lets a
+    // restart step over its own sockets left in TIME_WAIT, which is the only
+    // sharing wanted here; on Windows, where SO_REUSEADDR is what lets one
+    // process take a port another is actively serving, SO_EXCLUSIVEADDRUSE is
+    // the same statement spelled for that platform.
+    server_.set_socket_options ([] (socket_t sock) {
+#if VAYU_PLATFORM_WINDOWS
+        httplib::set_socket_opt (sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, 1);
+#else
+        httplib::set_socket_opt (sock, SOL_SOCKET, SO_REUSEADDR, 1);
+#endif
+    });
+
+    // Bind here rather than inside the listener thread: `listen()` folds the
+    // bind into the serve loop and reports its failure only as a `false` no
+    // caller was reading, so a taken port printed a listening banner and exited
+    // 0 (#983). Binding first makes the outcome this call's return value.
+    const std::string where = "127.0.0.1:" + std::to_string (port_);
+    if (!server_.bind_to_port ("127.0.0.1", port_)) {
+        bind_error_ = "Could not bind " +
+        where + " - another process, possibly another Vayu engine, is already listening there";
+        vayu::utils::log_error (bind_error_);
+        return false;
+    }
 
     is_running_    = true;
     server_thread_ = std::thread ([this] () {
-        vayu::utils::log_info ("Vayu Engine " + std::string (vayu::Version::string));
-
-        // Load and display config
-        auto entries = db_.get_all_config_entries ();
-        nlohmann::json config;
-        for (const auto& entry : entries) {
-            config[entry.key] = entry.value;
-        }
-        config["verbose"] = verbose_;
-        vayu::utils::log_info ("Configuration: " + config.dump ());
-
-        vayu::utils::log_info ("Listening on http://127.0.0.1:" + std::to_string (port_));
-        server_.listen ("127.0.0.1", port_);
+        server_.listen_after_bind ();
         is_running_ = false;
     });
+
+    // `stop()` racing ahead of the accept loop is missed by cpp-httplib and the
+    // join that follows then waits out its 3s detach fallback, so `start()`
+    // returns only once the loop is live - the rule managed_listener.hpp spells
+    // out for every other listener in the engine.
+    server_.wait_until_ready ();
+
+    vayu::utils::log_info ("Listening on http://" + where);
+    return true;
 }
 
 void Server::stop () {
@@ -98,6 +140,10 @@ void Server::stop () {
 
 bool Server::is_running () const {
     return is_running_;
+}
+
+const std::string& Server::bind_error () const {
+    return bind_error_;
 }
 
 void Server::set_shutdown_callback (routes::ShutdownCallback callback) {

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(vayu_tests
     sse_load_stream_test.cpp
     load_stream_events_test.cpp
     sse_stream_test.cpp
+    server_bind_test.cpp
     transport_policy_test.cpp
     tls_verification_test.cpp
     client_certificates_test.cpp
@@ -332,6 +333,7 @@ set(vayu_scratch_database_suites
     ScratchDatabaseCleanup
     ScriptRequestNameTest
     ScriptVariableScopesTest
+    ServerBindTest
     SpecBindRouteTest
     SpecExportRouteTest
     SpecMatchRouteTest

--- a/engine/tests/server_bind_test.cpp
+++ b/engine/tests/server_bind_test.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file tests/server_bind_test.cpp
+ * @brief The engine listener's bind outcome (issue #983).
+ *
+ * A taken port used to be reported nowhere: `listen()` folded the bind into the
+ * serve loop, returned false into a thread nobody read, and the daemon saw only
+ * a server that had stopped running - which it treated as a shutdown request
+ * and exited 0, one line after printing its listening banner.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/server.hpp"
+
+#include "temp_database.hpp"
+
+namespace {
+
+/// A listener holding a port for as long as it is alive, the way any other
+/// process on the machine would. `stop()` is what releases the port, so the
+/// fixture's own teardown cannot leave it held for the next test.
+class PortHolder {
+    public:
+    PortHolder () {
+        port_   = server_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { server_.listen_after_bind (); });
+        server_.wait_until_ready ();
+    }
+
+    ~PortHolder () {
+        server_.stop ();
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+
+    PortHolder (const PortHolder&)            = delete;
+    PortHolder& operator= (const PortHolder&) = delete;
+    PortHolder (PortHolder&&)                 = delete;
+    PortHolder& operator= (PortHolder&&)      = delete;
+
+    int port () const {
+        return port_;
+    }
+
+    private:
+    httplib::Server server_;
+    std::thread thread_;
+    int port_ = 0;
+};
+
+class ServerBindTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_server_bind.db";
+
+    void SetUp () override {
+        vayu::tests::remove_database_files (DB_PATH);
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+    vayu::core::RunManager run_manager_;
+};
+
+TEST_F (ServerBindTest, ATakenPortFailsToStartAndNamesTheReason) {
+    PortHolder holder;
+    ASSERT_GT (holder.port (), 0);
+
+    vayu::http::Server server (*db_, run_manager_, holder.port (), false);
+
+    EXPECT_FALSE (server.start ());
+    EXPECT_FALSE (server.is_running ());
+
+    const std::string reason = server.bind_error ();
+    EXPECT_NE (reason.find ("127.0.0.1:" + std::to_string (holder.port ())), std::string::npos)
+    << reason;
+    EXPECT_NE (reason.find ("already listening"), std::string::npos) << reason;
+}
+
+TEST_F (ServerBindTest, AFreePortStartsAndServesWithNoRecordedError) {
+    int port = 0;
+    {
+        PortHolder holder;
+        port = holder.port ();
+    }
+    ASSERT_GT (port, 0);
+
+    vayu::http::Server server (*db_, run_manager_, port, false);
+    ASSERT_TRUE (server.start ());
+    EXPECT_TRUE (server.is_running ());
+    EXPECT_EQ (server.bind_error (), "");
+
+    httplib::Client client ("127.0.0.1", port);
+    auto response = client.Get ("/health");
+    ASSERT_TRUE (response);
+    EXPECT_EQ (response->status, 200);
+
+    server.stop ();
+}
+
+} // namespace

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -1343,7 +1343,7 @@ TEST (SseServerShutdownTest, StoppingTheServerDrainsALiveStream) {
     const int port = free_port ();
     {
         vayu::http::Server server (*db, run_manager, port, false);
-        server.start ();
+        ASSERT_TRUE (server.start ());
 
         httplib::Client client ("127.0.0.1", port);
         client.set_read_timeout (20, 0);


### PR DESCRIPTION
## Description

**Plan.** Root cause: `Server::start()` passed the port to `httplib::Server::listen()`, which folds the bind into the serve loop and reports failure only as a `false` returned on the listener thread that nobody read; the thread set `is_running_` false, `daemon.cpp`'s wait loop read that as a shutdown request, ran the graceful path and returned **0** - one line after the banner had announced the engine as listening. Approach: bind on the caller's thread with `bind_to_port`, so `start()` returns the outcome and records the reason in `bind_error()`, and have the daemon print the remedy and exit **1** through the *same* teardown as an ordinary shutdown (the lock file and curl's global state must be released either way - only the exit code differs). The alternative I rejected is the one the issue rejects too: auto-selecting a free port. The app and CLI both address the engine at a fixed 9876, so a wrong-port engine would be a quieter failure than a loud one. I also rejected porting this listener onto `ManagedListener`: that helper joins unconditionally where `Server::stop()` has a 3s detach fallback for a handler still in flight, so the swap would change shutdown semantics for no gain here.

One thing the issue's pathway does not mention and the fix does not work without: cpp-httplib's `default_socket_options` sets `SO_REUSEPORT` where it exists, so on Linux `bind_to_port` on a port a live listener already holds **succeeds** and the kernel splits arriving connections between the two accept loops (the #512 defect, at the one listener whose port is a contract). The management listener therefore clears that option - keeping only the `SO_REUSEADDR` that lets a restart reclaim its own sockets in TIME_WAIT, and `SO_EXCLUSIVEADDRUSE` on Windows, where `SO_REUSEADDR` is itself what lets one process step over another's live listener. Verified by mutation: dropping the socket-options change alone leaves the regression test red.

Anchors verified against master `70bffc8`; the code had not drifted from the line numbers in the issue.

**App finding (the issue asked for it explicitly): no app change is needed, and the app already surfaces this.** `describeSpawnFailure` in `app/electron/sidecar.ts:310` renders `exit code ${failure.code}` plus the engine's last stderr lines into a `showErrorBox`, and `waitForEngine` stops polling as soon as the child exits rather than burning the 45s ceiling. So the new stderr line and exit 1 reach the user as-is. No follow-up issue filed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All on this branch, Linux:

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2414/2414 passed**, 0 failed (66.3s). 2412 before this branch; the 2 new ones are `ServerBindTest`.
- `cd app && pnpm test` - **5702 passed** across 531 files, 0 failed.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `mkdocs build --strict` - clean.
- `scripts/pre-commit` on the staged set with clang-format 19 / clang-tidy 19 - clean, no warnings in the touched files.
- No pre-existing failures encountered on the base commit.

New tests (`engine/tests/server_bind_test.cpp`):
- `ATakenPortFailsToStartAndNamesTheReason` - a plain httplib listener holds a port, the engine `Server` is constructed on it; `start()` returns false, `is_running()` is false, and `bind_error()` names `127.0.0.1:<port>` and "already listening".
- `AFreePortStartsAndServesWithNoRecordedError` - the same port after the holder is gone: `start()` returns true, `/health` answers 200, `bind_error()` is empty.

Mutation-checked both ways, each rebuilt and run:
- Restore `listen()` on the listener thread → `ATakenPortFails...` fails (start returns true, reason empty).
- Keep `bind_to_port` but drop `set_socket_options` → same test fails, because `SO_REUSEPORT` makes the bind succeed on a taken port.

End-to-end on the real binary, not just the harness:
- Port held by another process: stderr carries `Could not bind 127.0.0.1:39737 - another process, possibly another Vayu engine, is already listening there` plus the remedy line, **exit code 1**.
- Same port free: `/health` 200, `POST /shutdown`, **exit code 0**.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the doc table: `docs/architecture.md` (lifecycle - the taken-port behaviour and why there is no port fallback), `docs/engine/architecture.md` (the listener inventory's `SO_REUSEPORT` paragraph, which the management listener now answers the other way round), `docs/engine/cli.md` (daemon exit codes, next to the "start the daemon" prerequisite).

Deviations from the issue spec: two, both additive. (1) The socket-options change above, without which the fix is inert on Linux. (2) `Server::start()` is now `[[nodiscard]] bool` rather than recording a reason a caller must remember to ask for - the one other call site (`sse_stream_test.cpp`) became `ASSERT_TRUE`. The daemon prints the actionable remedy rather than repeating the reason, because `start()`'s `log_error` already puts the reason on stderr *and* in the log file; printing both duplicated the line verbatim.

## Related Issues
Closes #983

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug5KW83n8UoUvcikNvS6tS)_