### PR TITLE
fix(engine): six response assertions give chai-postman's verdict - #998

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -23,13 +23,13 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | ------------------- | -------------------------------------------------------------------------------- |
 | Core                | `pm`, `pm.test(name, fn)` - in either script, each result naming the one that made it (see below), `pm.expect(value[, message])` - the message prefixes the failure, as in chai |
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
-| Response headers    | `pm.response.headers.get(name)`, `.has(name)` - case-insensitive              |
+| Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
 | Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear(url?)`, see below |
-| Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
+| Response assertions | `pm.response.to.have.status(code \| reason)`, `.header(name[, value])`, `.body(expected)`, `.jsonBody(path?[, value])`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url` (Postman's `Url` object - `protocol`/`host`/`port`/`path`/`hash`/`query`, `getHost()`, `getPath()`, `getQueryString()`, `update()`), `.method`, `.headers`, `.body` |
-| Request headers     | `pm.request.headers.get/has(name)`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
+| Request headers     | `pm.request.headers.get(name)`, `.has(name[, value])`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
 | Environment         | `pm.environment.get/set/has/unset/clear/toObject`                                |
 | Globals             | `pm.globals.get/set/has/unset/clear/toObject`                                    |
 | Collection vars     | `pm.collectionVariables.get/set/has/unset/clear/toObject`                        |
@@ -351,7 +351,7 @@ raises a `RangeError` after 64 levels rather than hanging.
 Getters, so the paren-less form is the assertion:
 
 ```
-.to.be.ok          .to.be.success       (2xx)
+.to.be.ok          (200 only)           .to.be.success       (2xx)
 .to.be.info        (1xx)                .to.be.redirection   (3xx)
 .to.be.clientError (4xx)                .to.be.serverError   (5xx)
 .to.be.error       (4xx or 5xx)
@@ -361,6 +361,19 @@ Getters, so the paren-less form is the assertion:
 .to.be.json        (body parses as JSON)
 .to.be.withBody    (body is not empty)
 ```
+
+**`ok` narrowed to status 200 only (#998)** - it used to match any 2xx, the same
+class `success` still matches. A script that asserted `.ok` meaning "any 2xx"
+should assert `.success` instead; a script that meant "200 exactly" needed no
+change. Postman's own named statuses (`accepted`, `badRequest`, `notFound`, ...)
+match by reason phrase as well as by code; Vayu's stay code-only.
+
+**`have.body`'s substring form is gone (#998).** A string argument now has to
+equal the body exactly, not merely appear in it - `.to.have.body(sub)` written
+for "the body contains `sub`" should become `.to.have.body(new RegExp(sub))`.
+`.have.jsonBody(path, value)` also started comparing `value`, which it used to
+accept and ignore - a script relying on the old no-op should not pass an
+argument it does not want checked.
 
 **Every other name under `pm.response.to` throws a `TypeError`** naming the
 chain - a misspelling, or an idiom Vayu does not implement such as the negated

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -332,9 +332,14 @@ named in its error line by an assertion its own Tests list did not contain.
 
 ```javascript
 pm.response.headers.get('Content-Type');   // case-insensitive; undefined if absent
-pm.response.headers.has('X-Request-Id');   // boolean
+pm.response.headers.has('X-Request-Id');   // name present, boolean
+pm.response.headers.has('Content-Type', 'application/json');
+                                           // present and holding that exact value
 pm.response.headers['content-type'];       // indexing: exact key only
 ```
+
+`has()`'s optional second argument is compared strictly against the header's
+wire value - a number never matches, since the wire value is always a string.
 
 `headers` is a plain object, not Postman's `HeaderList`, but `get()` and `has()`
 are on it and behave the way HTTP header names do - case-insensitively. Indexing
@@ -394,16 +399,46 @@ cookie boundary, and the `=` padding on a base64 value stays in the value.
 ### Response Assertions
 
 ```javascript
-pm.response.to.have.status(200);
-pm.response.to.have.header('Content-Type');
-pm.response.to.have.jsonBody();
+pm.response.to.have.status(200);                          // status code
+pm.response.to.have.status('OK');                         // reason phrase, not a code
+pm.response.to.have.header('Content-Type');               // header exists
+pm.response.to.have.header('Content-Type', 'text/plain'); // exact value, strict
+pm.response.to.have.body('{"ok":true}');                  // body equals this exactly
+pm.response.to.have.body(/"ok":\s*true/);                 // regex run against the body
+pm.response.to.have.body({ ok: true });                   // parsed JSON deep-equals this
+pm.response.to.have.jsonBody();                           // body parses as JSON
+pm.response.to.have.jsonBody('data.id');                  // that property exists
+pm.response.to.have.jsonBody('data.id', 42);              // exists and deep-equals 42
 ```
+
+`have.status` means two different things depending on the argument's type: a
+number is the status code, a string is compared against the reason phrase
+`pm.response.reason()` answers. **`status('200')` fails** - a string is always
+a reason phrase to compare, never a code coerced to one.
+
+`have.header`'s second argument is compared strictly against the header as it
+arrived on the wire. `header('X-Count', 5)` fails rather than stringifying `5`
+into agreement; the expected value must already be the string form.
+
+`have.body` accepts exactly three forms. A string must equal the body
+**exactly** - this used to be a substring search. A regular expression is run
+against the body text. An object is deep-equalled against the parsed JSON
+body. Any other argument type - a number, a boolean - is a `TypeError` naming
+the three accepted forms rather than a verdict: Postman silently asserts
+nothing for those inputs, and Vayu refuses a silent non-assertion instead
+(#998).
+
+`have.jsonBody` takes an optional path and an optional value. No arguments
+checks only that the body parses as JSON. A path checks that the property
+exists. A path plus a value checks that the property exists **and** deeply
+equals it - before #998 the value argument was accepted but never compared,
+so a wrong expected value still passed.
 
 Status-class assertions hang off `pm.response.to.be`. They are **getters** - the
 paren-less form is the assertion:
 
 ```javascript
-pm.response.to.be.ok;            // 2xx
+pm.response.to.be.ok;            // status 200 only
 pm.response.to.be.success;       // 2xx
 pm.response.to.be.info;          // 1xx
 pm.response.to.be.redirection;   // 3xx
@@ -419,6 +454,11 @@ pm.response.to.be.rateLimited;   // 429
 pm.response.to.be.json;          // body parses as JSON
 pm.response.to.be.withBody;      // body is not empty
 ```
+
+**`ok` is status 200 only, not any 2xx** (#998) - `success` is the 2xx one. A
+script that meant "any 2xx" and asserted `.ok` needs `.success` instead.
+Postman's named statuses (`accepted`, `badRequest`, ...) also match by reason
+phrase; Vayu's stay code-only.
 
 **Anything else under `pm.response.to` throws.** A misspelled or unimplemented
 name - `pm.response.to.be.definitelyNotAMatcher`, or the negated
@@ -542,7 +582,8 @@ Rules worth knowing before you rely on them:
 
 ```javascript
 pm.request.headers.get('authorization');                  // case-insensitive
-pm.request.headers.has('Authorization');                  // boolean
+pm.request.headers.has('Authorization');                  // name present, boolean
+pm.request.headers.has('Authorization', 'Bearer abc');    // present with that value
 pm.request.headers.upsert({ key: 'X-Trace', value: id }); // add or replace
 pm.request.headers.upsert('X-Trace', id);                 // same, two-arg form
 pm.request.headers.add({ key: 'X-New', value: '1' });     // add; throws if present
@@ -565,6 +606,9 @@ Three behaviours worth knowing:
   carries a single value per name, so the difference is reported rather than
   silently collapsed into an `upsert`.
 - **`remove` on an absent header is a no-op**, not an error.
+- **`has`'s optional value argument is a strict string compare**, the same rule
+  `pm.response.headers.has` follows - a number never matches, since the
+  outgoing header is always a string.
 
 A bad argument fails loudly: a name must be a non-empty string and a value a
 string, number or boolean - the same set plain assignment accepts. Detaching a

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -195,8 +195,11 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.response.headers.has" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.response.headers.has(\"${1:Content-Type}\")" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.response.headers.has(name: string): boolean" },
-    { "documentation", "Whether the response carries a header of that name, case-insensitively." },
+    { "detail", "pm.response.headers.has(name: string, value?: string): boolean" },
+    { "documentation",
+    "Whether the response carries a header of that name, case-insensitively. "
+    "With a second argument, whether it also carries that exact value - the "
+    "comparison is strict, so a number never matches the wire's string." },
     { "sortText", "1_pm_response_headers_has" } });
 
     completions.push_back ({ { "label", "pm.response.cookies" }, { "kind", KIND_FIELD },
@@ -269,26 +272,45 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.response.to.have.status" },
     { "kind", KIND_FUNCTION }, { "insertText", "pm.response.to.have.status(${1:200})" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.response.to.have.status(code: number)" },
+    { "detail", "pm.response.to.have.status(code: number | string)" },
     { "documentation",
-    "Assert that the response has a specific HTTP status "
-    "code.\n\nExample:\npm.response.to.have.status(200);\npm.response.to.have."
-    "status(201);" },
+    "Assert that the response has a specific HTTP status code, or - given a "
+    "string - the reason phrase pm.response.reason() "
+    "answers.\n\nExample:\npm.response.to.have.status(200);\npm.response.to."
+    "have.status('OK');" },
     { "sortText", "1_pm_response_to_have_status" } });
 
     completions.push_back ({ { "label", "pm.response.to.have.header" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.response.to.have.header(\"${1:Content-Type}\")" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.response.to.have.header(name: string)" },
+    { "detail", "pm.response.to.have.header(name: string, value?: string)" },
     { "documentation",
-    "Assert that a specific header exists in the "
-    "response.\n\nExample:\npm.response.to.have.header('Content-Type');" },
+    "Assert that a specific header exists in the response, and - with a second "
+    "argument - that it holds that exact value. The value comparison is "
+    "strict, so a number never matches the wire's "
+    "string.\n\nExample:\npm.response.to.have.header('Content-Type');\npm."
+    "response.to.have.header('Content-Type', 'application/json');" },
     { "sortText", "1_pm_response_to_have_header" } });
+
+    completions.push_back ({ { "label", "pm.response.to.have.body" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.to.have.body(\"${1:body}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.response.to.have.body(expected: string | RegExp | object)" },
+    { "documentation",
+    "Assert what the response body is. A string must equal the body exactly, a "
+    "regular expression must match it, and an object must deeply equal the "
+    "parsed JSON.\n\nExample:\npm.response.to.have.body('pong');\npm.response."
+    "to.have.body(/^\\{\"ok\"/);\npm.response.to.have.body({ ok: true });" },
+    { "sortText", "1_pm_response_to_have_body" } });
 
     completions.push_back ({ { "label", "pm.response.to.have.jsonBody" },
     { "kind", KIND_FUNCTION }, { "insertText", "pm.response.to.have.jsonBody()" },
-    { "detail", "pm.response.to.have.jsonBody()" },
-    { "documentation", "Assert that the response has a valid JSON body." },
+    { "detail", "pm.response.to.have.jsonBody(path?: string, value?: unknown)" },
+    { "documentation",
+    "Assert that the response has a valid JSON body; with a path, that the "
+    "body holds that property; with a value, that the property deeply equals "
+    "it.\n\nExample:\npm.response.to.have.jsonBody();\npm.response.to.have."
+    "jsonBody('data.id');\npm.response.to.have.jsonBody('data.id', 42);" },
     { "sortText", "1_pm_response_to_have_jsonBody" } });
 
     // ========================================
@@ -303,7 +325,7 @@ nlohmann::json get_script_completions () {
         const char* condition;
     };
     constexpr auto status_classes = std::to_array<StatusClassCompletion> ({
-    { "ok", "a 2xx status code" },
+    { "ok", "status 200" },
     { "success", "a 2xx status code" },
     { "info", "a 1xx status code" },
     { "redirection", "a 3xx status code" },
@@ -587,8 +609,11 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.request.headers.has" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.request.headers.has(\"${1:Authorization}\")" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.request.headers.has(name: string): boolean" },
-    { "documentation", "Whether the outgoing request carries that header, case-insensitively." },
+    { "detail", "pm.request.headers.has(name: string, value?: string): boolean" },
+    { "documentation",
+    "Whether the outgoing request carries that header, case-insensitively. "
+    "With a second argument, whether it also carries that exact value - the "
+    "comparison is strict, so a number never matches the header's string." },
     { "sortText", "1_pm_request_headers_has" } });
 
     completions.push_back ({ { "label", "pm.request.headers.upsert" }, { "kind", KIND_FUNCTION },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -2643,6 +2643,13 @@ JSValue js_response_have_body (JSContext* ctx, JSValueConst this_val, int argc, 
     // RegExp here and satisfies it, and a matcher object a script built itself
     // is run rather than silently deep-equalled against the body.
     JSValue test_fn = JS_GetPropertyStr (ctx, argv[0], "test");
+    // Reading `test` runs a getter if the script defined one, and a getter that
+    // throws leaves the exception pending. Falling through to the deep-equal
+    // branch there would report a mismatch and drop the script's own error -
+    // the shape of silent wrongness this assertion was fixed for.
+    if (JS_IsException (test_fn)) {
+        return JS_EXCEPTION;
+    }
     if (JS_IsFunction (ctx, test_fn)) {
         JSValue subject = JS_NewString (ctx, body.c_str ());
         JSValue result  = JS_Call (ctx, test_fn, argv[0], 1, &subject);

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -2638,17 +2638,12 @@ JSValue js_response_have_body (JSContext* ctx, JSValueConst this_val, int argc, 
         js_type_name (ctx, argv[0]));
     }
 
-    // A regular expression is recognised by its class tag or, as `expect(...)
-    // .to.match` reads one, by carrying a callable `test` - so a script that
-    // built its own matcher object is not silently deep-equalled instead.
-    JSValue test_fn       = JS_GetPropertyStr (ctx, argv[0], "test");
-    const bool is_pattern = js_class_tag (ctx, argv[0]) == "[object RegExp]" ||
-    JS_IsFunction (ctx, test_fn);
-    if (is_pattern) {
-        if (!JS_IsFunction (ctx, test_fn)) {
-            JS_FreeValue (ctx, test_fn);
-            return JS_ThrowTypeError (ctx, "body() pattern has no test() to run");
-        }
+    // A pattern is whatever carries a callable `test`, which is how
+    // `expect(...).to.match` reads one: a regular expression literal is a real
+    // RegExp here and satisfies it, and a matcher object a script built itself
+    // is run rather than silently deep-equalled against the body.
+    JSValue test_fn = JS_GetPropertyStr (ctx, argv[0], "test");
+    if (JS_IsFunction (ctx, test_fn)) {
         JSValue subject = JS_NewString (ctx, body.c_str ());
         JSValue result  = JS_Call (ctx, test_fn, argv[0], 1, &subject);
         JS_FreeValue (ctx, subject);

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -2485,6 +2485,34 @@ void install_response_body_readers (JSContext* ctx, JSValue response, const std:
 // takes a status code, not a message), so they call the helper directly rather
 // than through `throw_expect_failure`, which exists to apply that prefix.
 
+// The reason phrase as `pm.response.reason()` answers it: what the status line
+// carried when it carried one, and the registered phrase for the code when it
+// did not - HTTP/2 has no reason phrase on the wire at all. One definition,
+// because `to.have.status("OK")` and `reason()` are two readings of the same
+// response and a script that compares them must not get two answers.
+std::string response_reason_phrase (const Response& response) {
+    if (!response.status_text.empty ()) {
+        return response.status_text;
+    }
+    return vayu::http::status_text (response.status_code);
+}
+
+// A body can be megabytes, so a failure message quotes a bounded prefix rather
+// than the whole of it - and cuts on a UTF-8 boundary, because a message split
+// mid-sequence reaches the report as replacement characters.
+constexpr std::string::size_type kBodyExcerptBytes = 120;
+
+std::string describe_body (const std::string& body) {
+    if (body.size () <= kBodyExcerptBytes) {
+        return "'" + body + "'";
+    }
+    std::string::size_type cut = kBodyExcerptBytes;
+    while (cut > 0 && (static_cast<unsigned char> (body[cut]) & 0xC0) == 0x80) {
+        --cut;
+    }
+    return "'" + body.substr (0, cut) + "...' (" + std::to_string (body.size ()) + " bytes)";
+}
+
 JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     if (argc < 1) {
         return JS_ThrowTypeError (ctx, "status() requires an expected status code");
@@ -2493,6 +2521,21 @@ JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc
     auto* data = get_context_data (ctx);
     if (!data->response) {
         return JS_ThrowInternalError (ctx, "No response available");
+    }
+
+    // Postman takes either form and decides by type, never by coercion:
+    // chai-postman compares a string against `reason()` and a number against
+    // the code. Coercing both through `JS_ToInt32` read "OK" as 0 - failing an
+    // assertion Postman passes - and "200" as 200 - passing one Postman fails.
+    if (JS_IsString (argv[0])) {
+        const std::string expected_reason = js_to_string (ctx, argv[0]);
+        const std::string actual_reason = response_reason_phrase (*data->response);
+        if (actual_reason != expected_reason) {
+            std::string msg = "Expected status reason '" + expected_reason +
+            "' but got '" + actual_reason + "'";
+            return throw_assertion_failure (ctx, msg);
+        }
+        return JS_UNDEFINED;
     }
 
     int32_t expected_status;
@@ -2542,12 +2585,17 @@ JSValue js_response_have_header (JSContext* ctx, JSValueConst this_val, int argc
         return throw_assertion_failure (ctx, msg);
     }
 
-    // If a second argument is provided, check the value
+    // A header value is a string on the wire, and chai-postman compares the
+    // expected value against it strictly. Coercing the expectation instead let
+    // `header("X-Count", 5)` pass against the string "5" - a verdict Postman
+    // does not give - so a non-string expectation fails the assertion here
+    // rather than being stringified into agreement with the wire.
     if (argc >= 2) {
-        std::string expected_value = js_to_string (ctx, argv[1]);
-        if (found_value != expected_value) {
-            std::string msg = "Expected header '" + header_name + "' to be '" +
-            expected_value + "' but got '" + found_value + "'";
+        const bool matches =
+        JS_IsString (argv[1]) && js_to_string (ctx, argv[1]) == found_value;
+        if (!matches) {
+            std::string msg = "Expected header '" + header_name + "' to be " +
+            js_describe (ctx, argv[1]) + " but got '" + found_value + "'";
             return throw_assertion_failure (ctx, msg);
         }
     }
@@ -2565,10 +2613,77 @@ JSValue js_response_have_body (JSContext* ctx, JSValueConst this_val, int argc, 
         return JS_ThrowInternalError (ctx, "No response available");
     }
 
-    std::string expected = js_to_string (ctx, argv[0]);
+    const std::string& body = data->response->body;
 
-    if (data->response->body.find (expected) == std::string::npos) {
-        std::string msg = "Expected response body to contain '" + expected + "'";
+    // chai-postman decides by the argument's type, and each form is a
+    // different comparison: a string is exact, a regular expression is
+    // executed against the body, an object is deep-equalled against the parsed
+    // JSON. Vayu stringified all three and substring-searched the result, so a
+    // partial string passed where Postman fails, and a regex or an object was
+    // searched for as the literal text "/re/" or "[object Object]" - failing
+    // where Postman passes.
+    if (JS_IsString (argv[0])) {
+        const std::string expected = js_to_string (ctx, argv[0]);
+        if (body != expected) {
+            std::string msg = "Expected response body to be '" + expected +
+            "' but got " + describe_body (body);
+            return throw_assertion_failure (ctx, msg);
+        }
+        return JS_UNDEFINED;
+    }
+
+    if (!JS_IsObject (argv[0])) {
+        return JS_ThrowTypeError (ctx,
+        "body() expects a string, a regular expression or an object, got %s",
+        js_type_name (ctx, argv[0]));
+    }
+
+    // A regular expression is recognised by its class tag or, as `expect(...)
+    // .to.match` reads one, by carrying a callable `test` - so a script that
+    // built its own matcher object is not silently deep-equalled instead.
+    JSValue test_fn       = JS_GetPropertyStr (ctx, argv[0], "test");
+    const bool is_pattern = js_class_tag (ctx, argv[0]) == "[object RegExp]" ||
+    JS_IsFunction (ctx, test_fn);
+    if (is_pattern) {
+        if (!JS_IsFunction (ctx, test_fn)) {
+            JS_FreeValue (ctx, test_fn);
+            return JS_ThrowTypeError (ctx, "body() pattern has no test() to run");
+        }
+        JSValue subject = JS_NewString (ctx, body.c_str ());
+        JSValue result  = JS_Call (ctx, test_fn, argv[0], 1, &subject);
+        JS_FreeValue (ctx, subject);
+        JS_FreeValue (ctx, test_fn);
+        if (JS_IsException (result)) {
+            JS_FreeValue (ctx, result);
+            return JS_EXCEPTION;
+        }
+        const bool matched = JS_ToBool (ctx, result) == 1;
+        JS_FreeValue (ctx, result);
+        if (!matched) {
+            std::string msg =
+            "Expected response body to match the pattern but got " + describe_body (body);
+            return throw_assertion_failure (ctx, msg);
+        }
+        return JS_UNDEFINED;
+    }
+    JS_FreeValue (ctx, test_fn);
+
+    JSValue json = JS_ParseJSON (ctx, body.c_str (), body.size (), "<response>");
+    if (JS_IsException (json)) {
+        // Swallow the parse exception so we report a clean assertion failure.
+        JS_FreeValue (ctx, JS_GetException (ctx));
+        return throw_assertion_failure (ctx, "Response body is not valid JSON");
+    }
+
+    DeepEqualPath path;
+    const int same = js_deep_equal (ctx, json, argv[0], 0, path);
+    JS_FreeValue (ctx, json);
+    if (same < 0) {
+        return JS_EXCEPTION;
+    }
+    if (same == 0) {
+        std::string msg = "Expected response body to deeply equal " +
+        js_describe (ctx, argv[0]) + " but got " + describe_body (body);
         return throw_assertion_failure (ctx, msg);
     }
 
@@ -2627,6 +2742,29 @@ JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int ar
         start = end + 1;
     }
 
+    // chai-postman's two-argument form is `_.has(json, path)` and then
+    // `_.isEqual(_.get(json, path), value)`. Vayu walked the path and stopped,
+    // never reading the expected value at all, so every value-checking
+    // assertion in an imported suite passed on any value the path held - the
+    // silent false pass #998 was filed for.
+    if (argc >= 2) {
+        DeepEqualPath path;
+        const int same = js_deep_equal (ctx, current, argv[1], 0, path);
+        if (same < 0) {
+            JS_FreeValue (ctx, current);
+            JS_FreeValue (ctx, json);
+            return JS_EXCEPTION;
+        }
+        if (same == 0) {
+            std::string msg = "Expected response body property '" + prop_path +
+            "' to deeply equal " + js_describe (ctx, argv[1]) + " but got " +
+            js_describe (ctx, current);
+            JS_FreeValue (ctx, current);
+            JS_FreeValue (ctx, json);
+            return throw_assertion_failure (ctx, msg);
+        }
+    }
+
     JS_FreeValue (ctx, current);
     JS_FreeValue (ctx, json);
     return JS_UNDEFINED;
@@ -2649,7 +2787,11 @@ struct StatusClassMatcher {
 // ranges, so they get their own getters below.
 constexpr StatusClassMatcher status_class_matchers[] = {
     { "info", 100, 199, "a 1xx status code" },
-    { "ok", 200, 299, "a 2xx status code" },
+    // `ok` is a named code in chai-postman, not a class: it asserts 200, so a
+    // 204 passes here and fails in Postman while the two ranges agree. Vayu
+    // scripts that meant the class have `success`, which is the 2xx one in
+    // both - the migration note is in docs/app/pm-api-compatibility.md.
+    { "ok", 200, 200, "status 200" },
     { "success", 200, 299, "a 2xx status code" },
     { "accepted", 202, 202, "status 202" },
     { "redirection", 300, 399, "a 3xx status code" },
@@ -3035,6 +3177,11 @@ JSValue js_headers_get (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     return JS_GetPropertyStr (ctx, this_val, key->c_str ());
 }
 
+// Postman's PropertyList spells this `has(key, value?)` and checks the value
+// when one is given. Vayu read only the name, so `has(name, value)` answered
+// true for any value the header held - a check that looked like one and was
+// not. The comparison is strict against the wire string, as `to.have.header`'s
+// is: a non-string expectation matches nothing rather than being coerced.
 JSValue js_headers_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     if (!header_this_is_usable (ctx, this_val, "has")) {
         return JS_EXCEPTION;
@@ -3043,7 +3190,20 @@ JSValue js_headers_has (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     if (!name) {
         return JS_EXCEPTION;
     }
-    return JS_NewBool (ctx, find_header_key (ctx, this_val, *name).has_value ());
+    auto key = find_header_key (ctx, this_val, *name);
+    if (!key) {
+        return JS_NewBool (ctx, 0);
+    }
+    if (argc < 2) {
+        return JS_NewBool (ctx, 1);
+    }
+    if (!JS_IsString (argv[1])) {
+        return JS_NewBool (ctx, 0);
+    }
+    JSValue stored           = JS_GetPropertyStr (ctx, this_val, key->c_str ());
+    const std::string actual = js_to_string (ctx, stored);
+    JS_FreeValue (ctx, stored);
+    return JS_NewBool (ctx, actual == js_to_string (ctx, argv[1]) ? 1 : 0);
 }
 
 // Postman spells this `add({ key, value })`; Bruno spells it `(name, value)`.

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3340,11 +3340,7 @@ JSValue js_response_reason (JSContext* ctx, JSValueConst this_val, int argc, JSV
     if (!data || !data->response) {
         return JS_ThrowInternalError (ctx, "No response available");
     }
-    if (!data->response->status_text.empty ()) {
-        return JS_NewString (ctx, data->response->status_text.c_str ());
-    }
-    return JS_NewString (
-    ctx, vayu::http::status_text (data->response->status_code).c_str ());
+    return JS_NewString (ctx, response_reason_phrase (*data->response).c_str ());
 }
 
 // pm.response.size() -> { body, header, total }, in bytes.

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -655,9 +655,9 @@ declare const pm: {
 			 */
 			get(name: string): string | undefined;
 			/**
-			 * Whether the outgoing request carries that header, case-insensitively.
+			 * Whether the outgoing request carries that header, case-insensitively. With a second argument, whether it also carries that exact value - the comparison is strict, so a number never matches the header's string.
 			 */
-			has(name: string): boolean;
+			has(name: string, value?: string): boolean;
 			/**
 			 * Remove a header from the outgoing request, including one the Auth tab applied. Case-insensitive, and removing an absent header is a no-op.
 			 */
@@ -847,9 +847,9 @@ declare const pm: {
 			 */
 			get(name: string): string | undefined;
 			/**
-			 * Whether the response carries a header of that name, case-insensitively.
+			 * Whether the response carries a header of that name, case-insensitively. With a second argument, whether it also carries that exact value - the comparison is strict, so a number never matches the wire's string.
 			 */
-			has(name: string): boolean;
+			has(name: string, value?: string): boolean;
 		};
 		/**
 		 * Parse and return the response body as JSON.
@@ -962,7 +962,7 @@ declare const pm: {
 				 */
 				notFound: void;
 				/**
-				 * Assert that the response has a 2xx status code.
+				 * Assert that the response has status 200.
 				 * 
 				 * Written without parentheses - the property access is the assertion.
 				 * 
@@ -1027,24 +1027,39 @@ declare const pm: {
 			};
 			have: {
 				/**
-				 * Assert that a specific header exists in the response.
+				 * Assert what the response body is. A string must equal the body exactly, a regular expression must match it, and an object must deeply equal the parsed JSON.
+				 * 
+				 * Example:
+				 * pm.response.to.have.body('pong');
+				 * pm.response.to.have.body(/^\{"ok"/);
+				 * pm.response.to.have.body({ ok: true });
+				 */
+				body(expected: string | RegExp | object): void;
+				/**
+				 * Assert that a specific header exists in the response, and - with a second argument - that it holds that exact value. The value comparison is strict, so a number never matches the wire's string.
 				 * 
 				 * Example:
 				 * pm.response.to.have.header('Content-Type');
+				 * pm.response.to.have.header('Content-Type', 'application/json');
 				 */
-				header(name: string): void;
+				header(name: string, value?: string): void;
 				/**
-				 * Assert that the response has a valid JSON body.
+				 * Assert that the response has a valid JSON body; with a path, that the body holds that property; with a value, that the property deeply equals it.
+				 * 
+				 * Example:
+				 * pm.response.to.have.jsonBody();
+				 * pm.response.to.have.jsonBody('data.id');
+				 * pm.response.to.have.jsonBody('data.id', 42);
 				 */
-				jsonBody(): void;
+				jsonBody(path?: string, value?: unknown): void;
 				/**
-				 * Assert that the response has a specific HTTP status code.
+				 * Assert that the response has a specific HTTP status code, or - given a string - the reason phrase pm.response.reason() answers.
 				 * 
 				 * Example:
 				 * pm.response.to.have.status(200);
-				 * pm.response.to.have.status(201);
+				 * pm.response.to.have.status('OK');
 				 */
-				status(code: number): void;
+				status(code: number | string): void;
 			};
 		};
 		/**

--- a/engine/tests/script_assertion_error_test.cpp
+++ b/engine/tests/script_assertion_error_test.cpp
@@ -180,11 +180,35 @@ TEST_F (AssertionErrorTest, ResponseAssertionsFailWithTheAssertionErrorName) {
     "AssertionError: Expected header 'Content-Type' to be 'text/plain' but got "
     "'application/json'");
     EXPECT_EQ (failure_of (R"(pm.response.to.have.body("nope"))"),
-    "AssertionError: Expected response body to contain 'nope'");
+    "AssertionError: Expected response body to be 'nope' but got '{\"id\": "
+    "1}'");
     EXPECT_EQ (failure_of (R"(pm.response.to.have.jsonBody("missing"))"),
     "AssertionError: Expected response body to have property 'missing'");
     EXPECT_EQ (failure_of (R"(pm.response.to.be.notFound)"),
     "AssertionError: Expected response to have status 404 but got 200");
+}
+
+/**
+ * The verdicts #998 corrected report what they compared, because each of them
+ * used to report nothing at all: the assertion passed. A message naming only
+ * the matcher would leave the reader of a newly-red suite with no way to see
+ * which half of the comparison moved.
+ */
+TEST_F (AssertionErrorTest, TheCorrectedVerdictsNameBothSidesOfTheComparison) {
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.jsonBody("id", 2))"),
+    "AssertionError: Expected response body property 'id' to deeply equal 2 "
+    "but got 1");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.status("Not Found"))"),
+    "AssertionError: Expected status reason 'Not Found' but got 'OK'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.header("Content-Type", 5))"),
+    "AssertionError: Expected header 'Content-Type' to be 5 but got "
+    "'application/json'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.body(/nope/))"),
+    "AssertionError: Expected response body to match the pattern but got "
+    "'{\"id\": 1}'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.body({ id: 2 }))"),
+    "AssertionError: Expected response body to deeply equal {\"id\":2} but got "
+    "'{\"id\": 1}'");
 }
 
 /** The body-shape assertions read the body rather than the status. */
@@ -220,6 +244,7 @@ TEST_F (AssertionErrorTest, AMisusedMatcherIsStillATypeError) {
         R"(pm.expect(1).to.be.instanceOf("Array"))",
         R"(pm.expect(1).to.throw())",
         R"(pm.response.to.have.status())",
+        R"(pm.response.to.have.body(5))",
     };
 
     for (const auto& usage_error : usage_errors) {

--- a/engine/tests/script_assertion_error_test.cpp
+++ b/engine/tests/script_assertion_error_test.cpp
@@ -245,6 +245,7 @@ TEST_F (AssertionErrorTest, AMisusedMatcherIsStillATypeError) {
         R"(pm.expect(1).to.throw())",
         R"(pm.response.to.have.status())",
         R"(pm.response.to.have.body(5))",
+        R"(pm.response.to.have.body(null))",
     };
 
     for (const auto& usage_error : usage_errors) {

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -952,6 +952,183 @@ TEST_F (ScriptEngineTest, ResponseJsonBodyNoArgFailsOnNonJson) {
 }
 
 // ============================================================================
+// Chai-postman verdicts (issue #998)
+// ============================================================================
+//
+// Six assertions returned a verdict Postman does not give, five of them in the
+// dangerous direction - Vayu passed where Postman fails, which in a testing
+// tool is a green suite over a broken API. Each test below asserts BOTH
+// directions, so it is its own mutation check: on the code these replaced, the
+// false-pass half goes red.
+
+TEST_F (ScriptEngineTest, ResponseJsonBodyComparesTheValueItWasGiven) {
+    response.body = R"({"id": 1, "user": {"name": "John"}})";
+
+    auto result = engine.execute_test (R"(
+        pm.test("right value", function() { pm.response.to.have.jsonBody("id", 1); });
+        pm.test("nested deep value", function() { pm.response.to.have.jsonBody("user", { name: "John" }); });
+        pm.test("wrong value", function() { pm.response.to.have.jsonBody("id", 2); });
+        pm.test("wrong nested value", function() { pm.response.to.have.jsonBody("user", { name: "Jane" }); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[1].passed) << result.tests[1].error_message;
+    EXPECT_FALSE (result.tests[2].passed)
+    << "jsonBody must compare the expected value";
+    EXPECT_FALSE (result.tests[3].passed) << "jsonBody must compare deeply";
+    EXPECT_NE (result.tests[2].error_message.find ("'id'"), std::string::npos)
+    << "the failure must name the path: " << result.tests[2].error_message;
+}
+
+TEST_F (ScriptEngineTest, ResponseBodyStringIsExactNotSubstring) {
+    response.body = "pong";
+
+    auto result = engine.execute_test (R"(
+        pm.test("exact", function() { pm.response.to.have.body("pong"); });
+        pm.test("substring", function() { pm.response.to.have.body("pon"); });
+        pm.test("superstring", function() { pm.response.to.have.body("pongpong"); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 3u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed)
+    << "a substring must not satisfy body()";
+    EXPECT_FALSE (result.tests[2].passed);
+}
+
+TEST_F (ScriptEngineTest, ResponseBodyRunsARegularExpressionAndDeepEqualsAnObject) {
+    response.body = R"({"ok": true, "count": 2})";
+
+    auto result = engine.execute_test (R"(
+        pm.test("pattern matches", function() { pm.response.to.have.body(/"count":\s*2/); });
+        pm.test("pattern misses", function() { pm.response.to.have.body(/"count":\s*3/); });
+        pm.test("object equal", function() { pm.response.to.have.body({ ok: true, count: 2 }); });
+        pm.test("object differs", function() { pm.response.to.have.body({ ok: true, count: 3 }); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed);
+    EXPECT_TRUE (result.tests[2].passed) << result.tests[2].error_message;
+    EXPECT_FALSE (result.tests[3].passed);
+}
+
+// A number is neither of the three forms chai-postman reads, and stringifying
+// it into a comparison is how the substring version passed on anything. It is
+// a mistake in the script text, so it is a TypeError rather than a verdict.
+TEST_F (ScriptEngineTest, ResponseBodyRefusesAnArgumentItCannotCompare) {
+    response.body = "5";
+
+    auto result = engine.execute_test (R"(
+        pm.test("number", function() { pm.response.to.have.body(5); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_FALSE (result.tests[0].passed);
+    EXPECT_NE (result.tests[0].error_message.find ("TypeError"), std::string::npos)
+    << result.tests[0].error_message;
+}
+
+TEST_F (ScriptEngineTest, ResponseStatusTakesAReasonPhrase) {
+    auto result = engine.execute_test (R"(
+        pm.test("reason", function() { pm.response.to.have.status("OK"); });
+        pm.test("code", function() { pm.response.to.have.status(200); });
+        pm.test("wrong reason", function() { pm.response.to.have.status("Not Found"); });
+        pm.test("code as a string", function() { pm.response.to.have.status("200"); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[1].passed) << result.tests[1].error_message;
+    EXPECT_FALSE (result.tests[2].passed);
+    EXPECT_FALSE (result.tests[3].passed)
+    << "a string is a reason phrase, never a coerced code";
+}
+
+// HTTP/2 carries no reason phrase, so the assertion reads the same fallback
+// pm.response.reason() does rather than comparing against an empty string.
+TEST_F (ScriptEngineTest, ResponseStatusReasonFallsBackToTheRegisteredPhrase) {
+    response.status_code = 404;
+    response.status_text.clear ();
+
+    auto result = engine.execute_test (R"(
+        pm.test("registered phrase", function() { pm.response.to.have.status("Not Found"); });
+        pm.test("agrees with the reason accessor", function() { pm.expect(pm.response.reason()).to.equal("Not Found"); });
+        pm.test("other phrase", function() { pm.response.to.have.status("OK"); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 3u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[1].passed) << result.tests[1].error_message;
+    EXPECT_FALSE (result.tests[2].passed);
+}
+
+TEST_F (ScriptEngineTest, ResponseHeaderValueComparisonIsStrict) {
+    response.headers["X-Count"] = "5";
+
+    auto result = engine.execute_test (R"(
+        pm.test("string matches", function() { pm.response.to.have.header("Content-Type", "application/json"); });
+        pm.test("number does not", function() { pm.response.to.have.header("X-Count", 5); });
+        pm.test("wrong string", function() { pm.response.to.have.header("X-Count", "6"); });
+        pm.test("right string", function() { pm.response.to.have.header("X-Count", "5"); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed)
+    << "a number must not be stringified into agreement with the wire";
+    EXPECT_FALSE (result.tests[2].passed);
+    EXPECT_TRUE (result.tests[3].passed) << result.tests[3].error_message;
+}
+
+TEST_F (ScriptEngineTest, HeadersHasChecksTheValueWhenItIsGivenOne) {
+    response.headers["X-Count"] = "5";
+
+    auto result = engine.execute_test (R"(
+        pm.test("present", function() { pm.expect(pm.response.headers.has("X-Request-Id")).to.equal(true); });
+        pm.test("value matches", function() { pm.expect(pm.response.headers.has("X-Request-Id", "abc123")).to.equal(true); });
+        pm.test("value differs", function() { pm.expect(pm.response.headers.has("X-Request-Id", "nope")).to.equal(false); });
+        pm.test("number never matches", function() { pm.expect(pm.response.headers.has("X-Count", 5)).to.equal(false); });
+        pm.test("absent with a value", function() { pm.expect(pm.response.headers.has("X-Absent", "x")).to.equal(false); });
+        pm.test("request side too", function() { pm.expect(pm.request.headers.has("Content-Type", "application/json")).to.equal(true); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+    ASSERT_EQ (result.tests.size (), 6u);
+    for (const auto& test : result.tests) {
+        EXPECT_TRUE (test.passed) << test.name << ": " << test.error_message;
+    }
+}
+
+// `ok` is a named code in chai-postman, not the 2xx class `success` is, so the
+// two stop being synonyms exactly here: a 204 satisfies one and not the other.
+TEST_F (ScriptEngineTest, ResponseToBeOkIsStatus200Only) {
+    response.status_code = 204;
+    response.status_text = "No Content";
+    response.body.clear ();
+
+    auto result = engine.execute_test (R"(
+        pm.test("success is the class", function() { pm.response.to.be.success; });
+        pm.test("ok is the code", function() { pm.response.to.be.ok; });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 2u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed)
+    << "ok must be status 200, not any 2xx";
+}
+
+// ============================================================================
 // pm.response.to.be Tests
 // ============================================================================
 //
@@ -1003,6 +1180,8 @@ TEST_F (ScriptEngineTest, ResponseToBeStatusClassMatchersAssertOnBothSides) {
     };
     const auto cases = std::to_array<Case> ({
     { 100, "info", "ok" },
+    { 200, "ok", "info" },
+    { 204, "success", "ok" },
     { 202, "accepted", "notFound" },
     { 301, "redirection", "success" },
     { 400, "badRequest", "serverError" },

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1034,6 +1034,31 @@ TEST_F (ScriptEngineTest, ResponseBodyRefusesAnArgumentItCannotCompare) {
     << result.tests[0].error_message;
 }
 
+// Reading the pattern's `test` runs a getter the script may have written, and
+// one that throws must reach the report as the script's own error - not as a
+// deep-equal mismatch against a body it never got to look at.
+TEST_F (ScriptEngineTest, ResponseBodyPropagatesAThrowFromTheArgumentItReads) {
+    response.body = R"({"id": 1})";
+
+    auto result = engine.execute_test (R"(
+        pm.test("throwing getter", function() {
+            pm.response.to.have.body({ get test () { throw new Error("from the getter"); } });
+        });
+        pm.test("throwing pattern", function() {
+            pm.response.to.have.body({ test: function () { throw new Error("from the pattern"); } });
+        });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 2u);
+    EXPECT_FALSE (result.tests[0].passed);
+    EXPECT_NE (result.tests[0].error_message.find ("from the getter"), std::string::npos)
+    << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed);
+    EXPECT_NE (result.tests[1].error_message.find ("from the pattern"), std::string::npos)
+    << result.tests[1].error_message;
+}
+
 TEST_F (ScriptEngineTest, ResponseStatusTakesAReasonPhrase) {
     auto result = engine.execute_test (R"(
         pm.test("reason", function() { pm.response.to.have.status("OK"); });


### PR DESCRIPTION
## Description

Six assertions on `pm.response` returned a verdict chai-postman does not give, five of them in the direction that matters most in a testing tool: Vayu passed where Postman fails, so an imported suite reported green against a broken API and said nothing.

**Root cause, one sentence:** every one of the six coerced or stringified its argument instead of comparing it by type - `jsonBody` never read its value argument at all, `body` stringified all three of Postman's argument forms into one substring search, `status` pushed both a code and a reason phrase through `JS_ToInt32`, `header` and `headers.has` compared a stringified expectation against the wire, and `ok` was registered as a status *class* where chai-postman has a named *code*.

**Approach:** each assertion now decides by the argument's type, the way chai-postman does, and compares through the helpers that already exist here - `js_deep_equal` for values, `js_describe` for message text, `throw_assertion_failure` for the failure, `vayu::http::status_text` for the reason table. The one new helper is `response_reason_phrase`, which exists so `to.have.status("OK")` and `pm.response.reason()` cannot answer differently about a response whose status line carried no phrase; `js_response_reason` was moved onto it rather than left as a second copy.

**The alternative I rejected:** matching chai-postman exactly on `body(5)` and `body(null)`, where lodash's `isString`/`isRegExp`/`isObject` all answer false and the assertion silently asserts nothing. Postman's behaviour there is a non-assertion, and this engine's standing rule (#188) is that a matcher which quietly accepts anything is the false pass the whole program exists to remove - so those are a `TypeError` naming the three accepted forms. It is the one deliberate divergence and it is documented in both docs.

Per-assertion:

- **`to.have.jsonBody(path, value)`** walked the path and never read `argv[1]`, so every value-checking assertion in an imported suite passed on any value the path held. It deep-equals now, as `_.has` then `_.isEqual` does.
- **`to.have.body(expected)`** substring-searched a stringified argument, so a partial string passed where Postman fails and a regex or object was searched for as the literal text `/re/` or `[object Object]`. Three forms, three comparisons: a string is exact, a pattern is executed, an object deep-equals the parsed JSON.
- **`to.have.status(...)`** read `"OK"` as 0 and `"200"` as 200. A string is compared against the reason phrase now - implemented consistently with #1000's recorded decision (phrase from the table, `code` stays numeric).
- **`to.have.header(name, value)`** stringified the expectation, so `header("X-Count", 5)` passed against the wire's `"5"`. Strict now.
- **`headers.has(name, value)`** ignored the value on all three header surfaces, answering true on presence alone.
- **`to.be.ok`** was a synonym for `success`. It is status 200 now; `success` stays the 2xx class and is what a script that meant the class should assert.

The completion table gains the argument forms and `to.have.body` - which had shipped with no completion, no typedef and no line in either doc, because the `pm.response.to.*` subtree is exempt from the completion drift guard and nothing caught it. `engine/tests/fixtures/script-typedefs.d.ts` is regenerated from that table.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

Breaking for Vayu scripts in two places, both with a migration note in `docs/app/pm-api-compatibility.md`: `.ok` narrows to 200 (a script that meant any 2xx asserts `.success`), and `body(sub)` written as a substring check becomes `body(new RegExp(sub))`.

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2554 tests, 2554 passed, 0 failed.**
- `cd app && pnpm test` - **5728 tests, 5728 passed** (532 files). One run before this reddened on `data-file` picker test unrelated to this change and green on re-run with no edit in between; nothing here touches app source.
- `cd app && pnpm type-check` - clean on all three projects.
- `clang-format-19 --dry-run -Werror` clean on every engine file touched.
- `mkdocs build --strict -f .github/mkdocs.yml` - built, no strict errors.

New behavioural tests assert **both** directions of each verdict, so each is its own mutation check: on the code it replaces, the false-pass half goes red. The pinned failure messages in `script_assertion_error_test.cpp` move with the behaviour, and the corrected verdicts get their own pins naming both sides of the comparison - a suite that reddens on this change needs to show the reader which half moved. The docs' fenced examples are compiled against the regenerated typedefs by `script-typedefs.docs-compile.test.ts`, which passes.

No pre-existing failures reproduced on the base commit.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Two findings from review were fixed in follow-up commits on this branch rather than left: `body()` dropped a script's own exception when reading a throwing `test` getter and reported it as a deep-equal mismatch (fixed, with a test), and the class-tag check beside the duck-typed pattern detection bought nothing but an unreachable branch (removed, so patterns are recognised exactly as `expect(...).to.match` recognises them).

Two further findings were **deliberately not fixed here** and are filed as #1048 instead of being carried in this diff: `js_deep_equal` swallows a throwing getter one layer below these assertions (a pre-existing defect in a helper the `deep`/`eql` chains share, so fixing it here would turn a verdict change into a comparison-engine change), and `to.have.status(200.5)` still truncates through `JS_ToInt32` (the numeric arm, which #998 does not name).

## Related Issues

Closes #998

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFRQ2CegoAjPKq25DWwikm)_