### PR TITLE
feat(engine): pm.request.url becomes Postman's Url object, members and all - #991, #1040

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -83,6 +83,7 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			'pm.request.headers.upsert("X-Trace", traceId)',
 			'delete pm.request.headers["Authorization"]',
 			'pm.request.url.query.get("page")',
+			'pm.request.url.query.upsert({ key: "page", value: 2 })',
 			'pm.request.url = "https://api.example.com/v2/users"',
 			"pm.request.body = JSON.stringify({ n: 2 })",
 			"pm.sendRequest(url, (err, res) => { ... })",
@@ -107,7 +108,9 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 				<code className={CODE_CLASS}>query</code> and{" "}
 				<code className={CODE_CLASS}>getQueryString()</code> - and still reads as the full
 				URL string everywhere except <code className={CODE_CLASS}>===</code> and{" "}
-				<code className={CODE_CLASS}>typeof</code>. Assign a string to retarget.
+				<code className={CODE_CLASS}>typeof</code>. Edit a member -{" "}
+				<code className={CODE_CLASS}>path.push</code>,{" "}
+				<code className={CODE_CLASS}>query.add</code> - or assign a whole URL string.
 			</>,
 			<>
 				Indexing is case-sensitive in JS: use the exact name (

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -82,7 +82,8 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			'pm.request.headers["X-Timestamp"] = Date.now().toString()',
 			'pm.request.headers.upsert("X-Trace", traceId)',
 			'delete pm.request.headers["Authorization"]',
-			'pm.request.url = pm.request.url + "?trace=1"',
+			'pm.request.url.query.get("page")',
+			'pm.request.url = "https://api.example.com/v2/users"',
 			"pm.request.body = JSON.stringify({ n: 2 })",
 			"pm.sendRequest(url, (err, res) => { ... })",
 			"pm.info.requestName",
@@ -98,6 +99,15 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			<>
 				A script wins over the <strong>Auth</strong> tab - auth is applied before the script
 				runs, so setting <code className={CODE_CLASS}>Authorization</code> here replaces it.
+			</>,
+			<>
+				<code className={CODE_CLASS}>url</code> is Postman&apos;s URL object -{" "}
+				<code className={CODE_CLASS}>protocol</code>,{" "}
+				<code className={CODE_CLASS}>host</code>, <code className={CODE_CLASS}>path</code>,{" "}
+				<code className={CODE_CLASS}>query</code> and{" "}
+				<code className={CODE_CLASS}>getQueryString()</code> - and still reads as the full
+				URL string everywhere except <code className={CODE_CLASS}>===</code> and{" "}
+				<code className={CODE_CLASS}>typeof</code>. Assign a string to retarget.
 			</>,
 			<>
 				Indexing is case-sensitive in JS: use the exact name (

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -573,10 +573,6 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
 - `pm.cookies.set(...)` / `.unset(...)` / `.clear()` - the *flat* write half.
   Writing goes through `pm.cookies.jar()`, which ships whole - see
   [above](#the-cookie-jar-pmcookies)
-- **Mutating one member of `pm.request.url`** - pushing to `path`, editing a
-  `query` entry. The read surface ships whole (see
-  [Request mutation & URL variables](#request-mutation--url-variables) below);
-  a write is the whole URL, by assignment or `url.update(...)`.
 - `pm.visualizer`
 - The `tests["name"] = bool` legacy assertion style (use `pm.test`)
 - Chai matchers outside the list above: `.include.keys` (the subset form),
@@ -629,6 +625,12 @@ pm.request.body = JSON.stringify({ n: 2 });
   `String.prototype` methods, `JSON.stringify`, `.length` - and two things changed:
   `===` and `typeof`. The full surface and the migration note are in
   [scripting.md](../engine/scripting.md#url-parts-pmrequesturl).
+- **The URL is writable a member at a time, not only whole** (#1040). `path` and
+  `host` are arrays a script mutates in place (`push`, `splice`, index assignment,
+  a `length` truncation); `protocol` / `port` / `hash` take an assignment; and the
+  query carries Postman's `PropertyList` writers - `add`, `upsert`, `remove`,
+  `clear`. A URL nobody edited is sent as the exact bytes it arrived as, because
+  the parts are recomposed only when a member actually changed.
 - **`body` is a string for every mode, including the two that store fields.** A
   `x-www-form-urlencoded` or `form-data` body reads as its **enabled** fields encoded
   `key=value&…` rather than as `""` - the empty string a `content`-only read used to give,

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -28,7 +28,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
 | Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear(url?)`, see below |
 | Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
-| Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
+| Request             | `pm.request.url` (Postman's `Url` object - `protocol`/`host`/`port`/`path`/`hash`/`query`, `getHost()`, `getPath()`, `getQueryString()`, `update()`), `.method`, `.headers`, `.body` |
 | Request headers     | `pm.request.headers.get/has(name)`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
 | Environment         | `pm.environment.get/set/has/unset/clear/toObject`                                |
 | Globals             | `pm.globals.get/set/has/unset/clear/toObject`                                    |
@@ -573,13 +573,10 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
 - `pm.cookies.set(...)` / `.unset(...)` / `.clear()` - the *flat* write half.
   Writing goes through `pm.cookies.jar()`, which ships whole - see
   [above](#the-cookie-jar-pmcookies)
-- `pm.request.url.query` / `.path` / `.host` - and any other `url.*` accessor.
-  `pm.request.url` is a writable **string** that the write-back requires to still
-  be one, and a JS string primitive cannot carry properties; boxing it would
-  reject every request. A separate accessor (`pm.request.getUrlParts()`-shaped)
-  could work, but that shape has not been decided, so URL parsing is string work
-  today. Deferred deliberately - see
-  [scripting.md](../engine/scripting.md#url-parts-are-not-exposed-deferred).
+- **Mutating one member of `pm.request.url`** - pushing to `path`, editing a
+  `query` entry. The read surface ships whole (see
+  [Request mutation & URL variables](#request-mutation--url-variables) below);
+  a write is the whole URL, by assignment or `url.update(...)`.
 - `pm.visualizer`
 - The `tests["name"] = bool` legacy assertion style (use `pm.test`)
 - Chai matchers outside the list above: `.include.keys` (the subset form),
@@ -618,10 +615,20 @@ pm.request.body = JSON.stringify({ n: 2 });
   engine applied.
 - **The script wins over engine-applied auth.** `build_request` resolves auth into the
   request before the script runs, so a script-set `Authorization` replaces the resolved one.
-- **A value the engine cannot send is refused, not coerced.** `url`/`method`/`body` must be
+- **A value the engine cannot send is refused, not coerced.** `method`/`body` must be
   strings (`method` one of the seven verbs); a header value may be a string, number or
   boolean. Anything else rejects the whole write-back - all or nothing - and surfaces as
-  `preScriptError`, which the response pane's Console tab shows.
+  `preScriptError`, which the response pane's Console tab shows. `url` is refused a step
+  earlier: assigning anything that is not a URL string throws at the assignment, so the
+  script author is told which line was wrong rather than reading it off the write-back.
+- **`url` is Postman's `Url` object, not a string** (#991 - the owner decision that
+  compatibility wins over the shipped string shape). `protocol`, `host`, `port`, `path`,
+  `hash`, `query` with `get`/`has`/`all`/`toObject`/`count`, plus `getHost()`,
+  `getPath()`, `getQueryString()`, `toString()` and `update()`. It still behaves as a
+  string in every context JavaScript allows - concatenation, template literals, `==`,
+  `String.prototype` methods, `JSON.stringify`, `.length` - and two things changed:
+  `===` and `typeof`. The full surface and the migration note are in
+  [scripting.md](../engine/scripting.md#url-parts-pmrequesturl).
 - **`body` is a string for every mode, including the two that store fields.** A
   `x-www-form-urlencoded` or `form-data` body reads as its **enabled** fields encoded
   `key=value&…` rather than as `""` - the empty string a `content`-only read used to give,

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -612,16 +612,57 @@ Four rules behind those answers:
 - **A URL the parser cannot read has no parts.** `toString()` still answers the
   whole string, and every part is empty rather than a plausible half.
 
-**Writing** is the whole URL, not a member - assign a string, or call
-`update()`, which is Postman's spelling of the same write:
+#### Writing
+
+The whole URL - assign a string, or call `update()`, which is Postman's
+spelling of the same write:
 
 ```javascript
 pm.request.url = 'https://api.example.com/v3/orders';   // re-parses in place
 pm.request.url.update('https://api.example.com/v3/orders'); // the same write
 ```
 
-Editing a single member (pushing to `path`, changing a `query` entry) is not
-supported; build the URL and assign it.
+Or one member at a time. `path` and `host` are live arrays, and the query has
+Postman's `PropertyList` writers beside its reads:
+
+```javascript
+pm.request.url.path.push('active');          // .../v2/users/active
+pm.request.url.path[0] = 'v3';               // index assignment, splice, pop,
+pm.request.url.path.length = 1;              //   unshift and length all work
+pm.request.url.host = ['api', 'staging', 'example', 'com'];
+pm.request.url.protocol = 'http';            // and port / hash likewise
+
+pm.request.url.query.add({ key: 'trace', value: id });  // appends, duplicates ok
+pm.request.url.query.add({ key: 'flag' });              // a bare ?flag
+pm.request.url.query.upsert({ key: 'page', value: 4 }); // replaces in place
+pm.request.url.query.remove('page');                    // every match, not the first
+pm.request.url.query.clear();                           // and the '?' with them
+```
+
+Four rules behind those, each the reason for a decision you might otherwise
+undo:
+
+- **A URL nobody edited is sent exactly as it arrived.** The parts are
+  recomposed only when a member was actually written to, so a read-only script
+  cannot change a single byte - which is what keeps `getQueryString()`
+  byte-exact against the wire.
+- **`upsert` keeps wire position**, `add` appends. A parameter that quietly
+  moved to the end would change the shape of any signature computed over the
+  query.
+- **`remove(name)` takes every match.** Removing `page` from `?page=1&page=2`
+  and getting one back has removed nothing the caller can observe.
+- **An edit that cannot reach the wire is an error, never a no-op.** A URL the
+  parser could not read has no parts to edit, so a write is refused rather than
+  composing `://` out of empty pieces, and a path segment that is not a string
+  or a number is refused rather than becoming `[object Object]`. `path` and
+  `host` are ordinary arrays that are **read back** when the URL is needed - the
+  same rule `pm.request.headers` follows - so a bad segment surfaces as a
+  rejected write-back, with the member and the index named, rather than at the
+  `push`.
+
+In a **test** script these behave like every other `pm.request` write: they
+change what the script sees and reach nothing, because the request has already
+gone out.
 
 #### It was a string, and mostly still behaves as one
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -433,7 +433,7 @@ Access request data:
 
 ```javascript
 pm.request.method            // HTTP method (string)
-pm.request.url               // Full URL (string)
+pm.request.url               // Full URL (Postman Url object - see below)
 pm.request.headers           // Request headers (object, with the methods below)
 pm.request.body              // Request body (string, if any)
 ```
@@ -522,8 +522,9 @@ Rules worth knowing before you rely on them:
 - **A script beats engine-applied auth.** Auth (bearer / basic / apikey /
   oauth2) is resolved into the request *before* the script runs, so the script
   sees the real `Authorization` header and can replace or remove it.
-- **A bad value is refused, not coerced.** `url` and `method` must be strings
-  (`method` one of the seven HTTP verbs), header values must be strings,
+- **A bad value is refused, not coerced.** `method` must be a string (one of the
+  seven HTTP verbs), `url` a URL string (assigning anything else throws at the
+  assignment), header values must be strings,
   numbers or booleans, and `body` must be a string. Anything else fails the
   whole write-back - the request is sent unchanged and the reason is reported
   as the pre-request script error, visible in the response pane's Console tab.
@@ -570,16 +571,85 @@ string, number or boolean - the same set plain assignment accepts. Detaching a
 method from its object (`const get = pm.request.headers.get`) throws rather than
 answering as though the header were missing.
 
-### URL parts are not exposed (deferred)
+### URL parts (`pm.request.url`)
 
-Postman has `pm.request.url.query` / `.path` / `.host`. Vayu does not, and it is
-not an oversight: `pm.request.url` is a **writable string**, and the write-back
-requires it to still be one when the script returns. A JS string primitive
-cannot carry properties, and boxing it into a `String` object to hang them off
-would make the write-back reject every request. Any URL-parts accessor therefore
-has to be a separate member (something like `pm.request.getUrlParts()`) rather
-than `url.*`; that shape has not been decided, so parsing the URL remains string
-work - see [Add or replace a query parameter](#add-or-replace-a-query-parameter).
+`pm.request.url` is Postman's `Url` object, so a script lifted from Postman
+reads its parts under the same names:
+
+```javascript
+pm.request.url.protocol          // 'https'          - scheme, no colon
+pm.request.url.host              // ['api','example','com'] - segments
+pm.request.url.port              // '8443'           - '' when unstated
+pm.request.url.path              // ['v2','users']   - decoded segments
+pm.request.url.hash              // 'top'            - fragment, no '#'
+pm.request.url.query             // the query, with the reads below
+
+pm.request.url.getHost();        // 'api.example.com'
+pm.request.url.getPath();        // '/v2/users'
+pm.request.url.getQueryString(); // 'page=2&sort=name' - no '?'
+pm.request.url.toString();       // the whole URL
+```
+
+```javascript
+pm.request.url.query.get('page');     // first value, or null
+pm.request.url.query.has('page');     // boolean
+pm.request.url.query.all();           // [{key, value}, ...] in wire order
+pm.request.url.query.toObject();      // {page: '2'} - last wins
+pm.request.url.query.count();         // 3
+```
+
+Four rules behind those answers:
+
+- **Path segments are decoded, query values are not.** A path is what you want
+  to read; a query is what you want to *sign*, and a canonical string has to be
+  built from the bytes that were sent. `getQueryString()` is byte-exact against
+  the wire.
+- **`all()` keeps wire order and duplicates**, which is the whole reason it
+  exists beside `toObject()`. `get(name)` answers the **first** match (Postman's
+  `PropertyList.one`); `toObject()` is last-wins and says so.
+- **A bare `?flag` reads as `null`, an empty `?flag=` as `''`.** Both are
+  `has()`-true.
+- **A URL the parser cannot read has no parts.** `toString()` still answers the
+  whole string, and every part is empty rather than a plausible half.
+
+**Writing** is the whole URL, not a member - assign a string, or call
+`update()`, which is Postman's spelling of the same write:
+
+```javascript
+pm.request.url = 'https://api.example.com/v3/orders';   // re-parses in place
+pm.request.url.update('https://api.example.com/v3/orders'); // the same write
+```
+
+Editing a single member (pushing to `path`, changing a `query` entry) is not
+supported; build the URL and assign it.
+
+#### It was a string, and mostly still behaves as one
+
+This shape replaced a plain string (issue #991: Postman compatibility over the
+shipped string shape). The object keeps as much of the old behaviour as
+JavaScript allows - it carries its own `toString`, `valueOf`, `toJSON` and
+`Symbol.toPrimitive`, and inherits from `String.prototype`:
+
+```javascript
+'' + pm.request.url;                    // the URL
+`${pm.request.url}`;                    // the URL
+pm.request.url == 'https://a/b';        // compares as the URL
+pm.request.url.startsWith('https://');  // String methods work
+pm.request.url.split('?')[0];           //   ... including this one
+JSON.stringify({ u: pm.request.url });  // embeds the URL string
+```
+
+Two things did change, and no mitigation can fix them:
+
+| Was | Now | Use |
+|-----|-----|-----|
+| `pm.request.url === 'https://a/b'` | `false` | `==`, or `.toString()` |
+| `typeof pm.request.url` | `'object'` | - |
+
+`.length` is **not** one of them: it is defined on the object as the URL's own
+length. Inheriting it from `String.prototype` - which is a String object holding
+`""` - would have answered `0` for every URL, and a plausible wrong number is
+worse than a break you can see.
 
 ## Script Identity (`pm.info`)
 
@@ -1252,25 +1322,24 @@ you do not need to. Any header you derive yourself works the same way.
 
 ### Add or replace a query parameter
 
-There is no `URL` or `URLSearchParams` in the sandbox, so this is string work.
-Handle three cases - no query, parameter absent, parameter already present -
-and encode the value.
+`pm.request.url.query` reads the parameters; the write is the whole URL, so
+rebuild the query string and assign it back.
 
 ```javascript
-function setQueryParam(url, name, value) {
-  var pair = encodeURIComponent(name) + '=' + encodeURIComponent(value);
-  var hashAt = url.indexOf('#');
-  var fragment = hashAt === -1 ? '' : url.slice(hashAt);
-  var base = hashAt === -1 ? url : url.slice(0, hashAt);
+function withQueryParam(url, name, value) {
+  var pair = { key: encodeURIComponent(name), value: encodeURIComponent(value) };
+  var kept = url.query.all().filter(function (p) { return p.key !== pair.key; });
+  kept.push(pair);
 
-  var re = new RegExp('([?&])' + name + '=[^&]*');
-  if (re.test(base)) {
-    return base.replace(re, '$1' + pair) + fragment;
-  }
-  return base + (base.indexOf('?') === -1 ? '?' : '&') + pair + fragment;
+  var query = kept
+    .map(function (p) { return p.value === null ? p.key : p.key + '=' + p.value; })
+    .join('&');
+
+  return url.protocol + '://' + url.getHost() + (url.port ? ':' + url.port : '') +
+    url.getPath() + (query ? '?' + query : '') + (url.hash ? '#' + url.hash : '');
 }
 
-pm.request.url = setQueryParam(pm.request.url, 'traceId', 'run-' + Date.now());
+pm.request.url = withQueryParam(pm.request.url, 'traceId', 'run-' + Date.now());
 ```
 
 ### Switch method and body together
@@ -1330,9 +1399,19 @@ can be signed for what it actually became:
 
 ```javascript
 var timestamp = Date.now().toString();
+
+// The sorted-query canonicalization every HMAC scheme wants. `all()` is the
+// view that keeps duplicates and wire-order values, so what is signed is what
+// was sent.
+var sortedQuery = pm.request.url.query.all()
+  .map(function (p) { return p.key + '=' + (p.value === null ? '' : p.value); })
+  .sort()
+  .join('&');
+
 var canonical = [
   pm.request.method,
-  pm.request.url,
+  pm.request.url.getPath(),
+  sortedQuery,
   timestamp,
   pm.request.body || ''
 ].join('\n');
@@ -1426,9 +1505,8 @@ silently falling back to hex.
 
 **Not** available: `crypto` / `crypto.subtle`, `TextEncoder`, `URL`,
 `URLSearchParams`, `setTimeout`, `require`, `fetch`. The practical
-consequences: no URL parsing helper - which is why `pm.request.url` has no
-`.query` / `.path` accessors either, see
-[URL parts are not exposed](#url-parts-are-not-exposed-deferred) - no hash
+consequences: no general URL constructor - the request's own URL is already
+parsed for you, see [URL parts](#url-parts-pmrequesturl) - no hash
 other than SHA-256 (no MD5, no SHA-1, nothing asymmetric), and nothing
 asynchronous. There is no `fetch`, but there **is**
 [`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest), which is

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -445,6 +445,7 @@ add_library(vayu_core STATIC
     src/http/header_text.cpp
     src/http/graphql_body.cpp
     src/http/jsonrpc_body.cpp
+    src/http/url_parts.cpp
     src/utils/json.cpp
     src/utils/logger.cpp
     src/utils/metrics_helper.cpp

--- a/engine/include/vayu/http/url_parts.hpp
+++ b/engine/include/vayu/http/url_parts.hpp
@@ -102,6 +102,34 @@ struct UrlParts {
 [[nodiscard]] std::vector<UrlQueryParam> parse_query_params (std::string_view query);
 
 /**
+ * @brief The params back as a wire query string, without the leading `?`.
+ *
+ * The inverse of @ref parse_query_params, and byte-for-byte its inverse for a
+ * list that came out of it: values are already the wire bytes, so nothing is
+ * encoded here. A `nullopt` value is a bare key.
+ */
+[[nodiscard]] std::string compose_query (const std::vector<UrlQueryParam>& params);
+
+/**
+ * @brief The parts back as a URL.
+ *
+ * The inverse of @ref parse_url_parts, for a caller that has *edited* the parts
+ * - `pm.request.url.path.push(...)` and the query writers (issue #1040). It is
+ * not a round-trip helper: a URL nobody edited must reach the wire as the bytes
+ * it arrived as, so the script surface composes only when a member was actually
+ * written to, and this is never called otherwise.
+ *
+ * Path segments are percent-encoded here because @ref parse_url_parts decoded
+ * them, each segment on its own so an edited segment containing `/` stays one
+ * segment. The query is passed through unencoded, for the same reason it was
+ * never decoded.
+ *
+ * Empty when `parts.parsed` is false: there is nothing to compose from, and a
+ * plausible-looking URL built out of empty pieces is worse than none.
+ */
+[[nodiscard]] std::string compose_url (const UrlParts& parts);
+
+/**
  * @brief `{"api", "example", "com"}` -> `"api.example.com"`.
  */
 [[nodiscard]] std::string join_host (const std::vector<std::string>& host);

--- a/engine/include/vayu/http/url_parts.hpp
+++ b/engine/include/vayu/http/url_parts.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+/**
+ * @file url_parts.hpp
+ * @brief A URL split into the pieces Postman's `Url` object presents.
+ *
+ * The engine had no URL splitter that anything but the cookie jar could reach:
+ * `cookie_jar.cpp` reads a host, a path and a scheme through libcurl's `CURLU`
+ * for its own scoping, and stops there. `pm.request.url` (issue #991) needs the
+ * whole shape - scheme, host segments, port, decoded path segments, the query
+ * in wire order, the fragment - so it lives here rather than inside
+ * `script_engine.cpp`, where nothing could unit-test it without a JS context.
+ *
+ * **libcurl owns the parsing.** Splitting a URL by hand is the class of thing
+ * that is right for the URLs you thought of and wrong for the rest (IPv6
+ * literals in brackets, userinfo before the host, a `?` inside a fragment), and
+ * a private copy would not receive libcurl's fixes. `CURLU` is the same parser
+ * the transfer layer resolves the URL with, so what a script reads and what
+ * goes on the wire cannot disagree about where the host ends.
+ *
+ * ## What is decoded and what is not
+ *
+ * Path segments are percent-**decoded**, each segment on its own so an encoded
+ * `%2F` stays inside the segment it belongs to rather than splitting it.
+ *
+ * The query is **not** decoded, in either `UrlParts::query` or the parsed
+ * params: it is the wire bytes, in wire order, duplicates kept. That is what
+ * the request-signing workflows this exists for need - a canonical string is
+ * built from what was sent, not from a re-encoding of a decode - and it is what
+ * postman-collection's `QueryParam` holds, so a lifted Postman script reads the
+ * same values here as there.
+ */
+
+namespace vayu::http {
+
+/**
+ * @brief One `key=value` of a query string, exactly as it appears on the wire.
+ *
+ * `value` is `nullopt` for a bare key (`?flag`), which is a different fact from
+ * an empty value (`?flag=`) - Postman tells the two apart and so does anything
+ * rebuilding the string.
+ */
+struct UrlQueryParam {
+    std::string key;
+    std::optional<std::string> value;
+};
+
+/**
+ * @brief The pieces of a URL. Every field is empty when @ref parsed is false.
+ */
+struct UrlParts {
+    /// libcurl could read the string as a URL. False leaves every field empty:
+    /// a caller that shows parts of an unparseable URL must show none of them
+    /// rather than a plausible half.
+    bool parsed = false;
+    /// Scheme with no trailing colon (`https`).
+    std::string protocol;
+    /// Host split on `.` (`api.example.com` -> `{"api", "example", "com"}`).
+    std::vector<std::string> host;
+    /// The port the URL states, empty when it states none. A scheme's default
+    /// port is never filled in - the URL either carried one or it did not.
+    std::string port;
+    /// Percent-decoded path segments, without the empty segment the leading
+    /// `/` produces. A root path is one empty segment, which is how `/` and a
+    /// URL with no path at all both read.
+    std::vector<std::string> path;
+    /// The query as it appears on the wire, without the leading `?`.
+    std::string query;
+    /// The same query split on `&`, in wire order, duplicates kept.
+    std::vector<UrlQueryParam> query_params;
+    /// The fragment without the leading `#`.
+    std::string hash;
+};
+
+/**
+ * @brief Split @p url into its parts, or return an unparsed @ref UrlParts.
+ *
+ * Never throws and never reports a diagnostic: a URL the parser cannot read is
+ * an answer (`parsed == false`), because the callers all have a string to fall
+ * back on that is more useful than an error.
+ */
+[[nodiscard]] UrlParts parse_url_parts (const std::string& url);
+
+/**
+ * @brief Split a raw query string (no leading `?`) on `&`, in wire order.
+ *
+ * Empty runs between separators are dropped (`a=1&&b=2` is two params), which
+ * is what every consumer of a query string does with them.
+ */
+[[nodiscard]] std::vector<UrlQueryParam> parse_query_params (std::string_view query);
+
+/**
+ * @brief `{"api", "example", "com"}` -> `"api.example.com"`.
+ */
+[[nodiscard]] std::string join_host (const std::vector<std::string>& host);
+
+/**
+ * @brief `{"a", "b"}` -> `"/a/b"`, from the decoded segments back to a path.
+ *
+ * The inverse of the split, not of the decode: a segment that arrived
+ * percent-encoded comes back decoded, matching Postman's `getPath()`.
+ */
+[[nodiscard]] std::string join_path (const std::vector<std::string>& path);
+
+} // namespace vayu::http

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -431,7 +431,9 @@ std::string intersection_base (const std::string& detail) {
     if (amp == std::string::npos || trim (base.substr (amp + 1)) != "object") {
         return {};
     }
-    const std::string left = trim (base.substr (0, amp));
+    // Not `const`: it is returned by value, and a const local is copied where a
+    // non-const one is moved (performance-no-automatic-move).
+    std::string left = trim (base.substr (0, amp));
     if (left == "string" || left == "number" || left == "boolean") {
         return left;
     }

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -117,8 +117,13 @@ constexpr auto ABSENT_GLOBALS = std::to_array<AbsentGlobal> ({
 "no filesystem to load from." },
 { "process", "Not Node. There is no process, no argv and no env." },
 { "Buffer", "Not Node. Use btoa/atob, or pm.crypto for hashing." },
-{ "URL", "No URL parser in the sandbox. pm.request.url is a plain string." },
-{ "URLSearchParams", "No URL parser in the sandbox." },
+{ "URL",
+"No WHATWG URL constructor in the sandbox. pm.request.url is "
+"already Postman's Url object - read its protocol, host, port, "
+"path, query and hash there." },
+{ "URLSearchParams",
+"No URLSearchParams. pm.request.url.query answers the same "
+"questions: get, has, all, toObject, count." },
 { "TextEncoder", "Absent. pm.crypto accepts strings directly." },
 { "TextDecoder", "Absent. pm.crypto accepts strings directly." },
 { "structuredClone", "Absent. Use JSON.parse(JSON.stringify(value))." },
@@ -402,6 +407,38 @@ bool is_string_literal_union (const std::string& base) {
 }
 
 /**
+ * @brief The primitive a member's own members sit on top of, or "" for none.
+ *
+ * One member needs it: `pm.request.url` is Postman's `Url` object, with
+ * `query`/`path`/`host` members *and* a prototype and `@@toPrimitive` that keep
+ * it usable everywhere the string it replaced was (issue #991). Declared as an
+ * object alone, every documented `jar().set(pm.request.url, ...)` stops
+ * compiling; declared as a string alone, `url.query.get(...)` does. `string &
+ * { ... }` is the only declaration that types both halves, and the table says
+ * so by spelling the member's type `string & object`.
+ *
+ * The member is emitted as an accessor pair, because that is what it *is* at
+ * run time: the getter answers the object, and the setter takes the string a
+ * script assigns.
+ */
+std::string intersection_base (const std::string& detail) {
+    std::string base = trim (detail);
+    const auto paren = base.find (" (");
+    if (paren != std::string::npos) {
+        base = trim (base.substr (0, paren));
+    }
+    const auto amp = base.find ('&');
+    if (amp == std::string::npos || trim (base.substr (amp + 1)) != "object") {
+        return {};
+    }
+    const std::string left = trim (base.substr (0, amp));
+    if (left == "string" || left == "number" || left == "boolean") {
+        return left;
+    }
+    return {};
+}
+
+/**
  * @brief The type of a non-function leaf, read from its `detail`.
  *
  * A `detail` that restates the member's own dotted name (`.to.be.true`) is an
@@ -525,6 +562,15 @@ bool in_chain) {
             out += indent + name + "(" + (sig.parsed ? sig.params : "") + "): {\n";
             out += render_body (node, indent + "\t", in_chain);
             out += indent + "};\n";
+            return out;
+        }
+        // `pm.request.url` - members on top of the string it still behaves as.
+        // See intersection_base.
+        if (const std::string base = intersection_base (node.detail); !base.empty ()) {
+            out += indent + "get " + name + "(): " + base + " & {\n";
+            out += render_body (node, indent + "\t", in_chain);
+            out += indent + "};\n";
+            out += indent + "set " + name + "(value: " + base + ");\n";
             return out;
         }
         // `pm.iterationData?: {...}` - the surface is undefined outside a

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -374,7 +374,8 @@ nlohmann::json get_script_completions () {
     { "insertText", "pm.request.url.host" }, { "detail", "string[]" },
     { "documentation",
     "The host split on dots, as Postman presents it: \"api.example.com\" is "
-    "[\"api\", \"example\", \"com\"]. Use getHost() for the joined form." },
+    "[\"api\", \"example\", \"com\"]. Use getHost() for the joined form.\n\n"
+    "Editable in a pre-request script, the same way path is." },
     { "sortText", "2_pm_request_url_host" } });
 
     completions.push_back ({ { "label", "pm.request.url.port" }, { "kind", KIND_FIELD },
@@ -389,7 +390,9 @@ nlohmann::json get_script_completions () {
     { "documentation",
     "The path as decoded segments: \"/v2/users\" is [\"v2\", \"users\"]. Each "
     "segment is decoded on its own, so an encoded slash stays inside the "
-    "segment it belongs to. Use getPath() for the joined form." },
+    "segment it belongs to. Use getPath() for the joined form.\n\nEditable in "
+    "a pre-request script - push, splice, index assignment and replacing the "
+    "whole array all reach the URL that is sent." },
     { "sortText", "2_pm_request_url_path" } });
 
     completions.push_back ({ { "label", "pm.request.url.length" }, { "kind", KIND_FIELD },
@@ -408,10 +411,10 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.request.url.query" }, { "kind", KIND_FIELD },
     { "insertText", "pm.request.url.query" }, { "detail", "Url query object" },
     { "documentation",
-    "The query parameters, with Postman's PropertyList reads over them: "
-    "get(name), has(name), all(), toObject() and count(). Values are the "
-    "wire bytes, not decoded - a signature has to canonicalize what was "
-    "sent." },
+    "The query parameters, with Postman's PropertyList reads over them - "
+    "get(name), has(name), all(), toObject(), count() - and its writers: "
+    "add, upsert, remove, clear. Values are the wire bytes, not decoded - a "
+    "signature has to canonicalize what was sent." },
     { "sortText", "2_pm_request_url_query" } });
 
     completions.push_back ({ { "label", "pm.request.url.query.get" },
@@ -455,6 +458,42 @@ nlohmann::json get_script_completions () {
     { "detail", "pm.request.url.query.count(): number" },
     { "documentation", "How many parameters the query carries, counting duplicates separately." },
     { "sortText", "3_pm_request_url_query_count" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.add" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.url.query.add({ key: \"${1:trace}\", value: ${2:id} })" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.query.add(param: { key: string, value?: string | number | boolean | null }): void" },
+    { "documentation",
+    "Append a parameter, even when the name is already there - a query may "
+    "repeat a name, which is why all() exists. Omit value for a bare "
+    "\"?flag\". Use upsert to replace instead of appending." },
+    { "sortText", "3_pm_request_url_query_add" } });
+
+    completions.push_back (
+    { { "label", "pm.request.url.query.upsert" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.url.query.upsert({ key: \"${1:page}\", value: ${2:n} })" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.query.upsert(param: { key: string, value?: string | number | boolean | null }): void" },
+    { "documentation",
+    "Replace the first parameter of that name, keeping its position in the "
+    "query, or append it when there is none. Position is kept because a "
+    "signature over the query changes shape if a parameter moves." },
+    { "sortText", "3_pm_request_url_query_upsert" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.remove" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.remove(\"${1:page}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.query.remove(name: string): void" },
+    { "documentation",
+    "Remove every parameter of that name, not just the first. A name that is "
+    "not there is a no-op, the same rule pm.request.headers.remove follows." },
+    { "sortText", "3_pm_request_url_query_remove" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.clear" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.clear()" },
+    { "detail", "pm.request.url.query.clear(): void" },
+    { "documentation", "Drop every query parameter. The URL loses its \"?\" with them." },
+    { "sortText", "3_pm_request_url_query_clear" } });
 
     completions.push_back ({ { "label", "pm.request.url.getHost" },
     { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.getHost()" },

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -351,11 +351,170 @@ nlohmann::json get_script_completions () {
     { "sortText", "0_pm_request" } });
 
     completions.push_back ({ { "label", "pm.request.url" }, { "kind", KIND_FIELD },
-    { "insertText", "pm.request.url" }, { "detail", "string (writable pre-request)" },
+    { "insertText", "pm.request.url" }, { "detail", "string & object (writable pre-request)" },
     { "documentation",
-    "The full request URL. Assign to retarget the request before it is sent - "
-    "must be a non-empty string. {{variables}} are already resolved here." },
+    "The full request URL, as Postman's Url object: protocol, host, port, "
+    "path, query and hash, plus getHost(), getPath(), getQueryString() and "
+    "toString(). {{variables}} are already resolved here.\n\nIt still behaves "
+    "as the string it used to be - concatenation, template literals, ==, the "
+    "String methods and .length all give the full URL - so `===` and `typeof` "
+    "are the two things that changed. Assign a string to retarget "
+    "the request before it is sent, or call url.update(...); either way it "
+    "must be non-empty." },
     { "sortText", "1_pm_request_url" } });
+
+    completions.push_back ({ { "label", "pm.request.url.protocol" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.protocol" }, { "detail", "string" },
+    { "documentation",
+    "The scheme with no trailing colon (\"https\"). Empty when the URL "
+    "cannot be parsed." },
+    { "sortText", "2_pm_request_url_protocol" } });
+
+    completions.push_back ({ { "label", "pm.request.url.host" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.host" }, { "detail", "string[]" },
+    { "documentation",
+    "The host split on dots, as Postman presents it: \"api.example.com\" is "
+    "[\"api\", \"example\", \"com\"]. Use getHost() for the joined form." },
+    { "sortText", "2_pm_request_url_host" } });
+
+    completions.push_back ({ { "label", "pm.request.url.port" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.port" }, { "detail", "string" },
+    { "documentation",
+    "The port the URL states, as a string. Empty when it states none - a "
+    "scheme's default port is never filled in." },
+    { "sortText", "2_pm_request_url_port" } });
+
+    completions.push_back ({ { "label", "pm.request.url.path" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.path" }, { "detail", "string[]" },
+    { "documentation",
+    "The path as decoded segments: \"/v2/users\" is [\"v2\", \"users\"]. Each "
+    "segment is decoded on its own, so an encoded slash stays inside the "
+    "segment it belongs to. Use getPath() for the joined form." },
+    { "sortText", "2_pm_request_url_path" } });
+
+    completions.push_back ({ { "label", "pm.request.url.length" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.length" }, { "detail", "number" },
+    { "documentation",
+    "The length of the whole URL string - defined on the object rather than "
+    "inherited, so it is the URL's own length and not the 0 that String's "
+    "prototype would have answered." },
+    { "sortText", "2_pm_request_url_length" } });
+
+    completions.push_back ({ { "label", "pm.request.url.hash" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.hash" }, { "detail", "string" },
+    { "documentation", "The fragment with no leading #. Empty when there is none." },
+    { "sortText", "2_pm_request_url_hash" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.url.query" }, { "detail", "Url query object" },
+    { "documentation",
+    "The query parameters, with Postman's PropertyList reads over them: "
+    "get(name), has(name), all(), toObject() and count(). Values are the "
+    "wire bytes, not decoded - a signature has to canonicalize what was "
+    "sent." },
+    { "sortText", "2_pm_request_url_query" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.get" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.get(\"${1:page}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.query.get(name: string): string | null" },
+    { "documentation",
+    "The first value of that parameter, or null when the name is absent or "
+    "carries no value (\"?flag\"). First rather than last, matching "
+    "Postman's PropertyList - all() is the view that keeps duplicates." },
+    { "sortText", "3_pm_request_url_query_get" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.has" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.has(\"${1:page}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.query.has(name: string): boolean" },
+    { "documentation",
+    "Whether the query carries that parameter at all, including a bare "
+    "\"?flag\" that has no value." },
+    { "sortText", "3_pm_request_url_query_has" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.all" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.all()" },
+    { "detail", "pm.request.url.query.all(): { key: string, value: string | null }[]" },
+    { "documentation",
+    "Every parameter as { key, value }, in wire order, duplicates kept - the "
+    "view a canonical query string is built from. A parameter with no value "
+    "has value null." },
+    { "sortText", "3_pm_request_url_query_all" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.toObject()" },
+    { "detail", "pm.request.url.query.toObject(): { [key: string]: string | null }" },
+    { "documentation",
+    "The query as a plain { name: value } object, last wins on a repeated "
+    "name. Use all() when duplicates matter." },
+    { "sortText", "3_pm_request_url_query_toObject" } });
+
+    completions.push_back ({ { "label", "pm.request.url.query.count" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.query.count()" },
+    { "detail", "pm.request.url.query.count(): number" },
+    { "documentation", "How many parameters the query carries, counting duplicates separately." },
+    { "sortText", "3_pm_request_url_query_count" } });
+
+    completions.push_back ({ { "label", "pm.request.url.getHost" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.getHost()" },
+    { "detail", "pm.request.url.getHost(): string" },
+    { "documentation", "The host as one string - the segments of host joined by dots." },
+    { "sortText", "2_pm_request_url_getHost" } });
+
+    completions.push_back ({ { "label", "pm.request.url.getPath" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.getPath()" },
+    { "detail", "pm.request.url.getPath(): string" },
+    { "documentation",
+    "The decoded path as one string, leading slash included (\"/v2/users\"). "
+    "A URL with no path answers \"/\"." },
+    { "sortText", "2_pm_request_url_getPath" } });
+
+    completions.push_back ({ { "label", "pm.request.url.getQueryString" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.getQueryString()" },
+    { "detail", "pm.request.url.getQueryString(): string" },
+    { "documentation",
+    "The query exactly as it appears on the wire, with no leading ?. Empty "
+    "when the URL carries none." },
+    { "sortText", "2_pm_request_url_getQueryString" } });
+
+    completions.push_back ({ { "label", "pm.request.url.toString" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.toString()" },
+    { "detail", "pm.request.url.toString(): string" },
+    { "documentation",
+    "The whole URL as a string. The same answer concatenation, a template "
+    "literal and JSON.stringify already give, spelled out for the one place "
+    "that needs a real string - strict equality." },
+    { "sortText", "2_pm_request_url_toString" } });
+
+    // `valueOf` and `toJSON` are the same answer toString gives - offered
+    // because the runtime binds them, and a bound member the list never names
+    // is one no user can discover in the editor.
+    completions.push_back ({ { "label", "pm.request.url.valueOf" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.valueOf()" },
+    { "detail", "pm.request.url.valueOf(): string" },
+    { "documentation",
+    "The whole URL as a string - what == and arithmetic-style coercion use, "
+    "and the same answer toString() gives." },
+    { "sortText", "2_pm_request_url_valueOf" } });
+
+    completions.push_back ({ { "label", "pm.request.url.toJSON" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.url.toJSON()" },
+    { "detail", "pm.request.url.toJSON(): string" },
+    { "documentation",
+    "The whole URL as a string, which is why JSON.stringify embeds the URL "
+    "rather than an object dump." },
+    { "sortText", "2_pm_request_url_toJSON" } });
+
+    completions.push_back ({ { "label", "pm.request.url.update" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.url.update(\"${1:https://api.example.com/v2/users}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.url.update(url: string): void" },
+    { "documentation",
+    "Retarget the request, Postman's spelling of pm.request.url = '...'. "
+    "Both re-parse the whole URL in place; editing a single member (pushing "
+    "to path, changing a query entry) is not supported." },
+    { "sortText", "2_pm_request_url_update" } });
 
     completions.push_back ({ { "label", "pm.request.method" }, { "kind", KIND_FIELD },
     { "insertText", "pm.request.method" }, { "detail", "string (writable pre-request)" },

--- a/engine/src/http/url_parts.cpp
+++ b/engine/src/http/url_parts.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/http/url_parts.hpp"
+
+#include <curl/curl.h>
+
+namespace vayu::http {
+
+namespace {
+
+/// One field off a parsed handle. `nullopt` is libcurl saying the URL states
+/// none of that field - an absent port and an absent fragment are both normal.
+std::optional<std::string> url_field (CURLU* handle, CURLUPart part) {
+    char* value = nullptr;
+    if (curl_url_get (handle, part, &value, 0) != CURLUE_OK) {
+        return std::nullopt;
+    }
+    std::string out (value);
+    curl_free (value);
+    return out;
+}
+
+/// libcurl's percent-decoder, applied to one path segment. The handle argument
+/// is documented as unused, so this needs no easy handle - the same reason
+/// `form_body.cpp` calls it with `nullptr`. The decoded length comes back
+/// out-of-band because a decoded segment may contain NUL bytes.
+std::string percent_decode (const std::string& value) {
+    int decoded_length = 0;
+    char* unescaped    = curl_easy_unescape (
+    nullptr, value.c_str (), static_cast<int> (value.size ()), &decoded_length);
+    if (!unescaped) {
+        return value;
+    }
+    std::string out (unescaped, static_cast<size_t> (decoded_length));
+    curl_free (unescaped);
+    return out;
+}
+
+/// Split a raw path on `/`, dropping the empty segment the leading slash makes
+/// and decoding each of the rest on its own. Segment-at-a-time decoding is the
+/// point: decoding the whole path first would turn an encoded `%2F` into a
+/// separator and invent a segment that was never there.
+std::vector<std::string> split_path (std::string_view raw) {
+    std::vector<std::string> segments;
+    if (raw.empty ()) {
+        return segments;
+    }
+    if (raw.front () == '/') {
+        raw.remove_prefix (1);
+    }
+    while (true) {
+        const size_t slash = raw.find ('/');
+        if (slash == std::string_view::npos) {
+            segments.push_back (percent_decode (std::string (raw)));
+            break;
+        }
+        segments.push_back (percent_decode (std::string (raw.substr (0, slash))));
+        raw.remove_prefix (slash + 1);
+    }
+    return segments;
+}
+
+} // namespace
+
+std::vector<UrlQueryParam> parse_query_params (std::string_view query) {
+    std::vector<UrlQueryParam> params;
+    while (!query.empty ()) {
+        const size_t amp = query.find ('&');
+        const std::string_view pair =
+        amp == std::string_view::npos ? query : query.substr (0, amp);
+        if (!pair.empty ()) {
+            const size_t equals = pair.find ('=');
+            if (equals == std::string_view::npos) {
+                params.push_back ({ std::string (pair), std::nullopt });
+            } else {
+                params.push_back ({ std::string (pair.substr (0, equals)),
+                std::string (pair.substr (equals + 1)) });
+            }
+        }
+        if (amp == std::string_view::npos) {
+            break;
+        }
+        query.remove_prefix (amp + 1);
+    }
+    return params;
+}
+
+std::string join_host (const std::vector<std::string>& host) {
+    std::string out;
+    for (const auto& segment : host) {
+        if (!out.empty ()) {
+            out += '.';
+        }
+        out += segment;
+    }
+    return out;
+}
+
+std::string join_path (const std::vector<std::string>& path) {
+    std::string out;
+    for (const auto& segment : path) {
+        out += '/';
+        out += segment;
+    }
+    return out;
+}
+
+UrlParts parse_url_parts (const std::string& url) {
+    UrlParts parts;
+    CURLU* handle = curl_url ();
+    if (!handle) {
+        return parts;
+    }
+    // `CURLU_NON_SUPPORT_SCHEME` so a `ws://` or `grpc://` URL still splits -
+    // this parser answers "what are the pieces", never "can libcurl transfer
+    // it". No guess flag: inventing a scheme the string does not carry would
+    // make `protocol` report something the URL never said.
+    const bool ok = curl_url_set (handle, CURLUPART_URL, url.c_str (),
+                    CURLU_NON_SUPPORT_SCHEME) == CURLUE_OK;
+    if (ok) {
+        parts.parsed = true;
+        if (auto scheme = url_field (handle, CURLUPART_SCHEME)) {
+            parts.protocol = std::move (*scheme);
+        }
+        if (auto host = url_field (handle, CURLUPART_HOST)) {
+            // A host is split on `.` only when it has one to split on; an IPv6
+            // literal comes back bracketed and is one segment either way.
+            std::string_view remaining (*host);
+            while (true) {
+                const size_t dot = remaining.find ('.');
+                if (dot == std::string_view::npos) {
+                    parts.host.emplace_back (remaining);
+                    break;
+                }
+                parts.host.emplace_back (remaining.substr (0, dot));
+                remaining.remove_prefix (dot + 1);
+            }
+        }
+        if (auto port = url_field (handle, CURLUPART_PORT)) {
+            parts.port = std::move (*port);
+        }
+        if (auto path = url_field (handle, CURLUPART_PATH)) {
+            parts.path = split_path (*path);
+        }
+        if (auto query = url_field (handle, CURLUPART_QUERY)) {
+            parts.query        = std::move (*query);
+            parts.query_params = parse_query_params (parts.query);
+        }
+        if (auto fragment = url_field (handle, CURLUPART_FRAGMENT)) {
+            parts.hash = std::move (*fragment);
+        }
+    }
+    curl_url_cleanup (handle);
+    return parts;
+}
+
+} // namespace vayu::http

--- a/engine/src/http/url_parts.cpp
+++ b/engine/src/http/url_parts.cpp
@@ -41,6 +41,22 @@ std::string percent_decode (const std::string& value) {
     return out;
 }
 
+/// libcurl's percent-encoder, the inverse of the decode above and the same
+/// pure-function call `form_body.cpp` makes. It encodes everything outside the
+/// unreserved set, which is wider than a path segment strictly needs - an
+/// encoded `:` or `@` is still the same path, and over-encoding cannot change
+/// what the URL means the way under-encoding can.
+std::string percent_encode (const std::string& value) {
+    char* escaped =
+    curl_easy_escape (nullptr, value.c_str (), static_cast<int> (value.size ()));
+    if (!escaped) {
+        return value;
+    }
+    std::string out (escaped);
+    curl_free (escaped);
+    return out;
+}
+
 /// Split a raw path on `/`, dropping the empty segment the leading slash makes
 /// and decoding each of the rest on its own. Segment-at-a-time decoding is the
 /// point: decoding the whole path first would turn an encoded `%2F` into a
@@ -88,6 +104,51 @@ std::vector<UrlQueryParam> parse_query_params (std::string_view query) {
         query.remove_prefix (amp + 1);
     }
     return params;
+}
+
+std::string compose_query (const std::vector<UrlQueryParam>& params) {
+    std::string out;
+    for (const auto& param : params) {
+        if (!out.empty ()) {
+            out += '&';
+        }
+        out += param.key;
+        if (param.value) {
+            out += '=';
+            out += *param.value;
+        }
+    }
+    return out;
+}
+
+std::string compose_url (const UrlParts& parts) {
+    if (!parts.parsed) {
+        return {};
+    }
+    std::string out = parts.protocol;
+    out += "://";
+    out += join_host (parts.host);
+    if (!parts.port.empty ()) {
+        out += ':';
+        out += parts.port;
+    }
+    // Encoded per segment, undoing `split_path`'s per-segment decode - so a
+    // segment an edit put a `/` into stays one segment rather than becoming
+    // two, which is the same rule read the other way round.
+    for (const auto& segment : parts.path) {
+        out += '/';
+        out += percent_encode (segment);
+    }
+    const std::string query = compose_query (parts.query_params);
+    if (!query.empty ()) {
+        out += '?';
+        out += query;
+    }
+    if (!parts.hash.empty ()) {
+        out += '#';
+        out += parts.hash;
+    }
+    return out;
 }
 
 std::string join_host (const std::vector<std::string>& host) {

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -174,6 +174,28 @@ std::optional<int64_t> remaining_script_budget_ms (JSContext* ctx) {
     .count ();
 }
 
+// Frees a borrowed JSValue on every exit. QuickJS ships no such helper, and the
+// surfaces that read a handful of properties and refuse on most of them - the
+// pm.request write-back, pm.sendRequest's options object, the Url query
+// writers - each have several early returns to leak from.
+class ScopedValue {
+    public:
+    ScopedValue (JSContext* ctx, JSValue value) : ctx_ (ctx), value_ (value) {
+    }
+    ~ScopedValue () {
+        JS_FreeValue (ctx_, value_);
+    }
+    ScopedValue (const ScopedValue&)            = delete;
+    ScopedValue& operator= (const ScopedValue&) = delete;
+    [[nodiscard]] JSValue get () const {
+        return value_;
+    }
+
+    private:
+    JSContext* ctx_;
+    JSValue value_;
+};
+
 // Convert JS string to C++ string
 std::string js_to_string (JSContext* ctx, JSValue val) {
     const char* str = JS_ToCString (ctx, val);
@@ -365,7 +387,105 @@ struct RequestUrlState {
     std::string text;
     vayu::http::UrlParts parts;
     bool built = false;
+    // A member was written to, so `parts` is ahead of `text` (issue #1040).
+    // The composition is deferred to whoever needs the whole URL next, and -
+    // more to the point - **never happens at all** for a URL nobody edited,
+    // which is what keeps `getQueryString()` byte-exact against the wire and
+    // keeps a read-only script's request identical to the one it was handed.
+    bool dirty = false;
 };
+
+// Defined with the header accessors below, and needed here: naming a rejected
+// value the way the script author wrote it is the same courtesy on a URL
+// member as on a header.
+const char* js_type_name (JSContext* ctx, JSValueConst value);
+
+/**
+ * @brief Bring the URL up to date with whatever the script did to its members,
+ *        and answer the whole URL (issue #1040).
+ *
+ * Two kinds of edit reach here by two routes. `query.add` and the
+ * `protocol`/`port`/`hash` setters are methods, so they update the parts and
+ * set `dirty` themselves. `path` and `host` are plain JS arrays a script
+ * mutates in place, and nothing tells us when that happened - so they are
+ * **read back** here and compared, which is the same rule
+ * `apply_pm_request_writeback` already follows for `pm.request.headers`: the
+ * object the script holds is what is sent, read at the moment it is needed.
+ *
+ * Comparing rather than assuming is what keeps the promise that matters: a
+ * script that only *read* the URL leaves `dirty` false, nothing is composed,
+ * and the request goes out as the exact bytes it arrived as - which is what
+ * `getQueryString()` being byte-exact against the wire depends on.
+ *
+ * @return why the members could not be read, or nullopt when @p state is
+ *         current. Never throws: three of the four callers want a JS
+ *         exception and the fourth wants a write-back reason, so the message
+ *         is handed back rather than raised.
+ */
+std::optional<std::string>
+refresh_url_from_members (JSContext* ctx, JSValueConst url, RequestUrlState& state) {
+    if (state.built) {
+        struct SegmentList {
+            const char* member;
+            std::vector<std::string>* parts;
+        };
+        const std::array<SegmentList, 2> LISTS = { {
+        { "path", &state.parts.path },
+        { "host", &state.parts.host },
+        } };
+
+        for (const auto& [member, target] : LISTS) {
+            ScopedValue list (ctx, JS_GetPropertyStr (ctx, url, member));
+            if (!JS_IsArray (list.get ())) {
+                return "pm.request.url." + std::string (member) + " must be an array of " +
+                "strings, got " + std::string (js_type_name (ctx, list.get ()));
+            }
+            int64_t length = 0;
+            if (JS_GetLength (ctx, list.get (), &length) < 0) {
+                JS_FreeValue (ctx, JS_GetException (ctx));
+                return "pm.request.url." + std::string (member) + " could not be read";
+            }
+            std::vector<std::string> segments;
+            segments.reserve (static_cast<size_t> (length < 0 ? 0 : length));
+            for (int64_t i = 0; i < length; i++) {
+                ScopedValue element (ctx, JS_GetPropertyInt64 (ctx, list.get (), i));
+                // A number is taken - pushing an id onto a path is the obvious
+                // case. An object, an array or a hole is refused rather than
+                // reaching the wire as "[object Object]" or "undefined".
+                if (!JS_IsString (element.get ()) && !JS_IsNumber (element.get ())) {
+                    return "pm.request.url." + std::string (member) + " takes strings, got " +
+                    std::string (js_type_name (ctx, element.get ())) +
+                    " at index " + std::to_string (i);
+                }
+                segments.push_back (js_to_string (ctx, element.get ()));
+            }
+            if (segments != *target) {
+                if (!state.parts.parsed) {
+                    return "pm.request.url." + std::string (member) + " cannot be edited: \"" +
+                    state.text + "\" could not be parsed as a URL. Assign a whole URL instead.";
+                }
+                *target     = std::move (segments);
+                state.dirty = true;
+            }
+        }
+    }
+
+    if (state.dirty) {
+        state.parts.query = vayu::http::compose_query (state.parts.query_params);
+        state.text  = vayu::http::compose_url (state.parts);
+        state.dirty = false;
+    }
+    return std::nullopt;
+}
+
+/// The whole URL for a caller with no way to report a bad member - the parts
+/// stay as they were and the text is whatever was last composed, which is the
+/// URL the write-back will refuse by name a moment later.
+const std::string&
+request_url_current_text (JSContext* ctx, JSValueConst url, RequestUrlState& state) {
+    (void)refresh_url_from_members (ctx, url, state);
+    return state.text;
+}
 
 JSClassID request_url_class_id = 0;
 
@@ -402,11 +522,23 @@ RequestUrlState* request_url_state (JSValueConst value) {
  * then become the string `[object Object]` and reach the wire, which is exactly
  * the silent-wrong-request class this program exists to close.
  */
-std::optional<std::string> script_url_text (JSContext* ctx, JSValueConst value) {
+std::optional<std::string>
+script_url_text (JSContext* ctx, JSValueConst value, std::string* out_error = nullptr) {
     if (JS_IsString (value)) {
         return js_to_string (ctx, value);
     }
     if (auto* state = request_url_state (value)) {
+        // A member the script left in a state the URL cannot be built from is
+        // reported by name, through @p out_error where the caller has one -
+        // "pm.request.url.path takes strings, got object at index 2" says more
+        // than "this is not a URL", and the caller that reports it is the
+        // write-back, which is where every other pm.request refusal surfaces.
+        if (auto reason = refresh_url_from_members (ctx, value, *state)) {
+            if (out_error != nullptr) {
+                *out_error = std::move (*reason);
+            }
+            return std::nullopt;
+        }
         return state->text;
     }
     return std::nullopt;
@@ -1056,13 +1188,14 @@ JSValue expect_include (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     // is the idiom in this repo's own docs and tests, and #991 turned its
     // target from a string into an object - a verdict that silently flipped to
     // failing is the worst thing an assertion can do.
-    const RequestUrlState* url = request_url_state (state->actual);
+    RequestUrlState* url = request_url_state (state->actual);
 
     if (JS_IsString (state->actual) || url != nullptr) {
-        const std::string str =
-        url != nullptr ? url->text : js_to_string (ctx, state->actual);
-        std::string substr = js_to_string (ctx, argv[0]);
-        includes           = str.find (substr) != std::string::npos;
+        const std::string str = url != nullptr ?
+        request_url_current_text (ctx, state->actual, *url) :
+        js_to_string (ctx, state->actual);
+        std::string substr    = js_to_string (ctx, argv[0]);
+        includes              = str.find (substr) != std::string::npos;
     } else if (JS_IsArray (state->actual)) {
         JSValue length = JS_GetPropertyStr (ctx, state->actual, "length");
         uint32_t len;
@@ -3487,6 +3620,15 @@ RequestUrlState* url_state_of_this (JSContext* ctx, JSValueConst this_val, const
     if (!state->built) {
         build_request_url_members (ctx, this_val, *state);
     }
+    // And up to date with the arrays a script may have mutated since. Without
+    // this, `path.push(...)` followed by `getPath()` in the same script reads
+    // the parts as they were parsed and answers the pre-edit path - the reads
+    // have to follow the writes, or a script that edits and then signs would
+    // sign a URL it is not sending.
+    if (auto reason = refresh_url_from_members (ctx, this_val, *state)) {
+        JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+        return nullptr;
+    }
     return state;
 }
 
@@ -3571,6 +3713,13 @@ RequestUrlState* url_state_of_query (JSContext* ctx, JSValue* func_data, const c
     auto* state = request_url_state (func_data[0]);
     if (!state) {
         JS_ThrowInternalError (ctx, "pm.request.url.query.%s lost its URL", member);
+        return nullptr;
+    }
+    // Same reason the url's own methods refresh: a `path.push` before a
+    // `query.get` must not leave the two members describing different URLs.
+    if (auto reason = refresh_url_from_members (ctx, func_data[0], *state)) {
+        JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+        return nullptr;
     }
     return state;
 }
@@ -3703,6 +3852,163 @@ JSValue* func_data) {
     return JS_NewInt32 (ctx, static_cast<int32_t> (state->parts.query_params.size ()));
 }
 
+/**
+ * @brief Refuse a member edit on a URL that has no members (issue #1040).
+ *
+ * `parse_url_parts` leaves every part empty for a URL libcurl cannot read, so a
+ * write there would compose a plausible URL out of nothing - `://` and whatever
+ * was pushed - and send it. There is no honest edit to make, so it is an error
+ * rather than a no-op.
+ */
+bool require_parsed_url (JSContext* ctx, const RequestUrlState& state, const char* member) {
+    if (state.parts.parsed) {
+        return true;
+    }
+    JS_ThrowTypeError (ctx,
+    "pm.request.url.%s cannot be edited: \"%s\" could not be parsed as a URL. "
+    "Assign a whole URL instead.",
+    member, state.text.c_str ());
+    return false;
+}
+
+/// A member write happened, so the parts are ahead of the text. What follows
+/// from that - recomposing the raw query string and the URL - is
+/// `refresh_url_from_members`' job, at the moment someone needs the whole URL.
+void mark_url_edited (RequestUrlState& state) {
+    state.dirty = true;
+}
+
+/// One `{key, value}` argument of a query writer, read the way `all()` hands
+/// them back. A missing `value` is a bare key, which is the `?flag` form.
+bool read_query_param_arg (JSContext* ctx,
+JSValueConst arg,
+const char* member,
+vayu::http::UrlQueryParam& out) {
+    if (!JS_IsObject (arg) || JS_IsArray (arg) || JS_IsFunction (ctx, arg)) {
+        JS_ThrowTypeError (ctx, "pm.request.url.query.%s needs a { key, value } object, got %s",
+        member, js_type_name (ctx, arg));
+        return false;
+    }
+    ScopedValue key (ctx, JS_GetPropertyStr (ctx, arg, "key"));
+    if (!JS_IsString (key.get ())) {
+        JS_ThrowTypeError (ctx, "pm.request.url.query.%s needs a string key, got %s",
+        member, js_type_name (ctx, key.get ()));
+        return false;
+    }
+    out.key = js_to_string (ctx, key.get ());
+    if (out.key.empty ()) {
+        JS_ThrowTypeError (ctx, "pm.request.url.query.%s needs a non-empty key", member);
+        return false;
+    }
+    ScopedValue value (ctx, JS_GetPropertyStr (ctx, arg, "value"));
+    if (JS_IsUndefined (value.get ()) || JS_IsNull (value.get ())) {
+        out.value = std::nullopt; // a bare `?key`
+        return true;
+    }
+    if (!JS_IsString (value.get ()) && !JS_IsNumber (value.get ()) &&
+    !JS_IsBool (value.get ())) {
+        JS_ThrowTypeError (ctx, "pm.request.url.query.%s value must be a string, number, boolean or null, got %s",
+        member, js_type_name (ctx, value.get ()));
+        return false;
+    }
+    out.value = js_to_string (ctx, value.get ());
+    return true;
+}
+
+/// `add` appends even when the key is already there - a query may repeat a key,
+/// and `all()` exists because of it. `upsert` is the "one of these" spelling:
+/// it replaces the first match in place, keeping wire position, and appends
+/// when there is none.
+enum QueryWriter : int { QUERY_ADD, QUERY_UPSERT };
+
+JSValue js_url_query_add (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    const char* member = magic == QUERY_ADD ? "add" : "upsert";
+    auto* state        = url_state_of_query (ctx, func_data, member);
+    if (!state || !require_parsed_url (ctx, *state, "query")) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1) {
+        return JS_ThrowTypeError (
+        ctx, "pm.request.url.query.%s needs a { key, value } object", member);
+    }
+    vayu::http::UrlQueryParam param;
+    if (!read_query_param_arg (ctx, argv[0], member, param)) {
+        return JS_EXCEPTION;
+    }
+    auto& params = state->parts.query_params;
+    if (magic == QUERY_UPSERT) {
+        for (auto& existing : params) {
+            if (existing.key == param.key) {
+                existing.value = std::move (param.value);
+                mark_url_edited (*state);
+                return JS_UNDEFINED;
+            }
+        }
+    }
+    params.push_back (std::move (param));
+    mark_url_edited (*state);
+    return JS_UNDEFINED;
+}
+
+/// `remove(name)` takes **every** parameter of that name, not the first: a
+/// caller removing `page` and getting one of two back has removed nothing they
+/// can observe, and would have to loop to find that out.
+JSValue js_url_query_remove (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)magic;
+    auto* state = url_state_of_query (ctx, func_data, "remove");
+    if (!state || !require_parsed_url (ctx, *state, "query")) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1 || !JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx, "pm.request.url.query.remove needs a name string, got %s",
+        argc < 1 ? "no argument" : js_type_name (ctx, argv[0]));
+    }
+    const std::string name = js_to_string (ctx, argv[0]);
+    auto& params           = state->parts.query_params;
+    const size_t before    = params.size ();
+    std::erase_if (params,
+    [&name] (const vayu::http::UrlQueryParam& p) { return p.key == name; });
+    // Removing a name that is not there is a no-op rather than an error, the
+    // same rule `pm.request.headers.remove` follows.
+    if (params.size () != before) {
+        mark_url_edited (*state);
+    }
+    return JS_UNDEFINED;
+}
+
+JSValue js_url_query_clear (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    auto* state = url_state_of_query (ctx, func_data, "clear");
+    if (!state || !require_parsed_url (ctx, *state, "query")) {
+        return JS_EXCEPTION;
+    }
+    if (!state->parts.query_params.empty ()) {
+        state->parts.query_params.clear ();
+        mark_url_edited (*state);
+    }
+    return JS_UNDEFINED;
+}
+
 /// The `query` sub-object: the params as an array plus the PropertyList reads
 /// over them, each bound to @p url so the two can never describe different
 /// URLs.
@@ -3715,12 +4021,16 @@ JSValue build_query_object (JSContext* ctx, JSValue url, const RequestUrlState& 
         int length;
         int magic;
     };
-    static constexpr std::array<QueryMethod, 5> METHODS = {
+    static constexpr std::array<QueryMethod, 9> METHODS = {
         QueryMethod{ "get", js_url_query_get, 1, 0 },
         QueryMethod{ "has", js_url_query_get, 1, 1 },
         QueryMethod{ "all", js_url_query_all, 0, 0 },
         QueryMethod{ "toObject", js_url_query_to_object, 0, 0 },
         QueryMethod{ "count", js_url_query_count, 0, 0 },
+        QueryMethod{ "add", js_url_query_add, 1, QUERY_ADD },
+        QueryMethod{ "upsert", js_url_query_add, 1, QUERY_UPSERT },
+        QueryMethod{ "remove", js_url_query_remove, 1, 0 },
+        QueryMethod{ "clear", js_url_query_clear, 0, 0 },
     };
     for (const auto& method : METHODS) {
         JS_SetPropertyStr (ctx, query, method.name,
@@ -3758,9 +4068,105 @@ JSValue string_array (JSContext* ctx, const std::vector<std::string>& values) {
  * script reading the whole URL is unaffected, while a script reading parts of
  * an unparseable URL gets nothing rather than a plausible half.
  */
+/// Which single-string part an accessor reads and writes.
+enum UrlStringPart : int { URL_PART_PROTOCOL, URL_PART_PORT, URL_PART_HASH };
+
+const char* url_string_part_name (int magic) {
+    return magic == URL_PART_PROTOCOL ? "protocol" :
+    magic == URL_PART_PORT            ? "port" :
+                                        "hash";
+}
+
+std::string& url_string_part (RequestUrlState& state, int magic) {
+    return magic == URL_PART_PROTOCOL ? state.parts.protocol :
+    magic == URL_PART_PORT            ? state.parts.port :
+                                        state.parts.hash;
+}
+
+JSValue js_url_string_part_get (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto* state = request_url_state (func_data[0]);
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "pm.request.url part lost its URL");
+    }
+    const std::string& value = url_string_part (*state, magic);
+    return JS_NewStringLen (ctx, value.data (), value.size ());
+}
+
+/**
+ * `url.protocol = 'http'`, `url.port = '8443'`, `url.hash = 'top'`.
+ *
+ * Accessors rather than plain data properties for the reason the segment lists
+ * are proxies: a writable data property would take the assignment and reach
+ * nothing. There is no read-only-member case to preserve here - a test script's
+ * pm.request is a record nothing writes back, which is a property of the hook,
+ * not of the member.
+ */
+JSValue js_url_string_part_set (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    auto* state = request_url_state (func_data[0]);
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "pm.request.url part lost its URL");
+    }
+    const char* member = url_string_part_name (magic);
+    if (!require_parsed_url (ctx, *state, member)) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1 || (!JS_IsString (argv[0]) && !JS_IsNumber (argv[0]))) {
+        return JS_ThrowTypeError (ctx, "pm.request.url.%s must be assigned a string, got %s",
+        member, argc < 1 ? "no value" : js_type_name (ctx, argv[0]));
+    }
+    std::string value = js_to_string (ctx, argv[0]);
+    if (magic == URL_PART_PROTOCOL && value.empty ()) {
+        // Every other part may legitimately be cleared; a URL with no scheme is
+        // one `parse_url_parts` would refuse to read back.
+        return JS_ThrowTypeError (ctx, "pm.request.url.protocol must not be empty");
+    }
+    url_string_part (*state, magic) = std::move (value);
+    mark_url_edited (*state);
+    return JS_UNDEFINED;
+}
+
+/// `url.length` - the current URL's length, and read-only. A setter that threw
+/// would be noise; one that silently accepted would be the defect this whole
+/// issue is about, so the property simply has no setter and an assignment is
+/// the ordinary JavaScript no-op for that.
+JSValue js_url_length_get (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    auto* state = request_url_state (func_data[0]);
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "pm.request.url lost its URL");
+    }
+    if (auto reason = refresh_url_from_members (ctx, func_data[0], *state)) {
+        return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+    }
+    return JS_NewInt64 (ctx, static_cast<int64_t> (state->text.size ()));
+}
+
 void build_request_url_members (JSContext* ctx, JSValue url, RequestUrlState& state) {
     state.parts = vayu::http::parse_url_parts (state.text);
     state.built = true;
+    state.dirty = false;
 
     // **Defined, not set.** The prototype here is `String.prototype`, which is
     // itself a String object holding "" - so it carries a non-writable own
@@ -3771,18 +4177,34 @@ void build_request_url_members (JSContext* ctx, JSValue url, RequestUrlState& st
     const auto define = [&] (const char* name, JSValue value) {
         JS_DefinePropertyValueStr (ctx, url, name, value, JS_PROP_C_W_E);
     };
-    const auto define_string = [&] (const char* name, const std::string& value) {
-        define (name, JS_NewStringLen (ctx, value.data (), value.size ()));
+    // The single-string parts are accessors so an assignment reaches the URL
+    // instead of replacing the property with a value nothing reads (#1040).
+    const auto define_accessor = [&] (const char* name, JSCFunctionData* getter,
+                                 JSCFunctionData* setter, int magic) {
+        JSAtom atom = JS_NewAtom (ctx, name);
+        JS_DefinePropertyGetSet (ctx, url, atom,
+        JS_NewCFunctionData (ctx, getter, 0, magic, 1, &url),
+        setter != nullptr ? JS_NewCFunctionData (ctx, setter, 1, magic, 1, &url) : JS_UNDEFINED,
+        JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE);
+        JS_FreeAtom (ctx, atom);
     };
-    define_string ("protocol", state.parts.protocol);
-    define_string ("port", state.parts.port);
-    define_string ("hash", state.parts.hash);
+    define_accessor ("protocol", js_url_string_part_get, js_url_string_part_set,
+    URL_PART_PROTOCOL);
+    define_accessor ("port", js_url_string_part_get, js_url_string_part_set, URL_PART_PORT);
+    define_accessor ("hash", js_url_string_part_get, js_url_string_part_set, URL_PART_HASH);
     // `length` is defined rather than left as one of the documented breaks,
     // because the alternative is not "absent": inherited from that same String
     // prototype it answers `0` - a plausible number for a URL that is not
     // empty, which is the silent-wrong-answer class this program exists to
     // close. One property, and `url.length` means what it always did.
-    define ("length", JS_NewInt64 (ctx, static_cast<int64_t> (state.text.size ())));
+    define_accessor ("length", js_url_length_get, nullptr, 0);
+    // Plain arrays, not accessors and not proxies: `pm.request.headers` is
+    // already the object the write-back *reads back*, and the same rule answers
+    // every spelling of a segment edit at once - push, splice, index
+    // assignment, a length truncation, or replacing the array outright. A
+    // proxy would have intercepted each write instead, and `JS_IsArray`
+    // answers on the class id, so `pm.expect(url.host).to.include(...)` would
+    // have stopped seeing an array at all. See `refresh_url_from_members`.
     define ("host", string_array (ctx, state.parts.host));
     define ("path", string_array (ctx, state.parts.path));
     define ("query", build_query_object (ctx, url, state));
@@ -4021,26 +4443,6 @@ void setup_pm_info (JSContext* ctx, JSValue pm) {
 // pm.request write-back (pre-request scripts)
 // ============================================================================
 
-// Frees a borrowed JSValue on every exit. The write-back below reads a dozen
-// properties and refuses on most of them, and QuickJS ships no such helper.
-class ScopedValue {
-    public:
-    ScopedValue (JSContext* ctx, JSValue value) : ctx_ (ctx), value_ (value) {
-    }
-    ~ScopedValue () {
-        JS_FreeValue (ctx_, value_);
-    }
-    ScopedValue (const ScopedValue&)            = delete;
-    ScopedValue& operator= (const ScopedValue&) = delete;
-    [[nodiscard]] JSValue get () const {
-        return value_;
-    }
-
-    private:
-    JSContext* ctx_;
-    JSValue value_;
-};
-
 // Read a header object into `out`, naming it @p label in every message it can
 // reject with. Two callers - the pm.request write-back and pm.sendRequest's
 // object header form - because the rules below (empty name, non-primitive
@@ -4154,10 +4556,13 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
     // string, which is what a script that replaced `pm.request` wholesale with
     // an object literal leaves there. Both are the URL; neither is a diff.
     ScopedValue js_url (ctx, JS_GetPropertyStr (ctx, js_request.get (), "url"));
-    auto url_text = script_url_text (ctx, js_url.get ());
+    std::string url_error;
+    auto url_text = script_url_text (ctx, js_url.get (), &url_error);
     if (!url_text) {
-        return "pm.request.url must be a string or a URL object, got " +
-        std::string (js_type_name (ctx, js_url.get ()));
+        return url_error.empty () ?
+        "pm.request.url must be a string or a URL object, got " +
+        std::string (js_type_name (ctx, js_url.get ())) :
+        url_error;
     }
     staged.url = std::move (*url_text);
     if (staged.url.empty ()) {

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -39,6 +39,7 @@
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/set_cookie.hpp"
 #include "vayu/http/status.hpp"
+#include "vayu/http/url_parts.hpp"
 #include "vayu/utils/encoding.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/sha256.hpp"
@@ -337,6 +338,78 @@ void setup_console (JSContext* ctx) {
 
     JS_SetPropertyStr (ctx, global, "console", console);
     JS_FreeValue (ctx, global);
+}
+
+// ============================================================================
+// pm.request.url - the identity half of Postman's Url object
+// ============================================================================
+
+/**
+ * @brief What `pm.request.url` is, behind the members a script reads.
+ *
+ * `pm.request.url` was a string primitive; issue #991 records the owner
+ * decision that Postman compatibility wins over keeping that shape, so it is
+ * now the `Url` object a lifted Postman script expects - `url.query.get(...)`,
+ * `url.getPath()`, `url.host` and the rest. The members are built in
+ * `build_request_url` further down; what lives up here is the *identity*, which
+ * three surfaces before that point need: the `pm.request` write-back, the jar
+ * methods and `pm.sendRequest` all had "is this a string?" as their entire
+ * type check, and each of them is documented as taking `pm.request.url`.
+ *
+ * `text` is authoritative and `parts` is derived from it. `built` says whether
+ * the JS members have been materialised yet: a script that never mentions the
+ * URL never pays for the parse, which is why the property is an accessor rather
+ * than a plain member (see `install_request_url`).
+ */
+struct RequestUrlState {
+    std::string text;
+    vayu::http::UrlParts parts;
+    bool built = false;
+};
+
+JSClassID request_url_class_id = 0;
+
+void request_url_finalizer (JSRuntime* rt, JSValue val) {
+    (void)rt;
+    delete static_cast<RequestUrlState*> (JS_GetOpaque (val, request_url_class_id));
+}
+
+// No gc_mark: the state holds C++ strings, never a JSValue, so it can be part
+// of no cycle the collector has to break.
+JSClassDef request_url_class = { .class_name = "Url",
+    .finalizer                               = request_url_finalizer,
+    .gc_mark                                 = nullptr,
+    .call                                    = nullptr,
+    .exotic                                  = nullptr };
+
+/// The state behind a Url object, or nullptr for anything else. A real class
+/// test rather than a marker property, so a script cannot forge one by naming
+/// a field the same thing.
+RequestUrlState* request_url_state (JSValueConst value) {
+    return static_cast<RequestUrlState*> (JS_GetOpaque (value, request_url_class_id));
+}
+
+/**
+ * @brief The URL a value carries, for the surfaces that used to require a
+ *        string and are documented as taking `pm.request.url`.
+ *
+ * A JS string is itself; a Url object is the string it was built from. Anything
+ * else is `nullopt` - the caller says so in its own words, because
+ * "pm.sendRequest was given a number" and "jar().set needs a URL" are different
+ * sentences about the same refusal.
+ *
+ * Deliberately *not* "any object, via toString": `pm.request.url = {}` would
+ * then become the string `[object Object]` and reach the wire, which is exactly
+ * the silent-wrong-request class this program exists to close.
+ */
+std::optional<std::string> script_url_text (JSContext* ctx, JSValueConst value) {
+    if (JS_IsString (value)) {
+        return js_to_string (ctx, value);
+    }
+    if (auto* state = request_url_state (value)) {
+        return state->text;
+    }
+    return std::nullopt;
 }
 
 // ============================================================================
@@ -978,8 +1051,16 @@ JSValue expect_include (JSContext* ctx, JSValueConst this_val, int argc, JSValue
 
     bool includes = false;
 
-    if (JS_IsString (state->actual)) {
-        std::string str    = js_to_string (ctx, state->actual);
+    // A Url object takes the substring branch, not the "neither string nor
+    // array" one that answers false. `pm.expect(pm.request.url).to.include(...)`
+    // is the idiom in this repo's own docs and tests, and #991 turned its
+    // target from a string into an object - a verdict that silently flipped to
+    // failing is the worst thing an assertion can do.
+    const RequestUrlState* url = request_url_state (state->actual);
+
+    if (JS_IsString (state->actual) || url != nullptr) {
+        const std::string str =
+        url != nullptr ? url->text : js_to_string (ctx, state->actual);
         std::string substr = js_to_string (ctx, argv[0]);
         includes           = str.find (substr) != std::string::npos;
     } else if (JS_IsArray (state->actual)) {
@@ -3381,6 +3462,468 @@ const Headers& script_request_header_view (const ContextData& data) {
     return data.request->headers;
 }
 
+// ============================================================================
+// pm.request.url - the Url object's members
+// ============================================================================
+
+void build_request_url_members (JSContext* ctx, JSValue url, RequestUrlState& state);
+
+// `this` is the Url object every one of these was reached through. A method
+// pulled off it and called bare has no state, which is a script error rather
+// than an engine one - the same rule the header methods follow.
+//
+// The parts are built here rather than assumed: today the only way a script can
+// hold this object is through the accessor, which builds - but `getHost()`
+// reading unbuilt parts would answer `""` for a real host, and a rule that
+// holds only because of how the object is reached today is one a later change
+// breaks silently. Built already, this costs a branch.
+RequestUrlState* url_state_of_this (JSContext* ctx, JSValueConst this_val, const char* member) {
+    auto* state = request_url_state (this_val);
+    if (!state) {
+        JS_ThrowTypeError (ctx, "pm.request.url.%s must be called on the URL object, not detached from it",
+        member);
+        return nullptr;
+    }
+    if (!state->built) {
+        build_request_url_members (ctx, this_val, *state);
+    }
+    return state;
+}
+
+/**
+ * The whole URL, and the single answer behind every string context.
+ *
+ * `toString`, `valueOf`, `toJSON` and `@@toPrimitive` all land here, so
+ * concatenation, a template literal, `==` against a string, `JSON.stringify`
+ * and `String.prototype`'s generic methods (which coerce through
+ * `ToString(this)`) keep behaving the way they did when this was a string.
+ * `@@toPrimitive`'s hint argument is ignored on purpose: a URL has one
+ * primitive form, and answering a number hint with anything else would make
+ * `+url` a different kind of surprise.
+ */
+JSValue js_url_to_string (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = url_state_of_this (ctx, this_val, "toString");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    return JS_NewStringLen (ctx, state->text.data (), state->text.size ());
+}
+
+/// `getHost()` / `getPath()` / `getQueryString()`, told apart by their magic -
+/// three readers of the same state that differ only in which part they join.
+enum UrlPartGetter : int { URL_GET_HOST, URL_GET_PATH, URL_GET_QUERY_STRING };
+
+JSValue
+js_url_part_getter (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)argc;
+    (void)argv;
+    const char* member = magic == URL_GET_HOST ? "getHost" :
+    magic == URL_GET_PATH                      ? "getPath" :
+                                                 "getQueryString";
+    auto* state        = url_state_of_this (ctx, this_val, member);
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    std::string out;
+    switch (magic) {
+    case URL_GET_HOST: out = vayu::http::join_host (state->parts.host); break;
+    case URL_GET_PATH: out = vayu::http::join_path (state->parts.path); break;
+    default: out = state->parts.query; break;
+    }
+    return JS_NewStringLen (ctx, out.data (), out.size ());
+}
+
+/**
+ * `url.update(newUrl)` - Postman's spelling of a whole-URL write, and the same
+ * write `pm.request.url = '...'` performs.
+ *
+ * Mutates in place rather than handing back a new object, because Postman's
+ * does: a script that held a reference to the URL before the update has to see
+ * the update through it, or the write-back and the script disagree about what
+ * is being sent. Member mutation (pushing to `path`, editing a query member) is
+ * out of scope for v1 and documented as such.
+ */
+JSValue js_url_update (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* state = url_state_of_this (ctx, this_val, "update");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "pm.request.url.update needs a URL string");
+    }
+    auto text = script_url_text (ctx, argv[0]);
+    if (!text) {
+        return JS_ThrowTypeError (ctx, "pm.request.url.update needs a URL string, got %s",
+        js_type_name (ctx, argv[0]));
+    }
+    state->text = std::move (*text);
+    build_request_url_members (ctx, this_val, *state);
+    return JS_UNDEFINED;
+}
+
+/// The Url object a query method was bound to. Query methods hang off
+/// `url.query`, so `this` is that sub-object and the URL comes through the
+/// bound data instead - one source of truth for the parsed params rather than a
+/// second copy living on the query object.
+RequestUrlState* url_state_of_query (JSContext* ctx, JSValue* func_data, const char* member) {
+    auto* state = request_url_state (func_data[0]);
+    if (!state) {
+        JS_ThrowInternalError (ctx, "pm.request.url.query.%s lost its URL", member);
+    }
+    return state;
+}
+
+/// The value of the first param named @p name, or nullptr when there is none.
+const std::optional<std::string>*
+find_query_param (const RequestUrlState& state, const std::string& name) {
+    for (const auto& param : state.parts.query_params) {
+        if (param.key == name) {
+            return &param.value;
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * `query.get(name)` - the *first* match's value, `null` when the name is absent
+ * and `null` for a bare `?flag` that carries no value.
+ *
+ * First rather than last: postman-collection's `PropertyList.one` answers with
+ * the first, and a duplicated query key is exactly where a "last wins" guess
+ * would silently sign the wrong string. `toObject()` is the last-wins view, and
+ * it says so.
+ */
+JSValue js_url_query_get (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    auto* state = url_state_of_query (ctx, func_data, magic == 0 ? "get" : "has");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1 || !JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx,
+        "pm.request.url.query.%s needs a name string, got %s", magic == 0 ? "get" : "has",
+        argc < 1 ? "no argument" : js_type_name (ctx, argv[0]));
+    }
+    const std::string name = js_to_string (ctx, argv[0]);
+    const auto* found      = find_query_param (*state, name);
+    if (magic != 0) {
+        return JS_NewBool (ctx, found != nullptr ? 1 : 0);
+    }
+    if (!found || !found->has_value ()) {
+        return JS_NULL;
+    }
+    return JS_NewStringLen (ctx, (*found)->data (), (*found)->size ());
+}
+
+/// One `{ key, value }`, with a bare key's value as `null` - the distinction
+/// between `?flag` and `?flag=` survives into the script.
+JSValue query_param_entry (JSContext* ctx, const vayu::http::UrlQueryParam& param) {
+    JSValue entry = JS_NewObject (ctx);
+    JS_SetPropertyStr (ctx, entry, "key",
+    JS_NewStringLen (ctx, param.key.data (), param.key.size ()));
+    JS_SetPropertyStr (ctx, entry, "value",
+    param.value ? JS_NewStringLen (ctx, param.value->data (), param.value->size ()) : JS_NULL);
+    return entry;
+}
+
+/**
+ * `query.all()` - every param, in wire order, duplicates kept.
+ *
+ * The canonicalization workhorse this whole issue exists for: an HMAC over a
+ * sorted query has to see the parameters as they were sent, which is the one
+ * view a `{name: value}` map cannot give.
+ */
+JSValue js_url_query_all (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    auto* state = url_state_of_query (ctx, func_data, "all");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    JSValue list  = JS_NewArray (ctx);
+    uint32_t next = 0;
+    for (const auto& param : state->parts.query_params) {
+        JS_SetPropertyUint32 (ctx, list, next++, query_param_entry (ctx, param));
+    }
+    return list;
+}
+
+/// `query.toObject()` - last wins, because that is what a plain object can say.
+/// `all()` is the view that keeps duplicates.
+JSValue js_url_query_to_object (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    auto* state = url_state_of_query (ctx, func_data, "toObject");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    JSValue out = JS_NewObject (ctx);
+    for (const auto& param : state->parts.query_params) {
+        JS_SetPropertyStr (ctx, out, param.key.c_str (),
+        param.value ? JS_NewStringLen (ctx, param.value->data (), param.value->size ()) : JS_NULL);
+    }
+    return out;
+}
+
+JSValue js_url_query_count (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    auto* state = url_state_of_query (ctx, func_data, "count");
+    if (!state) {
+        return JS_EXCEPTION;
+    }
+    return JS_NewInt32 (ctx, static_cast<int32_t> (state->parts.query_params.size ()));
+}
+
+/// The `query` sub-object: the params as an array plus the PropertyList reads
+/// over them, each bound to @p url so the two can never describe different
+/// URLs.
+JSValue build_query_object (JSContext* ctx, JSValue url, const RequestUrlState& state) {
+    JSValue query = JS_NewObject (ctx);
+
+    struct QueryMethod {
+        const char* name;
+        JSCFunctionData* fn;
+        int length;
+        int magic;
+    };
+    static constexpr std::array<QueryMethod, 5> METHODS = {
+        QueryMethod{ "get", js_url_query_get, 1, 0 },
+        QueryMethod{ "has", js_url_query_get, 1, 1 },
+        QueryMethod{ "all", js_url_query_all, 0, 0 },
+        QueryMethod{ "toObject", js_url_query_to_object, 0, 0 },
+        QueryMethod{ "count", js_url_query_count, 0, 0 },
+    };
+    for (const auto& method : METHODS) {
+        JS_SetPropertyStr (ctx, query, method.name,
+        JS_NewCFunctionData (ctx, method.fn, method.length, method.magic, 1, &url));
+    }
+
+    // Deliberately no `members` array beside them. Postman's PropertyList has
+    // one, but a copy of it here would be a second view of the same params
+    // that no doc names and no completion offers - and `all()` is that view,
+    // documented. The real PropertyList is a list of QueryParam objects with
+    // their own methods, which is more than v1 ships either way.
+    return query;
+}
+
+/// A JS array of strings, for the two parts Postman presents as segment lists.
+JSValue string_array (JSContext* ctx, const std::vector<std::string>& values) {
+    JSValue list  = JS_NewArray (ctx);
+    uint32_t next = 0;
+    for (const auto& value : values) {
+        JS_SetPropertyUint32 (
+        ctx, list, next++, JS_NewStringLen (ctx, value.data (), value.size ()));
+    }
+    return list;
+}
+
+/**
+ * @brief Parse `state.text` and (re)define the members a script reads.
+ *
+ * Called on the first read of `pm.request.url` and again after every write to
+ * it, so the members and the string can never disagree. Redefining rather than
+ * patching: a URL with no fragment must not keep the previous URL's `hash`.
+ *
+ * A URL libcurl cannot parse leaves every part empty (see `parse_url_parts`)
+ * and the string intact. That is deliberate: `toString()` still answers, so a
+ * script reading the whole URL is unaffected, while a script reading parts of
+ * an unparseable URL gets nothing rather than a plausible half.
+ */
+void build_request_url_members (JSContext* ctx, JSValue url, RequestUrlState& state) {
+    state.parts = vayu::http::parse_url_parts (state.text);
+    state.built = true;
+
+    // **Defined, not set.** The prototype here is `String.prototype`, which is
+    // itself a String object holding "" - so it carries a non-writable own
+    // `length`, and a plain `JS_SetPropertyStr` (which is `[[Set]]`, and walks
+    // the chain) is *refused* by it. Defining puts the property on this object
+    // and never consults the prototype, which is what every member wants
+    // anyway: these are the URL's own facts, not writes through to something.
+    const auto define = [&] (const char* name, JSValue value) {
+        JS_DefinePropertyValueStr (ctx, url, name, value, JS_PROP_C_W_E);
+    };
+    const auto define_string = [&] (const char* name, const std::string& value) {
+        define (name, JS_NewStringLen (ctx, value.data (), value.size ()));
+    };
+    define_string ("protocol", state.parts.protocol);
+    define_string ("port", state.parts.port);
+    define_string ("hash", state.parts.hash);
+    // `length` is defined rather than left as one of the documented breaks,
+    // because the alternative is not "absent": inherited from that same String
+    // prototype it answers `0` - a plausible number for a URL that is not
+    // empty, which is the silent-wrong-answer class this program exists to
+    // close. One property, and `url.length` means what it always did.
+    define ("length", JS_NewInt64 (ctx, static_cast<int64_t> (state.text.size ())));
+    define ("host", string_array (ctx, state.parts.host));
+    define ("path", string_array (ctx, state.parts.path));
+    define ("query", build_query_object (ctx, url, state));
+}
+
+/// The well-known symbol, reached through the `Symbol` global because QuickJS
+/// does not export its atom.
+JSAtom well_known_symbol_atom (JSContext* ctx, const char* name) {
+    JSValue global = JS_GetGlobalObject (ctx);
+    JSValue symbol = JS_GetPropertyStr (ctx, global, "Symbol");
+    JSValue member = JS_GetPropertyStr (ctx, symbol, name);
+    JSAtom atom    = JS_ValueToAtom (ctx, member);
+    JS_FreeValue (ctx, member);
+    JS_FreeValue (ctx, symbol);
+    JS_FreeValue (ctx, global);
+    return atom;
+}
+
+/// A fresh Url object holding @p text, with its members not yet built.
+JSValue new_request_url (JSContext* ctx, std::string text) {
+    JSValue url = JS_NewObjectClass (ctx, request_url_class_id);
+    if (JS_IsException (url)) {
+        return url;
+    }
+    auto* state = new RequestUrlState{ std::move (text), {}, false };
+    if (JS_SetOpaque (url, state) < 0) {
+        // The object is not of this class, so the finalizer will never run and
+        // nothing else would free the state.
+        delete state;
+        JS_FreeValue (ctx, url);
+        return JS_EXCEPTION;
+    }
+
+    // Defined rather than set, for the reason build_request_url_members gives:
+    // `String.prototype` is the prototype here, and `[[Set]]` consults it.
+    const auto define = [&] (const char* name, JSValue value) {
+        JS_DefinePropertyValueStr (ctx, url, name, value, JS_PROP_C_W_E);
+    };
+    define ("toString", JS_NewCFunction (ctx, js_url_to_string, "toString", 0));
+    define ("valueOf", JS_NewCFunction (ctx, js_url_to_string, "valueOf", 0));
+    define ("toJSON", JS_NewCFunction (ctx, js_url_to_string, "toJSON", 0));
+    JSAtom to_primitive = well_known_symbol_atom (ctx, "toPrimitive");
+    JS_DefinePropertyValue (ctx, url, to_primitive,
+    JS_NewCFunction (ctx, js_url_to_string, "[Symbol.toPrimitive]", 1), JS_PROP_CONFIGURABLE);
+    JS_FreeAtom (ctx, to_primitive);
+
+    define ("update", JS_NewCFunction (ctx, js_url_update, "update", 1));
+    for (const auto& [name, magic] :
+    std::array<std::pair<const char*, int>, 3>{ { { "getHost", URL_GET_HOST },
+    { "getPath", URL_GET_PATH }, { "getQueryString", URL_GET_QUERY_STRING } } }) {
+        define (name,
+        JS_NewCFunctionMagic (ctx, js_url_part_getter, name, 0, JS_CFUNC_generic_magic, magic));
+    }
+    return url;
+}
+
+/// The Url object behind the accessor, with its members materialised.
+JSValue bound_request_url (JSContext* ctx, JSValue* func_data) {
+    auto* state = request_url_state (func_data[0]);
+    if (state && !state->built) {
+        build_request_url_members (ctx, func_data[0], *state);
+    }
+    return JS_DupValue (ctx, func_data[0]);
+}
+
+JSValue js_request_url_get (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    return bound_request_url (ctx, func_data);
+}
+
+/**
+ * `pm.request.url = '...'` - the write that shipped, still working, still
+ * feeding `apply_pm_request_writeback`.
+ *
+ * Refuses anything that is neither a string nor a Url object *at the assignment
+ * itself*, rather than letting the write-back reject it several lines later:
+ * the script author is told which line was wrong, and a test script - which has
+ * no write-back to be rejected by - stops silently accepting a number.
+ */
+JSValue js_request_url_set (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)magic;
+    auto text = argc > 0 ? script_url_text (ctx, argv[0]) : std::nullopt;
+    if (!text) {
+        return JS_ThrowTypeError (ctx,
+        "pm.request.url must be assigned a URL string, got %s (call "
+        ".toString() "
+        "on a value that is not one)",
+        argc > 0 ? js_type_name (ctx, argv[0]) : "no value");
+    }
+    auto* state = request_url_state (func_data[0]);
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "pm.request.url lost its URL");
+    }
+    state->text = std::move (*text);
+    build_request_url_members (ctx, func_data[0], *state);
+    return JS_UNDEFINED;
+}
+
+/**
+ * @brief Install `pm.request.url` as the accessor pair over a Url object.
+ *
+ * An accessor rather than a plain member for two reasons. The parse is paid on
+ * the first *read*, so a script that never mentions the URL - most scripts -
+ * costs one object allocation and nothing else. And a write goes through the
+ * setter, so `pm.request.url = 'https://...'` leaves a Url object behind rather
+ * than replacing the object with a bare string, which is what would make
+ * `pm.request.url = x; pm.request.url.query.get('a')` throw.
+ *
+ * Enumerable, like every other member of `pm.request`: `JSON.stringify` and
+ * `console.log` have to keep showing the URL, and the object's own `toJSON`
+ * makes that the string it always was.
+ */
+void install_request_url (JSContext* ctx, JSValue request, const std::string& url_text) {
+    JSValue url = new_request_url (ctx, url_text);
+    if (JS_IsException (url)) {
+        JS_FreeValue (ctx, url);
+        return;
+    }
+    JSAtom atom = JS_NewAtom (ctx, "url");
+    JS_DefinePropertyGetSet (ctx, request, atom,
+    JS_NewCFunctionData (ctx, js_request_url_get, 0, 0, 1, &url),
+    JS_NewCFunctionData (ctx, js_request_url_set, 1, 0, 1, &url),
+    JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE);
+    JS_FreeAtom (ctx, atom);
+    JS_FreeValue (ctx, url);
+}
+
 void setup_pm_request (JSContext* ctx, JSValue pm) {
     auto* data = get_context_data (ctx);
 
@@ -3393,9 +3936,8 @@ void setup_pm_request (JSContext* ctx, JSValue pm) {
     JSValue request = JS_NewObject (ctx);
 
     if (data && data->request) {
-        // pm.request.url
-        JS_SetPropertyStr (
-        ctx, request, "url", JS_NewString (ctx, data->request->url.c_str ()));
+        // pm.request.url - Postman's Url object, not the string it used to be.
+        install_request_url (ctx, request, data->request->url);
 
         // pm.request.method
         JS_SetPropertyStr (ctx, request, "method",
@@ -3608,12 +4150,16 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
 
     Request staged = request;
 
+    // Either shape: the Url object `pm.request.url` normally holds, or a plain
+    // string, which is what a script that replaced `pm.request` wholesale with
+    // an object literal leaves there. Both are the URL; neither is a diff.
     ScopedValue js_url (ctx, JS_GetPropertyStr (ctx, js_request.get (), "url"));
-    if (!JS_IsString (js_url.get ())) {
-        return "pm.request.url must be a string, got " +
+    auto url_text = script_url_text (ctx, js_url.get ());
+    if (!url_text) {
+        return "pm.request.url must be a string or a URL object, got " +
         std::string (js_type_name (ctx, js_url.get ()));
     }
-    staged.url = js_to_string (ctx, js_url.get ());
+    staged.url = std::move (*url_text);
     if (staged.url.empty ()) {
         return std::string ("pm.request.url must not be empty");
     }
@@ -4246,8 +4792,12 @@ read_send_request_body (JSContext* ctx, JSValueConst value, Body& out) {
 // @return why it was rejected, or nullopt when `out` is filled.
 std::optional<std::string>
 build_send_request (JSContext* ctx, JSValueConst arg, Request& out) {
-    if (JS_IsString (arg)) {
-        out.url = js_to_string (ctx, arg);
+    // A Url object here is `pm.sendRequest(pm.request.url, cb)`, which #991
+    // made the natural spelling of "send this request again" - it has to be
+    // read before the options-object branch, or the Url object falls into it
+    // and is refused for having no `url` member.
+    if (auto direct = script_url_text (ctx, arg)) {
+        out.url = std::move (*direct);
         if (out.url.empty ()) {
             return std::string ("pm.sendRequest was given an empty URL");
         }
@@ -4261,12 +4811,15 @@ build_send_request (JSContext* ctx, JSValueConst arg, Request& out) {
     }
 
     ScopedValue js_url (ctx, JS_GetPropertyStr (ctx, arg, "url"));
-    if (!JS_IsString (js_url.get ())) {
-        return "pm.sendRequest options.url must be a string, got " +
-        std::string (js_type_name (ctx, js_url.get ())) +
-        " (Postman's URL-object form is not supported)";
+    auto options_url = script_url_text (ctx, js_url.get ());
+    if (!options_url) {
+        // Postman's *literal* URL-object form - a `{host: [...], path: [...]}`
+        // built by hand - is still not accepted; pm.request.url is.
+        return "pm.sendRequest options.url must be a string or pm.request.url, "
+               "got " +
+        std::string (js_type_name (ctx, js_url.get ()));
     }
-    out.url = js_to_string (ctx, js_url.get ());
+    out.url = std::move (*options_url);
     if (out.url.empty ()) {
         return std::string ("pm.sendRequest options.url is empty");
     }
@@ -4649,19 +5202,33 @@ std::vector<vayu::http::CookieWrite>* jar_writes (JSContext* ctx, const char* me
 // One required string argument of a jar() method. Every one of them is
 // URL-scoped, which is the whole reason Postman's write half hangs off `jar()`
 // rather than off `pm.cookies` - so the URL is never optional.
+//
+// @p url_arg marks the positions that take a URL, which since #991 also accept
+// the Url object `pm.request.url` holds - `jar().set(pm.request.url, ...)` is
+// the documented example in both script docs and was a string argument until
+// that object replaced the string. A cookie *name* stays string-only: nothing
+// makes a URL a plausible name, so accepting one there would only let a
+// misplaced argument through.
 std::optional<std::string> read_jar_string_arg (JSContext* ctx,
 const char* member,
 const char* label,
 int index,
 int argc,
-JSValueConst* argv) {
-    if (index >= argc || !JS_IsString (argv[index])) {
+JSValueConst* argv,
+bool url_arg = false) {
+    std::optional<std::string> text;
+    if (index < argc) {
+        text = url_arg ? script_url_text (ctx, argv[index]) :
+                         (JS_IsString (argv[index]) ?
+                         std::optional<std::string> (js_to_string (ctx, argv[index])) :
+                         std::nullopt);
+    }
+    if (!text) {
         JS_ThrowTypeError (ctx, "pm.cookies.jar().%s needs a %s string, got %s", member,
         label, index >= argc ? "no argument" : js_type_name (ctx, argv[index]));
         return std::nullopt;
     }
-    std::string text = js_to_string (ctx, argv[index]);
-    if (text.empty ()) {
+    if (text->empty ()) {
         JS_ThrowTypeError (ctx, "pm.cookies.jar().%s needs a non-empty %s", member, label);
         return std::nullopt;
     }
@@ -4826,7 +5393,7 @@ JSValue finish_jar_call (JSContext* ctx, int argc, JSValueConst* argv, int callb
 
 JSValue js_jar_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
-    auto url = read_jar_string_arg (ctx, "get", "URL", 0, argc, argv);
+    auto url = read_jar_string_arg (ctx, "get", "URL", 0, argc, argv, /*url_arg=*/true);
     if (!url) {
         return JS_EXCEPTION;
     }
@@ -4849,7 +5416,7 @@ JSValue js_jar_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueCons
 
 JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
-    auto url = read_jar_string_arg (ctx, "set", "URL", 0, argc, argv);
+    auto url = read_jar_string_arg (ctx, "set", "URL", 0, argc, argv, /*url_arg=*/true);
     if (!url) {
         return JS_EXCEPTION;
     }
@@ -4902,7 +5469,7 @@ JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueCons
 
 JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
-    auto url = read_jar_string_arg (ctx, "unset", "URL", 0, argc, argv);
+    auto url = read_jar_string_arg (ctx, "unset", "URL", 0, argc, argv, /*url_arg=*/true);
     if (!url) {
         return JS_EXCEPTION;
     }
@@ -4926,12 +5493,13 @@ JSValue js_jar_clear (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     (void)this_val;
     // Two forms, told apart by the first argument. Postman's is
     // `clear(url, cb?)`, scoped to one URL; Vayu's own `clear(cb?)` empties
-    // the scope and is what this method shipped as. A string in that position
-    // is unambiguously the URL - the only other thing it takes is a function.
+    // the scope and is what this method shipped as. A string or a Url object in
+    // that position is unambiguously the URL - the only other thing it takes is
+    // a function.
     std::optional<std::string> url;
     int callback_index = 0;
-    if (argc > 0 && JS_IsString (argv[0])) {
-        url = read_jar_string_arg (ctx, "clear", "URL", 0, argc, argv);
+    if (argc > 0 && (JS_IsString (argv[0]) || request_url_state (argv[0]) != nullptr)) {
+        url = read_jar_string_arg (ctx, "clear", "URL", 0, argc, argv, /*url_arg=*/true);
         if (!url) {
             return JS_EXCEPTION;
         }
@@ -5292,6 +5860,17 @@ void setup_pm_object (JSContext* ctx) {
     JS_FreeValue (ctx, plain);
     JS_SetClassProto (ctx, response_chain_class_id, object_proto);
 
+    // `pm.request.url` inherits from **String.prototype**, which is the whole
+    // of how `url.startsWith(...)`, `.includes(...)`, `.slice(...)` and the
+    // rest keep working on what used to be a string: every one of them coerces
+    // through `ToString(this)`, which the object's own `@@toPrimitive` answers
+    // with the URL. What it does not restore is `.length` - an own property of
+    // a real string, and one of the three breaks #991 documents.
+    JSValue string_ctor  = JS_GetPropertyStr (ctx, global, "String");
+    JSValue string_proto = JS_GetPropertyStr (ctx, string_ctor, "prototype");
+    JS_FreeValue (ctx, string_ctor);
+    JS_SetClassProto (ctx, request_url_class_id, string_proto);
+
     // pm.test()
     JS_SetPropertyStr (ctx, pm, "test", JS_NewCFunction (ctx, js_pm_test, "test", 2));
 
@@ -5416,6 +5995,13 @@ class ScriptEngine::Impl {
             JS_NewClassID (rt, &response_chain_class_id);
         }
         JS_NewClass (rt, response_chain_class_id, &response_chain_class);
+
+        // Register the pm.request.url class - see setup_pm_object for the
+        // prototype that keeps it usable as the string it replaced.
+        if (request_url_class_id == 0) {
+            JS_NewClassID (rt, &request_url_class_id);
+        }
+        JS_NewClass (rt, request_url_class_id, &request_url_class);
 
         JSContext* ctx = JS_NewContext (rt);
         if (ctx) {

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ add_executable(vayu_tests
     form_body_test.cpp
     graphql_body_test.cpp
     jsonrpc_body_test.cpp
+    url_parts_test.cpp
+    script_request_url_test.cpp
     xml_body_test.cpp
     stats_route_test.cpp
     execution_timeout_test.cpp

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -720,7 +720,7 @@ declare const pm: {
 				/**
 				 * Every parameter as { key, value }, in wire order, duplicates kept - the view a canonical query string is built from. A parameter with no value has value null.
 				 */
-				all(): object[];
+				all(): { key: string, value: string | null }[];
 				/**
 				 * How many parameters the query carries, counting duplicates separately.
 				 */
@@ -736,7 +736,7 @@ declare const pm: {
 				/**
 				 * The query as a plain { name: value } object, last wins on a repeated name. Use all() when duplicates matter.
 				 */
-				toObject(): object;
+				toObject(): { [key: string]: string | null };
 			};
 			/**
 			 * The whole URL as a string, which is why JSON.stringify embeds the URL rather than an object dump.

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -672,9 +672,90 @@ declare const pm: {
 		 */
 		method: string;
 		/**
-		 * The full request URL. Assign to retarget the request before it is sent - must be a non-empty string. {{variables}} are already resolved here.
+		 * The full request URL, as Postman's Url object: protocol, host, port, path, query and hash, plus getHost(), getPath(), getQueryString() and toString(). {{variables}} are already resolved here.
+		 * 
+		 * It still behaves as the string it used to be - concatenation, template literals, ==, the String methods and .length all give the full URL - so `===` and `typeof` are the two things that changed. Assign a string to retarget the request before it is sent, or call url.update(...); either way it must be non-empty.
 		 */
-		url: string;
+		get url(): string & {
+			/**
+			 * The host as one string - the segments of host joined by dots.
+			 */
+			getHost(): string;
+			/**
+			 * The decoded path as one string, leading slash included ("/v2/users"). A URL with no path answers "/".
+			 */
+			getPath(): string;
+			/**
+			 * The query exactly as it appears on the wire, with no leading ?. Empty when the URL carries none.
+			 */
+			getQueryString(): string;
+			/**
+			 * The fragment with no leading #. Empty when there is none.
+			 */
+			hash: string;
+			/**
+			 * The host split on dots, as Postman presents it: "api.example.com" is ["api", "example", "com"]. Use getHost() for the joined form.
+			 */
+			host: string[];
+			/**
+			 * The length of the whole URL string - defined on the object rather than inherited, so it is the URL's own length and not the 0 that String's prototype would have answered.
+			 */
+			length: number;
+			/**
+			 * The path as decoded segments: "/v2/users" is ["v2", "users"]. Each segment is decoded on its own, so an encoded slash stays inside the segment it belongs to. Use getPath() for the joined form.
+			 */
+			path: string[];
+			/**
+			 * The port the URL states, as a string. Empty when it states none - a scheme's default port is never filled in.
+			 */
+			port: string;
+			/**
+			 * The scheme with no trailing colon ("https"). Empty when the URL cannot be parsed.
+			 */
+			protocol: string;
+			/**
+			 * The query parameters, with Postman's PropertyList reads over them: get(name), has(name), all(), toObject() and count(). Values are the wire bytes, not decoded - a signature has to canonicalize what was sent.
+			 */
+			query: {
+				/**
+				 * Every parameter as { key, value }, in wire order, duplicates kept - the view a canonical query string is built from. A parameter with no value has value null.
+				 */
+				all(): object[];
+				/**
+				 * How many parameters the query carries, counting duplicates separately.
+				 */
+				count(): number;
+				/**
+				 * The first value of that parameter, or null when the name is absent or carries no value ("?flag"). First rather than last, matching Postman's PropertyList - all() is the view that keeps duplicates.
+				 */
+				get(name: string): string | null;
+				/**
+				 * Whether the query carries that parameter at all, including a bare "?flag" that has no value.
+				 */
+				has(name: string): boolean;
+				/**
+				 * The query as a plain { name: value } object, last wins on a repeated name. Use all() when duplicates matter.
+				 */
+				toObject(): object;
+			};
+			/**
+			 * The whole URL as a string, which is why JSON.stringify embeds the URL rather than an object dump.
+			 */
+			toJSON(): string;
+			/**
+			 * The whole URL as a string. The same answer concatenation, a template literal and JSON.stringify already give, spelled out for the one place that needs a real string - strict equality.
+			 */
+			toString(): string;
+			/**
+			 * Retarget the request, Postman's spelling of pm.request.url = '...'. Both re-parse the whole URL in place; editing a single member (pushing to path, changing a query entry) is not supported.
+			 */
+			update(url: string): void;
+			/**
+			 * The whole URL as a string - what == and arithmetic-style coercion use, and the same answer toString() gives.
+			 */
+			valueOf(): string;
+		};
+		set url(value: string);
 	};
 	/**
 	 * Access the HTTP response data including status code, headers, body, and timing information.
@@ -1073,14 +1154,14 @@ declare const Buffer: never;
 /**
  * Not available in the Vayu script sandbox.
  *
- * No URL parser in the sandbox. pm.request.url is a plain string.
+ * No WHATWG URL constructor in the sandbox. pm.request.url is already Postman's Url object - read its protocol, host, port, path, query and hash there.
  */
 declare const URL: never;
 
 /**
  * Not available in the Vayu script sandbox.
  *
- * No URL parser in the sandbox.
+ * No URLSearchParams. pm.request.url.query answers the same questions: get, has, all, toObject, count.
  */
 declare const URLSearchParams: never;
 

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -695,6 +695,8 @@ declare const pm: {
 			hash: string;
 			/**
 			 * The host split on dots, as Postman presents it: "api.example.com" is ["api", "example", "com"]. Use getHost() for the joined form.
+			 * 
+			 * Editable in a pre-request script, the same way path is.
 			 */
 			host: string[];
 			/**
@@ -703,6 +705,8 @@ declare const pm: {
 			length: number;
 			/**
 			 * The path as decoded segments: "/v2/users" is ["v2", "users"]. Each segment is decoded on its own, so an encoded slash stays inside the segment it belongs to. Use getPath() for the joined form.
+			 * 
+			 * Editable in a pre-request script - push, splice, index assignment and replacing the whole array all reach the URL that is sent.
 			 */
 			path: string[];
 			/**
@@ -714,13 +718,21 @@ declare const pm: {
 			 */
 			protocol: string;
 			/**
-			 * The query parameters, with Postman's PropertyList reads over them: get(name), has(name), all(), toObject() and count(). Values are the wire bytes, not decoded - a signature has to canonicalize what was sent.
+			 * The query parameters, with Postman's PropertyList reads over them - get(name), has(name), all(), toObject(), count() - and its writers: add, upsert, remove, clear. Values are the wire bytes, not decoded - a signature has to canonicalize what was sent.
 			 */
 			query: {
+				/**
+				 * Append a parameter, even when the name is already there - a query may repeat a name, which is why all() exists. Omit value for a bare "?flag". Use upsert to replace instead of appending.
+				 */
+				add(param: { key: string, value?: string | number | boolean | null }): void;
 				/**
 				 * Every parameter as { key, value }, in wire order, duplicates kept - the view a canonical query string is built from. A parameter with no value has value null.
 				 */
 				all(): { key: string, value: string | null }[];
+				/**
+				 * Drop every query parameter. The URL loses its "?" with them.
+				 */
+				clear(): void;
 				/**
 				 * How many parameters the query carries, counting duplicates separately.
 				 */
@@ -734,9 +746,17 @@ declare const pm: {
 				 */
 				has(name: string): boolean;
 				/**
+				 * Remove every parameter of that name, not just the first. A name that is not there is a no-op, the same rule pm.request.headers.remove follows.
+				 */
+				remove(name: string): void;
+				/**
 				 * The query as a plain { name: value } object, last wins on a repeated name. Use all() when duplicates matter.
 				 */
 				toObject(): { [key: string]: string | null };
+				/**
+				 * Replace the first parameter of that name, keeping its position in the query, or append it when there is none. Position is kept because a signature over the query changes shape if a parameter moves.
+				 */
+				upsert(param: { key: string, value?: string | number | boolean | null }): void;
 			};
 			/**
 			 * The whole URL as a string, which is why JSON.stringify embeds the URL rather than an object dump.

--- a/engine/tests/script_request_url_test.cpp
+++ b/engine/tests/script_request_url_test.cpp
@@ -1,0 +1,446 @@
+/**
+ * @file tests/script_request_url_test.cpp
+ * @brief `pm.request.url` as Postman's `Url` object (issue #991).
+ *
+ * The owner decision this ships is that Postman compatibility wins over the
+ * string shape `pm.request.url` had. That trade has two halves and both are
+ * pinned here, because only one of them is what the issue is *for*:
+ *
+ * - the compatibility half - a lifted Postman script reading `url.query.get`,
+ *   `url.getPath()`, `url.host` runs unmodified;
+ * - the mitigation half - concatenation, template literals, `==`, the generic
+ *   `String.prototype` methods and `JSON.stringify` still behave as they did,
+ *   because a change that quietly broke every script that treats the URL as a
+ *   string would not be worth the compatibility it bought.
+ *
+ * The two things that genuinely changed - `===` and `typeof` - are asserted
+ * **as** breaks. A documented break nothing pins is a break that comes
+ * back as an accident later, and the docs would then be describing behaviour
+ * the engine no longer has.
+ *
+ * Where an assertion could pass vacuously (an empty query list, a script that
+ * threw before its `pm.test`), it is paired with something that fails if the
+ * work did not happen - a count, or the value itself.
+ */
+
+#include "vayu/runtime/script_engine.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "vayu/http/cookie_jar.hpp"
+#include "vayu/types.hpp"
+
+using namespace vayu;
+using namespace vayu::runtime;
+
+namespace {
+
+#ifdef VAYU_HAS_QUICKJS
+
+class ScriptRequestUrlTest : public ::testing::Test {
+    protected:
+    ScriptEngine engine;
+    Request request;
+    Response response;
+    Environment env;
+
+    void SetUp () override {
+        request.method       = HttpMethod::GET;
+        request.url          = "https://api.example.com:8443/v2/"
+                               "users%20list?page=2&sort=name&page=3#top";
+        response.status_code = 200;
+        response.status_text = "OK";
+        response.body        = "{}";
+    }
+
+    /// Run @p script as a test script - the read-only view of what was sent.
+    ScriptResult run_test_script (const std::string& script) {
+        ScriptContext ctx;
+        ctx.request     = &request;
+        ctx.response    = &response;
+        ctx.environment = &env;
+        return engine.execute (script, ctx);
+    }
+
+    /// A single `pm.test` whose verdict is the assertion. The name is asserted
+    /// too, so a script that threw before reaching its test - which produces no
+    /// verdict at all - cannot read as a pass.
+    void expect_script_passes (const std::string& body) {
+        const ScriptResult result =
+        run_test_script ("pm.test('assertion', function () {\n" + body + "\n});");
+        ASSERT_TRUE (result.success) << result.error_message;
+        ASSERT_EQ (result.tests.size (), 1u) << body;
+        EXPECT_EQ (result.tests[0].name, "assertion");
+        EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// The Url read surface - what a lifted Postman script reaches for.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestUrlTest, PresentsEveryPartOfTheUrl) {
+    expect_script_passes (R"JS(
+        var url = pm.request.url;
+        pm.expect(url.protocol).to.equal('https');
+        pm.expect(url.port).to.equal('8443');
+        pm.expect(url.hash).to.equal('top');
+        pm.expect(url.host.join('.')).to.equal('api.example.com');
+        pm.expect(url.getHost()).to.equal('api.example.com');
+    )JS");
+}
+
+// Decoded, and each segment on its own - "v2/users%20list" is two segments and
+// the second one holds a space, not a percent escape.
+TEST_F (ScriptRequestUrlTest, PathSegmentsAreDecoded) {
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.path.length).to.equal(2);
+        pm.expect(pm.request.url.path[0]).to.equal('v2');
+        pm.expect(pm.request.url.path[1]).to.equal('users list');
+        pm.expect(pm.request.url.getPath()).to.equal('/v2/users list');
+    )JS");
+}
+
+TEST_F (ScriptRequestUrlTest, QueryReadsFollowPostmansPropertyList) {
+    expect_script_passes (R"JS(
+        var query = pm.request.url.query;
+        pm.expect(query.count()).to.equal(3);
+        pm.expect(query.has('sort')).to.equal(true);
+        pm.expect(query.has('nope')).to.equal(false);
+        // First wins, matching PropertyList.one - `page` appears twice.
+        pm.expect(query.get('page')).to.equal('2');
+        pm.expect(query.get('missing')).to.equal(null);
+        // Last wins is what a plain object can say, and toObject says it.
+        pm.expect(query.toObject().page).to.equal('3');
+    )JS");
+}
+
+// The canonicalization workhorse: wire order, duplicates kept. A map-shaped
+// answer would silently drop the second `page` and sign a different string.
+TEST_F (ScriptRequestUrlTest, QueryAllKeepsWireOrderAndDuplicates) {
+    expect_script_passes (R"JS(
+        var all = pm.request.url.query.all();
+        pm.expect(all.length).to.equal(3);
+        pm.expect(all.map(function (p) { return p.key + '=' + p.value; }).join('&'))
+          .to.equal('page=2&sort=name&page=3');
+    )JS");
+}
+
+TEST_F (ScriptRequestUrlTest, GetQueryStringIsByteExactAgainstTheWire) {
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.getQueryString()).to.equal('page=2&sort=name&page=3');
+    )JS");
+}
+
+// `?flag` carries no value and `?flag=` carries an empty one. Collapsing them
+// would make a rebuilt query string differ from the one that was sent.
+TEST_F (ScriptRequestUrlTest, ABareQueryKeyReadsAsNullAndAnEmptyOneAsEmpty) {
+    request.url = "https://example.com/s?flag&empty=";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.query.get('flag')).to.equal(null);
+        pm.expect(pm.request.url.query.has('flag')).to.equal(true);
+        pm.expect(pm.request.url.query.get('empty')).to.equal('');
+        pm.expect(pm.request.url.query.all()[0].value).to.equal(null);
+    )JS");
+}
+
+// The query is the wire bytes. Decoding here would break every signature built
+// from `all()`, which is the workflow the object exists for.
+TEST_F (ScriptRequestUrlTest, QueryValuesAreNotDecoded) {
+    request.url = "https://example.com/s?q=hello%20world";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.query.get('q')).to.equal('hello%20world');
+    )JS");
+}
+
+// A URL the parser cannot read still answers as a whole string; it just has no
+// parts. Better than a plausible half, and better than throwing on a read.
+TEST_F (ScriptRequestUrlTest, AnUnparseableUrlKeepsItsStringAndReportsNoParts) {
+    request.url = "not a url at all";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.toString()).to.equal('not a url at all');
+        pm.expect(pm.request.url.host.length).to.equal(0);
+        pm.expect(pm.request.url.query.count()).to.equal(0);
+        pm.expect(pm.request.url.protocol).to.equal('');
+    )JS");
+}
+
+/**
+ * The compatibility proof this issue exists for: a script written against
+ * Postman, pasted in unmodified.
+ */
+TEST_F (ScriptRequestUrlTest, APostmanScriptUsingTheUrlMembersRunsUnmodified) {
+    const ScriptResult result = run_test_script (R"JS(
+        pm.test("targets the right endpoint", function () {
+            pm.expect(pm.request.url.getPath()).to.equal("/v2/users list");
+            pm.expect(pm.request.url.host).to.include("example");
+            pm.expect(pm.request.url.query.get("sort")).to.equal("name");
+        });
+        pm.test("query string is intact", function () {
+            pm.expect(pm.request.url.getQueryString()).to.include("sort=name");
+        });
+    )JS");
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 2u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[1].passed) << result.tests[1].error_message;
+}
+
+/**
+ * The payoff, end to end: a sorted canonical query of the kind an HMAC scheme
+ * signs, built from `all()` alone. This is the workflow that used to need
+ * hand-rolled string surgery.
+ */
+TEST_F (ScriptRequestUrlTest, CanonicalizesASortedQueryForSigning) {
+    request.url =
+    "https://api.example.com/pay?amount=10&Timestamp=99&currency=EUR";
+    expect_script_passes (R"JS(
+        var canonical = pm.request.url.query.all()
+            .map(function (p) { return p.key + '=' + (p.value === null ? '' : p.value); })
+            .sort()
+            .join('&');
+        pm.expect(canonical).to.equal('Timestamp=99&amount=10&currency=EUR');
+        // And the signature over it is a real one, not a placeholder.
+        pm.expect(pm.crypto.hmacSha256('key', canonical).length).to.equal(64);
+    )JS");
+}
+
+// ---------------------------------------------------------------------------
+// The string mitigations - what must NOT have changed.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestUrlTest, StillBehavesAsAStringInEveryContextItCan) {
+    request.url = "https://api.example.com/users";
+    expect_script_passes (R"JS(
+        var url = pm.request.url;
+        pm.expect('' + url).to.equal('https://api.example.com/users');
+        pm.expect(`${url}`).to.equal('https://api.example.com/users');
+        pm.expect(url == 'https://api.example.com/users').to.equal(true);
+        pm.expect(url.startsWith('https://')).to.equal(true);
+        pm.expect(url.includes('api.example.com')).to.equal(true);
+        pm.expect(url.slice(0, 5)).to.equal('https');
+        pm.expect(url.indexOf('/users')).to.equal(23);
+        pm.expect(url.split('?')[0]).to.equal('https://api.example.com/users');
+        pm.expect(url.toString()).to.equal('https://api.example.com/users');
+        pm.expect(JSON.stringify({ u: url })).to.equal(
+            '{"u":"https://api.example.com/users"}');
+    )JS");
+}
+
+// The repo's own docs and tests spell it this way. #991 turned the target from
+// a string into an object, and an assertion that silently started failing is
+// the worst outcome a testing tool has.
+TEST_F (ScriptRequestUrlTest, ExpectIncludeStillReadsItAsAString) {
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url).to.include('example.com');
+        pm.expect(pm.request.url).to.not.include('nowhere.invalid');
+    )JS");
+}
+
+/**
+ * The two documented breaks, asserted as breaks.
+ *
+ * If a later change made either behave the old way again, this test fails - and
+ * the docs that describe them would need rewriting, which is the point of
+ * pinning them rather than leaving them to be rediscovered.
+ */
+TEST_F (ScriptRequestUrlTest, TheTwoDocumentedBreaksAreWhatTheDocsSay) {
+    request.url = "https://api.example.com/users";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url === 'https://api.example.com/users').to.equal(false);
+        pm.expect(typeof pm.request.url).to.equal('object');
+    )JS");
+}
+
+/**
+ * `.length` is an own property, not an inherited one - and that is the whole
+ * point of asserting it.
+ *
+ * `String.prototype` is a String exotic object holding "", so an object that
+ * only inherits from it answers `0` here. Deleting the own definition makes
+ * this test read 0 for a 29-character URL, which is exactly the silent wrong
+ * answer the object is built to avoid.
+ */
+TEST_F (ScriptRequestUrlTest, LengthIsTheUrlsOwnLengthAndNotTheInheritedZero) {
+    request.url = "https://api.example.com/users";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.url.length).to.equal(29);
+        pm.expect(pm.request.url.length).to.equal(pm.request.url.toString().length);
+    )JS");
+}
+
+// ---------------------------------------------------------------------------
+// Writes.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestUrlTest, StringAssignmentStillRetargetsTheRequest) {
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url = 'https://api.example.com/v3/orders?page=1';
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v3/orders?page=1");
+}
+
+// The reason `url` is an accessor rather than a plain member: a write leaves a
+// Url object behind, so the parts reflect what was just assigned instead of the
+// property becoming a bare string.
+TEST_F (ScriptRequestUrlTest, AWriteReParsesSoThePartsFollowIt) {
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url = 'https://other.example.org/v3/orders?page=7';
+        if (pm.request.url.getPath() !== '/v3/orders') {
+            throw new Error('path did not follow the write: ' + pm.request.url.getPath());
+        }
+        if (pm.request.url.query.get('page') !== '7') {
+            throw new Error('query did not follow the write');
+        }
+        if (pm.request.url.getHost() !== 'other.example.org') {
+            throw new Error('host did not follow the write');
+        }
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://other.example.org/v3/orders?page=7");
+}
+
+TEST_F (ScriptRequestUrlTest, UpdateIsTheSameWriteWithPostmansSpelling) {
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.update('https://api.example.com/v3/orders');
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v3/orders");
+}
+
+// Postman's update mutates in place, so a reference taken before it has to see
+// it - otherwise a script and the write-back disagree about what is being sent.
+TEST_F (ScriptRequestUrlTest, UpdateMutatesTheObjectAScriptAlreadyHolds) {
+    const auto result = engine.execute_prerequest (R"JS(
+        var url = pm.request.url;
+        url.update('https://api.example.com/v3/orders');
+        if (url.getPath() !== '/v3/orders') {
+            throw new Error('the held reference did not follow update()');
+        }
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v3/orders");
+}
+
+TEST_F (ScriptRequestUrlTest, AnEmptyUrlIsStillRejectedAndAppliesNothing) {
+    const std::string original = request.url;
+    const auto result          = engine.execute_prerequest (R"JS(
+        pm.request.headers['X-Signature'] = 'abc123';
+        pm.request.url = '';
+    )JS",
+             request, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("pm.request.url"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (request.url, original);
+    EXPECT_FALSE (request.headers.contains ("X-Signature"));
+}
+
+// Loud at the assignment, not several lines later in the write-back: the script
+// author is told which line was wrong. `[object Object]` reaching the wire is
+// the silent-wrong-request class this whole program exists to close.
+TEST_F (ScriptRequestUrlTest, AssigningSomethingThatIsNotAUrlThrowsAtTheAssignment) {
+    const std::string original = request.url;
+    for (const char* value : { "42", "{}", "null", "undefined", "['a']" }) {
+        const auto result = engine.execute_prerequest (
+        std::string ("pm.request.url = ") + value + ";", request, env);
+
+        EXPECT_FALSE (result.success) << value;
+        EXPECT_NE (result.error_message.find ("pm.request.url"), std::string::npos)
+        << value << ": " << result.error_message;
+        EXPECT_EQ (request.url, original) << value;
+    }
+}
+
+// A test script's pm.request is a read-only record: the write is allowed to
+// change what the script sees and must reach nothing that was sent.
+TEST_F (ScriptRequestUrlTest, TestScriptWritesAreStillNotWrittenBack) {
+    const std::string original = request.url;
+    const ScriptResult result  = run_test_script (R"JS(
+        pm.request.url = 'https://evil.example.com';
+    )JS");
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, original);
+}
+
+// A script that replaces pm.request wholesale leaves a plain string there, and
+// the write-back has to keep taking it - that shape predates the Url object.
+TEST_F (ScriptRequestUrlTest, AReplacedRequestObjectMayStillCarryAPlainString) {
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request = { url: 'https://api.example.com/v9/ping', method: 'GET', headers: {} };
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v9/ping");
+}
+
+// ---------------------------------------------------------------------------
+// The surfaces that used to require a string and are documented as taking
+// pm.request.url.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestUrlTest, TheJarStillTakesPmRequestUrlAsItsScope) {
+    std::vector<vayu::http::CookieWrite> writes;
+    vayu::http::CookieJar jar;
+    ScriptContext ctx = ScriptContext::for_prerequest (request);
+    ctx.environment   = &env;
+    ctx.cookie_jar    = &jar;
+    ctx.cookie_scope  = "env_1";
+    ctx.cookie_writes = &writes;
+
+    // `unset` and `clear` record the URL they were scoped to, which is what
+    // makes the scoping observable; `set` folds it into the cookie line.
+    const ScriptResult result = engine.execute (R"JS(
+        pm.cookies.jar().set(pm.request.url, { name: 'session', value: 'abc' });
+        pm.cookies.jar().unset(pm.request.url, 'session');
+        pm.cookies.jar().clear(pm.request.url);
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (writes.size (), 3u);
+    EXPECT_EQ (writes[0].kind, vayu::http::CookieWrite::Kind::Set);
+    EXPECT_NE (writes[0].line.find ("session"), std::string::npos);
+    EXPECT_EQ (writes[1].kind, vayu::http::CookieWrite::Kind::Unset);
+    EXPECT_EQ (writes[1].url, request.url);
+    EXPECT_EQ (writes[2].kind, vayu::http::CookieWrite::Kind::ClearUrl);
+    EXPECT_EQ (writes[2].url, request.url);
+}
+
+TEST_F (ScriptRequestUrlTest, TheJarStillRefusesSomethingThatIsNotAUrl) {
+    std::vector<vayu::http::CookieWrite> writes;
+    vayu::http::CookieJar jar;
+    ScriptContext ctx = ScriptContext::for_prerequest (request);
+    ctx.environment   = &env;
+    ctx.cookie_jar    = &jar;
+    ctx.cookie_scope  = "env_1";
+    ctx.cookie_writes = &writes;
+
+    const ScriptResult result = engine.execute (R"JS(
+        pm.cookies.jar().set(42, { name: 'session', value: 'abc' });
+    )JS",
+    ctx);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_TRUE (writes.empty ());
+}
+
+#endif // VAYU_HAS_QUICKJS
+
+} // namespace

--- a/engine/tests/script_request_url_test.cpp
+++ b/engine/tests/script_request_url_test.cpp
@@ -27,6 +27,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -388,6 +389,238 @@ TEST_F (ScriptRequestUrlTest, AReplacedRequestObjectMayStillCarryAPlainString) {
 
     ASSERT_TRUE (result.success) << result.error_message;
     EXPECT_EQ (request.url, "https://api.example.com/v9/ping");
+}
+
+// ---------------------------------------------------------------------------
+// Member mutation (issue #1040) - the edits that must reach the wire, and the
+// untouched URL that must not be rebuilt.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestUrlTest, PushingAPathSegmentReachesTheWire) {
+    request.url       = "https://api.example.com/v2/users";
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.path.push('active');
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v2/users/active");
+}
+
+// The reason the segment lists are proxies rather than arrays: every spelling
+// of the mutation has to reach the URL, not just the one that was tested for.
+TEST_F (ScriptRequestUrlTest, EverySpellingOfASegmentEditReachesTheWire) {
+    struct Case {
+        const char* script;
+        const char* expected;
+    };
+    const std::array<Case, 5> CASES = { {
+    { "pm.request.url.path[1] = 'admins';", "https://api.example.com/v2/admins" },
+    { "pm.request.url.path.splice(0, 1);", "https://api.example.com/users" },
+    { "pm.request.url.path.pop();", "https://api.example.com/v2" },
+    { "pm.request.url.path.unshift('api');", "https://api.example.com/api/v2/users" },
+    { "pm.request.url.path.length = 1;", "https://api.example.com/v2" },
+    } };
+
+    for (const auto& [script, expected] : CASES) {
+        Request target    = request;
+        target.url        = "https://api.example.com/v2/users";
+        const auto result = engine.execute_prerequest (script, target, env);
+
+        ASSERT_TRUE (result.success) << script << ": " << result.error_message;
+        EXPECT_EQ (target.url, expected) << script;
+    }
+}
+
+TEST_F (ScriptRequestUrlTest, ReplacingTheHostReachesTheWire) {
+    request.url       = "https://api.example.com/v2/users";
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.host = ['api', 'staging', 'example', 'com'];
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.staging.example.com/v2/users");
+}
+
+TEST_F (ScriptRequestUrlTest, TheSingleStringPartsAreWritable) {
+    request.url       = "https://api.example.com/v2/users";
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.protocol = 'http';
+        pm.request.url.port = '8080';
+        pm.request.url.hash = 'top';
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "http://api.example.com:8080/v2/users#top");
+}
+
+TEST_F (ScriptRequestUrlTest, TheQueryWritersReachTheWire) {
+    request.url       = "https://api.example.com/s?page=2";
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.query.add({ key: 'sort', value: 'name' });
+        pm.request.url.query.upsert({ key: 'page', value: '7' });
+        pm.request.url.query.add({ key: 'flag' });
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/s?page=7&sort=name&flag");
+}
+
+// upsert replaces in place, so a signature over the query does not silently
+// change shape because a parameter moved to the end.
+TEST_F (ScriptRequestUrlTest, UpsertKeepsWirePositionAndAddAppendsADuplicate) {
+    request.url = "https://api.example.com/s?a=1&b=2";
+    ASSERT_TRUE (engine
+    .execute_prerequest ("pm.request.url.query.upsert({key:'a', value:'9'});", request, env)
+    .success);
+    EXPECT_EQ (request.url, "https://api.example.com/s?a=9&b=2");
+
+    ASSERT_TRUE (engine
+    .execute_prerequest ("pm.request.url.query.add({key:'a', value:'8'});", request, env)
+    .success);
+    EXPECT_EQ (request.url, "https://api.example.com/s?a=9&b=2&a=8");
+}
+
+// Every match, not the first: removing `page` and getting one of two back has
+// removed nothing the caller can observe.
+TEST_F (ScriptRequestUrlTest, RemoveTakesEveryParameterOfThatName) {
+    request.url       = "https://api.example.com/s?page=1&sort=name&page=2";
+    const auto result = engine.execute_prerequest (R"JS(
+        pm.request.url.query.remove('page');
+        pm.request.url.query.remove('nothing-here');
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/s?sort=name");
+}
+
+TEST_F (ScriptRequestUrlTest, ClearEmptiesTheQueryAndTheQuestionMarkWithIt) {
+    request.url = "https://api.example.com/s?page=1&sort=name";
+    const auto result =
+    engine.execute_prerequest ("pm.request.url.query.clear();", request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/s");
+}
+
+// The reads have to follow the writes within the same script, or a script that
+// edits and then signs would sign the pre-edit URL.
+TEST_F (ScriptRequestUrlTest, TheReadsFollowAnEditWithinTheSameScript) {
+    request.url = "https://api.example.com/v2/users?page=1";
+    expect_script_passes (R"JS(
+        pm.request.url.query.upsert({ key: 'page', value: '4' });
+        pm.request.url.path.push('active');
+        pm.expect(pm.request.url.query.get('page')).to.equal('4');
+        pm.expect(pm.request.url.getPath()).to.equal('/v2/users/active');
+        pm.expect(pm.request.url.getQueryString()).to.equal('page=4');
+        pm.expect(pm.request.url.toString())
+          .to.equal('https://api.example.com/v2/users/active?page=4');
+        pm.expect(pm.request.url.length).to.equal(pm.request.url.toString().length);
+    )JS");
+}
+
+/**
+ * The regression the whole dirty-flag design exists to prevent.
+ *
+ * Composing on every read would put every URL through a split-and-join, and a
+ * URL that survives that is not guaranteed byte-identical - which would quietly
+ * break `getQueryString()` being byte-exact against the wire, the property the
+ * signing workflows depend on. A script that only *reads* must leave the
+ * request exactly as it found it.
+ */
+TEST_F (ScriptRequestUrlTest, AScriptThatOnlyReadsLeavesTheUrlByteIdentical) {
+    for (const char* url :
+    { "https://api.example.com/s?q=hello%20world&plus=a+b",
+    "https://api.example.com/v2/users%20list?page=2&sort=name&page=3#top",
+    "https://api.example.com/s?flag&empty=" }) {
+        Request target    = request;
+        target.url        = url;
+        const auto result = engine.execute_prerequest (R"JS(
+            var seen = pm.request.url.getQueryString() + pm.request.url.getPath() +
+                       pm.request.url.query.count() + pm.request.url.host.length;
+        )JS",
+        target, env);
+
+        ASSERT_TRUE (result.success) << url << ": " << result.error_message;
+        EXPECT_EQ (target.url, url) << "a read-only script rewrote the URL";
+    }
+}
+
+// A URL with no parts has no honest edit to make, and composing from empty
+// pieces would send "://" plus whatever was pushed.
+TEST_F (ScriptRequestUrlTest, EditingAnUnparseableUrlIsRefusedRatherThanComposed) {
+    const std::array<const char*, 4> EDITS = { {
+    "pm.request.url.path.push('x');",
+    "pm.request.url.query.add({key:'a', value:'1'});",
+    "pm.request.url.query.clear();",
+    "pm.request.url.protocol = 'https';",
+    } };
+
+    for (const char* edit : EDITS) {
+        Request target    = request;
+        target.url        = "not a url at all";
+        const auto result = engine.execute_prerequest (edit, target, env);
+
+        EXPECT_FALSE (result.success) << edit;
+        EXPECT_EQ (target.url, "not a url at all") << edit;
+    }
+}
+
+// A segment that cannot be a path segment fails at the mutation rather than
+// reaching the wire as "[object Object]".
+TEST_F (ScriptRequestUrlTest, ASegmentThatIsNotAStringIsRefused) {
+    const std::string original = request.url;
+    const auto result          = engine.execute_prerequest (R"JS(
+        pm.request.url.path.push({ a: 1 });
+    )JS",
+             request, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("path"), std::string::npos) << result.error_message;
+    EXPECT_EQ (request.url, original);
+}
+
+// A number is the one non-string taken: pushing an id onto a path is the
+// obvious case, and there is no ambiguity about what it means.
+TEST_F (ScriptRequestUrlTest, ANumericSegmentIsTakenAsItsDigits) {
+    request.url = "https://api.example.com/v2/users";
+    const auto result =
+    engine.execute_prerequest ("pm.request.url.path.push(42);", request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, "https://api.example.com/v2/users/42");
+}
+
+TEST_F (ScriptRequestUrlTest, AQueryWriterRefusesAnArgumentThatIsNotAKeyValueObject) {
+    const std::string original = request.url;
+    for (const char* edit : { "pm.request.url.query.add('sort=name');",
+         "pm.request.url.query.add({ value: 'name' });", "pm.request.url.query.add({ key: '' });",
+         "pm.request.url.query.add({ key: 'a', value: { b: 1 } });",
+         "pm.request.url.query.remove(42);" }) {
+        Request target    = request;
+        const auto result = engine.execute_prerequest (edit, target, env);
+
+        EXPECT_FALSE (result.success) << edit;
+        EXPECT_EQ (target.url, original) << edit;
+    }
+}
+
+// A test script's pm.request is a read-only record, so an edit there changes
+// what the script sees and reaches nothing that was sent - the same rule the
+// header mutators follow, now that the URL has mutators of its own.
+TEST_F (ScriptRequestUrlTest, MemberEditsInATestScriptAreNotWrittenBack) {
+    const std::string original = request.url;
+    const ScriptResult result  = run_test_script (R"JS(
+        pm.request.url.path.push('evil');
+        pm.request.url.query.add({ key: 'leak', value: '1' });
+    )JS");
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.url, original);
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/tests/url_parts_test.cpp
+++ b/engine/tests/url_parts_test.cpp
@@ -1,0 +1,196 @@
+/**
+ * @file url_parts_test.cpp
+ * @brief The URL splitter behind `pm.request.url` (issue #991).
+ *
+ * These are the answers the script surface presents as `url.host`, `url.path`,
+ * `url.query` and their getters, asserted here rather than through a JS context
+ * so a wrong split is located in the parser instead of in a script that read
+ * it. The script-level contract - that a lifted Postman script sees these under
+ * Postman's names - is `script_engine_test.cpp`'s.
+ *
+ * Two rules carry most of the weight and each has a test that fails if it is
+ * reversed: a path segment is decoded **on its own**, so an encoded separator
+ * cannot invent a segment; and a query is **not** decoded at all, because the
+ * request-signing workflows this exists for canonicalize the bytes that were
+ * sent.
+ */
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "optional_assert.hpp"
+#include "vayu/http/url_parts.hpp"
+
+namespace vayu::http {
+namespace {
+
+TEST (UrlPartsTest, SplitsAFullUrlIntoItsParts) {
+    const UrlParts parts = parse_url_parts (
+    "https://api.example.com:8443/v2/users?page=2&sort=name#top");
+
+    ASSERT_TRUE (parts.parsed);
+    EXPECT_EQ (parts.protocol, "https");
+    EXPECT_EQ (parts.host, (std::vector<std::string>{ "api", "example", "com" }));
+    EXPECT_EQ (parts.port, "8443");
+    EXPECT_EQ (parts.path, (std::vector<std::string>{ "v2", "users" }));
+    EXPECT_EQ (parts.query, "page=2&sort=name");
+    EXPECT_EQ (parts.hash, "top");
+
+    EXPECT_EQ (join_host (parts.host), "api.example.com");
+    EXPECT_EQ (join_path (parts.path), "/v2/users");
+}
+
+// A scheme's default port is not the port the URL states. Filling one in would
+// make a canonical string built from these parts differ from the wire.
+TEST (UrlPartsTest, AnUnstatedPortStaysEmptyRatherThanBecomingTheDefault) {
+    const UrlParts parts = parse_url_parts ("https://api.example.com/users");
+
+    ASSERT_TRUE (parts.parsed);
+    EXPECT_EQ (parts.port, "");
+    EXPECT_EQ (parts.hash, "");
+    EXPECT_EQ (parts.query, "");
+    EXPECT_TRUE (parts.query_params.empty ());
+}
+
+// `/` is one empty segment, which is what Postman's Url reports and what makes
+// `getPath()` answer "/" rather than "".
+TEST (UrlPartsTest, ARootPathIsOneEmptySegment) {
+    const UrlParts root = parse_url_parts ("https://example.com/");
+    ASSERT_TRUE (root.parsed);
+    EXPECT_EQ (root.path, (std::vector<std::string>{ "" }));
+    EXPECT_EQ (join_path (root.path), "/");
+
+    // libcurl normalises "no path" to "/", so the two spellings agree.
+    const UrlParts bare = parse_url_parts ("https://example.com");
+    ASSERT_TRUE (bare.parsed);
+    EXPECT_EQ (join_path (bare.path), "/");
+}
+
+TEST (UrlPartsTest, PathSegmentsAreDecoded) {
+    const UrlParts parts = parse_url_parts ("https://example.com/a%20b/c%2Bd");
+
+    ASSERT_TRUE (parts.parsed);
+    EXPECT_EQ (parts.path, (std::vector<std::string>{ "a b", "c+d" }));
+    EXPECT_EQ (join_path (parts.path), "/a b/c+d");
+}
+
+// Decoding the whole path first and splitting afterwards - the obvious
+// implementation - turns this into three segments and reports a path the server
+// never saw. Segment-at-a-time decoding is what keeps it at two.
+TEST (UrlPartsTest, AnEncodedSlashStaysInsideItsSegment) {
+    const UrlParts parts = parse_url_parts ("https://example.com/a%2Fb/c");
+
+    ASSERT_TRUE (parts.parsed);
+    EXPECT_EQ (parts.path, (std::vector<std::string>{ "a/b", "c" }));
+}
+
+TEST (UrlPartsTest, QueryParamsKeepWireOrderAndDuplicates) {
+    const UrlParts parts =
+    parse_url_parts ("https://example.com/s?b=2&a=1&b=3");
+
+    ASSERT_TRUE (parts.parsed);
+    ASSERT_EQ (parts.query_params.size (), 3u);
+    EXPECT_EQ (parts.query_params[0].key, "b");
+    EXPECT_EQ (parts.query_params[0].value, "2");
+    EXPECT_EQ (parts.query_params[1].key, "a");
+    EXPECT_EQ (parts.query_params[2].key, "b");
+    EXPECT_EQ (parts.query_params[2].value, "3");
+    // Byte-exact against the wire: the canonical string is built from this.
+    EXPECT_EQ (parts.query, "b=2&a=1&b=3");
+}
+
+// `?flag` and `?flag=` are different facts. A single "empty means absent" would
+// erase the distinction a rebuilt query string has to reproduce.
+TEST (UrlPartsTest, ABareKeyIsToldApartFromAnEmptyValue) {
+    const UrlParts parts =
+    parse_url_parts ("https://example.com/s?flag&empty=");
+
+    ASSERT_EQ (parts.query_params.size (), 2u);
+    EXPECT_FALSE (parts.query_params[0].value.has_value ());
+    const std::optional<std::string>& empty_value = parts.query_params[1].value;
+    ASSERT_HAS_VALUE (empty_value);
+    EXPECT_EQ (*empty_value, "");
+}
+
+// The query is the wire bytes. A decode here would make a signature built from
+// `all()` differ from the one the server computes over what it received.
+TEST (UrlPartsTest, QueryValuesAreNotDecoded) {
+    const UrlParts parts =
+    parse_url_parts ("https://example.com/s?q=hello%20world&plus=a+b");
+
+    ASSERT_EQ (parts.query_params.size (), 2u);
+    EXPECT_EQ (parts.query_params[0].value, "hello%20world");
+    EXPECT_EQ (parts.query_params[1].value, "a+b");
+}
+
+TEST (UrlPartsTest, AValueMayContainItsOwnEquals) {
+    const auto params = parse_query_params ("token=a=b=c");
+
+    ASSERT_EQ (params.size (), 1u);
+    EXPECT_EQ (params[0].key, "token");
+    EXPECT_EQ (params[0].value, "a=b=c");
+}
+
+TEST (UrlPartsTest, EmptyRunsBetweenSeparatorsAreDropped) {
+    const auto params = parse_query_params ("a=1&&b=2&");
+
+    ASSERT_EQ (params.size (), 2u);
+    EXPECT_EQ (params[0].key, "a");
+    EXPECT_EQ (params[1].key, "b");
+}
+
+// An address literal has no dots to split on in the IPv6 case and is not a
+// hostname in the IPv4 case; neither is special-cased, and both come back as
+// something `join_host` puts together again unchanged.
+TEST (UrlPartsTest, HostLiteralsSurviveTheSplitAndTheJoin) {
+    const UrlParts v4 = parse_url_parts ("http://127.0.0.1:9876/health");
+    ASSERT_TRUE (v4.parsed);
+    EXPECT_EQ (join_host (v4.host), "127.0.0.1");
+    EXPECT_EQ (v4.port, "9876");
+
+    const UrlParts v6 = parse_url_parts ("http://[::1]:9876/health");
+    ASSERT_TRUE (v6.parsed);
+    EXPECT_EQ (v6.host.size (), 1u);
+    EXPECT_EQ (join_host (v6.host), "[::1]");
+}
+
+// The parser answers "what are the pieces", never "can libcurl transfer it" -
+// so a scheme no driver here supports still splits.
+TEST (UrlPartsTest, AnUnsupportedSchemeStillSplits) {
+    const UrlParts parts = parse_url_parts ("ws://example.com/socket?room=1");
+
+    ASSERT_TRUE (parts.parsed);
+    EXPECT_EQ (parts.protocol, "ws");
+    EXPECT_EQ (join_path (parts.path), "/socket");
+    EXPECT_EQ (parts.query, "room=1");
+}
+
+// No scheme guessing: reporting `http` for a string that never said so would
+// put a protocol into a canonical string the request does not carry.
+TEST (UrlPartsTest, AUrlWithoutASchemeIsNotParsedRatherThanGuessedAt) {
+    const UrlParts parts = parse_url_parts ("example.com/users");
+
+    EXPECT_FALSE (parts.parsed);
+    EXPECT_TRUE (parts.protocol.empty ());
+    EXPECT_TRUE (parts.host.empty ());
+    EXPECT_TRUE (parts.path.empty ());
+}
+
+TEST (UrlPartsTest, AnUnparseableUrlReportsNoPartsAtAll) {
+    const UrlParts parts = parse_url_parts ("{{base_url}}/users");
+
+    EXPECT_FALSE (parts.parsed);
+    EXPECT_TRUE (parts.host.empty ());
+    EXPECT_TRUE (parts.query_params.empty ());
+}
+
+TEST (UrlPartsTest, JoinHostAndJoinPathAreEmptyForEmptyInput) {
+    EXPECT_EQ (join_host ({}), "");
+    EXPECT_EQ (join_path ({}), "");
+}
+
+} // namespace
+} // namespace vayu::http

--- a/engine/tests/url_parts_test.cpp
+++ b/engine/tests/url_parts_test.cpp
@@ -187,6 +187,75 @@ TEST (UrlPartsTest, AnUnparseableUrlReportsNoPartsAtAll) {
     EXPECT_TRUE (parts.query_params.empty ());
 }
 
+// ---------------------------------------------------------------------------
+// Composition - the inverse, for a caller that edited the parts (issue #1040).
+// ---------------------------------------------------------------------------
+
+TEST (UrlPartsTest, ComposesTheEditedPartsBackIntoAUrl) {
+    UrlParts parts =
+    parse_url_parts ("https://api.example.com:8443/v2/users?page=2#top");
+    ASSERT_TRUE (parts.parsed);
+
+    parts.path.emplace_back ("active");
+    parts.query_params.push_back ({ "sort", "name" });
+
+    EXPECT_EQ (compose_url (parts),
+    "https://api.example.com:8443/v2/users/active?page=2&sort=name#top");
+}
+
+// The parts a URL was split into put it back together unchanged, for the
+// ordinary shapes. Where that is *not* guaranteed - an unusual escape - the
+// script surface never composes at all, which is what the dirty flag is for;
+// this pins the cases where it is.
+TEST (UrlPartsTest, ComposeRoundTripsAParsedUrl) {
+    for (const char* url :
+    { "https://api.example.com/v2/users?page=2&sort=name#top",
+    "http://127.0.0.1:9876/health", "https://example.com/",
+    "ws://example.com/socket?room=1", "https://example.com/s?flag&empty=" }) {
+        const UrlParts parts = parse_url_parts (url);
+        ASSERT_TRUE (parts.parsed) << url;
+        EXPECT_EQ (compose_url (parts), url);
+    }
+}
+
+// Encoded on the way out because it was decoded on the way in, per segment - so
+// a segment holding a slash stays one segment rather than becoming two.
+TEST (UrlPartsTest, ComposeEncodesEachPathSegmentOnItsOwn) {
+    UrlParts parts = parse_url_parts ("https://example.com/root");
+    ASSERT_TRUE (parts.parsed);
+    parts.path = { "a b", "c/d" };
+
+    EXPECT_EQ (compose_url (parts), "https://example.com/a%20b/c%2Fd");
+    // And it reads back as the two segments it was written from.
+    const UrlParts reparsed = parse_url_parts (compose_url (parts));
+    EXPECT_EQ (reparsed.path, (std::vector<std::string>{ "a b", "c/d" }));
+}
+
+// The query is the wire bytes in both directions: a value that arrived
+// percent-encoded is written back as it arrived, not doubly encoded.
+TEST (UrlPartsTest, ComposeDoesNotReEncodeTheQuery) {
+    const UrlParts parts =
+    parse_url_parts ("https://example.com/s?q=hello%20world");
+    ASSERT_TRUE (parts.parsed);
+
+    EXPECT_EQ (compose_url (parts), "https://example.com/s?q=hello%20world");
+}
+
+TEST (UrlPartsTest, ComposeQueryKeepsTheBareKeyDistinction) {
+    EXPECT_EQ (compose_query ({ { "flag", std::nullopt }, { "empty", std::string () } }),
+    "flag&empty=");
+    EXPECT_EQ (compose_query ({}), "");
+}
+
+// Nothing to compose from, and a URL built out of empty pieces ("://") would
+// look plausible enough to send.
+TEST (UrlPartsTest, ComposingAnUnparsedUrlAnswersNothing) {
+    const UrlParts parts = parse_url_parts ("{{base_url}}/users");
+
+    ASSERT_FALSE (parts.parsed);
+    EXPECT_EQ (compose_url (parts), "");
+}
+
 TEST (UrlPartsTest, JoinHostAndJoinPathAreEmptyForEmptyInput) {
     EXPECT_EQ (join_host ({}), "");
     EXPECT_EQ (join_path ({}), "");


### PR DESCRIPTION
## Description

`pm.request.url` becomes Postman's `Url` object, shipping the deferred decision
recorded in `docs/engine/scripting.md` and `docs/app/pm-api-compatibility.md`
under the owner call in #991: **compatibility wins over the shipped string
shape**. It then closes #1040 on top, so the object is writable a member at a
time rather than only whole.

**Plan (#991).** The root cause of the deferral was believed to be structural -
a JS string primitive cannot carry properties, and the write-back required
`pm.request.url` to still be a string when the script returned. Both halves are
solvable without touching the write-back's contract: the property becomes an
**accessor pair** whose getter answers a `Url`-class object and whose setter
takes the string a script assigns, and the write-back learns one extra shape
(that object) beside the string it already took. The object is given
`String.prototype` as its prototype and its own `toString` / `valueOf` /
`toJSON` / `@@toPrimitive`, so every string context a script already relies on -
concatenation, template literals, `==`, the generic `String` methods,
`JSON.stringify` - keeps working. **The alternative I rejected** was making it a
plain data property built eagerly (which is what Postman itself effectively
does): it is simpler, but `pm.request.url = '...'` would then leave a bare
string behind, so `pm.request.url = x; pm.request.url.query.get('a')` throws -
and every script would pay a URL parse whether or not it reads the URL. The
accessor is lazy (the parse happens on the first *read*) and keeps the member a
`Url` across writes.

**Plan (#1040).** #991's read surface shipped whole and its write surface was
the whole URL, which left `path` and `host` as ordinary arrays: a
`pm.request.url.path.push('v2')` - how a Postman script edits a URL - succeeded,
reached nothing, and said nothing. A write no layer reads is this codebase's
most repeated defect wearing its other face, so it is closed here rather than
left filed.

**The design decision worth reviewing** is how those array edits are seen. My
first attempt made each list a `Proxy` and trapped the writes. It worked, and it
broke `pm.expect(pm.request.url.host).to.include(...)` - `JS_IsArray` answers on
the class id and a proxy is not one, so every array-shaped matcher silently
stopped seeing an array. I threw it away for the mechanism the codebase already
uses: `apply_pm_request_writeback` reads `pm.request.headers` back at the moment
it needs it, and the lists are read back the same way. Plain arrays, no traps,
no eval'd Proxy factory, and everything that works on an array keeps working.

Reading them back means *comparing* them, and comparing is what preserves the
property the read path depends on: a script that only read the URL leaves the
parts untouched, nothing is composed, and the request goes out as the exact
bytes it arrived as.

The parsing lives in a new `vayu::http::parse_url_parts` / `compose_url`
(`engine/src/http/url_parts.cpp`) rather than inside `script_engine.cpp`:
libcurl's `CURLU` owns the splitting - the same parser the transfer layer
resolves the URL with - and a module outside the JS runtime is unit-testable
without a JS context. `cookie_jar.cpp`'s private `url_scope_of` is deliberately
**not** folded onto it in this PR: its `nullopt`-on-missing-host semantics are
load-bearing for jar scoping, and rewiring them is not this issue's scope.

## Type of Change

- [x] New feature
- [x] Breaking change (two documented breaks, listed below)
- [x] Documentation update

## What ships

**Read surface** - `protocol`, `host` segments, `port`, decoded `path` segments,
`hash`, `query` with `get`/`has`/`all`/`toObject`/`count`, plus `getHost()`,
`getPath()`, `getQueryString()`, `toString()`.

**Write surface** - the whole URL by assignment or Postman's `url.update()`
(which mutates in place, so a reference taken before it sees it), **and** one
member at a time: `path` / `host` as arrays (push, pop, unshift, splice, index
assignment, a `length` truncation, or replacing the array outright),
`protocol` / `port` / `hash` by assignment, and the query's `add`, `upsert`,
`remove`, `clear`.

Three rules the write surface holds, each the reason for a decision a later
change might otherwise undo:

- **`upsert` replaces in place, `add` appends.** A parameter that quietly moved
  to the end would change the shape of any signature computed over the query.
- **`remove(name)` takes every match.** Removing `page` from `?page=1&page=2`
  and getting one back has removed nothing the caller can observe.
- **An edit that cannot reach the wire is an error, never a no-op.** A URL the
  parser could not read has no parts to edit, and a segment that is not a string
  or a number is refused by member and index rather than reaching the wire as
  `[object Object]`.

The reads follow the writes within a script - `path.push` then `getPath()`
answers the edited path - because the member readers refresh from the arrays
too. Without that the two halves of the object would describe different URLs,
and a script that edits and then signs would sign a URL it is not sending.

**Two decodes, deliberately different.** Path segments are percent-decoded, each
on its own so an encoded `%2F` cannot invent a segment (and re-encoded per
segment on the way out, so a segment an edit put a slash into stays one
segment). The query is **not** decoded, in `getQueryString()` or `query.all()` -
the request-signing workflows this exists for canonicalize the bytes that were
sent, and that is also what postman-collection's `QueryParam` holds.

**Surfaces that used to require a string** and are documented as taking
`pm.request.url` now take the object too: the `pm.request` write-back,
`pm.cookies.jar().get/set/unset/clear` (the URL positions only - a cookie *name*
stays string-only), and `pm.sendRequest` in both the bare-URL and `options.url`
positions. That last one is the guard #991 says must land with this PR or ahead
of it in #1001; it lands here, narrowly - Postman's *literal* URL-object form (a
hand-built `{host: [...], path: [...]}`) is still refused, and remains #1001's.

## Deliberate deviations from the issue spec

Two, both stated here rather than smuggled in:

1. **`.length` is not a break.** #991 lists `===`, `typeof` and `.length` as the
   accepted costs. `.length` turns out not to be a choice between "works" and
   "absent": `String.prototype` is a String exotic object holding `""`, so an
   object that merely inherits from it answers **`0`** - a plausible wrong
   number for a non-empty URL, which is precisely the silent-wrong-answer class
   #996's program exists to close. It is defined on the object as the URL's own
   length. Two breaks remain, both pinned by tests.
2. **The setter accepts a string or a `Url` object, not "any object via its
   `toString`".** Accepting any object would make `pm.request.url = {}` the
   string `[object Object]` and send it. Anything else throws *at the
   assignment*, so the script author is told which line was wrong instead of
   reading it off the write-back several lines later.

One thing #991 did not anticipate: `pm.expect(pm.request.url).to.include(...)`
is the idiom in this repo's own docs and tests, and `include` answered `false`
for anything that was neither a string nor an array. A verdict that silently
flipped to failing is the worst thing an assertion can do, so `expect_include`
reads a `Url` object on its substring branch.

## Touchpoints

Every code-side and doc-side surface from #991's inventory:

- `engine/src/http/routes/scripting.cpp` - the completion table, now offering
  the whole `Url` surface (the app has no `pm.request` member list of its own;
  completions and typedefs are engine-served, so there is no app-side list to
  update).
- `engine/src/http/routes/script_types.cpp` - the `URL` / `URLSearchParams`
  `ABSENT_GLOBALS` rationales, and one generator addition: a member with its own
  members *on top of* a primitive is emitted as
  `get url(): string & { ... }; set url(value: string);`. Declared as an object
  alone, every documented `jar().set(pm.request.url, ...)` stops compiling;
  declared as a string alone, `url.query.get(...)` does. The table says which by
  spelling the type `string & object`.
- `engine/tests/fixtures/script-typedefs.d.ts` - regenerated.
- `docs/engine/scripting.md` - the deferral section replaced with the shipped
  surface, the write rules and the migration table; the two worked examples that
  did URL string surgery rewritten onto `query.all()` (this issue's payoff made
  visible); the `pm.crypto` "not available" note.
- `docs/app/pm-api-compatibility.md` - the Request table row, the not-supported
  list, and the write-back rules.
- `app/src/.../script/script-variants.tsx` - the pre-request panel's quick
  reference and one note, which is where a script author looks before the docs.

`ScopedValue` moves up beside the other JS helpers: the query writers read
properties and refuse on most of them, which is what it was written for, and it
sat below them.

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
cd app && pnpm test && pnpm type-check && pnpm lint
mkdocs build --strict -f .github/mkdocs.yml
```

- **Engine: 2510 tests, all passing.** 60 new: `url_parts_test.cpp` (21 - the
  splitter and its inverse on their own) and `script_request_url_test.cpp` (39 -
  the script-level contract). Beyond the surface itself, three carry the
  arguments above: the two documented breaks asserted **as** breaks; `.length`
  with a test that reads `0` if the own definition is deleted; and
  `AScriptThatOnlyReadsLeavesTheUrlByteIdentical`, which is the regression a
  compose-on-every-read design would have introduced.
- **App: 5702 tests across 531 files, all passing**, including
  `script-typedefs.docs-compile.test.ts`, which compiles every `pm.*` block in
  both doc pages against the regenerated declarations - so the new `Url`
  examples are type-checked, not just written. That test earned its keep twice
  here: it caught `query.all()` declared as `object[]` (`object` carries no
  index signature, so the signing example's `p.key` was an error against this
  repo's own declarations), and a query writer declared narrower than it
  behaves.
- `mkdocs build --strict` clean; `clang-format-19 --dry-run -Werror` clean on
  every touched engine source.

Two flakes appeared once each mid-development on this machine under full-suite
load and passed in isolation and on every final run, in code this PR does not
touch: `send-with-row.test.tsx`'s "opens the list on the row that step bound" (a
5s default timeout on a render-heavy case, the shape `app/CLAUDE.md` documents)
and `ImportFetchBound.CutsOffAChunkedResponseThatGrowsPastTheBound`. Recorded
rather than fixed or hidden.

This PR adds a file to `engine/CMakeLists.txt`, so the Sanitizers workflow runs
per-PR on it - including the `asan on windows-latest` leg.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues

Closes #991
Closes #1040