### PR TITLE
fix(engine): jar.clear validates before it stages, and takes Postman's URL

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -26,7 +26,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Response headers    | `pm.response.headers.get(name)`, `.has(name)` - case-insensitive              |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
-| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear`, see below |
+| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear(url?)`, see below |
 | Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
 | Request headers     | `pm.request.headers.get/has(name)`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
@@ -450,6 +450,7 @@ const jar = pm.cookies.jar();
 jar.set(pm.request.url, { name: 'session', value: token });  // or (url, name, value)
 jar.get('https://api.example.com/', 'session');              // value, or undefined
 jar.unset('https://api.example.com/', 'session');
+jar.clear('https://api.example.com/');                       // that URL's cookies
 jar.clear();                                                 // this environment's jar
 ```
 
@@ -466,8 +467,11 @@ Divergences from Postman:
   it is called - so it rides that request and cannot be lost when the response's
   cookies are captured. Details in
   [scripting.md](../engine/scripting.md#writing-to-the-jar-pmcookiesjar).
-- **`jar.clear()` takes no URL** and empties this environment's jar. Postman's
-  clears per URL; Vayu's scope is the environment, so that is the unit here.
+- **`jar.clear(url)` matches Postman** - it removes every cookie that URL would
+  have carried, which is `unset` with no name to narrow it. **`jar.clear()`
+  with no URL is Vayu's own** and empties this environment's jar, because the
+  environment is Vayu's scope unit. A URL the engine cannot parse is refused
+  rather than cleared as a wipe matching nothing.
 - **`expires` is seconds since the epoch**, not a date string.
 - **Scope is the environment**, not the domain-with-permission model Postman
   uses. One jar per environment plus one for "no environment", in memory only,

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -897,11 +897,13 @@ jar.set(pm.request.url, { name: 'session', value: token });
 jar.set(pm.request.url, 'session', token);            // the same, flat
 jar.get('https://api.example.com/', 'session');        // value, or undefined
 jar.unset('https://api.example.com/', 'session');
+jar.clear('https://api.example.com/');                 // that URL's cookies
 jar.clear();                                           // this environment's jar
 ```
 
 Postman's jar object, whole. Every method is **URL-scoped** - it takes the URL
