### PR TITLE
feat(engine): setNextRequest takes request ids and the string "null" - #1006

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -487,7 +487,9 @@ Divergences from Postman:
 
 ```javascript
 pm.execution.setNextRequest('Checkout');  // run that request next
+pm.execution.setNextRequest(pm.info.requestId); // the same jump, by id
 pm.execution.setNextRequest(null);        // end this iteration, start the next
+pm.execution.setNextRequest('null');      // the quoted stop form, read the same way
 pm.execution.skipRequest();               // pre-request only: do not send this one
 ```
 
@@ -496,11 +498,18 @@ sentence naming why rather than being ignored - a single Send has no next
 request, and a load run's test scripts run after the run has finished, against
 responses already recorded.
 
+Both target spellings Postman accepts work: a request's name, and the id a
+script reads off `pm.info.requestId`. So does the quoted stop form
+`setNextRequest('null')` - with one stated precedence, which is a divergence
+only in the sense that Postman has no answer for it: a run that carries a
+request actually named `null` jumps to that request rather than stopping.
+
 Divergences from Postman:
 
-- **An unresolvable target fails the step**, by name. A name no request in the
-  run carries, and a name two of them share, are both errors that end the
-  iteration; Postman resolves an ambiguous name to whichever it finds.
+- **An unresolvable target fails the step**, naming it. A target no request in
+  the run answers to by name or by id, and a name two of them share, are both
+  errors that end the iteration; Postman resolves an ambiguous name to whichever
+  it finds.
 - **A cycle is bounded.** Two requests pointing at each other run forever in
   Postman's runner; here the iteration is cut off by `maxStepsPerIteration` and
   the failure names the steps that were looping.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -969,7 +969,9 @@ where the sequence goes next:
 
 ```javascript
 pm.execution.setNextRequest('Checkout');  // run that request next, after this one finishes
+pm.execution.setNextRequest(pm.info.requestId); // the same jump, by id
 pm.execution.setNextRequest(null);        // end this iteration; the next one still runs
+pm.execution.setNextRequest('null');      // the quoted form Postman reads the same way
 pm.execution.skipRequest();               // pre-request only: do not send this request
 ```
 
@@ -980,8 +982,17 @@ thing that knows what a sequence is, reads it once the step has finished. So
 and the jump happens afterwards. The last call in a script wins, across the
 pre-request and test scripts alike.
 
-`setNextRequest` takes a request's **name**, not its id or URL, and jumping
-backwards is allowed - that is how a retry loop is written.
+`setNextRequest` takes a request's **name** or its **id** - the one a script
+reads off `pm.info.requestId` - never its URL, and jumping backwards is allowed:
+that is how a retry loop is written. A target is resolved against the names
+first and the ids second, so a request whose *name* happens to be another
+request's id sends the jump to the request you can see in the sidebar.
+
+The string `'null'` is the stop form, exactly as the real `null` above is -
+Postman's runner reads it that way, and the quoted spelling is common in
+collections written against it. The one exception is a run that carries a
+request actually **named** `null`: a name the run carries is the more specific
+answer and wins, so that request stays reachable.
 
 ### Where it throws
 
@@ -1003,7 +1014,8 @@ reports success for something that never happened.
 Two cases are the runner's to refuse, because only it can see the plan. Both end
 the iteration with the step marked `errored` and the reason in its row:
 
-- **A name no request in the run carries.** The message names the target.
+- **A target no request in the run answers to**, by name or by id. The message
+  names the target and says both were searched.
 - **A name two or more requests share.** The message names every step that
   answers to it, so the fix - rename one - is obvious. Resolving to the first
   match would run a sequence nobody asked for.

