### PR TITLE
fix(engine): refuse a bad numeric flag by name instead of throwing stoi - #1028

### DIFF
--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -44,7 +44,7 @@ vayu-cli run request.json --daemon http://localhost:9999
 |--------|-------------|
 | `-h, --help` | Show help message |
 | `-v, --version` | Show version information |
-| `--verbose [LEVEL]` | Enable verbose output (0=warn/error, 1=info, 2=debug, default: 1) |
+| `--verbose [LEVEL]` | Enable verbose output. LEVEL is 0 (warn/error), 1 (info) or 2 (debug); `--verbose` on its own means 1. A level outside 0-2, or one that is not a whole number, is refused with exit code 1 |
 | `--no-color` | Disable colored output |
 | `--daemon <url>` | Vayu Engine URL (default: http://127.0.0.1:9876) |
 
@@ -162,6 +162,20 @@ vayu-cli run request.json
 The daemon exits **1** if it cannot take its port, naming the address on
 stderr - another process is listening there. Use `--port` to pick a different
 one, and `--daemon` to point the CLI at it. An ordinary shutdown exits **0**.
+
+Its numeric flags are checked before anything starts, and a value that is not
+one of the numbers the flag takes is refused on stderr with exit code **1**
+rather than clamped or read as its numeric prefix:
+
+| Daemon flag | Accepts |
+|-------------|---------|
+| `-p, --port <PORT>` | A whole number from 1 to 65535 |
+| `-v, --verbose [LEVEL]` | 0 (warn/error), 1 (info) or 2 (debug); `-v` on its own means 1 |
+
+```
+$ vayu-engine --port notanumber
+vayu-engine: --port expects a number between 1 and 65535, got "notanumber"
+```
 
 ## Error Handling
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -152,7 +152,12 @@ engine/
   (`utils/parse.hpp`) is a whole `std::string_view` as an integer or nothing -
   the five sites that spelled `from_chars`'s pointer range themselves each had
   to remember the `ptr != end` half that separates "42abc is 42" from "42abc is
-  not a number" - and **`vayu::http::CurlErrorBuffer`**
+  not a number". **`vayu::core::parse_numeric_flag`**
+  (`core/numeric_flag.hpp`, #1028) is the layer above it for a *flag*: it holds
+  the value to the range the flag documents and answers a refusal naming the
+  flag, the range and what was typed, because the two argument loops used to
+  reach for `std::stoi` and answer `vayu-engine: stoi`. A new numeric flag is
+  described there, never parsed at the site - and **`vayu::http::CurlErrorBuffer`**
   (`http/curl_error_buffer.hpp`) owns `CURLOPT_ERRORBUFFER`, whose three rules
   (at least `CURL_ERROR_SIZE` bytes, alive for the whole transfer, written only
   on failure so a reused handle must be cleared between transfers) a bare

--- a/engine/include/vayu/core/numeric_flag.hpp
+++ b/engine/include/vayu/core/numeric_flag.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/numeric_flag.hpp
+ * @brief A numeric command-line flag's value, or the refusal to print (#1028).
+ *
+ * Both argument loops - `vayu-engine`'s and `vayu-cli`'s - used to hand the
+ * text after a flag to `std::stoi` unchecked. That gets two things wrong at
+ * once, and neither is visible until a user hits it:
+ *
+ * - **It throws the name of a function at the user.** `--port notanumber` left
+ *   `std::invalid_argument` to travel to whatever caught it, so the daemon's
+ *   whole answer was `vayu-engine: stoi` - the function that threw, not the
+ *   flag, the value or what was expected. Before the top-level handler existed
+ *   the same input aborted with no message at all.
+ * - **It accepts a prefix.** `std::stoi ("1abc")` is 1, so a mistyped level was
+ *   silently a different level. `vayu::utils::parse_number` exists because that
+ *   half kept being forgotten; this is the layer above it that adds the range
+ *   and the sentence, which `parse.hpp` deliberately leaves to its callers.
+ *
+ * A flag is described once, here, and both the loop that reads it and the test
+ * that holds it to its range name the same `NumericFlag`. The range is part of
+ * the description rather than a second argument at the call site, because
+ * `--port 99999` parsing fine and failing at bind time is a worse place to
+ * learn it, and because a range spelled at the call site is a range that can
+ * disagree with the one the tests check.
+ */
+
+#include <expected>
+#include <string>
+#include <string_view>
+
+#include "vayu/utils/parse.hpp"
+
+namespace vayu::core {
+
+/// One numeric flag: the name to blame, and the values it accepts.
+struct NumericFlag {
+    /// The long spelling, which is what the refusal names however it was typed
+    /// - `-p` and `--port` are the same flag and the same mistake.
+    std::string_view name;
+    int min = 0;
+    int max = 0;
+};
+
+/// `-p` / `--port`. The upper bound is the last port a TCP socket can carry;
+/// 0 is excluded because it means "any port" to `bind`, which the engine's
+/// fixed-port contract does not offer (see docs/architecture.md).
+inline constexpr NumericFlag PORT_FLAG{ .name = "--port", .min = 1, .max = 65535 };
+
+/// `-v` / `--verbose <LEVEL>`. The three levels the logger has: 0 warn/error,
+/// 1 info, 2 debug.
+inline constexpr NumericFlag VERBOSITY_FLAG{ .name = "--verbose", .min = 0, .max = 2 };
+
+/**
+ * @brief @p text as @p flag's value, or the line to print before refusing.
+ *
+ * Non-numeric, partly numeric and out-of-range are one message on purpose:
+ * each is the same thing wrong from the user's side - the value does not name
+ * one of the numbers this flag takes - and the message says which numbers it
+ * does take, which is the part they need either way.
+ */
+inline std::expected<int, std::string>
+parse_numeric_flag (const NumericFlag& flag, std::string_view text) {
+    const auto value = vayu::utils::parse_number<int> (text);
+    if (!value.has_value () || *value < flag.min || *value > flag.max) {
+        return std::unexpected (std::string (flag.name) +
+        " expects a number between " + std::to_string (flag.min) + " and " +
+        std::to_string (flag.max) + ", got \"" + std::string (text) + "\"");
+    }
+    return *value;
+}
+
+} // namespace vayu::core

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -18,6 +18,7 @@
 #include <httplib.h>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/numeric_flag.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/utils/diagnostics.hpp"
@@ -307,13 +308,22 @@ bool& consumed_next) {
         return 0;
     }
     if (arg == "--verbose") {
-        // The level is optional: `--verbose` on its own means info. Clamped to
-        // the range the logger has.
+        // The level is optional: `--verbose` on its own means info, and a
+        // leading digit is what says the next argument was meant as a level at
+        // all - `--verbose run` is the command, not a bad level. Once it is
+        // meant as one it is held to the range the logger has rather than
+        // clamped into it, and `--verbose 1abc` is refused rather than read as
+        // 1 (see core/numeric_flag.hpp).
         if (!next.empty () &&
         std::isdigit (static_cast<unsigned char> (next.front ())) != 0) {
-            options.verbosity =
-            std::max (0, std::min (2, std::stoi (std::string (next))));
-            consumed_next = true;
+            const auto parsed =
+            vayu::core::parse_numeric_flag (vayu::core::VERBOSITY_FLAG, next);
+            if (!parsed) {
+                std::cerr << "vayu-cli: " << parsed.error () << "\n";
+                return 1;
+            }
+            options.verbosity = *parsed;
+            consumed_next     = true;
         } else {
             options.verbosity = 1;
         }

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -19,9 +19,11 @@
 #include <cstdlib>
 #include <iostream>
 #include <span>
+#include <string_view>
 #include <thread>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/numeric_flag.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -58,6 +60,49 @@ bool acquire_lock (const std::string& lock_path) {
     return true;
 }
 /**
+ * Read @p text as @p flag's value onto @p out.
+ *
+ * The refusal is printed here rather than returned, because both call sites do
+ * the same thing with it and the argument loop is at its complexity budget with
+ * one branch per flag, not two.
+ *
+ * @return true to carry on, false when the run is over.
+ */
+bool read_numeric_flag (const vayu::core::NumericFlag& flag, std::string_view text, int& out) {
+    const auto parsed = vayu::core::parse_numeric_flag (flag, text);
+    if (!parsed) {
+        std::cerr << "vayu-engine: " << parsed.error () << "\n";
+        return false;
+    }
+    out = *parsed;
+    return true;
+}
+
+/// `-p` / `--port <PORT>`. A flag with nothing after it leaves the default
+/// standing, which is what it has always done.
+bool read_port (std::span<char* const> args, size_t& i, int& port) {
+    if (i + 1 >= args.size ()) {
+        return true;
+    }
+    return read_numeric_flag (vayu::core::PORT_FLAG, args[++i], port);
+}
+
+/// `-v` / `--verbose [LEVEL]`. The level is optional, so a leading digit is
+/// what says the next argument was meant as one at all - `-v run` is verbose
+/// with no level, not a bad level. Once it is meant as one it is held to the
+/// range rather than clamped into it: `-v 5` was silently 2, which told the
+/// user nothing about the levels that exist.
+bool read_verbosity (std::span<char* const> args, size_t& i, int& verbosity) {
+    if (i + 1 < args.size () &&
+    std::isdigit (static_cast<unsigned char> (*args[i + 1])) != 0) {
+        return read_numeric_flag (vayu::core::VERBOSITY_FLAG, args[++i], verbosity);
+    }
+    // No level specified, default to 1 (info level)
+    verbosity = 1;
+    return true;
+}
+
+/**
  * The daemon's own arguments.
  *
  * @return the exit code to stop on - `--help` answers here - or nothing to
@@ -70,23 +115,16 @@ read_daemon_args (std::span<char* const> args, int& port, int& verbosity, std::s
 
         if (arg == vayu::core::constants::cli::ARG_PORT_SHORT ||
         arg == vayu::core::constants::cli::ARG_PORT_LONG) {
-            if (i + 1 < args.size ()) {
-                port = std::stoi (args[++i]);
+            if (!read_port (args, i, port)) {
+                return 1;
             }
         } else if (arg == "-d" || arg == "--data-dir") {
             if (i + 1 < args.size ()) {
                 data_dir = args[++i];
             }
         } else if (arg == "-v" || arg == "--verbose") {
-            // Check if next arg is a number (verbosity level)
-            if (i + 1 < args.size () &&
-            std::isdigit (static_cast<unsigned char> (*args[i + 1])) != 0) {
-                verbosity = std::stoi (args[++i]);
-                // Clamp to valid range [0, 2]
-                verbosity = std::max (0, std::min (2, verbosity));
-            } else {
-                // No level specified, default to 1 (info level)
-                verbosity = 1;
+            if (!read_verbosity (args, i, verbosity)) {
+                return 1;
             }
         } else if (arg == "-h" || arg == "--help") {
             std::cout << "Vayu Engine " << vayu::Version::string << "\n\n";

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(vayu_tests
     load_stream_events_test.cpp
     sse_stream_test.cpp
     server_bind_test.cpp
+    numeric_flag_test.cpp
     transport_policy_test.cpp
     tls_verification_test.cpp
     client_certificates_test.cpp

--- a/engine/tests/numeric_flag_test.cpp
+++ b/engine/tests/numeric_flag_test.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/numeric_flag_test.cpp
+ * @brief The numeric command-line flags and what each accepts (issue #1028),
+ *        and the guard that keeps `std::stoi` out of the two argument loops.
+ *
+ * `--port notanumber` used to answer `vayu-engine: stoi` - the name of the
+ * function that threw - and, before the daemon had a top-level handler at all,
+ * to abort with no message. Both are the same missing check: the text after a
+ * flag went to `std::stoi` without anyone asking whether it was a number, or
+ * one of the numbers that flag takes.
+ *
+ * The behavioural half below is per flag, because the range is the part a user
+ * needs and the part that can silently be wrong: `--port 99999` parsed fine and
+ * failed later at bind time, and `--verbose 5` was clamped to 2 without saying
+ * so. Each flag is described once in `core/numeric_flag.hpp`, so these tests
+ * and the argument loops read the same description rather than two copies of
+ * it that can drift.
+ *
+ * The scanning half is for what no behavioural test reaches: a *new* `std::stoi`
+ * arriving in either loop later. It is deliberately narrow - the engine parses
+ * integers out of stored config, imported documents and libcurl's replies in
+ * other places, and `std::stoi` is a reasonable answer there - so the rule is
+ * about the two files that read a human's arguments, not about the tree.
+ */
+
+#include <array>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "source_scan.hpp"
+#include "vayu/core/numeric_flag.hpp"
+
+namespace vayu {
+namespace {
+
+using core::parse_numeric_flag;
+using core::PORT_FLAG;
+using core::VERBOSITY_FLAG;
+
+/// Every refusal has to carry the three things the old `stoi` message did not.
+void expect_names_flag_value_and_range (const std::string& message,
+const core::NumericFlag& flag,
+std::string_view value) {
+    EXPECT_NE (message.find (flag.name), std::string::npos) << message;
+    EXPECT_NE (message.find (std::string (value)), std::string::npos) << message;
+    EXPECT_NE (message.find (std::to_string (flag.min)), std::string::npos) << message;
+    EXPECT_NE (message.find (std::to_string (flag.max)), std::string::npos) << message;
+}
+
+// ---------------------------------------------------------------------------
+// --port
+// ---------------------------------------------------------------------------
+
+TEST (NumericFlagTest, PortTakesEveryPortAndItsEnds) {
+    EXPECT_EQ (parse_numeric_flag (PORT_FLAG, "9876").value (), 9876);
+    EXPECT_EQ (parse_numeric_flag (PORT_FLAG, "1").value (), 1);
+    EXPECT_EQ (parse_numeric_flag (PORT_FLAG, "65535").value (), 65535);
+}
+
+TEST (NumericFlagTest, PortRefusesAValueThatIsNotANumber) {
+    const auto parsed = parse_numeric_flag (PORT_FLAG, "notanumber");
+    ASSERT_FALSE (parsed.has_value ());
+    expect_names_flag_value_and_range (parsed.error (), PORT_FLAG, "notanumber");
+
+    // The mistake `std::stoi` made quietly rather than loudly: a number with a
+    // tail was the number, so a typo became a different port.
+    const auto partial = parse_numeric_flag (PORT_FLAG, "9876x");
+    ASSERT_FALSE (partial.has_value ());
+    expect_names_flag_value_and_range (partial.error (), PORT_FLAG, "9876x");
+
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "").has_value ());
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, " 80").has_value ());
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "+80").has_value ());
+}
+
+TEST (NumericFlagTest, PortRefusesAValueOutsideTheRange) {
+    // Parsed fine and then failed at bind time, which is a worse place to learn
+    // it - the whole reason the range is checked here.
+    const auto high = parse_numeric_flag (PORT_FLAG, "99999");
+    ASSERT_FALSE (high.has_value ());
+    expect_names_flag_value_and_range (high.error (), PORT_FLAG, "99999");
+
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "65536").has_value ());
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "0").has_value ());
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "-1").has_value ());
+
+    // Wider than `int`: `std::stoi` answered this one with `std::out_of_range`,
+    // which reached the user as the word "stoi" like every other failure.
+    EXPECT_FALSE (parse_numeric_flag (PORT_FLAG, "99999999999999999999").has_value ());
+}
+
+// ---------------------------------------------------------------------------
+// --verbose
+// ---------------------------------------------------------------------------
+
+TEST (NumericFlagTest, VerbosityTakesTheThreeLevelsTheLoggerHas) {
+    EXPECT_EQ (parse_numeric_flag (VERBOSITY_FLAG, "0").value (), 0);
+    EXPECT_EQ (parse_numeric_flag (VERBOSITY_FLAG, "1").value (), 1);
+    EXPECT_EQ (parse_numeric_flag (VERBOSITY_FLAG, "2").value (), 2);
+}
+
+TEST (NumericFlagTest, VerbosityRefusesAValueThatIsNotANumber) {
+    // Both loops decide "was a level meant at all?" on a leading digit, so what
+    // reaches this parse is a value that was meant as one - `1abc` is a
+    // mistyped level, and used to be read as level 1.
+    const auto parsed = parse_numeric_flag (VERBOSITY_FLAG, "1abc");
+    ASSERT_FALSE (parsed.has_value ());
+    expect_names_flag_value_and_range (parsed.error (), VERBOSITY_FLAG, "1abc");
+}
+
+TEST (NumericFlagTest, VerbosityRefusesALevelThatDoesNotExist) {
+    // Clamped to 2 before, which answered a user who asked for something the
+    // logger does not have by silently giving them something else.
+    const auto parsed = parse_numeric_flag (VERBOSITY_FLAG, "5");
+    ASSERT_FALSE (parsed.has_value ());
+    expect_names_flag_value_and_range (parsed.error (), VERBOSITY_FLAG, "5");
+
+    EXPECT_FALSE (parse_numeric_flag (VERBOSITY_FLAG, "3").has_value ());
+    EXPECT_FALSE (parse_numeric_flag (VERBOSITY_FLAG, "-1").has_value ());
+}
+
+TEST (NumericFlagTest, TheMessageIsTheOneAUserCanActOn) {
+    // Named in full rather than only probed, because the shape of this sentence
+    // is the fix: the flag, the range and the value, where `stoi` was.
+    EXPECT_EQ (parse_numeric_flag (PORT_FLAG, "notanumber").error (),
+    "--port expects a number between 1 and 65535, got \"notanumber\"");
+}
+
+// ---------------------------------------------------------------------------
+// The guard
+// ---------------------------------------------------------------------------
+
+/// The two files that read a human's arguments. Everywhere else in the engine
+/// parses integers out of its own stored data, where a throwing parse has no
+/// user to confuse.
+constexpr std::array<std::string_view, 2> kArgumentLoops = { {
+"src/daemon.cpp",
+"src/cli.cpp",
+} };
+
+TEST (NumericFlagTest, TheArgumentLoopsDoNotThrowIntegersAtTheUser) {
+    const std::filesystem::path root{ VAYU_ENGINE_SOURCE_DIR };
+    std::vector<std::string> offenders;
+    std::size_t scanned_bytes = 0;
+
+    for (const auto& relative : kArgumentLoops) {
+        const auto path = root / relative;
+        ASSERT_TRUE (std::filesystem::is_regular_file (path))
+        << path.string () << " is not where the guard looks";
+
+        const std::string code = tests::strip_comments (tests::read_source (path));
+        ASSERT_FALSE (code.empty ()) << relative << " read as empty";
+        scanned_bytes += code.size ();
+
+        for (const auto* thrower : { "stoi", "stol", "stoll", "atoi" }) {
+            if (tests::names_call (code, thrower)) {
+                offenders.push_back (std::string (relative) + ": " + thrower);
+            }
+        }
+    }
+
+    // A scan that read nothing passes forever, so it says what it read.
+    ASSERT_GT (scanned_bytes, 10'000u) << "the guard read empty sources";
+
+    std::string joined;
+    for (const auto& offender : offenders) {
+        if (!joined.empty ()) {
+            joined += "\n  ";
+        }
+        joined += offender;
+    }
+    EXPECT_TRUE (offenders.empty ())
+    << "each of these throws the name of a function at whoever mistyped a "
+       "flag, and accepts a partial number besides. Describe the flag in "
+       "core/numeric_flag.hpp and read it with parse_numeric_flag. "
+       "Offenders:\n  "
+    << joined;
+}
+
+TEST (NumericFlagTest, TheGuardSeesTheCallsAndNotTheirNeighbours) {
+    // The planted positives. Without these, a broken matcher would leave the
+    // guard above passing on a loop that had brought every `stoi` back.
+    EXPECT_TRUE (tests::names_call ("port = std::stoi (args[++i]);", "stoi"));
+    EXPECT_TRUE (tests::names_call ("auto v = stoi(text);", "stoi"));
+
+    // And the names that merely contain one. `std::stoul` is a different
+    // function, and a variable is not a call at all.
+    EXPECT_FALSE (tests::names_call ("std::stoul (text)", "stoi"));
+    EXPECT_FALSE (tests::names_call ("const int stoic = 3;", "stoi"));
+
+    // And prose really is blanked, which is what lets these files explain the
+    // rule they are held to.
+    EXPECT_FALSE (tests::names_call (
+    tests::strip_comments ("// never std::stoi (text) here\n"), "stoi"));
+}
+
+} // namespace
+} // namespace vayu


