### PR TITLE
fix(engine): refuse an argument neither loop can act on - #1031

### DIFF
--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -45,6 +45,7 @@ vayu-cli run request.json --daemon http://localhost:9999
 | `-h, --help` | Show help message |
 | `-v, --version` | Show version information |
 | `--verbose [LEVEL]` | Enable verbose output. LEVEL is 0 (warn/error), 1 (info) or 2 (debug); `--verbose` on its own means 1. A level outside 0-2, or one that is not a whole number, is refused with exit code 1 |
+| *(anything else)* | Refused, naming the argument, with exit code 1 |
 | `--no-color` | Disable colored output |
 | `--daemon <url>` | Vayu Engine URL (default: http://127.0.0.1:9876) |
 
@@ -163,19 +164,44 @@ The daemon exits **1** if it cannot take its port, naming the address on
 stderr - another process is listening there. Use `--port` to pick a different
 one, and `--daemon` to point the CLI at it. An ordinary shutdown exits **0**.
 
-Its numeric flags are checked before anything starts, and a value that is not
-one of the numbers the flag takes is refused on stderr with exit code **1**
-rather than clamped or read as its numeric prefix:
+Its arguments are checked before anything starts, and one that cannot be acted
+on is refused on stderr with exit code **1** rather than dropped:
 
 | Daemon flag | Accepts |
 |-------------|---------|
 | `-p, --port <PORT>` | A whole number from 1 to 65535 |
+| `-d, --data-dir <DIR>` | A directory path |
 | `-v, --verbose [LEVEL]` | 0 (warn/error), 1 (info) or 2 (debug); `-v` on its own means 1 |
 
 ```
 $ vayu-engine --port notanumber
 vayu-engine: --port expects a number between 1 and 65535, got "notanumber"
+
+$ vayu-engine --port
+vayu-engine: --port expects a port number, and nothing follows it
+
+$ vayu-engine --data-dir --port 9999
+vayu-engine: --data-dir expects a directory, got "--port" - a value starting with "-" reads as another flag
+
+$ vayu-engine --prot 9999
+vayu-engine: unknown argument "--prot" - run vayu-engine --help for the arguments it takes
 ```
+
+Three rules behind those, and both binaries follow them:
+
+- **A flag that takes a value is refused when nothing follows it.** It never
+  falls back to the default silently, which is how a flag that was typed used
+  to have no effect and leave no trace.
+- **A value beginning with `-` is refused**, because it is far more often the
+  next flag than a value. `vayu-engine --data-dir --port 9999` used to create a
+  data directory literally named `--port`, database and lock file inside, and
+  then listen on the default port. A path that genuinely starts with `-` is
+  reachable as `./-name`.
+- **An argument matching no flag is refused**, naming it and pointing at
+  `--help`. A mistyped flag used to be indistinguishable from passing none.
+
+`--verbose` is exempt from the first rule alone: its level is optional, so
+`-v` with nothing after it is verbosity 1, as it has always been.
 
 ## Error Handling
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -157,7 +157,14 @@ engine/
   the value to the range the flag documents and answers a refusal naming the
   flag, the range and what was typed, because the two argument loops used to
   reach for `std::stoi` and answer `vayu-engine: stoi`. A new numeric flag is
-  described there, never parsed at the site - and **`vayu::http::CurlErrorBuffer`**
+  described there, never parsed at the site. **`core/flag_value.hpp`** (#1031)
+  is the rule that runs before either: a flag with nothing after it, and a value
+  beginning with `-`, are refused rather than defaulted or taken - `--data-dir
+  --port 9999` used to create a data directory named `--port`. Both argument
+  loops live in headers now (`core/daemon_args.hpp`, `core/cli_args.hpp`)
+  because a rule is only worth the loop wired to it, and the loop is what
+  `tests/argument_rules_test.cpp` has to be able to call - and
+  **`vayu::http::CurlErrorBuffer`**
   (`http/curl_error_buffer.hpp`) owns `CURLOPT_ERRORBUFFER`, whose three rules
   (at least `CURL_ERROR_SIZE` bytes, alive for the whole transfer, written only
   on failure so a reused handle must be cleared between transfers) a bare

--- a/engine/include/vayu/core/cli_args.hpp
+++ b/engine/include/vayu/core/cli_args.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/cli_args.hpp
+ * @brief What `vayu-cli`'s argument vector says to do (#1031).
+ *
+ * Moved out of `cli.cpp` for the reason `daemon_args.hpp` was moved out of
+ * `daemon.cpp`: the loop is where each rule is applied, so it is the loop a
+ * test has to be able to call. `--help` and `--version` become a *request* the
+ * caller answers rather than something the parse prints, which is what lets the
+ * usage text stay in the binary that owns it.
+ */
+
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "vayu/core/constants.hpp"
+#include "vayu/core/flag_value.hpp"
+#include "vayu/core/numeric_flag.hpp"
+
+namespace vayu::core {
+
+/** What the argument vector says to do, once it has been read. */
+struct CliOptions {
+    std::string command;
+    int verbosity = 0; ///< 0=warn/error, 1=info+, 2=debug+
+    bool color    = true;
+    std::string filepath;
+    std::string daemon_url{ vayu::core::constants::defaults::DAEMON_URL };
+};
+
+/// What the argument vector asked for, when it did not ask for a command.
+enum class CliRequest : std::uint8_t {
+    /// Carry on with what @ref CliOptions now holds.
+    Continue,
+    /// `-h` / `--help`: print the usage and stop, successfully.
+    Help,
+    /// `-v` / `--version`.
+    Version,
+};
+
+namespace detail {
+
+/// `--verbose [LEVEL]`. The level is optional, so a leading digit is what says
+/// the next argument was meant as one at all - `--verbose run` is the command
+/// with verbose on, not a bad level.
+inline std::expected<void, std::string>
+read_verbose_flag (std::span<char* const> args, size_t& i, CliOptions& options) {
+    if (!next_is_a_level (args, i)) {
+        options.verbosity = 1;
+        return {};
+    }
+    const auto level = parse_numeric_flag (VERBOSITY_FLAG, args[i + 1]);
+    if (!level) {
+        return std::unexpected (level.error ());
+    }
+    options.verbosity = *level;
+    ++i;
+    return {};
+}
+
+/// `--daemon <url>`.
+inline std::expected<void, std::string>
+read_daemon_flag (std::span<char* const> args, size_t& i, CliOptions& options) {
+    const auto value =
+    read_flag_value ("--daemon", "an engine URL", argument_after (args, i));
+    if (!value) {
+        return std::unexpected (value.error ());
+    }
+    options.daemon_url = *value;
+    ++i;
+    return {};
+}
+
+/// `run <file>`. The command's own argument, read where the command is - not by
+/// the trailing catch-all this replaced, which claimed the *first* non-flag
+/// word and so answered `vayu-cli run` by reporting the word `run` as a file it
+/// could not open (#1031).
+inline std::expected<void, std::string>
+read_run_command (std::span<char* const> args, size_t& i, CliOptions& options) {
+    const auto value =
+    read_flag_value ("run", "a request file path", argument_after (args, i));
+    if (!value) {
+        return std::unexpected (value.error ());
+    }
+    options.filepath = *value;
+    ++i;
+    return {};
+}
+
+} // namespace detail
+
+/**
+ * @brief Read @p args onto @p options.
+ *
+ * @return what to do next, or the line to print on stderr before exiting 1.
+ *
+ * `args[1]` is the command and is seeded onto @p options by the caller; the
+ * loop still visits it, because a command is also how `-h` reaches this.
+ */
+inline std::expected<CliRequest, std::string>
+read_cli_flags (std::span<char* const> args, CliOptions& options) {
+    for (size_t i = 1; i < args.size (); ++i) {
+        const std::string_view arg = args[i];
+        std::expected<void, std::string> outcome;
+
+        if (arg == "-h" || arg == "--help") {
+            return CliRequest::Help;
+        } else if (arg == "-v" || arg == "--version") {
+            return CliRequest::Version;
+        } else if (arg == "--no-color") {
+            options.color = false;
+        } else if (arg == "--verbose") {
+            outcome = detail::read_verbose_flag (args, i, options);
+        } else if (arg == "--daemon") {
+            outcome = detail::read_daemon_flag (args, i, options);
+        } else if (arg == "run") {
+            outcome = detail::read_run_command (args, i, options);
+        } else if (i == 1 && !looks_like_a_flag (arg)) {
+            // The command sits at `args[1]` and is not this loop's to judge: an
+            // unrecognised one is answered by the dispatch, which names it and
+            // points at `--help`. Anything else unrecognised is refused below,
+            // where it used to be dropped without a word.
+        } else {
+            outcome = std::unexpected (unknown_argument_error (arg, "vayu-cli"));
+        }
+
+        if (!outcome) {
+            return std::unexpected (outcome.error ());
+        }
+    }
+    return CliRequest::Continue;
+}
+
+} // namespace vayu::core

--- a/engine/include/vayu/core/daemon_args.hpp
+++ b/engine/include/vayu/core/daemon_args.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/daemon_args.hpp
+ * @brief What `vayu-engine`'s argument vector says to do (#1031).
+ *
+ * Moved out of `daemon.cpp` so it can be *called*: the loop is where every rule
+ * in #1031 is either applied or not, and a test that reaches only the helpers
+ * under it cannot tell a flag wired to the wrong reader from one wired to the
+ * right one. `daemon.cpp` keeps what a parse should not own - printing, and the
+ * exit code - so this answers with a decision rather than with `std::cout`.
+ */
+
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "vayu/core/constants.hpp"
+#include "vayu/core/flag_value.hpp"
+#include "vayu/core/numeric_flag.hpp"
+
+namespace vayu::core {
+
+/// What the daemon was asked to run with. Seeded by the caller, because the
+/// data directory's default is a platform path this header has no business
+/// knowing.
+struct DaemonArgs {
+    int port = vayu::core::constants::defaults::PORT;
+    /// 0=warn/error, 1=info+, 2=debug+
+    int verbosity = 0;
+    std::string data_dir;
+};
+
+/// What the argument vector asked for, when it did not ask for a run.
+enum class DaemonRequest : std::uint8_t {
+    /// Carry on with what @ref DaemonArgs now holds.
+    Continue,
+    /// `-h` / `--help`: print the usage and stop, successfully.
+    Help,
+};
+
+namespace detail {
+
+/// `-p` / `--port <PORT>`. Rule 1 only: a flag-shaped value is refused by the
+/// parse, which says the same thing and can name the range while doing it.
+inline std::expected<void, std::string>
+read_port_flag (std::span<char* const> args, size_t& i, DaemonArgs& out) {
+    const auto next = argument_after (args, i);
+    if (!next) {
+        return std::unexpected (missing_value_error (PORT_FLAG.name, "a port number"));
+    }
+    const auto port = parse_numeric_flag (PORT_FLAG, *next);
+    if (!port) {
+        return std::unexpected (port.error ());
+    }
+    out.port = *port;
+    ++i;
+    return {};
+}
+
+/// `-d` / `--data-dir <DIR>`.
+inline std::expected<void, std::string>
+read_data_dir_flag (std::span<char* const> args, size_t& i, DaemonArgs& out) {
+    const auto value =
+    read_flag_value ("--data-dir", "a directory", argument_after (args, i));
+    if (!value) {
+        return std::unexpected (value.error ());
+    }
+    out.data_dir = *value;
+    ++i;
+    return {};
+}
+
+/// `-v` / `--verbose [LEVEL]`. The level is optional, so an absent one is the
+/// default rather than the missing value rule 1 refuses.
+inline std::expected<void, std::string>
+read_verbosity_flag (std::span<char* const> args, size_t& i, DaemonArgs& out) {
+    if (!next_is_a_level (args, i)) {
+        out.verbosity = 1;
+        return {};
+    }
+    const auto level = parse_numeric_flag (VERBOSITY_FLAG, args[i + 1]);
+    if (!level) {
+        return std::unexpected (level.error ());
+    }
+    out.verbosity = *level;
+    ++i;
+    return {};
+}
+
+} // namespace detail
+
+/**
+ * @brief Read @p args onto @p out.
+ *
+ * @return what to do next, or the line to print on stderr before exiting 1.
+ *         Every argument is either acted on or refused - nothing is dropped.
+ */
+inline std::expected<DaemonRequest, std::string>
+read_daemon_args (std::span<char* const> args, DaemonArgs& out) {
+    for (size_t i = 1; i < args.size (); ++i) {
+        const std::string_view arg = args[i];
+        std::expected<void, std::string> outcome;
+
+        if (arg == vayu::core::constants::cli::ARG_PORT_SHORT ||
+        arg == vayu::core::constants::cli::ARG_PORT_LONG) {
+            outcome = detail::read_port_flag (args, i, out);
+        } else if (arg == "-d" || arg == "--data-dir") {
+            outcome = detail::read_data_dir_flag (args, i, out);
+        } else if (arg == "-v" || arg == "--verbose") {
+            outcome = detail::read_verbosity_flag (args, i, out);
+        } else if (arg == "-h" || arg == "--help") {
+            return DaemonRequest::Help;
+        } else {
+            outcome = std::unexpected (unknown_argument_error (arg, "vayu-engine"));
+        }
+
+        if (!outcome) {
+            return std::unexpected (outcome.error ());
+        }
+    }
+    return DaemonRequest::Continue;
+}
+
+} // namespace vayu::core

--- a/engine/include/vayu/core/flag_value.hpp
+++ b/engine/include/vayu/core/flag_value.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/flag_value.hpp
+ * @brief The two ways an argument can be unusable, said once (#1031).
+ *
+ * `core/numeric_flag.hpp` answers "is this value one of the numbers the flag
+ * takes". This answers the questions that come before it and apply to every
+ * flag, numeric or not - and that both argument loops used to answer by
+ * carrying on regardless:
+ *
+ * - **There is nothing after the flag.** `vayu-engine --data-dir . --port` used
+ *   to listen on the default 9876 and say nothing, so the flag that was typed
+ *   had no effect and left no trace.
+ * - **What follows is another flag.** This is the one that does damage, because
+ *   it *succeeds*: `vayu-engine --data-dir --port 9999` took the string
+ *   `--port` as the data directory and created it - database, log and lock file
+ *   inside - then listened on 9876, because `9999` matched nothing afterwards
+ *   and was dropped in turn.
+ *
+ * A value beginning with `-` is refused rather than taken, which is the
+ * conventional reading and the one that turns that case into a sentence. It
+ * costs the user who genuinely means a relative path starting with `-` the
+ * `./` prefix, and it is worth that: a leading `-` is a mistyped command line
+ * far more often than it is a filename.
+ *
+ * Numeric flags do not need the second rule - `parse_numeric_flag` refuses
+ * `--port` as a number already, and with a better sentence, because it can name
+ * the range. They do need the first, which is why `read_flag_value` reports the
+ * two separately rather than as one "bad value".
+ */
+
+#include <cctype>
+#include <expected>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace vayu::core {
+
+namespace detail {
+
+/// The argument after @p i, or nothing when @p i is the last one.
+inline std::optional<std::string_view> argument_after (std::span<char* const> args, size_t i) {
+    if (i + 1 >= args.size ()) {
+        return std::nullopt;
+    }
+    return std::string_view (args[i + 1]);
+}
+
+/// Whether the argument after @p i was meant as an *optional* level, which a
+/// leading digit is the whole of the question for: `-v run` is verbose with no
+/// level rather than a bad one, and so is `-v` last on the line. Stated once
+/// because both `--verbose` flags answer it and they must answer it alike.
+inline bool next_is_a_level (std::span<char* const> args, size_t i) {
+    const auto next = argument_after (args, i);
+    return next.has_value () && !next->empty () &&
+    std::isdigit (static_cast<unsigned char> (next->front ())) != 0;
+}
+
+} // namespace detail
+
+/// Whether @p text reads as another flag rather than as a value.
+inline bool looks_like_a_flag (std::string_view text) {
+    return text.starts_with ("-");
+}
+
+/// The first rule's refusal: nothing followed the flag. @p expected names what
+/// the flag wanted ("a directory", "a port number"), because "expects a value"
+/// tells someone who has just mistyped the flag the least useful half of it.
+inline std::string missing_value_error (std::string_view flag, std::string_view expected) {
+    return std::string (flag) + " expects " + std::string (expected) + ", and nothing follows it";
+}
+
+/// The second rule's refusal. Kept apart from the first because a numeric flag
+/// takes only rule 1 and answers this one better itself: `parse_numeric_flag`
+/// names the range where this can only say the value looked like a flag.
+inline std::string flag_shaped_value_error (std::string_view flag,
+std::string_view expected,
+std::string_view value) {
+    return std::string (flag) + " expects " + std::string (expected) + ", got \"" +
+    std::string (value) + "\" - a value starting with \"-\" reads as another flag";
+}
+
+/**
+ * @brief The value @p flag should take, or the line to refuse the run with.
+ *
+ * @param expected what the flag wants, as it reads after "expects".
+ * @param next the argument following the flag, or `std::nullopt` when the flag
+ *        was the last thing on the command line. Empty and absent are kept
+ *        apart deliberately: `--daemon ""` is a value, badly chosen, and
+ *        belongs to whatever validates it downstream rather than here.
+ */
+inline std::expected<std::string_view, std::string> read_flag_value (std::string_view flag,
+std::string_view expected,
+std::optional<std::string_view> next) {
+    if (!next.has_value ()) {
+        return std::unexpected (missing_value_error (flag, expected));
+    }
+    if (looks_like_a_flag (*next)) {
+        return std::unexpected (flag_shaped_value_error (flag, expected, *next));
+    }
+    return *next;
+}
+
+/**
+ * @brief The refusal for an argument that matches nothing.
+ *
+ * Both loops used to drop one silently, so a mistyped `--prot 9999` was
+ * indistinguishable from passing no flag at all - the engine listened on the
+ * default port and exited 0 whenever it was told to.
+ */
+inline std::string unknown_argument_error (std::string_view argument, std::string_view program) {
+    return "unknown argument \"" + std::string (argument) + "\" - run " +
+    std::string (program) + " --help for the arguments it takes";
+}
+
+} // namespace vayu::core

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -17,8 +17,8 @@
 
 #include <httplib.h>
 
+#include "vayu/core/cli_args.hpp"
 #include "vayu/core/constants.hpp"
-#include "vayu/core/numeric_flag.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/utils/diagnostics.hpp"
@@ -39,12 +39,6 @@
 #include <vector>
 
 namespace {
-// Default daemon URL. A view rather than a `std::string`, so the alias costs
-// nothing before `main` - a namespace-scope `std::string` allocates during
-// dynamic initialisation, where the allocation failure cannot be caught
-// (`cert-err58-cpp`).
-constexpr std::string_view DEFAULT_DAEMON_URL = vayu::core::constants::defaults::DAEMON_URL;
-
 void print_version () {
     std::cout << "vayu-cli " << vayu::Version::string << "\n";
     vayu::utils::log_info ("vayu-cli " + std::string (vayu::Version::string));
@@ -274,103 +268,6 @@ int run_via_daemon (const std::string& daemon_url, const std::string& filepath, 
     }
 }
 
-/** What the argument vector says to do, once it has been read. */
-struct CliOptions {
-    std::string command;
-    int verbosity = 0; ///< 0=warn/error, 1=info+, 2=debug+
-    bool color    = true;
-    std::string filepath;
-    std::string daemon_url{ DEFAULT_DAEMON_URL };
-};
-
-/**
- * One argument.
- *
- * @param next the argument a flag would consume; @p has_next is kept apart from
- *        its emptiness on purpose - `--daemon ""` is a value, badly chosen, and
- *        it stays the caller's to be told about downstream rather than silently
- *        reinterpreted as a missing one.
- * @param consumed_next set when the flag took @p next as its value.
- * @return the exit code to stop on - `--help` and `--version` answer here - or
- *         nothing to carry on.
- */
-std::optional<int> read_cli_flag (const std::string& arg,
-std::string_view next,
-bool has_next,
-CliOptions& options,
-bool& consumed_next) {
-    if (arg == "-h" || arg == "--help") {
-        print_help ();
-        return 0;
-    }
-    if (arg == "-v" || arg == "--version") {
-        print_version ();
-        return 0;
-    }
-    if (arg == "--verbose") {
-        // The level is optional: `--verbose` on its own means info, and a
-        // leading digit is what says the next argument was meant as a level at
-        // all - `--verbose run` is the command, not a bad level. Once it is
-        // meant as one it is held to the range the logger has rather than
-        // clamped into it, and `--verbose 1abc` is refused rather than read as
-        // 1 (see core/numeric_flag.hpp).
-        if (!next.empty () &&
-        std::isdigit (static_cast<unsigned char> (next.front ())) != 0) {
-            const auto parsed =
-            vayu::core::parse_numeric_flag (vayu::core::VERBOSITY_FLAG, next);
-            if (!parsed) {
-                std::cerr << "vayu-cli: " << parsed.error () << "\n";
-                return 1;
-            }
-            options.verbosity = *parsed;
-            consumed_next     = true;
-        } else {
-            options.verbosity = 1;
-        }
-        return std::nullopt;
-    }
-    if (arg == "--no-color") {
-        options.color = false;
-        return std::nullopt;
-    }
-    if (arg == "--daemon" && has_next) {
-        options.daemon_url = next;
-        consumed_next      = true;
-        return std::nullopt;
-    }
-    if (arg == "run" && has_next) {
-        options.filepath = next;
-        consumed_next    = true;
-        return std::nullopt;
-    }
-    // First non-flag argument after 'run' is the filepath
-    if (options.command == "run" && options.filepath.empty () && arg[0] != '-') {
-        options.filepath = arg;
-    }
-    return std::nullopt;
-}
-
-/**
- * The flags and the command's own argument, in one pass.
- *
- * @return the exit code to stop on, or nothing to carry on with what it read.
- */
-std::optional<int> read_cli_flags (std::span<char* const> args, CliOptions& options) {
-    for (size_t i = 1; i < args.size (); ++i) {
-        const bool has_next = i + 1 < args.size ();
-        const std::string_view next =
-        has_next ? std::string_view (args[i + 1]) : std::string_view ();
-        bool consumed_next = false;
-        if (auto stop = read_cli_flag (args[i], next, has_next, options, consumed_next)) {
-            return stop;
-        }
-        if (consumed_next) {
-            ++i;
-        }
-    }
-    return std::nullopt;
-}
-
 /**
  * The whole of the CLI, so that `main` is a catch and nothing else.
  *
@@ -393,10 +290,24 @@ int run_cli (std::span<char* const> args) {
         return 1;
     }
 
-    CliOptions options;
-    options.command = args[1];
-    if (auto stop = read_cli_flags (args, options)) {
-        return *stop;
+    vayu::core::CliOptions options;
+    options.command    = args[1];
+    const auto request = vayu::core::read_cli_flags (args, options);
+    if (!request) {
+        // Refused where it was typed, in the shape every bad argument answers
+        // with (#1028, #1031) - not dropped, which is what left a mistyped
+        // flag indistinguishable from no flag at all.
+        std::cerr << "vayu-cli: " << request.error () << "\n";
+        vayu::utils::log_error ("vayu-cli: " + request.error ());
+        return 1;
+    }
+    if (*request == vayu::core::CliRequest::Help) {
+        print_help ();
+        return 0;
+    }
+    if (*request == vayu::core::CliRequest::Version) {
+        print_version ();
+        return 0;
     }
 
     // Initialize curl (still needed for httplib?)

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -19,11 +19,10 @@
 #include <cstdlib>
 #include <iostream>
 #include <span>
-#include <string_view>
 #include <thread>
 
 #include "vayu/core/constants.hpp"
-#include "vayu/core/numeric_flag.hpp"
+#include "vayu/core/daemon_args.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -59,108 +58,51 @@ bool acquire_lock (const std::string& lock_path) {
 
     return true;
 }
-/**
- * Read @p text as @p flag's value onto @p out.
- *
- * The refusal is printed here rather than returned, because both call sites do
- * the same thing with it and the argument loop is at its complexity budget with
- * one branch per flag, not two.
- *
- * @return true to carry on, false when the run is over.
- */
-bool read_numeric_flag (const vayu::core::NumericFlag& flag, std::string_view text, int& out) {
-    const auto parsed = vayu::core::parse_numeric_flag (flag, text);
-    if (!parsed) {
-        std::cerr << "vayu-engine: " << parsed.error () << "\n";
-        return false;
-    }
-    out = *parsed;
-    return true;
-}
 
-/// `-p` / `--port <PORT>`. A flag with nothing after it leaves the default
-/// standing, which is what it has always done.
-bool read_port (std::span<char* const> args, size_t& i, int& port) {
-    if (i + 1 >= args.size ()) {
-        return true;
-    }
-    return read_numeric_flag (vayu::core::PORT_FLAG, args[++i], port);
-}
-
-/// `-v` / `--verbose [LEVEL]`. The level is optional, so a leading digit is
-/// what says the next argument was meant as one at all - `-v run` is verbose
-/// with no level, not a bad level. Once it is meant as one it is held to the
-/// range rather than clamped into it: `-v 5` was silently 2, which told the
-/// user nothing about the levels that exist.
-bool read_verbosity (std::span<char* const> args, size_t& i, int& verbosity) {
-    if (i + 1 < args.size () &&
-    std::isdigit (static_cast<unsigned char> (*args[i + 1])) != 0) {
-        return read_numeric_flag (vayu::core::VERBOSITY_FLAG, args[++i], verbosity);
-    }
-    // No level specified, default to 1 (info level)
-    verbosity = 1;
-    return true;
-}
-
-/**
- * The daemon's own arguments.
- *
- * @return the exit code to stop on - `--help` answers here - or nothing to
- *         carry on with what the pass read.
- */
-std::optional<int>
-read_daemon_args (std::span<char* const> args, int& port, int& verbosity, std::string& data_dir) {
-    for (size_t i = 1; i < args.size (); ++i) {
-        std::string arg = args[i];
-
-        if (arg == vayu::core::constants::cli::ARG_PORT_SHORT ||
-        arg == vayu::core::constants::cli::ARG_PORT_LONG) {
-            if (!read_port (args, i, port)) {
-                return 1;
-            }
-        } else if (arg == "-d" || arg == "--data-dir") {
-            if (i + 1 < args.size ()) {
-                data_dir = args[++i];
-            }
-        } else if (arg == "-v" || arg == "--verbose") {
-            if (!read_verbosity (args, i, verbosity)) {
-                return 1;
-            }
-        } else if (arg == "-h" || arg == "--help") {
-            std::cout << "Vayu Engine " << vayu::Version::string << "\n\n";
-            std::cout << "Usage: vayu-engine [OPTIONS]\n\n";
-            std::cout << "Options:\n";
-            std::cout
-            << "  -p, --port <PORT>        Port to listen on (default: 9876)\n";
-            std::cout << "  -d, --data-dir <DIR>     Data directory for DB, "
-                         "logs, and lock file "
-                         "(default: ../data)\n";
-            std::cout << "  -v, --verbose [LEVEL]    Enable verbose output "
-                         "(0=warn/error, 1=info, "
-                         "2=debug, default: 1)\n";
-            std::cout << "  -h, --help               Show this help message\n";
-            return 0;
-        }
-    }
-    return std::nullopt;
+/// The usage `-h` / `--help` answers with. Printed here rather than by the
+/// parse, which reports the request and owns no output stream (#1031).
+void print_help () {
+    std::cout << "Vayu Engine " << vayu::Version::string << "\n\n";
+    std::cout << "Usage: vayu-engine [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  -p, --port <PORT>        Port to listen on (default: 9876, "
+                 "1-65535)\n";
+    std::cout << "  -d, --data-dir <DIR>     Data directory for DB, "
+                 "logs, and lock file "
+                 "(default: ../data)\n";
+    std::cout << "  -v, --verbose [LEVEL]    Enable verbose output "
+                 "(0=warn/error, 1=info, "
+                 "2=debug, default: 1)\n";
+    std::cout << "  -h, --help               Show this help message\n";
 }
 
 } // namespace
 
 int main (int argc, char* argv[]) {
     // Parse arguments first (need data_dir for logging)
-    int port             = vayu::core::constants::defaults::PORT;
-    int verbosity        = 0; // 0=warn/error, 1=info+, 2=debug+
-    std::string data_dir = get_default_data_dir ();
+    vayu::core::DaemonArgs parsed;
+    parsed.data_dir = get_default_data_dir ();
 
     // The argument vector as the bounded range it is: `argv[i]` is arithmetic
     // on a pointer that carries no length, and the count is right there.
     const std::span<char* const> args (argv, static_cast<size_t> (argc));
 
-    if (auto stop = read_daemon_args (args, port, verbosity, data_dir)) {
-        return *stop;
+    const auto request = vayu::core::read_daemon_args (args, parsed);
+    if (!request) {
+        // Refused before anything starts - no logger yet, so stderr is the
+        // whole of the report, and it is the same shape every bad argument
+        // answers with (#1028, #1031).
+        std::cerr << "vayu-engine: " << request.error () << "\n";
+        return 1;
+    }
+    if (*request == vayu::core::DaemonRequest::Help) {
+        print_help ();
+        return 0;
     }
 
+    const int port             = parsed.port;
+    const int verbosity        = parsed.verbosity;
+    const std::string data_dir = parsed.data_dir;
 
     // Ensure data directory exists
     try {

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(vayu_tests
     sse_stream_test.cpp
     server_bind_test.cpp
     numeric_flag_test.cpp
+    argument_rules_test.cpp
     transport_policy_test.cpp
     tls_verification_test.cpp
     client_certificates_test.cpp

--- a/engine/tests/argument_rules_test.cpp
+++ b/engine/tests/argument_rules_test.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/argument_rules_test.cpp
+ * @brief What each argument loop does with an argument it cannot act on (#1031).
+ *
+ * Three rules, and the tests below are per rule *per loop* rather than on the
+ * helper under them, because a rule is only worth what the loop wired to it is:
+ * a flag reading the wrong helper, or none, is exactly the defect these replace
+ * and it is invisible from underneath.
+ *
+ * Each rule is here because it was silent, and each was measured on the real
+ * binaries before the fix:
+ *
+ * - `vayu-engine --data-dir . --port` listened on the default 9876 and said
+ *   nothing, so a flag that was typed had no effect and left no trace.
+ * - `vayu-engine --data-dir --port 9999` took the string `--port` as the data
+ *   directory and *created* it - `--port/db/vayu.db`, `--port/logs/`,
+ *   `--port/vayu.lock` - then listened on 9876, because `9999` matched nothing
+ *   afterwards and was dropped in turn. This is the one that does damage,
+ *   because it succeeds.
+ * - `vayu-engine --prot 9999` ran on 9876; `vayu-cli --prot 9999` printed
+ *   nothing and exited 0. A typo was indistinguishable from no flag.
+ *
+ * The loops take `std::span<char* const>`, the shape `main` hands them, so the
+ * fixture below builds one from string literals rather than the tests each
+ * spelling a `char*` array.
+ */
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "optional_assert.hpp"
+#include "vayu/core/cli_args.hpp"
+#include "vayu/core/daemon_args.hpp"
+
+namespace vayu {
+namespace {
+
+/// An argument vector with the program name in front, owned for as long as the
+/// span is read. `argv` is `char* const`, not `const char*`, so the strings are
+/// copied into buffers this holds rather than pointed at literals.
+class ArgumentVector {
+    public:
+    explicit ArgumentVector (std::initializer_list<std::string_view> arguments) {
+        storage_.emplace_back ("vayu-test");
+        for (const auto& argument : arguments) {
+            storage_.emplace_back (argument);
+        }
+        pointers_.reserve (storage_.size ());
+        for (auto& entry : storage_) {
+            pointers_.push_back (entry.data ());
+        }
+    }
+
+    std::span<char* const> span () const {
+        return { pointers_.data (), pointers_.size () };
+    }
+
+    private:
+    std::vector<std::string> storage_;
+    std::vector<char*> pointers_;
+};
+
+core::DaemonArgs seeded_daemon_args () {
+    core::DaemonArgs args;
+    args.data_dir = "seeded";
+    return args;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1 - a flag that takes a value, given none
+// ---------------------------------------------------------------------------
+
+TEST (ArgumentRulesTest, DaemonRefusesAValueFlagWithNothingAfterIt) {
+    for (const auto* flag : { "--port", "-p", "--data-dir", "-d" }) {
+        auto parsed = seeded_daemon_args ();
+        const ArgumentVector args ({ flag });
+        const auto request = core::read_daemon_args (args.span (), parsed);
+
+        ASSERT_FALSE (request.has_value ()) << flag << " was accepted with no value";
+        EXPECT_NE (request.error ().find ("nothing follows it"), std::string::npos)
+        << request.error ();
+        // The default must not quietly stand: that is what made the missing
+        // value invisible.
+        EXPECT_EQ (parsed.data_dir, "seeded");
+    }
+}
+
+TEST (ArgumentRulesTest, CliRefusesAValueFlagWithNothingAfterIt) {
+    for (const auto* flag : { "--daemon", "run" }) {
+        core::CliOptions options;
+        const ArgumentVector args ({ flag });
+        const auto request = core::read_cli_flags (args.span (), options);
+
+        ASSERT_FALSE (request.has_value ()) << flag << " was accepted with no value";
+        EXPECT_NE (request.error ().find (flag), std::string::npos) << request.error ();
+        EXPECT_NE (request.error ().find ("nothing follows it"), std::string::npos)
+        << request.error ();
+    }
+}
+
+TEST (ArgumentRulesTest, AnOptionalLevelIsNotAMissingValue) {
+    // `--verbose` takes its level optionally, so rule 1 must not reach it -
+    // `-v` last on the line is verbose at the default, as it has always been.
+    for (const auto* flag : { "-v", "--verbose" }) {
+        auto parsed = seeded_daemon_args ();
+        const ArgumentVector args ({ flag });
+        const auto request = core::read_daemon_args (args.span (), parsed);
+
+        ASSERT_HAS_VALUE (request) << request.error ();
+        EXPECT_EQ (parsed.verbosity, 1);
+    }
+
+    core::CliOptions options;
+    const ArgumentVector cli_args ({ "--verbose" });
+    ASSERT_HAS_VALUE (core::read_cli_flags (cli_args.span (), options));
+    EXPECT_EQ (options.verbosity, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2 - a value that reads as another flag
+// ---------------------------------------------------------------------------
+
+TEST (ArgumentRulesTest, DaemonRefusesAValueThatReadsAsAnotherFlag) {
+    // The reproduction from the issue: this used to create a data directory
+    // called `--port`, with a database in it, and then listen on 9876.
+    auto parsed = seeded_daemon_args ();
+    const ArgumentVector args ({ "--data-dir", "--port", "9999" });
+    const auto request = core::read_daemon_args (args.span (), parsed);
+
+    ASSERT_FALSE (request.has_value ());
+    EXPECT_NE (request.error ().find ("--data-dir"), std::string::npos)
+    << request.error ();
+    EXPECT_NE (request.error ().find ("--port"), std::string::npos) << request.error ();
+    EXPECT_EQ (parsed.data_dir, "seeded")
+    << "the flag was taken as a directory anyway";
+}
+
+TEST (ArgumentRulesTest, CliRefusesAValueThatReadsAsAnotherFlag) {
+    // `vayu-cli --daemon run req.json` set the daemon URL to the string "run",
+    // left the command empty, printed nothing and exited 0.
+    core::CliOptions options;
+    const ArgumentVector args ({ "--daemon", "--no-color" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_FALSE (request.has_value ());
+    EXPECT_NE (request.error ().find ("--daemon"), std::string::npos) << request.error ();
+    EXPECT_NE (request.error ().find ("--no-color"), std::string::npos)
+    << request.error ();
+}
+
+TEST (ArgumentRulesTest, ANumericFlagKeepsItsOwnBetterRefusal) {
+    // `--port` needs rule 1, not rule 2: `parse_numeric_flag` already refuses a
+    // flag-shaped value, and it can name the range while doing it. The message
+    // a user sees for `--port --data-dir` should be the numeric one.
+    auto parsed = seeded_daemon_args ();
+    const ArgumentVector args ({ "--port", "--data-dir", "." });
+    const auto request = core::read_daemon_args (args.span (), parsed);
+
+    ASSERT_FALSE (request.has_value ());
+    EXPECT_EQ (request.error (),
+    "--port expects a number between 1 and 65535, got \"--data-dir\"");
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3 - an argument that matches nothing
+// ---------------------------------------------------------------------------
+
+TEST (ArgumentRulesTest, DaemonRefusesAnUnknownArgument) {
+    auto parsed = seeded_daemon_args ();
+    const ArgumentVector args ({ "--prot", "9999" });
+    const auto request = core::read_daemon_args (args.span (), parsed);
+
+    ASSERT_FALSE (request.has_value ()) << "a mistyped flag was dropped again";
+    EXPECT_NE (request.error ().find ("--prot"), std::string::npos) << request.error ();
+    EXPECT_NE (request.error ().find ("--help"), std::string::npos) << request.error ();
+    EXPECT_EQ (parsed.port, vayu::core::constants::defaults::PORT);
+}
+
+TEST (ArgumentRulesTest, CliRefusesAnUnknownArgument) {
+    core::CliOptions options;
+    const ArgumentVector args ({ "run", "req.json", "--prot", "9999" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_FALSE (request.has_value ());
+    EXPECT_NE (request.error ().find ("--prot"), std::string::npos) << request.error ();
+    EXPECT_NE (request.error ().find ("--help"), std::string::npos) << request.error ();
+}
+
+TEST (ArgumentRulesTest, TheCommandItselfIsLeftToTheDispatch) {
+    // An unrecognised *command* is not this loop's to refuse: `run_cli` names it
+    // and points at `--help` already, and a refusal here would take that over
+    // with a worse sentence.
+    core::CliOptions options;
+    const ArgumentVector args ({ "frobnicate" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_HAS_VALUE (request) << request.error ();
+    EXPECT_EQ (*request, core::CliRequest::Continue);
+}
+
+// ---------------------------------------------------------------------------
+// What the rules must not have broken
+// ---------------------------------------------------------------------------
+
+TEST (ArgumentRulesTest, TheDaemonStillReadsAWholeCommandLine) {
+    auto parsed = seeded_daemon_args ();
+    const ArgumentVector args ({ "--port", "8080", "-d", "/tmp/vayu", "-v", "2" });
+    const auto request = core::read_daemon_args (args.span (), parsed);
+
+    ASSERT_HAS_VALUE (request) << request.error ();
+    EXPECT_EQ (*request, core::DaemonRequest::Continue);
+    EXPECT_EQ (parsed.port, 8080);
+    EXPECT_EQ (parsed.data_dir, "/tmp/vayu");
+    EXPECT_EQ (parsed.verbosity, 2);
+}
+
+TEST (ArgumentRulesTest, TheCliStillReadsAWholeCommandLine) {
+    core::CliOptions options;
+    options.command = "run";
+    const ArgumentVector args ({ "run", "req.json", "--daemon",
+    "http://127.0.0.1:9999", "--no-color", "--verbose", "2" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_HAS_VALUE (request) << request.error ();
+    EXPECT_EQ (*request, core::CliRequest::Continue);
+    EXPECT_EQ (options.filepath, "req.json");
+    EXPECT_EQ (options.daemon_url, "http://127.0.0.1:9999");
+    EXPECT_FALSE (options.color);
+    EXPECT_EQ (options.verbosity, 2);
+}
+
+TEST (ArgumentRulesTest, RunWithNoPathLeavesTheFilepathForTheDispatchToReport) {
+    // The trailing catch-all this replaced claimed the word `run` itself as the
+    // filepath, so `vayu-cli run` answered "Failed to open file: run" and left
+    // `run_cli`'s own "Missing request file" branch unreachable.
+    core::CliOptions options;
+    options.command = "run";
+    const ArgumentVector args ({ "run" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_FALSE (request.has_value ());
+    EXPECT_EQ (options.filepath, "")
+    << "the command word was taken as its own argument";
+}
+
+TEST (ArgumentRulesTest, HelpAndVersionAreRequestsRatherThanOutput) {
+    auto parsed = seeded_daemon_args ();
+    const ArgumentVector help ({ "--help" });
+    const auto daemon_request = core::read_daemon_args (help.span (), parsed);
+    ASSERT_HAS_VALUE (daemon_request) << daemon_request.error ();
+    EXPECT_EQ (*daemon_request, core::DaemonRequest::Help);
+
+    core::CliOptions options;
+    const ArgumentVector version ({ "--version" });
+    const auto cli_request = core::read_cli_flags (version.span (), options);
+    ASSERT_HAS_VALUE (cli_request) << cli_request.error ();
+    EXPECT_EQ (*cli_request, core::CliRequest::Version);
+}
+
+TEST (ArgumentRulesTest, AnEmptyValueIsAValueRatherThanAMissingOne) {
+    // `--daemon ""` is a value, badly chosen, and belongs to whatever validates
+    // it downstream - the distinction `read_flag_value` keeps deliberately.
+    core::CliOptions options;
+    const ArgumentVector args ({ "--daemon", "" });
+    const auto request = core::read_cli_flags (args.span (), options);
+
+    ASSERT_HAS_VALUE (request) << request.error ();
+    EXPECT_EQ (options.daemon_url, "");
+}
+
+} // namespace
+} // namespace vayu


### PR DESCRIPTION
## Description

**Plan.** Root cause: both argument loops were written as "if I recognise this, consume it", with no branch for the two things that make an argument unusable - nothing follows a flag that needs a value, and this argument matches nothing. Approach: three rules in one shared header (`core/flag_value.hpp`) that both loops read, each refusing at parse time with a line naming the flag, what it wanted and what was typed. The alternative I rejected: adding the checks at each of the six call sites, which is the same rule spelled six times and the shape that let the two loops disagree in the first place - `--verbose` was already clamping in one and refusing in the other before #1030.

The second half of the plan is where the diff gets big, and it is deliberate. **Both loops moved into headers** (`core/daemon_args.hpp`, `core/cli_args.hpp`) so a test can call them. A rule is only worth the loop wired to it, and a flag reading the wrong helper - or none - is exactly the defect this replaces and is invisible from underneath; acceptance criterion 5 asks for a test per rule *per loop*, which the old anonymous-namespace-in-an-executable shape made impossible. Printing and the exit code stay in the binaries: the parse answers with a *request*, so `--help` and `--version` are decisions rather than output and the usage text stays where it belongs.

Sequencing prerequisite satisfied: #1030 merged as `75df1af`, so the `read_port` / `read_verbosity` seam this builds on is in the base.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All on this branch, Linux:

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2446 / 2446 passed**, 0 failed (67.0s). The 14 new ones are `ArgumentRulesTest`.
- `cd app && pnpm test` - **5702 / 5702 passed**, 531 / 531 files (see the flake note below).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `mkdocs build --strict` - clean.
- `scripts/pre-commit` with clang-format 19 / clang-tidy 19 - clean on all staged sources.

New tests (`engine/tests/argument_rules_test.cpp`), per rule per loop as the issue asks:

| Rule | Daemon | CLI |
|---|---|---|
| 1 - no value after the flag | `--port`, `-p`, `--data-dir`, `-d` | `--daemon`, `run` |
| 2 - value reads as another flag | `--data-dir --port 9999` | `--daemon --no-color` |
| 3 - argument matches nothing | `--prot 9999` | `--prot 9999` after a valid `run` |

Plus what the rules must not have broken: `--verbose` exempt from rule 1 in both loops (its level is optional), `--port` keeping the numeric refusal rather than rule 2's, an unrecognised *command* still left to `run_cli`'s own dispatch, `--daemon ""` still a value rather than a missing one, and a whole valid command line still read correctly on both sides.

Mutation-checked, each rebuilt and run:
- Drop the terminal `else` → `DaemonRefusesAnUnknownArgument` fails, nothing else.
- Drop the `looks_like_a_flag` check → both rule-2 tests fail, nothing else.
- Restore "a missing value leaves the default standing" → `DaemonRefusesAValueFlagWithNothingAfterIt` fails, nothing else.

End-to-end on the real binaries, the issue's own reproductions:

| Invocation | before | after |
|---|---|---|
| `vayu-engine --data-dir . --port` | listens on 9876, silent | `1` - `--port expects a port number, and nothing follows it` |
| `vayu-engine --data-dir --port 9999` | creates `--port/db/vayu.db`, listens on 9876 | `1` - `--data-dir expects a directory, got "--port" - a value starting with "-" reads as another flag` |
| `vayu-engine --prot 9999` | listens on 9876 | `1` - `unknown argument "--prot" - run vayu-engine --help for the arguments it takes` |
| `vayu-cli --daemon` | exit 0, no output | `1` - `--daemon expects an engine URL, and nothing follows it` |
| `vayu-cli run` | `Failed to open file: run` | `1` - `run expects a request file path, and nothing follows it` |
| `vayu-cli --prot 9999` | exit 0, no output | `1` - `unknown argument "--prot" …` |
| `vayu-engine --port 9876 -v 2 -d .` | starts | starts, unchanged |
| `vayu-engine --help`, `vayu-cli --version`, `vayu-cli frobnicate` | - | unchanged (`0`, `0`, `1` with the dispatch's own message) |

Verified no junk directory is created on the second row any more.

**One flaky failure, recorded rather than hidden.** A first app-suite run reported 5701 / 5702 while the engine ctest and a ninja build were running beside it on this 4-core box; my capture kept only the summary, so I re-ran the whole suite idle with the full log rather than assume - 5702 / 5702, zero failures, and no `FAIL` / `timed out` lines anywhere in it. Same shape as the flake #1024 and #1030 each recorded. No app file is in this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the doc table: `docs/engine/cli.md` (the three rules, a per-flag table for the daemon including `--data-dir`, the refusals verbatim, and an "anything else" row on the CLI options table) and `engine/CLAUDE.md` (the new primitive named under the bounds rule, next to `parse_numeric_flag`).

**Deliberate deviations and decisions, each with its reason:**

- **The messages name what the flag wanted**, not "a value" - `--data-dir expects a directory`, `run expects a request file path`. The issue's own suggested wording, and the half a user who has just mistyped something actually needs.
- **`--port` takes rule 1 only, not rule 2.** `parse_numeric_flag` refuses a flag-shaped value already *and* can name the range while doing it, so `--port --data-dir` keeps `expects a number between 1 and 65535`. `read_flag_value` reports the two refusals separately so a numeric flag can take one without the other. There is a test pinning that exact message.
- **`vayu-cli run` is refused by the loop, not by `run_cli`.** Criterion 4 asks that it say the path is missing rather than report `run` as an unopenable file, and it does. It does not resurrect `run_cli`'s "Missing request file" branch, which stays unreachable - one refusal in one place beat two messages for one mistake.
- **An unrecognised *command* is still the dispatch's.** `vayu-cli frobnicate` keeps `Error: Unknown command 'frobnicate'`; refusing it in the loop would have taken that over with a worse sentence. The loop exempts `args[1]` when it is not flag-shaped, and that exemption is tested.
- **The `--help` exit code was already right** (criterion's "check while here"): `-h` returns 0 and a refusal returns 1, and they are now visibly different paths - `DaemonRequest::Help` versus `std::unexpected`, rather than two `std::optional<int>`s that happened to differ.
- **Per-flag readers extracted in both loops.** Not cosmetic: with the refusal branches inline, `read_cli_flags` measured a cognitive complexity of 30 and `read_daemon_args` 26, against the gate's 25. Same remedy #1030 used for the same gate.
- **Out of scope, and worth knowing:** `vayu-cli --daemon http://x run f.json` still does nothing quietly, because the command is positionally `args[1]` and so is `--daemon` here. That is unchanged by this PR (before it, the same line set the daemon URL to the string `run` and exited 0), and fixing it means changing what "the command" means, which this issue does not ask for. Happy to file it.

## Related Issues
Closes #1031

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug5KW83n8UoUvcikNvS6tS)_