### PR TITLE
feat(engine): on-demand workspace backup - VACUUM INTO endpoint, CLI verb, retention - #987

### DIFF
--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -207,6 +207,14 @@ export const API_ENDPOINTS = {
 	// deliberately not a second IMPORT_FETCH.
 	DIAGNOSTICS_CONNECTION: `/diagnostics/connection`,
 
+	// Workspace backup (issue #987). A verb path rather than a stored resource,
+	// like INBOX_START and MOCK_SERVER_START: the engine takes a snapshot and
+	// the file it writes is not a row anything here reads back. There is no
+	// restore counterpart on purpose - a live engine overwriting its own open
+	// database is the thing this feature exists to spare the user, so restoring
+	// is a documented manual copy with the engine stopped.
+	WORKSPACE_BACKUP: `/workspace/backup`,
+
 	// Webhook inbox (issue #480). The engine hosts the listener; these drive its
 	// lifecycle and read what it captured. START is a verb path rather than a
 	// POST to `/inbox` because an inbox is not a stored resource - it exists for

--- a/app/src/modules/settings/main/app-settings.ts
+++ b/app/src/modules/settings/main/app-settings.ts
@@ -89,6 +89,14 @@ export const APP_SETTINGS = [
 		keywords: ["clear history", "delete runs", "database"],
 	},
 	{
+		anchor: "workspace-backup",
+		panel: "general",
+		label: "Workspace backup",
+		searchText:
+			"Take a complete copy of the workspace database, and where the snapshot was written.",
+		keywords: ["backup", "snapshot", "restore", "export database", "copy"],
+	},
+	{
 		anchor: "cookies",
 		panel: "general",
 		label: "Cookies",

--- a/app/src/modules/settings/main/panels/GeneralPanel.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.tsx
@@ -37,6 +37,7 @@ import { appSetting } from "../app-settings";
 import { OptionButtons, ToggleRow } from "./SettingControls";
 import { UpdatesCard } from "./UpdatesCard";
 import { CookiesCard } from "./CookiesCard";
+import { WorkspaceBackupCard } from "./WorkspaceBackupCard";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import type { EngineSettingsCategory } from "@/types";
 
@@ -225,6 +226,12 @@ export default function GeneralPanel() {
 					</p>
 				</CardContent>
 			</Card>
+
+			{/* A copy of the whole workspace the user controls (#987). Beside
+			    Data management because it answers the question that card
+			    raises - what happens to all this if the file is lost - and
+			    above Storage paths, which prints the database it copies. */}
+			<WorkspaceBackupCard />
 
 			{/* The engine's cookie jar - engine-held state the user never typed,
 			    which is why it sits beside run history rather than in a panel

--- a/app/src/modules/settings/main/panels/WorkspaceBackupCard.test.tsx
+++ b/app/src/modules/settings/main/panels/WorkspaceBackupCard.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The workspace backup card (issue #987).
+ *
+ * Three things this card can get wrong and no other test would catch:
+ *
+ *  - **The path must survive on screen.** Restoring is a manual file copy, so a
+ *    card that only toasts leaves the user with nowhere to look afterwards.
+ *  - **A 409 is not a failure.** "A backup is already running" means their own
+ *    earlier request is still writing the file; reporting it as an error sends
+ *    them hunting for a problem that does not exist.
+ *  - **A real failure must be visible**, not swallowed into a toast that fades.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { ApiError } from "@/services/http-client";
+import { WorkspaceBackupCard } from "./WorkspaceBackupCard";
+
+const backupWorkspace = vi.fn();
+const showToast = vi.fn();
+
+vi.mock("@/services", () => ({
+	apiService: {
+		backupWorkspace: (...args: unknown[]) => backupWorkspace(...args),
+	},
+}));
+
+vi.mock("@/stores", () => ({
+	useToastStore: (selector: (s: { showToast: typeof showToast }) => unknown) =>
+		selector({ showToast }),
+}));
+
+const SNAPSHOT = {
+	path: "/home/someone/.vayu/backups/vayu-20260827-120000-000.db",
+	sizeBytes: 2_097_152,
+	createdAt: 1_787_745_600_000,
+	pruned: 2,
+};
+
+beforeEach(() => {
+	backupWorkspace.mockReset();
+	showToast.mockReset();
+});
+
+/** Press the card's one button. */
+function backUp() {
+	fireEvent.click(screen.getByRole("button", { name: /back up now/i }));
+}
+
+describe("WorkspaceBackupCard", () => {
+	it("shows the path, size and what retention removed", async () => {
+		backupWorkspace.mockResolvedValue(SNAPSHOT);
+		render(<WorkspaceBackupCard />);
+		backUp();
+
+		// The path itself, not a summary of it: this is what the user copies.
+		expect(await screen.findByText(SNAPSHOT.path)).toBeInTheDocument();
+		expect(screen.getByText(/2\.0 MB/)).toBeInTheDocument();
+		expect(screen.getByText(/removed 2 older snapshots/)).toBeInTheDocument();
+		expect(showToast).toHaveBeenCalledWith("Workspace backed up", "success");
+	});
+
+	it("does not claim to have removed anything when it removed nothing", async () => {
+		backupWorkspace.mockResolvedValue({ ...SNAPSHOT, pruned: 0 });
+		render(<WorkspaceBackupCard />);
+		backUp();
+
+		await screen.findByText(SNAPSHOT.path);
+		expect(screen.queryByText(/removed/)).not.toBeInTheDocument();
+	});
+
+	it("prints the restore procedure beside the file it applies to", async () => {
+		backupWorkspace.mockResolvedValue(SNAPSHOT);
+		render(<WorkspaceBackupCard />);
+		backUp();
+
+		await screen.findByText(SNAPSHOT.path);
+		// There is no restore button by design - a live engine overwriting its
+		// own open database is the footgun this feature avoids - so the steps
+		// have to be here.
+		expect(
+			screen.getByText(/quit Vayu, copy this file over the database/i)
+		).toBeInTheDocument();
+	});
+
+	it("reads a 409 as a backup already running, not as a failure of this one", async () => {
+		backupWorkspace.mockRejectedValue(
+			new ApiError(409, "CONFLICT", "A workspace backup is already running")
+		);
+		render(<WorkspaceBackupCard />);
+		backUp();
+
+		expect(
+			await screen.findByText(/already running - it will finish on its own/i)
+		).toBeInTheDocument();
+		// And it does not present the engine's raw sentence, which reads as an
+		// error where this is a state.
+		expect(screen.queryByText(/could not/i)).not.toBeInTheDocument();
+	});
+
+	it("shows a real failure on the card rather than only in a toast", async () => {
+		backupWorkspace.mockRejectedValue(
+			new ApiError(500, "INTERNAL", "Could not write the backup to /nowhere: disk full")
+		);
+		render(<WorkspaceBackupCard />);
+		backUp();
+
+		expect(await screen.findByText(/disk full/)).toBeInTheDocument();
+		expect(showToast).toHaveBeenCalledWith("Could not back up the workspace", "error");
+	});
+
+	it("clears a previous failure when a retry succeeds", async () => {
+		backupWorkspace.mockRejectedValueOnce(new ApiError(500, "INTERNAL", "disk full"));
+		render(<WorkspaceBackupCard />);
+		backUp();
+		await screen.findByText(/disk full/);
+
+		backupWorkspace.mockResolvedValue(SNAPSHOT);
+		backUp();
+
+		await screen.findByText(SNAPSHOT.path);
+		await waitFor(() => expect(screen.queryByText(/disk full/)).not.toBeInTheDocument());
+	});
+});

--- a/app/src/modules/settings/main/panels/WorkspaceBackupCard.tsx
+++ b/app/src/modules/settings/main/panels/WorkspaceBackupCard.tsx
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * WorkspaceBackupCard
+ *
+ * One button that asks the engine for a snapshot of the workspace, and the path
+ * it wrote (issue #987).
+ *
+ * Everything a person has built in Vayu - collections, environments, stored
+ * credentials, run history - lives in one SQLite file, and until this there was
+ * no copy of it the user controlled. The `.bak` the engine keeps is not one: it
+ * is overwritten on every clean start and exists so a corrupt file has
+ * something to restore from, not so someone can go back to last week.
+ *
+ * It sits in General beside Data management and Storage paths, because this is
+ * engine-held state the user did not type - the same reason CookiesCard is
+ * there - and because the path this prints only means something next to the
+ * Data directory printed below it.
+ *
+ * **The path is shown, not just toasted.** Restoring is a file copy the user
+ * performs with the engine stopped (there is deliberately no restore button),
+ * so the one thing they need afterwards is where the file went - and a toast
+ * that has faded cannot tell them.
+ */
+
+import { useState } from "react";
+import { HardDriveDownload, Loader2 } from "lucide-react";
+
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { apiService } from "@/services";
+import { ApiError } from "@/services/http-client";
+import { useToastStore } from "@/stores";
+import type { WorkspaceBackupResult } from "@/types";
+import { appSetting } from "../app-settings";
+
+// Headings come from the catalogue so search cannot offer a name this panel
+// does not print - see `app-settings.ts`.
+const WORKSPACE_BACKUP = appSetting("workspace-backup");
+
+/** A snapshot's size, in the units a person reads a file size in. */
+function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KB", "MB", "GB"] as const;
+	let value = bytes / 1024;
+	let unit = 0;
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024;
+		unit += 1;
+	}
+	return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+export function WorkspaceBackupCard() {
+	const showToast = useToastStore((s) => s.showToast);
+	const [running, setRunning] = useState(false);
+	const [result, setResult] = useState<WorkspaceBackupResult | null>(null);
+	const [failure, setFailure] = useState<string | null>(null);
+
+	const backUp = async () => {
+		setRunning(true);
+		setFailure(null);
+		try {
+			const snapshot = await apiService.backupWorkspace();
+			setResult(snapshot);
+			showToast("Workspace backed up", "success");
+		} catch (error) {
+			// A 409 is not a failure of the backup - the user's own earlier
+			// request is still writing the file - and saying "could not back up"
+			// would send them looking for a problem that is not there.
+			const message =
+				error instanceof ApiError && error.statusCode === 409
+					? "A backup is already running - it will finish on its own."
+					: error instanceof Error
+						? error.message
+						: "The engine did not answer";
+			setFailure(message);
+			showToast("Could not back up the workspace", "error");
+		} finally {
+			setRunning(false);
+		}
+	};
+
+	return (
+		<Card data-setting-anchor={WORKSPACE_BACKUP.anchor}>
+			<CardHeader className="pb-3">
+				<div className="flex items-center gap-2">
+					<HardDriveDownload className="w-5 h-5 text-muted-foreground" />
+					<CardTitle className="text-base">{WORKSPACE_BACKUP.label}</CardTitle>
+				</div>
+				<CardDescription>
+					Writes a complete, compacted copy of the workspace - collections, environments,
+					credentials and run history - into a backups folder beside the database. Safe to
+					run while Vayu is working; copying the database file by hand is not.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<div className="flex items-center justify-between gap-4">
+					<p className="text-sm text-muted-foreground">
+						How many snapshots are kept is set by Max Backups Retained under Engine &gt;
+						Data &amp; retention.
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={running}
+						onClick={() => void backUp()}
+					>
+						{running ? (
+							<Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+						) : (
+							<HardDriveDownload className="w-4 h-4 mr-1.5" />
+						)}
+						Back up now
+					</Button>
+				</div>
+
+				{failure && <p className="text-sm text-status-error-text">{failure}</p>}
+
+				{result && (
+					<div className="surface-sunken rounded-md border border-rule p-3 space-y-1">
+						<p className="text-xs text-muted-foreground">
+							Saved {formatSize(result.sizeBytes)} at{" "}
+							{new Date(result.createdAt).toLocaleString()}
+							{result.pruned > 0 &&
+								` - removed ${result.pruned} older snapshot${result.pruned === 1 ? "" : "s"}`}
+						</p>
+						<p className="text-xs font-mono break-all text-foreground">{result.path}</p>
+						{/* Restoring is a manual copy with the engine stopped, so the
+						    procedure is where the file name is, not in a doc the user
+						    has to know exists. */}
+						<p className="text-xs text-muted-foreground">
+							To restore: quit Vayu, copy this file over the database shown under
+							Storage paths, delete its <code>-wal</code> and <code>-shm</code>{" "}
+							neighbours, and start Vayu again.
+						</p>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -59,6 +59,7 @@ import type {
 	ClientCertificate,
 	ClientCertificateInput,
 	ConnectionTestResult,
+	WorkspaceBackupResult,
 	GetConfigResponse,
 	UpdateConfigRequest,
 	GlobalsResponse,
@@ -485,6 +486,17 @@ export const apiService = {
 		return await httpClient.post<ConnectionTestResult>(API_ENDPOINTS.DIAGNOSTICS_CONNECTION, {
 			url,
 		});
+	},
+
+	/**
+	 * Take one workspace snapshot (issue #987).
+	 *
+	 * Rejects on 409 - another backup is already running - which is a state the
+	 * caller shows rather than a failure: the file the user asked for is still
+	 * being written by their earlier request.
+	 */
+	async backupWorkspace(): Promise<WorkspaceBackupResult> {
+		return await httpClient.post<WorkspaceBackupResult>(API_ENDPOINTS.WORKSPACE_BACKUP, {});
 	},
 
 	// Client-certificate registry (issue #707)

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -866,6 +866,28 @@ export interface ConnectionTestResult {
 	detail?: string;
 }
 
+// Workspace backup (issue #987)
+
+/**
+ * What `POST /workspace/backup` answers with.
+ *
+ * `path` is the whole point of the shape: restoring is a file copy the user
+ * performs themselves, with the engine stopped, so the one thing they need back
+ * is where the snapshot went. There is deliberately no restore call to pair
+ * with this - a live engine overwriting its own open database is the footgun
+ * the feature avoids.
+ */
+export interface WorkspaceBackupResult {
+	/** Absolute path of the snapshot written. */
+	path: string;
+	/** Its size on disk - a compacted copy, so smaller than the live database. */
+	sizeBytes: number;
+	/** When it was taken, in Unix ms. */
+	createdAt: number;
+	/** How many older snapshots `maxBackupsRetained` removed in the same call. */
+	pruned: number;
+}
+
 // Webhook inbox API (issue #480). An inbox is engine-hosted listener state, so
 // none of these shapes is stored client-side - the surface reads them back.
 

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -851,6 +851,13 @@ export const API_ENDPOINTS = {
   // Cookie jar - GET reads every scope, DELETE clears one or all
   COOKIES: "/cookies",
 
+  // Workspace backup - one VACUUM INTO snapshot into `backups/` beside the
+  // database, with retention. A verb path for the reason the inbox uses one:
+  // the engine takes a snapshot and the file is not a row anything reads back.
+  // There is no restore counterpart on purpose - restoring is a manual copy
+  // with the engine stopped, which is why the card prints the path.
+  WORKSPACE_BACKUP: "/workspace/backup",
+
   // Execution
   EXECUTE_REQUEST: "/execute",
   START_LOAD_TEST: "/runs",

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -834,6 +834,52 @@ range, nothing is applied and the response is `400` with the specific reason(s):
 **Success response:** `200` - the full updated entries array (same shape as
 `GET /config`) plus `"success": true`.
 
+## Workspace
+
+### POST /workspace/backup
+
+Write one complete, compacted snapshot of the workspace database into
+`backups/` beside it, then prune older snapshots to `maxBackupsRetained`
+(issue #987). Takes no body.
+
+```json
+{
+  "path": "/home/someone/.local/share/vayu/db/backups/vayu-20260827-124932-118.db",
+  "sizeBytes": 2097152,
+  "createdAt": 1787745600000,
+  "pruned": 1
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `path` | The snapshot written. The whole point of the response: restoring is a file copy you perform yourself |
+| `sizeBytes` | Its size on disk. A compacted copy, so smaller than the live database |
+| `createdAt` | When it was taken, epoch milliseconds - the stamp its file name carries |
+| `pruned` | How many older snapshots retention removed in the same call |
+
+**It runs SQLite's `VACUUM INTO`, which is why it is safe while the engine is
+working.** Copying `vayu.db` by hand is not: the `-wal` beside it holds
+committed transactions the main file does not, so a hand copy is a database
+missing its most recent writes. `VACUUM INTO` reads one consistent snapshot and
+writes a defragmented database complete on its own, and is read-only with
+respect to the workspace.
+
+**A second backup while one is running is a `409`.** Two concurrent copies would
+each write a whole second database - unbounded disk for a button someone
+double-clicked - and the second would race the first's retention pass. Anything
+else that goes wrong is a `500` naming what SQLite or the filesystem refused;
+there is no success response with an empty path.
+
+**Retention only removes files this endpoint wrote** (`vayu-<stamp>.db`), so a
+copy you put in that directory yourself is left where it is. `0` keeps every
+snapshot.
+
+**There is deliberately no restore endpoint.** A running engine overwriting the
+database file it holds open is the failure this feature exists to prevent.
+Restore by hand with the engine stopped - see
+[architecture.md](architecture.md#restoring).
+
 ## Collections
 
 Collections are folders that organize requests in a hierarchy.

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -991,12 +991,49 @@ Default configuration values (from `constants.hpp`):
 ```
 data/
 ├── db/
-│   └── vayu.db          # SQLite database
+│   ├── vayu.db          # SQLite database
+│   ├── vayu.db.bak      # Rewritten on every clean start - crash recovery, not a user backup
+│   └── backups/
+│       └── vayu-<stamp>.db  # On-demand snapshots (UTC, %Y%m%d-%H%M%S-mmm)
 ├── logs/
 │   ├── vayu_<stamp>.log # One file per process start (local time, %Y%m%d_%H%M%S)
 │   └── vayu_<stamp>.log.1  # The rotated half of a file that reached the size cap
 └── vayu.lock            # Single-instance lock file
 ```
+
+### Workspace backups
+
+`vayu.db` holds everything a person has built - collections, environments,
+stored credentials and run history - and until issue #987 there was no copy of
+it the user controlled. The `.bak` beside it is **not** one: it is rewritten on
+every clean start, so it exists to give a corrupt file something to restore
+from, not to let anyone go back to last week.
+
+`POST /workspace/backup` (or `vayu-cli backup`) writes one snapshot into
+`db/backups/`. It runs SQLite's `VACUUM INTO`, which is why it is safe while
+the engine is working: copying `vayu.db` by hand is not, because the `-wal`
+beside it holds committed transactions the main file does not, so the copy is a
+database missing its most recent writes. `VACUUM INTO` reads one consistent
+snapshot and writes a defragmented database that is complete on its own.
+
+Names are UTC and fixed-width so they sort chronologically as text. After each
+backup the newest `maxBackupsRetained` snapshots are kept (default 5, `0` =
+unlimited) and older ones removed - **only files matching `vayu-<stamp>.db`**,
+so a copy you put in that directory yourself is left alone. A second backup
+requested while one is running is refused with `409` rather than queued.
+
+#### Restoring
+
+There is deliberately no restore endpoint: a running engine overwriting the
+database file it holds open is the failure this feature exists to spare you.
+Restore by hand, with the engine stopped.
+
+1. Quit Vayu (or stop `vayu-engine`).
+2. Copy the snapshot over `db/vayu.db`.
+3. Delete `db/vayu.db-wal` and `db/vayu.db-shm` if they are present - they
+   belong to the database you just replaced, and leaving them behind reapplies
+   its writes on top of the snapshot.
+4. Start Vayu again.
 
 ### Log retention, level and size
 

--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -38,6 +38,33 @@ vayu-cli run load-test.json
 vayu-cli run request.json --daemon http://localhost:9999
 ```
 
+### backup
+
+Take one snapshot of the workspace database and print where it was written.
+
+```bash
+vayu-cli backup
+```
+
+The snapshot is a complete, compacted copy of everything the engine stores -
+collections, environments, credentials and run history - written into
+`backups/` beside the database. It is taken through the running daemon on
+purpose: the engine holds the database open, and copying that file by hand is
+not safe under WAL, because the `-wal` beside it holds committed transactions
+the main file does not.
+
+The path is the only thing printed on stdout, so a script can capture it:
+
+```bash
+SNAPSHOT=$(vayu-cli backup)
+```
+
+Exit code 1 with the engine's message on stderr if the daemon is unreachable or
+refuses - including while another backup is still running, which answers `409`.
+How many snapshots are kept is the `maxBackupsRetained` setting; restoring one
+is a manual copy with the engine stopped, described in
+[Architecture](architecture.md#workspace-backups).
+
 ## Options
 
 | Option | Description |

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -34,6 +34,13 @@ on every launch forever - but it is total: collections, requests, environments,
 saved examples, spec documents and run history are all gone, and the app comes
 up looking like a fresh install.
 
+> **`<db>.bak` is not a user backup.** It is rewritten on every clean start, so
+> it exists to give a corrupt file something to restore *from*, not to let
+> anyone go back to last week - and the row above where it is the only copy
+> left is the one that ends in an empty workspace. The snapshot a user owns is
+> `POST /workspace/backup` / `vayu-cli backup`, described in
+> [architecture.md](architecture.md#workspace-backups).
+
 ### The quarantine (issue #984)
 
 A database that fails validation is **moved, not deleted**: `<db>` becomes

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -351,6 +351,7 @@ The daemon listens on `http://127.0.0.1:9876`. Key endpoints:
 | GET | `/runs/:runId/metrics` | Historical time-series (JSON) for a run |
 | POST | `/oauth2/token` | Acquire/return a cached OAuth 2.0 token (auth resolved engine-side) |
 | GET | `/health` | Health check |
+| POST | `/workspace/backup` | One `VACUUM INTO` snapshot of the workspace into `backups/` beside the database, with retention (issue #987); no restore endpoint - see `docs/engine/architecture.md` |
 | POST | `/import/parse` | Read a raw import document - OpenAPI 2.0/3.x, Postman v2.0/v2.1, a Postman environment or globals export, Insomnia v4 - into the tree `/import/apply` persists (issue #877); reads only |
 | POST | `/import` | The same parse, flattened and applied in one call - what MCP `import_document` wraps; the app parses and applies separately because a person previews in between |
 | POST | `/import/document` | A document's bytes as a JSON DOM, through the engine's one reader - the whole of what the app's `$ref` bundler needs, and what took the last YAML dependency out of `app/src` |

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -621,6 +621,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/managed_listener.cpp
         src/http/routes/health.cpp
         src/http/routes/config.cpp
+        src/http/routes/workspace.cpp
         src/http/routes/collections.cpp
         src/http/routes/requests.cpp
         src/http/routes/examples.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -882,6 +882,16 @@ constexpr int MAX_RUNS_RETAINED = 200;
 /// Run retention: delete runs older than N days (0 = unlimited).
 constexpr int RUN_RETENTION_DAYS = 30;
 /**
+ * Workspace backups: keep at most N snapshots in `backups/` (0 = unlimited).
+ *
+ * Five rather than one, because the failure a backup guards against is often
+ * noticed late - a collection deleted last week is discovered missing today -
+ * and a single slot would have been overwritten by then. Each snapshot is a
+ * compacted copy of the whole workspace, so the ceiling is about disk: five is
+ * a few times the live file for a workspace of any ordinary size.
+ */
+constexpr int MAX_BACKUPS_RETAINED = 5;
+/**
  * How recently a stored OpenAPI document must have arrived to be spared by the
  * orphan sweep, whatever else says nothing references it (issue #718).
  *

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -8,6 +8,7 @@
  */
 
 #include <chrono>
+#include <expected>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -144,6 +145,40 @@ struct SpecSyncBatch {
     /// The imported example rows @ref examples replaces. Ids, because the row
     /// they name is stored and only its identity matters here.
     std::vector<std::string> deleted_examples;
+};
+
+/**
+ * @brief One workspace snapshot, as `POST /workspace/backup` reports it
+ *        (issue #987).
+ *
+ * The path is absolute wherever the engine's own database path is, which is
+ * every real start - the daemon is given a data directory - and it is what the
+ * user needs, because restoring is a file copy they perform themselves.
+ */
+struct BackupRecord {
+    /// The snapshot written, as a path the user can act on.
+    std::string path;
+    /// Its size on disk. A compacted copy, so smaller than the live file.
+    int64_t size_bytes = 0;
+    /// The stamp its file name carries - the caller's clock, in Unix ms.
+    int64_t created_at = 0;
+    /// How many older snapshots retention removed in the same call.
+    int64_t pruned = 0;
+};
+
+/**
+ * @brief Why a workspace backup did not happen (issue #987).
+ *
+ * The two cases answer with different statuses and read differently to a user,
+ * so they are one type with a flag rather than a message a route has to parse:
+ * a refused *concurrent* backup is a 409 and nothing is wrong, while anything
+ * else is a 500 naming what SQLite or the filesystem refused.
+ */
+struct BackupFailure {
+    /// Another backup holds the slot; nothing was written.
+    bool already_running = false;
+    /// What went wrong, in the words the caller prints.
+    std::string message;
 };
 
 class Database {
@@ -584,6 +619,78 @@ class Database {
      * process's leftovers are reconciled before anything can read them.
      */
     int64_t clear_inbox_requests_all ();
+
+    // Workspace backup (issue #987)
+
+    /**
+     * @brief Where snapshots are written - `backups/` beside the database file.
+     *
+     * Derived from @ref path rather than threaded through as a second
+     * parameter, on the rule that directory already carries (the CA bundle
+     * `resolve_transport_policy` materializes is a sibling for the same
+     * reason): a caller holding a `Database` knows where the workspace lives.
+     */
+    [[nodiscard]] std::string backups_directory () const;
+
+    /**
+     * @brief Write one consistent, compacted snapshot of this workspace and
+     *        prune older ones to `maxBackupsRetained`.
+     *
+     * SQLite's `VACUUM INTO` rather than a file copy: copying the database file
+     * out from under a running engine is not safe under WAL - the `-wal` holds
+     * committed transactions the main file does not - while `VACUUM INTO` reads
+     * one snapshot and writes a defragmented database that is complete on its
+     * own. It is read-only with respect to the workspace, so nothing here can
+     * cost the user the data it is copying.
+     *
+     * @param now The caller's clock, in Unix ms. It names the file, so a test
+     *        can state which snapshot it is asking for; a stamp already taken
+     *        is stepped over rather than written through, exactly as the
+     *        corruption quarantine does.
+     *
+     * @return the snapshot, or why there is none. Never throws: every failure
+     *         is a @ref BackupFailure the route turns into a status.
+     */
+    std::expected<BackupRecord, BackupFailure> backup_workspace (int64_t now);
+
+    /**
+     * @brief The single-backup slot, held for as long as one snapshot is being
+     *        written (issue #987).
+     *
+     * Two concurrent `VACUUM INTO`s would each write a whole second copy of the
+     * database - unbounded disk for a button someone double-clicked - and the
+     * later one would race the retention pass of the earlier for the files it
+     * is pruning. So a second caller is refused rather than queued: a backup is
+     * a thing the user asked for *now*, and "one is already running" is a
+     * better answer than a copy they did not ask for arriving later.
+     *
+     * `backup_workspace` takes the slot for its own duration. The type is
+     * public because "a backup is already running" is a state a caller can be
+     * in deliberately, and a test that cannot enter it can only assert the
+     * refusal by racing.
+     */
+    class BackupSlot {
+        public:
+        explicit BackupSlot (Database& db);
+        ~BackupSlot ();
+
+        // Neither copyable nor movable: this is a lock, and every one of the
+        // four would produce a second object claiming to hold the one slot.
+        BackupSlot (const BackupSlot&)            = delete;
+        BackupSlot& operator= (const BackupSlot&) = delete;
+        BackupSlot (BackupSlot&&)                 = delete;
+        BackupSlot& operator= (BackupSlot&&)      = delete;
+
+        /// False when another backup already had the slot - nothing was taken,
+        /// and the destructor releases nothing.
+        [[nodiscard]] bool held () const {
+            return held_;
+        }
+
+        private:
+        Database& db_;
+        bool held_;
+    };
 
     // Config Entries - Structured configuration with metadata
     void save_config_entry (const ConfigEntry& entry);

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -1041,6 +1041,7 @@ struct RouteContext {
 // Route registration functions (implemented in separate files)
 void register_health_routes (RouteContext& ctx);
 void register_config_routes (RouteContext& ctx);
+void register_workspace_routes (RouteContext& ctx);
 void register_collection_routes (RouteContext& ctx);
 void register_request_routes (RouteContext& ctx);
 void register_request_example_routes (RouteContext& ctx);

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -53,7 +53,8 @@ USAGE:
 
 COMMANDS:
     run <file>          Execute a request or load test via the daemon
-    
+    backup              Snapshot the workspace database and print the file path
+
 OPTIONS:
     -h, --help          Show this help message
     -v, --version       Show version information
@@ -64,6 +65,7 @@ OPTIONS:
 EXAMPLES:
     vayu-cli run request.json
     vayu-cli run load-test.json --daemon http://localhost:9876
+    vayu-cli backup
 
 REQUEST FILE FORMAT:
     See documentation for request and load test configuration formats.
@@ -269,6 +271,56 @@ int run_via_daemon (const std::string& daemon_url, const std::string& filepath, 
 }
 
 /**
+ * `vayu-cli backup` - one snapshot of the workspace, printed as the path it was
+ * written to (issue #987).
+ *
+ * Through the daemon rather than by opening the database directly, like every
+ * other CLI verb: the engine holds the file open, and a second process taking a
+ * copy of it is exactly the unsafe-under-WAL move this feature exists to
+ * replace. The path goes to stdout on its own line so a shell can capture it;
+ * everything else is a log line or stderr.
+ */
+int backup_via_daemon (const std::string& daemon_url) {
+    httplib::Client cli (daemon_url);
+    cli.set_connection_timeout (5);
+    // A snapshot of a large workspace outlives httplib's default read timeout,
+    // and a timed-out client would report a failure for a backup that is still
+    // being written - and then be told 409 on the retry.
+    cli.set_read_timeout (std::chrono::minutes (10));
+
+    auto res = cli.Post ("/workspace/backup", "", "application/json");
+    if (!res) {
+        const std::string msg = "Error: Failed to connect to daemon at " + daemon_url;
+        std::cerr << msg << "\n";
+        vayu::utils::log_error (msg);
+        return 1;
+    }
+    if (res->status != 200) {
+        const std::string msg =
+        "Backup failed (Status " + std::to_string (res->status) + ")";
+        std::cerr << msg << "\n";
+        std::cerr << res->body << "\n";
+        vayu::utils::log_error (msg);
+        vayu::utils::log_error (res->body);
+        return 1;
+    }
+
+    try {
+        const auto body = nlohmann::json::parse (res->body);
+        std::cout << body.value ("path", std::string{}) << "\n";
+        vayu::utils::log_info ("Workspace backed up (" +
+        std::to_string (body.value ("sizeBytes", int64_t{ 0 })) + " bytes)");
+        return 0;
+    } catch (const std::exception& e) {
+        const std::string msg =
+        "Error parsing daemon response: " + std::string (e.what ());
+        std::cerr << msg << "\n";
+        vayu::utils::log_error (msg);
+        return 1;
+    }
+}
+
+/**
  * The whole of the CLI, so that `main` is a catch and nothing else.
  *
  * `main` must not let an exception escape: an uncaught one terminates the
@@ -331,6 +383,8 @@ int run_cli (std::span<char* const> args) {
             result = run_via_daemon (options.daemon_url, options.filepath,
             options.verbosity, options.color);
         }
+    } else if (options.command == "backup") {
+        result = backup_via_daemon (options.daemon_url);
     } else if (options.command[0] == '-') {
         // Already handled flags above
         result = 0;

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -144,7 +144,6 @@ MonitorConfig& out) {
         return rejection;
     }
     return read_monitor_series (monitor, limits, out);
-    return std::nullopt;
 }
 
 /// The `monitor` value on a run config, or null when the run declared none.

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -38,7 +38,10 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <ctime>
+#include <expected>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -54,6 +57,7 @@
 #include "vayu/core/spec_binding.hpp"
 #include "vayu/http/transport_policy.hpp"
 #include "vayu/utils/logger.hpp"
+#include "vayu/utils/reentrant.hpp"
 
 // ============================================================================
 // SQLite ORM Type Adapters
@@ -502,6 +506,13 @@ struct Database::Impl {
     /// the first connection). Read back rather than echoed, so it states the
     /// size in force instead of the size requested.
     std::atomic<int> applied_cache_size_bytes{ 0 };
+
+    /// Whether a workspace backup is being written right now (issue #987).
+    /// `Database::BackupSlot` is the only thing that touches it; see the note
+    /// there for why a second backup is refused rather than queued. Atomic
+    /// because the slot is deliberately taken *outside* the DB mutex - a
+    /// `VACUUM INTO` of a large workspace must not stall every other endpoint.
+    std::atomic<bool> backup_running{ false };
 
     /// The file `storage` was opened on, for `Database::path`. Named for the
     /// file rather than `db_path`, which the constructor below already uses for
@@ -2018,6 +2029,253 @@ void Database::prune_runs_configured () {
 }
 
 // ============================================================================
+// Workspace backup (issue #987) - a snapshot the user owns
+// ============================================================================
+
+namespace {
+
+/// The two halves of a snapshot's file name. Retention only ever removes a file
+/// carrying both, so anything else that has found its way into `backups/` -
+/// including a copy the user made themselves - is left where it is.
+constexpr std::string_view BACKUP_PREFIX    = "vayu-";
+constexpr std::string_view BACKUP_EXTENSION = ".db";
+
+/// Bound on the collision walk below. A thousand snapshots inside one
+/// millisecond is not a case that happens; the loop is finite so that a
+/// filesystem answering `exists` wrongly cannot hang a request.
+constexpr int BACKUP_NAME_ATTEMPTS = 1000;
+
+/**
+ * A snapshot's file name for the instant @p stamp_ms, or an empty string for an
+ * instant that cannot be converted.
+ *
+ * `vayu-YYYYMMDD-HHMMSS-mmm.db`. UTC rather than local time, so a machine that
+ * changes timezone does not reorder its own backups, and fixed-width so the
+ * names sort chronologically as *text* - which is what lets retention pick the
+ * oldest without asking the filesystem for an mtime it may round, or may not
+ * have preserved across a copy.
+ */
+std::string backup_file_name (int64_t stamp_ms) {
+    const auto seconds = static_cast<std::time_t> (stamp_ms / 1000);
+    const auto millis  = static_cast<int> (stamp_ms % 1000);
+    const std::string stamp = vayu::utils::format_utc_time (seconds, "%Y%m%d-%H%M%S");
+    if (stamp.empty ()) {
+        return {};
+    }
+    return std::format ("{}{}-{:03d}{}", BACKUP_PREFIX, stamp, millis, BACKUP_EXTENSION);
+}
+
+/// Whether @p name is a file this feature wrote - the only kind retention removes.
+bool is_backup_file_name (const std::string& name) {
+    return name.starts_with (BACKUP_PREFIX) && name.ends_with (BACKUP_EXTENSION) &&
+    name.size () > BACKUP_PREFIX.size () + BACKUP_EXTENSION.size ();
+}
+
+/**
+ * Copy the database at @p source into @p destination with `VACUUM INTO`.
+ *
+ * @return an empty string on success, or what SQLite refused.
+ *
+ * On a connection of its own rather than the one every write is serialized
+ * through. Two reasons, and they agree: sqlite_orm exposes no way to run a
+ * statement on the connection it holds, and a `VACUUM INTO` of a large
+ * workspace occupies its connection for as long as the copy takes - on the
+ * shared one that is every other endpoint waiting behind a button someone
+ * pressed. Under WAL a second reader sees every committed transaction and
+ * blocks no writer, so the snapshot is consistent and costs the running engine
+ * nothing but disk bandwidth.
+ *
+ * The destination is *bound*, not concatenated: a path is user data on every
+ * platform and a quote in a directory name would otherwise be a SQL fragment.
+ */
+std::string vacuum_into (const std::string& source, const std::string& destination) {
+    sqlite3* connection = nullptr;
+    // Read-write rather than read-only: under WAL a reader still writes the
+    // `-shm` index, and a read-only open of a database whose WAL has not been
+    // checkpointed fails outright on a directory it cannot write.
+    int rc = sqlite3_open_v2 (source.c_str (), &connection, SQLITE_OPEN_READWRITE, nullptr);
+    if (rc != SQLITE_OK) {
+        std::string message = connection != nullptr ?
+        std::string (sqlite3_errmsg (connection)) :
+        std::string ("could not open the workspace database");
+        sqlite3_close (connection);
+        return message;
+    }
+    sqlite3_busy_timeout (connection, vayu::core::constants::database::BUSY_TIMEOUT_MS);
+
+    sqlite3_stmt* statement = nullptr;
+    rc = sqlite3_prepare_v2 (connection, "VACUUM INTO ?", -1, &statement, nullptr);
+    if (rc != SQLITE_OK) {
+        std::string message = sqlite3_errmsg (connection);
+        sqlite3_close (connection);
+        return message;
+    }
+    // SQLITE_TRANSIENT: sqlite copies the text, so `destination` need not
+    // outlive the bind - which it does anyway, said here so a later refactor
+    // cannot quietly make the lifetime load-bearing.
+    sqlite3_bind_text (statement, 1, destination.c_str (), -1, SQLITE_TRANSIENT);
+
+    std::string message;
+    if (sqlite3_step (statement) != SQLITE_DONE) {
+        message = sqlite3_errmsg (connection);
+    }
+    sqlite3_finalize (statement);
+    sqlite3_close (connection);
+    return message;
+}
+
+/**
+ * Remove all but the newest @p keep snapshots from @p directory.
+ *
+ * @return how many files were removed. @p keep of 0 or less is unlimited, which
+ *         is what the `maxBackupsRetained` entry documents.
+ */
+int64_t prune_backup_files (const fs::path& directory, int keep) {
+    if (keep <= 0) {
+        return 0;
+    }
+    std::error_code ec;
+    std::vector<fs::path> snapshots;
+    for (const auto& entry : fs::directory_iterator (directory, ec)) {
+        if (entry.is_regular_file (ec) &&
+        is_backup_file_name (entry.path ().filename ().string ())) {
+            snapshots.push_back (entry.path ());
+        }
+    }
+    if (snapshots.size () <= static_cast<size_t> (keep)) {
+        return 0;
+    }
+    // Chronological, because the names are fixed-width UTC stamps - see
+    // `backup_file_name`.
+    std::sort (snapshots.begin (), snapshots.end ());
+
+    int64_t removed        = 0;
+    const size_t to_remove = snapshots.size () - static_cast<size_t> (keep);
+    for (size_t i = 0; i < to_remove; ++i) {
+        // `.at` rather than a subscript: the index is computed above, and one
+        // predictable compare turns a wrong bound into a throw the route
+        // reports instead of a read past the end that deletes something else.
+        const fs::path& oldest = snapshots.at (i);
+        std::error_code remove_ec;
+        if (fs::remove (oldest, remove_ec)) {
+            ++removed;
+        } else {
+            // Best-effort: a snapshot that will not delete is a file the user
+            // still has, which is the safe direction for this feature to fail
+            // in. It is said out loud rather than swallowed, because a
+            // retention setting that silently stops applying grows a disk.
+            vayu::utils::log_warning ("Could not prune the backup " +
+            oldest.string () + ": " + remove_ec.message ());
+        }
+    }
+    return removed;
+}
+
+} // namespace
+
+Database::BackupSlot::BackupSlot (Database& db) : db_ (db), held_ (false) {
+    bool expected = false;
+    held_ = db_.impl_->backup_running.compare_exchange_strong (expected, true);
+}
+
+Database::BackupSlot::~BackupSlot () {
+    if (held_) {
+        db_.impl_->backup_running.store (false);
+    }
+}
+
+std::string Database::backups_directory () const {
+    return (fs::path (impl_->opened_file).parent_path () / "backups").string ();
+}
+
+std::expected<BackupRecord, BackupFailure> Database::backup_workspace (int64_t now) {
+    BackupSlot slot (*this);
+    if (!slot.held ()) {
+        return std::unexpected (
+        BackupFailure{ true, "A workspace backup is already running" });
+    }
+
+    if (now <= 0) {
+        // A snapshot is named for the instant it was taken, so an instant that
+        // is not one has no name. Refused rather than defaulted to "now": a
+        // caller with a broken clock would otherwise get a file whose name says
+        // something untrue about when its contents are from.
+        return std::unexpected (BackupFailure{ false,
+        "Invalid backup timestamp " + std::to_string (now) +
+        ": a snapshot is named for the instant it was taken" });
+    }
+
+    const fs::path directory = backups_directory ();
+    std::error_code ec;
+    fs::create_directories (directory, ec);
+    if (ec && !fs::is_directory (directory)) {
+        return std::unexpected (BackupFailure{ false,
+        "Could not create the backup directory " + directory.string () + ": " +
+        ec.message () });
+    }
+
+    // A taken name is stepped over rather than written through, exactly as the
+    // corruption quarantine does - and here it is also what keeps SQLite happy,
+    // since `VACUUM INTO` refuses a destination that already exists.
+    int64_t stamp = now;
+    fs::path destination;
+    for (int attempt = 0; attempt < BACKUP_NAME_ATTEMPTS; ++attempt, ++stamp) {
+        const std::string name = backup_file_name (stamp);
+        if (name.empty ()) {
+            return std::unexpected (BackupFailure{ false,
+            "Could not name a backup for the instant " + std::to_string (stamp) });
+        }
+        std::error_code exists_ec;
+        if (fs::path candidate = directory / name; !fs::exists (candidate, exists_ec)) {
+            destination = std::move (candidate);
+            break;
+        }
+    }
+    if (destination.empty ()) {
+        return std::unexpected (BackupFailure{ false,
+        "Could not find an unused backup name in " + directory.string () });
+    }
+
+    if (const std::string refusal = vacuum_into (impl_->opened_file, destination.string ());
+    !refusal.empty ()) {
+        // A failed VACUUM INTO can leave a partial file behind, and a partial
+        // file with a snapshot's name is worse than no snapshot: retention
+        // would count it, and a restore would reach for it.
+        std::error_code remove_ec;
+        fs::remove (destination, remove_ec);
+        return std::unexpected (BackupFailure{ false,
+        "Could not write the backup to " + destination.string () + ": " + refusal });
+    }
+
+    std::error_code size_ec;
+    const auto size = fs::file_size (destination, size_ec);
+
+    BackupRecord record;
+    record.path       = destination.string ();
+    record.size_bytes = size_ec ? 0 : static_cast<int64_t> (size);
+    record.created_at = stamp;
+    // Retention runs *after* the snapshot exists, and a failure here must not
+    // turn a backup that succeeded into a reported failure - the user has the
+    // file they asked for, and the worst this leaves behind is one snapshot too
+    // many. This is also what makes the declared "never throws" true: it is the
+    // one step that reads the database.
+    try {
+        record.pruned = prune_backup_files (directory,
+        get_config_int ("maxBackupsRetained",
+        vayu::core::constants::database::MAX_BACKUPS_RETAINED));
+    } catch (const std::exception& e) {
+        vayu::utils::log_warning (
+        "Backup retention did not run: " + std::string (e.what ()));
+    }
+
+    vayu::utils::log_info ("Workspace backed up to " + record.path + " (" +
+    std::to_string (record.size_bytes) + " bytes" +
+    (record.pruned > 0 ? ", pruned " + std::to_string (record.pruned) + " older snapshot(s)" : "") +
+    ")");
+    return record;
+}
+
+// ============================================================================
 // Metric ticks - one wide row per tick (the current time-series storage)
 // ============================================================================
 
@@ -3200,6 +3458,18 @@ void Database::seed_default_config () {
     "disk. In-progress runs are never pruned.",
     "data_retention", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
     "0", "3650", std::nullopt, now })));
+
+    upsert_config (
+    keywords ({ "restore", "cleanup" }) (ConfigEntry{ "maxBackupsRetained",
+    std::to_string (vayu::core::constants::database::MAX_BACKUPS_RETAINED), "integer", "Max Backups Retained",
+    "Keep at most this many workspace snapshots in the backups folder beside "
+    "the database; older ones are removed after each new backup. Each snapshot "
+    "is a compacted copy of the whole workspace - collections, environments, "
+    "secrets and run history - so a higher value, or 0 for unlimited, costs "
+    "disk. Only files Vayu wrote are ever removed; a copy you put there "
+    "yourself is left alone.",
+    "data_retention", std::to_string (vayu::core::constants::database::MAX_BACKUPS_RETAINED),
+    "0", "100", std::nullopt, now }));
 
     // =========================================================================
     // LIMITS (limits) - added by #703

--- a/engine/src/http/routes/workspace.cpp
+++ b/engine/src/http/routes/workspace.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/workspace.cpp
+ * @brief `POST /workspace/backup` - a snapshot of the workspace the user owns
+ *        (issue #987).
+ *
+ * Everything a Vayu user has typed lives in one SQLite file: collections,
+ * environments, stored credentials and run history. Until this route there was
+ * no way to take a copy of it that the user controlled. The `.bak` the
+ * constructor writes is not one - it is overwritten on every clean start and
+ * exists so a corrupt file has something to restore *from*, not so a person can
+ * go back to last week. And copying the file by hand while the engine runs is
+ * not safe under WAL: the `-wal` holds committed transactions the main file
+ * does not, so the copy is a database missing its most recent writes.
+ *
+ * The route is a verb path rather than a stored resource, on the same reasoning
+ * as `/inbox/start` and `/mock/start`: a backup is something the engine *does*,
+ * and the file it produces is not a row anything here can later read back.
+ *
+ * There is deliberately **no restore endpoint**. Restoring means putting a file
+ * where the engine's open database is, and a live engine overwriting the file
+ * it holds open is precisely the footgun this feature exists to spare the user.
+ * The procedure is documented instead - stop the engine, copy a snapshot over
+ * `db/vayu.db`, delete the `-wal` and `-shm`, start - in
+ * `docs/engine/architecture.md`.
+ */
+
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/logger.hpp"
+
+#include <chrono>
+#include <string>
+#include <utility>
+
+namespace vayu::http::routes {
+
+/**
+ * Testable core of POST /workspace/backup.
+ *
+ * @param now the caller's clock in Unix ms - the instant the snapshot is named
+ *        for. A parameter rather than a call to the clock inside, so a test can
+ *        say which snapshot it is asking for.
+ *
+ * A backup already running is a **409**: nothing is wrong, and the caller's own
+ * earlier request is still producing the file they asked for. Anything else
+ * that goes wrong is a **500** naming what SQLite or the filesystem refused,
+ * never a 200 with an empty path - a backup that reports success and wrote
+ * nothing is the one outcome this feature must not have.
+ */
+std::pair<int, nlohmann::json> workspace_backup_response (vayu::db::Database& db, int64_t now) {
+    const auto outcome = db.backup_workspace (now);
+    if (!outcome) {
+        return outcome.error ().already_running ?
+        std::pair{ 409, error_body (409, outcome.error ().message) } :
+        std::pair{ 500, error_body (500, outcome.error ().message) };
+    }
+    return { 200,
+        nlohmann::json{ { "path", outcome->path }, { "sizeBytes", outcome->size_bytes },
+        { "createdAt", outcome->created_at }, { "pruned", outcome->pruned } } };
+}
+
+void register_workspace_routes (RouteContext& ctx) {
+    /**
+     * POST /workspace/backup
+     * Writes one consistent, compacted snapshot of the workspace into
+     * `backups/` beside the database and prunes older ones to
+     * `maxBackupsRetained`. Takes no body.
+     * Returns: {path, sizeBytes, createdAt, pruned}, 409 while another backup
+     * is running, or 500 naming what refused.
+     */
+    ctx.server.Post ("/workspace/backup",
+    [&ctx] (const httplib::Request&, httplib::Response& res) {
+        try {
+            const auto now = std::chrono::duration_cast<std::chrono::milliseconds> (
+            std::chrono::system_clock::now ().time_since_epoch ())
+                             .count ();
+            auto [status, body] = workspace_backup_response (ctx.db, now);
+            if (status != 200) {
+                vayu::utils::log_warning ("POST /workspace/backup - " +
+                std::to_string (status) + ": " + error_message_of (body));
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "POST /workspace/backup - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+}
+
+} // namespace vayu::http::routes

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -176,6 +176,7 @@ void Server::setup_routes () {
 
     routes::register_health_routes (*route_ctx_);
     routes::register_config_routes (*route_ctx_);
+    routes::register_workspace_routes (*route_ctx_);
     routes::register_collection_routes (*route_ctx_);
     routes::register_request_routes (*route_ctx_);
     routes::register_request_example_routes (*route_ctx_);

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ add_executable(vayu_tests
     spec_diff_test.cpp
     openapi_export_test.cpp
     spec_export_route_test.cpp
+    workspace_backup_test.cpp
     spec_coverage_test.cpp
     schema_validation_test.cpp
     version_isolation_test.cpp
@@ -147,6 +148,7 @@ add_executable(vayu_tests
     ../src/http/routes/diagnostics.cpp
     ../src/http/routes/compose.cpp
     ../src/http/routes/config.cpp
+    ../src/http/routes/workspace.cpp
     ../src/http/routes/requests.cpp
     ../src/http/routes/examples.cpp
     ../src/http/routes/specs.cpp
@@ -351,6 +353,7 @@ set(vayu_scratch_database_suites
     StreamedSampleRouteTest
     TransportPolicyDbTest
     TreeOrderTest
+    WorkspaceBackupTest
 )
 
 # Both guards read the same scan: every test macro in this suite sits at the

--- a/engine/tests/workspace_backup_test.cpp
+++ b/engine/tests/workspace_backup_test.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/workspace_backup_test.cpp
+ * @brief Tests for `POST /workspace/backup` and the `Database` half behind it
+ *        (issue #987).
+ *
+ * What is pinned here is what a backup feature can silently get wrong:
+ *
+ *  - **The file is a database, not bytes.** A snapshot that cannot be opened,
+ *    or that opens and is missing the rows the workspace had, is the failure
+ *    this feature exists to prevent - and it looks identical from the outside
+ *    to one that worked. So the snapshot is opened as a `Database` and read.
+ *  - **Retention removes only what Vayu wrote.** The directory belongs to the
+ *    user; a pass that deleted by count without looking at the name would eat a
+ *    copy they put there themselves.
+ *  - **Retention keeps the *newest*.** Pruning the wrong end of the list would
+ *    leave the oldest snapshots and pass every count-based assertion.
+ *  - **A second concurrent backup is refused, and the slot is released.** A
+ *    guard that never releases turns the second *sequential* backup into a 409,
+ *    which is why both directions are asserted.
+ *
+ * Follows the suite's route-test convention: the route's extracted core is
+ * exercised directly, no in-process HTTP server.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "optional_assert.hpp"
+#include "temp_database.hpp"
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in workspace.cpp / collections.cpp; each returns {http_status,
+// json_body} - the pair the handler writes out.
+std::pair<int, nlohmann::json> workspace_backup_response (vayu::db::Database& db, int64_t now);
+std::pair<int, nlohmann::json>
+create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
+} // namespace vayu::http::routes
+
+namespace {
+
+namespace fs     = std::filesystem;
+namespace routes = vayu::http::routes;
+
+/// An arbitrary but plausible instant, so the snapshot names in a failure
+/// message read as dates rather than as noise. 2026-08-27T12:00:00.000Z.
+constexpr int64_t A_MOMENT = 1'787'745'600'000;
+
+/// A field of the engine's `{"error": {"code", "message"}}` envelope, or "" -
+/// so a body that is not an error fails the assertion rather than throwing.
+std::string error_field (const json& body, const char* field) {
+    const auto error = body.find ("error");
+    if (error == body.end () || !error->is_object ()) {
+        return {};
+    }
+    return error->value (field, std::string{});
+}
+
+class WorkspaceBackupTest : public ::testing::Test {
+    protected:
+    /// A directory of its own rather than a bare filename, because this feature
+    /// writes a *sibling* directory of the database - so the fixture has to own
+    /// the parent to clean up after itself.
+    static constexpr const char* WORKSPACE = "workspace_backup_scratch";
+    static constexpr const char* DB_PATH   = "workspace_backup_scratch/vayu.db";
+
+    void SetUp () override {
+        cleanup ();
+        fs::create_directories (WORKSPACE);
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+        std::error_code ec;
+        fs::remove_all (WORKSPACE, ec);
+    }
+
+    /// Write @p value to the config row @p key, the way the Settings screen
+    /// does - `save_config_entry` replaces the whole row, so the entry is read
+    /// back and edited rather than rebuilt.
+    void set_config (const std::string& key, int value) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_HAS_VALUE (entry) << key;
+        entry->value = std::to_string (value);
+        db_->save_config_entry (*entry);
+    }
+
+    std::string create_collection (const std::string& name) {
+        auto [status, response] =
+        routes::create_collection_response (*db_, json{ { "name", name } });
+        EXPECT_EQ (status, 200) << response.dump ();
+        return response.value ("id", std::string{});
+    }
+
+    /// The snapshot files in the backups directory, oldest first.
+    std::vector<std::string> snapshot_names () const {
+        std::vector<std::string> names;
+        std::error_code ec;
+        for (const auto& entry : fs::directory_iterator (db_->backups_directory (), ec)) {
+            names.push_back (entry.path ().filename ().string ());
+        }
+        std::sort (names.begin (), names.end ());
+        return names;
+    }
+
+    vayu::db::BackupRecord backup_ok (int64_t now) {
+        auto outcome = db_->backup_workspace (now);
+        EXPECT_TRUE (outcome.has_value ())
+        << (outcome ? std::string{} : outcome.error ().message);
+        return outcome ? *outcome : vayu::db::BackupRecord{};
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ============================================================================
+// The snapshot itself
+// ============================================================================
+
+TEST_F (WorkspaceBackupTest, WritesADatabaseThatOpensAndStillHasTheRows) {
+    create_collection ("Kept");
+
+    const auto record = backup_ok (A_MOMENT);
+    ASSERT_FALSE (record.path.empty ());
+    ASSERT_TRUE (fs::exists (record.path)) << record.path;
+    EXPECT_EQ (record.created_at, A_MOMENT);
+    EXPECT_GT (record.size_bytes, 0);
+    EXPECT_EQ (record.size_bytes, static_cast<int64_t> (fs::file_size (record.path)));
+
+    // The whole point of the feature: the file is a workspace, not bytes. A
+    // plain file copy taken while the engine is running would open and be
+    // missing whatever the `-wal` still held.
+    {
+        vayu::db::Database restored (record.path);
+        restored.init ();
+        const auto collections = restored.get_collections ();
+        ASSERT_EQ (collections.size (), 1U);
+        EXPECT_EQ (collections.front ().name, "Kept");
+    }
+    vayu::tests::remove_database_files (record.path);
+}
+
+TEST_F (WorkspaceBackupTest, SnapshotsLandBesideTheDatabaseInBackups) {
+    const auto record = backup_ok (A_MOMENT);
+    EXPECT_EQ (fs::path (record.path).parent_path (), fs::path (db_->backups_directory ()));
+    EXPECT_EQ (db_->backups_directory (), (fs::path (WORKSPACE) / "backups").string ());
+}
+
+TEST_F (WorkspaceBackupTest, TwoBackupsInTheSameMillisecondAreTwoFiles) {
+    // The stamp names the file, so an unstepped collision would either
+    // overwrite the first snapshot or - since VACUUM INTO refuses an existing
+    // destination - fail the second.
+    const auto first  = backup_ok (A_MOMENT);
+    const auto second = backup_ok (A_MOMENT);
+    EXPECT_NE (first.path, second.path);
+    EXPECT_EQ (snapshot_names ().size (), 2U);
+}
+
+TEST_F (WorkspaceBackupTest, NamesSortIntoTheOrderTheyWereTakenIn) {
+    // Retention picks the oldest by sorting the names as text, so the names
+    // have to be chronological as text - across a second boundary, which a
+    // stamp without zero padding would not be.
+    const auto early = backup_ok (A_MOMENT + 999);
+    const auto late  = backup_ok (A_MOMENT + 1'000);
+    EXPECT_LT (fs::path (early.path).filename ().string (),
+    fs::path (late.path).filename ().string ());
+}
+
+// ============================================================================
+// Retention
+// ============================================================================
+
+TEST_F (WorkspaceBackupTest, RetentionKeepsTheNewestSnapshots) {
+    set_config ("maxBackupsRetained", 2);
+
+    const auto oldest = backup_ok (A_MOMENT);
+    backup_ok (A_MOMENT + 1'000);
+    const auto third  = backup_ok (A_MOMENT + 2'000);
+    const auto newest = backup_ok (A_MOMENT + 3'000);
+
+    const auto names = snapshot_names ();
+    ASSERT_EQ (names.size (), 2U);
+    EXPECT_EQ (names[0], fs::path (third.path).filename ().string ());
+    EXPECT_EQ (names[1], fs::path (newest.path).filename ().string ());
+    EXPECT_FALSE (fs::exists (oldest.path));
+}
+
+TEST_F (WorkspaceBackupTest, RetentionReportsWhatItRemoved) {
+    set_config ("maxBackupsRetained", 1);
+
+    EXPECT_EQ (backup_ok (A_MOMENT).pruned, 0);
+    EXPECT_EQ (backup_ok (A_MOMENT + 1'000).pruned, 1);
+    EXPECT_EQ (backup_ok (A_MOMENT + 2'000).pruned, 1);
+}
+
+TEST_F (WorkspaceBackupTest, ZeroRetainsEverything) {
+    set_config ("maxBackupsRetained", 0);
+
+    for (int64_t offset = 0; offset < 4; ++offset) {
+        backup_ok (A_MOMENT + (offset * 1'000));
+    }
+    EXPECT_EQ (snapshot_names ().size (), 4U);
+}
+
+TEST_F (WorkspaceBackupTest, LeavesFilesItDidNotWriteAlone) {
+    set_config ("maxBackupsRetained", 1);
+
+    backup_ok (A_MOMENT);
+    // Dropped in after the directory exists, exactly as a user copying a
+    // snapshot somewhere safe would leave things.
+    const fs::path directory = db_->backups_directory ();
+    const fs::path note      = directory / "why-I-kept-these.txt";
+    const fs::path adopted   = directory / "monday-before-the-import.db";
+    std::ofstream (note) << "keep me";
+    std::ofstream (adopted) << "not a vayu- name";
+
+    backup_ok (A_MOMENT + 1'000);
+    backup_ok (A_MOMENT + 2'000);
+
+    EXPECT_TRUE (fs::exists (note));
+    EXPECT_TRUE (fs::exists (adopted));
+    // One snapshot, plus the two files retention must not have counted.
+    EXPECT_EQ (snapshot_names ().size (), 3U);
+}
+
+// ============================================================================
+// The single-backup slot
+// ============================================================================
+
+TEST_F (WorkspaceBackupTest, RefusesASecondBackupWhileOneIsRunning) {
+    vayu::db::Database::BackupSlot held (*db_);
+    ASSERT_TRUE (held.held ());
+
+    const auto refused = db_->backup_workspace (A_MOMENT);
+    ASSERT_FALSE (refused.has_value ());
+    EXPECT_TRUE (refused.error ().already_running);
+    EXPECT_FALSE (refused.error ().message.empty ());
+    // Refused means refused: nothing half-written was left behind.
+    EXPECT_FALSE (fs::exists (db_->backups_directory ()));
+}
+
+TEST_F (WorkspaceBackupTest, ReleasesTheSlotSoTheNextBackupSucceeds) {
+    {
+        vayu::db::Database::BackupSlot held (*db_);
+        EXPECT_TRUE (held.held ());
+    }
+    EXPECT_TRUE (db_->backup_workspace (A_MOMENT).has_value ());
+    // And the slot a completed backup took is released too - without which a
+    // user gets exactly one backup per engine process.
+    EXPECT_TRUE (db_->backup_workspace (A_MOMENT + 1'000).has_value ());
+}
+
+// ============================================================================
+// The route
+// ============================================================================
+
+TEST_F (WorkspaceBackupTest, RouteAnswersWithThePathSizeAndStamp) {
+    create_collection ("Kept");
+
+    auto [status, body] = routes::workspace_backup_response (*db_, A_MOMENT);
+    ASSERT_EQ (status, 200) << body.dump ();
+    const auto path = body.value ("path", std::string{});
+    ASSERT_FALSE (path.empty ());
+    EXPECT_TRUE (fs::exists (path)) << path;
+    EXPECT_EQ (body.value ("sizeBytes", int64_t{ 0 }),
+    static_cast<int64_t> (fs::file_size (path)));
+    EXPECT_EQ (body.value ("createdAt", int64_t{ 0 }), A_MOMENT);
+    EXPECT_EQ (body.value ("pruned", int64_t{ -1 }), 0);
+}
+
+TEST_F (WorkspaceBackupTest, RouteAnswers409WhileAnotherBackupIsRunning) {
+    vayu::db::Database::BackupSlot held (*db_);
+    ASSERT_TRUE (held.held ());
+
+    auto [status, body] = routes::workspace_backup_response (*db_, A_MOMENT);
+    EXPECT_EQ (status, 409) << body.dump ();
+    EXPECT_EQ (error_field (body, "code"), "conflict") << body.dump ();
+    EXPECT_FALSE (error_field (body, "message").empty ()) << body.dump ();
+}
+
+TEST_F (WorkspaceBackupTest, RouteRefusesAnInstantThatIsNotOne) {
+    // A snapshot is named for the instant it was taken. Loudly refused rather
+    // than defaulted to the wall clock, which would name the file something
+    // untrue about when its contents are from.
+    for (const int64_t bad : { int64_t{ 0 }, int64_t{ -1 } }) {
+        auto [status, body] = routes::workspace_backup_response (*db_, bad);
+        EXPECT_EQ (status, 500) << body.dump ();
+        EXPECT_NE (error_field (body, "message").find (std::to_string (bad)), std::string::npos)
+        << body.dump ();
+    }
+    EXPECT_FALSE (fs::exists (db_->backups_directory ()));
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Root cause.** Everything a Vayu user builds lives in one SQLite file, and there was no copy of it they controlled. Verified at `717da15`: no backup endpoint, no CLI verb, no documented file-copy story. The `.bak` at `database.cpp:713` is not a user backup - it is rewritten on every clean start, so it exists to give a corrupt file something to restore *from*, not to let anyone go back to last week; and since the recovery path can end in an empty workspace (`db-schema.md`'s table), a user whose file goes bad has nothing of their own to fall back on. Copying `vayu.db` by hand while the engine runs is not a workaround: under WAL the `-wal` holds committed transactions the main file does not, so the copy is a database missing its most recent writes.

**Approach.** `POST /workspace/backup` runs SQLite's `VACUUM INTO` - consistent under WAL, compacted, and read-only with respect to the workspace, so nothing here can cost the user the data it is copying. It runs on a **connection of its own** rather than the live one, which is the one place this diverges from the issue's wording ("on the live connection"): sqlite_orm's `get_connection()` is `protected`, so there is no way to run a statement on the connection it holds - and a `VACUUM INTO` of a large workspace would occupy that connection for the whole copy, parking every other endpoint behind a button someone pressed. Under WAL a second reader sees every committed transaction and blocks no writer, so the snapshot is identical and the running engine pays nothing but disk bandwidth. This is stated at the helper.

**Alternative rejected.** sqlite_orm's public `storage.backup_to()` (the `sqlite3_backup` API) would have used the live connection, but it produces a page-for-page copy rather than a compacted one and restarts if the source is written mid-copy - so it is both larger and less predictable than the thing the issue asked for.

Names are UTC and fixed-width (`vayu-YYYYMMDD-HHMMSS-mmm.db`) so retention sorts them chronologically **as text**, rather than trusting an mtime a copy may not preserve; a taken name is stepped over rather than written through, exactly as `quarantine_db_files` does - and `VACUUM INTO` refuses an existing destination, so that step is load-bearing. Retention keeps the newest `maxBackupsRetained` (default 5, `0` = unlimited) and removes **only** files matching that name, so a copy the user put in the directory themselves survives. A second concurrent backup is refused with `409` through one RAII-held slot, since two would each write a whole second database and race each other's pruning. A retention failure cannot demote a snapshot that succeeded.

There is deliberately **no restore endpoint**: a live engine overwriting its own open database is the footgun this feature exists to prevent. The procedure is documented, and the app card keeps it on screen next to the path.

### App changes

- `WorkspaceBackupCard` in Settings > General, beside Data management / Storage paths (engine-held state the user did not type - the same shelf as `CookiesCard`). It keeps the **path** on screen rather than only toasting it, because restoring is a manual copy and a faded toast cannot tell you where the file went.
- A `409` reads as "a backup is already running - it will finish on its own", not as a failure: it is their own earlier request still writing the file.
- `maxBackupsRetained` renders through the generic engine settings rows under Engine > Data & retention; the card points at it.

### Second commit: an unrelated dead return (#1037)

`e6e04692` deletes one unreachable `return std::nullopt;` from `read_monitor_block`, left behind when #1021 extracted `read_monitor_series`. It is not this feature's code and would normally not be in this PR - it is here at the owner's request, because it is what fails `asan on windows-latest` and this PR is the first thing to run that leg since the line landed (`sanitizers.yml` runs per-PR only for a diff touching `engine/CMakeLists.txt`, which this one does; the weekly cron last ran 2026-08-25, a day before `79b9f124`). MSVC's C4702 needs a `/Od /Ob0` build and `/WX` is unconditional there, so `windows-prod` at `/O2` and every GCC/Clang leg stay silent. Reproduced before fixing with `clang++-19 -Wunreachable-code-return`, the nearest analogue available here; a sweep of `engine/{src,include}` for two same-depth returns in a row found no other instance.

## Type of Change

- [x] Bug fix (the second commit only - see above)
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run locally on this branch.

- **Engine:** `python build.py -e -t && ctest --preset linux-dev --output-on-failure` - **2459 / 2459 passed, 0 failed** (13 new in `workspace_backup_test.cpp`), re-run after the second commit. The new cases pin what a backup feature gets silently wrong: the snapshot is opened as a `Database` and asserted to still carry its rows; retention keeps the *newest* (pruning the wrong end passes every count-based check) and leaves a `.txt` and a foreign `.db` in the directory alone; two backups in the same millisecond are two files; names sort chronologically across a second boundary; the slot refuses a second backup **and** releases, so a completed one is not the only one an engine process ever takes; the route's 200 / 409 / 500. `Monitor*` 28 / 28.
- **App:** `pnpm test` - 5707 / 5708 passed. The single failure is `send-with-row.test.tsx > opens the list on the row that step bound`, a 5s timeout while an engine build had the cores - the exact case `CLAUDE.md` documents. It touches nothing in this diff and **passes on its own** (41 / 41, re-run after the build finished). Not fixed or hidden here.
- `pnpm type-check`, `pnpm lint`, `prettier --check` on every app file touched: clean.
- `clang-format-19 --dry-run -Werror` over the whole of `engine/{src,include,tests}`: clean.
- `clang-tidy-19 -p build` on all four touched/new engine sources (`workspace.cpp`, `database.cpp`, `cli.cpp`, `workspace_backup_test.cpp`): no findings. The only diagnostic emitted is `clang-diagnostic-ignored-gch` from running clang-tidy against a GCC build tree.
- `mkdocs build --strict`: clean.
- **End to end**, against a real daemon: the endpoint returned a snapshot; `vayu-cli backup` printed the path alone on stdout; a `POST /config` setting `maxBackupsRetained: 2` pruned to the newest two on the next backup (`"pruned": 2`); a snapshot opened with an independent SQLite client contained a collection written seconds earlier; an unreachable daemon exited 1 with a message.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests - none for `e6e04692`, and the commit says why: the deleted statement is unreachable, so nothing behavioural can tell before from after
- [x] I have updated documentation - `docs/engine/api-reference.md` (new endpoint), `docs/engine/cli.md` (new verb), `docs/engine/architecture.md` (data directory + the restore procedure), `docs/engine/db-schema.md` (why `.bak` is not this), `docs/app/api-integration.md` and `engine/CLAUDE.md`'s endpoint table - all in the feature commit

## Related Issues

Closes #987
Closes #1037

Unblocks #988 and #990, which the issue's Sequencing says build on this `VACUUM INTO` machinery in the same file region.