-the cookie belongs to rather than assuming this request's - and each accepts an
+the cookie belongs to rather than assuming this request's (`clear`'s URL is
+optional; see below) - and each accepts an
 optional trailing `callback(err, value)`, invoked inline the way
 [`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest)'s is,
 since the work has already happened by the time it is called. `get` also
@@ -944,11 +946,19 @@ made, and the next transfer of that execution carries it:
 - A `set` in a **post-request script** has no transfer left to ride, so it is
   applied to the jar when the script ends.
 
-`clear()` empties **this environment's jar and no other**. Nothing is on disk,
-so the cost is a re-login; other environments, and the no-environment jar, are
-untouched. There is no confirmation gate for scripts - "reset my session" is a
-legitimate thing for a script to want, and Settings → General → Cookies shows
-the result.
+**`clear` has two forms.** `clear(url)` is Postman's: it removes every cookie a
+request to that URL would have carried - `unset` with no name to narrow it, and
+the same matching, so a cookie stored for another host or under `/admin` when
+you cleared `/` is left alone. `clear()` with no URL empties **this
+environment's jar and no other**. Nothing is on disk either way, so the cost is
+a re-login; other environments, and the no-environment jar, are untouched.
+There is no confirmation gate for scripts - "reset my session" is a legitimate
+thing for a script to want, and Settings → General → Cookies shows the result.
+
+A URL the engine cannot parse is **refused** rather than cleared as a wipe that
+happens to match nothing: `clear` is destructive, so "cleared no cookies" and
+"that was not a URL" must not read the same to the script. Pass no argument at
+all for the whole-jar form.
 
 Load runs have no jar, so these throw there exactly as the read half does.
 

--- a/engine/include/vayu/http/cookie_jar.hpp
+++ b/engine/include/vayu/http/cookie_jar.hpp
@@ -170,6 +170,19 @@ int64_t now_seconds);
 cookie_for_url (const std::string& url, JarCookie cookie);
 
 /**
+ * @brief Can @p url scope a jar operation - does libcurl read a host and a
+ *        path out of it?
+ *
+ * The question `matching_in` cannot answer, because it returns an empty list
+ * both for a URL that matched nothing and for one it could not parse. A
+ * *destructive* call needs the two kept apart: `pm.cookies.jar().clear(url)`
+ * on an unparseable URL would otherwise report success for a wipe that never
+ * happened, which is the same false success `jar_writes` refuses a jarless
+ * execution over (issue #997).
+ */
+[[nodiscard]] bool url_can_scope_cookies (const std::string& url);
+
+/**
  * @brief One staged jar mutation from a script (issue #337).
  *
  * Staged rather than applied - see the file comment for why the write cannot
@@ -183,12 +196,16 @@ struct CookieWrite {
         Unset,
         /// Empty the scope.
         Clear,
+        /// Drop every cookie that would be sent to `url` - `Unset` without the
+        /// name filter, which is Postman's `jar.clear(url)` (issue #997).
+        ClearUrl,
     };
 
     Kind kind = Kind::Set;
     /// `Set` only: the line to merge, from `format_cookie_line`.
     std::string line;
-    /// `Unset` only: the URL the removal is scoped to, and the cookie name.
+    /// `Unset` and `ClearUrl`: the URL the removal is scoped to. `Unset` also
+    /// carries the cookie name; `ClearUrl` leaves it empty and takes them all.
     std::string url;
     std::string name;
 };

--- a/engine/src/http/cookie_jar.cpp
+++ b/engine/src/http/cookie_jar.cpp
@@ -68,6 +68,60 @@ std::optional<std::string> url_part (CURLU* handle, CURLUPart part) {
     return out;
 }
 
+/// What every URL-scoped jar operation needs off a URL. `scheme` may be empty
+/// where the caller does not care; `nullopt` means libcurl could not read a
+/// host and a path, which is the whole of "this URL cannot scope anything".
+struct UrlScope {
+    std::string host;
+    std::string path;
+    std::string scheme;
+};
+
+std::optional<UrlScope> url_scope_of (const std::string& url) {
+    CURLU* parsed = curl_url ();
+    if (!parsed) {
+        return std::nullopt;
+    }
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    std::optional<std::string> scheme;
+    if (curl_url_set (parsed, CURLUPART_URL, url.c_str (), 0) == CURLUE_OK) {
+        host   = url_part (parsed, CURLUPART_HOST);
+        path   = url_part (parsed, CURLUPART_PATH);
+        scheme = url_part (parsed, CURLUPART_SCHEME);
+    }
+    curl_url_cleanup (parsed);
+    if (!host || !path) {
+        return std::nullopt;
+    }
+    return UrlScope{ std::move (*host), std::move (*path),
+        scheme ? std::move (*scheme) : std::string{} };
+}
+
+/**
+ * @brief Erase the cookies among @p lines that a request to @p url would have
+ *        carried, optionally narrowed to one @p name.
+ *
+ * The one removal rule behind both `Unset` and `ClearUrl`: the name filter is
+ * the only difference between them, so it is a parameter rather than a second
+ * copy of the matching.
+ */
+void erase_url_scoped (std::vector<std::string>& lines,
+const std::string& url,
+std::optional<std::string_view> name) {
+    const auto doomed = matching_in (lines, url);
+    std::erase_if (lines, [&doomed, name] (const std::string& line) {
+        const auto held = parse_cookie_line (line);
+        if (!held || (name && held->name != *name)) {
+            return false;
+        }
+        return std::any_of (doomed.begin (), doomed.end (), [&held] (const JarCookie& match) {
+            return match.name == held->name && match.domain == held->domain &&
+            match.path == held->path;
+        });
+    });
+}
+
 } // namespace
 
 std::optional<JarCookie> parse_cookie_line (std::string_view line) {
@@ -207,31 +261,21 @@ std::optional<JarCookie> cookie_for_url (const std::string& url, JarCookie cooki
         return cookie;
     }
 
-    CURLU* parsed = curl_url ();
-    if (!parsed) {
-        return std::nullopt;
-    }
-    std::optional<std::string> host;
-    std::optional<std::string> path;
-    if (curl_url_set (parsed, CURLUPART_URL, url.c_str (), 0) == CURLUE_OK) {
-        host = url_part (parsed, CURLUPART_HOST);
-        path = url_part (parsed, CURLUPART_PATH);
-    }
-    curl_url_cleanup (parsed);
-    if (!host || !path) {
+    const auto scope = url_scope_of (url);
+    if (!scope) {
         return std::nullopt;
     }
 
     if (cookie.domain.empty ()) {
         // Host-only, which is what a Set-Cookie with no Domain attribute is.
-        cookie.domain = *host;
+        cookie.domain = scope->host;
     }
     if (cookie.path.empty ()) {
         // RFC 6265 §5.1.4 default-path: everything up to the last `/`, and `/`
         // when that leaves nothing.
-        const size_t last = path->rfind ('/');
+        const size_t last = scope->path.rfind ('/');
         cookie.path =
-        (last == std::string::npos || last == 0) ? "/" : path->substr (0, last);
+        (last == std::string::npos || last == 0) ? "/" : scope->path.substr (0, last);
     }
     cookie.include_subdomains = cookie.domain.starts_with (".");
     return cookie;
@@ -262,54 +306,42 @@ const std::vector<CookieWrite>& writes) {
             break;
         }
 
-        case CookieWrite::Kind::Unset: {
+        case CookieWrite::Kind::Unset:
             // URL-scoped, like the read half: `unset` removes what a request to
             // that URL would have carried, not every cookie sharing the name.
-            const auto doomed = matching_in (lines, write.url);
-            std::erase_if (lines, [&write, &doomed] (const std::string& line) {
-                const auto held = parse_cookie_line (line);
-                if (!held || held->name != write.name) {
-                    return false;
-                }
-                return std::any_of (doomed.begin (), doomed.end (),
-                [&held] (const JarCookie& match) {
-                    return match.name == held->name &&
-                    match.domain == held->domain && match.path == held->path;
-                });
-            });
+            erase_url_scoped (lines, write.url, write.name);
             break;
-        }
+
+        case CookieWrite::Kind::ClearUrl:
+            // Postman's `jar.clear(url)`: the same scoping `unset` uses, with
+            // no name to narrow it. One definition of "this URL's cookies"
+            // rather than a second that differs in the corners.
+            erase_url_scoped (lines, write.url, std::nullopt);
+            break;
         }
     }
     return lines;
 }
 
+bool url_can_scope_cookies (const std::string& url) {
+    return url_scope_of (url).has_value ();
+}
+
 std::vector<JarCookie>
 matching_in (const std::vector<std::string>& lines, const std::string& url) {
-    CURLU* parsed = curl_url ();
-    if (!parsed) {
-        return {};
-    }
-    std::optional<std::string> host;
-    std::optional<std::string> path;
-    std::optional<std::string> scheme;
-    if (curl_url_set (parsed, CURLUPART_URL, url.c_str (), 0) == CURLUE_OK) {
-        host   = url_part (parsed, CURLUPART_HOST);
-        path   = url_part (parsed, CURLUPART_PATH);
-        scheme = url_part (parsed, CURLUPART_SCHEME);
-    }
-    curl_url_cleanup (parsed);
-    if (!host || !path) {
+    const auto scope = url_scope_of (url);
+    if (!scope) {
         return {};
     }
 
-    const bool secure_transport = scheme && hosts_equal (*scheme, "https");
+    const bool secure_transport = hosts_equal (scope->scheme, "https");
     const auto now              = static_cast<int64_t> (std::time (nullptr));
 
     std::vector<JarCookie> out;
     for (const auto& line : lines) {
         auto cookie = parse_cookie_line (line);
-        if (cookie && cookie_matches (*cookie, *host, *path, secure_transport, now)) {
+        if (cookie &&
+        cookie_matches (*cookie, scope->host, scope->path, secure_transport, now)) {
             out.push_back (std::move (*cookie));
         }
     }

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -858,8 +858,9 @@ nlohmann::json get_script_completions () {
     { "insertText", "pm.cookies.jar()" }, { "detail", "pm.cookies.jar(): object" },
     { "documentation",
     "Postman's cookie jar object - the write half, plus a URL-scoped read. "
-    "get(url, name), set(url, cookie), unset(url, name) and clear() all take "
-    "the URL the cookie belongs to rather than assuming this request's.\n\nA "
+    "get(url, name), set(url, cookie), unset(url, name) and clear(url) all "
+    "take the URL the cookie belongs to rather than assuming this request's; "
+    "clear() with no URL empties this environment's jar.\n\nA "
     "write is applied after the transfer it was made before, so the request "
     "that follows carries it and the jar keeps it.\n\nExample:\n"
     "pm.cookies.jar().set(pm.request.url, { name: 'session', value: token "
@@ -902,11 +903,13 @@ nlohmann::json get_script_completions () {
 
     completions.push_back ({ { "label", "pm.cookies.jar().clear" },
     { "kind", KIND_FUNCTION }, { "insertText", "pm.cookies.jar().clear()" },
-    { "detail", "pm.cookies.jar().clear(callback?: Function): void" },
+    { "detail", "pm.cookies.jar().clear(url?: string, callback?: Function): void" },
     { "documentation",
-    "Empty this environment's jar - a session reset, and nothing wider: "
-    "other environments' jars are untouched. Nothing is on disk, so this "
-    "costs a re-login and no more." },
+    "clear(url) removes every cookie that URL would have carried - unset "
+    "without a name to narrow it. clear() with no URL empties this "
+    "environment's jar: a session reset, and nothing wider, since other "
+    "environments' jars are untouched. Nothing is on disk either way, so "
+    "this costs a re-login and no more." },
     { "sortText", "1_pm_cookies_jar_clear" } });
 
     // ========================================

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -4766,6 +4766,34 @@ read_jar_cookie_arg (JSContext* ctx, JSValueConst arg, vayu::http::JarCookie& ou
     return std::nullopt;
 }
 
+// A jar method's optional trailing callback, classified without invoking it.
+enum class JarCallbackArg : std::uint8_t {
+    /// None given - absent, `undefined` or `null`. The call is complete.
+    Absent,
+    /// A function, ready to be invoked inline.
+    Present,
+    /// Something else entirely; a TypeError is pending on @p ctx.
+    Invalid,
+};
+
+// Split out of finish_jar_call so that a method which *stages* a write can
+// check the callback slot before staging. **Every jar method validates all of
+// its arguments before it stages anything** - jar().clear used to push a
+// whole-jar wipe and only then discover the URL sitting where it expected a
+// callback, so the script got a TypeError pointing away from a wipe that
+// stayed staged and rode the next transfer regardless (issue #997).
+JarCallbackArg classify_jar_callback (JSContext* ctx, int argc, JSValueConst* argv, int index) {
+    if (index >= argc || JS_IsUndefined (argv[index]) || JS_IsNull (argv[index])) {
+        return JarCallbackArg::Absent;
+    }
+    if (!JS_IsFunction (ctx, argv[index])) {
+        JS_ThrowTypeError (ctx, "pm.cookies.jar()'s callback must be a function, got %s",
+        js_type_name (ctx, argv[index]));
+        return JarCallbackArg::Invalid;
+    }
+    return JarCallbackArg::Present;
+}
+
 // Postman's callback, honoured the way pm.sendRequest honours its own: the
 // work already happened synchronously, so it is invoked inline with
 // `(null, result)`. Optional, because the call is complete without it - and
@@ -4774,14 +4802,13 @@ read_jar_cookie_arg (JSContext* ctx, JSValueConst arg, vayu::http::JarCookie& ou
 //
 // Takes ownership of @p result either way.
 JSValue finish_jar_call (JSContext* ctx, int argc, JSValueConst* argv, int callback_index, JSValue result) {
-    if (callback_index >= argc || JS_IsUndefined (argv[callback_index]) ||
-    JS_IsNull (argv[callback_index])) {
+    const auto callback = classify_jar_callback (ctx, argc, argv, callback_index);
+    if (callback == JarCallbackArg::Absent) {
         return result;
     }
-    if (!JS_IsFunction (ctx, argv[callback_index])) {
+    if (callback == JarCallbackArg::Invalid) {
         JS_FreeValue (ctx, result);
-        return JS_ThrowTypeError (ctx, "pm.cookies.jar()'s callback must be a function, got %s",
-        js_type_name (ctx, argv[callback_index]));
+        return JS_EXCEPTION;
     }
 
     JSValue args[2] = { JS_NULL, JS_DupValue (ctx, result) };
@@ -4848,6 +4875,10 @@ JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueCons
         return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
     }
 
+    if (classify_jar_callback (ctx, argc, argv, callback_index) == JarCallbackArg::Invalid) {
+        return JS_EXCEPTION;
+    }
+
     auto* writes = jar_writes (ctx, "jar().set");
     if (!writes) {
         return JS_EXCEPTION;
@@ -4879,6 +4910,9 @@ JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     if (!name) {
         return JS_EXCEPTION;
     }
+    if (classify_jar_callback (ctx, argc, argv, 2) == JarCallbackArg::Invalid) {
+        return JS_EXCEPTION;
+    }
     auto* writes = jar_writes (ctx, "jar().unset");
     if (!writes) {
         return JS_EXCEPTION;
@@ -4890,15 +4924,50 @@ JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
 
 JSValue js_jar_clear (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
+    // Two forms, told apart by the first argument. Postman's is
+    // `clear(url, cb?)`, scoped to one URL; Vayu's own `clear(cb?)` empties
+    // the scope and is what this method shipped as. A string in that position
+    // is unambiguously the URL - the only other thing it takes is a function.
+    std::optional<std::string> url;
+    int callback_index = 0;
+    if (argc > 0 && JS_IsString (argv[0])) {
+        url = read_jar_string_arg (ctx, "clear", "URL", 0, argc, argv);
+        if (!url) {
+            return JS_EXCEPTION;
+        }
+        // Refused rather than staged as a wipe that matches nothing: a clear
+        // is destructive, so "cleared no cookies" and "was handed something
+        // that is not a URL" must not read the same to the script.
+        if (!vayu::http::url_can_scope_cookies (*url)) {
+            return JS_ThrowTypeError (ctx,
+            "pm.cookies.jar().clear could not scope to \"%s\": the URL must be "
+            "absolute and parseable. Call clear() with no URL to empty this "
+            "environment's jar.",
+            url->c_str ());
+        }
+        callback_index = 1;
+    }
+    if (classify_jar_callback (ctx, argc, argv, callback_index) == JarCallbackArg::Invalid) {
+        return JS_EXCEPTION;
+    }
+
     auto* writes = jar_writes (ctx, "jar().clear");
     if (!writes) {
         return JS_EXCEPTION;
     }
-    // The current environment's jar, and no other - decision 2 of #337. The
-    // blast radius is a session reset, which Settings shows and a script can
-    // legitimately want; it is not the whole process's cookies.
-    writes->push_back ({ vayu::http::CookieWrite::Kind::Clear, {}, {}, {} });
-    return finish_jar_call (ctx, argc, argv, 0, JS_UNDEFINED);
+    if (url) {
+        // Scoped exactly as unset is - the cookies a request to this URL would
+        // have carried - so the two spellings cannot disagree about what "this
+        // URL's cookies" are.
+        writes->push_back (
+        { vayu::http::CookieWrite::Kind::ClearUrl, {}, std::move (*url), {} });
+    } else {
+        // The current environment's jar, and no other - decision 2 of #337. The
+        // blast radius is a session reset, which Settings shows and a script can
+        // legitimately want; it is not the whole process's cookies.
+        writes->push_back ({ vayu::http::CookieWrite::Kind::Clear, {}, {}, {} });
+    }
+    return finish_jar_call (ctx, argc, argv, callback_index, JS_UNDEFINED);
 }
 
 // pm.cookies.jar() - Postman's jar object, built per call as Postman's is.
@@ -4913,7 +4982,7 @@ JSValue js_cookies_jar (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     JS_SetPropertyStr (ctx, jar, "get", JS_NewCFunction (ctx, js_jar_get, "get", 3));
     JS_SetPropertyStr (ctx, jar, "set", JS_NewCFunction (ctx, js_jar_set, "set", 4));
     JS_SetPropertyStr (ctx, jar, "unset", JS_NewCFunction (ctx, js_jar_unset, "unset", 3));
-    JS_SetPropertyStr (ctx, jar, "clear", JS_NewCFunction (ctx, js_jar_clear, "clear", 1));
+    JS_SetPropertyStr (ctx, jar, "clear", JS_NewCFunction (ctx, js_jar_clear, "clear", 2));
     return jar;
 }
 

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -830,6 +830,79 @@ TEST (CookieJarWrite, ClearEmptiesOnlyThisEnvironmentsJar) {
     EXPECT_EQ (*survivor, "env_b");
 }
 
+TEST (CookieJarWrite, ClearWithAUrlRemovesOnlyThatUrlsCookies) {
+    // Postman's spelling, which used to be a TypeError *and* a whole-jar wipe
+    // (issue #997). Scoped exactly as unset is, minus the name filter.
+    CookieJar jar;
+    vayu::Environment env;
+    jar.store ("env_a",
+    { netscape_line ("example.com", "FALSE", "/", "FALSE",
+      std::to_string (FAR_FUTURE), "session", "here"),
+    netscape_line ("example.com", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "csrf", "here-too"),
+    netscape_line ("other.example.org", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "session", "elsewhere") });
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "pm.cookies.jar().clear('http://example.com/', function (err) {"
+    "  pm.environment.set('err', String(err)); });",
+    "http://example.com/users", env);
+    EXPECT_TRUE (error.empty ()) << error;
+    EXPECT_EQ (env["err"].value, "null")
+    << "the per-URL clear did not invoke its callback with (null)";
+
+    EXPECT_TRUE (jar.matching ("env_a", "http://example.com/users").empty ())
+    << "the URL's own cookies survived the clear";
+    const auto elsewhere = jar.matching ("env_a", "http://other.example.org/users");
+    ASSERT_EQ (elsewhere.size (), 1u)
+    << "clear(url) reached a cookie stored for another host";
+    EXPECT_EQ (elsewhere[0].value, "elsewhere");
+}
+
+TEST (CookieJarWrite, NoJarMethodStagesItsWriteBeforeItsArgumentsValidate) {
+    // The #997 regression, and the rule it teaches. Each of these fails
+    // validation *after* the argument that decides what would be staged, so a
+    // method that staged first would leave a write behind that then rode the
+    // next transfer - the script seeing only an error that points elsewhere.
+    //
+    // Mutation check: move any of the three `classify_jar_callback` calls back
+    // below its `writes->push_back` and this reddens on a wiped survivor.
+    const auto seeded = [] (const std::string& domain, const std::string& value) {
+        return netscape_line (domain, "FALSE", "/", "FALSE",
+        std::to_string (FAR_FUTURE), "session", value);
+    };
+
+    const auto cases = std::to_array<const char*> ({
+    "pm.cookies.jar().clear('http://example.com/', 'not a function');",
+    "pm.cookies.jar().unset('http://example.com/', 'session', 'nope');",
+    "pm.cookies.jar().set('http://example.com/', { name: 'session', value: "
+    "'new' }, 'not a function');",
+    // The original report: a URL where the whole-jar clear expected its
+    // callback. It must not wipe the environment on its way to the error.
+    "pm.cookies.jar().clear(pm.request.url, 42);",
+    });
+
+    for (const char* script : cases) {
+        CookieJar jar;
+        vayu::Environment env;
+        jar.store ("env_a",
+        { seeded ("example.com", "here"), seeded ("other.example.org", "elsewhere") });
+
+        const std::string error =
+        apply_after_script (jar, "env_a", script, "http://example.com/users", env);
+        EXPECT_NE (error.find ("callback must be a function"), std::string::npos)
+        << "script: " << script << "\ngot: " << error;
+
+        const auto named = jar.matching ("env_a", "http://example.com/users");
+        ASSERT_EQ (named.size (), 1u)
+        << "a refused call staged its write anyway: " << script;
+        EXPECT_EQ (named[0].value, "here")
+        << "a refused set replaced the value anyway: " << script;
+        EXPECT_EQ (jar.matching ("env_a", "http://other.example.org/x").size (), 1u)
+        << "a refused call wiped a cookie it never named: " << script;
+    }
+}
+
 TEST (CookieJarWrite, AWrittenCookieDoesNotCrossAnEnvironmentBoundary) {
     // The isolation guarantee has to hold for written cookies too, or the
     // write half becomes the way a staging session reaches production.
@@ -892,7 +965,10 @@ TEST (CookieJarWrite, BadInputIsRefusedLoudlyRatherThanStoredWrong) {
     { "pm.cookies.jar().set('not a url', { name: 'n', value: 'v' });", "parseable" },
     { "pm.cookies.jar().set();", "URL string" },
     { "pm.cookies.jar().unset('http://example.com/');", "cookie name string" },
-    { "pm.cookies.jar().clear('nope');", "callback must be a function" },
+    // A clear is destructive, so a string that is not a URL is refused
+    // rather than staged as a wipe that quietly matches nothing.
+    { "pm.cookies.jar().clear('nope');", "could not scope" },
+    { "pm.cookies.jar().clear(42);", "callback must be a function" },
     });
 
     for (const auto& one : cases) {
@@ -1022,6 +1098,34 @@ TEST (CookieJarWriteValue, ASecondWriteOfTheSameNameDomainAndPathReplaces) {
     { vayu::http::CookieWrite::Kind::Set, line_for ("/", "after"), {}, {} } });
     ASSERT_EQ (lines.size (), 1u);
     EXPECT_NE (lines[0].find ("after"), std::string::npos);
+}
+
+TEST (CookieJarWriteValue, ClearUrlTakesEveryCookieThatUrlWouldHaveCarried) {
+    // The path half of the scoping, which the host-level test above cannot
+    // see: `/admin` is a different cookie from `/`, and a clear at `/` must
+    // not reach it - the same rule `unset` is held to.
+    const auto line_for = [] (const std::string& path, const std::string& name) {
+        return vayu::http::format_cookie_line (
+        JarCookie{ "example.com", false, path, false, false, 0, name, "v" });
+    };
+
+    std::vector<std::string> lines = { line_for ("/", "session"),
+        line_for ("/", "csrf"), line_for ("/admin", "elevated") };
+    lines = vayu::http::apply_cookie_writes (std::move (lines),
+    { { vayu::http::CookieWrite::Kind::ClearUrl, {}, "http://example.com/", {} } });
+
+    ASSERT_EQ (lines.size (), 1u)
+    << "a clear at / missed a cookie there, or reached /admin";
+    EXPECT_NE (lines[0].find ("elevated"), std::string::npos);
+}
+
+TEST (CookieJarWriteValue, OnlyAUrlThatParsesCanScopeAJarOperation) {
+    // What separates "cleared nothing" from "that was not a URL" - the
+    // distinction `matching_in`'s empty list cannot carry (issue #997).
+    EXPECT_TRUE (
+    vayu::http::url_can_scope_cookies ("https://api.example.com/v1"));
+    EXPECT_FALSE (vayu::http::url_can_scope_cookies ("nope"));
+    EXPECT_FALSE (vayu::http::url_can_scope_cookies (""));
 }
 
 // ============================================================================

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -367,7 +367,7 @@ declare const pm: {
 		 */
 		has(name: string): boolean;
 		/**
-		 * Postman's cookie jar object - the write half, plus a URL-scoped read. get(url, name), set(url, cookie), unset(url, name) and clear() all take the URL the cookie belongs to rather than assuming this request's.
+		 * Postman's cookie jar object - the write half, plus a URL-scoped read. get(url, name), set(url, cookie), unset(url, name) and clear(url) all take the URL the cookie belongs to rather than assuming this request's; clear() with no URL empties this environment's jar.
 		 * 
 		 * A write is applied after the transfer it was made before, so the request that follows carries it and the jar keeps it.
 		 * 
@@ -376,9 +376,9 @@ declare const pm: {
 		 */
 		jar(): {
 			/**
-			 * Empty this environment's jar - a session reset, and nothing wider: other environments' jars are untouched. Nothing is on disk, so this costs a re-login and no more.
+			 * clear(url) removes every cookie that URL would have carried - unset without a name to narrow it. clear() with no URL empties this environment's jar: a session reset, and nothing wider, since other environments' jars are untouched. Nothing is on disk either way, so this costs a re-login and no more.
 			 */
-			clear(callback?: Function): void;
+			clear(url?: string, callback?: Function): void;
 			/**
 			 * The value of a stored cookie that would be sent to that URL, or undefined. Same matching as pm.cookies.get, against the URL you pass instead of this request's; a cookie this script has just set is included. The value is returned and also handed to the optional callback as (null, value).
 			 */

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -318,7 +318,7 @@ TEST (ScriptTypesTest, ACallInsideALabelDoesNotEmptyTheSignature) {
     "get(url: string, name: string, callback?: "
     "Function): string | undefined;"));
     EXPECT_TRUE (contains (dts, "unset(url: string, name: string, callback?: Function): void;"));
-    EXPECT_TRUE (contains (dts, "clear(callback?: Function): void;"));
+    EXPECT_TRUE (contains (dts, "clear(url?: string, callback?: Function): void;"));
     // The flat `set(url, name, value)` form the docs also show has to fit the
     // one signature the table can express.
     EXPECT_TRUE (contains (dts,


### PR DESCRIPTION
## Description

**Plan (root cause, approach, rejected alternative).** `js_jar_clear` pushed a whole-jar `CookieWrite::Kind::Clear` and *then* called `finish_jar_call (ctx, argc, argv, 0, ...)`, which found the URL string sitting at callback position 0 - neither absent nor a function - and threw. Nothing rolls a staged write back: pre-script writes ride the send even when the script errored (`request_exchange.cpp:366-373`) and post-script writes apply unconditionally (`:385`). So `jar.clear(pm.request.url, cb)` - the plain Postman spelling - produced a loud TypeError *and* a silent full-environment cookie wipe, with the error pointing away from the damage. I verified the anchors still hold at `717da15`; the code is as #997 describes it. The approach is the general rule the bug teaches - every jar method validates all of its arguments before it stages anything - implemented by splitting the callback check out of `finish_jar_call` into `classify_jar_callback`, plus a new `CookieWrite::Kind::ClearUrl` for Postman's per-URL form. **Rejected alternative:** deriving `ClearUrl`'s domain and path through `cookie_for_url` the way `jar().set` does, which the issue's pathway suggests. That would be a *second* definition of "this URL's cookies" living beside `unset`'s, differing in the corners (secure-only cookies over http, expired rows) - so instead `ClearUrl` shares `unset`'s matcher through one `erase_url_scoped` helper whose only parameter is the name filter. Per CLAUDE.md, a hand-rolled copy of a primitive never receives the primitive's fixes.

**Blast radius traced.** `CookieWrite::Kind` is switched on in exactly one place (`apply_cookie_writes`), consumed by `curl_utils.cpp` (the transfer seed), `CookieJar::apply` (the post-script drain) and `staged_jar_lines` (so `jar().get` and the flat `pm.cookies` read half see a staged `ClearUrl` too, automatically). Nothing serialises a `CookieWrite`. The declared `clear` signature is not free-standing: it is generated from the completions table in `routes/scripting.cpp` into `engine/tests/fixtures/script-typedefs.d.ts`, which the app's `script-typedefs.docs-compile.test.ts` compiles the docs' `pm.*` examples against - so the table, the regenerated fixture and its engine-side pin all move here. **No app changes**, confirmed as the issue states: the jar surface is engine + script only, and Settings' cookie view reads the jar after the fact.

**One deliberate addition beyond the issue spec.** A URL that libcurl cannot parse is now *refused* by `clear(url)` rather than staged as a wipe that quietly matches nothing. `matching_in` returns an empty list both for "matched nothing" and "could not parse", and a clear is destructive, so the two must not read alike to the script - the same false-success argument `jar_writes` already refuses a jarless execution over. `url_can_scope_cookies` answers that distinction. This changes one existing test's expectation (`jar().clear('nope')` now says "could not scope" instead of "callback must be a function"); `jar().clear(42)` covers the old message. `unset`'s existing leniency about unparseable URLs is left alone as out of scope.

Incidentally, the three copies of the libcurl URL parse in `cookie_jar.cpp` collapse into one `url_scope_of`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure   # 2450 passed, 0 failed
cd app && pnpm test                                         # 531 files, 5702 passed
cd app && pnpm type-check                                   # clean (3 projects)
```

Four new tests, all in `engine/tests/cookie_jar_test.cpp`:

- `CookieJarWrite.ClearWithAUrlRemovesOnlyThatUrlsCookies` - two domains seeded, both of the URL's cookies gone, the other host's survivor intact, callback invoked with `(null)`.
- `CookieJarWrite.NoJarMethodStagesItsWriteBeforeItsArgumentsValidate` - the regression, over `clear`, `unset` and `set`, plus the original report (`clear(pm.request.url, 42)`). **Mutation-checked:** moving `classify_jar_callback` back below `writes->push_back` in `js_jar_clear`, rebuilding and re-running gives `a refused call staged its write anyway: pm.cookies.jar().clear('http://example.com/', 'not a function');` - the test reddens on exactly the wiped survivor the bug produced.
- `CookieJarWriteValue.ClearUrlTakesEveryCookieThatUrlWouldHaveCarried` - the path half the host-level test cannot see: a clear at `/` takes both cookies there and does not reach `/admin`.
- `CookieJarWriteValue.OnlyAUrlThatParsesCanScopeAJarOperation` - the parse predicate.

`CookieJarWrite.ClearEmptiesOnlyThisEnvironmentsJar` still covers the bare form unchanged, and `BadInputIsRefusedLoudlyRatherThanStoredWrong` gained the two `clear` cases.

**Two gates I could not run locally, flagged rather than assumed:** this environment has clang-format 18 and clang-tidy 18 only. CLAUDE.md pins clang-format to 19 exactly, and clang-tidy 19+ (18 rejects `ExcludeHeaderFilterRegex` in `engine/.clang-tidy`, which it did here). I formatted against 18 and hand-reconciled every delta inside new code, keeping the `ContinuationIndentWidth: 0` spelling where 18 and 19 are known to disagree - the touched files now show only the pre-existing 18-vs-19 deltas on lines this PR does not touch. CI's `Engine formatting` and `Lint changed engine sources` jobs are the real verdict. `mkdocs` is likewise not installed; the docs edits add no page, link or heading, only prose and fence content inside existing sections.

**Pre-existing flake, not fixed or hidden:** `ImportFetchStream.StopsFetchingOnceTheListenerHasGone` failed once on an early run and passed on every run since, including the two full-suite runs above. It is an import-fetch listener test and shares no code with this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #997

Sub-issue of #996, and the one it names to land first. `docs/engine/scripting.md` (jar section, both `clear` forms and the refusal rule) and `docs/app/pm-api-compatibility.md` (the surface table, the example block, and the divergence bullet that used to read "`jar.clear()` takes no URL") are updated in the same commit, as is the generated `script-typedefs.d.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UUAwUBykfyacy6EqqtFMe)_