### PR DESCRIPTION
## Description

**Plan.** Root cause: both argument loops handed the text after a numeric flag to `std::stoi` unchecked. That is two defects, not one - a non-numeric value leaves as `std::invalid_argument` and an out-of-range one as `std::out_of_range`, so the whole user-facing answer was `what()`, the string `"stoi"`; and a *partly* numeric value is accepted silently, so `--verbose 1abc` was level 1 (the "42abc is 42" mistake `vayu::utils::parse_number` exists to prevent). Approach: `vayu::core::parse_numeric_flag` (`core/numeric_flag.hpp`) as the layer above that primitive which adds what a flag has and a parse does not - the range and the sentence - with each flag described once (`--port` 1..65535, `--verbose` 0..2) so the loop that reads it and the test that holds it to its range read one description rather than two that can drift. The alternative I rejected: passing `min`/`max` at each call site, which is a range that can disagree with the one the tests check, and which would have left the same rule spelled in three places.

```
$ vayu-engine --port notanumber
vayu-engine: --port expects a number between 1 and 65535, got "notanumber"
```

**I checked #1024 before writing anything, because the issue anchors to it, and its account is exact.** That PR gives `main` a `try`/`catch` and moves the body into `run_daemon (std::span)` - which is *why* the symptom is a legible `stoi` rather than a silent `SIGABRT` - and leaves the loop alone: `std::stoi (args[++i])` appears in its diff only as unchanged context. It does not touch `engine/src/cli.cpp` at all (28 changed files, that one is not among them), so the `--verbose` hole there was untouched too. Our line ranges do not overlap - its hunks are the function header and the file tail, mine are inside the loop - and it is already `dirty` against a master that has since extracted `read_daemon_args`, so it owes a merge regardless of this PR.