--- a/engine/include/vayu/core/scenario_runner.hpp
+++ b/engine/include/vayu/core/scenario_runner.hpp
@@ -173,38 +173,63 @@ class ScenarioStepStore {
 };
 
 /**
- * @brief Every position a step name occupies in the plan.
+ * @brief Every position one key - a step name or a request id - occupies in the
+ *        plan.
  *
  * Names are not unique - two requests in the same collection may share one, and
  * nothing in the schema prevents it - so the value is a list rather than an
  * index. That list is what makes an ambiguous `setNextRequest` target a named
  * error instead of a silent jump to whichever one resolution happened to see
- * first.
+ * first. Ids are unique by the schema, and are held in the same shape so an
+ * impossible duplicate is refused the same way rather than resolved by
+ * whichever the walk saw first.
  */
-using ScenarioStepNameIndex = std::unordered_map<std::string, std::vector<size_t>>;
+using ScenarioStepPositions = std::unordered_map<std::string, std::vector<size_t>>;
+
+/**
+ * @brief The two keys a `setNextRequest` target may be, indexed once per run.
+ *
+ * Postman documents both spellings - a request's name, and the id a script
+ * reads off `pm.info.requestId` - so a target that is neither is what makes the
+ * step fail (issue #1006).
+ */
+struct ScenarioStepIndex {
+    ScenarioStepPositions by_name;
+    ScenarioStepPositions by_request_id;
+};
 
 /** Build that index once per run; positions are indices into `plan.steps`. */
-[[nodiscard]] ScenarioStepNameIndex build_step_name_index (const ScenarioPlan& plan);
+[[nodiscard]] ScenarioStepIndex build_step_index (const ScenarioPlan& plan);
 
 /** Where a `setNextRequest` target points, or why it points nowhere. */
 struct NextStepResolution {
-    bool ok      = false;
+    enum class Kind {
+        Unresolved,  ///< Nothing answers to the target; `error` says why.
+        Step,        ///< Continue the iteration at `index`.
+        EndIteration ///< The target was the stop form; this iteration is over.
+    };
+    Kind kind    = Kind::Unresolved;
     size_t index = 0;
-    /// Caller-facing sentence, on the failure path only. It reaches the step's
-    /// `results.error` and the app's step list, so it names the target and, for
-    /// an ambiguous one, every step that answers to it.
+    /// Caller-facing sentence, on the `Unresolved` path only. It reaches the
+    /// step's `results.error` and the app's step list, so it names the target
+    /// and, for an ambiguous one, every step that answers to it.
     std::string error;
 };
 
 /**
  * @brief Resolve a `setNextRequest` target against the plan.
  *
- * Both failures are loud by design (issue #355): a name no step carries is a
- * script pointing at a request that is not in the run, and a duplicated name is
- * ambiguous - continuing past either would run a sequence nobody asked for.
+ * Resolution order, and the order is the contract: the stop form `"null"`
+ * first, then names, then request ids. A step actually *named* `null` wins over
+ * the stop form - a name the run carries is the more specific answer, and the
+ * alternative is a step nothing can ever jump to.
+ *
+ * Both failures are loud by design (issue #355): a target no step answers to is
+ * a script pointing at a request that is not in the run, and a duplicated name
+ * is ambiguous - continuing past either would run a sequence nobody asked for.
  */
 [[nodiscard]] NextStepResolution
