### PR TITLE
fix(engine): bound the log directory - retention, file level, size cap - #985

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -247,7 +247,8 @@ there. Pass `-jN` to override. See
 ### Development
 - **All platforms**: `engine/data/`
   - Database: `engine/data/db/vayu.db`
-  - Logs: `engine/data/logs/`
+  - Logs: `engine/data/logs/` (one file per start, newest 10 kept - see
+    [Log retention, level and size](engine/architecture.md#log-retention-level-and-size))
   - Lock file: `engine/data/vayu.lock`
 
 ### Production

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -984,9 +984,29 @@ data/
 ├── db/
 │   └── vayu.db          # SQLite database
 ├── logs/
-│   └── vayu_*.log       # Rotating log files
+│   ├── vayu_<stamp>.log # One file per process start (local time, %Y%m%d_%H%M%S)
+│   └── vayu_<stamp>.log.1  # The rotated half of a file that reached the size cap
 └── vayu.lock            # Single-instance lock file
 ```
+
+### Log retention, level and size
+
+Three bounds, all applied by the engine itself (issue #985):
+
+- **Retention.** A start opens its own file and then deletes every
+  `vayu_*.log` beyond the newest 10, taking each pruned file's `.1` with it.
+  Newest is decided by the timestamp in the name, which is what makes those
+  names sortable. Nothing else in the directory is a candidate.
+- **Level.** The `logLevel` config entry (`debug` | `info` | `warn` | `error`,
+  default `debug`) is the lowest severity the **file** takes. The console is
+  separate and still follows the daemon's `-v` flag. The value is read once,
+  when the database opens, so the few lines a start writes before that always
+  land and a change needs a restart.
+- **Size.** `maxLogFileBytes` (default 64 MiB, `0` = unlimited) caps one file.
+  On reaching it the file is renamed to `<name>.1` - overwriting whatever that
+  held - and writing continues in a fresh one. One rotation generation is
+  enough because history is the per-start files, which retention already
+  bounds.
 
 ## Security
 

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -334,6 +334,7 @@ Every entry below was verified by locating the read site in the engine source.
 | `oauth2RefreshLeadMs`, `oauth2RefreshMinIntervalMs`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs`, `oauth2RefreshPollIntervalMs` | `core/auth_refresh.cpp` (read at `core/run_manager.cpp`) | Per run. Mid-run OAuth 2.0 renewal: lead time, floor between renewals, the retry backoff's first wait and ceiling, and how often the watchdog wakes to notice the run ended |
 | `inboxMaxBodyBytes`, `inboxMaxCaptures`, `inboxLivePollIntervalMs` | `http/routes/inbox.cpp` (`read_inbox_limits`) | **Per inbox.** Resolved when `POST /inbox/start` runs; a running inbox keeps what it was started with |
 | `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize` | `db/database.cpp` | DB open. **Restart required.** `dbCacheSize` is per-connection state, so it is re-applied to every connection from the value read at startup |
+| `logLevel`, `maxLogFileBytes` | `daemon.cpp` (applied to `utils/logger.cpp`) | Daemon start, just after the database opens. **Restart required.** The lines written before that point are the ones the file sink's default level allows |
 
 The dead entries this table used to list - `maxConnections` and `statsInterval`,
 plus `tcpKeepAliveIdle` / `tcpKeepAliveInterval`, `maxJsonFieldSize`, the three

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -52,6 +52,16 @@ constexpr const char* DIR = "engine/logs";
 constexpr const char* FILE_PREFIX = "/vayu_";
 /// Timestamp format for log filenames
 constexpr const char* TIME_FORMAT = "%Y%m%d_%H%M%S";
+/// How many per-start log files survive a start; the rest are deleted oldest
+/// first. One file is written per process start and nothing else ever removes
+/// them, so without this an install accumulates a file per launch forever.
+constexpr int RETAINED_FILES = 10;
+/// Default value of the `maxLogFileBytes` config entry: the size one log file
+/// may reach before it is rotated once to `.log.1`. 0 means unlimited.
+constexpr int DEFAULT_MAX_FILE_BYTES = 64 * 1024 * 1024;
+/// Default value of the `logLevel` config entry. `debug` preserves the
+/// behaviour the file sink had before it was filtered at all.
+constexpr const char* DEFAULT_LEVEL = "debug";
 } // namespace logging
 
 /**

--- a/engine/include/vayu/utils/logger.hpp
+++ b/engine/include/vayu/utils/logger.hpp
@@ -13,8 +13,10 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include "vayu/core/constants.hpp"
@@ -50,6 +52,16 @@ class Logger {
 
     void init (const std::string& log_dir = vayu::core::constants::logging::DIR);
     void log (Level level, const std::string& message);
+
+    // The file sink's own floor, separate from `verbosity_level_`, which is
+    // what `-v` buys the console. The file used to take everything at DEBUG
+    // unconditionally; `logLevel` is what moves that floor, and it is applied
+    // once the database is open - so the handful of lines startup writes before
+    // that always land.
+    void set_file_level (Level level);
+    // Size one log file may reach before it is rotated once to `<name>.1`;
+    // 0 means unlimited. Config entry `maxLogFileBytes`.
+    void set_max_file_bytes (int64_t bytes);
     void debug (const std::string& message);
     void info (const std::string& message);
     void warning (const std::string& message);
@@ -81,12 +93,44 @@ class Logger {
     std::string get_timestamp () const;
     std::string get_thread_id () const;
     void ensure_log_directory ();
+    // Rotate the open file to `<path>.1` and continue in a fresh one. Called
+    // with `mutex_` held, from `log` only.
+    void rotate_locked ();
 
     std::unique_ptr<std::ofstream> log_file_;
     std::mutex mutex_;
     int verbosity_level_ = 0; // 0=warn/error, 1=info+, 2=debug+
     std::string log_dir_;
+    std::string log_file_path_;
+    Level file_level_       = Level::DEBUG;
+    int64_t max_file_bytes_ = 0; // 0 = unlimited
+    // Bytes in the open file, seeded from its size because it is opened for
+    // append: a restart inside the same clock second reopens the file the
+    // previous start wrote, and the cap is on the file, not on this process.
+    int64_t file_bytes_ = 0;
 };
+
+/**
+ * @brief The level named by @p name (`debug`, `info`, `warn`, `error`).
+ * @return `std::nullopt` for anything else, so a bad config value is a
+ *         reportable failure rather than a silent fallback.
+ *
+ * Case-insensitive; `warning` is accepted alongside `warn` because that is what
+ * the level prints as.
+ */
+std::optional<Logger::Level> parse_log_level (std::string_view name);
+
+/**
+ * @brief Delete `vayu_*.log` files in @p log_dir beyond the newest @p keep.
+ * @return How many files were deleted.
+ *
+ * Newest is decided by filename, not by modification time: the names embed
+ * `%Y%m%d_%H%M%S`, so they sort chronologically, and a copied or touched
+ * directory keeps sorting the way the log timestamps read. A file's `.1`
+ * rotation goes with it, so a pruned generation leaves nothing behind, and
+ * anything not named `vayu_<stamp>.log` is never a candidate.
+ */
+std::size_t prune_old_logs (const std::string& log_dir, std::size_t keep);
 
 // Convenience functions
 inline void log_debug (const std::string& msg) {

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -173,6 +173,23 @@ int main (int argc, char* argv[]) {
         return 1;
     }
 
+    // Apply the file sink's configuration, which needs the database the logger
+    // is initialised before: the log directory has to exist and be writable
+    // from the first line, and the first lines are written opening this file.
+    // Both entries are restart-required for that reason - the value in force is
+    // the one read here.
+    const std::string configured_level =
+    db.get_config_string ("logLevel", vayu::core::constants::logging::DEFAULT_LEVEL);
+    if (auto level = vayu::utils::parse_log_level (configured_level)) {
+        vayu::utils::Logger::instance ().set_file_level (*level);
+    } else {
+        vayu::utils::log_warning ("Ignoring unrecognised logLevel '" +
+        configured_level + "' - the log file keeps its default level (" +
+        vayu::core::constants::logging::DEFAULT_LEVEL + ")");
+    }
+    vayu::utils::Logger::instance ().set_max_file_bytes (db.get_config_int (
+    "maxLogFileBytes", vayu::core::constants::logging::DEFAULT_MAX_FILE_BYTES));
+
     // Initialize curl
     vayu::http::global_init ();
 

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -2402,6 +2402,14 @@ std::string proxy_mode_options_json () {
     return options.dump ();
 }
 
+std::string log_level_options_json () {
+    const nlohmann::json options = { { { "value", "debug" }, { "label", "Debug" } },
+        { { "value", "info" }, { "label", "Info" } },
+        { { "value", "warn" }, { "label", "Warning" } },
+        { { "value", "error" }, { "label", "Error" } } };
+    return options.dump ();
+}
+
 std::string db_synchronous_options_json () {
     const nlohmann::json options = { { { "value", "0" }, { "label", "Off" } },
         { { "value", "1" }, { "label", "Normal" } },
@@ -3030,6 +3038,30 @@ void Database::seed_default_config () {
     "the run is evicted and the dashboard falls back to the stored report. 0 "
     "disables retention, so that fallback is immediate.",
     "observability", "60000", "0", "600000", std::nullopt, now }));
+
+    upsert_config (restart_required (keywords ({ "verbosity", "logging" }) (
+    ConfigEntry{ "logLevel", vayu::core::constants::logging::DEFAULT_LEVEL, "enum", "Engine Log Level",
+    "The lowest severity the engine writes to its log file. Debug records "
+    "everything, which is what a bug report wants and what fills a disk "
+    "fastest; "
+    "Warning and Error keep a long-running install quiet. The console is "
+    "separate - it follows the daemon's -v flag, so raising this does not "
+    "silence a terminal you started the engine in.",
+    "observability", vayu::core::constants::logging::DEFAULT_LEVEL,
+    std::nullopt, std::nullopt, log_level_options_json (), now })));
+
+    upsert_config (advanced (restart_required (unit ("bytes") (
+    keywords ({ "rotation", "retention" }) (ConfigEntry{ "maxLogFileBytes",
+    std::to_string (vayu::core::constants::logging::DEFAULT_MAX_FILE_BYTES), "integer", "Max Log File Size",
+    "How large one log file may grow before it is rotated once to a '.1' "
+    "beside it and writing continues in a fresh one. A start already gets its "
+    "own file, and the newest " +
+    std::to_string (vayu::core::constants::logging::RETAINED_FILES) +
+    " of those are what the log directory keeps, so this bounds the one case "
+    "that naming cannot: a single run chatty enough to fill the disk by "
+    "itself. 0 removes the bound.",
+    "observability", std::to_string (vayu::core::constants::logging::DEFAULT_MAX_FILE_BYTES),
+    "0", "1073741824", std::nullopt, now })))));
 
     upsert_config (keywords ({ "ttfb", "timings" }) (ConfigEntry{
     "phaseHistograms", vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",

--- a/engine/src/utils/logger.cpp
+++ b/engine/src/utils/logger.cpp
@@ -7,11 +7,15 @@
 
 #include "vayu/utils/logger.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <system_error>
 #include <thread>
+#include <vector>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/utils/reentrant.hpp"
@@ -31,12 +35,53 @@ void Logger::init (const std::string& log_dir) {
     auto now  = std::chrono::system_clock::now ();
     auto time = std::chrono::system_clock::to_time_t (now);
 
-    std::string log_file = log_dir_ + vayu::core::constants::logging::FILE_PREFIX +
+    log_file_path_ = log_dir_ + vayu::core::constants::logging::FILE_PREFIX +
     format_local_time (time, vayu::core::constants::logging::TIME_FORMAT) + ".log";
-    log_file_ = std::make_unique<std::ofstream> (log_file, std::ios::app);
+    log_file_ = std::make_unique<std::ofstream> (log_file_path_, std::ios::app);
 
     if (!log_file_ || !log_file_->is_open ()) {
-        std::cerr << "Failed to open log file: " << log_file << "\n";
+        std::cerr << "Failed to open log file: " << log_file_path_ << "\n";
+    }
+
+    std::error_code ec;
+    const auto existing = std::filesystem::file_size (log_file_path_, ec);
+    file_bytes_         = ec ? 0 : static_cast<int64_t> (existing);
+
+    // Retention runs after the new file exists, so it is one of the N kept -
+    // pruning first would keep N old files plus this one, which is N+1 on
+    // disk for every value of N.
+    prune_old_logs (log_dir_,
+    static_cast<std::size_t> (vayu::core::constants::logging::RETAINED_FILES));
+}
+
+void Logger::set_file_level (Level level) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    file_level_ = level;
+}
+
+void Logger::set_max_file_bytes (int64_t bytes) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    max_file_bytes_ = bytes > 0 ? bytes : 0;
+}
+
+void Logger::rotate_locked () {
+    log_file_->close ();
+
+    // One rotation generation, overwriting whatever `.1` held: the file name
+    // already carries the process start, so history is the per-start files
+    // retention bounds - a `.2`, `.3` chain would be a second, unbounded
+    // history under a naming scheme that does not need one.
+    const std::string rotated = log_file_path_ + ".1";
+    std::error_code ec;
+    std::filesystem::rename (log_file_path_, rotated, ec);
+    if (ec) {
+        std::cerr << "Failed to rotate log file: " << ec.message () << "\n";
+    }
+
+    log_file_ = std::make_unique<std::ofstream> (log_file_path_, std::ios::trunc);
+    file_bytes_ = 0;
+    if (!log_file_->is_open ()) {
+        std::cerr << "Failed to reopen log file after rotation: " << log_file_path_ << "\n";
     }
 }
 
@@ -50,12 +95,24 @@ void Logger::log (Level level, const std::string& message) {
     std::string log_message =
     timestamp + " [" + level_str + "] [" + thread_id + "] " + message;
 
-    // Always write to file (irrespective of log level)
-    if (log_file_ && log_file_->is_open ()) {
-        *log_file_ << log_message << "\n";
-        log_file_->flush ();
-    } else {
-        std::cerr << "Log file is not open." << "\n";
+    // The file takes everything at or above `logLevel`, which defaults to
+    // DEBUG - the level the file used to take unconditionally.
+    if (level >= file_level_) {
+        if (log_file_ && log_file_->is_open ()) {
+            const auto line_bytes = static_cast<int64_t> (log_message.size ()) + 1;
+            // Rotate *before* the line that would cross the cap rather than
+            // after, so the cap bounds the file rather than being the point it
+            // is already past.
+            if (max_file_bytes_ > 0 && file_bytes_ > 0 &&
+            file_bytes_ + line_bytes > max_file_bytes_) {
+                rotate_locked ();
+            }
+            *log_file_ << log_message << "\n";
+            log_file_->flush ();
+            file_bytes_ += line_bytes;
+        } else {
+            std::cerr << "Log file is not open." << "\n";
+        }
     }
 
     // Console output based on verbosity level:
@@ -142,6 +199,63 @@ std::string Logger::get_thread_id () const {
 
 void Logger::ensure_log_directory () {
     std::filesystem::create_directories (log_dir_);
+}
+
+std::optional<Logger::Level> parse_log_level (std::string_view name) {
+    std::string lowered (name);
+    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
+    [] (unsigned char ch) { return static_cast<char> (std::tolower (ch)); });
+
+    if (lowered == "debug")
+        return Logger::Level::DEBUG;
+    if (lowered == "info")
+        return Logger::Level::INFO;
+    if (lowered == "warn" || lowered == "warning")
+        return Logger::Level::WARNING;
+    if (lowered == "error")
+        return Logger::Level::ERROR;
+    return std::nullopt;
+}
+
+std::size_t prune_old_logs (const std::string& log_dir, std::size_t keep) {
+    namespace fs = std::filesystem;
+
+    // FILE_PREFIX leads with the separator it is concatenated onto a
+    // directory with; a filename does not carry it.
+    constexpr std::string_view PREFIX =
+    std::string_view (vayu::core::constants::logging::FILE_PREFIX).substr (1);
+    constexpr std::string_view SUFFIX = ".log";
+
+    std::error_code ec;
+    std::vector<fs::path> candidates;
+    for (const auto& entry : fs::directory_iterator (log_dir, ec)) {
+        if (!entry.is_regular_file ())
+            continue;
+        const std::string name = entry.path ().filename ().string ();
+        if (name.size () > PREFIX.size () + SUFFIX.size () &&
+        name.starts_with (PREFIX) && name.ends_with (SUFFIX)) {
+            candidates.push_back (entry.path ());
+        }
+    }
+    if (ec || candidates.size () <= keep) {
+        return 0;
+    }
+
+    std::sort (candidates.begin (), candidates.end ());
+
+    std::size_t deleted = 0;
+    for (std::size_t i = 0; i + keep < candidates.size (); ++i) {
+        std::error_code remove_ec;
+        if (fs::remove (candidates[i], remove_ec)) {
+            ++deleted;
+        }
+        // The generation's rotated half, if it has one. Removed with its
+        // parent so a `.1` cannot outlive the file it rotated out of and sit
+        // in the directory forever, which is the growth this prune exists to
+        // stop.
+        fs::remove (candidates[i].string () + ".1", remove_ec);
+    }
+    return deleted;
 }
 
 } // namespace vayu::utils

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(vayu_tests
     schema_validation_test.cpp
     version_isolation_test.cpp
     reentrant_test.cpp
+    logger_test.cpp
     ../src/http/routes/import.cpp
     ../src/http/routes/diagnostics.cpp
     ../src/http/routes/compose.cpp

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -298,7 +298,10 @@ TEST_F (ConfigRouteTest, RestartRequiredIsClaimedOnlyByTheEntriesReadAtStartup) 
     << "catalogue empty or unseeded - nothing was scanned";
 
     const std::set<std::string> read_once_at_startup{ "dbBusyTimeout",
-        "dbCacheSize", "dbSynchronous" };
+        "dbCacheSize", "dbSynchronous",
+        // Applied to the logger by daemon.cpp once the database is open
+        // (#985); the file sink then keeps them for the life of the process.
+        "logLevel", "maxLogFileBytes" };
 
     std::set<std::string> flagged;
     for (const auto& entry : entries) {
@@ -386,7 +389,10 @@ TEST_F (ConfigRouteTest, AdvancedFlagsExactlyTheRecordedInternals) {
     const std::set<std::string> expected = { "dbBusyTimeout", "oauth2RefreshRetryMs",
         "oauth2RefreshRetryMaxMs", "oauth2RefreshPollIntervalMs", "inboxLivePollIntervalMs",
         "sseIdleTimeoutMs", "oauth2RefreshMinIntervalMs", "maxStepsPerIteration",
-        "monitorScrapeTimeoutMs", "liveMaxRetainedTicks", "scriptStackSize" };
+        "monitorScrapeTimeoutMs", "liveMaxRetainedTicks", "scriptStackSize",
+        // A per-start log file plus the retention count is the bound a user
+        // reaches for; this one is the backstop under it (#985).
+        "maxLogFileBytes" };
 
     auto entries = db_->get_all_config_entries ();
     ASSERT_FALSE (entries.empty ()) << "catalogue empty - nothing was scanned";

--- a/engine/tests/logger_test.cpp
+++ b/engine/tests/logger_test.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file logger_test.cpp
+ * @brief The three bounds on the log directory (issue #985).
+ *
+ * Before this, the directory grew on three axes at once: a file per process
+ * start that nothing deleted, a file sink that took DEBUG whatever the engine
+ * was told, and no cap on how large one of those files could get. Each bound
+ * is tested where it is enforced - retention in `prune_old_logs`, the level and
+ * the rotation through the singleton, which is what actually writes.
+ */
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "optional_assert.hpp"
+
+#include "vayu/core/constants.hpp"
+#include "vayu/utils/logger.hpp"
+
+namespace {
+
+using vayu::utils::Logger;
+
+namespace constants = vayu::core::constants;
+
+/// A directory of its own per test, since the singleton under test keeps
+/// writing into whichever one it was last initialised with.
+class ScratchLogDir {
+    public:
+    ScratchLogDir () {
+        static std::atomic<int> counter{ 0 };
+        path_ = std::filesystem::temp_directory_path () /
+        ("vayu-logger-test-" + std::to_string (counter.fetch_add (1)) + "-" +
+        std::to_string (static_cast<unsigned long long> (std::hash<std::string>{}(
+        ::testing::UnitTest::GetInstance ()->current_test_info ()->name ()))));
+        std::filesystem::create_directories (path_);
+    }
+
+    ~ScratchLogDir () {
+        // Best effort: the logger holds the newest file open for the life of
+        // the process, and Windows refuses to remove an open file.
+        std::error_code ignored;
+        std::filesystem::remove_all (path_, ignored);
+    }
+    ScratchLogDir (const ScratchLogDir&)            = delete;
+    ScratchLogDir& operator= (const ScratchLogDir&) = delete;
+    ScratchLogDir (ScratchLogDir&&)                 = delete;
+    ScratchLogDir& operator= (ScratchLogDir&&)      = delete;
+
+    std::string string () const {
+        return path_.string ();
+    }
+    const std::filesystem::path& path () const {
+        return path_;
+    }
+
+    private:
+    std::filesystem::path path_;
+};
+
+/// A log file as a start would have left it, named for @p stamp.
+void write_log_file (const std::filesystem::path& dir,
+const std::string& stamp,
+const std::string& contents = "x") {
+    std::ofstream out (dir / ("vayu_" + stamp + ".log"));
+    out << contents;
+}
+
+std::set<std::string> names_in (const std::filesystem::path& dir) {
+    std::set<std::string> names;
+    for (const auto& entry : std::filesystem::directory_iterator (dir)) {
+        names.insert (entry.path ().filename ().string ());
+    }
+    return names;
+}
+
+/// The file the logger is currently writing - the newest `vayu_*.log`.
+std::filesystem::path newest_log (const std::filesystem::path& dir) {
+    std::filesystem::path newest;
+    for (const auto& entry : std::filesystem::directory_iterator (dir)) {
+        const std::string name = entry.path ().filename ().string ();
+        if (name.starts_with ("vayu_") && name.ends_with (".log") && entry.path () > newest) {
+            newest = entry.path ();
+        }
+    }
+    return newest;
+}
+
+std::string read_file (const std::filesystem::path& file) {
+    std::ifstream in (file);
+    std::stringstream buffer;
+    buffer << in.rdbuf ();
+    return buffer.str ();
+}
+
+// ---------------------------------------------------------------------------
+// Retention: the axis that made the directory grow forever.
+// ---------------------------------------------------------------------------
+
+// Mutation-check: return before the loop in `prune_old_logs` and all fifteen
+// files remain, which is the behaviour this issue was filed about.
+TEST (LoggerRetentionTest, KeepsTheNewestNAndDeletesTheRestOldestFirst) {
+    ScratchLogDir dir;
+    for (int day = 1; day <= 15; ++day) {
+        std::ostringstream stamp;
+        stamp << "202608" << (day < 10 ? "0" : "") << day << "_120000";
+        write_log_file (dir.path (), stamp.str ());
+    }
+
+    EXPECT_EQ (vayu::utils::prune_old_logs (dir.string (), 10), 5u);
+
+    auto remaining = names_in (dir.path ());
+    ASSERT_EQ (remaining.size (), 10u);
+    EXPECT_EQ (remaining.count ("vayu_20260806_120000.log"), 1u)
+    << "the tenth-newest file was deleted";
+    EXPECT_EQ (remaining.count ("vayu_20260805_120000.log"), 0u)
+    << "an older file survived, so the deletion is not oldest-first";
+}
+
+// The other half of the same rule: everything that is not a per-start log file
+// is somebody else's, and a prune that took it would be a data loss bug rather
+// than a retention policy. Mutation-check: drop the `starts_with`/`ends_with`
+// guard and every file here disappears.
+TEST (LoggerRetentionTest, NeverTouchesAFileItDoesNotName) {
+    ScratchLogDir dir;
+    std::ofstream (dir.path () / "notes.txt") << "keep";
+    std::ofstream (dir.path () / "engine.log") << "keep";
+    std::ofstream (dir.path () / "vayu_20260801_120000.log.bak") << "keep";
+    std::filesystem::create_directories (dir.path () / "vayu_subdir.log");
+
+    EXPECT_EQ (vayu::utils::prune_old_logs (dir.string (), 0), 0u);
+
+    EXPECT_EQ (names_in (dir.path ()).size (), 4u);
+}
+
+// A pruned generation leaves nothing behind. Mutation-check: drop the `.1`
+// removal and the rotated half outlives the file it rotated out of - a second,
+// unbounded history under a naming scheme that has no room for one.
+TEST (LoggerRetentionTest, TakesARotatedSiblingWithThePrunedFile) {
+    ScratchLogDir dir;
+    write_log_file (dir.path (), "20260801_120000");
+    std::ofstream (dir.path () / "vayu_20260801_120000.log.1") << "rotated";
+    write_log_file (dir.path (), "20260802_120000");
+
+    EXPECT_EQ (vayu::utils::prune_old_logs (dir.string (), 1), 1u);
+
+    EXPECT_EQ (names_in (dir.path ()), std::set<std::string>{ "vayu_20260802_120000.log" });
+}
+
+// Retention is applied by a start, which is the only moment anything runs it.
+// The file this start opens is one of the N kept, not an N+1th beside them.
+// Mutation-check: remove the `prune_old_logs` call from `Logger::init` and the
+// directory keeps every file it was given plus the new one.
+TEST (LoggerRetentionTest, AStartPrunesTheDirectoryItOpensInto) {
+    ScratchLogDir dir;
+    for (int index = 0; index < constants::logging::RETAINED_FILES + 5; ++index) {
+        std::ostringstream stamp;
+        stamp << "20250101_" << (index < 10 ? "00000" : "0000") << index;
+        write_log_file (dir.path (), stamp.str ());
+    }
+
+    Logger::instance ().init (dir.string ());
+
+    EXPECT_EQ (names_in (dir.path ()).size (),
+    static_cast<size_t> (constants::logging::RETAINED_FILES));
+    // The stamps above are all in 2025, so the file this start opened - stamped
+    // now - sorts last and is one of the survivors.
+    EXPECT_GT (newest_log (dir.path ()).filename ().string (), std::string ("vayu_2025"));
+}
+
+// ---------------------------------------------------------------------------
+// Level: the file sink used to take DEBUG unconditionally.
+// ---------------------------------------------------------------------------
+
+TEST (LoggerLevelTest, ParsesEveryNameTheEnumHasAndRefusesAnythingElse) {
+    EXPECT_EQ (vayu::utils::parse_log_level ("debug"), Logger::Level::DEBUG);
+    EXPECT_EQ (vayu::utils::parse_log_level ("INFO"), Logger::Level::INFO);
+    EXPECT_EQ (vayu::utils::parse_log_level ("Warn"), Logger::Level::WARNING);
+    EXPECT_EQ (vayu::utils::parse_log_level ("warning"), Logger::Level::WARNING);
+    EXPECT_EQ (vayu::utils::parse_log_level ("error"), Logger::Level::ERROR);
+
+    // A refusal rather than a silent fall back to DEBUG: the daemon reports the
+    // unusable value and keeps the default, which it can only do if told.
+    EXPECT_FALSE (vayu::utils::parse_log_level ("trace").has_value ());
+    EXPECT_FALSE (vayu::utils::parse_log_level ("").has_value ());
+}
+
+// Mutation-check: drop the `level >= file_level_` guard in `Logger::log` and
+// the two lines below it land in the file, which is what `logLevel` exists to
+// stop.
+TEST (LoggerLevelTest, TheFileTakesOnlyWhatTheConfiguredLevelAllows) {
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string ());
+    Logger::instance ().set_max_file_bytes (0);
+    Logger::instance ().set_file_level (Logger::Level::WARNING);
+
+    Logger::instance ().debug ("a debug line");
+    Logger::instance ().info ("an info line");
+    Logger::instance ().warning ("a warning line");
+    Logger::instance ().error ("an error line");
+    Logger::instance ().flush ();
+
+    const std::string written = read_file (newest_log (dir.path ()));
+    EXPECT_EQ (written.find ("a debug line"), std::string::npos) << written;
+    EXPECT_EQ (written.find ("an info line"), std::string::npos) << written;
+    EXPECT_NE (written.find ("a warning line"), std::string::npos) << written;
+    EXPECT_NE (written.find ("an error line"), std::string::npos) << written;
+}
+
+// The default is what it always was, so an install that configures nothing logs
+// exactly what it logged before.
+TEST (LoggerLevelTest, TheDefaultLevelStillTakesDebug) {
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string ());
+    Logger::instance ().set_max_file_bytes (0);
+    auto default_level = vayu::utils::parse_log_level (constants::logging::DEFAULT_LEVEL);
+    ASSERT_HAS_VALUE (default_level) << "the seeded default names no level";
+    Logger::instance ().set_file_level (*default_level);
+
+    Logger::instance ().debug ("a debug line");
+    Logger::instance ().flush ();
+
+    EXPECT_NE (read_file (newest_log (dir.path ())).find ("a debug line"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Size: one file could grow until the disk objected.
+// ---------------------------------------------------------------------------
+
+// Mutation-check: drop the `rotate_locked` call and no `.1` is ever written,
+// while the open file grows past the cap it was given.
+TEST (LoggerRotationTest, RotatesOnceAtTheCapAndKeepsWriting) {
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string ());
+    Logger::instance ().set_file_level (Logger::Level::DEBUG);
+    constexpr int64_t CAP = 2048;
+    Logger::instance ().set_max_file_bytes (CAP);
+
+    const std::filesystem::path active = newest_log (dir.path ());
+    for (int line = 0; line < 200; ++line) {
+        Logger::instance ().info (
+        "a line long enough to reach the cap quickly " + std::to_string (line));
+    }
+    Logger::instance ().flush ();
+
+    const std::filesystem::path rotated = active.string () + ".1";
+    ASSERT_TRUE (std::filesystem::exists (rotated))
+    << "the cap was never enforced - nothing rotated";
+    EXPECT_LE (static_cast<int64_t> (std::filesystem::file_size (active)), CAP)
+    << "the live file is past the cap it was given";
+    EXPECT_NE (
+    read_file (active).find ("a line long enough to reach the cap quickly 199"),
+    std::string::npos)
+    << "writing did not continue in the new file after the rotation";
+}
+
+// 0 is the documented escape hatch, and the entry's own minimum. Mutation-check:
+// make the cap check `max_file_bytes_ >= 0` and this rotates on the first line.
+TEST (LoggerRotationTest, ZeroMeansUnlimited) {
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string ());
+    Logger::instance ().set_file_level (Logger::Level::DEBUG);
+    Logger::instance ().set_max_file_bytes (0);
+
+    const std::filesystem::path active = newest_log (dir.path ());
+    for (int line = 0; line < 200; ++line) {
+        Logger::instance ().info (
+        "a line long enough to reach a small cap " + std::to_string (line));
+    }
+    Logger::instance ().flush ();
+
+    EXPECT_FALSE (std::filesystem::exists (active.string () + ".1"));
+    EXPECT_GT (std::filesystem::file_size (active), 2048u);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

The engine's log directory grew without bound on three axes at once, exactly as #985 describes and as the code still read at `master` `70bffc8`: a file per process start (`logger.cpp` `init`) that nothing ever deleted, a file sink that wrote every level unconditionally ("Always write to file (irrespective of log level)") while `-v` moved only the console, and no cap on a single file. All three anchors were where the issue put them; the only drift is line numbers, since #973's reentrant-time fix has been through the file since.

**Plan (root cause, approach, rejected alternative).** The root cause is that the logger has exactly one policy - open a file named for now, append forever - and no layer above it ever states a different one, so every bound the issue asks for has to start existing rather than start being read. The approach keeps all three inside `logger.cpp` plus config plumbing, with no new dependency: a free `prune_old_logs (dir, keep)` that a start calls after opening its own file (so that file is one of the N kept, not an N+1th beside them), a `file_level_` the sink filters on that is separate from the console's `verbosity_level_`, and a byte counter seeded from the open file's size that renames to `.log.1` once at the cap. `logLevel` and `maxLogFileBytes` are seeded as ordinary config entries under Observability and applied by `daemon.cpp` right after the database opens - which is also why both are `requiresRestart`. The alternative I rejected was a rotating multi-generation scheme (`.1`, `.2`, …) with its own retention count: the file name already carries the process start, so history is the per-start files, and a second unbounded history under a naming scheme that has no room for one is the defect this issue is about, spelled differently. For the same reason a pruned generation takes its `.1` with it, and retention is a constant (10) rather than a third config knob the issue did not ask for.

Behaviour with nothing configured is unchanged apart from the retention sweep: the file sink still defaults to `debug`.

**App changes.** None were needed and none were made - the issue predicted this and asked for it to be verified rather than assumed. `SettingsMain` renders `configResponse.entries` generically, filtered by category and split by `advanced`, so both keys appear in **Settings → Engine → Observability**: `logLevel` as a select built from its `options` (`type: "enum"` is already a rendered case), `maxLogFileBytes` in the collapsed Advanced section with human-readable byte formatting, which it gets from its declared `unit: "bytes"` rather than from any hardcoded key list. The engine-side guard tests pin the category against the app's `EngineSettingsCategory` union, so an invisible entry would have failed the suite.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on this branch; nothing pre-existing failed.

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2421 tests, 2421 passed, 0 failed** (2412 before this branch; 9 new in `engine/tests/logger_test.cpp`).
- `cd app && pnpm test` - **531 files, 5702 tests, all passed**.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (docs-touching change).
- clang-format 19 and clang-tidy 19 run over every file this diff touches - clean. One real tidy finding was fixed on the way (a `.value ()` in the new test, replaced with `ASSERT_HAS_VALUE`, per the engine convention).

**Mutation checks were run, not just reasoned about.** Each fix was reverted in a scratch build and the suite re-run:

| Mutation | Tests that went red |
|---|---|
| `prune_old_logs` returns before its delete loop | `KeepsTheNewestNAndDeletesTheRestOldestFirst`, `TakesARotatedSiblingWithThePrunedFile`, `AStartPrunesTheDirectoryItOpensInto` |
| file sink's `level >= file_level_` guard removed | `TheFileTakesOnlyWhatTheConfiguredLevelAllows` |
| rotation at the cap disabled | `RotatesOnceAtTheCapAndKeepsWriting` |
| prune's name filter widened to every file | `NeverTouchesAFileItDoesNotName` |
| cap check loosened to `max_file_bytes_ >= 0` | `ZeroMeansUnlimited` |

The two remaining cases are `ParsesEveryNameTheEnumHasAndRefusesAnythingElse` (a bad `logLevel` must be a refusal, so the daemon can report it and keep the default) and `TheDefaultLevelStillTakesDebug` (the promise that an install configuring nothing logs what it logged before).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs are in the same commit, per the doc table: `docs/engine/architecture.md`'s data-directory section (the real file naming, plus a section on all three bounds), `docs/building.md` (the dev log path, linked to it) and `docs/engine/benchmarks.md`'s config-semantics table (read site and restart semantics for both keys).

**Deviations from the issue spec:** two, both small. (1) The branch is `claude/issue-985-prigrs` rather than `claude/issue-985` - that is the branch this run was assigned. (2) A pruned log file's `.1` rotation is deleted with it; the issue specified retention over `vayu_*.log` alone, which would have left rotated halves accumulating forever under the very rule meant to stop that.

## Related Issues
Closes #985

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRFHnuQfPhWsfbumKXU7PV)_