### PR TITLE
refactor(engine): split walk_operations and run_rate_limited into named steps

### DIFF
--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -416,6 +416,62 @@ class ConstantLoadStrategy : public LoadStrategy {
 
     private:
     /**
+     * Pay out the requests one tick owes, up to the in-flight cap's headroom.
+     * Requests the cap refuses are dropped at the instant they came due, not
+     * deferred. Deferring is what let a saturated run submit its backlog past
+     * the deadline and still report itself on rate. Returns how many were
+     * actually submitted.
+     */
+    static size_t submit_due (const std::shared_ptr<RunContext>& context,
+    vayu::db::Database& db,
+    SubmissionRequest& live,
+    size_t due,
+    size_t max_pending) {
+        const size_t in_flight = context->in_flight ();
+        const size_t headroom = max_pending > in_flight ? max_pending - in_flight : 0;
+        const size_t to_submit = std::min (due, headroom);
+        if (due > to_submit) {
+            context->metrics_collector->record_drop_batch (due - to_submit);
+        }
+        size_t sent = 0;
+        for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
+            context->event_loop->submit (live.current (),
+            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
+                handle_result (context, db, result);
+            });
+            sent++;
+            context->requests_sent++;
+        }
+        return sent;
+    }
+
+    /**
+     * Wait out the remainder of a tick. Oversleeping is self-correcting - the
+     * next tick accrues the extra elapsed time - so the sleep can be the full
+     * remainder; on Windows short waits still spin, since 15.6ms timer
+     * rounding would make sub-tick sleeps bursty. @p context is read only by
+     * that spin, so the leg without it leaves the parameter unused.
+     */
+    static void wait_for_next_tick ([[maybe_unused]] const std::shared_ptr<RunContext>& context,
+    std::chrono::steady_clock::time_point next_tick) {
+        const auto sleep_us = std::chrono::duration_cast<std::chrono::microseconds> (
+        next_tick - std::chrono::steady_clock::now ())
+                              .count ();
+        if (sleep_us <= 100) {
+            return;
+        }
+#ifdef _WIN32
+        if (sleep_us <= 2000) {
+            while (std::chrono::steady_clock::now () < next_tick && !context->should_stop) {
+                /* spin */
+            }
+            return;
+        }
+#endif
+        std::this_thread::sleep_for (std::chrono::microseconds (sleep_us));
+    }
+
+    /**
      * Rate-limited mode: submit what each tick owes, drop what the in-flight
      * cap refuses, and stop at the deadline.
      */
@@ -470,54 +526,15 @@ class ConstantLoadStrategy : public LoadStrategy {
 
             const size_t due = take_due_requests (debt, target_rps, elapsed_us);
             if (due > 0) {
-                const size_t in_flight = context->in_flight ();
-                const size_t headroom =
-                max_pending > in_flight ? max_pending - in_flight : 0;
-                const size_t to_submit = std::min (due, headroom);
-
-                // Requests the in-flight cap refuses are dropped at the
-                // instant they came due, not deferred. Deferring is what
-                // let a saturated run submit its backlog past the deadline
-                // and still report itself on rate.
-                if (due > to_submit) {
-                    context->metrics_collector->record_drop_batch (due - to_submit);
-                }
-
-                for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
-                    context->event_loop->submit (live.current (),
-                    [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                        handle_result (context, db, result);
-                    });
-                    submitted++;
-                    context->requests_sent++;
-                }
+                submitted += submit_due (context, db, live, due, max_pending);
             }
 
             if (now >= duration_end) {
                 break;
             }
 
-            // Wait for the next tick. Oversleeping is self-correcting - the
-            // next tick accrues the extra elapsed time - so the sleep can be
-            // the full remainder; on Windows short waits still spin, since
-            // 15.6ms timer rounding would make sub-tick sleeps bursty.
-            const auto next_tick = accrued_through + std::chrono::microseconds (tick_us);
-            const auto sleep_us = std::chrono::duration_cast<std::chrono::microseconds> (
-            next_tick - std::chrono::steady_clock::now ())
-                                  .count ();
-            if (sleep_us > 100) {
-#ifdef _WIN32
-                if (sleep_us <= 2000) {
-                    while (std::chrono::steady_clock::now () < next_tick &&
-                    !context->should_stop) {
-                        /* spin */
-                    }
-                } else
-#endif
-                {
-                    std::this_thread::sleep_for (std::chrono::microseconds (sleep_us));
-                }
-            }
+            wait_for_next_tick (
+            context, accrued_through + std::chrono::microseconds (tick_us));
         }
 
         vayu::utils::log_info ("Submitted " + std::to_string (submitted) + " requests");

--- a/engine/src/core/openapi_walk.hpp
+++ b/engine/src/core/openapi_walk.hpp
@@ -255,6 +255,82 @@ struct WalkedOperation {
     bool identified = true;
 };
 