-resolve_next_step (const ScenarioStepNameIndex& index, const std::string& target);
+resolve_next_step (const ScenarioStepIndex& index, const std::string& target);
 
 /**
  * @brief How many step executions one iteration may perform.

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -8,9 +8,11 @@
 #include "vayu/core/scenario_runner.hpp"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <deque>
 #include <optional>
+#include <string_view>
 #include <utility>
 
 #include "vayu/core/constants.hpp"
@@ -228,41 +230,80 @@ std::string describe_recent_steps (const std::deque<std::string>& trail) {
 
 } // namespace
 
-ScenarioStepNameIndex build_step_name_index (const ScenarioPlan& plan) {
-    ScenarioStepNameIndex index;
+ScenarioStepIndex build_step_index (const ScenarioPlan& plan) {
+    ScenarioStepIndex index;
     for (size_t position = 0; position < plan.steps.size (); ++position) {
-        index[plan.steps[position].name].push_back (position);
+        index.by_name[plan.steps[position].name].push_back (position);
+        // A step whose request carries no id - the plan tests build such steps,
+        // and nothing in this type forbids one - is indexed by name alone
+        // rather than under an empty key that `setNextRequest("")` could never
+        // reach anyway (the binding refuses an empty target).
+        if (!plan.steps[position].request_id.empty ()) {
+            index.by_request_id[plan.steps[position].request_id].push_back (position);
+        }
     }
     return index;
 }
 
-NextStepResolution resolve_next_step (const ScenarioStepNameIndex& index,
-const std::string& target) {
+NextStepResolution
+resolve_next_step (const ScenarioStepIndex& index, const std::string& target) {
     NextStepResolution resolution;
 
-    auto found = index.find (target);
-    if (found == index.end ()) {
-        resolution.error =
-        "setNextRequest(\"" + target + "\") names no request in this collection run";
+    // Postman's runner reads the string "null" as the stop form real `null`
+    // already means here, and the quoted spelling is endemic in collections
+    // written against it. A step actually named `null` is the more specific
+    // answer and wins - which is why this asks the name index rather than
+    // answering on the string alone.
+    if (target == "null" && !index.by_name.contains (target)) {
+        resolution.kind = NextStepResolution::Kind::EndIteration;
         return resolution;
     }
 
-    if (found->second.size () > 1) {
-        std::string positions;
-        for (size_t i = 0; i < found->second.size (); ++i) {
-            if (i > 0) {
-                positions += i + 1 == found->second.size () ? " and " : ", ";
-            }
-            positions += std::to_string (found->second[i]);
+    // Names first, ids second: a name is what a script author writes, and the
+    // order is what keeps a collection whose request is *named* like some
+    // other request's id resolving to the request the author can see.
+    struct TargetKey {
+        const ScenarioStepPositions* positions;
+        std::string_view noun;
+        /// What the author can actually do about a collision, which differs by
+        /// key: two steps may be renamed, and two steps carrying one id is a
+        /// plan that listed a request twice - nothing a rename fixes.
+        std::string_view remedy;
+    };
+    const std::array<TargetKey, 2> keys{
+        { { &index.by_name, "name", "rename one of them so the target names a single request" },
+        { &index.by_request_id, "id", "jump by name instead - one request cannot be two steps of a run" } }
+    };
+    for (const auto& [positions, noun, remedy] : keys) {
+        auto found = positions->find (target);
+        if (found == positions->end ()) {
+            continue;
         }
-        resolution.error = "setNextRequest(\"" + target +
-        "\") is ambiguous - the name is carried by steps " + positions +
-        "; rename one of them so the target names a single request";
+
+        if (found->second.size () > 1) {
+            std::string steps;
+            for (size_t i = 0; i < found->second.size (); ++i) {
+                if (i > 0) {
+                    steps += i + 1 == found->second.size () ? " and " : ", ";
+                }
+                steps += std::to_string (found->second[i]);
+            }
+            resolution.error = "setNextRequest(\"" + target + "\") is ambiguous - the ";
+            resolution.error += noun;
+            resolution.error += " is carried by steps ";
+            resolution.error += steps;
+            resolution.error += "; ";
+            resolution.error += remedy;
+            return resolution;
+        }
+
+        resolution.kind  = NextStepResolution::Kind::Step;
+        resolution.index = found->second.front ();
         return resolution;
     }
 
-    resolution.ok    = true;
-    resolution.index = found->second.front ();
+    resolution.error = "setNextRequest(\"" + target +
+    "\") matches no request name or id in this collection run";
     return resolution;
 }
 
@@ -597,7 +638,7 @@ ScenarioSummaryInputs& summary) {
  *         it continues at all.
  */
 size_t decide_next_step (const vayu::http::routes::ExchangeOutcome& exchange,
-const ScenarioStepNameIndex& name_index,
+const ScenarioStepIndex& step_index,
 const std::deque<std::string>& recent_steps,
 size_t position,
 size_t steps_this_iteration,
@@ -636,13 +677,24 @@ bool& end_iteration) {
                 std::to_string (max_steps_per_iteration) +
                 ") - setNextRequest is cycling through: " + describe_recent_steps (recent_steps);
                 end_iteration = true;
-            } else if (auto next = resolve_next_step (name_index, control.target);
-            !next.ok) {
-                record.outcome = StepOutcome::Errored;
-                record.error   = next.error;
-                end_iteration  = true;
             } else {
-                next_position = next.index;
+                // Three answers, not two: a target may also *be* the stop
+                // form - `setNextRequest("null")`, which Postman's runner
+                // reads as the real `null` this switch's other arm handles.
+                switch (auto next = resolve_next_step (step_index, control.target);
+                next.kind) {
+                case NextStepResolution::Kind::Unresolved:
+                    record.outcome = StepOutcome::Errored;
+                    record.error   = next.error;
+                    end_iteration  = true;
+                    break;
+                case NextStepResolution::Kind::EndIteration:
+                    end_iteration = true;
+                    break;
+                case NextStepResolution::Kind::Step:
+                    next_position = next.index;
+                    break;
+                }
             }
             break;
         }
