### PR TITLE
feat(engine,app): bind data rows on a single-request load run, and pre-fill the declared file

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -3197,6 +3197,11 @@ describe("start_load_run scenario runs", () => {
 			["maxInFlight", 10],
 			["stream", true],
 			["sloMs", 500],
+			// The single-target row set (issue #993): a sequence states its rows
+			// as `scenario.data`, and they bind per iteration there rather than
+			// per request sent, so a payload carrying both would have one of the
+			// two silently dropped.
+			["data", [{ id: "1" }]],
 		] as Array<[string, unknown]>) {
 			const res = await dispatchTool(
 				"start_load_run",
@@ -6774,6 +6779,23 @@ describe("start_load_run recording knobs", () => {
 		]) {
 			expect(started(client)).not.toHaveProperty(camel);
 		}
+	});
+
+	// The rows go through untouched (issue #993): every rule about what a set may
+	// be lives engine-side, so a second copy of them here could only drift - and
+	// a set the schema quietly dropped would be a run of literal `{{data.*}}`
+	// tokens that reads as the feature working.
+	test("forwards a data set verbatim, under the engine's own key", async () => {
+		const rows = [{ id: "1" }, { id: "2" }];
+		const { res, client } = await start({ data: rows });
+
+		expect(res.isError).toBeFalsy();
+		expect(started(client)).toMatchObject({ data: rows });
+	});
+
+	test("sends no `data` key when the caller named no rows", async () => {
+		const { client } = await start({ comment: "just a note" });
+		expect(started(client)).not.toHaveProperty("data");
 	});
 
 	test("a knob the caller did not name is absent, not defaulted", async () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -2473,6 +2473,10 @@ const SINGLE_TARGET_LOAD_FIELDS: ReadonlyArray<[string, string]> = [
 		"maxRedirects",
 		"each step keeps its own stored redirect policy - set it on the saved request",
 	],
+	[
+		"data",
+		"a collection run states its rows as `scenario.data`, where one row is bound per iteration and shared by every step",
+	],
 	["postRequestScript", "each step runs the scripts stored on it and its collection chain"],
 	["tests", "each step runs the scripts stored on it and its collection chain"],
 	[
@@ -6025,6 +6029,18 @@ export const TOOLS: McpTool[] = [
 			collectionId: collectionIdInput,
 			postRequestScript: validationScriptInput,
 			tests: validationScriptAliasInput,
+			// The single-target data set (issue #993). Bounded by the engine's
+			// own `maxScenarioDataRows` / `maxScenarioDataBytes`, whose 400 is
+			// surfaced verbatim rather than re-derived here - the same posture
+			// `scenarioDataInput` takes, and for the same reason: a copy of a
+			// limit the user can raise in Settings would refuse payloads the
+			// engine accepts.
+			data: z
+				.array(z.record(z.unknown()))
+				.optional()
+				.describe(
+					'Data rows for a single-target run, one flat object per row (e.g. [{"id":"1"},{"id":"2"}]). One row is bound per request sent, claimed off a run-wide cursor that wraps, so a run longer than the set repeats it. Every {{data.column}} in the URL, headers, body and auth credentials binds per submission, and the post-request script reads that submission\'s row as pm.iterationData. A present-but-empty array is refused by the engine, as is `data` beside a `scenario` block - a collection run states its rows as scenario.data instead. The set is not persisted (only its count is recorded on the run), but a bound value travels in the request that carried it and is stored with the run\'s retained traces.'
+				),
 			// The other shape POST /runs accepts (issue #754). Mutually exclusive
 			// with every single-target argument, which the handler refuses by name
 			// rather than ignoring - see SINGLE_TARGET_LOAD_FIELDS.
@@ -6139,6 +6155,10 @@ export const TOOLS: McpTool[] = [
 				const v = str(args, key);
 				if (v !== undefined) payload[key] = v;
 			}
+			// Forwarded verbatim, rows and all: the engine validates the set
+			// before the run row exists and its refusal names the field, so a
+			// second copy of those rules here could only drift (issue #993).
+			if (Array.isArray(args.data)) payload.data = args.data;
 			// Forwarded verbatim - the keys are the engine's own metric names,
 			// and they come back unchanged in `get_run_report`'s
 			// `thresholdValidation`. Zod has already bounded every value.

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -14,6 +14,7 @@ export { useVariableResolver } from "./useVariableResolver";
 export { useActiveEnvironmentGuard } from "./useActiveEnvironmentGuard";
 export { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 export { useDataContract } from "./useDataContract";
+export { useDeclaredDataFile, type DeclaredDataFileState } from "./useDeclaredDataFile";
 export { useElectronTheme } from "./useElectronTheme";
 export { useResizable } from "./useResizable";
 export { useOverflowTitle } from "./useOverflowTitle";

--- a/app/src/hooks/useDeclaredDataFile.ts
+++ b/app/src/hooks/useDeclaredDataFile.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The file a collection's data contract was last run with, re-read from disk
+ * (issue #599, through the chain since #729, shared since #1039).
+ *
+ * Two dialogs start a run that can bind `{{data.*}}`: the Run collection dialog
+ * and the load dialog. Both want the same opening state - "the file you
+ * declared" rather than an empty picker - and the load dialog shipped without
+ * it, so a user who had declared a file on the Data tab re-picked it by hand
+ * for every load run of a request in that collection.
+ *
+ * It is one hook rather than a copy in each dialog because the interesting part
+ * is not the read: it is the *four* rules around it, each of which was learned
+ * once and would have to be re-learned by a second copy.
+ *
+ * 1. **The contract's collection, not the caller's.** A request in a
+ *    sub-collection is governed by the nearest ancestor that declares a
+ *    contract, so the remembered location is filed under `contract.collectionId`
+ *    and reading the store at the id the caller passed in finds nothing for
+ *    exactly the users the chain walk exists to serve.
+ * 2. **One attempt.** The collections query may answer a render *after* the
+ *    dialog mounts, so a mount-only effect would read an empty chain and never
+ *    look again; the ref keeps what the mount-only spelling was there for -
+ *    writing the store while the dialog is open must not yank the user's own
+ *    selection back to what was remembered.
+ * 3. **The row cap applies to a pre-filled file too** (issue #751), against the
+ *    live setting. Without it, the remembered path is the one way past a
+ *    refusal the picker makes on every hand-picked file - the file would
+ *    pre-fill, preview, and be refused by the engine at Run.
+ * 4. **A file that cannot be re-read is a note, never a blocker.** Both runs
+ *    are startable without a file, and picking one again is the whole remedy.
+ *
+ * What this hook deliberately does **not** do is decide anything about the run
+ * it is pre-filling. The Run collection dialog turns a pristine `iterations` of
+ * `1` into "one pass per row" when a file arrives; that is a fact about the
+ * *engine's* default for a collection run, not about the file, and a load run's
+ * length is its profile's. So that coupling reaches the dialog through the
+ * `onPrefill` callback it supplies - the hook fires the seam and knows nothing
+ * about what is on the other side of it, which is what lets the load dialog
+ * share the pre-fill and share none of the consequence.
+ *
+ * It writes nothing to the store either: the Data tab is where a contract is
+ * declared, and one run started against a different file is not a
+ * redeclaration of it for every run that follows.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDataFileStore } from "@/stores";
+import { useCollectionsQuery } from "@/queries";
+import { resolveDataContract } from "@/lib/data-contract";
+import { useDataFileLimits } from "@/hooks/useDataFileLimits";
+import { DataFileError } from "@/services/data-files";
+import {
+	canReadDeclaredDataFile,
+	readDeclaredDataFile,
+	type DeclaredDataFile,
+} from "@/services/data-files/read-declared";
+import type { SelectedDataFile } from "@/modules/collections/DataFilePicker";
+import type { Collection, DataContractScope } from "@/types";
+
+export interface DeclaredDataFileState {
+	/**
+	 * The file the run will bind - pre-filled from the declaration, or whatever
+	 * the user has picked since. `null` when there is none: no contract, no
+	 * remembered location, a read still in flight, a read that failed, or a
+	 * selection the user cleared.
+	 *
+	 * The *selection* lives here rather than in each dialog because the two
+	 * would otherwise have to copy the pre-fill into their own state in an
+	 * effect - a render-phase write React has no reason to allow, and which
+	 * `react-hooks/set-state-in-effect` refuses. One owner, so there is no
+	 * second copy to fall out of step with the first.
+	 */
+	file: SelectedDataFile | null;
+	/**
+	 * Take the user's pick, or `null` to clear it. The pickers' `onSelect`.
+	 *
+	 * `SelectedDataFile` rather than `DeclaredDataFile` because a hand-picked
+	 * file may have no path at all - a browser, or a drag-and-drop of remote
+	 * content - while a re-read one always does. The wider type is the one both
+	 * ways in.
+	 */
+	setFile: (next: SelectedDataFile | null) => void;
+	/**
+	 * Why the remembered file is not in `file`, in the words the caller renders
+	 * in a warning. `null` when nothing went wrong, including the ordinary case
+	 * of there being no remembered file at all.
+	 */
+	note: string | null;
+	/** The contract in scope, which every caller also audits the pick against. */
+	contract: DataContractScope | undefined;
+	/**
+	 * Drop the note.
+	 *
+	 * A file the user picks by hand replaces whatever was pre-filled, so the
+	 * note about one that could not be re-read has nothing left to say. It is
+	 * the caller that knows a pick happened, and it is this hook that owns the
+	 * note - so the dismissal is offered rather than each dialog keeping a
+	 * second flag beside a note it cannot reach.
+	 */
+	dismissNote: () => void;
+}
+
+/**
+ * Both callers mount only while their dialog is open, so there is no `enabled`
+ * gate here: the one attempt is always spent on a render the user can see.
+ *
+ * @param collectionId The collection the run is scoped to - a request's own
+ *        collection is fine, since the contract walk finds the declaring
+ *        ancestor from it.
+ * @param options.collection The caller's own row for that collection, when it
+ *        holds one. It stands *ahead* of the query's copy of itself: the Run
+ *        collection dialog is opened with a row and must resolve a contract it
+ *        declares even on a render where the collections query has not
+ *        answered. Ancestors can only ever come from the query.
+ * @param options.onPrefill Called once, with the file, if the pre-fill lands.
+ *        This is the seam for what a *caller* concludes from a file arriving,
+ *        as opposed to what the file is: the Run collection dialog turns a
+ *        pristine `iterations` of `1` into "one pass per row" here, because
+ *        that is the engine's default for a collection run. The load dialog
+ *        passes nothing - a load run's length is its profile's - which is why
+ *        this is a callback the caller supplies rather than behaviour the hook
+ *        performs.
+ */
+export function useDeclaredDataFile(
+	collectionId: string | null | undefined,
+	options: { collection?: Collection; onPrefill?: (file: DeclaredDataFile) => void } = {}
+): DeclaredDataFileState {
+	const { collection, onPrefill } = options;
+	/*
+	 * Held in a ref so a caller may pass an inline closure without it becoming
+	 * a dependency of the read below - which would re-run the effect on every
+	 * render, and is exactly the shape that turns "once" into "every time".
+	 */
+	const onPrefillRef = useRef(onPrefill);
+	// Synced in an effect, not during render, and declared ahead of the read
+	// below so it is current before that one first runs. The read resolves
+	// asynchronously in any case, so what it calls is the latest closure.
+	useEffect(() => {
+		onPrefillRef.current = onPrefill;
+	}, [onPrefill]);
+	const { data: collections = [] } = useCollectionsQuery();
+	/*
+	 * `useDataContract` is the plain adapter onto the same walk and is what
+	 * every other surface reads; this hook cannot use it, because it is the one
+	 * caller that has a row the query may not have yet. The walk itself is
+	 * still `resolveDataContract` - the override is the only difference.
+	 */
+	const chain = useMemo(
+		() =>
+			collection
+				? [collection, ...collections.filter((row) => row.id !== collection.id)]
+				: collections,
+		[collection, collections]
+	);
+	const contract = useMemo(
+		() => resolveDataContract(collectionId, chain) ?? undefined,
+		[collectionId, chain]
+	);
+	// The store is keyed by the collection that *declares* the contract, which
+	// is the whole point of rule 1 above. Falling back to the caller's id keeps
+	// a collection that declares its own contract working before the query
+	// answers, and finds nothing otherwise - which is the correct answer.
+	const declaringCollectionId = contract?.collectionId ?? collectionId ?? "";
+	const rememberedFile = useDataFileStore((s) => s.locations[declaringCollectionId]);
+	const { maxRows } = useDataFileLimits();
+
+	const [file, setFile] = useState<SelectedDataFile | null>(null);
+	const [note, setNote] = useState<string | null>(null);
+	const attempted = useRef(false);
+
+	useEffect(() => {
+		if (attempted.current) return;
+		if (!rememberedFile?.path) return;
+		attempted.current = true;
+		let cancelled = false;
+		// No Electron, no path to re-read - the picker stands, and this is not
+		// a failure worth a note: it is a state that will never resolve.
+		if (!canReadDeclaredDataFile()) return;
+
+		void readDeclaredDataFile(rememberedFile.path, { maxRows })
+			.then((read) => {
+				if (cancelled) return;
+				setFile(read);
+				onPrefillRef.current?.(read);
+			})
+			.catch((e: unknown) => {
+				if (cancelled) return;
+				setNote(
+					e instanceof DataFileError || e instanceof Error
+						? e.message
+						: `The declared file is no longer at ${rememberedFile.fileName} - pick it again.`
+				);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [rememberedFile, maxRows]);
+
+	const dismissNote = useCallback(() => setNote(null), []);
+
+	return { file, setFile, note, contract, dismissNote };
+}

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -62,7 +62,7 @@
  * arrival-rate executor, which Vayu does not implement - so it is not offered.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Loader2, Play } from "lucide-react";
 import {
 	Dialog,
@@ -78,13 +78,11 @@ import {
 	Switch,
 } from "@/components/ui";
 import { Callout } from "@/components/shared";
-import { useCollectionsQuery, useStartScenarioRunMutation } from "@/queries";
-import { resolveDataContract } from "@/lib/data-contract";
-import { useDashboardStore, useDataFileStore, useSessionStore, useTabsStore } from "@/stores";
+import { useStartScenarioRunMutation } from "@/queries";
+import { useDashboardStore, useSessionStore, useTabsStore } from "@/stores";
 import { loadTestService, scenarioRunService } from "@/services";
-import { DataFileError, describeDataSchemaDiff } from "@/services/data-files";
-import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
-import { useDataFileLimits } from "@/hooks/useDataFileLimits";
+import { describeDataSchemaDiff } from "@/services/data-files";
+import { useDeclaredDataFile } from "@/hooks/useDeclaredDataFile";
 import type { Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "./DataFilePicker";
 
@@ -139,7 +137,6 @@ export default function RunCollectionDialog({
 	 * was still being read.
 	 */
 	const iterationsTouched = useRef(false);
-	const [dataFile, setDataFile] = useState<SelectedDataFile | null>(null);
 	const [dataFileError, setDataFileError] = useState<string | null>(null);
 	const [loadTest, setLoadTest] = useState(false);
 	/**
@@ -152,13 +149,6 @@ export default function RunCollectionDialog({
 	const [failOnSchemaError, setFailOnSchemaError] = useState(false);
 	const [virtualUsers, setVirtualUsers] = useState(DEFAULT_VIRTUAL_USERS);
 	const [durationSeconds, setDurationSeconds] = useState(DEFAULT_DURATION_SECONDS);
-	/**
-	 * A file that could not be re-read - moved, renamed, or over a cap that has
-	 * since been lowered. Kept apart from `dataFileError`, which is a *blocking*
-	 * refusal of a file the user just picked: this one leaves the picker empty
-	 * and usable, because picking the file again is the whole fix.
-	 */
-	const [prefillNote, setPrefillNote] = useState<string | null>(null);
 
 	/*
 	 * The contract this run is measured against, resolved through the chain
@@ -172,81 +162,40 @@ export default function RunCollectionDialog({
 	 * collection that *declared* the contract, since that is whose Data tab the
 	 * file was picked in - and falling back to this collection's own id, which
 	 * is what the store holds when no contract is in scope at all.
-	 */
-	const { data: collections = [] } = useCollectionsQuery();
-	// The collection being run stands ahead of the query's copy of itself: it is
-	// the row the caller opened this dialog with, and the walk must find a
-	// contract it declares even on a render where the query has not answered.
-	// Ancestors can only come from the query, which is the half that is new here.
-	const chain = useMemo(
-		() => [collection, ...collections.filter((row) => row.id !== collection.id)],
-		[collection, collections]
-	);
-	const contract = resolveDataContract(collection.id, chain);
-	const declaringCollectionId = contract?.collectionId ?? collection.id;
-	const rememberedFile = useDataFileStore((s) => s.locations[declaringCollectionId]);
-	/*
-	 * The row cap the pre-filled file has to fit inside, same as a hand-picked
-	 * one (issue #751). Read here as well as in the picker below because the
-	 * re-read happens before any picker holds the file - a file that grew past
-	 * the setting would otherwise pre-fill, preview, and be refused by the
-	 * engine at Run.
-	 */
-	const { maxRows } = useDataFileLimits();
-
-	/**
-	 * Whether the pre-fill has had its one turn.
 	 *
-	 * The effect below used to key off mount alone. It cannot any more: which
-	 * file is remembered now depends on the resolved contract, and the
-	 * collections query behind it may answer a render *after* this dialog
-	 * mounts - a mount-only effect would read an empty chain, find no file and
-	 * never look again. The ref keeps the one property the mount-only spelling
-	 * was there for: writing the store while the dialog is open must not yank
-	 * the user's selection back to what was remembered.
-	 */
-	const prefillAttempted = useRef(false);
-
-	/**
-	 * Pre-fill from the file this collection's contract was last run with
-	 * (issue #599; through the chain since #729).
+	 * ...and the file that contract was last run with, pre-filled (issue #599;
+	 * through the chain since #729; shared with the load dialog since #1039).
 	 *
 	 * Still part of the dialog's mount-is-reset contract: the options start at
 	 * their defaults every time this component appears, and one of those
 	 * defaults is "the file you declared" rather than a value carried over from
-	 * a previous open.
+	 * a previous open. The hook owns the one-attempt rule, the row cap and the
+	 * moved-file note; what stays here is the half that is *this* dialog's -
+	 * the iterations coupling below, which is a fact about the engine's default
+	 * for a collection run and not about the file.
+	 *
+	 * `collection` is handed over because the row this dialog was opened with
+	 * stands ahead of the query's copy of itself: the walk must find a contract
+	 * it declares even on a render where the query has not answered.
 	 */
-	useEffect(() => {
-		if (prefillAttempted.current) return;
-		if (!rememberedFile?.path) return;
-		prefillAttempted.current = true;
-		let cancelled = false;
-		// No Electron, no path to re-read - the picker stands.
-		if (!canReadDeclaredDataFile()) return;
-
-		void readDeclaredDataFile(rememberedFile.path, { maxRows })
-			.then((read) => {
-				if (cancelled) return;
-				setDataFile(read);
-				// Same rule as a hand-picked file: a pristine `1` becomes "one
-				// pass per row", a typed one is the user's.
-				if (!iterationsTouched.current) {
-					setIterations((current) => (current === "1" ? "" : current));
-				}
-			})
-			.catch((e: unknown) => {
-				if (cancelled) return;
-				setPrefillNote(
-					e instanceof DataFileError || e instanceof Error
-						? e.message
-						: `The declared file is no longer at ${rememberedFile.fileName} - pick it again.`
-				);
-			});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [rememberedFile, maxRows]);
+	const {
+		file: dataFile,
+		setFile: setDataFile,
+		note: prefillNote,
+		contract,
+		dismissNote,
+	} = useDeclaredDataFile(collection.id, {
+		collection,
+		// Same rule as a hand-picked file: a pristine `1` becomes "one pass per
+		// row", a typed one is the user's. It rides `onPrefill` rather than the
+		// hook because it is a fact about the engine's default for a *collection*
+		// run - the load dialog shares the pre-fill and must not share this.
+		onPrefill: () => {
+			if (!iterationsTouched.current) {
+				setIterations((current) => (current === "1" ? "" : current));
+			}
+		},
+	});
 
 	/*
 	 * Empty is a meaningful value only with a data file: it means "one pass per
@@ -298,7 +247,7 @@ export default function RunCollectionDialog({
 		setDataFile(next);
 		// A file the user picks by hand replaces whatever was pre-filled, so the
 		// note about a file that could not be re-read has nothing left to say.
-		if (next) setPrefillNote(null);
+		if (next) dismissNote();
 		if (next && !iterationsTouched.current && iterations === "1") setIterations("");
 		if (!next && iterationsBlank) setIterations("1");
 	};

--- a/app/src/modules/dashboard/components/RunMetadata.tsx
+++ b/app/src/modules/dashboard/components/RunMetadata.tsx
@@ -11,7 +11,7 @@
  * Displays API endpoint, test mode, timing information
  */
 
-import { Activity, Clock, Globe, Calendar, Timer } from "lucide-react";
+import { Activity, Clock, Globe, Calendar, Table2, Timer } from "lucide-react";
 import type { RunMetadataProps } from "../types";
 import { formatDuration } from "../utils/format";
 import { loadTestTypeToLabel } from "@/utils";
@@ -75,6 +75,26 @@ export default function RunMetadata({
 						)}
 					</div>
 				)}
+
+				{/* What a data-driven run bound (issue #993). The rows themselves
+				    are never stored - the snapshot keeps their count in their
+				    place - so this is the whole record that the run was driven by
+				    a file, and the only place a reader learns how large the set
+				    was. Absent for every run without one, rather than "0 rows". */}
+				{typeof configuration?.dataRowCount === "number" &&
+					configuration.dataRowCount > 0 && (
+						<div className="flex items-center gap-2">
+							<Table2 className="w-4 h-4 text-muted-foreground" />
+							<span className="font-medium text-muted-foreground">Data:</span>
+							<span className="text-foreground">
+								{configuration.dataRowCount}{" "}
+								{configuration.dataRowCount === 1 ? "row" : "rows"}
+							</span>
+							<span className="text-muted-foreground text-xs">
+								(one per request, repeating)
+							</span>
+						</div>
+					)}
 			</div>
 
 			{/* Timing Info */}

--- a/app/src/modules/dashboard/types.ts
+++ b/app/src/modules/dashboard/types.ts
@@ -41,6 +41,12 @@ export interface DashboardHeaderProps {
 		targetRps?: number;
 		concurrency?: number;
 		comment?: string;
+		/**
+		 * How many `data` rows the run bound (issue #993), off the stored
+		 * snapshot - which keeps the count in the rows' place, since the rows
+		 * themselves are never persisted. Absent for a run without a data file.
+		 */
+		dataRowCount?: number;
 	};
 }
 
@@ -58,6 +64,8 @@ export interface RunMetadataProps {
 		targetRps?: number;
 		concurrency?: number;
 		comment?: string;
+		/** See {@link DashboardHeaderProps}: the row count, never the rows. */
+		dataRowCount?: number;
 	};
 }
 

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -42,7 +42,15 @@ vi.mock("../OAuth2LoadTestGuard", () => ({
 let configEntries: { key: string; value: string }[] = [];
 vi.mock("@/queries", () => ({
 	useConfigQuery: () => ({ data: { entries: configEntries } }),
+	// The data-file picker's column audit resolves the contract in scope from
+	// the collection chain (issue #993); with no collections there is nothing to
+	// audit against, which is what every case here wants except the one that
+	// declares its own.
+	useCollectionsQuery: () => ({ data: collectionRows }),
 }));
+
+/** Collections the contract walk sees. Mutable, like `configEntries` above. */
+let collectionRows: { id: string; name: string; dataSchema?: { columns: string[] } }[] = [];
 
 function open(props: Partial<React.ComponentProps<typeof LoadTestConfigDialog>> = {}) {
 	const onStart = vi.fn();
@@ -73,6 +81,7 @@ beforeEach(() => {
 	cleanup();
 	localStorage.clear();
 	configEntries = [];
+	collectionRows = [];
 	// The ceilings store is module-level and persists across tests in this
 	// file; clearing localStorage does not roll it back.
 	useClientSettingsStore.getState().setLoadTestCeilings(DEFAULT_LOAD_TEST_CEILINGS);
@@ -183,6 +192,62 @@ describe("payload", () => {
 		expect(config.success_sample_period).toBeTypeOf("number");
 		expect(config.slow_threshold_ms).toBeTypeOf("number");
 		expect(config.save_timing_breakdown).toBeTypeOf("boolean");
+	});
+});
+
+describe("data rows (issue #993)", () => {
+	/** Pick @p file through the picker's hidden input, as a user would. */
+	const pick = (file: File) => {
+		const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+		fireEvent.change(input, { target: { files: [file] } });
+	};
+
+	it("offers a data file, described as a load run binds one", () => {
+		open();
+		// The load reading - a row per iteration off a cursor every virtual user
+		// shares, wrapping when the set runs out - and not design mode's "one
+		// iteration per row", which would be wrong for every run this dialog
+		// starts.
+		expect(screen.getByText(/cursor every virtual user shares/i)).toBeInTheDocument();
+		expect(screen.queryByText(/one iteration per row/i)).not.toBeInTheDocument();
+	});
+
+	it("sends the parsed rows on the payload", async () => {
+		const { onStart } = open();
+		pick(new File(["id\na\nb"], "rows.csv"));
+		await screen.findByText(/rows\.csv/);
+
+		expect(started(onStart).data).toEqual([{ id: "a" }, { id: "b" }]);
+	});
+
+	it("sends no `data` key at all when no file was picked", () => {
+		// Absent rather than `[]`: the engine refuses a present-but-empty array
+		// rather than running it, so an empty array would turn "no data set"
+		// into a 400.
+		const { onStart } = open();
+		expect(started(onStart)).not.toHaveProperty("data");
+	});
+
+	it("refuses to start while the picked file cannot be read", async () => {
+		const { onStart } = open();
+		// A ragged row is one of the parser's own refusals; it leaves no
+		// selection behind, so starting would send the request with its
+		// `{{data.*}}` tokens written as they stand.
+		pick(new File(["id,name\na"], "ragged.csv"));
+		await screen.findByText(/could not read the data file/i);
+
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		expect(onStart).not.toHaveBeenCalled();
+	});
+
+	it("audits the file against the contract the collection chain declares", async () => {
+		collectionRows = [{ id: "col_1", name: "Orders", dataSchema: { columns: ["id", "plan"] } }];
+		open({ collectionId: "col_1" });
+		pick(new File(["id\na"], "rows.csv"));
+
+		// A missing column is a warning here and a loud engine-side failure at
+		// bind time - hearing about it before the run is the whole point.
+		expect(await screen.findByText(/plan/)).toBeInTheDocument();
 	});
 });
 

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, within, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, within, cleanup, act } from "@testing-library/react";
 import LoadTestConfigDialog from "./index";
 import type { LoadTestConfig } from "@/types";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
-import { useClientSettingsStore } from "@/stores";
+import { useClientSettingsStore, useDataFileStore } from "@/stores";
 import {
 	DEFAULT_LOAD_TEST_CEILINGS,
 	LOAD_TEST_CEILING_BOUNDS,
@@ -50,7 +50,46 @@ vi.mock("@/queries", () => ({
 }));
 
 /** Collections the contract walk sees. Mutable, like `configEntries` above. */
-let collectionRows: { id: string; name: string; dataSchema?: { columns: string[] } }[] = [];
+let collectionRows: {
+	id: string;
+	name: string;
+	parentId?: string;
+	dataSchema?: { columns: string[] };
+}[] = [];
+
+/*
+ * Re-reading the remembered path (issue #1039). Mocked at the service rather
+ * than at the hook, so what these cases drive is the real `useDeclaredDataFile`
+ * - the one-attempt ref and the declaring-ancestor lookup included - with only
+ * the filesystem stubbed out.
+ */
+const readDeclared = vi.fn();
+let bridgePresent = true;
+vi.mock("@/services/data-files/read-declared", () => ({
+	canReadDeclaredDataFile: () => bridgePresent,
+	readDeclaredDataFile: (path: string, options: { maxRows: number }) =>
+		readDeclared(path, options),
+}));
+
+/**
+ * A file as `readDeclaredDataFile` resolves it.
+ *
+ * Built through one helper rather than spelled out per case so the stub carries
+ * every member the picker renders - `format` is the one a hand-written literal
+ * forgets, and the picker reads it unguarded.
+ */
+function declared(fileName: string, rows: Record<string, string>[]) {
+	return {
+		fileName,
+		path: `/data/${fileName}`,
+		parsed: {
+			format: "csv" as const,
+			columns: Object.keys(rows[0] ?? {}),
+			rows,
+			warnings: [],
+		},
+	};
+}
 
 function open(props: Partial<React.ComponentProps<typeof LoadTestConfigDialog>> = {}) {
 	const onStart = vi.fn();
@@ -248,6 +287,132 @@ describe("data rows (issue #993)", () => {
 		// A missing column is a warning here and a loud engine-side failure at
 		// bind time - hearing about it before the run is the whole point.
 		expect(await screen.findByText(/plan/)).toBeInTheDocument();
+	});
+});
+
+describe("the declared file pre-fills (issue #1039)", () => {
+	const pick = (file: File) => {
+		const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+		fireEvent.change(input, { target: { files: [file] } });
+	};
+
+	beforeEach(() => {
+		useDataFileStore.setState({ locations: {} });
+		readDeclared.mockReset();
+		bridgePresent = true;
+	});
+
+	it("reads the path remembered for the declaring ancestor, not the request's collection", async () => {
+		/*
+		 * The #729 rule, and the one a copy of this pre-fill gets wrong: the
+		 * request sits in `col_child`, which declares nothing, so the contract -
+		 * and therefore the remembered location - belongs to `col_parent`.
+		 * Reading the store at the id the caller passed in finds nothing for
+		 * exactly the users the chain walk exists to serve.
+		 */
+		collectionRows = [
+			{ id: "col_parent", name: "Orders", dataSchema: { columns: ["id"] } },
+			{ id: "col_child", name: "Checkout", parentId: "col_parent" },
+		];
+		useDataFileStore.setState({
+			locations: { col_parent: { path: "/data/users.csv", fileName: "users.csv" } },
+		});
+		readDeclared.mockResolvedValue(declared("users.csv", [{ id: "a" }]));
+
+		const { onStart } = open({ collectionId: "col_child" });
+
+		expect(await screen.findByText(/users\.csv/)).toBeInTheDocument();
+		expect(readDeclared).toHaveBeenCalledWith("/data/users.csv", expect.anything());
+		// And it is a real selection, not just a label: the rows reach the run.
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		expect(onStart.mock.calls[0][0].data).toEqual([{ id: "a" }]);
+	});
+
+	it("shows a note and leaves Start working when the file has moved", async () => {
+		collectionRows = [{ id: "col_1", name: "Orders", dataSchema: { columns: ["id"] } }];
+		useDataFileStore.setState({
+			locations: { col_1: { path: "/gone/users.csv", fileName: "users.csv" } },
+		});
+		readDeclared.mockRejectedValue(new Error("The declared file is no longer at users.csv."));
+
+		const { onStart } = open({ collectionId: "col_1" });
+
+		expect(await screen.findByText(/no longer at users\.csv/)).toBeInTheDocument();
+		// A warning, never a blocker: a load run without rows is an ordinary
+		// load run, and picking the file again is the whole remedy.
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		expect(onStart).toHaveBeenCalled();
+		expect(onStart.mock.calls[0][0]).not.toHaveProperty("data");
+	});
+
+	it("does not yank a hand-picked file back when the store is written while open", async () => {
+		collectionRows = [{ id: "col_1", name: "Orders", dataSchema: { columns: ["id"] } }];
+		useDataFileStore.setState({
+			locations: { col_1: { path: "/data/first.csv", fileName: "first.csv" } },
+		});
+		readDeclared.mockResolvedValue(declared("first.csv", [{ id: "a" }]));
+
+		const { onStart } = open({ collectionId: "col_1" });
+		await screen.findByText(/first\.csv/);
+
+		pick(new File(["id\nz"], "mine.csv"));
+		await screen.findByText(/mine\.csv/);
+
+		// The pre-fill has had its one turn. A store write now - the Data tab
+		// in another pane, another dialog - must not replace what the user
+		// chose in front of them.
+		act(() => {
+			useDataFileStore
+				.getState()
+				.setDataFile("col_1", { path: "/data/second.csv", fileName: "second.csv" });
+		});
+
+		expect(screen.getByText(/mine\.csv/)).toBeInTheDocument();
+		expect(screen.queryByText(/second\.csv/)).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		expect(onStart.mock.calls[0][0].data).toEqual([{ id: "z" }]);
+	});
+
+	it("leaves the profile fields alone", async () => {
+		/*
+		 * The Run collection dialog turns a pristine `iterations` of 1 into "one
+		 * pass per row" when a file arrives. That is a fact about the engine's
+		 * default for a *collection* run; a load run's length is its profile's,
+		 * so the pre-fill may not touch a single field here.
+		 */
+		collectionRows = [{ id: "col_1", name: "Orders", dataSchema: { columns: ["id"] } }];
+		useDataFileStore.setState({
+			locations: { col_1: { path: "/data/users.csv", fileName: "users.csv" } },
+		});
+		readDeclared.mockResolvedValue(
+			declared("users.csv", [{ id: "a" }, { id: "b" }, { id: "c" }])
+		);
+
+		const { onStart } = open({ collectionId: "col_1" });
+		await screen.findByText(/users\.csv/);
+
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		const config = onStart.mock.calls[0][0] as LoadTestConfig;
+		expect(config.duration_seconds).toBe(LOAD_TEST_DEFAULTS.DURATION_S);
+		expect(config.rps).toBe(LOAD_TEST_DEFAULTS.RPS);
+		// Three rows, and not one iteration per row: the default profile is
+		// `constant_rps`, whose length is its duration.
+		expect(config.iterations).toBeUndefined();
+	});
+
+	it("attempts nothing when there is no filesystem to re-read from", async () => {
+		// A browser build has no path to re-read and never will, so this is not
+		// a failure worth a note - it is a state that will never resolve.
+		bridgePresent = false;
+		collectionRows = [{ id: "col_1", name: "Orders", dataSchema: { columns: ["id"] } }];
+		useDataFileStore.setState({
+			locations: { col_1: { path: "/data/users.csv", fileName: "users.csv" } },
+		});
+
+		open({ collectionId: "col_1" });
+
+		expect(readDeclared).not.toHaveBeenCalled();
+		expect(screen.queryByText(/The remembered data file/i)).not.toBeInTheDocument();
 	});
 });
 

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -66,8 +66,7 @@ import { cn } from "@/lib/utils";
 import { Callout, SEVERITY_ORDER, type Severity } from "@/components/shared";
 import DataFilePicker, { type SelectedDataFile } from "@/modules/collections/DataFilePicker";
 import { describeDataSchemaDiff } from "@/services/data-files";
-import { resolveDataContract } from "@/lib/data-contract";
-import { useCollectionsQuery } from "@/queries";
+import { useDeclaredDataFile } from "@/hooks/useDeclaredDataFile";
 import { ProfilePicker } from "./ProfilePicker";
 import { summarise } from "./summary";
 import {
@@ -358,9 +357,9 @@ export default function LoadTestConfigDialog({
 	 * Per-run and deliberately not memoed like the numbers above: rows are user
 	 * data of unknown sensitivity, and neither side stores the set - the same
 	 * rule the collection run dialog keeps. Picking a file again is the whole
-	 * cost of that.
+	 * cost of that - which is what the declared-file pre-fill below spares the
+	 * user, without the rows ever being what is remembered.
 	 */
-	const [dataFile, setDataFile] = useState<SelectedDataFile | null>(null);
 	const [dataFileError, setDataFileError] = useState<string | null>(null);
 	const [oauthGated, setOauthGated] = useState(false);
 	const [recordingOpen, setRecordingOpen] = useState(false);
@@ -384,8 +383,38 @@ export default function LoadTestConfigDialog({
 	 * columns is simply a file with extra columns. What it buys is hearing about
 	 * it here rather than at the first submission.
 	 */
-	const { data: collections = [] } = useCollectionsQuery();
-	const contract = resolveDataContract(collectionId, collections);
+	/*
+	 * ...and the file that contract was last run with, pre-filled (issue #1039).
+	 *
+	 * The same hook the Run collection dialog reads, so the two cannot drift on
+	 * which ancestor is consulted or on what a moved file says. What does *not*
+	 * come across with it is that dialog's iterations coupling: a load run's
+	 * length is its profile's, so nothing about a data file may touch the fields
+	 * below. `contract` comes back from the same call because the audit and the
+	 * pre-fill are answers about the same declaration.
+	 */
+	const {
+		file: dataFile,
+		setFile: setDataFile,
+		note: prefillNote,
+		contract,
+		dismissNote,
+	} = useDeclaredDataFile(collectionId);
+
+	/*
+	 * Picking by hand replaces whatever was pre-filled, so the note about a file
+	 * that could not be re-read has nothing left to say. Deliberately *not* a
+	 * write back to `useDataFileStore`: the Data tab is where a contract is
+	 * declared, and starting one load run with a different file is not a
+	 * redeclaration of it for every collection run that follows. And no
+	 * `onPrefill`: a load run's length is its profile's, so a file arriving
+	 * changes no field of it.
+	 */
+	const handleSelectDataFile = (next: SelectedDataFile | null) => {
+		setDataFile(next);
+		if (next) dismissNote();
+	};
+
 	const schemaDiff = dataFile
 		? describeDataSchemaDiff(contract?.columns ?? [], dataFile.parsed.columns)
 		: [];
@@ -822,9 +851,19 @@ export default function LoadTestConfigDialog({
 					    iteration" reading, which would be wrong for every run
 					    this dialog starts.
 					 */}
+					{/* A file that could not be re-read is a warning, not a blocker -
+					    the run is startable without one, and picking the file again
+					    is the whole remedy. Same rule, same words, as the Run
+					    collection dialog (issue #1039). */}
+					{prefillNote && (
+						<Callout severity="warning" title="The remembered data file">
+							{prefillNote}
+						</Callout>
+					)}
+
 					<DataFilePicker
 						selected={dataFile}
-						onSelect={setDataFile}
+						onSelect={handleSelectDataFile}
 						error={dataFileError}
 						onError={setDataFileError}
 						iterations={undefined}

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -64,6 +64,10 @@ import {
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { Callout, SEVERITY_ORDER, type Severity } from "@/components/shared";
+import DataFilePicker, { type SelectedDataFile } from "@/modules/collections/DataFilePicker";
+import { describeDataSchemaDiff } from "@/services/data-files";
+import { resolveDataContract } from "@/lib/data-contract";
+import { useCollectionsQuery } from "@/queries";
 import { ProfilePicker } from "./ProfilePicker";
 import { summarise } from "./summary";
 import {
@@ -229,6 +233,17 @@ export interface LoadTestConfigDialogProps {
 	 * happening.
 	 */
 	isStreamingRequest: boolean;
+	/**
+	 * The collection the request being load-tested belongs to, for the data
+	 * file's column audit (issue #993).
+	 *
+	 * Only the *contract* is resolved from it - the nearest declaring ancestor,
+	 * the rule every other surface applies (`resolveDataContract`) - so a file
+	 * missing a column the collection declares is said here rather than at the
+	 * first bind. Undefined for a request that belongs to no collection, which
+	 * simply audits nothing.
+	 */
+	collectionId?: string;
 }
 
 export default function LoadTestConfigDialog({
@@ -239,6 +254,7 @@ export default function LoadTestConfigDialog({
 	hasDynamicVariables,
 	oauth2Config,
 	isStreamingRequest,
+	collectionId,
 }: LoadTestConfigDialogProps) {
 	const saved = loadSavedConfig();
 
@@ -335,6 +351,17 @@ export default function LoadTestConfigDialog({
 	);
 	const [monitorOpen, setMonitorOpen] = useState(false);
 	const [comment, setComment] = useState(""); // Per-run: never restored.
+	/**
+	 * The data set this run binds (issue #993), and the parse failure that
+	 * blocks starting one.
+	 *
+	 * Per-run and deliberately not memoed like the numbers above: rows are user
+	 * data of unknown sensitivity, and neither side stores the set - the same
+	 * rule the collection run dialog keeps. Picking a file again is the whole
+	 * cost of that.
+	 */
+	const [dataFile, setDataFile] = useState<SelectedDataFile | null>(null);
+	const [dataFileError, setDataFileError] = useState<string | null>(null);
 	const [oauthGated, setOauthGated] = useState(false);
 	const [recordingOpen, setRecordingOpen] = useState(false);
 
@@ -348,6 +375,20 @@ export default function LoadTestConfigDialog({
 	 * a duration-based warning would be nonsense.
 	 */
 	const usesDuration = mode !== "iterations";
+
+	/*
+	 * The chosen file against the contract in scope for this request's
+	 * collection - the nearest declaring ancestor, as everywhere else in the
+	 * feature (issue #729). A mismatch is a warning and never blocks: a missing
+	 * column fails loudly engine-side at bind time, and a file carrying extra
+	 * columns is simply a file with extra columns. What it buys is hearing about
+	 * it here rather than at the first submission.
+	 */
+	const { data: collections = [] } = useCollectionsQuery();
+	const contract = resolveDataContract(collectionId, collections);
+	const schemaDiff = dataFile
+		? describeDataSchemaDiff(contract?.columns ?? [], dataFile.parsed.columns)
+		: [];
 
 	const rampDurationError = validateRampDuration(mode, duration, rampDuration);
 	// Checked before the two range rules, which both compare the start against
@@ -364,7 +405,12 @@ export default function LoadTestConfigDialog({
 		startConcurrencyError ??
 		capacityRangeError ??
 		budgetsError ??
-		monitoringError;
+		monitoringError ??
+		// A file the parser refused leaves no rows behind, so starting the run
+		// would send the request with its `{{data.*}}` tokens written as they
+		// stand - the failure the whole namespace exists to prevent. The picker
+		// prints the reason; this is what stops the Start button.
+		dataFileError;
 
 	const notices = useMemo(() => {
 		const list: { key: string; severity: Severity; node: React.ReactNode }[] = [];
@@ -526,6 +572,11 @@ export default function LoadTestConfigDialog({
 		// Omitted in `iterations` - see `usesDuration`. Sending a value the engine
 		// discards makes the stored run config claim something untrue about it.
 		if (usesDuration) config.duration_seconds = duration;
+
+		// The parsed rows themselves - the same array the preview showed, never
+		// a re-parse (issue #993). Absent when no file was picked, which is what
+		// keeps a run without data on exactly the path it took before.
+		if (dataFile) config.data = dataFile.parsed.rows;
 
 		// Streaming requests only. Always sent when the request streams, never
 		// elided as "the engine has defaults": the engine's default is the
@@ -756,6 +807,31 @@ export default function LoadTestConfigDialog({
 							blockingError !== null
 						)}
 					</p>
+
+					{/*
+					    A data file, for a run that parameterises its request
+					    (issue #993). Beside the profile rather than under
+					    Recording & limits: rows change what each submission
+					    *sends*, which is the same kind of decision the profile
+					    fields are, while everything folded away below changes
+					    only what the run keeps.
+
+					    `loadTest` is set, so the picker describes what a row
+					    means here - one per submission off a shared cursor that
+					    wraps - rather than the design-mode "one row is one
+					    iteration" reading, which would be wrong for every run
+					    this dialog starts.
+					 */}
+					<DataFilePicker
+						selected={dataFile}
+						onSelect={setDataFile}
+						error={dataFileError}
+						onError={setDataFileError}
+						iterations={undefined}
+						loadTest
+						additionalWarnings={schemaDiff}
+						disabled={isStarting}
+					/>
 
 					{/*
 					 * Header and contents are one card, not a bordered header with

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -643,6 +643,11 @@ export default function RequestBuilder() {
 					// same reason - and a run without it behaves exactly as it did
 					// before server monitoring existed.
 					monitor: config.monitor,
+					// The rows the dialog's file picker parsed (issue #993), which
+					// the engine binds one per submission. Undefined when no file
+					// was picked: a present-but-empty array is refused engine-side,
+					// so "no data set" has to be the absent key rather than `[]`.
+					data: config.data,
 				};
 
 				const result = await apiService.startLoadTest(apiRequest);
@@ -789,6 +794,7 @@ export default function RequestBuilder() {
 					hasDynamicVariables={requestUsesDynamicVariables(pendingLoadTestRequest)}
 					oauth2Config={pendingOAuth2Config ?? undefined}
 					isStreamingRequest={!!pendingLoadTestRequest?.stream}
+					collectionId={fetchedRequest?.collectionId}
 				/>
 			)}
 		</>

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -578,6 +578,25 @@ export interface StartLoadTestRequest {
 	maxStreamDurationMs?: number;
 	/** Ceiling on events delivered by one stream; omitted takes `sseMaxStreamEvents`. */
 	maxStreamEvents?: number;
+
+	/**
+	 * The data set this run binds, one object per row (issue #993).
+	 *
+	 * The single-request spelling of `scenario.data`, read by the same engine
+	 * validator and bounded by the same `maxScenarioDataRows` /
+	 * `maxScenarioDataBytes` settings - a present-but-empty array is refused
+	 * rather than run. **One row per submission**, claimed off a run-wide cursor
+	 * that wraps, so a run longer than the set repeats it; a scenario run's row
+	 * is per iteration and shared by every step instead, which is why the two
+	 * fields are separate and why sending both is a `400`.
+	 *
+	 * Every `{{data.column}}` in the URL, headers, body and auth credentials
+	 * binds per submission, and the deferred `tests` script reads the row its
+	 * sample carried as `pm.iterationData`. The set is never persisted - the run
+	 * snapshot records `dataRowCount` alone - but a bound cell travels in the
+	 * request that carried it, which the run stores with its retained traces.
+	 */
+	data?: Record<string, unknown>[];
 }
 
 export interface StartLoadTestResponse {

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1435,6 +1435,17 @@ export interface LoadTestConfig {
 	 */
 	stream_duration_seconds?: number;
 	stream_max_events?: number;
+	/**
+	 * The rows this run binds, one object per row (issue #993) - the parsed
+	 * file the dialog's picker holds, never a re-parse of it.
+	 *
+	 * Absent when no file was picked, which is what leaves the run on the path
+	 * it took before data-driven single-request runs existed. Named `data`
+	 * rather than snake_cased like its neighbours because it is the engine's own
+	 * field name, the same reason {@link RunThresholds} and
+	 * {@link RunMonitorConfig} are camelCase here.
+	 */
+	data?: Record<string, unknown>[];
 }
 
 /**

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -595,6 +595,13 @@ run. The engine resolves the whole plan before answering, so an empty
 collection, a step that will not compose, or a plan over `maxScenarioSteps` is a
 `400` with **no run row created** - a failed start leaves nothing to clean up.
 
+`startLoadTest` takes rows too, as a **top-level `data`** array (issue #993):
+the load dialog's file picker parses the file and sends the same array it
+previewed, and the engine binds one row per request the run sends. Omitted when
+no file was picked - a present-but-empty array is refused engine-side, so
+"no data set" has to be the absent key rather than `[]` - and never sent beside
+a `scenario` block, whose rows are `scenario.data` and bind per iteration.
+
 `failOnSchemaError` rides the design-mode payload beside `environmentId`, from
 the dialog's **Fail steps on schema errors** switch (issue #720), and is
 **omitted when off**: the engine defaults it to false, so absent already says
@@ -1175,7 +1182,10 @@ await apiService.startLoadTest({
   comment: "Stress test",
   // Optional pass/fail budgets. Omitted entirely when none were declared - the
   // engine rejects an empty object rather than starting an unjudged run.
-  thresholds: { latencyP99Ms: 50, maxErrorRatePct: 0.1 }
+  thresholds: { latencyP99Ms: 50, maxErrorRatePct: 0.1 },
+  // Optional data rows, bound one per request sent. Omitted when the dialog's
+  // picker holds no file.
+  data: [{ id: "1" }, { id: "2" }]
 });
 ```
 

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -1,14 +1,28 @@
 ---
 description: >-
-  Drive a Vayu collection run from a CSV, TSV, JSON or JSONL file - one row per iteration, exposed as {{data.column}} and pm.iterationData.
+  Drive a Vayu run from a CSV, TSV, JSON or JSONL file - a row per iteration, exposed as {{data.column}} and pm.iterationData, for a collection run or a single request's load test.
 ---
 
 # Data-Driven Runs
 
-A collection run can be driven by a file: one row per iteration, its columns
-readable from the requests themselves and from scripts. Pick the file in the
-**Run collection** dialog, beside Iterations and Load test - or declare it once
-on the collection's **Data** tab and have the dialog pre-fill it.
+A run can be driven by a file: a row per iteration, its columns readable from
+the requests themselves and from scripts.
+
+Two runs take one:
+
+- **A collection run.** Pick the file in the **Run collection** dialog, beside
+  Iterations and Load test - or declare it once on the collection's **Data** tab
+  and have the dialog pre-fill it.
+- **A single request's load test** (issue #993). Pick the file in the **Run a
+  load test** dialog, under the profile fields. The request needs no collection
+  wrapper: `N` users each sending the same request with different data is the
+  canonical load shape, and until this it was expressible only by wrapping the
+  request in a one-step collection.
+
+What differs between them is only *which* row a given request binds - see
+[How many iterations, and which row](#how-many-iterations-and-which-row). The
+file, the refusals, the `{{data.column}}` namespace and `pm.iterationData` are
+the same on both.
 
 This page is the file's contract - what Vayu accepts, what it refuses, and what
 a value becomes once it is bound.
@@ -209,6 +223,14 @@ the rows then repeat for as long as the duration lasts. Once they wrap, users do
 share rows - size the file to the concurrency if that matters. The row count
 says nothing about how long the run is.
 
+**A single request's load test** is that same cursor with one request where a
+collection run has a sequence: one row is claimed per request sent, in turn,
+wrapping when the set runs out. So a 3-row file under a 6-request run sends rows
+0, 1, 2, 0, 1, 2 - the file bounds *which values* the run sends and never how
+many requests it sends, which is the load profile's job. Iterations is not
+defaulted from the row count here, unlike a collection run: a load profile
+already says how long the run is.
+
 ## Declaring the contract: the Data tab
 
 A file picked in the Run dialog is parsed, sent and forgotten, so at the moment
@@ -356,7 +378,7 @@ itself is stored like any other design send, bound values included - see
 ## What is stored
 
 **The row set is not.** The rows ride the run payload and are dropped when the
-dialog closes. They are user data of unknown sensitivity - credentials,
+dialog closes - both dialogs, and both shapes of run. They are user data of unknown sensitivity - credentials,
 customer records - so neither the app nor the engine keeps the set, and the file
 itself is read fresh every time - whether you pick it or the dialog pre-fills it
 from the declared path. Declaring a contract does not change this: what is saved

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -14,7 +14,9 @@ Two runs take one:
   Iterations and Load test - or declare it once on the collection's **Data** tab
   and have the dialog pre-fill it.
 - **A single request's load test** (issue #993). Pick the file in the **Run a
-  load test** dialog, under the profile fields. The request needs no collection
+  load test** dialog, under the profile fields - or, again, declare it on the
+  collection's **Data** tab and have the dialog pre-fill it (issue #1039). The
+  request needs no collection
   wrapper: `N` users each sending the same request with different data is the
   canonical load shape, and until this it was expressible only by wrapping the
   request in a one-step collection.
@@ -121,7 +123,7 @@ The caps apply to a file **re-read from a remembered path** exactly as they do
 to one picked by hand, and both refusals name the setting. That matters because
 neither side of the comparison holds still: a declared file grows rows after it
 was declared, and the setting itself can be lowered under a file that has not
-changed at all. So the Run dialog's pre-fill, Send-with-row and the Data tab
+changed at all. So both run dialogs' pre-fill, Send-with-row and the Data tab
 each refuse a file over the cap instead of previewing it - the byte cap when the
 file is opened (the app's main process stats it before reading), the row cap
 once it is parsed, since counting rows means parsing and the engine never opens
@@ -250,13 +252,24 @@ Declaring changes no binding rule - a token still binds from the row the run
 carries. What it buys is everything that needs to know the columns _before_ a
 run:
 
-- **The Run dialog pre-fills.** If the declared file is still where you left it,
-  opening **Run collection** re-reads it and previews it, ready to start. Move
-  or rename the file and the dialog says so and offers the picker - it is a
-  note, not a refusal. Which file that is follows the chain rule like everything
-  else here: running a sub-collection that declares nothing offers the file its
-  nearest declaring ancestor was given, because that is the contract the run
-  binds against.
+- **Both run dialogs pre-fill.** If the declared file is still where you left
+  it, opening **Run collection** - or the **Load test** dialog for a request in
+  that collection - re-reads it and previews it, ready to start. Move or rename
+  the file and the dialog says so and offers the picker - it is a note, not a
+  refusal. Which file that is follows the chain rule like everything else here:
+  running a sub-collection that declares nothing offers the file its nearest
+  declaring ancestor was given, because that is the contract the run binds
+  against - and a request's load run resolves it from the request's own
+  collection, up the same chain.
+
+    The two dialogs differ in one thing only, and it is not about the file: a
+    collection run with rows and no explicit count runs one pass per row, so
+    picking a file there clears an untouched `iterations` of `1`. A load run's
+    length is its profile's - a duration, a request count, a search - so nothing
+    about picking or pre-filling a file changes a single field of it. Picking a
+    file in the load dialog also does not re-declare it: the Data tab is where a
+    collection says which file its contract came from, and one load run started
+    against a different file is not a change to that.
 - **The Data tab re-opens it too.** Coming back to the tab reads the declared
   file again and lines it up against the contract with no re-pick: comparing
   them is what the tab is for, so it does not wait to be handed the same file a

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4209,6 +4209,7 @@ Start a load test run (Vayu Mode).
   "requestName": "Create user",       // Optional, read by the tests script as pm.info.requestName
   "environmentId": "env_1234567890",  // Optional
   "tests": "",               // Optional, deferred validation script
+  "data": [],                // Optional data rows, one object per row - see below
   "thresholds": {},          // Optional pass/fail budgets - see below
   "monitor": {},             // Optional server-vitals scrape - see below
   "followRedirects": true,   // Optional, default true - see POST /execute
@@ -4272,6 +4273,55 @@ capped one.
 Streaming is **not** supported on a scenario run: `scenario` composes its steps
 at plan time and each step is its own request, so there is no single stream for
 the caps to bound.
+
+#### The `data` rows (a data-driven load run)
+
+A single-request run may carry a top-level `data` array - one flat object per
+row - and bind it into the request it repeats (issue #993):
+
+```jsonc
+{
+  "method": "POST",
+  "url": "https://api.example.com/orders/{{data.id}}",
+  "mode": "constant_concurrency",
+  "duration": "30s",
+  "concurrency": 50,
+  "data": [
+    { "id": "1", "email": "ada@example.com" },
+    { "id": "2", "email": "grace@example.com" }
+  ]
+}
+```
+
+**One row per request sent**, claimed off a run-wide cursor that wraps: a run
+longer than the set repeats it from the top, so the file bounds which values go
+out and never how many requests do - that is the load profile's job. The row a
+completion was bound to is recorded as `dataRowIndex` on every retained result,
+and the deferred `tests` script reads that submission's own row as
+`pm.iterationData`.
+
+Everything else is the scenario path's, because it is the same code: the same
+validation (an array of objects, present-but-empty refused, bounded by
+`maxScenarioDataRows` / `maxScenarioDataBytes`), the same `{{data.column}}`
+placement rules and escaping, the same credentials-bind-before-they-are-encoded
+order, and the same refusal of a `{{data.*}}` in an `oauth2` config. Every
+rejection is a `400` `invalid_run_config` before the run row exists, so a
+refused set leaves nothing behind.
+
+Two differences from `scenario.data` worth stating:
+
+- **`iterations` is not defaulted from the row count.** A load profile already
+  says how long the run is; a collection run without an explicit count takes one
+  pass per row.
+- **The two fields cannot be combined.** A top-level `data` beside a `scenario`
+  block is a `400` naming `scenario.data` - the two bind differently (per
+  submission here, per iteration and shared by every step there), so a payload
+  carrying both would have one of them silently dropped.
+
+The rows are **never persisted**: the stored run snapshot carries
+`dataRowCount` in their place, exactly as a scenario manifest does. A cell that
+*binds* travels in the request that carried it, so it is stored with whatever
+traces the run retains.
 
 #### The `thresholds` block (pass/fail budgets)
 
@@ -4531,13 +4581,17 @@ the data pass then binds it. That is usable, and it is also why the
 no-data refusal below says "or from the variable value it was written into" -
 the token it names may not appear anywhere in the request as you wrote it.
 
-**Only scenario runs bind at all.** `POST /execute` and a non-scenario
-`POST /runs` have no rows and perform no data pass, so a `{{data.*}}` token in
-either reaches the wire as the literal text `{{data.id}}` - no substitution, and
-no warning, since composition leaves the reserved namespace written as it stands
-by design. The refusal below exists for scenario runs only. A raw API or MCP
-caller putting `{{data.*}}` into a single request is asking for the literal
-braces and gets them.
+**A run binds only what it was given rows for.** A `POST /runs` carrying
+`scenario.data` binds per iteration, one carrying the top-level
+[`data`](#the-data-rows-a-data-driven-load-run) binds per submission, and a
+`POST /execute` carrying a `data` object binds that one row. A request sent
+*without* rows performs no data pass at all, so a `{{data.*}}` token in it
+reaches the wire as the literal text `{{data.id}}` - no substitution, and no
+warning, since composition leaves the reserved namespace written as it stands by
+design. The no-data refusal below is the scenario path's alone: a single request
+has no plan to refuse before it starts, so a raw API or MCP caller putting
+`{{data.*}}` into one without rows is asking for the literal braces and gets
+them.
 
 > **Credentials bind before they are encoded.** A credentials file behind basic
 > auth is the canonical data-driven run, so a step whose credentials carry a
@@ -5838,7 +5892,8 @@ named it.
       "concurrency": 100,
       "followRedirects": true,
       "maxRedirects": 10,
-      "httpVersion": "auto"
+      "httpVersion": "auto",
+      "dataRowCount": 2
     },
     "openapi": {
       "specId": "spec_3f2b1c9a-...",

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -910,6 +910,17 @@ row exists - and the executor is the only thing that differs.
   (`DATA_BINDING_FAILED`). Every retained result carries its `dataRowIndex`,
   which is what makes a failure attributable to a row when no per-step `results`
   rows exist.
+- **A single-request load run binds rows too** (issue #993). Its rows ride the
+  payload's top-level `data` rather than a scenario block, and one is claimed per
+  *submission* off the same kind of run-wide cursor, wrapping the same way - a
+  single request has no sequence for an iteration to span, so the unit of a claim
+  is the request. The templates are split once, when the run's one request is
+  built (`LoadDataSet::fields`), the credentials defer exactly as a step's do,
+  and every retained result carries its `dataRowIndex`. **A run without rows
+  carries no set at all**, which is the throughput guard stated structurally: the
+  strategies test one pointer and otherwise submit the shared request they always
+  did. The validation, the binder and the escaping are the scenario path's own
+  functions rather than copies - `read_data_rows` and `bind_iteration_row`.
 - **Scripts stay deferred, keyed per step.** Nothing runs inline; after the run
   drains, each step's own `post_script` is replayed against the responses *that
   step* produced, and the tallies land on that step's entry in the breakdown

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -191,7 +191,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `set_run_baseline`     | write    | `PUT /runs/:id/baseline`                     | write toggle               |
 | `delete_run`           | write    | `GET /runs/:id` + `DELETE /runs/:id`         | write toggle + confirm     |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /compose` + `POST /runs`, or (with `scenario`) `GET /requests?…` + `POST /compose` (×N) + `POST /runs` | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity`, narrowed to the middle three for a scenario; the recording knobs and `comment` below apply to both shapes, the redirect policy to a single target only |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`, or (with `scenario`) `GET /requests?…` + `POST /compose` (×N) + `POST /runs` | allowlist + caps + confirm; optional `data` rows (single target) or `scenario.data` (sequence); optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity`, narrowed to the middle three for a scenario; the recording knobs and `comment` below apply to both shapes, the redirect policy to a single target only |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
 | `fetch_oauth2_token`   | execute  | `POST /oauth2/token`                         | allowlist, on `accessTokenUrl` **and** `refreshTokenUrl`; `authorization_code` refused before the call; the access token is never returned |
 | `get_oauth2_token_status` | read  | `GET /oauth2/token?key=`                     | - (an absent entry is `found: false`, not a 404); the access token is never returned |
@@ -901,8 +901,12 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   template in the authority is still "unknown host" and denied.
   `run_collection_smoke` stays out of it: it runs each request on its own, with
   no sequence to iterate, so there is no row for it to bind. A whole *data set*
-  - many rows, one pass each - is the scenario tools' argument instead
-  (`run_collection` and `start_load_run`'s `scenario.data`, below).
+  is a run's argument instead: `scenario.data` on `run_collection` and on
+  `start_load_run`'s scenario shape (below), or `start_load_run`'s **top-level
+  `data`** for a single target (issue #993) - the same rows, the same refusals,
+  bound one per request the run sends off a cursor that wraps rather than one
+  per iteration of a sequence. The two fields are mutually exclusive: `data`
+  beside a `scenario` block is refused by name rather than dropped.
 - **Protocol** - `run_request` and `start_load_run` both take an optional
   `httpVersion` Zod-enum arg (`"auto" | "http1.1" | "http2"`, default `"auto"`),
   mirroring the request builder's Settings-tab picker. `run_collection_smoke`

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1017,10 +1017,12 @@ was none; the app's step list shows that rather than an empty `200`.
 
 ## Data rows (`pm.iterationData`)
 
-A collection run can be given a set of rows - a CSV, TSV, JSON or JSONL file the
-app parses and sends inline on the run payload as `scenario.data`
-([the file format](../app/data-driven-runs.md)). **Row `i % rows` binds to
-iteration `i`**, and that row is what `pm.iterationData` reads:
+A run can be given a set of rows - a CSV, TSV, JSON or JSONL file the app parses
+and sends inline on the run payload ([the file
+format](../app/data-driven-runs.md)). A collection run states them as
+`scenario.data` and a single-request load run as the top-level `data` (issue
+#993). **Row `i % rows` binds to iteration `i`** - for a single request an
+iteration is one submission - and that row is what `pm.iterationData` reads:
 
 ```javascript
 pm.iterationData.get('username');  // this iteration's value for that column
@@ -1060,11 +1062,14 @@ script that reads a row gets an edit loop that is not "start a run, find the
 step, read the result"; the row binds `{{data.column}}` in the request as well.
 See [api-reference.md](api-reference.md#post-execute).
 
-**`pm.iterationData` is `undefined` where there is no row** - an ordinary Send, a
-single-request load run's deferred `tests` script, and any run started without a
-data set. A scenario load run's deferred per-step script *does* read one: the
-sampled response carries the row its iteration was bound to, so the row is a
-fact about that response rather than a guess. That is deliberate, and it is the opposite treatment to `pm.execution`
+**`pm.iterationData` is `undefined` where there is no row** - an ordinary Send,
+and any run started without a data set. Where a run *was* given rows, its
+deferred script reads one whichever shape the run took: a sampled response
+carries the row the submission or iteration that produced it was bound to, so
+the row is a fact about that response rather than a guess. (`pm.info.iteration`
+is narrower and stays so: a scenario step carries the virtual user's real
+iteration index, while a single-request run has none to report - a reservoir
+position is not an iteration.) That is deliberate, and it is the opposite treatment to `pm.execution`
 above: flow control is a *capability*, and one that silently does nothing is a
 false success, so it is always bound and explains itself. A data row is *data*,
 and "this run is not data-driven" is a fact a script may legitimately branch on:
@@ -1535,9 +1540,10 @@ shape:
 
 - `pm.request` is the step's own request, and `pm.info.requestId` /
   `requestName` are that step's, not a run-level one.
-- `pm.info.iteration` and `pm.iterationData` are bound: the sample carries the
-  virtual user's iteration and the data row that iteration used, so a script
-  asserting on `{{data.*}}`-driven behaviour grades the right row.
+- `pm.info.iteration` is bound - the sample carries the virtual user's real
+  iteration index - beside the `pm.iterationData` a single-request run's rows
+  also provide, so a script asserting on `{{data.*}}`-driven behaviour grades the
+  right row either way.
 - The sample budget is split across the steps that carry a script rather than
   spent run-wide, so the last step of a long plan is validated instead of being
   crowded out by the first. A step with no script is never sampled.

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -14,13 +14,67 @@
 #include <optional>
 #include <string>
 
+#include "vayu/core/scenario_data.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/event_loop.hpp"
+#include "vayu/http/request_builder.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::core {
 
 struct RunContext; // Forward declaration
+
+/**
+ * @brief The `data` rows a **single-request** load run binds, split once
+ *        (issue #993).
+ *
+ * Before this, `{{data.column}}` bound on the scenario path alone, so the
+ * canonical load shape - one request, N users, a row each - was expressible
+ * only by wrapping the request in a one-step collection. The rows now ride the
+ * run payload's top-level `data`, validated by the same `read_data_rows` the
+ * scenario block goes through, and are claimed one per submission off a
+ * run-wide cursor that wraps: a run longer than the set repeats it, exactly as
+ * a scenario run's iterations do.
+ *
+ * **Null on the context for every run sent without rows**, and that emptiness
+ * is the throughput guard made structural: the strategies test one pointer and
+ * otherwise submit the shared request they always did - no copy, no claim, no
+ * annotation. Nothing here is per-iteration work a token-free run can pay.
+ *
+ * Filled in two stages, because the halves are known at different moments: the
+ * route validates the rows and decides how the credentials resolve before any
+ * run row exists, and `fields` can only be split once the request has been
+ * composed and built on the run's own worker thread.
+ */
+struct LoadDataSet {
+    /// The validated rows, in payload order. Never empty - a present-but-empty
+    /// `data` array is refused by the route, and a run without rows carries no
+    /// set at all.
+    std::vector<nlohmann::json> rows;
+    /**
+     * The parsed auth, read only when @ref credentials is non-empty - which is
+     * exactly when the request's build was deferred and carries no credential
+     * until a row reaches it. `NoAuth` for every run whose auth the build
+     * applied.
+     */
+    vayu::http::Auth auth;
+    /// The credentials split around their `{{data.column}}` tokens; empty when
+    /// none carries one.
+    StepDataTemplate credentials;
+    /// The built request's own tokens, split once so the run does not re-scan
+    /// its fields per submission - the same bargain a plan step makes, at a
+    /// single request's full rate.
+    StepDataTemplate fields;
+
+    /// What `build_request` must be told: the credentials are bound after the
+    /// build, so an auth carrying a token must not be encoded during it.
+    /// Derived rather than stored, so it cannot disagree with @ref credentials.
+    [[nodiscard]] vayu::http::AuthResolution auth_resolution () const {
+        return credentials.empty () ? vayu::http::AuthResolution::Apply :
+                                      vayu::http::AuthResolution::Defer;
+    }
+};
 
 /**
  * @brief Closed-loop concurrency controller. Seeds target(0), then refills the

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -54,16 +54,22 @@ struct ResponseSample {
     double latency_ms = 0.0;
     int64_t timestamp = 0;
     /**
-     * Scenario load runs only: the virtual user's iteration this response was
-     * sent in, and the data row that iteration was bound to.
+     * The virtual user's iteration this response was sent in, and the data row
+     * the submission was bound to.
      *
-     * Both absent for a single-request load run, where neither exists - the
-     * deferred script then reads `pm.info.iteration` and `pm.iterationData` as
-     * `undefined`, which is issue #300's ruling and stays intact: what that
-     * ruling refuses is reporting a *reservoir position* as an iteration
-     * number, a binding that cannot fail. A scenario step carries the real
-     * iteration index it ran in, so reporting it is the honest answer rather
-     * than the invented one.
+     * `iteration` is a scenario load run's alone: a single-request run has no
+     * iteration index to report, and the deferred script reads
+     * `pm.info.iteration` as `undefined` there - issue #300's ruling, intact.
+     * What that ruling refuses is reporting a *reservoir position* as an
+     * iteration number, a binding that cannot fail; a scenario step carries the
+     * real index it ran in, so reporting that one is honest rather than
+     * invented.
+     *
+     * `data_row_index` is carried by **either** shape now (issue #993): a
+     * single-request run started with `data` claims a row per submission, and
+     * the row it claimed is a fact about this response the same way it is for a
+     * step. Absent for every run sent without rows, which is what leaves
+     * `pm.iterationData` `undefined`.
      */
     std::optional<size_t> iteration;
     std::optional<size_t> data_row_index;
@@ -346,8 +352,16 @@ class MetricsCollector {
     /**
      * @brief Record a response sample for deferred script validation
      * Thread-safe, stores sampled responses for post-test script execution
+     *
+     * @param data_row_index The `data` row this submission bound, for a
+     *        single-request run started with rows (issue #993). Carried onto
+     *        the sample so the deferred script reads that row as
+     *        `pm.iterationData` rather than the run's first one; absent - the
+     *        default, and every caller that has no rows - leaves the scope
+     *        `undefined`, which is what a run without a set means.
      */
-    void record_response_sample (const Response& response);
+    void record_response_sample (const Response& response,
+    std::optional<size_t> data_row_index = std::nullopt);
 
     /**
      * @brief Size the per-step sample stores for a scenario load run (#450).

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -314,7 +314,7 @@ struct RunContext {
      * `build_load_request` before the first submission - and only read
      * afterwards, all on the run's worker thread.
      */
-    std::unique_ptr<LoadDataSet> data;
+    std::unique_ptr<LoadDataSet> load_data;
 
     // Real-time counters (also tracked by MetricsCollector, but kept for backward compat)
     std::atomic<size_t> requests_sent{ 0 }; // Number of requests submitted to event loop

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -26,6 +26,7 @@
 #include "vayu/core/capacity_controller.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/load_pacing.hpp"
+#include "vayu/core/load_strategy.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/monitor.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -300,6 +301,20 @@ struct RunContext {
      * choice of executor differs, and that is the one place this is read.
      */
     std::shared_ptr<const ScenarioExecution> scenario;
+
+    /**
+     * The rows a *single-request* load run binds, or null for a run sent
+     * without `data` (issue #993) - and for every scenario load run, whose rows
+     * live on @ref scenario beside the plan that binds them.
+     *
+     * Here for the reason the plan above is: the lifecycle around the executor
+     * is the same either way, and this is what the four strategies, the
+     * completion annotation and the deferred script replay each read. Written
+     * once - the rows by `start_run`, the request's own template by
+     * `build_load_request` before the first submission - and only read
+     * afterwards, all on the run's worker thread.
+     */
+    std::unique_ptr<LoadDataSet> data;
 
     // Real-time counters (also tracked by MetricsCollector, but kept for backward compat)
     std::atomic<size_t> requests_sent{ 0 }; // Number of requests submitted to event loop
@@ -889,12 +904,20 @@ class RunManager {
      *                 event loop, metrics thread, drain, flush and summary are
      *                 the same, and only the executor differs. The design-mode
      *                 sequential runner is `start_scenario_run` instead.
+     * @param data The validated `data` rows a single-request run binds, or null
+     *             for a run sent without them (issue #993). Passed rather than
+     *             read back out of @p config, because what makes a row set
+     *             usable is the route's validation and its credential plan -
+     *             a run started with the raw payload alone would be trusting a
+     *             check nobody ran. Null for a scenario run, whose rows travel
+     *             on @p scenario.
      */
     bool start_run (const std::string& run_id,
     const nlohmann::json& config,
     vayu::db::Database& db,
     bool verbose,
-    std::shared_ptr<const ScenarioExecution> scenario = nullptr);
+    std::shared_ptr<const ScenarioExecution> scenario = nullptr,
+    std::unique_ptr<LoadDataSet> data                 = nullptr);
 
     /**
      * @brief Start a scenario run: the same lifecycle, a different executor.

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -307,6 +307,33 @@ const nlohmann::json& row,
 size_t row_index);
 
 /**
+ * One iteration's whole bind, in the order that makes it correct: @p fields
+ * into @p request, then @p credentials into the auth applied on top of it.
+ *
+ * The order is the point, and it is why this is one function rather than two
+ * calls each executor makes in sequence: a credential has to carry the row's
+ * value *before* `apply_auth` base64-encodes it (issue #591), so a caller that
+ * bound them the other way round would send base64 of the literal token text -
+ * the failure that is invisible once encoded. Both load executors drive this,
+ * so a request cannot bind differently depending on whether it was repeated on
+ * its own or as a step of a sequence.
+ *
+ * A no-op returning success when both templates are empty, so a caller may call
+ * it unconditionally. @p auth is only read when @p credentials is non-empty,
+ * which is exactly when the request's build was deferred; a caller whose auth
+ * was applied at build time passes its `NoAuth` and pays nothing.
+ *
+ * On failure @p request is left partially bound and must not be sent - see
+ * `apply_data_template`, whose rule this inherits.
+ */
+[[nodiscard]] DataBindResult bind_iteration_row (vayu::Request& request,
+const StepDataTemplate& fields,
+const vayu::http::Auth& auth,
+const StepDataTemplate& credentials,
+const nlohmann::json& row,
+size_t row_index);
+
+/**
  * The first `{{data.column}}` in any string of @p value, recursively, written
  * back with its braces - or `nullopt` when it carries none.
  *

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -40,6 +40,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "vayu/core/scenario_data.hpp"
@@ -304,6 +305,30 @@ struct ScenarioResolution {
 };
 
 /**
+ * Validate a run's `data` rows against @p limits and copy them into
+ * @p rows_out, or answer the caller-facing refusal that says why not.
+ *
+ * One reader for both shapes a run can carry rows in - a collection run's
+ * `scenario.data` and a single-request load run's top-level `data` (issue
+ * #993) - so the two cannot come to disagree about what a row is. @p field
+ * names the payload field in every refusal, because the caller has to be told
+ * which one of theirs was wrong.
+ *
+ * Every refusal is loud, for the reason the whole `{{data.column}}` namespace
+ * exists: a token says the value came from the file, so a set the engine could
+ * not read must never become a run that sends the token as it stands. A present
+ * but **empty** array is refused too - a data set that binds nothing is a
+ * mistake, not an empty run.
+ *
+ * A rejected set leaves @p rows_out empty, never holding the rows before the
+ * bad one, which would be a partial data set.
+ */
+[[nodiscard]] std::optional<std::string> read_data_rows (const nlohmann::json& data,
+const ScenarioLimits& limits,
+std::string_view field,
+std::vector<nlohmann::json>& rows_out);
+
+/**
  * Validate a `scenario` block and resolve it into a plan.
  *
  * Ordering is the order the sidebar displays, top to bottom. A collection's
@@ -343,19 +368,23 @@ const ScenarioResolveOptions& options);
 [[nodiscard]] CoverageTally make_coverage_tally (const ScenarioExecution& execution);
 
 /**
- * Bind @p row into @p step's deferred credentials and apply them to @p request.
+ * Bind @p row into @p step - its request's `{{data.column}}` fields first, then
+ * the credentials the plan deliberately left unresolved.
+ *
+ * The step-shaped spelling of `core::bind_iteration_row`, which is where the
+ * order lives and which the single-request load path drives with its own
+ * templates (issue #993). Both scenario executors call this rather than the two
+ * halves in sequence, so a step cannot bind differently depending on which one
+ * ran it, and neither can put the credentials before the fields.
  *
  * A no-op returning success for the ordinary step, whose auth was resolved into
- * the plan and whose `auth_template` is therefore empty - both executors call
- * it beside `apply_data_template` rather than testing first, because the two
- * halves of one iteration's bind belong together and one binder for both modes
- * is what keeps a step from binding differently depending on which one ran it.
+ * the plan and whose templates are therefore both empty - an executor may call
+ * it without testing first.
  *
- * Call it **after** the request's own data pass and before the send: the
- * credentials must be bound before `apply_auth` encodes them, which is the
- * ordering the deferral exists to fix.
+ * Call it before the send: the credentials must be bound before `apply_auth`
+ * encodes them, which is the ordering the deferral exists to fix.
  */
-[[nodiscard]] DataBindResult bind_step_auth (vayu::Request& request,
+[[nodiscard]] DataBindResult bind_step_row (vayu::Request& request,
 const ScenarioStep& step,
 const nlohmann::json& row,
 size_t row_index);

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -958,6 +958,46 @@ struct SendRowAuth {
 SendRowAuth plan_send_row_auth (const nlohmann::json& json, bool has_row);
 
 /**
+ * The outcome of reading `POST /runs`' top-level `data` rows (issue #993).
+ *
+ * `set` is null when the payload carried none - the ordinary load run, which
+ * must stay distinguishable from a run whose rows happen to be empty, since a
+ * present-but-empty array is refused rather than run.
+ *
+ * `ok == false` carries the 400 the route answers with. Every rejection is loud
+ * for the reason the whole `{{data.column}}` namespace exists: a token says the
+ * value came from the file, so a set the engine could not read must never
+ * become a run that sends the token as it stands.
+ */
+struct LoadDataRows {
+    bool ok = true;
+    std::string error;
+    std::unique_ptr<vayu::core::LoadDataSet> set;
+};
+
+/**
+ * Read the `data` rows off a `POST /runs` payload, bounded by @p limits (the
+ * `maxScenarioDataRows` / `maxScenarioDataBytes` settings - the same bounds a
+ * collection run's set is held to).
+ *
+ * Two things at once, because both must happen before any run row exists: the
+ * rows are validated through `core::read_data_rows`, and the credentials are
+ * planned through `plan_send_row_auth` - the build is what would otherwise
+ * base64 a `{{data.column}}` out of reach, so how it resolves auth has to be
+ * decided before it runs.
+ *
+ * @p is_scenario refuses the field by name: a collection run states its rows as
+ * `scenario.data`, where they are bound per iteration and shared by every step,
+ * and a payload carrying both would have one of the two silently dropped.
+ *
+ * Extracted from the handler (execution.cpp) so load_data_test.cpp can
+ * drive it directly, matching the suite's other route-core tests.
+ */
+LoadDataRows read_load_data_set (const nlohmann::json& json,
+const vayu::core::ScenarioLimits& limits,
+bool is_scenario);
+
+/**
  * The stream-only half of a recorded design result (issue #573).
  *
  * Passed to `record_design_result` rather than written by the stream worker

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -181,7 +181,12 @@ const ResultAnnotations& annotations) {
         *annotations.step_index, annotations.iteration.value_or (0),
         annotations.data_row_index);
     } else if (!context->test_script.empty ()) {
-        context->metrics_collector->record_response_sample (response);
+        // The row this submission bound travels with the sample, so the
+        // deferred `tests` script reads it as `pm.iterationData` (issue #993).
+        // Absent for a run sent without rows, which is what keeps that scope
+        // `undefined` there.
+        context->metrics_collector->record_response_sample (
+        response, annotations.data_row_index);
     }
 }
 
@@ -306,11 +311,79 @@ class SubmissionRequest {
         return request_;
     }
 
+    /**
+     * The row this submission binds, claimed off the run-wide cursor and
+     * wrapping always (issue #993) - the rule a scenario run's virtual users
+     * share, with one submission where that one has an iteration.
+     *
+     * The cursor lives here because the strategy thread is the event loop's
+     * sole producer, so the claim needs no atomic and no lock.
+     */
+    size_t claim_row (size_t row_count) {
+        return cursor_++ % row_count;
+    }
+
     private:
     std::shared_ptr<AuthRefreshState> state_;
     vayu::Request request_;
     uint64_t seen_generation_ = 0;
+    size_t cursor_            = 0;
 };
+
+/**
+ * One submission of the run's request, with this submission's data row bound
+ * into it when the run carries rows (issue #993).
+ *
+ * Every strategy submits through here rather than each writing its own
+ * `submit_one`, so a run's rows reach whichever pacing mode the user picked
+ * instead of the one whose lambda remembered them - and so does the
+ * mid-run credential swap, which two of the four used to miss.
+ *
+ * **A run without rows takes the path it always did**: one test of a null
+ * pointer, then the same submit of the same shared request. No copy, no claim,
+ * no annotation - the throughput guard #992 states, kept structurally rather
+ * than by measurement alone.
+ */
+void submit_one_request (const std::shared_ptr<RunContext>& context,
+vayu::db::Database& db,
+SubmissionRequest& live) {
+    const LoadDataSet* data = context->data.get ();
+    if (data == nullptr) {
+        context->event_loop->submit (live.current (),
+        [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
+            handle_result (context, db, result);
+        });
+        context->requests_sent++;
+        return;
+    }
+
+    const size_t row = live.claim_row (data->rows.size ());
+    // Copied per submission because the bind rewrites it, exactly as a scenario
+    // step's request is copied per iteration: the shared one has to stay the
+    // template every later row is bound against.
+    vayu::Request request = live.current ();
+    if (auto bound = bind_iteration_row (request, data->fields, data->auth,
+        data->credentials, data->rows[row], row);
+    !bound.ok) {
+        // Nothing goes on the wire, so nothing will ever complete for this
+        // submission: this path owns the whole accounting a completion would
+        // have done. `requests_sent` is incremented beside the error record so
+        // `in_flight()` - sent minus completed - stays honest, which is the
+        // same discipline the scenario executor's bind failure keeps.
+        context->requests_sent++;
+        handle_result (context, db,
+        vayu::Result<vayu::Response> (
+        vayu::Error{ vayu::ErrorCode::DataBindingFailed, bound.error }),
+        ResultAnnotations{ row });
+        return;
+    }
+
+    context->event_loop->submit (request,
+    [context, &db, row] (size_t, const vayu::Result<vayu::Response>& result) {
+        handle_result (context, db, result, ResultAnnotations{ row });
+    });
+    context->requests_sent++;
+}
 
 } // namespace
 
@@ -400,11 +473,7 @@ class ConstantLoadStrategy : public LoadStrategy {
             vayu::utils::log_info ("  Concurrency: " + std::to_string (concurrency));
 
             auto submit_one = [&context, &db, &live] () {
-                context->event_loop->submit (live.current (),
-                [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                    handle_result (context, db, result);
-                });
-                context->requests_sent++;
+                submit_one_request (context, db, live);
             };
 
             maintain_concurrency (
@@ -435,12 +504,11 @@ class ConstantLoadStrategy : public LoadStrategy {
         }
         size_t sent = 0;
         for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
-            context->event_loop->submit (live.current (),
-            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                handle_result (context, db, result);
-            });
+            // The same submission every other mode makes, rows and all: this
+            // is the open-loop half of `constant_rps`, and a copy of the submit
+            // here is a copy that stops receiving what that one is given.
+            submit_one_request (context, db, live);
             sent++;
-            context->requests_sent++;
         }
         return sent;
     }
@@ -562,11 +630,7 @@ class IterationsLoadStrategy : public LoadStrategy {
         context->requests_expected = iterations;
 
         auto submit_one = [&context, &db, &live] () {
-            context->event_loop->submit (live.current (),
-            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                handle_result (context, db, result);
-            });
-            context->requests_sent++;
+            submit_one_request (context, db, live);
         };
 
         maintain_concurrency (
@@ -612,11 +676,7 @@ class RampUpLoadStrategy : public LoadStrategy {
         vayu::utils::log_info ("  Target Concurrency: " + std::to_string (target_concurrency));
 
         auto submit_one = [&context, &db, &live] () {
-            context->event_loop->submit (live.current (),
-            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                handle_result (context, db, result);
-            });
-            context->requests_sent++;
+            submit_one_request (context, db, live);
         };
 
         // target(t): linear from start_concurrency to target_concurrency over
@@ -810,12 +870,13 @@ class CapacityLoadStrategy : public LoadStrategy {
         " -> " + std::to_string (capacity_config.max_concurrency));
         vayu::utils::log_info ("  Deadline: " + std::to_string (deadline_ms) + " ms");
 
-        auto submit_one = [&context, &db, &request] () {
-            context->event_loop->submit (request,
-            [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {
-                handle_result (context, db, result);
-            });
-            context->requests_sent++;
+        // Through `SubmissionRequest` like every other mode since #993: a
+        // capacity search binds its data rows the same way, and picks up a
+        // credential the refresh watchdog renewed mid-search, which submitting
+        // the built request directly never did.
+        SubmissionRequest live (context, request);
+        auto submit_one = [&context, &db, &live] () {
+            submit_one_request (context, db, live);
         };
 
         CapacitySearch search (capacity_config, context);

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -374,13 +374,17 @@ SubmissionRequest& live) {
         handle_result (context, db,
         vayu::Result<vayu::Response> (
         vayu::Error{ vayu::ErrorCode::DataBindingFailed, bound.error }),
-        ResultAnnotations{ row });
+        // Every member named: a single-request run has no step and no
+        // iteration to report, and `-Wmissing-field-initializers` is an error
+        // in the release build rather than a suggestion.
+        ResultAnnotations{ row, std::nullopt, std::nullopt });
         return;
     }
 
     context->event_loop->submit (request,
     [context, &db, row] (size_t, const vayu::Result<vayu::Response>& result) {
-        handle_result (context, db, result, ResultAnnotations{ row });
+        handle_result (context, db, result,
+        ResultAnnotations{ row, std::nullopt, std::nullopt });
     });
     context->requests_sent++;
 }

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -347,7 +347,7 @@ class SubmissionRequest {
 void submit_one_request (const std::shared_ptr<RunContext>& context,
 vayu::db::Database& db,
 SubmissionRequest& live) {
-    const LoadDataSet* data = context->data.get ();
+    const LoadDataSet* data = context->load_data.get ();
     if (data == nullptr) {
         context->event_loop->submit (live.current (),
         [context, &db] (size_t, const vayu::Result<vayu::Response>& result) {

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -416,7 +416,8 @@ bool MetricsCollector::should_sample_success () {
     return config_.store_success_traces && counter % config_.success_sample_rate == 0;
 }
 
-void MetricsCollector::record_response_sample (const Response& response) {
+void MetricsCollector::record_response_sample (const Response& response,
+std::optional<size_t> data_row_index) {
     // Only sample based on configured rate
     size_t counter = response_sample_counter_.fetch_add (1, std::memory_order_relaxed);
     if (counter % config_.response_sample_rate != 0) {
@@ -441,6 +442,7 @@ void MetricsCollector::record_response_sample (const Response& response) {
     }
 
     ResponseSample sample (response, now_ms ());
+    sample.data_row_index = data_row_index;
 
     bool displaced = false;
     {

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -459,7 +459,8 @@ bool verbose) {
         // step's replay gets, off the row index the sample was stamped with
         // (issue #993). Null for a run sent without rows, which is what keeps
         // `pm.iterationData` `undefined` there.
-        replay.data_rows = context->data == nullptr ? nullptr : &context->data->rows;
+        replay.data_rows =
+        context->load_data == nullptr ? nullptr : &context->load_data->rows;
         replay.request_id   = script_request_id;
         replay.request_name = script_request_name;
         replay.sse_limits   = sse_limits;
@@ -984,7 +985,7 @@ std::unique_ptr<LoadDataSet> data) {
         context->scenario = std::move (scenario);
         // Same rule, same moment: the worker splits this set's request template
         // before its first submission and every strategy reads it after.
-        context->data = std::move (data);
+        context->load_data = std::move (data);
         // Spawn metrics collection thread first - it is NOT detached and is
         // joined by the worker thread below.
         context->metrics_thread =
@@ -1120,8 +1121,10 @@ vayu::Request& request) {
     // out of reach (issue #591), so a run with rows tells the build to defer
     // and `bind_iteration_row` applies them per submission. Every other run
     // resolves its auth here exactly as it always did.
-    auto built = vayu::http::build_request (config, db_ptr, timeout_ms,
-    context->data ? context->data->auth_resolution () : vayu::http::AuthResolution::Apply);
+    const auto auth_resolution = context->load_data ?
+    context->load_data->auth_resolution () :
+    vayu::http::AuthResolution::Apply;
+    auto built = vayu::http::build_request (config, db_ptr, timeout_ms, auth_resolution);
     if (!built.ok) {
         vayu::utils::log_error (built.parse_failed ?
         std::string ("Load test: invalid request format") :
@@ -1134,8 +1137,8 @@ vayu::Request& request) {
     // run binds at its full rate, which is the same reason a plan step is split
     // when the plan resolves (issue #993). The `{}` a row-free run keeps is
     // what makes the join free for it - it has no set at all.
-    if (context->data) {
-        context->data->fields = tokenize_data_fields (request);
+    if (context->load_data) {
+        context->load_data->fields = tokenize_data_fields (request);
     }
 
     // A streaming run's caps ride on the request itself, because the

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -451,9 +451,15 @@ bool verbose) {
         }
 
         ScriptReplay replay;
-        replay.script       = &context->test_script;
-        replay.request      = &dummy_request;
-        replay.samples      = &samples;
+        replay.script  = &context->test_script;
+        replay.request = &dummy_request;
+        replay.samples = &samples;
+        // The rows this run bound, so a sampled submission reads the row it
+        // actually carried as `pm.iterationData` - the same reading a scenario
+        // step's replay gets, off the row index the sample was stamped with
+        // (issue #993). Null for a run sent without rows, which is what keeps
+        // `pm.iterationData` `undefined` there.
+        replay.data_rows = context->data == nullptr ? nullptr : &context->data->rows;
         replay.request_id   = script_request_id;
         replay.request_name = script_request_name;
         replay.sse_limits   = sse_limits;
@@ -970,11 +976,15 @@ bool RunManager::start_run (const std::string& run_id,
 const nlohmann::json& config,
 vayu::db::Database& db,
 bool verbose,
-std::shared_ptr<const ScenarioExecution> scenario) {
+std::shared_ptr<const ScenarioExecution> scenario,
+std::unique_ptr<LoadDataSet> data) {
     return spawn_run (run_id, config, db, [&] (const std::shared_ptr<RunContext>& context) {
         // Set before either thread starts: the worker reads it to choose an
         // executor, and a later write would race the run it is meant to shape.
         context->scenario = std::move (scenario);
+        // Same rule, same moment: the worker splits this set's request template
+        // before its first submission and every strategy reads it after.
+        context->data = std::move (data);
         // Spawn metrics collection thread first - it is NOT detached and is
         // joined by the worker thread below.
         context->metrics_thread =
@@ -1105,7 +1115,13 @@ vayu::Request& request) {
     if (context->scenario) {
         return true;
     }
-    auto built = vayu::http::build_request (config, db_ptr, timeout_ms);
+    // Credentials carrying a `{{data.column}}` are the one case the build
+    // leaves alone: the row has to reach them before `apply_auth` base64s them
+    // out of reach (issue #591), so a run with rows tells the build to defer
+    // and `bind_iteration_row` applies them per submission. Every other run
+    // resolves its auth here exactly as it always did.
+    auto built = vayu::http::build_request (config, db_ptr, timeout_ms,
+    context->data ? context->data->auth_resolution () : vayu::http::AuthResolution::Apply);
     if (!built.ok) {
         vayu::utils::log_error (built.parse_failed ?
         std::string ("Load test: invalid request format") :
@@ -1113,6 +1129,14 @@ vayu::Request& request) {
         return false;
     }
     request = std::move (built.request);
+
+    // Split once, here, so no submission re-scans the request's fields: a load
+    // run binds at its full rate, which is the same reason a plan step is split
+    // when the plan resolves (issue #993). The `{}` a row-free run keeps is
+    // what makes the join free for it - it has no set at all.
+    if (context->data) {
+        context->data->fields = tokenize_data_fields (request);
+    }
 
     // A streaming run's caps ride on the request itself, because the
     // event loop is what enforces them and the request is all it sees.

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -776,6 +776,20 @@ size_t row_index) {
     return joiner.result ();
 }
 
+DataBindResult bind_iteration_row (vayu::Request& request,
+const StepDataTemplate& fields,
+const vayu::http::Auth& auth,
+const StepDataTemplate& credentials,
+const nlohmann::json& row,
+size_t row_index) {
+    if (auto bound = apply_data_template (request, fields, row, row_index); !bound.ok) {
+        return bound;
+    }
+    // The credentials second, which is the whole reason this order lives in one
+    // place - see the header.
+    return bind_auth_row (request, auth, credentials, row, row_index);
+}
+
 DataBindResult bind_auth_row (vayu::Request& request,
 vayu::http::Auth auth,
 const StepDataTemplate& tmpl,

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -782,7 +782,8 @@ const vayu::http::Auth& auth,
 const StepDataTemplate& credentials,
 const nlohmann::json& row,
 size_t row_index) {
-    if (auto bound = apply_data_template (request, fields, row, row_index); !bound.ok) {
+    if (auto bound = apply_data_template (request, fields, row, row_index);
+    !bound.ok) {
         return bound;
     }
     // The credentials second, which is the whole reason this order lives in one

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -268,14 +268,13 @@ class ScenarioLoadDriver {
         // `{{data.*}}` token has empty templates and is not walked at all,
         // which is what makes a token-free plan free per iteration.
         if (row && !(step.data_template.empty () && step.auth_template.empty ())) {
-            auto bound = apply_data_template (
-            request, step.data_template, execution_.data_rows[*row], *row);
-            if (bound.ok) {
-                // Then the credentials, which is why the plan left them typed:
-                // they have to carry the row's values *before* `apply_auth`
-                // base64-encodes them onto the request (issue #591).
-                bound = bind_step_auth (request, step, execution_.data_rows[*row], *row);
-            }
+            // Both halves through the one binder the single-request load path
+            // also drives (issue #993), so a request carrying a row binds
+            // identically whether it is repeated on its own or walked as a step
+            // - including the credentials-after-fields order the encoding
+            // depends on.
+            const auto bound =
+            bind_step_row (request, step, execution_.data_rows[*row], *row);
             if (!bound.ok) {
                 // Nothing goes on the wire, so nothing will ever complete for
                 // this step: this path owns the whole accounting a completion

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -164,7 +164,7 @@ collect_requests (vayu::db::Database& db, const std::string& root_id, bool recur
 }
 
 /**
- * The `data` rows a run binds.
+ * The `data` rows a *scenario* binds, through the shared reader below.
  *
  * They reach the run's worker (as `pm.iterationData`) but never the plan or the
  * snapshot - the app owns parsing the file they came from, and only their count
@@ -175,49 +175,10 @@ std::optional<std::string> read_scenario_data (const nlohmann::json& data,
 const ScenarioLimits& limits,
 ScenarioRequest& out,
 std::vector<nlohmann::json>& rows_out) {
-
-    if (!data.is_array ()) {
-        return "'scenario.data' must be an array of objects (got " +
-        std::string (data.type_name ()) + ")";
+    if (auto reason = read_data_rows (data, limits, "scenario.data", rows_out)) {
+        return reason;
     }
-    if (data.empty ()) {
-        return "'scenario.data' is present but empty. A data set that "
-               "binds "
-               "nothing is a mistake, not an empty run - omit the field to "
-               "run without one.";
-    }
-    if (data.size () > limits.max_data_rows) {
-        return "'scenario.data' has " + std::to_string (data.size ()) +
-        " rows, over the limit of " + std::to_string (limits.max_data_rows) +
-        " (raise the 'maxScenarioDataRows' setting to allow more)";
-    }
-    rows_out.reserve (data.size ());
-    // Accumulated row by row rather than dumping the whole array: an
-    // oversized set is refused as soon as it crosses the bound, so the
-    // check never materializes a second copy of a payload that is already
-    // too big to want one.
-    size_t data_bytes = 0;
-    for (size_t i = 0; i < data.size (); ++i) {
-        if (!data[i].is_object ()) {
-            // A rejected set leaves no rows behind - never the ones before
-            // the bad one, which would be a partial data set.
-            rows_out.clear ();
-            return "'scenario.data' row " + std::to_string (i) +
-            " must be an object of name/value pairs (got " +
-            std::string (data[i].type_name ()) + ")";
-        }
-        data_bytes += data[i].dump ().size ();
-        if (data_bytes > limits.max_data_bytes) {
-            rows_out.clear ();
-            return "'scenario.data' is larger than the limit of " +
-            std::to_string (limits.max_data_bytes) +
-            " bytes (raise the 'maxScenarioDataBytes' setting to allow "
-            "more). The row count is within its own limit - a data set can "
-            "exceed this one with few but large rows.";
-        }
-        rows_out.push_back (data[i]);
-    }
-    out.data_row_count = data.size ();
+    out.data_row_count = rows_out.size ();
     return std::nullopt;
 }
 
@@ -503,6 +464,55 @@ ScenarioPlan& plan) {
 
 } // namespace
 
+std::optional<std::string> read_data_rows (const nlohmann::json& data,
+const ScenarioLimits& limits,
+std::string_view field,
+std::vector<nlohmann::json>& rows_out) {
+    const std::string name = "'" + std::string (field) + "'";
+    if (!data.is_array ()) {
+        return name + " must be an array of objects (got " +
+        std::string (data.type_name ()) + ")";
+    }
+    if (data.empty ()) {
+        return name +
+        " is present but empty. A data set that binds "
+        "nothing is a mistake, not an empty run - omit the field to "
+        "run without one.";
+    }
+    if (data.size () > limits.max_data_rows) {
+        return name + " has " + std::to_string (data.size ()) +
+        " rows, over the limit of " + std::to_string (limits.max_data_rows) +
+        " (raise the 'maxScenarioDataRows' setting to allow more)";
+    }
+    rows_out.reserve (data.size ());
+    // Accumulated row by row rather than dumping the whole array: an
+    // oversized set is refused as soon as it crosses the bound, so the
+    // check never materializes a second copy of a payload that is already
+    // too big to want one.
+    size_t data_bytes = 0;
+    for (size_t i = 0; i < data.size (); ++i) {
+        if (!data[i].is_object ()) {
+            // A rejected set leaves no rows behind - never the ones before
+            // the bad one, which would be a partial data set.
+            rows_out.clear ();
+            return name + " row " + std::to_string (i) +
+            " must be an object of name/value pairs (got " +
+            std::string (data[i].type_name ()) + ")";
+        }
+        data_bytes += data[i].dump ().size ();
+        if (data_bytes > limits.max_data_bytes) {
+            rows_out.clear ();
+            return name + " is larger than the limit of " +
+            std::to_string (limits.max_data_bytes) +
+            " bytes (raise the 'maxScenarioDataBytes' setting to allow "
+            "more). The row count is within its own limit - a data set can "
+            "exceed this one with few but large rows.";
+        }
+        rows_out.push_back (data[i]);
+    }
+    return std::nullopt;
+}
+
 ScenarioResolution resolve_scenario (vayu::db::Database& db,
 const nlohmann::json& scenario,
 const ScenarioResolveOptions& options) {
@@ -561,15 +571,17 @@ CoverageTally make_coverage_tally (const ScenarioExecution& execution) {
     return CoverageTally (execution.spec.declared_operations, step_operations);
 }
 
-DataBindResult bind_step_auth (vayu::Request& request,
+DataBindResult bind_step_row (vayu::Request& request,
 const ScenarioStep& step,
 const nlohmann::json& row,
 size_t row_index) {
-    // The join-then-apply order lives in one place, shared with the single
-    // send that binds credentials once (issue #642); this is the per-iteration
-    // caller of it. The step's auth is copied by the callee, which is what a
-    // plan shared by every virtual user of the run requires.
-    return bind_auth_row (request, step.auth, step.auth_template, row, row_index);
+    // The fields-then-credentials order lives in one place, shared with the
+    // single-request load path that binds its own templates the same way
+    // (issue #993); this is the step-shaped caller of it. The step's auth is
+    // copied by the callee, which is what a plan shared by every virtual user
+    // of the run requires.
+    return bind_iteration_row (
+    request, step.data_template, step.auth, step.auth_template, row, row_index);
 }
 
 nlohmann::json build_scenario_manifest (const ScenarioRequest& request,

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -493,21 +493,14 @@ vayu::http::routes::ExchangeOutcome& exchange) {
     std::string data_bind_error;
     if (ctx.data_row_index) {
         inputs.iteration_data = &ctx.data_rows[*ctx.data_row_index];
-        // Through the step's own template rather than re-splitting
-        // the request here: one binder for both executors, so a
-        // step cannot bind differently depending on which one ran
-        // it.
-        auto bound = apply_data_template (inputs.request, step.data_template,
+        // Through the step's own templates rather than re-splitting
+        // the request here, and through the one binder every
+        // executor drives, so a step cannot bind differently
+        // depending on which one ran it - fields first, then the
+        // credentials the plan deliberately left unresolved, which
+        // is the order `apply_auth` makes load-bearing (issue #591).
+        const auto bound = bind_step_row (inputs.request, step,
         ctx.data_rows[*ctx.data_row_index], *ctx.data_row_index);
-        if (bound.ok) {
-            // Then the credentials, for a step whose auth the plan
-            // deliberately left unresolved: they have to carry the
-            // row's values *before* `apply_auth` base64-encodes
-            // them onto the request (issue #591). A no-op for every
-            // other step.
-            bound = bind_step_auth (inputs.request, step,
-            ctx.data_rows[*ctx.data_row_index], *ctx.data_row_index);
-        }
         if (!bound.ok) {
             data_bind_error = std::move (bound.error);
         }

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -499,7 +499,7 @@ vayu::http::routes::ExchangeOutcome& exchange) {
         // depending on which one ran it - fields first, then the
         // credentials the plan deliberately left unresolved, which
         // is the order `apply_auth` makes load-bearing (issue #591).
-        const auto bound = bind_step_row (inputs.request, step,
+        auto bound = bind_step_row (inputs.request, step,
         ctx.data_rows[*ctx.data_row_index], *ctx.data_row_index);
         if (!bound.ok) {
             data_bind_error = std::move (bound.error);

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -503,6 +503,51 @@ std::string load_data_snapshot (const std::string& sanitized, size_t row_count) 
 
 namespace {
 
+/**
+ * @brief The stored `config_snapshot` for a run, with whatever this run's shape
+ *        deliberately keeps out of it already out (issue #993).
+ *
+ * The two rewrites are exclusive by construction - a scenario run states its
+ * work as a collection and refuses a `data` block beside it - so which one
+ * applies is a property of the payload rather than a decision the caller makes.
+ * It lives here rather than inline in `handle_start_load_test` because both
+ * arms are the same rule (a shape whose payload carries user data of unknown
+ * sensitivity is stored described rather than verbatim), and the route reads
+ * better asking for the snapshot than spelling the choice out a third time.
+ */
+std::string run_config_snapshot (const std::string& body,
+bool is_scenario,
+const nlohmann::json& scenario_manifest,
+const vayu::core::LoadDataSet* data) {
+    std::string sanitized = vayu::json::sanitize_config_snapshot (body);
+    if (is_scenario) {
+        return scenario_snapshot (sanitized, scenario_manifest);
+    }
+    if (data != nullptr && !data->rows.empty ()) {
+        // The rows out, their count in - the same rule the scenario manifest
+        // keeps, and for the same reason (issue #993).
+        return load_data_snapshot (sanitized, data->rows.size ());
+    }
+    return sanitized;
+}
+
+/**
+ * @brief The row-set limits a single-request run's `data` block is held to.
+ *
+ * The same two config rows the scenario path reads, so one payload cannot be
+ * refused for a size the other would accept.
+ */
+vayu::core::ScenarioLimits load_data_limits (vayu::db::Database& db) {
+    vayu::core::ScenarioLimits limits;
+    limits.max_data_rows =
+    static_cast<size_t> (db.get_config_int ("maxScenarioDataRows",
+    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_ROWS)));
+    limits.max_data_bytes =
+    static_cast<size_t> (db.get_config_int ("maxScenarioDataBytes",
+    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_BYTES)));
+    return limits;
+}
+
 // Build the final response JSON with script results
 nlohmann::json build_response_json (const vayu::Response& response,
 const nlohmann::json& scripts,
@@ -1707,20 +1752,12 @@ httplib::Response& res) {
     // The rows a single-request run binds (issue #993), validated and credential-
     // planned here for the reason the scenario block is resolved here: a set the
     // engine cannot read must leave no run row behind.
-    vayu::core::ScenarioLimits data_limits;
-    data_limits.max_data_rows =
-    static_cast<size_t> (ctx.db.get_config_int ("maxScenarioDataRows",
-    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_ROWS)));
-    data_limits.max_data_bytes =
-    static_cast<size_t> (ctx.db.get_config_int ("maxScenarioDataBytes",
-    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_BYTES)));
-    auto load_data = read_load_data_set (json, data_limits, is_scenario);
+    auto load_data = read_load_data_set (json, load_data_limits (ctx.db), is_scenario);
     if (!load_data.ok) {
         vayu::utils::log_warning ("POST /runs - " + load_data.error);
         send_error (res, 400, load_data.error, "invalid_run_config");
         return;
     }
-    const size_t data_row_count = load_data.set ? load_data.set->rows.size () : 0;
 
     // Create run record
     std::string run_id = vayu::utils::generate_id ("run_");
@@ -1737,14 +1774,8 @@ httplib::Response& res) {
     run.type   = (is_scenario && !is_scenario_load) ? vayu::RunType::Scenario :
                                                       vayu::RunType::Load;
     run.status = vayu::RunStatus::Pending;
-    run.config_snapshot = vayu::json::sanitize_config_snapshot (req.body);
-    if (is_scenario) {
-        run.config_snapshot = scenario_snapshot (run.config_snapshot, scenario_manifest);
-    } else if (data_row_count > 0) {
-        // The rows out, their count in - the same rule the scenario manifest
-        // keeps, and for the same reason (issue #993).
-        run.config_snapshot = load_data_snapshot (run.config_snapshot, data_row_count);
-    }
+    run.config_snapshot = run_config_snapshot (
+    req.body, is_scenario, scenario_manifest, load_data.set.get ());
     seed_run_times (run, now_ms ());
 
     if (json.contains ("requestId") && !json["requestId"].is_null ()) {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -413,6 +413,94 @@ SendRowAuth plan_send_row_auth (const nlohmann::json& json, bool has_row) {
     return out;
 }
 
+/**
+ * @brief Read `POST /runs`' top-level `data` rows (issue #993).
+ *
+ * Non-static: load_data_test.cpp drives it directly, the suite having no
+ * in-process HTTP route harness. See routes.hpp for what the field means.
+ */
+LoadDataRows read_load_data_set (const nlohmann::json& json,
+const vayu::core::ScenarioLimits& limits,
+bool is_scenario) {
+    LoadDataRows out;
+    const auto field = json.find ("data");
+    if (field == json.end () || field->is_null ()) {
+        return out;
+    }
+
+    // A collection run states its rows inside the block that names the
+    // collection, and the two are bound differently - one row per iteration
+    // shared by every step there, one per submission here. Refused rather than
+    // silently ignored: a caller that sent rows and had them dropped would read
+    // a run of literal `{{data.*}}` tokens as the feature working.
+    if (is_scenario) {
+        out.ok    = false;
+        out.error = "'data' is the single-request form of a data set. A "
+                    "collection run states its rows as 'scenario.data', where "
+                    "one row is bound per iteration and shared by every step - "
+                    "move them there, or drop the 'scenario' block.";
+        return out;
+    }
+
+    auto set = std::make_unique<vayu::core::LoadDataSet> ();
+    // The same reader the scenario block goes through, so the two shapes cannot
+    // come to disagree about what a row is or which limit refuses it.
+    if (auto reason = vayu::core::read_data_rows (*field, limits, "data", set->rows)) {
+        out.ok    = false;
+        out.error = *reason;
+        return out;
+    }
+
+    // How the credentials resolve, decided here because it is the *build* that
+    // would otherwise encode them out of reach - the same call, and the same
+    // reasoning, as a send that carries one row (issue #642). The refusal it
+    // can carry is an oauth2 config with a data token, which no deferral can
+    // serve.
+    auto row_auth = plan_send_row_auth (json, /*has_row=*/true);
+    if (!row_auth.ok) {
+        out.ok    = false;
+        out.error = std::move (row_auth.error);
+        return out;
+    }
+    set->auth        = std::move (row_auth.auth);
+    set->credentials = std::move (row_auth.credentials);
+    out.set          = std::move (set);
+    return out;
+}
+
+/**
+ * @brief Replace a single-request run's `data` rows with their count in the
+ *        stored snapshot (issue #993).
+ *
+ * `sanitize_config_snapshot` strips credentials out of `auth` and keeps
+ * everything else, which is not enough here for the reason `scenario_snapshot`
+ * exists: the rows are user data of unknown sensitivity and are deliberately
+ * never snapshotted. `dataRowCount` is what survives, exactly as it does on a
+ * scenario manifest, so a stored run still says it was data-driven and how
+ * large the set was.
+ *
+ * A snapshot that is not JSON (which `sanitize_config_snapshot` passes through
+ * verbatim) is left alone - there is nothing in it to rewrite.
+ *
+ * Non-static: run_row_seed_test.cpp declares and drives it, the way it does
+ * `scenario_snapshot`, because "the rows are never persisted" is a privacy
+ * property and deserves a test that does not need a run to exist.
+ */
+std::string load_data_snapshot (const std::string& sanitized, size_t row_count) {
+    nlohmann::json parsed;
+    try {
+        parsed = nlohmann::json::parse (sanitized);
+    } catch (const std::exception&) {
+        return sanitized;
+    }
+    if (!parsed.is_object ()) {
+        return sanitized;
+    }
+    parsed.erase ("data");
+    parsed["dataRowCount"] = row_count;
+    return parsed.dump ();
+}
+
 namespace {
 
 // Build the final response JSON with script results
@@ -1616,6 +1704,24 @@ httplib::Response& res) {
         }
     }
 
+    // The rows a single-request run binds (issue #993), validated and credential-
+    // planned here for the reason the scenario block is resolved here: a set the
+    // engine cannot read must leave no run row behind.
+    vayu::core::ScenarioLimits data_limits;
+    data_limits.max_data_rows =
+    static_cast<size_t> (ctx.db.get_config_int ("maxScenarioDataRows",
+    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_ROWS)));
+    data_limits.max_data_bytes =
+    static_cast<size_t> (ctx.db.get_config_int ("maxScenarioDataBytes",
+    static_cast<int> (vayu::core::constants::scenario::MAX_DATA_BYTES)));
+    auto load_data = read_load_data_set (json, data_limits, is_scenario);
+    if (!load_data.ok) {
+        vayu::utils::log_warning ("POST /runs - " + load_data.error);
+        send_error (res, 400, load_data.error, "invalid_run_config");
+        return;
+    }
+    const size_t data_row_count = load_data.set ? load_data.set->rows.size () : 0;
+
     // Create run record
     std::string run_id = vayu::utils::generate_id ("run_");
     vayu::db::Run run;
@@ -1634,6 +1740,10 @@ httplib::Response& res) {
     run.config_snapshot = vayu::json::sanitize_config_snapshot (req.body);
     if (is_scenario) {
         run.config_snapshot = scenario_snapshot (run.config_snapshot, scenario_manifest);
+    } else if (data_row_count > 0) {
+        // The rows out, their count in - the same rule the scenario manifest
+        // keeps, and for the same reason (issue #993).
+        run.config_snapshot = load_data_snapshot (run.config_snapshot, data_row_count);
     }
     seed_run_times (run, now_ms ());
 
@@ -1675,7 +1785,7 @@ httplib::Response& res) {
     ctx.run_manager.start_scenario_run (
     run_id, json, scenario_execution, ctx.db, ctx.cookie_jar, ctx.verbose) :
     ctx.run_manager.start_run (run_id, json, ctx.db, ctx.verbose,
-    is_scenario_load ? scenario_execution : nullptr);
+    is_scenario_load ? scenario_execution : nullptr, std::move (load_data.set));
     if (!started) {
         send_error (res, 503, "Engine is shutting down");
         return;

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -742,7 +742,14 @@ int64_t offset) {
 nlohmann::json build_run_report_config (const nlohmann::json& config) {
     nlohmann::json config_obj = nlohmann::json::object ();
     for (const char* key : { "mode", "duration", "concurrency", "startConcurrency",
-         "rampUpDuration", "timeout", "comment", "followRedirects", "maxRedirects" }) {
+         "rampUpDuration", "timeout", "comment", "followRedirects", "maxRedirects",
+         // The size of the data set a run bound (issue #993). The snapshot
+         // carries the count in the rows' place - they are never persisted -
+         // and this is what carries it to the reader: the dashboard's run
+         // metadata prints it, so "this run was data-driven, over N rows" is
+         // recoverable from the report rather than only from the payload the
+         // caller no longer has.
+         "dataRowCount" }) {
         add_if_present (config_obj, config, key);
     }
     add_http_version (config_obj, config);
@@ -938,10 +945,10 @@ nlohmann::json build_report_metadata (const std::string& run_id, const vayu::db:
             metadata["requestMethod"] = config["method"];
         }
 
-        // Ten keys, built by build_run_report_config above - the seven load-test
-        // tuning knobs plus httpVersion/followRedirects/maxRedirects. `rps` is
-        // the one rename (-> targetRps) and stays inline here rather than in
-        // that key list.
+        // Eleven keys, built by build_run_report_config above - the seven
+        // load-test tuning knobs, httpVersion/followRedirects/maxRedirects, and
+        // the bound row count. `rps` is the one rename (-> targetRps) and stays
+        // inline here rather than in that key list.
         nlohmann::json config_obj = build_run_report_config (config);
         if (config.contains ("rps"))
             config_obj["targetRps"] = config["rps"];

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(vayu_tests
     execution_timeout_test.cpp
     execution_http_version_test.cpp
     load_strategy_test.cpp
+    load_data_test.cpp
     refill_deficit_test.cpp
     reservoir_test.cpp
     sample_capture_test.cpp
@@ -306,6 +307,7 @@ set(vayu_scratch_database_suites
     ImportParseRoute
     InboxListenerTest
     InboxStorageTest
+    LoadDataTest
     LoadReplayEventsTest
     LoadScriptScopesTest
     LoadStrategyTest

--- a/engine/tests/load_data_test.cpp
+++ b/engine/tests/load_data_test.cpp
@@ -187,7 +187,7 @@ class LoadDataTest : public ::testing::Test {
 
         auto context =
         std::make_shared<vayu::core::RunContext> ("test-load-data", payload);
-        context->data = std::move (read.set);
+        context->load_data = std::move (read.set);
         vayu::http::EventLoopConfig loop_config;
         loop_config.max_concurrent = 100;
         loop_config.max_per_host   = 100;
@@ -386,7 +386,7 @@ TEST_F (LoadDataTest, ARunWithoutRowsCarriesNoSetAndAnnotatesNothing) {
 
     run (payload);
 
-    EXPECT_EQ (context_->data, nullptr)
+    EXPECT_EQ (context_->load_data, nullptr)
     << "a run sent without `data` must carry no set - the strategies test "
        "exactly this pointer before doing any per-submission work";
     const auto results = context_->metrics_collector->success_results ();

--- a/engine/tests/load_data_test.cpp
+++ b/engine/tests/load_data_test.cpp
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/load_data_test.cpp
+ * @brief Data rows on a **single-request** load run (issue #993).
+ *
+ * `{{data.column}}` bound on the scenario path alone until this, so the
+ * canonical load shape - one request, N users, a row each - was expressible
+ * only by wrapping the request in a one-step collection, which most users would
+ * never discover. The rows ride the run payload's top-level `data` now.
+ *
+ * Two halves, and both are here because neither is worth much alone: the
+ * route's reader (what a row set may be, and what the credentials do about a
+ * token) and the executor (what actually leaves on the wire, per submission).
+ * The wire is what the second half asserts on - a bind that produced the right
+ * string and then lost it downstream is still a request nobody meant to send,
+ * which is the reasoning `scenario_load_test.cpp` records for its own listener.
+ *
+ * The **rows-off** path is asserted here too, and deliberately: it is the
+ * throughput guard #992 states, and a guard nothing tests is a guard that
+ * decays into a branch someone deletes.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "optional_assert.hpp"
+#include "task_queue.hpp"
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/core/load_strategy.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_data.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/event_loop.hpp"
+#include "vayu/http/request_builder.hpp"
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/encoding.hpp"
+
+namespace {
+
+using nlohmann::json;
+using vayu::core::LoadDataSet;
+using vayu::http::routes::read_load_data_set;
+
+/**
+ * @brief A listener that records the path and `Authorization` of every request
+ *        it answers.
+ *
+ * Read off the wire rather than off the request the strategy built: a
+ * credential bound from a row is only correct once `apply_auth` has encoded it,
+ * and that encoding is what used to hide a token binding in the wrong order
+ * (issue #591).
+ */
+class RecordingServer {
+    public:
+    struct Hit {
+        std::string path;
+        std::string authorization;
+    };
+
+    RecordingServer () {
+        svr.new_task_queue = vayu::tests::pooled_task_queue (64);
+
+        // A `{{data.*}}` token substitutes into the path, so the row a
+        // submission bound is readable off the wire rather than inferred from a
+        // counter the test also owns.
+        svr.Get (R"(/row/(.*))", [this] (const httplib::Request& req, httplib::Response& res) {
+            record (req, "/row/" + req.matches[1].str ());
+            res.set_content ("{}", "application/json");
+        });
+        svr.Get ("/plain", [this] (const httplib::Request& req, httplib::Response& res) {
+            record (req, "/plain");
+            res.set_content ("{}", "application/json");
+        });
+
+        port   = svr.bind_to_any_port ("127.0.0.1");
+        thread = std::thread ([this] () { svr.listen_after_bind (); });
+        svr.wait_until_ready ();
+    }
+
+    ~RecordingServer () {
+        svr.stop ();
+        if (thread.joinable ())
+            thread.join ();
+    }
+    RecordingServer (const RecordingServer&)            = delete;
+    RecordingServer& operator= (const RecordingServer&) = delete;
+    RecordingServer (RecordingServer&&)                 = delete;
+    RecordingServer& operator= (RecordingServer&&)      = delete;
+
+    [[nodiscard]] std::string url (const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string (port) + path;
+    }
+
+    [[nodiscard]] std::vector<Hit> hits () const {
+        std::lock_guard<std::mutex> lock (hits_mtx_);
+        return hits_;
+    }
+
+    [[nodiscard]] std::vector<std::string> paths () const {
+        std::vector<std::string> out;
+        for (const auto& hit : hits ())
+            out.push_back (hit.path);
+        return out;
+    }
+
+    private:
+    void record (const httplib::Request& req, const std::string& path) {
+        std::lock_guard<std::mutex> lock (hits_mtx_);
+        hits_.push_back ({ path, req.get_header_value ("Authorization") });
+    }
+
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+    mutable std::mutex hits_mtx_;
+    std::vector<Hit> hits_;
+};
+
+constexpr const char* TEST_DB_PATH = "test_load_data.db";
+
+/// The engine's seeded limits, as the route resolves them.
+vayu::core::ScenarioLimits stock_limits () {
+    vayu::core::ScenarioLimits limits;
+    limits.max_data_rows  = vayu::core::constants::scenario::MAX_DATA_ROWS;
+    limits.max_data_bytes = vayu::core::constants::scenario::MAX_DATA_BYTES;
+    return limits;
+}
+
+class LoadDataTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        vayu::http::global_init ();
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (TEST_DB_PATH);
+        db_->init ();
+    }
+
+    void TearDown () override {
+        context_.reset ();
+        db_.reset ();
+        vayu::http::global_cleanup ();
+        cleanup ();
+    }
+
+    static void cleanup () {
+        vayu::tests::remove_database_files (TEST_DB_PATH);
+    }
+
+    /**
+     * Run @p payload to completion the way `execute_load_test` does around the
+     * strategy: the route's reader, the same build the run performs, the split
+     * `build_load_request` makes, then drain - the tallies are only final after
+     * it.
+     *
+     * Every step goes through production's own function rather than a
+     * hand-built equivalent, for the reason `scenario_load_test`'s `with_data`
+     * records: a test that built its own template would pass against a splitter
+     * the engine never runs.
+     */
+    void run (const json& payload) {
+        auto read = read_load_data_set (payload, stock_limits (), /*is_scenario=*/false);
+        ASSERT_TRUE (read.ok) << read.error;
+
+        auto built = vayu::http::build_request (payload, db_.get (), /*timeout_ms=*/5000,
+        read.set ? read.set->auth_resolution () : vayu::http::AuthResolution::Apply);
+        ASSERT_TRUE (built.ok) << built.error_message;
+        if (read.set) {
+            read.set->fields = vayu::core::tokenize_data_fields (built.request);
+        }
+
+        auto context =
+        std::make_shared<vayu::core::RunContext> ("test-load-data", payload);
+        context->data = std::move (read.set);
+        vayu::http::EventLoopConfig loop_config;
+        loop_config.max_concurrent = 100;
+        loop_config.max_per_host   = 100;
+        context->event_loop = std::make_unique<vayu::http::EventLoop> (loop_config);
+        context->event_loop->start ();
+
+        auto strategy = vayu::core::LoadStrategy::create (payload);
+        strategy->execute (context, *db_, built.request);
+        context->event_loop->stop (true, std::chrono::milliseconds (10000));
+        context_ = context;
+    }
+
+    /// What the deferred pass recorded as failures, for an assertion that has
+    /// to say *why* a replay failed rather than only that it did - the pass
+    /// stores them as a result row rather than returning them.
+    std::string replay_failures () {
+        std::string joined;
+        for (const auto& result : db_->get_results ("test-load-data")) {
+            const auto trace = nlohmann::json::parse (result.trace_data, nullptr, false);
+            if (trace.is_discarded () || !trace.contains ("failures")) {
+                continue;
+            }
+            for (const auto& failure : trace["failures"]) {
+                joined += failure.get<std::string> () + "; ";
+            }
+        }
+        return joined;
+    }
+
+    /// An iterations payload against @p url, retaining every completion so an
+    /// assertion is about what a record carries rather than which budget
+    /// claimed it.
+    static json iterations_payload (const std::string& url, size_t iterations) {
+        return json{ { "method", "GET" }, { "url", url }, { "mode", "iterations" },
+            { "iterations", iterations }, { "concurrency", 1 },
+            { "save_timing_breakdown", true }, { "success_sample_rate", 1 },
+            { "slow_threshold_ms", 0 }, { "response_sample_rate", 1 } };
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+    std::shared_ptr<vayu::core::RunContext> context_;
+};
+
+// ============================================================================
+// The route's reader - what a row set may be, before any run row exists
+// ============================================================================
+
+TEST (ReadLoadDataSet, AbsentAndNullAreNoRows) {
+    const json absent = { { "url", "https://example.test/" } };
+    auto read         = read_load_data_set (absent, stock_limits (), false);
+    EXPECT_TRUE (read.ok);
+    // No set at all, rather than an empty one: that emptiness is what keeps
+    // the rows-off path free of per-submission work.
+    EXPECT_EQ (read.set, nullptr) << "a run without rows carries a set";
+
+    const json null_rows = { { "url", "https://example.test/" }, { "data", nullptr } };
+    read = read_load_data_set (null_rows, stock_limits (), false);
+    EXPECT_TRUE (read.ok);
+    EXPECT_EQ (read.set, nullptr);
+}
+
+TEST (ReadLoadDataSet, RowsAreKeptInPayloadOrder) {
+    const json payload = { { "url", "https://example.test/" },
+        { "data", json::array ({ json{ { "id", "a" } }, json{ { "id", "b" } } }) } };
+
+    const auto read = read_load_data_set (payload, stock_limits (), false);
+    ASSERT_TRUE (read.ok) << read.error;
+    ASSERT_NE (read.set, nullptr);
+    ASSERT_EQ (read.set->rows.size (), 2u);
+    EXPECT_EQ (read.set->rows[0]["id"], "a");
+    EXPECT_EQ (read.set->rows[1]["id"], "b");
+    EXPECT_EQ (read.set->auth_resolution (), vayu::http::AuthResolution::Apply)
+    << "static credentials must still be applied by the build, exactly as they "
+       "were before rows existed";
+}
+
+// The refusals are the scenario path's, because they are the same reader -
+// which is the point of sharing it rather than writing a second one.
+TEST (ReadLoadDataSet, TheRefusalsMatchTheScenarioPathAndNameThisField) {
+    const auto refusal = [] (const json& data) {
+        const json payload = { { "url", "https://example.test/" }, { "data", data } };
+        const auto read = read_load_data_set (payload, stock_limits (), false);
+        EXPECT_FALSE (read.ok) << "accepted: " << data.dump ();
+        return read.error;
+    };
+
+    EXPECT_NE (refusal (json::object ()).find ("must be an array of objects"),
+    std::string::npos);
+    // A set that binds nothing is a mistake, not an empty run.
+    EXPECT_NE (refusal (json::array ()).find ("present but empty"), std::string::npos);
+    const auto row_error = refusal (json::array ({ json{ { "id", "a" } }, 7 }));
+    EXPECT_NE (row_error.find ("row 1"), std::string::npos) << row_error;
+    EXPECT_NE (row_error.find ("name/value pairs"), std::string::npos) << row_error;
+
+    // Every one of them names `data`, not `scenario.data`: the caller has to be
+    // told which field of *theirs* was wrong.
+    EXPECT_NE (refusal (json::array ()).find ("'data'"), std::string::npos);
+    EXPECT_EQ (refusal (json::array ()).find ("scenario.data"), std::string::npos);
+}
+
+TEST (ReadLoadDataSet, TheLimitsAreTheOnesACollectionRunIsHeldTo) {
+    vayu::core::ScenarioLimits tight;
+    tight.max_data_rows  = 1;
+    tight.max_data_bytes = 1024;
+    const json payload   = { { "url", "https://example.test/" },
+          { "data", json::array ({ json{ { "id", "a" } }, json{ { "id", "b" } } }) } };
+
+    auto read = read_load_data_set (payload, tight, false);
+    EXPECT_FALSE (read.ok);
+    EXPECT_NE (read.error.find ("maxScenarioDataRows"), std::string::npos)
+    << read.error;
+    EXPECT_EQ (read.set, nullptr) << "a refused set must leave nothing behind";
+
+    tight.max_data_rows  = 10;
+    tight.max_data_bytes = 4;
+    read                 = read_load_data_set (payload, tight, false);
+    EXPECT_FALSE (read.ok);
+    EXPECT_NE (read.error.find ("maxScenarioDataBytes"), std::string::npos)
+    << read.error;
+}
+
+// A collection run states its rows inside the block that names the collection,
+// and the two bind differently - one row per iteration shared by every step
+// there, one per submission here. Refused rather than dropped: a caller whose
+// rows were ignored would read a run of literal tokens as the feature working.
+TEST (ReadLoadDataSet, TopLevelRowsBesideAScenarioBlockAreRefusedByName) {
+    const json block = { { "source", "collection" }, { "collectionId", "c" } };
+    const json payload = { { "scenario", block },
+        { "data", json::array ({ json{ { "id", "a" } } }) } };
+
+    const auto read = read_load_data_set (payload, stock_limits (), /*is_scenario=*/true);
+    EXPECT_FALSE (read.ok);
+    EXPECT_NE (read.error.find ("scenario.data"), std::string::npos)
+    << "the refusal must say where a collection run's rows belong: " << read.error;
+    EXPECT_EQ (read.set, nullptr);
+}
+
+TEST (ReadLoadDataSet, CredentialsCarryingATokenDeferTheBuild) {
+    const json payload = { { "url", "https://example.test/" },
+        { "auth", { { "mode", "basic" }, { "username", "{{data.user}}" }, { "password", "pw" } } },
+        { "data", json::array ({ json{ { "user", "alice" } } }) } };
+
+    const auto read = read_load_data_set (payload, stock_limits (), false);
+    ASSERT_TRUE (read.ok) << read.error;
+    ASSERT_NE (read.set, nullptr);
+    EXPECT_FALSE (read.set->credentials.empty ());
+    EXPECT_EQ (read.set->auth_resolution (), vayu::http::AuthResolution::Defer)
+    << "a credential carrying a row value must not be encoded by the build - "
+       "after `apply_auth` the token is base64 of its own literal text";
+}
+
+// The one mode deferral cannot serve: the token is acquired against the token
+// endpoint before the run starts, so no submission exists for a row to reach.
+TEST (ReadLoadDataSet, ADataTokenInAnOAuth2ConfigIsRefused) {
+    const json payload = { { "url", "https://example.test/" },
+        { "auth",
+        { { "mode", "oauth2" },
+        { "config",
+        { { "tokenUrl", "https://auth.test/token" }, { "clientId", "c" },
+        { "clientSecret", "{{data.secret}}" } } } } },
+        { "data", json::array ({ json{ { "secret", "s" } } }) } };
+
+    const auto read = read_load_data_set (payload, stock_limits (), false);
+    EXPECT_FALSE (read.ok);
+    EXPECT_NE (read.error.find ("{{data.secret}}"), std::string::npos) << read.error;
+    EXPECT_EQ (read.set, nullptr);
+}
+
+// ============================================================================
+// The executor - what reaches the wire, per submission
+// ============================================================================
+
+// The headline: six submissions over three rows send three distinct values,
+// each row claimed in turn and the cursor wrapping when the set runs out.
+TEST_F (LoadDataTest, RowsBindPerSubmissionAndWrapWhenTheSetRunsOut) {
+    RecordingServer server;
+    json payload    = iterations_payload (server.url ("/row/{{data.id}}"), 6);
+    payload["data"] = json::array (
+    { json{ { "id", "a" } }, json{ { "id", "b" } }, json{ { "id", "c" } } });
+
+    run (payload);
+
+    auto paths = server.paths ();
+    ASSERT_EQ (paths.size (), 6u);
+    // One virtual submitter, so the order is the claim order.
+    EXPECT_EQ (paths,
+    (std::vector<std::string>{ "/row/a", "/row/b", "/row/c", "/row/a", "/row/b", "/row/c" }))
+    << "the rows were not claimed in turn, or the cursor did not wrap";
+}
+
+// The rows-off path, which is the throughput guard made structural: no set on
+// the context at all, so there is no template to walk and no row to claim.
+TEST_F (LoadDataTest, ARunWithoutRowsCarriesNoSetAndAnnotatesNothing) {
+    RecordingServer server;
+    const json payload = iterations_payload (server.url ("/plain"), 2);
+
+    run (payload);
+
+    EXPECT_EQ (context_->data, nullptr)
+    << "a run sent without `data` must carry no set - the strategies test "
+       "exactly this pointer before doing any per-submission work";
+    const auto results = context_->metrics_collector->success_results ();
+    ASSERT_FALSE (results.empty ());
+    for (const auto& result : results) {
+        const auto trace = json::parse (result.trace_data, nullptr, false);
+        ASSERT_FALSE (trace.is_discarded ()) << result.trace_data;
+        EXPECT_FALSE (trace.contains ("dataRowIndex"))
+        << "a row-free run gained a row index that reads like row 0: "
+        << result.trace_data;
+    }
+}
+
+// Which row produced which result is the question a data-driven run exists to
+// answer, so every retained record carries it.
+TEST_F (LoadDataTest, ARecordedResultCarriesItsDataRowIndex) {
+    RecordingServer server;
+    json payload = iterations_payload (server.url ("/row/{{data.id}}"), 2);
+    payload["data"] = json::array ({ json{ { "id", "a" } }, json{ { "id", "b" } } });
+
+    run (payload);
+
+    const auto results = context_->metrics_collector->success_results ();
+    ASSERT_FALSE (results.empty ());
+    std::vector<int> rows;
+    for (const auto& result : results) {
+        const auto trace = json::parse (result.trace_data, nullptr, false);
+        ASSERT_FALSE (trace.is_discarded ()) << result.trace_data;
+        ASSERT_TRUE (trace.contains ("dataRowIndex"))
+        << "a sampled load result carries no row: " << result.trace_data;
+        rows.push_back (trace["dataRowIndex"].get<int> ());
+    }
+    std::sort (rows.begin (), rows.end ());
+    EXPECT_EQ (rows, (std::vector<int>{ 0, 1 }));
+}
+
+// A column the row does not carry is the loud failure the whole namespace
+// exists for - and the submission it refuses must still be accounted for, or
+// the closed loop counts an in-flight request that will never complete.
+TEST_F (LoadDataTest, AnAbsentColumnErrorsTheSubmissionInsteadOfSendingIt) {
+    RecordingServer server;
+    json payload = iterations_payload (server.url ("/row/{{data.missing}}"), 2);
+    payload["data"] = json::array ({ json{ { "id", "a" } } });
+
+    run (payload);
+
+    EXPECT_TRUE (server.paths ().empty ())
+    << "a request whose token could not bind reached the wire";
+    const auto errors = context_->metrics_collector->errors ();
+    ASSERT_FALSE (errors.empty ());
+    EXPECT_EQ (errors[0].error_code, vayu::ErrorCode::DataBindingFailed);
+    EXPECT_NE (errors[0].error_message.find ("{{data.missing}}"), std::string::npos)
+    << "the error must name the token that could not bind: " << errors[0].error_message;
+    // Sent minus completed is what the refill controller reads, so a refused
+    // submission counts on both sides or the run leaks a slot for good.
+    EXPECT_EQ (context_->requests_sent.load (), context_->total_requests ())
+    << "a bind failure left the run believing a request was still in flight";
+}
+
+// The credentials half: a basic-auth username bound per submission, read off
+// the wire because base64 is where a wrongly ordered bind hides.
+TEST_F (LoadDataTest, CredentialsBindPerSubmissionOnTheWire) {
+    RecordingServer server;
+    json payload    = iterations_payload (server.url ("/plain"), 2);
+    payload["auth"] = { { "mode", "basic" }, { "username", "{{data.user}}" },
+        { "password", "pw" } };
+    payload["data"] =
+    json::array ({ json{ { "user", "alice" } }, json{ { "user", "bob" } } });
+
+    run (payload);
+
+    std::vector<std::string> sent;
+    for (const auto& hit : server.hits ())
+        sent.push_back (hit.authorization);
+    std::sort (sent.begin (), sent.end ());
+    ASSERT_EQ (sent.size (), 2u);
+    EXPECT_EQ (sent[0], "Basic " + vayu::utils::base64_encode ("alice:pw"));
+    EXPECT_EQ (sent[1], "Basic " + vayu::utils::base64_encode ("bob:pw"));
+}
+
+// The deferred `tests` script reads the row its sample was bound to, which is
+// what makes an assertion about the row meaningful rather than a comparison
+// against whichever row happened to be first.
+TEST_F (LoadDataTest, TheDeferredScriptReadsTheRowItsSampleBound) {
+    RecordingServer server;
+    json payload = iterations_payload (server.url ("/row/{{data.id}}"), 2);
+    payload["data"] = json::array ({ json{ { "id", "a" } }, json{ { "id", "b" } } });
+    // Passes only if each sample carries its own row: a replay bound to row 0
+    // for both would see 'a' twice and the set below would hold one entry.
+    payload["tests"] = R"js(pm.test('bound', function () {
+  var id = pm.iterationData.get('id');
+  if (id !== 'a' && id !== 'b') { throw new Error('sample saw ' + id); }
+});)js";
+
+    run (payload);
+
+    // The samples the replay ran against carry the rows they were sent with -
+    // both of them, not one row twice. Asserted beside the script's own verdict
+    // because the tallies alone cannot tell "each read its row" from "both read
+    // the same row and the assertion happened to accept it".
+    std::vector<size_t> sampled_rows;
+    for (const auto& sample : context_->metrics_collector->response_samples ()) {
+        ASSERT_HAS_VALUE (sample.data_row_index) << "a sample carries no row";
+        sampled_rows.push_back (*sample.data_row_index);
+    }
+    std::sort (sampled_rows.begin (), sampled_rows.end ());
+    EXPECT_EQ (sampled_rows, (std::vector<size_t>{ 0, 1 }));
+
+    const auto validation = vayu::core::validate_scripts (context_, *db_, false);
+    ASSERT_HAS_VALUE (validation.run);
+    EXPECT_EQ (validation.run->failed, 0u) << replay_failures ();
+    EXPECT_EQ (validation.run->passed, 2u)
+    << "both samples must replay, each against the row it actually sent";
+}
+
+// A run sent without rows leaves the scope `undefined`, which is the distinction
+// `pm.iterationData` has always kept between "no data set" and "an empty row".
+TEST_F (LoadDataTest, WithoutRowsTheDeferredScriptSeesNoIterationData) {
+    RecordingServer server;
+    json payload = iterations_payload (server.url ("/plain"), 1);
+    // `pm.iterationData` is the binding that is absent, not a column of it: a
+    // row-free run leaves the whole scope `undefined`, so a script reaching
+    // through it for a column would throw rather than read `undefined`.
+    payload["tests"] = R"js(pm.test('absent', function () {
+  if (typeof pm.iterationData !== 'undefined') {
+    throw new Error('a row-free run bound a row');
+  }
+});)js";
+
+    run (payload);
+
+    const auto validation = vayu::core::validate_scripts (context_, *db_, false);
+    ASSERT_HAS_VALUE (validation.run);
+    EXPECT_EQ (validation.run->failed, 0u) << replay_failures ();
+    EXPECT_EQ (validation.run->passed, 1u);
+}
+
+// Every pacing mode binds, not just the one whose submit path was written
+// first: the strategies share one submission helper, and this is what says so.
+TEST_F (LoadDataTest, EveryPacingModeBindsItsRows) {
+    // `constant_rps` included deliberately: it is the one mode whose submission
+    // goes through the rate-limited tick loop rather than the closed-loop
+    // controller, so a bind wired into only one of the two would pass every
+    // other case here.
+    for (const char* mode : { "constant_concurrency", "constant_rps", "ramp_up", "capacity" }) {
+        RecordingServer server;
+        json payload = { { "method", "GET" }, { "url", server.url ("/row/{{data.id}}") },
+            { "mode", mode }, { "duration", "300ms" }, { "concurrency", 2 },
+            { "targetRps", 50.0 }, { "startConcurrency", 1 },
+            { "stepDuration", "100ms" }, { "rampUpDuration", "100ms" } };
+        payload["data"] = json::array ({ json{ { "id", "a" } }, json{ { "id", "b" } } });
+
+        run (payload);
+
+        const auto paths = server.paths ();
+        ASSERT_FALSE (paths.empty ()) << "mode " << mode << " sent nothing";
+        for (const auto& path : paths) {
+            EXPECT_TRUE (path == "/row/a" || path == "/row/b")
+            << "mode " << mode << " sent an unbound path: " << path;
+        }
+    }
+}
+
+} // namespace

--- a/engine/tests/run_row_seed_test.cpp
+++ b/engine/tests/run_row_seed_test.cpp
@@ -39,11 +39,13 @@ namespace vayu::http::routes {
 // Both declared in execution.cpp.
 void seed_run_times (vayu::db::Run& run, int64_t started_at);
 std::string scenario_snapshot (const std::string& sanitized, const nlohmann::json& manifest);
+std::string load_data_snapshot (const std::string& sanitized, size_t row_count);
 } // namespace vayu::http::routes
 
 namespace {
 
 using nlohmann::json;
+using vayu::http::routes::load_data_snapshot;
 using vayu::http::routes::scenario_snapshot;
 using vayu::http::routes::seed_run_times;
 
@@ -102,6 +104,33 @@ TEST (ScenarioSnapshot, ReplacesTheSentBlockWithTheManifest) {
 TEST (ScenarioSnapshot, LeavesANonObjectSnapshotAlone) {
     EXPECT_EQ (scenario_snapshot ("not json at all", json::object ()), "not json at all");
     EXPECT_EQ (scenario_snapshot ("[1,2,3]", json::object ()), "[1,2,3]");
+}
+
+// The same rule one field over: a single-request load run's rows (issue #993)
+// are the same user data a scenario's are, so the stored snapshot keeps their
+// count and not the set.
+TEST (LoadDataSnapshot, ReplacesTheRowsWithTheirCount) {
+    const std::string sanitized =
+    json{ { "method", "POST" }, { "url", "https://api.test/login" },
+        { "data", json::array ({ json{ { "password", "hunter2" } },
+        json{ { "password", "hunter3" } } }) },
+        { "environmentId", "env_1" } }
+    .dump ();
+
+    const auto stored = json::parse (load_data_snapshot (sanitized, 2));
+
+    EXPECT_FALSE (stored.contains ("data"));
+    EXPECT_EQ (stored["dataRowCount"], 2);
+    EXPECT_EQ (stored.dump ().find ("hunter2"), std::string::npos)
+    << "a row's cell reached the run store";
+    // Everything else the client sent is left alone.
+    EXPECT_EQ (stored["environmentId"], "env_1");
+    EXPECT_EQ (stored["url"], "https://api.test/login");
+}
+
+TEST (LoadDataSnapshot, LeavesANonObjectSnapshotAlone) {
+    EXPECT_EQ (load_data_snapshot ("not json at all", 1), "not json at all");
+    EXPECT_EQ (load_data_snapshot ("[1,2,3]", 1), "[1,2,3]");
 }
 
 } // namespace

--- a/engine/tests/run_row_seed_test.cpp
+++ b/engine/tests/run_row_seed_test.cpp
@@ -110,11 +110,11 @@ TEST (ScenarioSnapshot, LeavesANonObjectSnapshotAlone) {
 // are the same user data a scenario's are, so the stored snapshot keeps their
 // count and not the set.
 TEST (LoadDataSnapshot, ReplacesTheRowsWithTheirCount) {
+    const json rows = json::array (
+    { json{ { "password", "hunter2" } }, json{ { "password", "hunter3" } } });
     const std::string sanitized =
     json{ { "method", "POST" }, { "url", "https://api.test/login" },
-        { "data", json::array ({ json{ { "password", "hunter2" } },
-        json{ { "password", "hunter3" } } }) },
-        { "environmentId", "env_1" } }
+        { "data", rows }, { "environmentId", "env_1" } }
     .dump ();
 
     const auto stored = json::parse (load_data_snapshot (sanitized, 2));

--- a/engine/tests/run_row_seed_test.cpp
+++ b/engine/tests/run_row_seed_test.cpp
@@ -110,14 +110,20 @@ TEST (ScenarioSnapshot, LeavesANonObjectSnapshotAlone) {
 // are the same user data a scenario's are, so the stored snapshot keeps their
 // count and not the set.
 TEST (LoadDataSnapshot, ReplacesTheRowsWithTheirCount) {
-    const json rows = json::array (
-    { json{ { "password", "hunter2" } }, json{ { "password", "hunter3" } } });
-    const std::string sanitized =
-    json{ { "method", "POST" }, { "url", "https://api.test/login" },
-        { "data", rows }, { "environmentId", "env_1" } }
-    .dump ();
+    // Built field by field rather than as one brace-init: the payload a load
+    // run sends is flat, and a nested literal here formats differently under
+    // the two clang-format majors this repo has seen.
+    json rows = json::array ();
+    rows.push_back (json{ { "password", "hunter2" } });
+    rows.push_back (json{ { "password", "hunter3" } });
 
-    const auto stored = json::parse (load_data_snapshot (sanitized, 2));
+    json payload;
+    payload["method"]        = "POST";
+    payload["url"]           = "https://api.test/login";
+    payload["data"]          = rows;
+    payload["environmentId"] = "env_1";
+
+    const auto stored = json::parse (load_data_snapshot (payload.dump (), 2));
 
     EXPECT_FALSE (stored.contains ("data"));
     EXPECT_EQ (stored["dataRowCount"], 2);

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -803,8 +803,8 @@ TEST_F (ScenarioPlanTest, BasicAuthCredentialsBindPerIterationRatherThanEncoding
     << "auth was applied at plan time, which is what hid the token";
 
     vayu::Request request = step.request;
-    const auto bound      = vayu::core::bind_step_auth (
-    request, step, resolved.data_rows[0], /*row_index=*/0);
+    const auto bound =
+    vayu::core::bind_step_row (request, step, resolved.data_rows[0], /*row_index=*/0);
     ASSERT_TRUE (bound.ok) << bound.error;
     EXPECT_EQ (authorization_of (request),
     "Basic " + vayu::utils::base64_encode ("alice:s3cret"));
@@ -830,7 +830,7 @@ TEST_F (ScenarioPlanTest, EachRowGetsItsOwnCredentialsFromTheSamePlan) {
     for (size_t row = 0; row < resolved.data_rows.size (); ++row) {
         vayu::Request request = step.request;
         const auto bound =
-        vayu::core::bind_step_auth (request, step, resolved.data_rows[row], row);
+        vayu::core::bind_step_row (request, step, resolved.data_rows[row], row);
         ASSERT_TRUE (bound.ok) << bound.error;
         sent.push_back (authorization_of (request));
     }
@@ -857,7 +857,7 @@ TEST_F (ScenarioPlanTest, BearerAndApiKeyCredentialsBindByContract) {
         const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
         EXPECT_TRUE (resolved.ok) << resolved.error;
         vayu::Request request = resolved.plan.steps[0].request;
-        const auto result     = vayu::core::bind_step_auth (
+        const auto result     = vayu::core::bind_step_row (
         request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
         EXPECT_TRUE (result.ok) << result.error;
         return request;
@@ -896,7 +896,7 @@ TEST_F (ScenarioPlanTest, AMissingColumnInACredentialEndsTheStepByName) {
     ASSERT_TRUE (resolved.ok) << resolved.error;
 
     vayu::Request request = resolved.plan.steps[0].request;
-    const auto bound      = vayu::core::bind_step_auth (
+    const auto bound      = vayu::core::bind_step_row (
     request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
     EXPECT_FALSE (bound.ok);
     EXPECT_NE (bound.error.find ("{{data.missing}}"), std::string::npos)
@@ -970,10 +970,10 @@ TEST_F (ScenarioPlanTest, CredentialsWithoutADataTokenAreStillResolvedIntoThePla
     EXPECT_EQ (authorization_of (step.request),
     "Basic " + vayu::utils::base64_encode ("alice:s3cret"));
 
-    // And `bind_step_auth` is the no-op the executors call unconditionally.
+    // And `bind_step_row` is the no-op the executors call unconditionally.
     vayu::Request request = step.request;
-    const auto bound      = vayu::core::bind_step_auth (
-    request, step, resolved.data_rows[0], /*row_index=*/0);
+    const auto bound =
+    vayu::core::bind_step_row (request, step, resolved.data_rows[0], /*row_index=*/0);
     EXPECT_TRUE (bound.ok) << bound.error;
     EXPECT_EQ (authorization_of (request), authorization_of (step.request));
 }
@@ -995,7 +995,7 @@ TEST_F (ScenarioPlanTest, AUserSuppliedAuthorizationHeaderStillWinsOverBoundCred
     ASSERT_TRUE (resolved.ok) << resolved.error;
 
     vayu::Request request = resolved.plan.steps[0].request;
-    const auto bound      = vayu::core::bind_step_auth (
+    const auto bound      = vayu::core::bind_step_row (
     request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
     ASSERT_TRUE (bound.ok) << bound.error;
     EXPECT_EQ (authorization_of (request), "Bearer mine");


### PR DESCRIPTION
## Description

**Plan (root cause, approach, rejected alternative).** `{{data.column}}`, the row cursor and `dataRowIndex` all lived on the scenario path - `ResultAnnotations::data_row_index` was documented "Absent for every single-request run", the claim sat in `scenario_load.cpp`'s `take_ready_vu`, and `scenario.data` was the only field that carried rows. So the canonical load shape - one request, N users, a row each - was expressible only by wrapping the request in a one-step collection, which most users would never find. I re-verified every anchor at `717da15`; the code is as #993 describes it. **The design call the issue names** (route the single-request case through the scenario machinery, or lift the trio into a shared helper) went to the **shared helper**, for a reason the first option cannot survive: `execute_scenario_load` refuses `constant_rps` and `capacity` and drives virtual users through a plan, so routing single-request runs into it would cost two of the five pacing modes and the open-loop path - a regression, not a unification. **What is shared instead is every piece that decides behaviour**: `read_data_rows` (extracted from `read_scenario_data`, so both shapes are validated by one function and refused by one set of messages, with the field name a parameter) and `bind_iteration_row` (new in `scenario_data.cpp`, owning the fields-then-credentials order that `apply_auth` makes load-bearing - `bind_step_row` is its step-shaped spelling, and both scenario executors now go through it, so there is one binder rather than three copies of the pair). What is *not* shared is the claim, deliberately: a scenario claims one row per VU iteration and shares it across the steps of that iteration, while a single request has no sequence for an iteration to span - the unit of a claim there is the submission. Both wrap.

**Blast radius traced.** `POST /runs`' new top-level `data` is read by `read_load_data_set` (route core, beside `read_data_row`'s precedent) and reaches the run as a `LoadDataSet` on `RunContext` (`load_data`), filled in two stages because its halves are known at different moments - the route validates the rows and plans the credentials before a run row exists, and `build_load_request` splits the request's own template once the request is built. Readers, all traced: the four strategies (through one `submit_one_request`), `record_successful_response` (the sample's row index), `validate_scripts` (the replay's `pm.iterationData`), `annotate` (the record's `dataRowIndex`, which needed no change). `record_response_sample` gained an optional row index - every existing caller keeps its default. **The written-but-never-read check**: the snapshot's `dataRowCount` would have been exactly that defect, so it is carried into the report's `configuration` node (`build_run_report_config`) and printed by the dashboard's run metadata; nothing else in the diff stores a field with no reader.

**Two deliberate additions beyond the issue's letter.**

1. **All five submission paths go through one helper.** `constant_rps`' rate-limited tick loop had its own `submit`, and `capacity` submitted the built request directly rather than through `SubmissionRequest` - so a data feature wired into the closed-loop lambdas alone would have sent unbound requests in two modes, silently. Routing them through `submit_one_request` also gives the capacity search the mid-run credential swap it never had, which is a fix rather than a regression, stated here because it is a behaviour change the issue did not ask for.
2. **`data` beside a `scenario` block is a `400`, not an ignored field.** The two bind differently, so dropping one would send a run of literal `{{data.*}}` tokens that reads as the feature working. MCP refuses it by name too, through the list that already refuses every other single-target argument.

**No `iterations` defaulting.** A collection run with rows and no explicit count runs one pass per row; a load profile already says how long the run is, so the row count changes nothing about it. Stated in the docs rather than left to be discovered.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure   # 2480 passed, 0 failed (merged with master)
cmake --build --preset linux-prod                           # clean; -Werror is on here, not in dev
clang-format 19 --dry-run -Werror engine/{src,include,tests} # clean, whole tree, CI's pinned version
mkdocs build --strict -f .github/mkdocs.yml                  # builds
cd app && pnpm test                                         # 532 files, 5720 passed
cd app && pnpm type-check                                   # clean (3 projects)
cd app && pnpm lint                                         # clean
```

**New: `engine/tests/load_data_test.cpp`** (15 tests), split between the route's reader and the executor:

- `RowsBindPerSubmissionAndWrapWhenTheSetRunsOut` - six submissions over three rows send `a, b, c, a, b, c`, read off the wire.
- `ARunWithoutRowsCarriesNoSetAndAnnotatesNothing` - the throughput guard as a test: `context->load_data` is null, and no record gains a `dataRowIndex` that would read like row 0.
- `ARecordedResultCarriesItsDataRowIndex`, `AnAbsentColumnErrorsTheSubmissionInsteadOfSendingIt` (nothing on the wire, `DataBindingFailed` naming the token, and `requests_sent == completed` so the closed loop does not leak a slot), `CredentialsBindPerSubmissionOnTheWire` (basic auth read off the wire, because base64 is where a wrongly ordered bind hides).
- `TheDeferredScriptReadsTheRowItsSampleBound` / `WithoutRowsTheDeferredScriptSeesNoIterationData`.
- `EveryPacingModeBindsItsRows` - `constant_concurrency`, `constant_rps`, `ramp_up`, `capacity`; `constant_rps` is in the list deliberately, since it is the one mode whose submission goes through the rate-limited tick loop.
- `ReadLoadDataSet.*` - order kept, refusals identical to the scenario path's and naming `data` rather than `scenario.data`, both limits, the scenario-block refusal, credential deferral, and the oauth2 refusal.

**Mutation-checked**: pinning the claim to row 0 (`const size_t row = 0;`) reddens `RowsBindPerSubmissionAndWrapWhenTheSetRunsOut`, `ARecordedResultCarriesItsDataRowIndex` and `CredentialsBindPerSubmissionOnTheWire`; the replay test then also asserts the sampled rows are `{0, 1}` rather than one row twice, since its script alone could not tell those apart.

`run_row_seed_test.cpp` gains `LoadDataSnapshot.*` - the rows are replaced by their count in the stored snapshot, and a non-JSON snapshot is left alone. App-side: five cases in `LoadTestConfigDialog.test.tsx` (the picker is offered and described as a load run binds one, the rows reach the payload, no `data` key without a file, a refused file blocks Start, and the column audit against the collection's contract) and two in `tools.test.ts` (rows forwarded verbatim; refused beside a scenario).

### The declared file pre-fills both dialogs (#1039)

Filed out of #993 as a follow-up and then picked up in the same PR on the owner's instruction, because its own sequencing note is literal: the load dialog has no picker before #993, so a branch cut from `master` has nothing to pre-fill into.

#993 gave that dialog the Run collection dialog's `DataFilePicker` and its column audit, but not the other half of that dialog's usage - the pre-fill. So a user who had declared a file on a collection's Data tab picked it again by hand for every load run of a request in that collection, while the *same file*, resolved through the *same contract*, pre-filled a collection run one dialog over.

**Lifted, not copied**, which is what the issue asks for and what this repo keeps finding the cost of. `useDeclaredDataFile` owns the four rules that were each learned once: the remembered location is filed under the collection that **declares** the contract (#729) rather than the one the caller names; the read gets **one attempt**, so a store write while a dialog is open cannot yank the user's own selection back; the row cap applies to a re-read file exactly as to a hand-picked one (#751); and a file that has moved is a **note, never a blocker**.

One thing the issue did not anticipate, and it is why this is a hook that owns state rather than one that returns a value: handing the file back for each dialog to copy into its own state is an effect whose only job is a `setState`, which is both a second copy to drift *and* something `react-hooks/set-state-in-effect` refuses outright. So the hook owns the selection, and the pickers' `onSelect` is its setter.

**The two exclusions the issue names are honoured, and one is a seam rather than an omission.** A collection run with rows and no explicit count runs one pass per row, so that dialog clears a pristine `iterations` of `1`; a load run's length is its profile's. That coupling reaches the dialog through an `onPrefill` callback it supplies - the hook fires the seam and knows nothing about what is on the other side of it, which is what lets the load dialog share the pre-fill and share none of the consequence. Neither dialog writes the store on a pick: the Data tab is where a contract is declared.

**Tests**: five cases in the load dialog suite, driving the *real* hook with only the filesystem stubbed - the declaring ancestor rather than the request's own collection (the #729 rule, and the one a copy gets wrong), a moved file that notes and does not block Start, the one-attempt rule under a store write mid-dialog, the profile fields left untouched, and the no-bridge case that attempts nothing rather than showing a note that will never resolve. **Mutation-checked**: dropping the pre-fill reddens three of them. The Run collection dialog's own pre-fill cases are the extraction's other half and pass unchanged - including the sub-collection one, which caught a real regression mid-refactor: that dialog stands its own `collection` row ahead of the query's copy of itself, so the walk resolves a contract even on a render where the query has not answered. The hook takes that override rather than losing it.

Docs: the pre-fill paragraph in `docs/app/data-driven-runs.md` read as the Run collection dialog's alone; it now covers both, and says which single thing differs between them and why.

### Benchmark evidence (the throughput guard)

Two **Release** engines - `master` at `36967e5` and this branch - each driven against `scripts/test/mock-server.go`'s `/fast` at `constant_concurrency`, `concurrency: 64`, 10s per run, on the same machine in one session. Two passes, alternating sides, one discarded warm-up per engine. Ten rows for the rows-on cases.

| Case | master | this branch |
|---|---:|---:|
| **rows-off** (no `data` at all) | **38,864** req/s (35,665-42,087, n=4) | **40,474** req/s (38,947-41,883, n=4) |
| rows-on, no token in the request | 40,819 (n=2)¹ | 42,225 (n=2) |
| rows-on, two `{{data.*}}` bound into the URL | 38,724 (n=2 pairs)¹ | 38,957 (36,744-41,177, n=4) |

0 errors, 0 drops, ~390k requests per run throughout.

¹ master ignores `data` entirely, so its two "rows-on" rows are the same rows-off work under a different payload - they are here as a **control for the noise band**, not as a comparison.

**Reading it honestly: the noise floor is wider than any effect this change could have.** Repeats of the *identical* binary and payload span 35,665-42,087 req/s - 16% of the mean - because this container has 4 shared cores and the mock server runs on them beside the engine. So:

- **rows-off is unchanged.** The branch's mean is 104% of master's, which is inside that band and not a speed-up; structurally the path is one null-pointer test and then the submit that was there before - no copy, no claim, no annotation, asserted by `ARunWithoutRowsCarriesNoSetAndAnnotatesNothing`.
- **rows-on costs, at most, a few percent** - 96% of the branch's own rows-off mean with two tokens bound per submission, 104% with rows bound but no token to substitute, both inside the same band. The per-submission work is one `vayu::Request` copy plus the join over the split template, which is what the scenario path already pays per iteration.

This machine is not the one `docs/engine/benchmarks.md` reports (M3 Pro, ~57k req/s ceiling); these numbers are an A/B on equal terms, not an absolute figure, and the doc's headline is untouched.

### Gates

**Every gate runs locally now, including the two I previously could not.** `mkdocs` and clang-format 19 are both installed here as of this round, so `mkdocs build --strict` passes here rather than being left to CI, and the formatter check is the *pinned* version over the whole engine tree instead of an 18 whose disagreements had to be guessed at. That upgrade paid for itself immediately: 18 flags two pre-existing lines 19 does not, and flagged none of the four spots in the new code that 19 rejected - so the earlier "reshape until both accept it" approach was working from the wrong oracle in both directions.

The release preset is built here too - `-Wmissing-field-initializers -Werror` is on there and not in the dev preset, which is what an early push got wrong. The Windows leg found one on its own: MSVC's `/W4 /WX` reports `C4458` for a member that shadows a parameter name elsewhere in the class, so `RunContext::data` is `RunContext::load_data` - which reads better beside `scenario` anyway.

**Both engine legs then found two more, and neither shows up on a build**: `Lint changed engine sources` gates whole files since #946, and clang-tidy reported `performance-move-const-arg` (a `const auto` binding turned the `std::move` onto `data_bind_error` into a silent copy - the move was what was meant) and `readability-function-cognitive-complexity` (reading the data set took `handle_start_load_test` from 25 to 28 against a threshold of 25). The snapshot decision moved out whole and the limits with it; the function is back to 25, where `run_streaming_execution` beside it already sits. Both are verified here by mutation - restoring each shape makes the check fire again - after first checking the check was live at all, which this repo has been burned by twice.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #993. Closes #1039.

First of #992's three subs - #994 (iteration identity) and #995 (per-iteration generators) build on this binding path, and #1007 (bare dataset columns, in the #996 program) explicitly builds on it. Docs updated in the same commit as the code they describe: `docs/app/data-driven-runs.md` (both shapes, which row each binds, and the pre-fill), `docs/engine/api-reference.md` (the `POST /runs` payload plus a `data` section), `docs/engine/scripting.md` (`pm.iterationData` availability), `docs/engine/architecture.md` (the load path's binding), `docs/engine/mcp.md` and `docs/app/api-integration.md`.