+/// The skipped members one path item hides from the walk (issue #877), counted
+/// once per item, before its methods - the position the renderer's parsers
+/// count these from. A `parameters` member that is not an array is the missing
+/// `-` in hand-written YAML; `trace` is a Path Item Object member in 3.x only,
+/// and only a present *object* is an operation that was dropped.
+inline void note_skipped_members (Dialect dialect,
+const nlohmann::ordered_json& item,
+WalkNotes& notes) {
+    if (const auto parameters = item.find ("parameters"); parameters != item.end () &&
+    !parameters->is_null () && !parameters->is_array ()) {
+        notes.malformed_spec += 1;
+    }
+    if (dialect == Dialect::V3) {
+        const auto trace = item.find ("trace");
+        if (trace != item.end () && trace->is_structured ()) {
+            notes.unsupported_method += 1;
+        }
+    }
+}
+
+/// The `operationId` @p operation keeps: its declared id, or "" - the no-id
+/// spelling `DeclaredOperation` documents - when it declares none, declares it
+/// as something other than a non-empty string, or repeats one a previous
+/// operation already claimed (issue #715). Only the repeat is counted on
+/// @p notes: a sync follows the identity a request records, so which request
+/// kept the id is not a detail the user should have to discover from a diff.
+inline std::string claim_operation_id (const nlohmann::ordered_json& operation,
+std::unordered_set<std::string>& claimed_ids,
+WalkNotes* notes) {
+    const auto id = operation.find ("operationId");
+    if (id == operation.end () || !id->is_string ()) {
+        return "";
+    }
+    std::string operation_id = id->get<std::string> ();
+    if (operation_id.empty ()) {
+        return "";
+    }
+    if (claimed_ids.insert (operation_id).second) {
+        return operation_id;
+    }
+    if (notes != nullptr) {
+        notes->duplicate_operation_id += 1;
+    }
+    return "";
+}
+
+/// Every operation one resolved Path Item Object declares, appended to
+/// @p walked in `HTTP_METHODS` order. Takes `claimed_ids` because the claim is
+/// document-wide: which of two operations keeps a repeated `operationId` spans
+/// path items, so the set outlives each call.
+inline void walk_path_item (const std::string& path,
+const nlohmann::ordered_json& item,
+std::unordered_set<std::string>& claimed_ids,
+WalkNotes* notes,
+std::vector<WalkedOperation>& walked) {
+    // A `paths` key that is not a path declares no operation - see
+    // `WalkedOperation::identified`. The row is still walked, because
+    // the import builds a request for it; no `operationId` is claimed
+    // off it, since the identity it would sit on does not exist.
+    const bool identified = !path.empty () && path[0] == '/';
+    for (const char* method : HTTP_METHODS) {
+        const nlohmann::ordered_json* operation = find_object (item, method);
+        if (operation == nullptr) {
+            continue;
+        }
+        DeclaredOperation row;
+        row.method = upper (method);
+        row.path   = path;
+        if (identified) {
+            row.operation_id = claim_operation_id (*operation, claimed_ids, notes);
+        }
+        row.responses = declared_responses_of (*operation);
+        walked.push_back ({ std::move (row), operation, &item, identified });
+    }
+}
+
 inline std::vector<WalkedOperation>
 walk_operations (const nlohmann::ordered_json& document, WalkNotes* notes = nullptr) {
     std::vector<WalkedOperation> walked;
@@ -272,7 +348,6 @@ walk_operations (const nlohmann::ordered_json& document, WalkNotes* notes = null
     std::unordered_set<std::string> claimed_ids;
 
     for (auto entry = paths->begin (); entry != paths->end (); ++entry) {
-        const std::string& path = entry.key ();
         const nlohmann::ordered_json* item =
         resolve_single_hop (document, entry.value ());
         if (item == nullptr) {
@@ -284,48 +359,9 @@ walk_operations (const nlohmann::ordered_json& document, WalkNotes* notes = null
             continue;
         }
         if (notes != nullptr) {
-            // Once per path item, before its methods - the position the
-            // renderer's parsers count these from.
-            if (const auto parameters = item->find ("parameters");
-            parameters != item->end () && !parameters->is_null () &&
-            !parameters->is_array ()) {
-                notes->malformed_spec += 1;
-            }
-            // `trace` is a Path Item Object member in 3.x only, and only a
-            // present *object* is an operation that was dropped.
-            if (dialect == Dialect::V3) {
-                const auto trace = item->find ("trace");
-                if (trace != item->end () && trace->is_structured ()) {
-                    notes->unsupported_method += 1;
-                }
-            }
+            note_skipped_members (dialect, *item, *notes);
         }
-        for (const char* method : HTTP_METHODS) {
-            const nlohmann::ordered_json* operation = find_object (*item, method);
-            if (operation == nullptr) {
-                continue;
-            }
-            // A `paths` key that is not a path declares no operation - see
-            // `WalkedOperation::identified`. The row is still walked, because
-            // the import builds a request for it; no `operationId` is claimed
-            // off it, since the identity it would sit on does not exist.
-            const bool identified = !path.empty () && path[0] == '/';
-            DeclaredOperation row;
-            row.method = upper (method);
-            row.path   = path;
-            if (const auto id = operation->find ("operationId"); identified &&
-            id != operation->end () && id->is_string () &&
-            !id->get<std::string> ().empty ()) {
-                const std::string operation_id = id->get<std::string> ();
-                if (claimed_ids.insert (operation_id).second) {
-                    row.operation_id = operation_id;
-                } else if (notes != nullptr) {
-                    notes->duplicate_operation_id += 1;
-                }
-            }
-            row.responses = declared_responses_of (*operation);
-            walked.push_back ({ std::move (row), operation, item, identified });
-        }
+        walk_path_item (entry.key (), *item, claimed_ids, notes, walked);
     }
     return walked;
 }


### PR DESCRIPTION
## Description

The two `readability-function-cognitive-complexity` findings the whole-tree scan reported on its first complete run (#1024, run 18 on `6192b29`) - the only findings on either leg - split into named steps, the way #1021 did the other 68.

**The plan, and the alternative I rejected.** Root cause is the same in both functions: several concerns accreted into one body. `walk_operations` interleaved dialect detection, path-item resolution, skip bookkeeping and the #715 identity rule inside a doubly-nested loop; `run_rate_limited` interleaved accrual, the tick payout with its drop accounting, and a platform-split sleep. The fix extracts each concern along the seams the issue names, with behaviour byte-for-byte unchanged: the walk gains `note_skipped_members` (the per-path-item skip counting, still gated on `notes != nullptr` at the call site), `claim_operation_id` (the repeated-`operationId` rule, answering `""` - the no-id spelling `DeclaredOperation` documents) and `walk_path_item` (one Path Item Object's methods, taking `claimed_ids` because the claim is document-wide); the rate limiter gains `submit_due` (one tick's payout against the in-flight cap's headroom, drops recorded at the instant they came due) and `wait_for_next_tick` (the sleep, now owning the `#ifdef _WIN32` spin - the branch that put the MSVC count over the threshold). The alternative rejected: `NOLINT` is ruled out by the issue itself (criterion 2), and restructuring the walk into a stateful iterator/class would touch all three readers' call sites for no gain - the check's point here is names on the steps, not new machinery.

Per the issue's anchors: both functions were exactly where the issue placed them (`openapi_walk.hpp:259`, `load_strategy.cpp:422` on `af2c6be`); nothing had drifted.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

(Neither box fits: this is a refactor with no behaviour change.)

## Testing

Local, on `af2c6be` + this diff, all green:

| Check | Result |
|-------|--------|
| `python build.py -e -t` | clean |
| `ctest --preset linux-dev --output-on-failure` | **2446 / 2446 passed**, 0 failed - `engine/tests/*` untouched, conformance fixtures (`declared-operations-conformance.json`, `import-conformance.json`) pass unmodified (criterion 3) |
| `cd app && pnpm test` | **5702 / 5702 passed** (531 files) |
| `cd app && pnpm type-check` | clean (all three tsconfigs) |
| `clang-format 19.1.7 --dry-run -Werror` on both files | clean |
| clang-tidy 19.1.0, repo config, whole-file over `load_strategy.cpp`, `openapi_document.cpp`, `openapi_drafts.cpp` with `-header-filter` reaching `openapi_walk.hpp` | **0 findings** |

### The measurement (criteria 1 and 4)

Per-function cognitive complexity, clang-tidy 19 with the threshold at 0 so the check names every value:

| Function | Before | After |
|----------|--------|-------|
| `walk_operations` | 37 (both legs) | **10** |
| `note_skipped_members` | - | 6 |
| `claim_operation_id` | - | 5 |
| `walk_path_item` | - | 6 |
| `run_rate_limited` | 26 (`windows-latest`) | **5** |
| `submit_due` | - | 4 |
| `wait_for_next_tick` | - | 1 on Linux; the MSVC-only spin adds `if` +1, nested `while` +2, `&&` +1 = **5** |

`openapi_walk.hpp` contains no platform branches, so its Linux measurement is both legs' measurement. `run_rate_limited` no longer contains the `#ifdef _WIN32` at all - the two legs can no longer disagree about it - and the spin's own MSVC count is arithmetic on a nine-line function. No `NOLINT` for this check introduced (criterion 2).

The whole-tree scan cannot run on this PR: its `pull_request` trigger fires only for the three files that invalidate the measurement (`engine/.clang-tidy` and the scan's own two files), none of which this diff touches, and `workflow_dispatch` is unusable from a branch. **Once this merges, re-run `Engine tidy scan` via `workflow_dispatch` on both legs** - run 18's only findings on either leg were these two functions, so that run is expected to read 0 findings on both (criterion 4's authoritative measurement).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - none added: a pure split, held by the 2446 existing tests and the conformance fixtures
- [ ] I have updated documentation - none needed: no doc describes these functions' internals; `docs/app/import-collections/openapi-v3.md` and `engine/CLAUDE.md` name `walk_operations` and describe what it answers, which is unchanged

## Related Issues

Closes #1033.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXz2h1MxtTAJ2xxuVWUpmB)_