@@ -738,7 +790,7 @@ bool verbose,
 vayu::http::routes::ScriptVariableScopes& scopes,
 const StepContext& base,
 const ScenarioPlan& plan,
-const ScenarioStepNameIndex& name_index,
+const ScenarioStepIndex& step_index,
 size_t max_steps_per_iteration,
 CoverageTally& coverage,
 ScenarioSummaryInputs& summary,
@@ -772,7 +824,7 @@ ScenarioStepStore& store) {
 
         bool end_iteration = record.outcome == StepOutcome::Errored;
         const size_t next_position =
-        decide_next_step (exchange, name_index, recent_steps, position,
+        decide_next_step (exchange, step_index, recent_steps, position,
         steps_this_iteration, max_steps_per_iteration, record, end_iteration);
 
         store_step_record (step_ctx, step, exchange, record, coverage, summary, store);
@@ -884,7 +936,7 @@ RunManager& manager) {
         // Flow control's two supports, both fixed for the run: where a
         // `setNextRequest` target resolves to, and how far one iteration may
         // travel before a cycle is called a cycle.
-        const auto name_index                = build_step_name_index (plan);
+        const auto step_index                = build_step_index (plan);
         const size_t max_steps_per_iteration = resolve_max_steps_per_iteration (
         db.get_config_int ("maxStepsPerIteration", 0), plan.steps.size ());
 
@@ -913,7 +965,7 @@ RunManager& manager) {
                 transport, cookie_scope, data_rows, data_row_index, iteration,
                 asked.iterations, fail_on_schema_error, max_trace_body_bytes };
             run_iteration (script_engine, cookie_jar, cookie_scope, verbose, scopes, step_ctx,
-            plan, name_index, max_steps_per_iteration, coverage, summary, store);
+            plan, step_index, max_steps_per_iteration, coverage, summary, store);
 
             if (!context->should_stop) {
                 ++summary.iterations_completed;

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -932,11 +932,13 @@ nlohmann::json get_script_completions () {
     { "detail", "pm.execution.setNextRequest(name: string | null): void" },
     { "documentation",
     "Run the named request next instead of the one that follows in the "
-    "collection - the request's name, not its URL. Pass null to end this "
-    "iteration and start the next one.\n\nThe current request still "
+    "collection - the request's name, or the id pm.info.requestId reads, never "
+    "its URL. Pass null - or the string \"null\" - to end this iteration and "
+    "start the next one.\n\nThe current request still "
     "completes; the jump happens after it. Calling it more than once in a "
-    "script keeps the last call. A name no request in the run carries, or one "
-    "two requests share, fails the step by name rather than guessing.\n\n"
+    "script keeps the last call. A target no request in the run answers to, or "
+    "a name two requests share, fails the step by name rather than "
+    "guessing.\n\n"
     "Jumping backwards is allowed and is how a retry loop is written; an "
     "iteration that never stops is cut off by the maxStepsPerIteration "
     "setting.\n\nExample:\nif (pm.response.code === 401) { "

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -472,9 +472,9 @@ declare const pm: {
 	 */
 	execution: {
 		/**
-		 * Run the named request next instead of the one that follows in the collection - the request's name, not its URL. Pass null to end this iteration and start the next one.
+		 * Run the named request next instead of the one that follows in the collection - the request's name, or the id pm.info.requestId reads, never its URL. Pass null - or the string "null" - to end this iteration and start the next one.
 		 * 
-		 * The current request still completes; the jump happens after it. Calling it more than once in a script keeps the last call. A name no request in the run carries, or one two requests share, fails the step by name rather than guessing.
+		 * The current request still completes; the jump happens after it. Calling it more than once in a script keeps the last call. A target no request in the run answers to, or a name two requests share, fails the step by name rather than guessing.
 		 * 
 		 * Jumping backwards is allowed and is how a retry loop is written; an iteration that never stops is cut off by the maxStepsPerIteration setting.
 		 * 

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -211,7 +211,8 @@ class ScenarioRunnerTest : public ::testing::Test {
 
     /// A request in `col_1`, ordered by @p order, pointing at the mock server.
     /// @p name defaults to one derived from @p id; flow-control tests pass it
-    /// explicitly, because `setNextRequest` targets a *name*.
+    /// explicitly, because a `setNextRequest` target is resolved as a *name*
+    /// before it is tried as an id (issue #1006).
     void seed_request (const std::string& id,
     int order,
     const std::string& path,
@@ -894,6 +895,75 @@ TEST_F (ScenarioRunnerTest, SkipRequestInATestScriptFailsTheStepRatherThanPreten
     EXPECT_EQ (scenario["errored"].get<size_t> (), 1u);
 }
 
+// Postman documents jumping by the id a script reads off `pm.info.requestId`
+// (issue #1006), and a script that does it end to end is what says the plan
+// carries the ids resolution needs.
+TEST_F (ScenarioRunnerTest, SetNextRequestJumpsByRequestIdToo) {
+    seed_collection ("col_1");
+    seed_request ("req_a", 0, "/ok", "", R"(pm.execution.setNextRequest("req_c");)");
+    seed_request ("req_b", 1, "/login");
+    seed_request ("req_c", 2, "/observe", "", "", "", "Checkout");
+
+    const auto run_id = start (/*iterations=*/1);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+
+    auto seen = server_->requests ();
+    ASSERT_EQ (seen.size (), 2u);
+    EXPECT_EQ (seen[0].path, "/ok");
+    EXPECT_EQ (seen[1].path, "/observe");
+
+    auto rows = db_->get_results (run_id);
+    ASSERT_EQ (rows.size (), 2u);
+    EXPECT_EQ (json::parse (rows[1].trace_data)["requestId"].get<std::string> (), "req_c");
+    EXPECT_TRUE (rows[1].error.empty ()) << rows[1].error;
+}
+
+// The quoted stop form: Postman's runner reads `setNextRequest("null")` as the
+// real `null` above, and collections written against it carry the spelling.
+TEST_F (ScenarioRunnerTest, SetNextRequestWithTheStringNullEndsTheIteration) {
+    seed_collection ("col_1");
+    seed_request ("req_a", 0, "/ok", "", R"(pm.execution.setNextRequest("null");)");
+    seed_request ("req_b", 1, "/login");
+
+    const auto run_id = start (/*iterations=*/2);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+
+    auto seen = server_->requests ();
+    ASSERT_EQ (seen.size (), 2u) << "step 2 ran despite the iteration ending";
+    EXPECT_EQ (seen[0].path, "/ok");
+    EXPECT_EQ (seen[1].path, "/ok");
+
+    auto rows = db_->get_results (run_id);
+    ASSERT_EQ (rows.size (), 2u);
+    // Ending an iteration is not erroring the step that ended it - the shape
+    // this used to take, when the string reached the name index and matched
+    // nothing.
+    EXPECT_EQ (json::parse (rows[0].trace_data)["outcome"].get<std::string> (), "passed");
+    EXPECT_TRUE (rows[0].error.empty ()) << rows[0].error;
+
+    auto scenario = summary_of (run_id)["scenario"];
+    EXPECT_EQ (scenario["errored"].get<size_t> (), 0u);
+    EXPECT_EQ (scenario["iterations_completed"].get<size_t> (), 2u);
+}
+
+// The precedence the docs state, on the wire: a collection that really does
+// carry a request named `null` can still jump to it.
+TEST_F (ScenarioRunnerTest, AStepNamedNullIsStillReachableByName) {
+    seed_collection ("col_1");
+    seed_request ("req_a", 0, "/ok", "", R"(pm.execution.setNextRequest("null");)");
+    seed_request ("req_b", 1, "/login");
+    seed_request ("req_c", 2, "/observe", "", "", "", "null");
+
+    const auto run_id = start (/*iterations=*/1);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+
+    auto seen = server_->requests ();
+    ASSERT_EQ (seen.size (), 2u);
+    EXPECT_EQ (seen[0].path, "/ok");
+    EXPECT_EQ (seen[1].path, "/observe")
+    << "the stop form won over a step the run carries";
+}
+
 TEST_F (ScenarioRunnerTest, AnUnknownTargetFailsTheStepByNameAndEndsTheIteration) {
     seed_collection ("col_1");
     seed_request ("req_a", 0, "/ok", "", R"(pm.execution.setNextRequest("Nowhere");)");
@@ -966,26 +1036,33 @@ TEST_F (ScenarioRunnerTest, ACycleTripsTheStepBudgetAndTheRunStillFinishes) {
 // Flow-control resolution (pure)
 // ============================================================================
 
+using NextStep = vayu::core::NextStepResolution::Kind;
+
 TEST (ScenarioNextStep, ResolvesAUniqueNameToItsPosition) {
     vayu::core::ScenarioPlan plan;
     plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
     plan.steps.push_back ({ 1, "req_b", "Second", {}, "", "", "" });
 
-    const auto index = vayu::core::build_step_name_index (plan);
+    const auto index = vayu::core::build_step_index (plan);
     auto resolved    = vayu::core::resolve_next_step (index, "Second");
-    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.kind, NextStep::Step) << resolved.error;
     EXPECT_EQ (resolved.index, 1u);
     EXPECT_TRUE (resolved.error.empty ());
 }
 
-TEST (ScenarioNextStep, RefusesANameNoStepCarries) {
+TEST (ScenarioNextStep, RefusesATargetNoStepAnswersTo) {
     vayu::core::ScenarioPlan plan;
     plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
 
-    auto resolved = vayu::core::resolve_next_step (
-    vayu::core::build_step_name_index (plan), "Missing");
-    EXPECT_FALSE (resolved.ok);
+    auto resolved =
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "Missing");
+    EXPECT_EQ (resolved.kind, NextStep::Unresolved);
     EXPECT_NE (resolved.error.find ("Missing"), std::string::npos) << resolved.error;
+    // The message has to say what was searched: since #1006 a target may be an
+    // id, so "names no request" would send the reader looking for a typo in a
+    // name they never wrote.
+    EXPECT_NE (resolved.error.find ("name or id"), std::string::npos)
+    << resolved.error;
 }
 
 TEST (ScenarioNextStep, RefusesADuplicatedNameAndNamesEveryPosition) {
@@ -995,10 +1072,63 @@ TEST (ScenarioNextStep, RefusesADuplicatedNameAndNamesEveryPosition) {
     plan.steps.push_back ({ 2, "req_c", "Twin", {}, "", "", "" });
 
     auto resolved =
-    vayu::core::resolve_next_step (vayu::core::build_step_name_index (plan), "Twin");
-    EXPECT_FALSE (resolved.ok);
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "Twin");
+    EXPECT_EQ (resolved.kind, NextStep::Unresolved);
     EXPECT_NE (resolved.error.find ("ambiguous"), std::string::npos) << resolved.error;
     EXPECT_NE (resolved.error.find ("0 and 2"), std::string::npos) << resolved.error;
+}
+
+// Postman documents passing the id a script reads off `pm.info.requestId`
+// (issue #1006). Resolution falls through to the ids only after the names, so a
+// collection whose steps carry neither surprise keeps behaving as it did.
+TEST (ScenarioNextStep, ResolvesARequestIdWhenNoNameAnswers) {
+    vayu::core::ScenarioPlan plan;
+    plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
+    plan.steps.push_back ({ 1, "req_b", "Second", {}, "", "", "" });
+
+    auto resolved =
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "req_b");
+    ASSERT_EQ (resolved.kind, NextStep::Step) << resolved.error;
+    EXPECT_EQ (resolved.index, 1u);
+}
+
+TEST (ScenarioNextStep, PrefersTheNameWhenOneStepsNameIsAnothersId) {
+    vayu::core::ScenarioPlan plan;
+    plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
+    // Step 1 is *named* what step 2 is *identified* by. The name is what a
+    // script author can see in the sidebar, so it wins.
+    plan.steps.push_back ({ 1, "req_b", "req_c", {}, "", "", "" });
+    plan.steps.push_back ({ 2, "req_c", "Third", {}, "", "", "" });
+
+    auto resolved =
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "req_c");
+    ASSERT_EQ (resolved.kind, NextStep::Step) << resolved.error;
+    EXPECT_EQ (resolved.index, 1u);
+}
+
+// The quoted spelling is endemic in collections written against Postman's
+// runner, which reads it as the stop form real `null` already means here.
+TEST (ScenarioNextStep, TheStringNullEndsTheIteration) {
+    vayu::core::ScenarioPlan plan;
+    plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
+
+    auto resolved =
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "null");
+    EXPECT_EQ (resolved.kind, NextStep::EndIteration);
+    EXPECT_TRUE (resolved.error.empty ());
+}
+
+// Honest precedence: a step a run actually carries is the more specific answer,
+// and reading the stop form first would make that step unreachable.
+TEST (ScenarioNextStep, AStepNamedNullWinsOverTheStopForm) {
+    vayu::core::ScenarioPlan plan;
+    plan.steps.push_back ({ 0, "req_a", "First", {}, "", "", "" });
+    plan.steps.push_back ({ 1, "req_b", "null", {}, "", "", "" });
+
+    auto resolved =
+    vayu::core::resolve_next_step (vayu::core::build_step_index (plan), "null");
+    ASSERT_EQ (resolved.kind, NextStep::Step) << resolved.error;
+    EXPECT_EQ (resolved.index, 1u);
 }
 
 TEST (ScenarioStepBudget, DerivesTheBoundFromThePlanWhenUnconfigured) {


### PR DESCRIPTION
## Description

**The plan.** Root cause: `setNextRequest` resolution was name-only against the step-name index (`scenario_runner.cpp`), so two argument forms Postman accepts ended the iteration with the step `errored` - the request **id** a script reads off `pm.info.requestId`, and the quoted stop form `setNextRequest("null")` that Postman's runner reads as the real `null`. Verified still present at `d44ef77`: `resolve_next_step` looked in one map and errored on a miss, and `setNextRequest(null)` (real null) was already handled correctly one layer up, which is why only the quoted form failed. The approach is three ordered questions - the stop form, then names, then ids - with the plan's existing `ScenarioStep::request_id` (already carried for the trace) indexed beside the names, so nothing had to be threaded through the plan. The alternative I rejected: reading `"null"` as the stop form unconditionally, which is one line shorter and makes a request actually named `null` unreachable by any target at all; asking the name index first costs a lookup and keeps that step reachable, which is the precedence the docs now state and a test pins.

Resolution order, and the order is the contract:

- **`"null"` is the stop form**, unless a step is literally named `null` - then the name wins, because a name the run carries is the more specific answer.
- **Names next.** A collection whose request is *named* like another request's id still jumps to the one its author can see in the sidebar.
- **Ids last**, unchanged behaviour for every target that already resolved.

`NextStepResolution` grows a `Kind` (`Step` / `EndIteration` / `Unresolved`) where it had a `bool ok`: there are three answers now, and a second bool beside the first would spell an impossible one. `build_step_name_index` becomes `build_step_index` over a `ScenarioStepIndex` holding both maps. The ambiguity refusal is unchanged and now covers both keys, with the remedy phrased per key - two steps sharing a name are renamed, while two steps carrying one id is a plan that listed a request twice, which no rename fixes. Ids are unique by the schema, so that arm is defensive; it is the same shared loop rather than a second resolver, and refusing still beats resolving to whichever the walk saw first.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Commands from the issue: `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`.

- **Full engine suite: 2487 tests, 2487 passed, 0 failed** (41s). No pre-existing failures on this base.
- **Seven new tests.** Four on the pure resolver - `ResolvesARequestIdWhenNoNameAnswers`, `PrefersTheNameWhenOneStepsNameIsAnothersId`, `TheStringNullEndsTheIteration`, `AStepNamedNullWinsOverTheStopForm` - and three end to end through the runner and its mock server: a jump by id lands on the right step, `setNextRequest("null")` ends the iteration with the step still `passed` and the next iteration still running, and a step named `null` is still reached by name.
- **Mutation-checked, not assumed**: with the stop-form branch disabled and the id index pointed back at the names, four of the seven fail (`SetNextRequestJumpsByRequestIdToo`, `SetNextRequestWithTheStringNullEndsTheIteration`, `ResolvesARequestIdWhenNoNameAnswers`, `TheStringNullEndsTheIteration`); restored, all pass. The other three assert precedence the mutation preserves, which is what they are for.
- **clang-format 19** clean over every changed source, and **clang-tidy 19** clean over the three changed translation units - run the way `pr-tests.yml` does it, against a compile database with the PCH flags stripped. It caught one `performance-inefficient-string-concatenation` in the ambiguity message, fixed before this landed rather than by a CI round.
- No app changes: the issue verified this is runner-side resolution only, and nothing in `app/` is touched, so no app suite run.
- `mkdocs build --strict` was not run - mkdocs is not installed in this environment. The docs edits add no page, link, anchor or nav entry, so there is nothing for the strict build to resolve differently.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit, per the issue's list: the `setNextRequest` rules in `docs/engine/scripting.md` (the name-only divergence line resolves, and the `null`-precedence rule lands), the flow-control section of `docs/app/pm-api-compatibility.md`, and the engine-served completion for `pm.execution.setNextRequest` - whose regenerated `script-typedefs.d.ts` fixture is the seventh file here. One deviation from the issue's spec, in the reader's favour rather than the code's: it named the unknown-target message only implicitly, and that message now says both keys were searched ("matches no request name or id"), because "names no request" would send a reader hunting a typo in a name they never wrote.

## Related Issues
Closes #1006

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES7PDjke84qWxdZeoTs16r)_