Anchors verified against master `39a4a00`. One drift from the issue's text: `daemon.cpp`'s loop is already extracted into `read_daemon_args (std::span, ...)` (landed with #1027), so the restructure the Sequencing section says to wait for is partly in the base already.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All on this branch, Linux:

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2432 / 2432 passed**, 0 failed (43.9s). The 9 new ones are `NumericFlagTest`.
- `cd app && pnpm test` - **5702 passed** across 531 files, 0 failed.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `mkdocs build --strict` - clean.
- `scripts/pre-commit` with clang-format 19 / clang-tidy 19 - clean on all four staged sources.

New tests (`engine/tests/numeric_flag_test.cpp`), per flag as the issue asks:
- `--port`: takes 1, 9876 and 65535; refuses `notanumber`, `9876x`, empty, `" 80"`, `+80`; refuses `0`, `65536`, `99999`, `-1` and a value wider than `int`.
- `--verbose`: takes 0, 1, 2; refuses `1abc`; refuses `5`, `3`, `-1`.
- `TheMessageIsTheOneAUserCanActOn` pins the sentence in full, because its shape is the fix.
- `TheArgumentLoopsDoNotThrowIntegersAtTheUser` scans `src/daemon.cpp` and `src/cli.cpp` for `stoi`/`stol`/`stoll`/`atoi` (acceptance criterion 2), with planted positives and negatives beside it so a broken matcher cannot pass on a tree that brought them back. Deliberately narrow: the engine parses integers out of stored config, imported documents and libcurl replies elsewhere, where a throwing parse has no user to confuse.

Mutation-checked, each rebuilt and run:
- Drop the range half of the check → `PortRefusesAValueOutsideTheRange` and `VerbosityRefusesALevelThatDoesNotExist` fail; the rest pass.
- Put `std::stoi` back in the daemon's `--port` branch → the source scan fails, naming `src/daemon.cpp: stoi`.

End-to-end on the real binaries, before and after the restructure below:

| Invocation | exit | stderr |
|---|---|---|
| `vayu-engine --port notanumber` | 1 | `vayu-engine: --port expects a number between 1 and 65535, got "notanumber"` |
| `vayu-engine --port 99999` | 1 | same shape, `"99999"` |
| `vayu-engine --port 0` | 1 | same shape, `"0"` |
| `vayu-engine -v 5` | 1 | `--verbose expects a number between 0 and 2, got "5"` |
| `vayu-engine --verbose 1abc` | 1 | `--verbose expects a number between 0 and 2, got "1abc"` |
| `vayu-cli --verbose 7` / `1abc` | 1 | same shape, `vayu-cli:` |
| `vayu-engine -v 2`, `--port 9876` | - | starts and listens, unchanged |

**One flaky failure worth recording rather than hiding.** A first app-suite run reported 5701 / 5702, `UrlBar/send-with-row.test.tsx` timing out, while this 4-core box was simultaneously running the engine ctest and a ninja build. Re-run with nothing else in flight, the suite passes 5702 / 5702. Same shape as the flake #1024 recorded; no app file is in this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the doc table: `docs/engine/cli.md` (the accepted range for each daemon flag, the refusal and its exit code, and the `--verbose` row's range) and `engine/CLAUDE.md` (the new primitive named under the bounds rule, so the next numeric flag is described rather than parsed at the site).

**Deliberate deviations and behaviour changes, each with its reason:**

- **`--verbose 5` is now refused rather than clamped to 2.** Acceptance criterion 1 says every numeric flag refuses an out-of-range value, and clamping answered a user who asked for a level that does not exist by silently giving them a different one. A leading digit still decides whether the next argument was meant as a level at all, so `-v run` is verbose with no level, as before.
- **`--port 99999` is refused at parse time**, where it used to parse and fail later at bind time - the issue's own point about the worse place to learn it.
- **`read_port` and `read_verbosity` split out of `read_daemon_args`.** The refusal branches took that function to a cognitive complexity of 29 against the gate's threshold of 25. The per-flag readers are simpler than the branches they replace, and they are what let the loop stop spelling `args[++i]` inside a condition that also reads `i` (`bugprone-inc-dec-in-conditions`, the gate's second finding).
- **A flag with no value after it still leaves the default standing.** `vayu-engine --port` with nothing following is silently the default 9876, as it has always been. The issue asks about non-numeric and out-of-range values, not missing ones, so that is left alone rather than widened into - noted on the issue instead.
- **Out of scope by the issue's own wording: the `std::stoi` calls outside the two argument loops** (`import_document.cpp`, `database.cpp`, `recovery.cpp`, `openapi_drafts.cpp`, `platform_*.cpp` and others). Criterion 2 is about the argument loops, and those sites parse the engine's own stored data where there is no user to hand a function name to.

## Related Issues
Closes #1028

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug5KW83n8UoUvcikNvS6tS)_