### PR TITLE
feat(engine): unresolved {{name}} stays literal, and layered values resolve - #1009

### DIFF
--- a/app/src/hooks/useVariableResolver.dynamic.test.tsx
+++ b/app/src/hooks/useVariableResolver.dynamic.test.tsx
@@ -90,10 +90,25 @@ describe("resolveString with dynamic variables", () => {
 		expect(resolveString("a={{$randomInteger}}")).toBe("a={{$randomInteger}}");
 	});
 
-	it("still resolves an ordinary unknown name to an empty string", () => {
-		// Unchanged behaviour - the `$` prefix is what marks the intent.
+	it("leaves an ordinary unknown name written as it stands too", () => {
+		// Since issue #1009 the `$` prefix no longer marks the difference: the
+		// preview shows the token because that is what the engine will send,
+		// and a preview that showed a hole would disagree with the request.
 		const { resolveString } = setup();
-		expect(resolveString("a={{nope}}")).toBe("a=");
+		expect(resolveString("a={{nope}}")).toBe("a={{nope}}");
+	});
+
+	it("follows a value that itself holds tokens, and stops on a cycle", () => {
+		// The layering imported environments are written with, previewed as
+		// the URL it spells rather than as braces the engine would resolve.
+		const { resolveString } = setup({
+			baseUrl: v("{{protocol}}://{{host}}"),
+			protocol: v("https"),
+			host: v("api.example.test"),
+			loop: v("x{{loop}}"),
+		});
+		expect(resolveString("{{baseUrl}}/orders")).toBe("https://api.example.test/orders");
+		expect(resolveString("{{loop}}")).toBe("x{{loop}}");
 	});
 
 	it("resolves generators inside nested objects via resolveObject", () => {

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -212,7 +212,8 @@ export function useVariableResolver(
 	 * generator that sent an empty field silently is the defect this table was
 	 * added to fix (issue #186); leaving `{{$randomInteger}}` on the wire makes
 	 * it visible in the request, and `EditableVariable` keeps painting the token
-	 * as unresolved. Ordinary unknown names still resolve to "" - unchanged.
+	 * as unresolved. Since issue #1009 an ordinary unknown name is the same
+	 * rule - the preview shows the token the engine will send.
 	 */
 	const resolveString = useCallback(
 		(input: string): string => resolveTemplate(input, (name) => variableMap[name]?.value),

--- a/app/src/lib/variable-resolution.ts
+++ b/app/src/lib/variable-resolution.ts
@@ -23,12 +23,14 @@
  *  - a definition is disabled only by an explicit `enabled: false`; absent or
  *    malformed counts as enabled (D17 - matches the importers and the engine)
  *  - a non-string stored `value` reads as "" (D17)
- *  - unknown plain name resolves to ""; unknown `$name` keeps its braces
+ *  - a name nothing defines keeps its braces, plain or `$name` (issue #1009)
  *  - a `data.*` name keeps its braces too: it addresses the reserved data
  *    namespace (issue #402), which only a scenario run's iteration can bind
  *  - a user-defined variable named `$guid` beats the generator; generators run
  *    once per occurrence
- *  - single pass, no recursion; the raw string, never the typed value
+ *  - a value that itself holds `{{tokens}}` resolves through them, to a depth
+ *    bound, cycles left literal (issue #1009); the raw string, never the typed
+ *    value
  *
  * The `{{name}}` matcher itself is `VARIABLE_PATTERN` from
  * `constants/variables.ts` - this module used to declare its own identical
@@ -120,28 +122,62 @@ export function dataColumnName(name: string): string | null {
 }
 
 /**
- * Substitute `{{name}}` occurrences in one pass: the reserved `data.*`
- * namespace first (kept verbatim), then scopes, then the dynamic-variable
- * table. A defined name (even one spelled `$guid`) wins over a generator; an
- * unknown `$name` keeps its braces (issue #186); an ordinary unknown name
- * becomes "". Replacements are never rescanned, so a value containing
- * `{{other}}` stays literal.
+ * How deep a value's own `{{tokens}}` are followed before the rest are left
+ * written as they stand (issue #1009). The engine's `MAX_NESTED_RESOLUTIONS`,
+ * restated: the two are pinned by the conformance fixture's cycle case, which
+ * only terminates because both sides bound the work.
+ */
+const MAX_NESTED_RESOLUTIONS = 8;
+
+/**
+ * Substitute `{{name}}` occurrences: the reserved `data.*` namespace first
+ * (kept verbatim), then scopes, then the dynamic-variable table. A defined
+ * name (even one spelled `$guid`) wins over a generator; a name nothing
+ * answers keeps its braces, `$name` (issue #186) and ordinary alike (issue
+ * #1009) - the token reaching the wire is what makes the miss visible, where
+ * an empty string silently changed the request.
+ *
+ * A replacement that carries tokens of its own is resolved through the same
+ * lookup, to `MAX_NESTED_RESOLUTIONS` levels, so a layered `{{baseUrl}}`
+ * previews as the URL it spells. A name already being expanded is a cycle and
+ * its token stays literal; the surrounding text is never rescanned.
  */
 export function resolveTemplate(
 	input: string,
 	lookup: (name: string) => string | undefined
 ): string {
 	if (!input || typeof input !== "string") return input;
-	return input.replace(VARIABLE_PATTERN, (match, rawName: string) => {
-		const name = rawName.trim();
-		// Before the lookup, not after: the namespace is disjoint from the
-		// scopes, so a variable named `data.id` must not answer for the column.
-		// Only a scenario run's iteration can bind one, and the engine's
-		// composer leaves it written as it stands for exactly that reason.
-		if (isDataVariableName(name)) return match;
-		const defined = lookup(name);
-		if (defined !== undefined) return defined;
-		if (isDynamicVariableName(name)) return resolveDynamicVariable(name) ?? match;
-		return "";
-	});
+	// The names currently being expanded, innermost last - the chain the cycle
+	// check reads, not a set of every name seen: `{{a}} {{a}}` side by side is
+	// two expansions of one name and neither is a cycle.
+	const expanding: string[] = [];
+	const substitute = (text: string): string =>
+		text.replace(VARIABLE_PATTERN, (match, rawName: string) => {
+			const name = rawName.trim();
+			// Before the lookup, not after: the namespace is disjoint from the
+			// scopes, so a variable named `data.id` must not answer for the column.
+			// Only a scenario run's iteration can bind one, and the engine's
+			// composer leaves it written as it stands for exactly that reason.
+			if (isDataVariableName(name)) return match;
+			if (expanding.includes(name)) return match;
+			const defined = lookup(name);
+			// The generator answers `null` for a name its table does not have,
+			// where a scope answers `undefined` - one shape here, so the miss is
+			// tested once rather than at each use below.
+			const value =
+				defined !== undefined
+					? defined
+					: isDynamicVariableName(name)
+						? (resolveDynamicVariable(name) ?? undefined)
+						: undefined;
+			if (value === undefined) return match;
+			if (!value.includes("{{") || expanding.length >= MAX_NESTED_RESOLUTIONS) return value;
+			expanding.push(name);
+			try {
+				return substitute(value);
+			} finally {
+				expanding.pop();
+			}
+		});
+	return substitute(input);
 }

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -79,9 +79,10 @@ what happened. The error names the three scoped setters. See
 with the exact semantics the request's own URL/headers/body get at compose
 time: scopes first (in `pm.variables`' precedence), then the dynamic-variable
 table - so `{{$guid}}`, `{{$timestamp}}` and the `{{$random*}}` set generate a
-fresh value **per occurrence**, an unknown `$name` keeps its braces, an
-ordinary unknown name becomes `""`, and resolution is a single pass over the
-raw stored strings.
+fresh value **per occurrence**, a name nothing defines keeps its braces
+(`$name` and ordinary alike, issue #1009), and a value that itself holds
+`{{tokens}}` resolves through them to a bounded depth, cycles left literal.
+Always over the raw stored strings.
 
 ```javascript
 const id      = pm.variables.replaceIn("{{$guid}}");

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -60,7 +60,8 @@ written exactly as it stands, because only a scenario run's iteration knows
 which row is bound; the run's worker substitutes it immediately before each
 send. A `data.*` token in an ordinary Send therefore reaches the wire as
 written: there is no row. `{{data.}}` with nothing after the dot names no column
-and follows the ordinary unknown-name rule (resolves to `""`) instead.
+and follows the ordinary unknown-name rule instead - which since #1009 also
+leaves it written as it stands, for a different reason.
 
 **The UI paints it as its own state, not as a broken variable.** Unresolved is
 the accurate word for what the resolvers do with the token, but it is the wrong
@@ -243,11 +244,26 @@ copy at all: it composes via the engine and its old `resolve.ts` port is
 deleted (#226).
 
 The resolved map is then used by `resolveString(input)` (preview) and
-`resolve_template` (engine) which replace all `{{name}}` occurrences. An
-ordinary name nothing defines resolves to the **empty string** - the token
-disappears from the outgoing request. A `{{$name}}` is the exception; see
-below. Resolution is a **single pass**: a value that itself contains
-`{{other}}` stays literal, and there is no way to escape a literal `{{`.
+`resolve_template` (engine) which replace all `{{name}}` occurrences.
+
+**A name nothing defines keeps its braces** (#1009), plain and `{{$name}}`
+alike. The token goes out on the wire, where it becomes a DNS or a `4xx`
+failure naming the thing that was never set; it used to resolve to the empty
+string, which sent `https://{{host}}/x` as `https:///x` - a different request,
+made silently. A definition that *exists* and holds an empty value still
+substitutes empty: the rule is about a name nothing answers, not about a blank
+answer. There is no way to escape a literal `{{`.
+
+**A value that itself holds `{{tokens}}` resolves through them** (#1009), which
+is how `baseUrl = "{{protocol}}://{{host}}"` - the shape most imported
+environments are written in - composes as the URL it spells. Two rules bound
+the walk, because the values come from a user's environment and nothing there
+promises to terminate: a name already being expanded is a **cycle** and its
+token is left written as it stands (`a = "{{b}}"` with `b = "{{a}}"` resolves
+to the literal `{{a}}`), and expansion stops after **8 levels**, keeping what
+it resolved and leaving the rest literal. Text that a substitution did *not*
+put there is never rescanned, and a value holding no `{{` costs one search - so
+everything that is not layered still resolves in a single pass.
 
 ### One value composition refuses: a header a variable would forge (#738)
 

--- a/engine/include/vayu/http/request_composer.hpp
+++ b/engine/include/vayu/http/request_composer.hpp
@@ -95,13 +95,19 @@ inline constexpr std::string_view DATA_NAMESPACE_PREFIX = "data.";
 bool is_data_variable_name (const std::string& name);
 
 /**
- * Scan `{{name}}` occurrences left to right in one pass over @p input and
- * replace each through @p resolve, which receives the trimmed name.
+ * Scan `{{name}}` occurrences left to right over @p input and replace each
+ * through @p resolve, which receives the trimmed name.
  *
  * `nullopt` leaves that occurrence written exactly as it stands; any string -
- * including an empty one - replaces it. Nested braces never match, and a
- * replacement is never rescanned, so a substituted value containing `{{b}}`
- * stays literal.
+ * including an empty one - replaces it. Nested braces never match.
+ *
+ * **A replacement that carries tokens of its own is resolved too** (#1009),
+ * through the same @p resolve, to a bound of 8 levels: `baseUrl =
+ * "{{protocol}}://{{host}}"` composes as the URL it spells rather than as
+ * literal braces. A name already being expanded is a cycle and its token is
+ * left written as it stands, so `a = "{{b}}"` with `b = "{{a}}"` terminates.
+ * A value holding no `{{` costs one search and nothing else, which is what
+ * keeps composition a single pass for everything that is not layered.
  *
  * This is the one scanner: `resolve_template` and the scenario runner's data
  * pass both drive it, so the two cannot disagree about what a token *is*.
@@ -120,9 +126,10 @@ struct TokenSplit {
 };
 
 /**
- * The same left-to-right pass as `substitute_tokens`, *reported* rather than
+ * The same left-to-right scan as `substitute_tokens`, *reported* rather than
  * applied: @p input split into its literal text and the names of the `{{name}}`
- * occurrences @p keep accepts. A token @p keep rejects stays part of the
+ * occurrences @p keep accepts. One pass and no nesting - it reports names, and
+ * a name has no value here to hold tokens of its own. A token @p keep rejects stays part of the
  * surrounding literal, written exactly as it stands.
  *
  * Through the same pattern as `substitute_tokens`, so the two cannot disagree
@@ -152,10 +159,11 @@ std::optional<std::string> resolve_dynamic_variable (const std::string& name);
 const std::vector<std::string>& dynamic_variable_names ();
 
 /**
- * Substitute `{{name}}` occurrences in one pass. The reserved `data.*`
- * namespace first (kept verbatim), then scopes, then the dynamic-variable
- * table; an ordinary unknown name becomes "", an unknown `$name` keeps its
- * braces. Nested braces never match and replacements are never rescanned.
+ * Substitute `{{name}}` occurrences. The reserved `data.*` namespace first
+ * (kept verbatim), then scopes, then the dynamic-variable table; a name
+ * nothing answers - ordinary or `$name` - keeps its braces (#186, #1009), and
+ * a value that itself holds tokens is resolved through them under
+ * `substitute_tokens`' bound. Nested braces never match.
  */
 std::string resolve_template (const std::string& input, const VariableValues& vars);
 

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -31,9 +31,11 @@ namespace {
  * The one `{{name}}` pattern, shared by every reader of a token in this file.
  *
  * Same as the clients' VARIABLE_PATTERN: no nested braces, no escape hatch.
- * Matches are consumed left to right over the *original* string only, which is
- * what makes both readers below a single pass - a replacement is never
- * rescanned, so `{{a}}` whose value contains `{{b}}` stays literal.
+ * Matches are consumed left to right over the string being scanned, never over
+ * the text a replacement put there - a substituted value is followed by
+ * re-entering the scanner on the *value* (`substitute_tokens_nested`, #1009),
+ * which is what bounds the work and lets a cycle be seen; the surrounding
+ * literal is never rescanned.
  */
 const std::regex& token_pattern () {
     static const std::regex pattern (R"(\{\{([^{}]+)\}\})");
@@ -238,8 +240,34 @@ const vayu::Environment& environment) {
     return values;
 }
 
-std::string substitute_tokens (const std::string& input,
-const std::function<std::optional<std::string> (const std::string& name)>& resolve) {
+namespace {
+
+/**
+ * How deep a value's own `{{tokens}}` are followed before the rest are left
+ * written as they stand (issue #1009).
+ *
+ * A bound rather than "until it stops changing", because the resolver has no
+ * way to know a chain is finite: the values come from a user's environment,
+ * and `a = "{{a}} "` grows on every pass. Eight is past every layering anyone
+ * writes by hand - `baseUrl = "{{protocol}}://{{host}}:{{port}}"` is two - and
+ * far short of a stack anyone would notice.
+ */
+constexpr size_t MAX_NESTED_RESOLUTIONS = 8;
+
+/**
+ * One pass over @p input, following each replacement that carries tokens of
+ * its own back through @p resolve.
+ *
+ * @p expanding is the chain of names currently being expanded, innermost last.
+ * A name already on it is a cycle, and its token is left written as it stands
+ * rather than expanded again - `a = "{{b}}"`, `b = "{{a}}"` resolves to the
+ * literal `{{a}}` instead of recurring until the stack ends. At the depth bound
+ * the value still substitutes; only its own tokens stay literal, so a chain
+ * longer than the bound keeps the work it had already done.
+ */
+std::string substitute_tokens_nested (const std::string& input,
+const std::function<std::optional<std::string> (const std::string& name)>& resolve,
+std::vector<std::string>& expanding) {
     if (input.empty ()) {
         return input;
     }
@@ -253,15 +281,44 @@ const std::function<std::optional<std::string> (const std::string& name)>& resol
     for (; it != end; ++it) {
         const auto& match = *it;
         out.append (input, last, static_cast<size_t> (match.position ()) - last);
-        if (auto replacement = resolve (trim (match[1].str ()))) {
-            out += *replacement;
-        } else {
-            out += match.str (); // left written as it stands
-        }
         last = static_cast<size_t> (match.position () + match.length ());
+
+        std::string name = trim (match[1].str ());
+        // The cycle is answered before `resolve` runs, not after: the callbacks
+        // record what they substituted (a header a value would forge, a column
+        // no row has), and a name this pass is not going to substitute must not
+        // leave a record saying it did.
+        if (std::find (expanding.begin (), expanding.end (), name) != expanding.end ()) {
+            out += match.str (); // a cycle - left written as it stands
+            continue;
+        }
+        auto replacement = resolve (name);
+        if (!replacement) {
+            out += match.str (); // left written as it stands
+            continue;
+        }
+        // The `find` is what keeps this a single pass for every value that
+        // holds no token, which is nearly all of them: only a value that
+        // itself spells `{{` pays a second scan.
+        if (replacement->find ("{{") == std::string::npos ||
+        expanding.size () >= MAX_NESTED_RESOLUTIONS) {
+            out += *replacement;
+            continue;
+        }
+        expanding.push_back (std::move (name));
+        out += substitute_tokens_nested (*replacement, resolve, expanding);
+        expanding.pop_back ();
     }
     out.append (input, last, input.size () - last);
     return out;
+}
+
+} // namespace
+
+std::string substitute_tokens (const std::string& input,
+const std::function<std::optional<std::string> (const std::string& name)>& resolve) {
+    std::vector<std::string> expanding;
+    return substitute_tokens_nested (input, resolve, expanding);
 }
 
 TokenSplit split_tokens (const std::string& input,
@@ -315,7 +372,14 @@ lookup_variable (const std::string& name, const VariableValues& vars) {
     if (is_dynamic_variable_name (name)) {
         return resolve_dynamic_variable (name); // unknown $name keeps its braces (#186)
     }
-    return std::string{}; // ordinary unknown name resolves to ""
+    // An unknown ordinary name keeps its braces too (#1009), on the rule the
+    // line above has held since #186: a token that resolved to "" left the
+    // request *different* and said nothing - `https://{{host}}/x` went out as
+    // `https:///x`, a URL nobody wrote, where the literal reaches DNS or the
+    // server and comes back as an error naming the host that was never set.
+    // It is also what makes a token survive composition for something later to
+    // resolve, which is the half #1008's residual pass is built on.
+    return std::nullopt;
 }
 
 std::string resolve_template (const std::string& input, const VariableValues& vars) {

--- a/engine/tests/fixtures/variable-resolution-conformance.json
+++ b/engine/tests/fixtures/variable-resolution-conformance.json
@@ -55,13 +55,13 @@
       "expected": "chain.test"
     },
     {
-      "name": "a name whose every definition is disabled resolves to empty",
+      "name": "a name whose every definition is disabled is unknown, so it stays literal",
       "scopes": {
         "globals": { "gone": { "value": "a", "enabled": false } },
         "environment": { "gone": { "value": "b", "enabled": false } }
       },
       "input": "[{{gone}}]",
-      "expected": "[]"
+      "expected": "[{{gone}}]"
     },
     {
       "name": "D17: absent 'enabled' counts as enabled",
@@ -107,10 +107,10 @@
       "expected": "kept/"
     },
     {
-      "name": "an ordinary unknown name resolves to empty string",
+      "name": "an ordinary unknown name keeps its braces (issue #1009)",
       "scopes": { "environment": { "known": { "value": "x", "enabled": true } } },
       "input": "a={{missing}}&b={{known}}",
-      "expected": "a=&b=x"
+      "expected": "a={{missing}}&b=x"
     },
     {
       "name": "an unknown $name keeps its braces (issue #186)",
@@ -134,7 +134,7 @@
       "name": "the data. prefix alone names no column and follows the unknown-name rule",
       "scopes": {},
       "input": "a{{data.}}b{{data}}c",
-      "expected": "abc"
+      "expected": "a{{data.}}b{{data}}c"
     },
     {
       "name": "a user-defined variable named $guid beats the generator",
@@ -149,7 +149,7 @@
       "expected": "trim.test"
     },
     {
-      "name": "single pass: a value containing {{other}} is not rescanned",
+      "name": "a value containing {{other}} resolves through it (issue #1009)",
       "scopes": {
         "environment": {
           "a": { "value": "{{b}}", "enabled": true },
@@ -157,7 +157,82 @@
         }
       },
       "input": "{{a}}",
-      "expected": "{{b}}"
+      "expected": "resolved-b"
+    },
+    {
+      "name": "the layered baseUrl every imported environment is written with",
+      "scopes": {
+        "globals": { "protocol": { "value": "https", "enabled": true } },
+        "chain": [{ "baseUrl": { "value": "{{protocol}}://{{host}}", "enabled": true } }],
+        "environment": { "host": { "value": "api.example.test", "enabled": true } }
+      },
+      "input": "{{baseUrl}}/orders",
+      "expected": "https://api.example.test/orders"
+    },
+    {
+      "name": "nesting resolves through several levels",
+      "scopes": {
+        "environment": {
+          "one": { "value": "<{{two}}>", "enabled": true },
+          "two": { "value": "[{{three}}]", "enabled": true },
+          "three": { "value": "end", "enabled": true }
+        }
+      },
+      "input": "{{one}}",
+      "expected": "<[end]>"
+    },
+    {
+      "name": "a token inside a value that nothing defines stays literal, like any other",
+      "scopes": { "environment": { "a": { "value": "x={{nope}}", "enabled": true } } },
+      "input": "{{a}}",
+      "expected": "x={{nope}}"
+    },
+    {
+      "name": "a two-name cycle stops with the token literal instead of looping",
+      "scopes": {
+        "environment": {
+          "a": { "value": "A{{b}}", "enabled": true },
+          "b": { "value": "B{{a}}", "enabled": true }
+        }
+      },
+      "input": "{{a}}",
+      "expected": "AB{{a}}"
+    },
+    {
+      "name": "a value referring to itself stops at its own token",
+      "scopes": { "environment": { "loop": { "value": "x{{loop}}", "enabled": true } } },
+      "input": "{{loop}}",
+      "expected": "x{{loop}}"
+    },
+    {
+      "name": "the same name twice side by side is two expansions, not a cycle",
+      "scopes": {
+        "environment": {
+          "a": { "value": "[{{b}}]", "enabled": true },
+          "b": { "value": "v", "enabled": true }
+        }
+      },
+      "input": "{{a}}{{a}}",
+      "expected": "[v][v]"
+    },
+    {
+      "name": "a chain longer than the depth bound keeps what it resolved and leaves the rest literal",
+      "scopes": {
+        "environment": {
+          "d0": { "value": "0{{d1}}", "enabled": true },
+          "d1": { "value": "1{{d2}}", "enabled": true },
+          "d2": { "value": "2{{d3}}", "enabled": true },
+          "d3": { "value": "3{{d4}}", "enabled": true },
+          "d4": { "value": "4{{d5}}", "enabled": true },
+          "d5": { "value": "5{{d6}}", "enabled": true },
+          "d6": { "value": "6{{d7}}", "enabled": true },
+          "d7": { "value": "7{{d8}}", "enabled": true },
+          "d8": { "value": "8{{d9}}", "enabled": true },
+          "d9": { "value": "9", "enabled": true }
+        }
+      },
+      "input": "{{d0}}",
+      "expected": "012345678{{d9}}"
     },
     {
       "name": "empty braces never match and stay literal",

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -489,6 +489,86 @@ TEST_F (RequestComposerTest, ResolvesVariablesInsideAFilePart) {
     EXPECT_EQ (field["type"], "file");
 }
 
+// Issue #1009's rule 1, at the layer that decides what is *sent*: a name no
+// scope defines leaves its token on the wire instead of a hole. Every field
+// composition resolves, because the fixture pins `resolve_template` and this
+// pins the fields wired to it - the URL is where the divergence shows worst
+// (`https:///x` is a URL nobody wrote), and a form field is the one that
+// reaches resolution through a second function.
+TEST_F (RequestComposerTest, AnUnknownNameReachesTheWireAsItsTokenNotAsAHole) {
+    seed_environment ("env_1", R"({"known":{"value":"k","enabled":true},
+                                   "blank":{"value":"","enabled":true}})");
+
+    const json body = {
+        { "request",
+        { { "method", "post" }, { "url", "https://{{host}}/x?k={{known}}" },
+        { "headers", { { "X-Note", "{{missing}}" }, { "X-Known", "{{known}}" } } },
+        { "body",
+        { { "mode", "form-data" },
+        { "fields", json::array ({ { { "key", "f" }, { "value", "{{gone}}" }, { "enabled", true } } }) } } } } },
+        { "environmentId", "env_1" }
+    };
+
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+    ASSERT_EQ (status, 200) << payload.dump ();
+    EXPECT_EQ (payload["url"], "https://{{host}}/x?k=k");
+    EXPECT_EQ (payload["headers"]["X-Note"], "{{missing}}");
+    EXPECT_EQ (payload["headers"]["X-Known"], "k");
+    EXPECT_EQ (payload["body"]["fields"][0]["value"], "{{gone}}");
+
+    // Defined-and-empty is still empty: the rule is about a name nothing
+    // answers, and erasing that distinction would make an intentionally blank
+    // variable send its own token.
+    const json blank = { { "request", { { "method", "get" }, { "url", "https://x.test/?b={{blank}}" } } },
+        { "environmentId", "env_1" } };
+    auto [blank_status, blank_payload] = vayu::http::compose_request_core (*db_, blank);
+    ASSERT_EQ (blank_status, 200) << blank_payload.dump ();
+    EXPECT_EQ (blank_payload["url"], "https://x.test/?b=");
+}
+
+// Issue #1009's rule 2. The layering under test is the one every imported
+// Postman environment is written with, and the cycle is the reason the walk is
+// bounded rather than run to a fixpoint.
+TEST_F (RequestComposerTest, AValueCarryingTokensResolvesThroughThemAndStopsOnACycle) {
+    seed_collection ("col", "",
+    R"({"baseUrl":{"value":"{{protocol}}://{{host}}","enabled":true}})");
+    seed_environment ("env_1", R"({"protocol":{"value":"https","enabled":true},
+                                   "host":{"value":"api.example.test","enabled":true},
+                                   "a":{"value":"A{{b}}","enabled":true},
+                                   "b":{"value":"B{{a}}","enabled":true}})");
+
+    const json body = { { "request",
+                        { { "method", "get" }, { "url", "{{baseUrl}}/orders" },
+                        { "headers", { { "X-Cycle", "{{a}}" } } } } },
+        { "collectionId", "col" }, { "environmentId", "env_1" } };
+
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+    ASSERT_EQ (status, 200) << payload.dump ();
+    EXPECT_EQ (payload["url"], "https://api.example.test/orders");
+    // A name already being expanded is left written as it stands, so the
+    // composition terminates and the request says where it gave up.
+    EXPECT_EQ (payload["headers"]["X-Cycle"], "AB{{a}}");
+}
+
+// The header refusal reads *substituted values*, and since #1009 a value can
+// arrive through another variable. The refusal has to name the variable that
+// carried the bytes, not the one the header spells - naming the outer one
+// would send an author looking at a value that is fine.
+TEST_F (RequestComposerTest, ANestedValueCarryingCrlfIsRefusedByTheNameThatCarriesIt) {
+    seed_environment ("env_1", R"({"outer":{"value":"pre-{{inner}}","enabled":true},
+                                   "inner":{"value":"ok\r\nX-Admin: true","enabled":true}})");
+    const json body        = { { "request",
+                               { { "method", "GET" }, { "url", "https://x.test/" },
+                               { "headers", { { "X-Note", "{{outer}}" } } } } },
+               { "environmentId", "env_1" } };
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+
+    EXPECT_EQ (status, 400) << payload.dump ();
+    EXPECT_EQ (payload["error"]["code"], "unsendable_header");
+    const auto message = payload["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("{{inner}}"), std::string::npos) << message;
+}
+
 TEST_F (RequestComposerTest, InlineOverlayReplacesStoredFieldsAndStillResolves) {
     seed_collection ("col", "", R"({"host":{"value":"stored.test","enabled":true}})");
     auto r = make_request ("req_1", "col");

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -766,8 +766,11 @@ TEST_F (RequestComposerTest, UnknownScopeIdsDegradeToAnEmptyScope) {
     const json body = { { "request", { { "method", "GET" }, { "url", "https://x.test/{{missing}}" } } },
         { "collectionId", "col_missing" }, { "environmentId", "env_missing" } };
     auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+    // What degrades is the *scope lookup* - an id naming nothing is an empty
+    // scope rather than a refusal. The token it leaves behind is #1009's rule:
+    // a name no scope defines is written as it stands.
     ASSERT_EQ (status, 200);
-    EXPECT_EQ (payload["url"], "https://x.test/");
+    EXPECT_EQ (payload["url"], "https://x.test/{{missing}}");
 }
 
 } // namespace

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -83,11 +83,22 @@ TEST (ScenarioDataNamespaceTest, AVariableNamedLikeAColumnDoesNotAnswerForIt) {
 
 TEST (ScenarioDataNamespaceTest, ThePrefixAloneIsNotAColumnReference) {
     // `{{data.}}` names nothing, so no iteration could ever bind it. It falls
-    // through to the ordinary unknown-name rule instead of surviving as a token
-    // that would reach the wire verbatim.
+    // through to the ordinary unknown-name rule - which since #1009 also leaves
+    // the token written as it stands. The two rules agree on the text and not
+    // on the reason: the namespace keeps a token *for* a later binder, and an
+    // unknown name keeps one because nothing will ever answer it. What this
+    // case still pins is that neither `data.` nor `data` is treated as a
+    // column, so no scan and no bind reads one.
     vayu::http::VariableValues vars;
-    EXPECT_EQ (vayu::http::resolve_template ("a{{data.}}b", vars), "ab");
-    EXPECT_EQ (vayu::http::resolve_template ("a{{data}}b", vars), "ab");
+    EXPECT_FALSE (vayu::http::is_data_variable_name ("data."));
+    EXPECT_FALSE (vayu::http::is_data_variable_name ("data"));
+    EXPECT_EQ (vayu::http::resolve_template ("a{{data.}}b", vars), "a{{data.}}b");
+    EXPECT_EQ (vayu::http::resolve_template ("a{{data}}b", vars), "a{{data}}b");
+    // A defined variable of either name answers, which is what says they took
+    // the ordinary path rather than the reserved one.
+    vars["data."] = "dot";
+    vars["data"]  = "bare";
+    EXPECT_EQ (vayu::http::resolve_template ("a{{data.}}b{{data}}c", vars), "adotbbarec");
 }
 
 TEST (ScenarioDataNamespaceTest, TheNameIsTrimmedTheSameWayEveryOtherNameIs) {
@@ -986,9 +997,10 @@ TEST (ScenarioDataAuthLineBreakTest, BasicCredentialsAndAQueryApiKeyStillBind) {
 }
 
 TEST (ScenarioDataScanTest, ThePrefixAloneIsNotSomethingToRefuse) {
-    // `{{data.}}` names no column, so composition already resolved it to "" and
-    // there is nothing left to send literally. Refusing it would block a run
-    // over a token that never reaches the wire.
+    // `{{data.}}` names no column, so the scan finds nothing to bind - it is
+    // not a data token, whatever composition left in the field (since #1009,
+    // the token itself). Refusing it would block a run over a token no row
+    // could ever answer.
     EXPECT_FALSE (vayu::core::tokenize_data_fields (
     request_with_url ("https://api.test/{{data.}}"))
     .first_token ()

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -751,16 +751,17 @@ TEST_F (ScenarioPlanTest, TheNoDataRefusalStaysUnchangedWithoutAContract) {
 }
 
 TEST_F (ScenarioPlanTest, ThePrefixAloneDoesNotBlockARunWithoutData) {
-    // `{{data.}}` names no column, so composition resolves it to "" like any
-    // other unknown name and nothing survives for the scan to find. Refusing it
-    // would block a run over a token that never reaches the wire.
+    // `{{data.}}` names no column, so composition treats it as any other
+    // unknown name - since #1009 that means the token is left written as it
+    // stands, and the scan for *columns* still finds nothing. Refusing the run
+    // would block it over a token that binds to nothing either way.
     seed_collection ("col", "");
     seed_request ("req", "col", /*order=*/0, "https://example.test/u/{{data.}}");
 
     const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    EXPECT_EQ (resolved.plan.steps[0].request.url, "https://example.test/u/");
+    EXPECT_EQ (resolved.plan.steps[0].request.url, "https://example.test/u/{{data.}}");
 }
 
 // --- Data tokens in the credentials (issue #591) ------------------------------

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -2730,13 +2730,14 @@ TEST_F (ScriptEngineTest, PmVariablesResolvesEnvironmentThenCollectionThenGlobal
 // pm.variables.replaceIn - the sanctioned way to use {{...}} inside a script
 // (script *text* is never interpolated; see D16 in issue #226). Semantics must
 // match the engine's compose-time resolver: same precedence, same unknown-name
-// pair, same single pass, raw stored strings.
+// rule, same nested resolution, raw stored strings.
 TEST_F (ScriptEngineTest, ReplaceInResolvesScopesLikeTheRequestFieldsDo) {
     Environment globals;
     globals["everywhere"] = Variable{ "from-globals", false, true };
     Environment collVars;
     collVars["everywhere"] = Variable{ "from-collection", false, true };
     collVars["nested"]     = Variable{ "{{everywhere}}", false, true };
+    collVars["selfRef"]    = Variable{ "{{selfRef}}", false, true };
     Environment environment;
     environment["everywhere"] = Variable{ "from-environment", false, true };
     environment["disabled"]   = Variable{ "hidden", false, false };
@@ -2754,19 +2755,23 @@ TEST_F (ScriptEngineTest, ReplaceInResolvesScopesLikeTheRequestFieldsDo) {
         pm.globals.set('unknownDollar', pm.variables.replaceIn('{{$notAGenerator}}'));
         pm.globals.set('definedDollar', pm.variables.replaceIn('{{$guid}}'));
         pm.globals.set('disabledIsInvisible', pm.variables.replaceIn('[{{disabled}}]'));
-        // Single pass, like every other {{}} in Vayu: a value containing
-        // {{other}} stays literal rather than being rescanned.
-        pm.globals.set('singlePass', pm.variables.replaceIn('{{nested}}'));
+        // Nested, like every other {{}} in Vayu since #1009: a value that
+        // itself holds {{other}} resolves through it, to the same bound.
+        pm.globals.set('nestedResolves', pm.variables.replaceIn('{{nested}}'));
+        pm.globals.set('cycleStopsLiteral', pm.variables.replaceIn('{{selfRef}}'));
     )JS",
     ctx);
 
     ASSERT_TRUE (result.success) << result.error_message;
     EXPECT_EQ (globals["winner"].value, "from-environment");
-    EXPECT_EQ (globals["unknownPlain"].value, "[]");
+    // Both halves of #1009's unknown-name rule: the token is what a script
+    // gets back, so a name nothing defines is visible rather than vanished.
+    EXPECT_EQ (globals["unknownPlain"].value, "[{{missing}}]");
     EXPECT_EQ (globals["unknownDollar"].value, "{{$notAGenerator}}");
     EXPECT_EQ (globals["definedDollar"].value, "pinned-guid");
-    EXPECT_EQ (globals["disabledIsInvisible"].value, "[]");
-    EXPECT_EQ (globals["singlePass"].value, "{{everywhere}}");
+    EXPECT_EQ (globals["disabledIsInvisible"].value, "[{{disabled}}]");
+    EXPECT_EQ (globals["nestedResolves"].value, "from-environment");
+    EXPECT_EQ (globals["cycleStopsLiteral"].value, "{{selfRef}}");
 }
 
 // ============================================================================

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -4066,8 +4066,9 @@ TEST_F (ScriptEngineTest, ReplaceInResolvesTheDataNamespaceAgainstTheBoundRow) {
         pm.test("the bare prefix names nothing", function() {
             // `{{data.}}` is not a column reference, so it falls through to the
             // ordinary unknown-name rule rather than erroring about a column
-            // called "".
-            pm.expect(pm.variables.replaceIn("[{{data.}}]")).to.equal("[]");
+            // called "" - and that rule leaves the token written as it stands
+            // (issue #1009), which is what a script gets back.
+            pm.expect(pm.variables.replaceIn("[{{data.}}]")).to.equal("[{{data.}}]");
         });
 
         pm.test("the scope readers stay out of the namespace", function() {


### PR DESCRIPTION
## Description

Two interpolation-semantics divergences from Postman, both in `substitute_tokens`' contract, shipped together because they change the same function.

**Rule 1 - an unknown ordinary name keeps its braces.** It resolved to `""`, so `https://{{host}}/x` left as `https:///x`: not a request that failed, a *different* request, sent silently. The rule the `$name` branch two lines above has held since #186 now covers every name. A definition that exists and holds an empty value still substitutes empty - the rule is about a name nothing answers, and erasing that distinction would make an intentionally blank variable send its own token.

**Rule 2 - a value carrying tokens of its own resolves through them.** `baseUrl = "{{protocol}}://{{host}}"` - the shape most imported Postman environments are written in - used to compose as literal braces, because a replacement was never rescanned.

**Plan (root cause, approach, alternative rejected).** Both halves live in one function: rule 1 is `lookup_variable`'s last line (`std::nullopt` instead of `std::string{}`), rule 2 re-enters the scanner on the *substituted value*, never on the surrounding text. The alternative for rule 2 - running to a fixpoint with a visited set alone - was rejected because `a = "{{a}} "` has no fixpoint to reach; the values come from a user's environment and nothing there promises to terminate, so the walk is bounded at 8 levels with the expansion chain as the cycle check (a name already being expanded is left written as it stands). Putting the nesting in `substitute_tokens` rather than in `resolve_template` is what makes `pm.variables.replaceIn` and the scenario data pass inherit it: Postman's `replaceIn` is recursive too, and a second implementation is the thing that file's "one scanner" comment exists to prevent. One detail worth naming: the cycle is answered *before* `resolve` runs, because the callbacks record what they substituted (a header a value would forge, a column no row has) and a name this pass will not substitute must leave no such record.

The problem was verified still present at `d44ef77` before any edit, and the fix matches the issue's stated pathway.

**Throughput guard (#996 / #992).** Untouched: nesting costs one `find` per substituted value, so any value with no `{{` still resolves in a single pass, and this is compose-time only - the load path splits fields once at plan time (`split_tokens`, unchanged) and joins them per row. Rule 1 changes only what bytes a plan carries, never how many passes it takes. No before/after numbers are included because nothing on the per-transfer or completion path was edited.

**Coordination with #1008** (asked for in this issue's Sequencing): rule 1 is the half its residual-token pass depends on - a token must survive composition to be re-resolvable later - and it lands here.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

Breaking in the sense the issue records: a request whose field named an undefined variable used to go out with a hole and now goes out with the token. That is the point - the wire bytes stop being silently different from what was written.

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **2483 passed, 0 failed**. `cd app && pnpm test`: **5727 passed of 5728**, the one failure being `send-with-row.test.tsx > "opens the list on the row that step bound"` timing out at the default 5s while the engine build had the four cores - it passes on its own (41/41 in 15.8s) and is the load-sensitivity `app/CLAUDE.md` documents, not this change. `pnpm type-check`, `pnpm lint`, `pnpm format:check` all clean; `clang-format --dry-run -Werror` clean on every file this touches (four pre-existing violations in `request_composer.cpp` and one in `scenario_data_test.cpp` reproduce unchanged on the base commit under clang-format 19.1.1 and are left alone).

What is pinned, mutation-check style:

- **Shared conformance fixture** (engine gtest + app vitest read the same table): nine new cases - the layered `baseUrl`, three-level nesting, a token inside a value that nothing defines, both cycle shapes, the depth bound keeping what it resolved, and `{{a}}{{a}}` side by side being two expansions rather than a cycle. Four existing cases restated for rule 1.
- **Engine, compose level**: URL / headers / form field all keep an unknown token, with defined-and-empty still substituting empty in the same test; the layered URL composing and a cycle stopping; and the header-forgery refusal naming the **nested** variable that carried the CRLF rather than the one the header spells.
- **Script level**: `replaceIn` inherits both rules, including a self-referencing value.

Three existing tests changed colour and are restated rather than relaxed, each because it asserted the old rule instead of the thing it guards: `UnknownScopeIdsDegradeToAnEmptyScope` (about an unknown scope id being an empty scope, not a refusal), and the two `{{data.}}` cases - which gained an assertion that neither `data.` nor `data` is read as a column, shown by a defined variable of each name answering, since the resulting *text* no longer tells the reserved rule and the unknown-name rule apart.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/variable-resolution.md` (both rules replace the old ones, with the cycle rule and the bound stated), the `{{data.}}` line beside it, and `docs/app/pm-api-compatibility.md`'s `replaceIn` paragraph.

## Related Issues
Closes #1009

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdmESQhtLQUMYSkPW3w3AB)_