### PR TITLE
feat(engine): soft delete for collections and requests - a trash, restore and purge - #988

### DIFF
--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -2782,8 +2782,9 @@ async function readCascadeScope(
 /** One sentence naming everything a cascade delete destroys. */
 function describeCascade(scope: CascadeScope): string {
 	return (
-		`Deleting "${scope.name}" also destroys ${scope.descendants} sub-collection(s) and ` +
-		`${scope.requests} saved request(s) inside it. This cannot be undone.`
+		`Deleting "${scope.name}" also removes ${scope.descendants} sub-collection(s) and ` +
+		`${scope.requests} saved request(s) inside it. All of it goes to Vayu's Trash, ` +
+		`where it can be restored.`
 	);
 }
 
@@ -4094,7 +4095,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["collection"],
 		description:
-			"Delete a collection AND EVERYTHING INSIDE IT - every nested sub-collection and every saved request in them. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation: if the client supports elicitation the user is prompted with the number of sub-collections and requests this destroys; otherwise call once to see those counts, then again with `confirmed: true`. There is no undo.",
+			"Delete a collection AND EVERYTHING INSIDE IT - every nested sub-collection and every saved request in them. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation: if the client supports elicitation the user is prompted with the number of sub-collections and requests this destroys; otherwise call once to see those counts, then again with `confirmed: true`. It goes to Vayu's Trash, where the user can restore it until the retention window (`trashRetentionDays`, 30 days by default) runs out - not something to undo from here.",
 		annotations: {
 			title: "Delete collection",
 			readOnlyHint: false,
@@ -4841,7 +4842,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Delete a saved request. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation: if the client supports elicitation the user is prompted with the request's name and URL; otherwise call once for a preview, then again with `confirmed: true`. There is no undo.",
+			"Delete a saved request. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation: if the client supports elicitation the user is prompted with the request's name and URL; otherwise call once for a preview, then again with `confirmed: true`. It goes to Vayu's Trash, where the user can restore it until the retention window (`trashRetentionDays`, 30 days by default) runs out - not something to undo from here.",
 		annotations: {
 			title: "Delete saved request",
 			readOnlyHint: false,
@@ -4877,13 +4878,13 @@ export const TOOLS: McpTool[] = [
 				.join(" ");
 			const subject = target ? `"${name}" (${target})` : `"${name}"`;
 			const unconfirmed = await confirmDestructive(args, ctx, {
-				message: `Delete the saved request ${subject}?\n\nThis cannot be undone.`,
+				message: `Delete the saved request ${subject}?\n\nIt goes to Vayu's Trash, where it can be restored.`,
 				acceptTitle: "Delete the request",
 				acceptDescription: "Confirm to delete this saved request.",
 				declined: "Request not deleted - the user declined.",
 				preview:
 					"AWAITING CONFIRMATION - nothing was deleted.\n\n" +
-					`This would delete the saved request ${subject}. This cannot be undone.\n\n` +
+					`This would delete the saved request ${subject}. It would go to Vayu's Trash, where it can be restored.\n\n` +
 					"This is a preview. To delete it, call delete_request again with confirmed: true and the same arguments.",
 			});
 			if (unconfirmed) return unconfirmed;

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -364,9 +364,13 @@ export default function CollectionTree() {
 							: "Delete request?"
 					}
 					description={
+						// What the engine does is a soft delete (issue #988): the row is
+						// stamped and kept, and the Trash view (issue #989) is where it
+						// is restored from. So the copy says where it went rather than
+						// "cannot be undone", which stopped being true.
 						panel.deleteConfirm?.type === "collection"
-							? `"${panel.deleteConfirm?.name}" and all its requests will be permanently removed. This cannot be undone.`
-							: `"${panel.deleteConfirm?.name}" will be permanently removed. This cannot be undone.`
+							? `"${panel.deleteConfirm?.name}" and all its requests will be moved to the Trash, where they can be restored.`
+							: `"${panel.deleteConfirm?.name}" will be moved to the Trash, where it can be restored.`
 					}
 					onConfirm={panel.confirmDelete}
 					isDeleting={panel.isDeleteInFlight}

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -640,6 +640,7 @@ governs what a run measures rather than what it keeps:
 | `phaseHistograms`   | `true`    | boolean      | Record DNS/connect/TLS/first-byte/download times for **every** load-test completion into five HdrHistograms, so the report can carry `timingBreakdown.phases` percentiles instead of averages over the retained trace sample. Costs five atomic histogram writes per completion; see [benchmarks](benchmarks.md). |
 | `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results, **including captured response bodies**) are pruned at startup and after each run finishes. `0` = unlimited. Captured data is stored verbatim, so this doubles as its expiry. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
+| `trashRetentionDays` | `30`     | 0–3650       | Destroy collections and requests deleted more than this many days ago, swept at startup. Until then they are restorable - see [Trash](#trash). `0` keeps the trash forever. |
 | `monitorIntervalMs` | `1000`    | 250–60000    | Scrape cadence for a [`monitor` block](#the-monitor-block-server-vitals) that names no `intervalMs` of its own. Read per run, so a change applies to the next run started. The *bounds* on a block's own `intervalMs` are fixed at 250–60000 either way - they exist to stop a cadence that measures the scraper rather than the target. |
 | `monitorMaxSeries`  | `8`       | 1–64         | How many metric names one run may chart from its monitored endpoint. A longer `series` list is a `400`. Raising it past 4 repeats chart colours (the categorical palette has four line-legible hues). |
 | `monitorScrapeTimeoutMs` | `0`  | 0–60000      | How long one scrape may take before it counts as a gap. `0` derives it from the cadence in force for that run - three quarters of the interval. Set it explicitly for an exposition that is slow to render: one taking longer than three quarters of the interval fails *every* scrape otherwise, and the only other way out is a slower cadence, which also thins the data. A value longer than the interval a run scrapes at is shortened to it (logged once per run), because a scrape that outlives its own cadence puts the loop behind itself. |
@@ -1016,10 +1017,16 @@ never cascaded away, see [DELETE /specs/:id](#delete-specsid).
 
 ### DELETE /collections/:id
 
-Delete a collection and all its requests (cascading delete). The cascade removes
-every descendant collection and its requests in a single transaction, and
-terminates even if the stored `parent_id` tree contains a cycle (see
+Delete a collection and all its requests (cascading delete). **The delete is
+soft** (issue #988): the collection and every descendant are stamped
+`deleted_at` in a single transaction rather than removed, which is why every
+read surface stops returning them while [`GET /trash`](#get-trash) still can.
+The walk terminates even if the stored `parent_id` tree contains a cycle (see
 [db-schema.md](db-schema.md) - collections).
+
+Restore it with [`POST /trash/:id/restore`](#post-trashidrestore); destroy it
+for good with [`DELETE /trash/:id`](#delete-trashid), which is also what the
+startup sweep does once `trashRetentionDays` has passed.
 
 **Response:**
 ```json
@@ -1241,9 +1248,12 @@ malformed `params` / `headers` entry, a malformed `specOperation`, or an
 
 ### DELETE /requests/:id
 
-Delete a request. Cascades to the request's
-[saved examples](#request-examples) - they are owned by it, and every read of
-them is by request id, so a row left behind would be unreachable.
+Delete a request. **The delete is soft** (issue #988) - the row is stamped
+`deleted_at` and [`GET /trash`](#get-trash) lists it until a purge. Its
+[saved examples](#request-examples) stay on the row rather than being removed:
+every read of them is by request id and runs the owner check first, so they are
+as unreachable as the request is, and a restore gets them back with it. A purge
+takes them.
 
 **Response:**
 ```json
@@ -1252,6 +1262,101 @@ them is by request id, so a row left behind would be unreachable.
   "id": "req_1234567890"
 }
 ```
+
+## Trash
+
+What deleting a collection or a request now does, and how to undo it
+(issue #988). `DELETE /collections/:id` and `DELETE /requests/:id` stamp rows
+instead of removing them; every other read surface filters stamped rows out, so
+the tree the app sees is unchanged, and these three endpoints are the whole of
+what the stamp buys.
+
+Two rules decide what a restore puts back:
+
+- **Cohort.** One delete stamps its whole subtree with one timestamp, and a
+  restore clears exactly the rows carrying the timestamp of the row it was
+  given. So restoring a collection cannot resurrect a request the user had
+  deleted separately beforehand - that request stays in the trash and becomes a
+  root of its own again, since its collection is live.
+- **Re-parent.** A restored collection whose parent is gone, or is itself in the
+  trash, comes back at the tree root (`parentId` cleared). A *request* has no
+  such root - `collectionId` is required - so restoring one whose collection is
+  in the trash is a `409` naming the collection to restore first.
+
+Rows sit in the trash until they are purged: explicitly through
+`DELETE /trash/:id`, or by the startup sweep once they are older than
+`trashRetentionDays` (default 30; `0` keeps them forever).
+
+### GET /trash
+
+Everything deleted and still restorable, newest first. **Roots only** - the rows
+a user asked to delete, never what their cascade took with them; that is what
+`collections` and `requests` count.
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "id": "col_1234567890",
+      "kind": "collection",
+      "name": "Payments API",
+      "deletedAt": 1787745600000,
+      "parentId": null,
+      "collections": 2,
+      "requests": 14
+    }
+  ],
+  "total": 1
+}
+```
+
+`kind` is `"collection"` or `"request"`. `parentId` is a collection's parent
+(`null` at the tree root) or a request's owning collection. An empty trash is
+`{"items": [], "total": 0}`, never a `404`.
+
+### POST /trash/:id/restore
+
+Put a deleted collection or request back, with everything the same delete took.
+Takes no body.
+
+**Response:** the entry that was restored, plus what happened to it:
+```json
+{
+  "id": "col_1234567890",
+  "kind": "collection",
+  "name": "Payments API",
+  "deletedAt": 1787745600000,
+  "parentId": null,
+  "collections": 2,
+  "requests": 14,
+  "restored": true,
+  "reparentedToRoot": false
+}
+```
+
+**Errors:**
+
+| Status | When |
+|--------|------|
+| `404` | Nothing in the trash carries that id - a live row, or one already purged |
+| `409` | A request whose collection is itself deleted or gone; restore the collection first |
+
+### DELETE /trash/:id
+
+Destroy a deleted collection or request for good, with its whole subtree -
+requests, and the examples they own. This is the hard cascade soft delete
+replaced, asked for deliberately; there is no undo for it.
+
+Unlike a restore, a purge is not limited to the cohort: a row an earlier delete
+left inside the subtree goes too, because a request under a removed collection
+is reachable by no read and restorable by nothing.
+
+**Response:** the entry that was purged, with `"purged": true`. Its
+`collections` / `requests` are the deleted row's own cohort, so they are a floor
+here rather than the whole: a purge that also swept up an earlier delete's rows
+destroyed more than they count. A `404` if the trash does not hold that id -
+which is also what stops a mistyped id from destroying a live collection.
 
 ## Request examples
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2228,8 +2228,21 @@ diff bounds its buckets rather than dropping entries: a call that answered only
 with what it wrote would read as "applied the drift", and the part it did not
 apply is exactly the part somebody has to decide about.
 
-Four rules the payload cannot opt out of:
+Five rules the payload cannot opt out of:
 
+- **A `delete` here is permanent - it does not go to the [Trash](#trash)**
+  (issues #988, #1046). Every other delete in the engine is soft: the row is
+  stamped and restorable. A sync is not a person removing a request, it is a
+  *reconciliation* to a document, and the two differ in where the decision is
+  made - [`POST /specs/diff`](#post-specsdiff) reports every removal before
+  anything is written, the app renders them as ticks the user unticks one by
+  one, and `policy: "safe"` refuses deletions outright, so a deletion here is
+  one a caller stated after being shown it. Leaving those rows stamped instead
+  would put the operations a document no longer declares back in the trash on
+  every sync, where restoring one re-creates a request the document cannot
+  explain. The rows and the examples they own are removed in the sync's own
+  transaction. A caller that wants the deletions recoverable omits them from the
+  payload and issues `DELETE /requests/:id` per row, which is soft.
 - **The bound subtree is the boundary.** Every request an `update` or a `delete`
   names, and every collection a created request lands in, must be the collection
   being synced or one beneath it. Anything else is a `400` naming the item -

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -516,8 +516,12 @@ See [Database Schema](db-schema.md) for the full column list.
 2. **Pruning**: run history is trimmed per `maxRunsRetained` / `runRetentionDays`.
    Reconciliation runs first so an orphan is terminal, and therefore prunable, in the
    same startup.
+3. **Trash retention**: collections and requests deleted more than
+   `trashRetentionDays` ago are destroyed for good (issue #988) - the subtree,
+   its requests and their examples. Until then a delete is only a stamp, and
+   `POST /trash/:id/restore` puts it back.
 
-Both passes are best-effort: a failure is logged and never blocks startup.
+All three passes are best-effort: a failure is logged and never blocks startup.
 
 ## Request Flow
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -143,6 +143,7 @@ Stores folder/group hierarchy for requests.
 | `order`              | INTEGER | Sort order within parent; default 0          |
 | `created_at`         | INTEGER | Unix ms                                      |
 | `updated_at`         | INTEGER | Unix ms                                      |
+| `deleted_at`         | INTEGER | Unix ms; NULL while the collection is live (issue #988) |
 
 **data_schema** - which columns this collection's data files are expected to
 carry, so `{{data.column}}` and `pm.iterationData` can be checked before a run
@@ -252,6 +253,7 @@ Stores individual HTTP request definitions.
 | `spec_operation`      | TEXT    | JSON: which spec operation this is; NULL when none   |
 | `created_at`          | INTEGER | Unix ms                                              |
 | `updated_at`          | INTEGER | Unix ms                                              |
+| `deleted_at`          | INTEGER | Unix ms; NULL while the request is live (issue #988) |
 
 **params / headers** - stored as a JSON array of objects:
 ```json

--- a/docs/request-storage-design.md
+++ b/docs/request-storage-design.md
@@ -169,6 +169,18 @@ still binds its OpenAPI document, so the orphan sweep leaves that document alone
 until the collection is purged. Reclaiming it earlier would restore a binding
 that points at nothing.
 
+**One delete path stays hard, by decision** (issue #1046): the requests a
+`POST /specs/sync` removes because the re-fetched document no longer declares
+their operation. A sync is a reconciliation to a document rather than a person
+removing a request, and it is the one delete whose removals are shown before
+they happen - `POST /specs/diff` reports every one, the app renders them as
+ticks the user can untick, and `policy: "safe"` declines deletions altogether.
+Stamping them instead would fill the Trash with operations a document dropped,
+where restoring one puts back a request the current document cannot explain. A
+caller that wants those rows recoverable leaves them out of the sync payload and
+deletes them with `DELETE /requests/:id`, which is soft like every other delete
+a person makes.
+
 ### 6. Response Viewer
 
 The Response Viewer shows the **RESOLVED** request in the "Raw Request" tab:

--- a/docs/request-storage-design.md
+++ b/docs/request-storage-design.md
@@ -127,10 +127,49 @@ a mock server serves the first example of a matched request.
 Reached through `GET /requests/:id/examples`, written today only by import
 (nested on the request item of `POST /import/apply`, so the whole tree lands in
 one transaction), and shown read-only in the request builder's **Examples** tab.
-Deleting the request - or the collection above it - deletes its examples in the
-same transaction.
+Deleting the request - or the collection above it - takes its examples with it,
+in the sense the next section describes: they stay on the row while the request
+is in the trash, unreachable because every read of them checks the owner first,
+and a purge removes them in the same transaction as the request.
 
-### 5. Response Viewer
+### 5. The deletion lifecycle (issue #988)
+
+**Deleting a collection or a request does not remove it.** `DELETE
+/collections/:id` and `DELETE /requests/:id` stamp `deleted_at` on the row - and,
+for a collection, on its whole subtree in one transaction - and every read
+surface filters stamped rows out. To the sidebar, an export, an MCP tool or a
+scenario plan, the row is gone; only `GET /trash` can still see it.
+
+A row leaves that state one of three ways:
+
+| | What happens |
+|---|---|
+| `POST /trash/:id/restore` | The stamp is cleared and the row is back exactly as it was - `order`, `parent_id` and every field untouched. |
+| `DELETE /trash/:id` | The old hard cascade: the subtree, its requests and their examples are removed for good. |
+| Retention | The same purge, run at startup for anything deleted more than `trashRetentionDays` ago (default 30; `0` keeps the trash forever). |
+
+Two rules make a restore mean something precise:
+
+- **The cohort.** One delete stamps its subtree with one timestamp, and a
+  restore clears exactly the rows carrying the timestamp of the row it was
+  given. A request the user deleted separately *before* its collection keeps its
+  own stamp, so restoring the collection leaves it in the trash - as a trash
+  root of its own, now that its collection is live again.
+- **Re-parenting.** A restored collection whose parent is gone or itself deleted
+  comes back at the tree root. A request cannot do this - `collection_id` is
+  required - so restoring one whose collection is in the trash is refused with a
+  `409` that names the collection to restore first.
+
+A purge is deliberately *not* limited to the cohort: it takes the whole subtree,
+because a request left under a removed collection would be reachable by no read
+and restorable by nothing.
+
+One thing a soft delete deliberately does not release: a stamped collection
+still binds its OpenAPI document, so the orphan sweep leaves that document alone
+until the collection is purged. Reclaiming it earlier would restore a binding
+that points at nothing.
+
+### 6. Response Viewer
 
 The Response Viewer shows the **RESOLVED** request in the "Raw Request" tab:
 - Shows exactly what was sent over the wire

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -352,6 +352,7 @@ The daemon listens on `http://127.0.0.1:9876`. Key endpoints:
 | POST | `/oauth2/token` | Acquire/return a cached OAuth 2.0 token (auth resolved engine-side) |
 | GET | `/health` | Health check |
 | POST | `/workspace/backup` | One `VACUUM INTO` snapshot of the workspace into `backups/` beside the database, with retention (issue #987); no restore endpoint - see `docs/engine/architecture.md` |
+| GET | `/trash` | What deleting a collection or request left recoverable (issue #988) - roots only, each with what its cascade took; `POST /trash/:id/restore` puts one back, `DELETE /trash/:id` destroys it, and `trashRetentionDays` purges the rest at startup |
 | POST | `/import/parse` | Read a raw import document - OpenAPI 2.0/3.x, Postman v2.0/v2.1, a Postman environment or globals export, Insomnia v4 - into the tree `/import/apply` persists (issue #877); reads only |
 | POST | `/import` | The same parse, flattened and applied in one call - what MCP `import_document` wraps; the app parses and applies separately because a person previews in between |
 | POST | `/import/document` | A document's bytes as a JSON DOM, through the engine's one reader - the whole of what the app's `$ref` bundler needs, and what took the last YAML dependency out of `app/src` |

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -625,6 +625,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/routes/collections.cpp
         src/http/routes/requests.cpp
         src/http/routes/examples.cpp
+        src/http/routes/trash.cpp
         src/http/routes/specs.cpp
         src/http/routes/spec_sync.cpp
         src/http/routes/spec_match.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -882,6 +882,17 @@ constexpr int MAX_RUNS_RETAINED = 200;
 /// Run retention: delete runs older than N days (0 = unlimited).
 constexpr int RUN_RETENTION_DAYS = 30;
 /**
+ * Trash retention: purge collections and requests deleted more than N days ago
+ * (0 = keep them forever), swept at startup (issue #988).
+ *
+ * Thirty days for the same reason runs get thirty: the mistake soft delete
+ * exists to undo - a collection removed by a misclick - is usually noticed the
+ * same day, and the tail is someone coming back from a month away. A stamped
+ * subtree costs only the rows it already occupied, so the ceiling is about not
+ * growing the file forever rather than about reclaiming space soon.
+ */
+constexpr int TRASH_RETENTION_DAYS = 30;
+/**
  * Workspace backups: keep at most N snapshots in `backups/` (0 = unlimited).
  *
  * Five rather than one, because the failure a backup guards against is often

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -88,6 +88,54 @@ struct DesignResultOutcome {
 };
 
 /**
+ * @brief One thing the user deleted, as the trash lists it (issue #988).
+ *
+ * A *root* only: the row the user asked to delete, never the descendants that
+ * went with it. What a cascade took is the two counts, because that is the
+ * question a trash view asks ("restoring this brings back what?") and listing
+ * every stamped row would answer a different one.
+ */
+struct TrashEntry {
+    std::string id;
+    /// "collection" or "request" - the two tables the trash spans, so a client
+    /// knows which shape it is looking at without a second read.
+    std::string kind;
+    std::string name;
+    /// When the delete ran, in Unix ms. Also the cohort key - see
+    /// `Collection::deleted_at`.
+    int64_t deleted_at = 0;
+    /// The collection this row hung under: a collection's parent (absent at the
+    /// tree root), a request's owning collection (always present).
+    std::optional<std::string> parent_id;
+    /// Descendants *this delete* took with it - the cohort, and therefore
+    /// exactly what a restore puts back. A purge may take more (a row an
+    /// earlier delete left inside the same subtree), which is the one place
+    /// these counts are a floor rather than the whole. Both 0 for a request.
+    int64_t collections = 0;
+    int64_t requests    = 0;
+};
+
+/// What a restore or a purge acted on - the entry as it was, plus whether the
+/// restore had to re-parent it (issue #988).
+struct TrashOutcome {
+    TrashEntry entry;
+    /// True when the restored collection's parent was gone or itself deleted,
+    /// so the row came back at the tree root instead. Always false for a purge.
+    bool reparented = false;
+};
+
+/// Why a restore did not happen. `NotFound` is a 404 - nothing in the trash
+/// carries that id; `OwnerGone` is a 409 - a request whose collection is itself
+/// deleted or missing, which has no root to come back to.
+enum class RestoreRefusal { NotFound, OwnerGone };
+
+/// A refused restore, as the route reports it (issue #988).
+struct RestoreFailure {
+    RestoreRefusal reason = RestoreRefusal::NotFound;
+    std::string message;
+};
+
+/**
  * Thrown by `apply_reorder` when a row it was told to write is not stored at
  * commit time. The batch is rolled back whole, and the row stays deleted.
  *
@@ -226,16 +274,72 @@ class Database {
 
     // Project Management
     void create_collection (const Collection& c);
+    /// Live collections only - a deleted one is gone to every reader but the
+    /// trash (issue #988).
     std::vector<Collection> get_collections ();
+    /// Live only, like `get_collections` - a deleted row reads as absent, which
+    /// is what turns every by-id route into its own 404 (issue #988).
     std::optional<Collection> get_collection (const std::string& id);
+    /// Stamps the collection and its whole subtree as deleted rather than
+    /// removing them (issue #988). `GET /trash` lists it, restore puts it back
+    /// and purge is what finally destroys it.
     void delete_collection (const std::string& id);
 
     void save_request (const Request& r);
+    /// Live only - see `get_collection` (issue #988).
     std::optional<Request> get_request (const std::string& id);
+    /// Live only, and empty for a deleted collection (issue #988).
     std::vector<Request> get_requests_in_collection (const std::string& collection_id);
-    /// Cascades to the request's examples - see the definition for why they
-    /// cannot be left behind.
+    /// Stamps the request as deleted (issue #988). Its examples stay on the
+    /// row - nothing can read them while the request is stamped, and a purge
+    /// takes them with it.
     void delete_request (const std::string& id);
+
+    // Trash - what soft delete left behind (issue #988)
+
+    /// Every deleted root, newest first. A root is a stamped row whose owner is
+    /// *not* stamped: the thing the user deleted, never what its cascade took.
+    std::vector<TrashEntry> get_trash ();
+
+    /**
+     * @brief Put a deleted row, and everything its delete took with it, back.
+     *
+     * Restores the *cohort*: the stamped subtree rows carrying this row's own
+     * `deleted_at`. A row deleted separately and earlier keeps its stamp, so
+     * restoring a collection cannot resurrect a request the user deleted before
+     * it - it becomes a trash root of its own again instead.
+     *
+     * A collection whose parent is gone or itself deleted comes back at the tree
+     * root (`parent_id` cleared) - the rule the issue names, and the only place
+     * a restore rewrites anything but the stamp.
+     */
+    std::expected<TrashOutcome, RestoreFailure> restore_deleted (const std::string& id);
+
+    /**
+     * @brief Destroy a deleted row for good - the hard cascade soft delete
+     *        replaced.
+     *
+     * Takes the whole subtree, stamp or no stamp, because a row left under a
+     * removed collection is reachable by no read and restorable by nothing.
+     * `nullopt` when no *deleted* row carries that id: purging a live row is
+     * not something this endpoint can be asked for by accident.
+     */
+    std::optional<TrashOutcome> purge_deleted (const std::string& id);
+
+    /**
+     * @brief Purge everything deleted longer ago than @p retention_days.
+     *
+     * @param retention_days 0 keeps the trash forever - the same reading
+     *        `maxRunsRetained` and `runRetentionDays` give 0.
+     * @param now the caller's clock in Unix ms, so a test can state the age it
+     *        is asking about rather than sleep for it.
+     * @return how many roots were purged.
+     */
+    int64_t purge_expired_trash (int retention_days, int64_t now);
+
+    /// `purge_expired_trash` with the configured `trashRetentionDays` and the
+    /// system clock - what startup runs (issue #988).
+    int64_t purge_expired_trash_configured ();
 
     // Saved example responses, owned by a request (issue #481). Every read is
     // by request id or by example id; there is no all-examples query, because
@@ -747,6 +851,69 @@ class Database {
      * function. The caller must already hold the DB mutex.
      */
     void remove_run_cascade_locked (const std::string& id);
+
+    /**
+     * @brief Every collection id in @p root_id's subtree, @p root_id first.
+     *
+     * The single definition of "the subtree", shared by the delete cascade, the
+     * restore, the purge and the trash's counts, so all four agree about what
+     * one collection owns. Stamped and live rows alike: a walk that skipped
+     * deleted rows could not find what a restore has to put back.
+     *
+     * The visited set is load-bearing rather than defensive - a cycle in
+     * `parent_id` written before write-time validation existed would otherwise
+     * loop forever while the global DB mutex is held (issue #79). The caller
+     * must already hold that mutex.
+     */
+    std::vector<std::string> collection_subtree_locked (const std::string& root_id);
+
+    /**
+     * @brief Destroy a collection subtree or a single request outright -
+     *        examples, requests, then collections, deepest first.
+     *
+     * The hard cascade soft delete replaced (issue #988), kept as the one
+     * definition purge and retention both reach for. The caller must already
+     * hold the DB mutex.
+     */
+    void purge_collection_locked (const std::string& id);
+    void purge_request_locked (const std::string& id);
+
+    /**
+     * @brief The trash entry for one deleted row, or nothing when @p id names
+     *        no *deleted* row.
+     *
+     * By id rather than by root, because restore and purge both take an id and
+     * a row a cascade took is not a root - so answering only about roots would
+     * make the re-parent rule unreachable and "restore this one request" a 404.
+     * The listing filters roots out of *its* answer; these three still agree
+     * about what an entry says. The caller must already hold the DB mutex.
+     */
+    std::optional<TrashEntry> trash_entry_locked (const std::string& id);
+
+    /**
+     * @brief Whether the collection @p owner_id names is missing or itself
+     *        deleted - the question both halves of a restore ask about the row
+     *        they are putting back.
+     *
+     * An empty optional is the *tree root*, which is not an absent owner: a
+     * collection that sits at the top has nothing above it by design. The
+     * caller must already hold the DB mutex.
+     */
+    bool owner_is_absent_locked (const std::optional<std::string>& owner_id);
+
+    /**
+     * @brief The two halves of `restore_deleted`, split by what a row can come
+     *        back to: a request needs a live collection and refuses without
+     *        one, a collection re-parents to the tree root instead.
+     *
+     * Named steps rather than one function with both shapes inside it (#1033's
+     * rule, and what `readability-function-cognitive-complexity` reports).
+     * Both take an entry `trash_entry_locked` already proved deleted, and both
+     * require the DB mutex.
+     */
+    std::expected<TrashOutcome, RestoreFailure> restore_request_locked (
+    const TrashEntry& entry);
+    TrashOutcome restore_collection_locked (const TrashEntry& entry);
 
     /**
      * @brief Clear `is_active` on every environment except @p keep_id.

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -1045,6 +1045,7 @@ void register_workspace_routes (RouteContext& ctx);
 void register_collection_routes (RouteContext& ctx);
 void register_request_routes (RouteContext& ctx);
 void register_request_example_routes (RouteContext& ctx);
+void register_trash_routes (RouteContext& ctx);
 void register_spec_routes (RouteContext& ctx);
 void register_spec_sync_routes (RouteContext& ctx);
 void register_spec_match_routes (RouteContext& ctx);

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -982,6 +982,15 @@ struct Collection {
     int order          = 0;
     int64_t created_at = 0;
     int64_t updated_at = 0;
+    // When this collection was deleted, in Unix ms - NULL while it is live
+    // (issue #988). Every read surface filters on it, so a stamped row is gone
+    // to every caller that is not the trash itself; the value is also the
+    // *cohort key*, shared by every row one cascade stamped, which is what
+    // makes a restore put back exactly what that delete took and nothing a
+    // separate earlier delete removed. Nullable rather than 0-means-live for
+    // the reason `spec_operation` is: NULL is the absence, and a second
+    // spelling of it is one every reader would have to handle.
+    std::optional<int64_t> deleted_at;
 };
 
 struct Request {
@@ -1033,6 +1042,11 @@ struct Request {
     std::optional<std::string> spec_operation;
     int64_t created_at = 0;
     int64_t updated_at = 0;
+    // When this request was deleted, in Unix ms - NULL while it is live
+    // (issue #988). Same rule and same cohort meaning as `Collection::deleted_at`;
+    // a request stamped by its collection's cascade carries that cascade's
+    // timestamp, not one of its own.
+    std::optional<int64_t> deleted_at;
 };
 
 /**

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1921,6 +1921,15 @@ void Database::verify_spec_sync_rows_locked (const SpecSyncBatch& batch) {
 }
 
 void Database::write_spec_sync_batch_locked (const SpecSyncBatch& batch) {
+    // These deletes are **hard**, and stay hard now that every delete a person
+    // makes is soft (issues #988, #1046 - owner decision). A sync is a
+    // reconciliation to a document, not somebody removing a request, and it is
+    // the one delete path whose removals are shown before they land: `POST
+    // /specs/diff` reports each one, the app renders them as ticks to untick,
+    // and `policy: "safe"` refuses deletions outright. Stamping them would fill
+    // the trash with operations a document dropped, where restoring one puts
+    // back a request the current document cannot explain. A caller that wants
+    // them recoverable omits them here and calls `DELETE /requests/:id`.
     for (const auto& id : batch.deleted) {
         impl_->storage.remove_all<RequestExample> (
         where (c (&RequestExample::request_id) == id));

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -56,6 +56,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/core/spec_binding.hpp"
 #include "vayu/http/transport_policy.hpp"
+#include "vayu/utils/invariant.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/utils/reentrant.hpp"
 
@@ -224,7 +225,11 @@ inline auto make_storage (const std::string& path) {
     make_column ("openapi", &Collection::openapi, default_value (std::string ("{}"))),
     make_column ("order", &Collection::order),
     make_column ("created_at", &Collection::created_at),
-    make_column ("updated_at", &Collection::updated_at)),
+    make_column ("updated_at", &Collection::updated_at),
+    // Soft delete (issue #988): NULL is live, a stamp is the instant the
+    // delete that took this row ran. Additive and nullable, which is the
+    // class `sync_schema` adds without touching a stored row.
+    make_column ("deleted_at", &Collection::deleted_at)),
 
     // Requests: HTTP request definitions with pre/post scripts
     make_table ("requests", make_column ("id", &Request::id, primary_key ()),
@@ -263,7 +268,9 @@ inline auto make_storage (const std::string& path) {
     // NULL is the only spelling of "declares no operation".
     make_column ("spec_operation", &Request::spec_operation),
     make_column ("created_at", &Request::created_at),
-    make_column ("updated_at", &Request::updated_at)),
+    make_column ("updated_at", &Request::updated_at),
+    // Soft delete (issue #988) - see the collections column above.
+    make_column ("deleted_at", &Request::deleted_at)),
 
     // Request examples: saved example responses for a request (issue #481).
     // Created by import today, and the response source a mock server serves
@@ -978,6 +985,18 @@ void Database::init () {
         vayu::utils::log_warning (
         "Startup run pruning failed: " + std::string (e.what ()));
     }
+
+    // Destroy what has sat in the trash past its retention (issue #988). Here
+    // rather than on every delete, on the same reasoning as run pruning: this
+    // is a sweep over rows nobody is looking at, and a startup is when the
+    // engine can afford one. Best-effort for the same reason too - a failed
+    // sweep must not be a daemon that will not start.
+    try {
+        purge_expired_trash_configured ();
+    } catch (const std::exception& e) {
+        vayu::utils::log_warning (
+        "Startup trash purge failed: " + std::string (e.what ()));
+    }
 }
 
 // ============================================================================
@@ -1008,54 +1027,54 @@ std::vector<Collection> Database::get_collections () {
     // clock resolution across three platforms. See the Ordering section of
     // docs/engine/api-reference.md. The renderer's comparator applies the
     // identical rule, pinned by tests/fixtures/tree-order-conformance.json.
-    return impl_->storage.get_all<Collection> (multi_order_by (order_by (&Collection::order),
+    //
+    // Deleted rows are excluded here rather than at each caller (issue #988):
+    // this is what the sidebar, the MCP tools, every export and every plan
+    // resolution read, and a filter one of them forgot is a ghost row
+    // resurfacing in exactly one place.
+    return impl_->storage.get_all<Collection> (where (is_null (&Collection::deleted_at)),
+    multi_order_by (order_by (&Collection::order),
     order_by (&Collection::created_at), order_by (&Collection::id)));
 }
 
 std::optional<Collection> Database::get_collection (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    auto cols = impl_->storage.get_all<Collection> (where (c (&Collection::id) == id));
+    auto cols = impl_->storage.get_all<Collection> (
+    where (c (&Collection::id) == id && is_null (&Collection::deleted_at)));
     if (cols.empty ())
         return std::nullopt;
     return cols.front ();
 }
 
-// Cascade delete: recursively removes all descendant collections and their requests.
-// BFS discovers all descendant IDs, then deletes deepest-first inside a single
-// transaction.
-void Database::delete_collection (const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("Deleting collection (cascade): id=" + id);
-
-    // 1. Collect all descendant IDs via BFS (root first). The visited set makes
-    //    the walk terminate even on cyclic parent_id data - a self-parent or an
-    //    A -> B -> A loop that may have been written before write-time
-    //    validation existed. Without it, `to_delete` grows forever while this
-    //    method holds the global DB mutex, hanging every endpoint including
-    //    /health until the daemon is restarted (issue #79).
-    std::vector<std::string> to_delete;
+std::vector<std::string> Database::collection_subtree_locked (const std::string& root_id) {
+    std::vector<std::string> subtree;
     std::unordered_set<std::string> visited;
-    to_delete.push_back (id);
-    visited.insert (id);
+    subtree.push_back (root_id);
+    visited.insert (root_id);
     size_t idx = 0;
-    while (idx < to_delete.size ()) {
+    while (idx < subtree.size ()) {
         auto children = impl_->storage.get_all<Collection> (
-        where (c (&Collection::parent_id) == to_delete[idx]));
+        where (c (&Collection::parent_id) == subtree[idx]));
         for (const auto& child : children) {
             if (visited.insert (child.id).second) {
-                to_delete.push_back (child.id);
+                subtree.push_back (child.id);
             }
         }
         ++idx;
     }
+    return subtree;
+}
 
-    // 2. Delete deepest-first so foreign-key integrity holds at each step,
-    //    wrapped in a single transaction so a crash mid-cascade cannot leave a
-    //    half-deleted subtree. Safe under the recursive mutex already held -
-    //    the lambda only calls sqlite_orm on the same storage handle (same
-    //    pattern as add_results_batch).
+void Database::purge_collection_locked (const std::string& id) {
+    const auto subtree = collection_subtree_locked (id);
+
+    // Deepest-first so foreign-key integrity holds at each step, wrapped in a
+    // single transaction so a crash mid-cascade cannot leave a half-deleted
+    // subtree. Safe under the recursive mutex already held - the lambda only
+    // calls sqlite_orm on the same storage handle (same pattern as
+    // add_results_batch).
     impl_->storage.transaction ([&] {
-        for (auto it = to_delete.rbegin (); it != to_delete.rend (); ++it) {
+        for (auto it = subtree.rbegin (); it != subtree.rend (); ++it) {
             // Examples first, and by request id rather than by collection: they
             // hang off the request, so deleting the requests before them would
             // leave rows no read can reach and no later delete can find.
@@ -1071,14 +1090,85 @@ void Database::delete_collection (const std::string& id) {
         return true; // Commit
     });
 
-    // 3. The cascade above is still deliberately not a cascade *to* the document
-    //    a deleted collection was bound to - several collections may bind one,
-    //    so the binding going away is not the document going away. It is the
-    //    moment to ask whether anything still holds it, though, and that is what
-    //    the sweep answers (issue #718). Outside the transaction: the subtree is
-    //    gone either way, and this must not be able to roll it back. Never
-    //    throws; see the declaration.
+    // The cascade above is deliberately not a cascade *to* the document a
+    // purged collection was bound to - several collections may bind one, so the
+    // binding going away is not the document going away. It is the moment to
+    // ask whether anything still holds it, though, and that is what the sweep
+    // answers (issue #718). Outside the transaction: the subtree is gone either
+    // way, and this must not be able to roll it back. Never throws; see the
+    // declaration.
     sweep_orphaned_spec_documents ();
+}
+
+void Database::purge_request_locked (const std::string& id) {
+    impl_->storage.transaction ([&] {
+        impl_->storage.remove_all<RequestExample> (
+        where (c (&RequestExample::request_id) == id));
+        impl_->storage.remove_all<Request> (where (c (&Request::id) == id));
+        return true; // Commit
+    });
+}
+
+// Soft delete (issue #988): the subtree is stamped, not removed. Every read
+// filters the stamp out, so the tree the user sees is the same tree a hard
+// cascade left - but `GET /trash` can still find it, `POST /trash/:id/restore`
+// can put it back, and only a purge (explicit, or retention at startup) is
+// what finally destroys it.
+void Database::delete_collection (const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    vayu::utils::log_debug ("Deleting collection (soft, cascade): id=" + id);
+
+    const auto subtree = collection_subtree_locked (id);
+
+    // The stamp is this delete's cohort key, and a cohort has to be
+    // distinguishable from an *earlier* delete inside the same subtree - that
+    // is what stops restoring a collection from also resurrecting a request the
+    // user deleted separately beforehand. Sharing a millisecond with such a row
+    // would erase the distinction, so the one case where it can happen is
+    // stepped over rather than left to chance.
+    int64_t stamp = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                    .count ();
+    const auto collides_with_an_earlier_delete = [&] (int64_t candidate) {
+        for (const auto& collection_id : subtree) {
+            if (impl_->storage.count<Collection> (where (c (&Collection::id) == collection_id &&
+                c (&Collection::deleted_at) == candidate)) > 0) {
+                return true;
+            }
+            if (impl_->storage.count<Request> (where (c (&Request::collection_id) == collection_id &&
+                c (&Request::deleted_at) == candidate)) > 0) {
+                return true;
+            }
+        }
+        return false;
+    };
+    while (collides_with_an_earlier_delete (stamp)) {
+        ++stamp;
+    }
+
+    // Only rows that are still live are stamped. A row an earlier delete
+    // already took keeps that delete's stamp, so restoring this collection
+    // leaves it in the trash - as its own root, since its owner is live again.
+    impl_->storage.transaction ([&] {
+        for (const auto& collection_id : subtree) {
+            for (auto& request : impl_->storage.get_all<Request> (
+                 where (c (&Request::collection_id) == collection_id &&
+                 is_null (&Request::deleted_at)))) {
+                request.deleted_at = stamp;
+                impl_->storage.update (request);
+            }
+            for (auto& collection : impl_->storage.get_all<Collection> (where (
+                 c (&Collection::id) == collection_id && is_null (&Collection::deleted_at)))) {
+                collection.deleted_at = stamp;
+                impl_->storage.update (collection);
+            }
+        }
+        return true; // Commit
+    });
+
+    // No spec-document sweep here, deliberately: a stamped collection still
+    // binds its document, and reclaiming it now would leave a restore pointing
+    // at a document that is gone. The sweep runs on the purge instead.
 }
 
 // ============================================================================
@@ -1093,7 +1183,8 @@ void Database::save_request (const Request& r) {
 
 std::optional<Request> Database::get_request (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    auto requests = impl_->storage.get_all<Request> (where (c (&Request::id) == id));
+    auto requests = impl_->storage.get_all<Request> (
+    where (c (&Request::id) == id && is_null (&Request::deleted_at)));
     if (requests.empty ())
         return std::nullopt;
     return requests.front ();
@@ -1102,24 +1193,284 @@ std::optional<Request> Database::get_request (const std::string& id) {
 std::vector<Request> Database::get_requests_in_collection (const std::string& collection_id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     // Same three-key tie rule as get_collections - see the comment there for why
-    // the implicit rowid cannot be the tiebreak.
-    return impl_->storage.get_all<Request> (where (c (&Request::collection_id) == collection_id),
+    // the implicit rowid cannot be the tiebreak. Deleted rows are excluded on
+    // the same reasoning too (issue #988); a deleted *collection* answers with
+    // nothing at all, because every caller reaches this through a
+    // `get_collection` that already refused.
+    return impl_->storage.get_all<Request> (
+    where (c (&Request::collection_id) == collection_id && is_null (&Request::deleted_at)),
     multi_order_by (order_by (&Request::order), order_by (&Request::created_at),
     order_by (&Request::id)));
 }
 
-// Cascade: a request owns its examples, so both go in one transaction. Deleting
-// only the request would leave rows that no route can list (every read is by
-// request id) and that the collection cascade can no longer find either.
+// Soft delete (issue #988): the row is stamped, not removed. Its examples stay
+// where they are - every read of them is by request id and goes through a
+// request this stamp has made unreadable, so they are as gone as the request
+// is, and a restore that had to re-create them could not.
 void Database::delete_request (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("Deleting request (cascade): id=" + id);
+    vayu::utils::log_debug ("Deleting request (soft): id=" + id);
+    const int64_t stamp = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                          .count ();
     impl_->storage.transaction ([&] {
-        impl_->storage.remove_all<RequestExample> (
-        where (c (&RequestExample::request_id) == id));
-        impl_->storage.remove_all<Request> (where (c (&Request::id) == id));
+        for (auto& request : impl_->storage.get_all<Request> (
+             where (c (&Request::id) == id && is_null (&Request::deleted_at)))) {
+            request.deleted_at = stamp;
+            impl_->storage.update (request);
+        }
         return true; // Commit
     });
+}
+
+// ============================================================================
+// Trash - the rows soft delete stamped, and the three things one can do with
+// them: look at them, put them back, destroy them (issue #988)
+// ============================================================================
+
+std::optional<TrashEntry> Database::trash_entry_locked (const std::string& id) {
+    constexpr const char* STAMPED =
+    "a row read under is_not_null(deleted_at) carries a stamp";
+
+    auto collections = impl_->storage.get_all<Collection> (
+    where (c (&Collection::id) == id && is_not_null (&Collection::deleted_at)));
+    if (!collections.empty ()) {
+        const auto& collection = collections.front ();
+        const int64_t stamp = vayu::utils::invariant_value (collection.deleted_at, STAMPED);
+        TrashEntry entry{ collection.id, "collection", collection.name, stamp,
+            collection.parent_id, 0, 0 };
+        // The counts are the *cohort's*, not the subtree's: what this delete
+        // took is what restoring it puts back, and a row an earlier delete
+        // already held is neither.
+        for (const auto& descendant_id : collection_subtree_locked (collection.id)) {
+            if (descendant_id != collection.id) {
+                entry.collections += impl_->storage.count<Collection> (
+                where (c (&Collection::id) == descendant_id &&
+                c (&Collection::deleted_at) == stamp));
+            }
+            entry.requests += impl_->storage.count<Request> (
+            where (c (&Request::collection_id) == descendant_id &&
+            c (&Request::deleted_at) == stamp));
+        }
+        return entry;
+    }
+
+    auto requests = impl_->storage.get_all<Request> (
+    where (c (&Request::id) == id && is_not_null (&Request::deleted_at)));
+    if (!requests.empty ()) {
+        const auto& request = requests.front ();
+        return TrashEntry{ request.id, "request", request.name,
+            vayu::utils::invariant_value (request.deleted_at, STAMPED),
+            request.collection_id, 0, 0 };
+    }
+    return std::nullopt;
+}
+
+std::vector<TrashEntry> Database::get_trash () {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    // "Is this row's owner deleted too?" is asked once per candidate, so the
+    // owning table is read once here rather than once per question.
+    std::unordered_map<std::string, bool> collection_is_deleted;
+    for (const auto& [id, deleted_at] :
+    impl_->storage.select (columns (&Collection::id, &Collection::deleted_at))) {
+        collection_is_deleted[id] = deleted_at.has_value ();
+    }
+    // A row whose owner is missing entirely is a root as much as one whose owner
+    // is live: there is nothing above it that a restore could come back under.
+    const auto owner_is_deleted = [&] (const std::string& owner_id) {
+        const auto it = collection_is_deleted.find (owner_id);
+        return it != collection_is_deleted.end () && it->second;
+    };
+    const auto push_root = [&] (std::vector<TrashEntry>& into, const std::string& id) {
+        if (auto entry = trash_entry_locked (id)) {
+            into.push_back (std::move (*entry));
+        }
+    };
+
+    std::vector<TrashEntry> entries;
+    for (const auto& collection : impl_->storage.get_all<Collection> (
+         where (is_not_null (&Collection::deleted_at)))) {
+        if (collection.parent_id.has_value () && owner_is_deleted (*collection.parent_id)) {
+            continue; // A cascade took it; its root is further up.
+        }
+        push_root (entries, collection.id);
+    }
+    for (const auto& request :
+    impl_->storage.get_all<Request> (where (is_not_null (&Request::deleted_at)))) {
+        if (owner_is_deleted (request.collection_id)) {
+            continue;
+        }
+        push_root (entries, request.id);
+    }
+
+    // Newest first - what a trash view shows at the top - with `id` as the
+    // tiebreak so a page of same-millisecond deletes is a total order rather
+    // than whatever the two table scans happened to produce.
+    std::sort (entries.begin (), entries.end (),
+    [] (const TrashEntry& a, const TrashEntry& b) {
+        return a.deleted_at != b.deleted_at ? a.deleted_at > b.deleted_at :
+                                              a.id < b.id;
+    });
+    return entries;
+}
+
+bool Database::owner_is_absent_locked (const std::optional<std::string>& owner_id) {
+    if (!owner_id.has_value ()) {
+        return false; // The tree root is not a missing owner.
+    }
+    auto owners =
+    impl_->storage.get_all<Collection> (where (c (&Collection::id) == *owner_id));
+    return owners.empty () || owners.front ().deleted_at.has_value ();
+}
+
+std::expected<TrashOutcome, RestoreFailure> Database::restore_request_locked (
+const TrashEntry& entry) {
+    // A request has no root to come back to: `collection_id` is NOT NULL, so
+    // "re-parent to the tree root" - what a collection does - is not a shape
+    // this row has. Its owner going away is only reachable by deleting the
+    // collection after the request, and the answer is the restore that *does*
+    // work, named rather than guessed at.
+    if (owner_is_absent_locked (entry.parent_id)) {
+        const bool gone = !entry.parent_id.has_value () ||
+        impl_->storage.count<Collection> (
+        where (c (&Collection::id) == *entry.parent_id)) == 0;
+        return std::unexpected (RestoreFailure{ RestoreRefusal::OwnerGone,
+        "Request '" + entry.id + "' cannot be restored on its own - the collection it belongs to is " +
+        (gone ? "gone" : "in the trash, so restore that first") });
+    }
+
+    impl_->storage.transaction ([&] {
+        for (auto& request : impl_->storage.get_all<Request> (where (
+             c (&Request::id) == entry.id && c (&Request::deleted_at) == entry.deleted_at))) {
+            request.deleted_at.reset ();
+            impl_->storage.update (request);
+        }
+        return true; // Commit
+    });
+    vayu::utils::log_info ("Restored request from trash: id=" + entry.id);
+    return TrashOutcome{ entry, false };
+}
+
+TrashOutcome Database::restore_collection_locked (const TrashEntry& entry) {
+    const auto subtree = collection_subtree_locked (entry.id);
+    // Only the root can be orphaned: every other row in this walk has a parent
+    // inside the same subtree, restored with it. Decided before the write so
+    // the transaction below stays one pass over the cohort.
+    const bool reparented = owner_is_absent_locked (entry.parent_id);
+
+    impl_->storage.transaction ([&] {
+        for (const auto& collection_id : subtree) {
+            for (auto& request : impl_->storage.get_all<Request> (
+                 where (c (&Request::collection_id) == collection_id &&
+                 c (&Request::deleted_at) == entry.deleted_at))) {
+                request.deleted_at.reset ();
+                impl_->storage.update (request);
+            }
+            for (auto& collection : impl_->storage.get_all<Collection> (
+                 where (c (&Collection::id) == collection_id &&
+                 c (&Collection::deleted_at) == entry.deleted_at))) {
+                collection.deleted_at.reset ();
+                if (reparented && collection.id == entry.id) {
+                    collection.parent_id.reset ();
+                }
+                impl_->storage.update (collection);
+            }
+        }
+        return true; // Commit
+    });
+
+    vayu::utils::log_info ("Restored collection from trash: id=" + entry.id +
+    ", +" + std::to_string (entry.collections) + " sub-collection(s), +" +
+    std::to_string (entry.requests) + " request(s)" +
+    (reparented ? " (re-parented to the tree root)" : ""));
+    return TrashOutcome{ entry, reparented };
+}
+
+std::expected<TrashOutcome, RestoreFailure> Database::restore_deleted (
+const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    // By id, not by root: a row a cascade took is restorable on its own - that
+    // is what the re-parent rule is for - and only a row that is not deleted at
+    // all is a 404.
+    auto entry = trash_entry_locked (id);
+    if (!entry) {
+        return std::unexpected (RestoreFailure{
+        RestoreRefusal::NotFound, "Nothing in the trash with id '" + id + "'" });
+    }
+    return entry->kind == "request" ?
+    restore_request_locked (*entry) :
+    std::expected<TrashOutcome, RestoreFailure>{ restore_collection_locked (*entry) };
+}
+
+std::optional<TrashOutcome> Database::purge_deleted (const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    auto entry = trash_entry_locked (id);
+    if (!entry) {
+        return std::nullopt;
+    }
+    // The purge takes the whole subtree, stamp or no stamp - a row left under a
+    // removed collection is reachable by no read and restorable by nothing, so
+    // "the cohort" is the wrong unit here even though it is the right one for a
+    // restore.
+    if (entry->kind == "collection") {
+        purge_collection_locked (id);
+    } else {
+        purge_request_locked (id);
+    }
+    vayu::utils::log_info ("Purged " + entry->kind + " from trash: id=" + id);
+    return TrashOutcome{ std::move (*entry), false };
+}
+
+int64_t Database::purge_expired_trash (int retention_days, int64_t now) {
+    if (retention_days <= 0) {
+        return 0; // Keep forever - the reading `runRetentionDays` gives 0.
+    }
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    const int64_t cutoff =
+    now - (static_cast<int64_t> (retention_days) * 24 * 60 * 60 * 1000);
+    std::vector<std::pair<std::string, std::string>> expired; // (kind, id)
+    for (const auto& entry : get_trash ()) {
+        if (entry.deleted_at <= cutoff) {
+            expired.emplace_back (entry.kind, entry.id);
+        }
+    }
+
+    int64_t purged = 0;
+    for (const auto& [kind, id] : expired) {
+        // A root purged as part of an ancestor's subtree is already gone. It
+        // cannot happen to a *root* by construction, but the walk below is what
+        // says so rather than assuming it.
+        if (kind == "collection") {
+            if (impl_->storage.count<Collection> (where (c (&Collection::id) == id)) == 0) {
+                continue;
+            }
+            purge_collection_locked (id);
+        } else {
+            if (impl_->storage.count<Request> (where (c (&Request::id) == id)) == 0) {
+                continue;
+            }
+            purge_request_locked (id);
+        }
+        ++purged;
+    }
+    if (purged > 0) {
+        vayu::utils::log_info ("Purged " + std::to_string (purged) +
+        " item(s) deleted more than " + std::to_string (retention_days) + " day(s) ago");
+    }
+    return purged;
+}
+
+int64_t Database::purge_expired_trash_configured () {
+    const int retention_days = get_config_int (
+    "trashRetentionDays", vayu::core::constants::database::TRASH_RETENTION_DAYS);
+    const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                        .count ();
+    return purge_expired_trash (retention_days, now);
 }
 
 // ============================================================================
@@ -1250,7 +1601,13 @@ std::vector<Collection> Database::get_collections_bound_to_spec (const std::stri
     // The binding is a JSON blob, so the match is made here rather than in SQL.
     // An unparseable blob binds nothing - the same reading every serializer
     // gives it - and must not make the spec undeletable.
-    for (auto& col : impl_->storage.get_all<Collection> ()) {
+    //
+    // Deleted collections are excluded (issue #988): this backs the "N
+    // collections still bind this document" refusal and the list beside it,
+    // and a collection in the trash is not something a user can act on. The
+    // *sweep* deliberately reads the unfiltered table instead - see there.
+    for (auto& col :
+    impl_->storage.get_all<Collection> (where (is_null (&Collection::deleted_at)))) {
         try {
             const auto parsed = nlohmann::json::parse (col.openapi);
             if (parsed.is_object () && parsed.value ("specId", std::string ()) == spec_id) {
@@ -1340,6 +1697,10 @@ size_t Database::sweep_orphaned_spec_documents () {
         // 2. Which of those does a collection still bind? The same parse
         //    `get_collections_bound_to_spec` makes, once over the sidebar-sized
         //    table rather than once per candidate.
+        //
+        //    Unfiltered by `deleted_at`, unlike that reader (issue #988): a
+        //    collection in the trash still binds its document, and reclaiming
+        //    the document now would leave the restore pointing at nothing.
         std::unordered_set<std::string> referenced;
         for (const auto& binding : impl_->storage.select (&Collection::openapi)) {
             auto spec_id = spec_id_at (binding, {});
@@ -1393,6 +1754,11 @@ size_t Database::sweep_orphaned_spec_documents () {
 int64_t Database::stamp_hashless_spec_bindings () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     int64_t stamped = 0;
+    // Deleted rows are backfilled too (issue #988). This repairs what a row
+    // always meant rather than answering a question a user asked, and a
+    // collection restored after this pass ran would otherwise carry an
+    // unstamped binding forever - the pass is a startup one, not a schedule.
+    // `replace` writes the whole struct, so `deleted_at` survives it.
     for (auto& col : impl_->storage.get_all<Collection> ()) {
         // `fetched_at`, not now: every row this pass can reach was written by an
         // import that stored the document in the same transaction, so that is
@@ -1500,16 +1866,21 @@ const std::vector<Request>& requests) {
 
     retry_on_busy ("apply reorder", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
+            // A deleted row does not exist to this batch (issue #988): the
+            // caller is repositioning the tree it can see, and writing the row
+            // it named would both resurrect it - `update` carries the caller's
+            // whole struct, `deleted_at` included - and move something nobody
+            // is looking at.
             for (const auto& row : collections) {
-                if (impl_->storage.count<Collection> (
-                    where (c (&Collection::id) == row.id)) == 0) {
+                if (impl_->storage.count<Collection> (where (
+                    c (&Collection::id) == row.id && is_null (&Collection::deleted_at))) == 0) {
                     throw MissingRowError ("Collection", row.id);
                 }
                 impl_->storage.update (row);
             }
             for (const auto& row : requests) {
-                if (impl_->storage.count<Request> (
-                    where (c (&Request::id) == row.id)) == 0) {
+                if (impl_->storage.count<Request> (where (
+                    c (&Request::id) == row.id && is_null (&Request::deleted_at))) == 0) {
                     throw MissingRowError ("Request", row.id);
                 }
                 impl_->storage.update (row);
@@ -1534,12 +1905,16 @@ const std::vector<Request>& requests) {
 // imported rows, write these" - two halves of one replacement, where writing
 // first would briefly double the list and, on a re-used id, lose the new row.
 void Database::verify_spec_sync_rows_locked (const SpecSyncBatch& batch) {
-    if (impl_->storage.count<Collection> (
-        where (c (&Collection::id) == batch.binding.id)) == 0) {
+    // Deleted rows are absent here too - same rule as `apply_reorder`, and the
+    // same reason: an `update` carrying the caller's struct would clear the
+    // stamp along with everything else (issue #988).
+    if (impl_->storage.count<Collection> (where (
+        c (&Collection::id) == batch.binding.id && is_null (&Collection::deleted_at))) == 0) {
         throw MissingRowError ("Collection", batch.binding.id);
     }
     for (const auto& row : batch.updated) {
-        if (impl_->storage.count<Request> (where (c (&Request::id) == row.id)) == 0) {
+        if (impl_->storage.count<Request> (where (
+            c (&Request::id) == row.id && is_null (&Request::deleted_at))) == 0) {
             throw MissingRowError ("Request", row.id);
         }
     }
@@ -3457,6 +3832,17 @@ void Database::seed_default_config () {
     "forever - retains more history at the cost of a larger database file on "
     "disk. In-progress runs are never pruned.",
     "data_retention", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
+    "0", "3650", std::nullopt, now })));
+
+    upsert_config (unit ("days") (keywords (
+    { "recycle bin", "recover", "cleanup" }) (ConfigEntry{ "trashRetentionDays",
+    std::to_string (vayu::core::constants::database::TRASH_RETENTION_DAYS), "integer", "Trash Retention",
+    "Deleted collections and requests are kept in the Trash this long before "
+    "they are destroyed for good; the sweep runs when Vayu starts. Until then "
+    "they can be restored exactly as they were. A higher value - or 0 to keep "
+    "them forever - leaves more to undo at the cost of a larger database file "
+    "on disk.",
+    "data_retention", std::to_string (vayu::core::constants::database::TRASH_RETENTION_DAYS),
     "0", "3650", std::nullopt, now })));
 
     upsert_config (

--- a/engine/src/http/routes/trash.cpp
+++ b/engine/src/http/routes/trash.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/trash.cpp
+ * @brief `GET /trash`, `POST /trash/:id/restore`, `DELETE /trash/:id` - what
+ *        soft delete left recoverable (issue #988).
+ *
+ * Deleting a collection used to be irreversible, with the confirm dialog as the
+ * entire safety net: one misclick destroyed a subtree and nothing in the engine
+ * could give it back. `Database::delete_collection` and `delete_request` now
+ * stamp rows instead of removing them, and these three routes are the whole of
+ * what that stamp is for - the list of what is recoverable, the undo, and the
+ * one deliberate way to make a delete permanent before retention does.
+ *
+ * The trash lists *roots* - the rows a user asked to delete - and never what a
+ * cascade took with them, because "restore this" is a question about the thing
+ * that was deleted and the counts answer the rest of it.
+ */
+
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/logger.hpp"
+
+#include <string>
+#include <utility>
+
+namespace vayu::http::routes {
+
+namespace {
+
+/// One trash entry as the wire carries it. `parentId` is a collection's parent
+/// and a request's owning collection - the same edge under two names in the
+/// tables, one name here, since a client restoring either asks the same
+/// question of it.
+nlohmann::json trash_entry_json (const vayu::db::TrashEntry& entry) {
+    nlohmann::json item{ { "id", entry.id }, { "kind", entry.kind },
+        { "name", entry.name }, { "deletedAt", entry.deleted_at },
+        { "collections", entry.collections }, { "requests", entry.requests } };
+    item["parentId"] = entry.parent_id.has_value () ? nlohmann::json (*entry.parent_id) :
+                                                      nlohmann::json (nullptr);
+    return item;
+}
+
+} // namespace
+
+/**
+ * Testable core of GET /trash.
+ *
+ * Always a 200 with an array, empty included: an empty trash is an answer, not
+ * a 404.
+ */
+nlohmann::json trash_list_body (vayu::db::Database& db) {
+    nlohmann::json items = nlohmann::json::array ();
+    for (const auto& entry : db.get_trash ()) {
+        items.push_back (trash_entry_json (entry));
+    }
+    return nlohmann::json{ { "items", items }, { "total", items.size () } };
+}
+
+/**
+ * Testable core of POST /trash/:id/restore.
+ *
+ * Two refusals, deliberately different statuses. **404** is an id the trash
+ * does not hold - a live row, or one already purged. **409** is the one shape a
+ * restore cannot express: a request whose collection is itself deleted or gone,
+ * which has no root to come back to the way a collection does. The message
+ * names the way forward (restore the collection) rather than reporting only
+ * that this failed.
+ */
+std::pair<int, nlohmann::json>
+trash_restore_response (vayu::db::Database& db, const std::string& id) {
+    auto outcome = db.restore_deleted (id);
+    if (!outcome) {
+        return error_response (
+        outcome.error ().reason == vayu::db::RestoreRefusal::NotFound ? 404 : 409,
+        outcome.error ().message);
+    }
+    nlohmann::json body      = trash_entry_json (outcome->entry);
+    body["restored"]         = true;
+    body["reparentedToRoot"] = outcome->reparented;
+    return { 200, body };
+}
+
+/**
+ * Testable core of DELETE /trash/:id - the hard cascade soft delete replaced,
+ * asked for on purpose.
+ *
+ * 404 on anything the trash does not hold, which is also what makes this
+ * unable to destroy a live collection by a mistyped id.
+ */
+std::pair<int, nlohmann::json>
+trash_purge_response (vayu::db::Database& db, const std::string& id) {
+    auto outcome = db.purge_deleted (id);
+    if (!outcome) {
+        return error_response (404, "Nothing in the trash with id '" + id + "'");
+    }
+    nlohmann::json body = trash_entry_json (outcome->entry);
+    body["purged"]      = true;
+    return { 200, body };
+}
+
+void register_trash_routes (RouteContext& ctx) {
+    /**
+     * GET /trash
+     * What has been deleted and can still be restored - roots only, newest
+     * first, each with the descendants its delete took.
+     * Returns: {items: [{id, kind, name, deletedAt, parentId, collections,
+     * requests}], total}.
+     */
+    ctx.server.Get ("/trash", [&ctx] (const httplib::Request&, httplib::Response& res) {
+        try {
+            res.set_content (trash_list_body (ctx.db).dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("GET /trash - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+
+    /**
+     * POST /trash/:id/restore
+     * Puts a deleted collection or request back, with everything the same
+     * delete took. Takes no body.
+     * Returns: the restored entry, 404 if the trash does not hold that id, or
+     * 409 for a request whose collection is itself deleted or gone.
+     */
+    ctx.server.Post (R"(/trash/([^/]+)/restore)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string id = req.matches[1];
+        vayu::utils::log_info ("POST /trash/:id/restore - Restoring: " + id);
+        try {
+            auto [status, body] = trash_restore_response (ctx.db, id);
+            if (status != 200) {
+                vayu::utils::log_warning ("POST /trash/:id/restore - " +
+                std::to_string (status) + ": " + error_message_of (body));
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "POST /trash/:id/restore - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+
+    /**
+     * DELETE /trash/:id
+     * Destroys a deleted collection or request for good, with its whole
+     * subtree. There is no undo for this one - it is the undo's counterpart.
+     * Returns: the purged entry, or 404 if the trash does not hold that id.
+     */
+    ctx.server.Delete (R"(/trash/([^/]+))",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string id = req.matches[1];
+        vayu::utils::log_info ("DELETE /trash/:id - Purging: " + id);
+        try {
+            auto [status, body] = trash_purge_response (ctx.db, id);
+            if (status != 200) {
+                vayu::utils::log_warning ("DELETE /trash/:id - " +
+                std::to_string (status) + ": " + error_message_of (body));
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "DELETE /trash/:id - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+}
+
+} // namespace vayu::http::routes

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -180,6 +180,7 @@ void Server::setup_routes () {
     routes::register_collection_routes (*route_ctx_);
     routes::register_request_routes (*route_ctx_);
     routes::register_request_example_routes (*route_ctx_);
+    routes::register_trash_routes (*route_ctx_);
     routes::register_spec_routes (*route_ctx_);
     routes::register_spec_sync_routes (*route_ctx_);
     routes::register_spec_match_routes (*route_ctx_);

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(vayu_tests
     openapi_export_test.cpp
     spec_export_route_test.cpp
     workspace_backup_test.cpp
+    trash_test.cpp
     spec_coverage_test.cpp
     schema_validation_test.cpp
     version_isolation_test.cpp
@@ -151,6 +152,7 @@ add_executable(vayu_tests
     ../src/http/routes/workspace.cpp
     ../src/http/routes/requests.cpp
     ../src/http/routes/examples.cpp
+    ../src/http/routes/trash.cpp
     ../src/http/routes/specs.cpp
     ../src/http/routes/spec_sync.cpp
     ../src/http/routes/spec_match.cpp
@@ -352,6 +354,7 @@ set(vayu_scratch_database_suites
     StreamExecuteTest
     StreamedSampleRouteTest
     TransportPolicyDbTest
+    TrashTest
     TreeOrderTest
     WorkspaceBackupTest
 )

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1242,11 +1242,20 @@ TEST_F (DatabaseTest, DeletingTheLastBinderReclaimsTheDocument) {
     seed_bound_collection (db, "col_1", "spec_1");
     seed_bound_collection (db, "col_2", "spec_1");
 
+    // A *delete* is soft since issue #988, and a collection in the trash still
+    // binds its document - reclaiming it there would leave a restore pointing
+    // at nothing. So it is the purge, not the delete, that releases the
+    // reference; both are asserted so neither half can regress silently.
     db.delete_collection ("col_1");
+    db.delete_collection ("col_2");
+    EXPECT_TRUE (db.get_spec_document ("spec_1").has_value ())
+    << "a document two collections in the trash still bind was swept";
+
+    db.purge_deleted ("col_1");
     EXPECT_TRUE (db.get_spec_document ("spec_1").has_value ())
     << "a document a second collection still binds was swept";
 
-    db.delete_collection ("col_2");
+    db.purge_deleted ("col_2");
     EXPECT_FALSE (db.get_spec_document ("spec_1").has_value ());
 }
 

--- a/engine/tests/examples_route_test.cpp
+++ b/engine/tests/examples_route_test.cpp
@@ -504,11 +504,19 @@ TEST_F (ExamplesRouteTest, DeletingTheRequestDeletesItsExamples) {
     routes::delete_request_example_response (*db_, "req_1", tombstoned);
     ASSERT_EQ (db_->get_suppressed_request_examples ("req_1").size (), 1u);
 
+    // Deleting a request is soft since issue #988, so the examples go with it in
+    // the sense that matters: every route reaching them checks the owner first,
+    // and the owner is unreadable. They are removed for good by the purge.
     db_->delete_request ("req_1");
+
+    EXPECT_EQ (routes::list_request_examples_response (*db_, "req_1").first, 404);
+    // The sibling request's examples are untouched.
+    EXPECT_TRUE (db_->get_request_example (theirs).has_value ());
+
+    db_->purge_deleted ("req_1");
 
     EXPECT_FALSE (db_->get_request_example (mine).has_value ());
     EXPECT_TRUE (db_->get_suppressed_request_examples ("req_1").empty ());
-    // The sibling request's examples are untouched.
     EXPECT_TRUE (db_->get_request_example (theirs).has_value ());
 }
 
@@ -518,6 +526,13 @@ TEST_F (ExamplesRouteTest, DeletingTheCollectionDeletesEveryDescendantsExamples)
     const std::string b = create_example ("req_2", json{ { "name", "b" } });
 
     db_->delete_collection ("col_1");
+
+    // Unreachable while the collection is in the trash (issue #988) - both
+    // requests answer 404 through the owner check - and gone once it is purged.
+    EXPECT_EQ (routes::list_request_examples_response (*db_, "req_1").first, 404);
+    EXPECT_EQ (routes::list_request_examples_response (*db_, "req_2").first, 404);
+
+    db_->purge_deleted ("col_1");
 
     EXPECT_FALSE (db_->get_request_example (a).has_value ());
     EXPECT_FALSE (db_->get_request_example (b).has_value ());

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -282,6 +282,46 @@ TEST_F (SpecSyncRouteTest, AppliesCreateUpdateAndDeleteInOneCall) {
     EXPECT_EQ (response["deleted"].get<int> (), 1);
 }
 
+// A sync's deletions are permanent, where every delete a person makes is soft
+// (issues #988, #1046 - owner decision). Both halves are asserted, and against
+// each other: making these deletes soft would still pass "the row is gone from
+// every read", because a stamped row reads as gone - what it would not pass is
+// the trash being empty afterwards and the restore refusing.
+TEST_F (SpecSyncRouteTest, ASyncsDeletionsAreNotRecoverableWhereAUsersDeleteIs) {
+    const std::string gone = create_request (root_, json{ { "name", "list owners" } });
+    const std::string stayed = create_request (root_, json{ { "name", "list pets" } });
+
+    vayu::db::RequestExample owned;
+    owned.id         = "exa_sync_1";
+    owned.request_id = gone;
+    owned.name       = "200 - owners";
+    owned.status     = 200;
+    owned.headers    = "[]";
+    owned.body       = "{}";
+    db_->save_request_example (owned);
+
+    auto [status, response] = routes::spec_sync_response (
+    *db_, body (json{ { "delete", json::array ({ gone }) } }));
+    ASSERT_EQ (status, 200) << response.dump ();
+
+    EXPECT_FALSE (db_->get_request (gone).has_value ());
+    EXPECT_FALSE (db_->get_request_example ("exa_sync_1").has_value ())
+    << "the examples the removed request owned go with it, in the same "
+       "transaction";
+    EXPECT_TRUE (db_->get_trash ().empty ())
+    << "a sync reconciles to a document - its removals are shown by "
+       "/specs/diff "
+       "before they land, so they are not put in the trash";
+    EXPECT_FALSE (db_->restore_deleted (gone).has_value ());
+
+    // The same request removed by a person *is* recoverable, which is what makes
+    // the assertion above a decision rather than a missing filter.
+    db_->delete_request (stayed);
+    auto entries = db_->get_trash ();
+    ASSERT_EQ (entries.size (), 1u);
+    EXPECT_EQ (entries.front ().id, stayed);
+}
+
 TEST_F (SpecSyncRouteTest, AnEmptySelectionStillMovesTheBindingAndNothingElse) {
     const std::string kept = create_request (root_);
 

--- a/engine/tests/trash_test.cpp
+++ b/engine/tests/trash_test.cpp
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/trash_test.cpp
+ * @brief Soft delete for collections and requests, and the three trash routes
+ *        on top of it (issue #988).
+ *
+ * What is pinned here is what a soft delete can silently get wrong, and each of
+ * these fails on a plausible implementation of the same feature:
+ *
+ *  - **A read surface that forgot the filter.** A stamped row that still shows
+ *    up somewhere is a ghost, and it looks exactly like working software from
+ *    every *other* surface. So each read is asserted, one per assertion, rather
+ *    than "the sidebar looks right".
+ *  - **A restore that brings back too much.** Restoring a collection must not
+ *    resurrect a request the user deleted separately beforehand - the cohort
+ *    rule, and the one thing a naive "clear every stamp under this subtree"
+ *    gets wrong.
+ *  - **A restore that brings back too little**, or into a parent that is gone:
+ *    the re-parent rule.
+ *  - **A purge that leaves rows behind.** A request left under a removed
+ *    collection is reachable by no read and restorable by nothing, so the purge
+ *    is asserted over the whole subtree and the examples under it.
+ *  - **Retention purging the wrong side of the window**, and `0` meaning
+ *    "immediately" rather than "keep forever".
+ *
+ * Follows the suite's route-test convention: the routes' extracted cores are
+ * exercised directly, no in-process HTTP server.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "optional_assert.hpp"
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in trash.cpp / examples.cpp - the pair (or body) each handler writes.
+nlohmann::json trash_list_body (vayu::db::Database& db);
+std::pair<int, nlohmann::json>
+trash_restore_response (vayu::db::Database& db, const std::string& id);
+std::pair<int, nlohmann::json>
+trash_purge_response (vayu::db::Database& db, const std::string& id);
+std::pair<int, nlohmann::json> list_request_examples_response (vayu::db::Database& db,
+const std::string& request_id);
+} // namespace vayu::http::routes
+
+namespace vayu::db {
+namespace {
+
+namespace routes = vayu::http::routes;
+
+constexpr const char* TEST_DB_PATH = "test_trash.db";
+
+/// A day in milliseconds - the unit `trashRetentionDays` is expressed in, spelled
+/// once so a test that means "31 days from now" reads as that.
+constexpr int64_t DAY_MS = 24LL * 60 * 60 * 1000;
+
+/// A field of the engine's `{"error": {"code", "message"}}` envelope, or "" - so
+/// a body that is not an error fails the assertion rather than throwing.
+std::string error_field (const json& body, const char* field) {
+    const auto error = body.find ("error");
+    if (error == body.end () || !error->is_object ()) {
+        return {};
+    }
+    return error->value (field, std::string{});
+}
+
+class TrashTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        vayu::tests::remove_database_files (TEST_DB_PATH);
+        db_ = std::make_unique<Database> (TEST_DB_PATH);
+        db_->init ();
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        vayu::tests::remove_database_files (TEST_DB_PATH);
+    }
+
+    void make_collection (const std::string& id,
+    const std::string& name,
+    const std::optional<std::string>& parent = std::nullopt) {
+        Collection col;
+        col.id         = id;
+        col.name       = name;
+        col.parent_id  = parent;
+        col.created_at = 1;
+        col.updated_at = 1;
+        db_->create_collection (col);
+    }
+
+    void make_request (const std::string& id, const std::string& collection_id) {
+        Request r;
+        r.id            = id;
+        r.collection_id = collection_id;
+        r.name          = id;
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test/" + id;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db_->save_request (r);
+    }
+
+    void make_example (const std::string& id, const std::string& request_id) {
+        RequestExample e;
+        e.id         = id;
+        e.request_id = request_id;
+        e.name       = id;
+        e.status     = 200;
+        e.headers    = "[]";
+        e.body       = "{}";
+        e.created_at = 1;
+        e.updated_at = 1;
+        db_->save_request_example (e);
+    }
+
+    /// The trash entry for @p id, so an assertion can name the row it means
+    /// instead of indexing into a list whose order it would then also be
+    /// asserting.
+    std::optional<TrashEntry> entry_for (const std::string& id) {
+        for (const auto& entry : db_->get_trash ()) {
+            if (entry.id == id) {
+                return entry;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::unique_ptr<Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// The filter: a stamped row is gone to every read surface
+// ---------------------------------------------------------------------------
+
+TEST_F (TrashTest, ADeletedCollectionIsAbsentFromEveryReadSurface) {
+    make_collection ("col_1", "API");
+    make_collection ("col_2", "Nested", "col_1");
+    make_request ("req_1", "col_1");
+
+    db_->delete_collection ("col_1");
+
+    EXPECT_TRUE (db_->get_collections ().empty ());
+    EXPECT_FALSE (db_->get_collection ("col_1").has_value ());
+    EXPECT_FALSE (db_->get_collection ("col_2").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_1").has_value ());
+    EXPECT_TRUE (db_->get_requests_in_collection ("col_1").empty ());
+}
+
+TEST_F (TrashTest, ADeletedRequestIsAbsentButItsCollectionIsUntouched) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    make_request ("req_2", "col_1");
+
+    db_->delete_request ("req_1");
+
+    EXPECT_FALSE (db_->get_request ("req_1").has_value ());
+    ASSERT_HAS_VALUE (db_->get_collection ("col_1"));
+    auto remaining = db_->get_requests_in_collection ("col_1");
+    ASSERT_EQ (remaining.size (), 1U);
+    EXPECT_EQ (remaining.front ().id, "req_2");
+}
+
+TEST_F (TrashTest, ADeletedRequestsExamplesAreUnreachable) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    make_example ("exa_1", "req_1");
+
+    ASSERT_EQ (routes::list_request_examples_response (*db_, "req_1").first, 200);
+    db_->delete_request ("req_1");
+
+    // The owner check every example route runs is what makes this a 404 rather
+    // than a list of examples belonging to a request nobody can see.
+    auto [status, body] = routes::list_request_examples_response (*db_, "req_1");
+    EXPECT_EQ (status, 404);
+    EXPECT_EQ (error_field (body, "message"), "Request not found");
+}
+
+TEST_F (TrashTest, ADeletedCollectionIsNotListedAsBindingItsSpecDocument) {
+    SpecDocument doc;
+    doc.id         = "spec_1";
+    doc.content    = "{\"openapi\":\"3.0.0\"}";
+    doc.hash       = "hash_1";
+    doc.fetched_at = 1;
+    db_->save_spec_document (doc);
+
+    Collection col;
+    col.id      = "col_1";
+    col.name    = "API";
+    col.openapi = R"({"specId":"spec_1","specHash":"hash_1","syncedAt":1})";
+    db_->create_collection (col);
+    ASSERT_EQ (db_->get_collections_bound_to_spec ("spec_1").size (), 1U);
+
+    db_->delete_collection ("col_1");
+    EXPECT_TRUE (db_->get_collections_bound_to_spec ("spec_1").empty ());
+
+    // But the document itself survives, deliberately: the sweep reads the
+    // unfiltered table, because a collection in the trash still binds what a
+    // restore would need. Reclaiming it here would restore a broken binding.
+    db_->sweep_orphaned_spec_documents ();
+    EXPECT_TRUE (db_->get_spec_document ("spec_1").has_value ());
+}
+
+TEST_F (TrashTest, AReorderRefusesADeletedRow) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    auto stored = db_->get_request ("req_1");
+    ASSERT_HAS_VALUE (stored);
+
+    db_->delete_request ("req_1");
+
+    // `update` carries the caller's whole struct, so a reorder that did not
+    // check would clear the stamp and resurrect the row silently.
+    stored->order = 5;
+    EXPECT_THROW (db_->apply_reorder ({}, { *stored }), MissingRowError);
+    EXPECT_FALSE (db_->get_request ("req_1").has_value ());
+}
+
+// ---------------------------------------------------------------------------
+// The listing: roots only, with what their cascade took
+// ---------------------------------------------------------------------------
+
+TEST_F (TrashTest, TheTrashListsTheDeletedRootWithItsCascadeAsCounts) {
+    make_collection ("col_1", "API");
+    make_collection ("col_2", "Nested", "col_1");
+    make_request ("req_1", "col_1");
+    make_request ("req_2", "col_2");
+
+    db_->delete_collection ("col_1");
+
+    auto entries = db_->get_trash ();
+    ASSERT_EQ (entries.size (), 1U) << "a cascaded child is not a second root";
+    EXPECT_EQ (entries.front ().id, "col_1");
+    EXPECT_EQ (entries.front ().kind, "collection");
+    EXPECT_EQ (entries.front ().name, "API");
+    EXPECT_GT (entries.front ().deleted_at, 0);
+    EXPECT_EQ (entries.front ().collections, 1);
+    EXPECT_EQ (entries.front ().requests, 2);
+}
+
+TEST_F (TrashTest, ADeletedRequestIsItsOwnRootWithNoCounts) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+
+    db_->delete_request ("req_1");
+
+    auto entries = db_->get_trash ();
+    ASSERT_EQ (entries.size (), 1U);
+    // One binding, so the guard below is about the same expression the read
+    // uses - `entries.front ()` written twice is two of them (engine/CLAUDE.md).
+    const auto& entry = entries.front ();
+    EXPECT_EQ (entry.kind, "request");
+    ASSERT_HAS_VALUE (entry.parent_id);
+    EXPECT_EQ (*entry.parent_id, "col_1");
+    EXPECT_EQ (entry.collections, 0);
+    EXPECT_EQ (entry.requests, 0);
+}
+
+TEST_F (TrashTest, TheListingIsNewestFirst) {
+    make_collection ("col_1", "First");
+    make_collection ("col_2", "Second");
+    db_->delete_collection ("col_1");
+    db_->delete_collection ("col_2");
+
+    auto entries = db_->get_trash ();
+    ASSERT_EQ (entries.size (), 2U);
+    EXPECT_GE (entries.front ().deleted_at, entries.back ().deleted_at);
+}
+
+TEST_F (TrashTest, TheListRouteCarriesEveryFieldOfAnEntry) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    db_->delete_collection ("col_1");
+
+    const auto body = routes::trash_list_body (*db_);
+    ASSERT_TRUE (body.contains ("items"));
+    ASSERT_EQ (body["total"], 1);
+    const auto& item = body["items"][0];
+    EXPECT_EQ (item["id"], "col_1");
+    EXPECT_EQ (item["kind"], "collection");
+    EXPECT_EQ (item["name"], "API");
+    EXPECT_TRUE (item["parentId"].is_null ());
+    EXPECT_EQ (item["collections"], 0);
+    EXPECT_EQ (item["requests"], 1);
+    EXPECT_GT (item["deletedAt"].get<int64_t> (), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Restore
+// ---------------------------------------------------------------------------
+
+TEST_F (TrashTest, RestoreBringsBackTheWholeSubtreeAsItWas) {
+    make_collection ("col_1", "API");
+    make_collection ("col_2", "Nested", "col_1");
+    make_request ("req_1", "col_2");
+    db_->delete_collection ("col_1");
+
+    auto outcome = db_->restore_deleted ("col_1");
+    ASSERT_HAS_VALUE (outcome);
+    EXPECT_FALSE (outcome->reparented);
+
+    ASSERT_HAS_VALUE (db_->get_collection ("col_1"));
+    auto nested = db_->get_collection ("col_2");
+    ASSERT_HAS_VALUE (nested);
+    ASSERT_HAS_VALUE (nested->parent_id);
+    EXPECT_EQ (*nested->parent_id, "col_1")
+    << "a restore rewrites nothing but the stamp";
+    ASSERT_HAS_VALUE (db_->get_request ("req_1"));
+    EXPECT_TRUE (db_->get_trash ().empty ());
+}
+
+TEST_F (TrashTest, RestoringACollectionLeavesAnEarlierSeparateDeleteInTheTrash) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    make_request ("req_2", "col_1");
+
+    db_->delete_request ("req_1");    // The user meant this one to go.
+    db_->delete_collection ("col_1"); // Then removed the whole collection.
+
+    ASSERT_HAS_VALUE (db_->restore_deleted ("col_1"));
+
+    ASSERT_HAS_VALUE (db_->get_request ("req_2"));
+    EXPECT_FALSE (db_->get_request ("req_1").has_value ())
+    << "the cohort rule: a restore puts back what its own delete took, no more";
+
+    // And the earlier delete is a root again, now that its collection is live.
+    auto entries = db_->get_trash ();
+    ASSERT_EQ (entries.size (), 1U);
+    EXPECT_EQ (entries.front ().id, "req_1");
+}
+
+TEST_F (TrashTest, RestoreReparentsToTheRootWhenTheParentIsInTheTrash) {
+    make_collection ("col_1", "API");
+    make_collection ("col_2", "Nested", "col_1");
+
+    db_->delete_collection ("col_2"); // Its own cohort.
+    db_->delete_collection ("col_1"); // A later one, which leaves col_2 alone.
+
+    auto outcome = db_->restore_deleted ("col_2");
+    ASSERT_HAS_VALUE (outcome);
+    EXPECT_TRUE (outcome->reparented);
+
+    auto restored = db_->get_collection ("col_2");
+    ASSERT_HAS_VALUE (restored);
+    EXPECT_FALSE (restored->parent_id.has_value ())
+    << "a collection whose parent is gone comes back at the tree root";
+}
+
+TEST_F (TrashTest, RestoringARequestUnderADeletedCollectionIsRefused) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+
+    db_->delete_request ("req_1");
+    db_->delete_collection ("col_1");
+
+    auto outcome = db_->restore_deleted ("req_1");
+    ASSERT_FALSE (outcome.has_value ())
+    << "the refusal is the point of this test";
+    EXPECT_EQ (outcome.error ().reason, RestoreRefusal::OwnerGone);
+
+    auto [status, body] = routes::trash_restore_response (*db_, "req_1");
+    EXPECT_EQ (status, 409);
+    EXPECT_NE (error_field (body, "message").find ("restore that first"), std::string::npos)
+    << "the refusal names the way forward: " << error_field (body, "message");
+}
+
+TEST_F (TrashTest, RestoringSomethingTheTrashDoesNotHoldIsA404) {
+    make_collection ("col_1", "API");
+
+    auto [live_status, live_body] = routes::trash_restore_response (*db_, "col_1");
+    EXPECT_EQ (live_status, 404)
+    << "a live row is not restorable - it is not deleted";
+    auto [missing_status, missing_body] = routes::trash_restore_response (*db_, "col_nope");
+    EXPECT_EQ (missing_status, 404);
+    EXPECT_NE (error_field (missing_body, "message").find ("col_nope"), std::string::npos);
+}
+
+TEST_F (TrashTest, TheRestoreRouteReportsWhatItPutBack) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    db_->delete_collection ("col_1");
+
+    auto [status, body] = routes::trash_restore_response (*db_, "col_1");
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["id"], "col_1");
+    EXPECT_EQ (body["requests"], 1);
+    EXPECT_TRUE (body["restored"].get<bool> ());
+    EXPECT_FALSE (body["reparentedToRoot"].get<bool> ());
+}
+
+// ---------------------------------------------------------------------------
+// Purge
+// ---------------------------------------------------------------------------
+
+TEST_F (TrashTest, PurgeDestroysTheWholeSubtreeIncludingExamples) {
+    make_collection ("col_1", "API");
+    make_collection ("col_2", "Nested", "col_1");
+    make_request ("req_1", "col_2");
+    make_example ("exa_1", "req_1");
+    db_->delete_collection ("col_1");
+
+    auto outcome = db_->purge_deleted ("col_1");
+    ASSERT_HAS_VALUE (outcome);
+    EXPECT_EQ (outcome->entry.requests, 1);
+
+    EXPECT_TRUE (db_->get_trash ().empty ());
+    EXPECT_FALSE (db_->restore_deleted ("col_1").has_value ())
+    << "nothing left to restore";
+    EXPECT_FALSE (db_->get_request_example ("exa_1").has_value ());
+    EXPECT_TRUE (db_->get_request_examples ("req_1").empty ());
+}
+
+TEST_F (TrashTest, PurgeTakesARowAnEarlierDeleteLeftUnderTheSubtree) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    db_->delete_request ("req_1");
+    db_->delete_collection ("col_1");
+
+    ASSERT_HAS_VALUE (db_->purge_deleted ("col_1"));
+
+    // The cohort is the unit of a *restore*, never of a purge: a request left
+    // under a removed collection is reachable by no read and restorable by
+    // nothing, so it would leak forever.
+    EXPECT_TRUE (db_->get_trash ().empty ());
+}
+
+TEST_F (TrashTest, PurgingALiveRowIsRefused) {
+    make_collection ("col_1", "API");
+
+    EXPECT_FALSE (db_->purge_deleted ("col_1").has_value ());
+    auto [status, body] = routes::trash_purge_response (*db_, "col_1");
+    EXPECT_EQ (status, 404);
+    ASSERT_HAS_VALUE (db_->get_collection ("col_1"))
+    << "a mistyped id destroys nothing";
+}
+
+TEST_F (TrashTest, ThePurgeRouteReportsWhatItDestroyed) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    db_->delete_collection ("col_1");
+
+    auto [status, body] = routes::trash_purge_response (*db_, "col_1");
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["id"], "col_1");
+    EXPECT_EQ (body["requests"], 1);
+    EXPECT_TRUE (body["purged"].get<bool> ());
+}
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+TEST_F (TrashTest, RetentionPurgesOnlyWhatIsPastTheWindow) {
+    make_collection ("col_1", "API");
+    make_request ("req_1", "col_1");
+    db_->delete_collection ("col_1");
+    auto entry = entry_for ("col_1");
+    ASSERT_HAS_VALUE (entry);
+
+    EXPECT_EQ (db_->purge_expired_trash (30, entry->deleted_at + (29 * DAY_MS)), 0);
+    EXPECT_EQ (db_->get_trash ().size (), 1U);
+
+    EXPECT_EQ (db_->purge_expired_trash (30, entry->deleted_at + (31 * DAY_MS)), 1);
+    EXPECT_TRUE (db_->get_trash ().empty ());
+}
+
+TEST_F (TrashTest, ARetentionOfZeroKeepsTheTrashForever) {
+    make_collection ("col_1", "API");
+    db_->delete_collection ("col_1");
+    auto entry = entry_for ("col_1");
+    ASSERT_HAS_VALUE (entry);
+
+    EXPECT_EQ (db_->purge_expired_trash (0, entry->deleted_at + (3650 * DAY_MS)), 0);
+    EXPECT_EQ (db_->get_trash ().size (), 1U);
+}
+
+TEST_F (TrashTest, RetentionIsConfiguredAndSeededAtThirtyDays) {
+    auto seeded = db_->get_config_entry ("trashRetentionDays");
+    ASSERT_HAS_VALUE (seeded);
+    EXPECT_EQ (seeded->value,
+    std::to_string (vayu::core::constants::database::TRASH_RETENTION_DAYS));
+    EXPECT_EQ (seeded->category, "data_retention");
+
+    // The configured pass reads that entry: set it to keep-forever and a very
+    // old delete survives a sweep that would otherwise take it.
+    make_collection ("col_1", "API");
+    db_->delete_collection ("col_1");
+    seeded->value = "0";
+    db_->save_config_entry (*seeded);
+    EXPECT_EQ (db_->purge_expired_trash_configured (), 0);
+    EXPECT_EQ (db_->get_trash ().size (), 1U);
+}
+
+} // namespace
+} // namespace vayu::db


### PR DESCRIPTION
## Description

**Plan (root cause, approach, rejected alternative).** Re-verified at `68f0bbb`: the problem is exactly as #988 describes it - `rg -ni "\btrash\b|soft.?delete|deleted_at|deletedAt" app/src engine/src` still yields no domain hits, and `Database::delete_collection` / `delete_request` were hard cascades removing rows in one transaction, with the confirm dialog as the entire safety net. The approach is the issue's: a nullable `deleted_at` on `collections` and `requests` (additive, the class `sync_schema` adds without touching a stored row), every read filtering it out, three routes, and a retention purge at startup. **The alternative I rejected was a separate `trash` table holding removed rows**: a restore then has to re-create rows from a serialized copy, every future column on `collections` / `requests` becomes a second migration of the archive, and "restored exactly as it was" becomes a property to maintain rather than one that holds by construction. Leaving the row in place makes a restore *clear a column*, which is why `RestoreBringsBackTheWholeSubtreeAsItWas` can assert `order` and `parent_id` survived without the code doing anything to preserve them.

Two rules decide what a restore means, and both are load-bearing rather than incidental:

- **The cohort.** One delete stamps its subtree with one timestamp; a restore clears exactly the rows carrying the timestamp of the row it was given. The naive version - clear every stamp under this subtree - resurrects a request the user had deleted *separately, beforehand*, which is the one thing a trash must not do. `delete_collection` steps its stamp past a collision with an earlier delete inside the same subtree, so the rule is exact rather than probabilistic.
- **The re-parent.** A restored collection whose parent is gone or itself deleted comes back at the tree root. A request cannot do this - `collection_id` is NOT NULL, so there is no root for it to land at - so restoring one whose collection is in the trash is a **409 naming the collection to restore first** rather than a silent re-home or an invalid row. This is a deliberate deviation from the issue's "restoring an item whose parent is deleted or gone re-parents to root", which has no meaning for the request half; it is stated in the docs and pinned by a test.

**Blast radius traced.** Every raw read of `Collection` / `Request` lives in `database.cpp` - no route or core reads the tables directly - which bounds the filter to one file. Each site was decided, not swept: `get_collections`, `get_collection`, `get_request`, `get_requests_in_collection` filter; `apply_reorder` and `verify_spec_sync_rows_locked` count only live rows, because their `update` carries the caller's whole struct and would clear the stamp - a silent resurrection inside an all-or-nothing batch; `get_collections_bound_to_spec` filters, since it backs the "N collections still bind this document" refusal and a collection in the trash is not something a user can act on. Two sites deliberately do **not** filter: `sweep_orphaned_spec_documents`, because a stamped collection still binds its document and reclaiming it would leave a restore pointing at nothing, and `stamp_hashless_spec_bindings`, a startup backfill that would otherwise leave a later-restored row unstamped forever. Downstream, `reject_missing_collection` (requests) and `reject_missing_request` (examples) already run owner checks through these readers, so creating into a trashed collection is a 400 and a trashed request's examples are a 404 without either file changing.

Examples stay on the row rather than being stamped: every read of them is by request id behind that owner check, so they are as unreachable as the request is - and a restore that had to re-create them could not.

**Deliberate scope calls, stated rather than smuggled in:**

1. **A purge takes the whole subtree, not the cohort.** A row an earlier delete left inside a purged collection would be reachable by no read and restorable by nothing. The purged entry's counts are therefore a floor, which the API reference says.
2. **Three "cannot be undone" claims are now false and were fixed** - the tree's delete dialog and the `delete_collection` / `delete_request` MCP tool descriptions and prompts. Not UI work (the Trash view is #989); a claim this diff falsifies is this diff's to correct.
3. **A spec sync's request deletions stay hard** - #1046, owner decision, second commit. A sync is a reconciliation to a document rather than a person removing a request, and it is the one delete whose removals are shown before they land: `POST /specs/diff` reports each, the app renders them as ticks the user can untick, and `policy: "safe"` refuses deletions outright. Stamping them would fill the trash with operations a document dropped, where restoring one puts back a request the current document cannot explain. Written at the site (`write_spec_sync_batch_locked`), as a fifth rule the sync payload cannot opt out of in the API reference, and in the deletion lifecycle section - which now promises recoverable deletes and so has to name the exception.
4. **Out of scope per the issue**, unchanged: environments, examples as independent entities, runs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure   # 2486 passed, 0 failed
cd app && pnpm test                                         # 532 files, 5708 passed
cd app && pnpm type-check                                   # clean (3 projects)
cd app && pnpm lint                                         # clean
cd app && pnpm format:check                                 # clean
clang-format-19 --dry-run -Werror <every touched engine file>   # clean
clang-tidy-19 -p engine/build <every touched engine source>     # clean
```

**New: `engine/tests/trash_test.cpp`** (20 tests), grouped by what a soft delete can silently get wrong:

- *The filter* - `ADeletedCollectionIsAbsentFromEveryReadSurface` asserts each read separately (a ghost row surfacing in exactly one place is the failure mode); `ADeletedRequestsExamplesAreUnreachable` (404 through the route, not "the rows are gone"); `ADeletedCollectionIsNotListedAsBindingItsSpecDocument`, which also pins the deliberate half - the sweep leaves the document alone; `AReorderRefusesADeletedRow`, the resurrection an unfiltered `count` would allow.
- *The listing* - roots only with cohort counts, a request as its own root, newest-first, and every field of the wire shape.
- *Restore* - the subtree comes back as it was; `RestoringACollectionLeavesAnEarlierSeparateDeleteInTheTrash` is the cohort rule and fails on the naive implementation; the re-parent rule; the 409 with its message; 404 for a live id and an unknown id.
- *Purge* - the subtree and its examples, the earlier-delete row inside it, a live id refused, the route's report.
- *Retention* - 29 days keeps and 31 days purges (both directions, so pruning the wrong side of the window fails); `0` keeps forever; the seeded entry and `purge_expired_trash_configured` reading it.

**Also new** (#1046): `SpecSyncRouteTest.ASyncsDeletionsAreNotRecoverableWhereAUsersDeleteIs` - the sync's removal leaves an empty trash and a refused restore, while the same request deleted by a person is a trash root. Both halves, because making those deletes soft would still pass "the row reads as gone" - a stamped row does too.

**Mutation-checked**: dropping either `is_null` filter reddens the read-surface tests; pinning the restore to "every stamped row in the subtree" reddens the cohort test; deriving trash roots without the owner check turns the one-root assertion into two.

Three existing tests asserted the *hard* delete and now assert both stages of the new one rather than being weakened: `DeletingTheLastBinderReclaimsTheDocument` (the delete keeps the document, the purge releases it - both asserted), and the two `ExamplesRouteTest` cascade tests (unreachable through the route while trashed, gone after the purge, sibling untouched throughout).

**One gate I cannot run here:** `mkdocs` is not installed in this environment, so `mkdocs build --strict` is CI's verdict; the docs edits add one heading (`## Trash`) with in-page relative links to it and one numbered subsection, no new pages or nav entries. It passed on the first commit's run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #988.
Closes #1046 - the owner's call on it (keep the sync's deletes hard, say why in the docs) landed here rather than in a separate PR.

Unblocks #989 (the app's Trash view and undo toast), which is the consumer of the three endpoints this adds - deliberately no renderer client methods here, since an unread field is this repo's most repeated defect. Sequenced after #987, which merged as PR #1036.