### PR TITLE
feat(engine): header objects gain Postman's PropertyList reads - #1005

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -23,13 +23,13 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | ------------------- | -------------------------------------------------------------------------------- |
 | Core                | `pm`, `pm.test(name, fn)` - in either script, each result naming the one that made it (see below), `pm.expect(value[, message])` - the message prefixes the failure, as in chai |
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
-| Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict |
+| Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict; `.each(fn, thisArg?)`, `.all()`, `.count()`, `.toObject(excludeDisabled?, caseSensitive?)`, `.one(name)`, `.indexOf(name)` - the read half of a Postman `PropertyList`, see [Header methods](#header-methods) |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
 | Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear(url?)`, see below |
 | Response assertions | `pm.response.to.have.status(code \| reason)`, `.header(name[, value])`, `.body(expected)`, `.jsonBody(path?[, value])`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url` (Postman's `Url` object - `protocol`/`host`/`port`/`path`/`hash`/`query`, `getHost()`, `getPath()`, `getQueryString()`, `update()`), `.method`, `.headers`, `.body` |
-| Request headers     | `pm.request.headers.get(name)`, `.has(name[, value])`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
+| Request headers     | `pm.request.headers.get(name)`, `.has(name[, value])`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)`, `.each(fn, thisArg?)`, `.all()`, `.count()`, `.toObject(excludeDisabled?, caseSensitive?)`, `.one(name)`, `.indexOf(name)` |
 | Environment         | `pm.environment.get/set/has/unset/clear/toObject`                                |
 | Globals             | `pm.globals.get/set/has/unset/clear/toObject`                                    |
 | Collection vars     | `pm.collectionVariables.get/set/has/unset/clear/toObject`                        |
@@ -43,8 +43,10 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Console             | `console.log/info/warn/error`                                                    |
 
 `pm.response.headers` is a plain object keyed by the **lower-cased** header name, not
-Postman's `HeaderList` - but it carries `get()` / `has()`, and those are
-case-insensitive the way HTTP header names are. Indexing is not, so
+Postman's `HeaderList` - but it carries `get()` / `has()` plus the read half of a
+Postman `PropertyList`: `each()`, `all()`, `count()`, `toObject()`, `one()` and
+`indexOf()`. Every one of them that takes a header name matches it the way HTTP
+header names work - case-insensitively. Indexing is not, so
 `headers['Content-Type']` reads back `undefined` while
 `headers.get('Content-Type')` works (see [Header methods](#header-methods)).
 
@@ -54,6 +56,11 @@ you two entries. That matters most for `Set-Cookie`, which servers routinely
 send once per cookie: both cookies are there, in one string. Do not split that
 string yourself - an `Expires=` value contains a comma of its own. Read
 `pm.response.cookies`, which is the same header already parsed.
+
+**`all()` reports the object's key order, not wire order, and can never report
+a duplicate** the way Postman's `HeaderList` does - a name sent twice is
+already the one folded entry above by the time any script sees it, so there is
+only ever one member for `all()` to report for it.
 
 Variable writes persist to the scope they target (environment / collection / globals) and
 participate in [variable resolution](./variable-resolution.md). Calling `set(name, value)`
@@ -193,9 +200,11 @@ script's mistake, so it arrives as `err` (an `Error` carrying `.code`, e.g.
 `TIMEOUT`) with `res` null. The script's own mistakes throw instead: an
 unreadable argument, an unsupported body mode, the request cap, and the
 capability being off. `res` carries `code`, `status`, `responseTime`,
-`headers.get()/has()`, `json()` and `text()` - a subset of `pm.response`, with
-no assertion chain. `status` is the numeric code there too, so the two objects
-called a response do not disagree inside one sandbox.
+`headers` with `get()`/`has()`/`each()`/`all()`/`count()`/`toObject()`/`one()`/
+`indexOf()` - the same read methods as `pm.response.headers` - `json()` and
+`text()`, a subset of `pm.response` with no assertion chain. `status` is the
+numeric code there too, so the two objects called a response do not disagree
+inside one sandbox.
 
 **It is bounded, and both bounds throw.** The request's timeout is clamped to
 whatever is left of the script's own time budget (`scriptTimeout`, 5s by
@@ -596,6 +605,11 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
 - `pm.cookies.set(...)` / `.unset(...)` / `.clear()` - the *flat* write half.
   Writing goes through `pm.cookies.jar()`, which ships whole - see
   [above](#the-cookie-jar-pmcookies)
+- The rest of postman-collection's `PropertyList` on a header object - `map`,
+  `filter`, `find`, `idx`, `insert`, the list-level `has(item, value)`,
+  `assimilate`, `populate`, `clear`, `eachParent`, `toString`. Only the read
+  half and the three mutators named under [Header methods](#header-methods)
+  ship
 - `pm.visualizer`
 - The `tests["name"] = bool` legacy assertion style (use `pm.test`)
 - Chai matchers outside the list above: `.include.keys` (the subset form),
@@ -684,13 +698,15 @@ immutable or provide no mutators for.
 
 ### Header methods
 
-Both header objects carry `get(name)` and `has(name)`; `pm.request.headers` also carries
-`upsert`, `add` and `remove`. They are **non-enumerable properties of the header object
-itself**, which is what makes them safe: `apply_pm_request_writeback` reads that object's
-own *enumerable* string properties as the outgoing header set, so an enumerable method
-would be read as a header whose value is a function and would fail the whole write-back.
-Being on the same object is also what makes a method call and a plain assignment agree -
-there is one property set, not two views of one.
+Both header objects carry `get(name)`, `has(name)`, and the read half of a Postman
+`PropertyList` - `each(fn, thisArg?)`, `all()`, `count()`, `toObject(excludeDisabled?,
+caseSensitive?)`, `one(name)` and `indexOf(name)`; `pm.request.headers` also carries the
+three mutators, `upsert`, `add` and `remove`. They are **non-enumerable properties of the
+header object itself**, which is what makes them safe: `apply_pm_request_writeback` reads
+that object's own *enumerable* string properties as the outgoing header set, so an
+enumerable method would be read as a header whose value is a function and would fail the
+whole write-back. Being on the same object is also what makes a method call and a plain
+assignment agree - there is one property set, not two views of one.
 
 ```javascript
 pm.request.headers.get('authorization');                  // case-insensitive
@@ -698,9 +714,25 @@ pm.request.headers.has('Authorization');
 pm.request.headers.upsert({ key: 'X-Trace', value: id }); // or ('X-Trace', id)
 pm.request.headers.add({ key: 'X-New', value: '1' });     // throws if already set
 pm.request.headers.remove('Authorization');               // no-op if absent
+pm.request.headers.all();                                 // [{key, value}, ...]
+pm.request.headers.count();                               // how many there are
+pm.request.headers.one('Content-Type');                   // {key, value}, or undefined
+pm.request.headers.toObject();                            // lower-cased keys
+pm.request.headers.indexOf('Content-Type');               // position in all(), or -1
+pm.request.headers.each(function (header, index, all) {
+  console.log(header.key, header.value, index, all.length);
+});
 ```
 
-Three deliberate divergences from Postman:
+`toObject()` lower-cases every key, which is what Postman does whenever the list
+it is called on is indexed case-insensitively - a header list always is - so
+`toObject()['content-type']` reads the header whatever casing it was set with.
+A truthy second argument (`toObject(false, true)`) keeps the stored spelling.
+The first argument is Postman's `excludeDisabled` and decides nothing here, as
+do the two it does not take: these objects hold no disabled row, no duplicate
+name and no empty one.
+
+Five deliberate divergences from Postman:
 
 - **The methods are case-insensitive, indexing is not.** `upsert('authorization', v)`
   replaces an existing `Authorization` instead of adding a second spelling - which the
@@ -709,13 +741,23 @@ Three deliberate divergences from Postman:
   Postman's `HeaderList` holds duplicates and `add` appends one; a single-valued
   `Headers` map cannot represent that, and silently behaving as `upsert` would hide the
   difference rather than report it.
-- **A header field literally named `get`/`has`/`add`/`upsert`/`remove` wins.** Entries are
+- **A header field literally named after one of the methods wins.** Entries are
   *defined* over the method, attributes included, so the header still reaches the wire
   and the shadowed method throws loudly. A dropped header would be the worse failure.
+- **`all()` reports this object's key order, not wire order, and can never report a
+  duplicate.** Postman's `HeaderList` keeps both; a `Headers` map cannot, because it is
+  single-valued and case-insensitive, so a name set twice already collapsed into one
+  entry before any script runs.
+- **`indexOf` matches a `{ key }` member by its `key`, not by identity.** Postman finds a
+  member by identity in its own list; the members handed out here are built fresh on
+  every call, so identity would answer `-1` for a member of the very list it came from.
+  Matching the key answers what Postman answers for that case, and `-1` for an object
+  naming a header this list does not hold.
 
 Bad input fails loudly: a name must be a non-empty string, a value a string, number or
-boolean (the set plain assignment already accepts), and calling a method detached from
-its object throws rather than answering as though the header were missing.
+boolean (the set plain assignment already accepts), `each` throws if its first argument
+is not a function, and calling a method detached from its object throws rather than
+answering as though the header were missing.
 
 ---
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -336,16 +336,53 @@ pm.response.headers.has('X-Request-Id');   // name present, boolean
 pm.response.headers.has('Content-Type', 'application/json');
                                            // present and holding that exact value
 pm.response.headers['content-type'];       // indexing: exact key only
+pm.response.headers.all();                 // [{key, value}, ...] in map order
+pm.response.headers.count();               // how many headers there are
+pm.response.headers.one('Content-Type');   // {key, value}, or undefined
+pm.response.headers.toObject();            // {'content-type': 'application/json', ...}
+pm.response.headers.toObject(false, true); // same, keys keep the stored spelling
+pm.response.headers.indexOf('Content-Type');
+                                           // position in all(), or -1
+pm.response.headers.each(function (header, index, all) {
+  console.log(header.key, header.value, index, all.length);
+});
 ```
 
 `has()`'s optional second argument is compared strictly against the header's
 wire value - a number never matches, since the wire value is always a string.
 
-`headers` is a plain object, not Postman's `HeaderList`, but `get()` and `has()`
-are on it and behave the way HTTP header names do - case-insensitively. Indexing
-does not: the engine lower-cases every response header name as it parses it, so
-`headers['Content-Type']` is `undefined` while `headers.get('Content-Type')`
-works. Prefer the methods unless you know the exact key.
+`headers` is a plain object, not Postman's `HeaderList`, but the read half of a
+Postman `PropertyList` is on it: `get()`, `has()`, `each()`, `all()`, `count()`,
+`toObject()`, `one()` and `indexOf()`. Every one of them that takes a header
+name matches it the way HTTP header names work - case-insensitively, and
+`toObject()`'s keys come back lower-cased for the same reason. Indexing does
+not: the engine lower-cases
+every response header name as it parses it, so `headers['Content-Type']` is
+`undefined` while `headers.get('Content-Type')` works. Prefer the methods
+unless you know the exact key.
+
+The six beyond `get`/`has`:
+
+- `all()` - every header as `{ key, value }`, in the object's own key order.
+- `count()` - how many headers there are, i.e. `all().length`.
+- `toObject(excludeDisabled?, caseSensitive?)` - a plain `{name: value}` object.
+  **Keys are lower-cased by default**; pass a truthy second argument to keep
+  the stored spelling instead. Postman's `toObject()` lower-cases whenever the
+  list it is called on is indexed case-insensitively, which a header list
+  always is.
+- `one(name)` - the `{ key, value }` member rather than its value,
+  case-insensitive, `undefined` when absent. `get` is the value half of the
+  same lookup.
+- `indexOf(name)` - the header's position in `all()`, case-insensitive, `-1`
+  when absent. It also accepts a `{ key }` member (what `all()` / `one()` hand
+  back) in place of a name.
+- `each(fn, thisArg?)` - calls `fn(header, index, all)` for every header, the
+  same three arguments Postman's iterator receives; `thisArg` becomes the
+  callback's `this`. The member list is built once before the walk starts, so
+  a callback that removes the header it was just handed does not shorten it.
+
+All six are non-enumerable, exactly like `get()` and `has()`, so none of them
+ever appear in `Object.keys()` or `JSON.stringify()`.
 
 The response object has **no** `add`/`upsert`/`remove` - the response has
 already arrived, so a mutator there would only appear to change something.
@@ -359,6 +396,12 @@ the RFC 7230 §3.2.2 equivalence for comma-list headers; before it, only the
 on `", "` - but not for `Set-Cookie`, whose values contain commas of their own
 (`Expires=Wed, 21 Oct ...`). Read `pm.response.cookies` instead: it is that
 header already parsed, boundaries and all.
+
+**`all()` reports the object's key order, not wire order, and can never report
+a duplicate.** Postman's `HeaderList` keeps both; this object cannot, because
+it is built from a single-valued case-insensitive map and a name sent twice has
+already been folded into the one entry above by the time any script sees
+it - there is only ever one member to report for it.
 
 ### Reading response cookies
 
@@ -593,6 +636,15 @@ pm.request.headers.upsert({ key: 'X-Trace', value: id }); // add or replace
 pm.request.headers.upsert('X-Trace', id);                 // same, two-arg form
 pm.request.headers.add({ key: 'X-New', value: '1' });     // add; throws if present
 pm.request.headers.remove('Authorization');               // case-insensitive
+pm.request.headers.all();                                 // [{key, value}, ...]
+pm.request.headers.count();                               // how many there are
+pm.request.headers.one('Content-Type');                   // {key, value} or undefined
+pm.request.headers.toObject();                            // lower-cased keys
+pm.request.headers.toObject(false, true);                 // keys kept as typed
+pm.request.headers.indexOf('Content-Type');               // position in all(), or -1
+pm.request.headers.each(function (header, index, all) {
+  console.log(header.key, header.value, index, all.length);
+});
 ```
 
 These act on the **same object** as indexing and `delete`, so the two styles
@@ -600,7 +652,7 @@ mix freely and the write-back sees one header set either way. They are
 non-enumerable properties of it, so they never appear in `Object.keys()`,
 `JSON.stringify()` or on the wire.
 
-Three behaviours worth knowing:
+Behaviours worth knowing:
 
 - **The methods are case-insensitive; indexing is not.** `upsert('authorization', v)`
   replaces an existing `Authorization` rather than adding a second spelling -
@@ -614,11 +666,28 @@ Three behaviours worth knowing:
 - **`has`'s optional value argument is a strict string compare**, the same rule
   `pm.response.headers.has` follows - a number never matches, since the
   outgoing header is always a string.
+- **`toObject()` lower-cases its keys by default.** `pm.request.headers` keeps
+  whatever casing the request holds - which can be whatever the user typed -
+  so copying its own keys would have answered `undefined` for
+  `toObject()['content-type']` on a request carrying `Content-Type`. Pass a
+  truthy second argument (`toObject(false, true)`) to keep the stored spelling
+  instead.
+- **`all()` reports this object's key order, not wire order, and can never
+  report a duplicate** - unlike Postman's `HeaderList`, which keeps both. A
+  name assigned twice already collapsed into one entry (the second write
+  replaced the first), so there is only ever one member for `all()` to report.
+- **`indexOf` matches a `{ key }` member by its `key`, not by identity.**
+  Postman finds a member by identity in its own list; the members here are
+  built fresh on every call, so identity would answer `-1` for a member of the
+  very list it came from. Matching the key answers what Postman answers for
+  that case, and `-1` for an object naming a header this list does not hold.
 
 A bad argument fails loudly: a name must be a non-empty string and a value a
-string, number or boolean - the same set plain assignment accepts. Detaching a
-method from its object (`const get = pm.request.headers.get`) throws rather than
-answering as though the header were missing.
+string, number or boolean - the same set plain assignment accepts. `each`
+throws if its first argument is not a function. Detaching a method from its
+object (`const get = pm.request.headers.get`) throws rather than answering as
+though the header were missing. A throw out of an `each` callback propagates as
+the script's own error.
 
 ### URL parts (`pm.request.url`)
 
@@ -977,8 +1046,10 @@ script's own mistakes throw out of the call instead: an unusable argument, an
 unsupported body mode, exceeding the request cap, and the capability being off.
 
 `res` carries `code`, `status` (the numeric code, as on `pm.response`),
-`responseTime`, `headers` with `get()`/`has()`, `json()` and `text()`. It is a
-subset of `pm.response` and has no `to.*` assertion chain.
+`responseTime`, `headers` with `get()`/`has()`/`each()`/`all()`/`count()`/
+`toObject()`/`one()`/`indexOf()` - the same read methods documented under
+[Reading response headers](#reading-response-headers) - `json()` and `text()`.
+It is a subset of `pm.response` and has no `to.*` assertion chain.
 
 **Two bounds, both hard.**
 

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -178,8 +178,9 @@ nlohmann::json get_script_completions () {
     { "insertText", "pm.response.headers" }, { "detail", "object" },
     { "documentation",
     "Response headers as key-value pairs, keyed by the lower-cased name the "
-    "HTTP client parsed. Index it (pm.response.headers['content-type']) or use "
-    "the case-insensitive get()/has() over it." },
+    "HTTP client parsed. Index it (pm.response.headers['content-type']), use "
+    "the case-insensitive get()/has() over it, or walk it with "
+    "each()/all()/toObject()." },
     { "sortText", "1_pm_response_headers" } });
 
     completions.push_back ({ { "label", "pm.response.headers.get" }, { "kind", KIND_FUNCTION },
@@ -201,6 +202,72 @@ nlohmann::json get_script_completions () {
     "With a second argument, whether it also carries that exact value - the "
     "comparison is strict, so a number never matches the wire's string." },
     { "sortText", "1_pm_response_headers_has" } });
+
+    // The PropertyList reads, offered on both header objects because
+    // `install_header_methods` installs them on both - the completion table and
+    // the runtime are held to each other by ScriptCompletions.
+    completions.push_back ({ { "label", "pm.response.headers.each" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.response.headers.each((header) => {\n\t$0\n})" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail",
+    "pm.response.headers.each(fn: (header: { key: string; value: string }, "
+    "index: "
+    "number, all: { key: string; value: string }[]) => void, thisArg?: any): "
+    "void" },
+    { "documentation",
+    "Call fn for each response header, with { key, value } as Postman does. "
+    "The list is taken once, so it is the set the call started "
+    "with.\n\nExample:"
+    "\npm.response.headers.each(h => console.log(h.key, h.value));" },
+    { "sortText", "1_pm_response_headers_each" } });
+
+    completions.push_back ({ { "label", "pm.response.headers.all" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.headers.all()" },
+    { "detail", "pm.response.headers.all(): { key: string; value: string }[]" },
+    { "documentation",
+    "Every response header as a { key, value }, in the object's own key order. "
+    "A name the server sent twice is one entry here, its values already folded "
+    "with ', ' - the wire order and the duplicate are gone before a script "
+    "sees them." },
+    { "sortText", "1_pm_response_headers_all" } });
+
+    completions.push_back ({ { "label", "pm.response.headers.count" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.headers.count()" },
+    { "detail", "pm.response.headers.count(): number" },
+    { "documentation", "How many headers the response carries - all().length without building the array." },
+    { "sortText", "1_pm_response_headers_count" } });
+
+    completions.push_back ({ { "label", "pm.response.headers.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.headers.toObject()" },
+    { "detail",
+    "pm.response.headers.toObject(excludeDisabled?: boolean, caseSensitive?: "
+    "boolean): Record<string, string>" },
+    { "documentation",
+    "A plain { name: value } object. Keys are lower-cased, as Postman's "
+    "case-insensitive list does it; pass a truthy second argument to keep the "
+    "stored spelling. Postman's other two switches decide nothing here - these "
+    "headers hold no duplicate and no empty name." },
+    { "sortText", "1_pm_response_headers_to_object" } });
+
+    completions.push_back ({ { "label", "pm.response.headers.one" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.response.headers.one(\"${1:Content-Type}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.response.headers.one(name: string): { key: string; value: string } | undefined" },
+    { "documentation",
+    "The header itself rather than its value, case-insensitively - undefined "
+    "when it is absent. get() is the value half of the same lookup." },
+    { "sortText", "1_pm_response_headers_one" } });
+
+    completions.push_back (
+    { { "label", "pm.response.headers.indexOf" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.response.headers.indexOf(\"${1:Content-Type}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.response.headers.indexOf(name: string): number" },
+    { "documentation",
+    "Where the header sits in all(), case-insensitively, or -1 when it is "
+    "absent. A { key } member from all() or one() is accepted in place of the "
+    "name." },
+    { "sortText", "1_pm_response_headers_index_of" } });
 
     completions.push_back ({ { "label", "pm.response.cookies" }, { "kind", KIND_FIELD },
     { "insertText", "pm.response.cookies" }, { "detail", "object" },
@@ -645,6 +712,72 @@ nlohmann::json get_script_completions () {
     "Remove a header from the outgoing request, including one the Auth tab "
     "applied. Case-insensitive, and removing an absent header is a no-op." },
     { "sortText", "1_pm_request_headers_remove" } });
+
+    // The PropertyList reads, the same six the response object carries - they
+    // look rather than write, so the mutator gate does not apply to them.
+    completions.push_back ({ { "label", "pm.request.headers.each" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.headers.each((header) => {\n\t$0\n})" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail",
+    "pm.request.headers.each(fn: (header: { key: string; value: string }, "
+    "index: "
+    "number, all: { key: string; value: string }[]) => void, thisArg?: any): "
+    "void" },
+    { "documentation",
+    "Call fn for each outgoing header, with { key, value } as Postman does. "
+    "The list is taken once, so removing a header from inside the callback "
+    "does not shorten the walk.\n\nExample:\npm.request.headers.each(h => "
+    "console.log(h.key, h.value));" },
+    { "sortText", "1_pm_request_headers_each" } });
+
+    completions.push_back ({ { "label", "pm.request.headers.all" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.headers.all()" },
+    { "detail", "pm.request.headers.all(): { key: string; value: string }[]" },
+    { "documentation",
+    "Every outgoing header as a { key, value }, in the object's own key order. "
+    "A snapshot: adding a header afterwards does not change the array." },
+    { "sortText", "1_pm_request_headers_all" } });
+
+    completions.push_back ({ { "label", "pm.request.headers.count" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.headers.count()" },
+    { "detail", "pm.request.headers.count(): number" },
+    { "documentation",
+    "How many headers the request will send - all().length without building "
+    "the array." },
+    { "sortText", "1_pm_request_headers_count" } });
+
+    completions.push_back ({ { "label", "pm.request.headers.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.headers.toObject()" },
+    { "detail",
+    "pm.request.headers.toObject(excludeDisabled?: boolean, caseSensitive?: "
+    "boolean): Record<string, string>" },
+    { "documentation",
+    "A plain { name: value } copy. Keys are lower-cased, as Postman's "
+    "case-insensitive list does it, so toObject()['content-type'] reads the "
+    "header whatever casing it was set with; pass a truthy second argument to "
+    "keep the spelling. The copy is not the header set - writing to it sends "
+    "nothing." },
+    { "sortText", "1_pm_request_headers_to_object" } });
+
+    completions.push_back ({ { "label", "pm.request.headers.one" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.headers.one(\"${1:Authorization}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.headers.one(name: string): { key: string; value: string } | undefined" },
+    { "documentation",
+    "The header itself rather than its value, case-insensitively - undefined "
+    "when it is absent. Its key is the spelling the request holds, which is "
+    "what upsert() writes through." },
+    { "sortText", "1_pm_request_headers_one" } });
+
+    completions.push_back ({ { "label", "pm.request.headers.indexOf" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.request.headers.indexOf(\"${1:Authorization}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.request.headers.indexOf(name: string): number" },
+    { "documentation",
+    "Where the header sits in all(), case-insensitively, or -1 when it is "
+    "absent. A { key } member from all() or one() is accepted in place of the "
+    "name." },
+    { "sortText", "1_pm_request_headers_index_of" } });
 
     completions.push_back ({ { "label", "pm.request.body" }, { "kind", KIND_FIELD },
     { "insertText", "pm.request.body" }, { "detail", "string | undefined (writable pre-request)" },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3077,6 +3077,17 @@ const std::string& value) {
     JS_NewString (ctx, value.c_str ()), JS_PROP_C_W_E);
 }
 
+/// A header name as a case-insensitive index keys it - which is the spelling
+/// Postman's `toObject()` hands back, and the only place here that needs one.
+/// The engine has no primitive for the fold and hand-rolls it 29 times; that is
+/// filed as #1060 rather than converted from under this one caller.
+std::string header_name_lowered (const std::string& name) {
+    std::string lowered = name;
+    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
+    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+    return lowered;
+}
+
 bool header_names_equal (const std::string& a, const std::string& b) {
     return a.size () == b.size () &&
     std::equal (a.begin (), a.end (), b.begin (), [] (unsigned char c1, unsigned char c2) {
@@ -3089,30 +3100,31 @@ bool header_names_equal (const std::string& a, const std::string& b) {
 // exact lookup would miss `Content-Type` on a response (whose keys the HTTP
 // client has lower-cased) and `content-type` on a request (whose keys keep
 // whatever the user typed).
-std::optional<std::string>
-find_header_key (JSContext* ctx, JSValueConst headers, const std::string& name) {
-    JSPropertyEnum* props = nullptr;
-    uint32_t count        = 0;
-    if (JS_GetOwnPropertyNames (ctx, &props, &count, headers,
-        JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) != 0) {
+/// The header names the object holds, in the order it holds them - which is the
+/// order the source `Headers` map was walked in when the entries were defined,
+/// and so the order every read below reports. The methods are non-enumerable
+/// (HEADER_METHOD_FLAGS), so they are never among the names. `std::nullopt`
+/// means QuickJS left an exception pending.
+std::optional<std::vector<std::string>> header_key_order (JSContext* ctx, JSValueConst headers) {
+    std::vector<std::string> keys;
+    if (!js_own_enumerable_keys (ctx, headers, keys)) {
         return std::nullopt;
     }
+    return keys;
+}
 
-    std::optional<std::string> found;
-    for (uint32_t i = 0; i < count; i++) {
-        if (!found) {
-            const char* raw = JS_AtomToCString (ctx, props[i].atom);
-            if (raw) {
-                if (header_names_equal (raw, name)) {
-                    found = std::string (raw);
-                }
-                JS_FreeCString (ctx, raw);
-            }
-        }
-        JS_FreeAtom (ctx, props[i].atom);
+std::optional<std::string>
+find_header_key (JSContext* ctx, JSValueConst headers, const std::string& name) {
+    auto keys = header_key_order (ctx, headers);
+    if (!keys) {
+        return std::nullopt;
     }
-    js_free (ctx, props);
-    return found;
+    for (auto& key : *keys) {
+        if (header_names_equal (key, name)) {
+            return std::move (key);
+        }
+    }
+    return std::nullopt;
 }
 
 // `this` is the header object the method was reached through. Detaching a
@@ -3206,6 +3218,209 @@ JSValue js_headers_has (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     const std::string actual = js_to_string (ctx, stored);
     JS_FreeValue (ctx, stored);
     return JS_NewBool (ctx, actual == js_to_string (ctx, argv[1]) ? 1 : 0);
+}
+
+// Postman's header object is a PropertyList, and the six reads below are the
+// half of it that only looks. `each` in particular is an everyday idiom - it
+// threw here, which is how an imported script died on a line that reads nothing
+// - so all six install on the response and sendRequest objects too, ahead of
+// the `mutators` gate.
+//
+// What they cannot report is what this object no longer holds: `Headers` is a
+// single-valued case-insensitive map, so a name the server sent twice arrived
+// folded with ", " and the wire order is gone with it. The order below is the
+// map's; the fold is documented beside these methods in both script docs.
+
+/// One `{ key, value }` member - the shape Postman's PropertyList hands its
+/// iterator, and the shape `add`/`upsert` already read back.
+JSValue header_member (JSContext* ctx, JSValueConst headers, const std::string& key) {
+    JSValue member = JS_NewObject (ctx);
+    JS_SetPropertyStr (
+    ctx, member, "key", JS_NewStringLen (ctx, key.data (), key.size ()));
+    JS_SetPropertyStr (
+    ctx, member, "value", JS_GetPropertyStr (ctx, headers, key.c_str ()));
+    return member;
+}
+
+/// Every member as an array. `all()` itself, and the list `each()` walks - built
+/// once, so a callback that removes a header does not shorten the walk under it.
+JSValue header_member_list (JSContext* ctx,
+JSValueConst headers,
+const std::vector<std::string>& keys) {
+    JSValue list  = JS_NewArray (ctx);
+    uint32_t next = 0;
+    for (const auto& key : keys) {
+        JS_SetPropertyUint32 (ctx, list, next++, header_member (ctx, headers, key));
+    }
+    return list;
+}
+
+/// A name, or the `{ key, value }` member `all()` and `one()` hand back - the
+/// two spellings `indexOf` answers to.
+std::optional<std::string>
+read_header_member_arg (JSContext* ctx, const char* member, int argc, JSValueConst* argv) {
+    if (argc >= 1 && JS_IsObject (argv[0]) && !JS_IsFunction (ctx, argv[0]) &&
+    !JS_IsArray (argv[0])) {
+        JSValue js_key = JS_GetPropertyStr (ctx, argv[0], "key");
+        JSValueConst only[1]{ js_key };
+        auto name = read_header_name_arg (ctx, member, 1, only);
+        JS_FreeValue (ctx, js_key);
+        return name;
+    }
+    return read_header_name_arg (ctx, member, argc, argv);
+}
+
+/// `headers.all()` - every header as a `{ key, value }`, in key order.
+JSValue js_headers_all (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    if (!header_this_is_usable (ctx, this_val, "all")) {
+        return JS_EXCEPTION;
+    }
+    auto keys = header_key_order (ctx, this_val);
+    if (!keys) {
+        return JS_EXCEPTION;
+    }
+    return header_member_list (ctx, this_val, *keys);
+}
+
+/// `headers.count()` - how many headers, which is `all().length` without
+/// building the array.
+JSValue js_headers_count (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    if (!header_this_is_usable (ctx, this_val, "count")) {
+        return JS_EXCEPTION;
+    }
+    auto keys = header_key_order (ctx, this_val);
+    if (!keys) {
+        return JS_EXCEPTION;
+    }
+    return JS_NewInt32 (ctx, static_cast<int32_t> (keys->size ()));
+}
+
+/**
+ * `headers.each(fn, thisArg)` - the iteration idiom, with Postman's arguments.
+ *
+ * postman-collection's `each` is `_.forEach(members, iterator.bind(context))`,
+ * so the callback is handed `(member, index, list)` and the optional second
+ * argument becomes its `this`. Passing only the member would have been the
+ * smaller change and would silently hand `undefined` to a script that reads the
+ * index - the class of quiet wrong answer this surface exists to close.
+ */
+JSValue js_headers_each (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (!header_this_is_usable (ctx, this_val, "each")) {
+        return JS_EXCEPTION;
+    }
+    if (argc < 1 || !JS_IsFunction (ctx, argv[0])) {
+        return JS_ThrowTypeError (ctx, "headers.each(fn) needs a function, got %s",
+        argc < 1 ? "no argument" : js_type_name (ctx, argv[0]));
+    }
+    auto keys = header_key_order (ctx, this_val);
+    if (!keys) {
+        return JS_EXCEPTION;
+    }
+
+    JSValue list                = header_member_list (ctx, this_val, *keys);
+    const JSValueConst this_arg = argc >= 2 ? argv[1] : JS_UNDEFINED;
+    JSValue outcome             = JS_UNDEFINED;
+    for (uint32_t i = 0; i < keys->size (); i++) {
+        JSValue member = JS_GetPropertyUint32 (ctx, list, i);
+        JSValue index  = JS_NewInt32 (ctx, static_cast<int32_t> (i));
+        JSValueConst args[3]{ member, index, list };
+        JSValue returned = JS_Call (ctx, argv[0], this_arg, 3, args);
+        JS_FreeValue (ctx, member);
+        JS_FreeValue (ctx, index);
+        if (JS_IsException (returned)) {
+            // A throw out of the callback is the script's, not ours - it goes
+            // back up as it is rather than being reported as an `each` failure.
+            outcome = JS_EXCEPTION;
+            break;
+        }
+        JS_FreeValue (ctx, returned);
+    }
+    JS_FreeValue (ctx, list);
+    return outcome;
+}
+
+/**
+ * `headers.toObject(excludeDisabled, caseSensitive)` - Postman's signature.
+ *
+ * Its header list is indexed case-insensitively, so `toObject()` there
+ * **lower-cases every key**, and only `caseSensitive` keeps the spelling the
+ * header was stored with. Copying the object's own keys instead - which is what
+ * a plain enumeration would do - reads as the harmless choice and is not:
+ * `pm.request.headers` keeps whatever the user typed, so
+ * `toObject()['content-type']` would answer `undefined` here against a request
+ * carrying `Content-Type`, and answer correctly in Postman.
+ *
+ * The other two switches Postman takes decide nothing here: `multiValue` has no
+ * duplicate to unfold (they arrived folded), and `sanitizeKeys` no falsy key to
+ * drop, since a header name is a non-empty string on both surfaces.
+ */
+JSValue js_headers_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (!header_this_is_usable (ctx, this_val, "toObject")) {
+        return JS_EXCEPTION;
+    }
+    auto keys = header_key_order (ctx, this_val);
+    if (!keys) {
+        return JS_EXCEPTION;
+    }
+    const bool case_sensitive = argc >= 2 && JS_ToBool (ctx, argv[1]) == 1;
+
+    JSValue out = JS_NewObject (ctx);
+    for (const auto& key : *keys) {
+        JSValue value = JS_GetPropertyStr (ctx, this_val, key.c_str ());
+        const std::string prop = case_sensitive ? key : header_name_lowered (key);
+        JS_SetPropertyStr (ctx, out, prop.c_str (), value);
+    }
+    return out;
+}
+
+/// `headers.one(name)` - the member rather than its value, `undefined` when the
+/// header is absent. `get` is the value half of the same lookup.
+JSValue js_headers_one (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (!header_this_is_usable (ctx, this_val, "one")) {
+        return JS_EXCEPTION;
+    }
+    auto name = read_header_name_arg (ctx, "one", argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto key = find_header_key (ctx, this_val, *name);
+    if (!key) {
+        return JS_UNDEFINED;
+    }
+    return header_member (ctx, this_val, *key);
+}
+
+/**
+ * `headers.indexOf(name)` - the header's position in `all()`, `-1` when absent.
+ *
+ * Postman takes a member object here as well as a name, and finds it by
+ * identity in its own member list. The members handed out here are built per
+ * call, so identity would answer `-1` for a member of this very list; matching
+ * the object's `key` answers what Postman answers for that case, and `-1` for
+ * an object naming a header this list does not hold, as Postman's does.
+ */
+JSValue js_headers_index_of (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (!header_this_is_usable (ctx, this_val, "indexOf")) {
+        return JS_EXCEPTION;
+    }
+    auto name = read_header_member_arg (ctx, "indexOf", argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto keys = header_key_order (ctx, this_val);
+    if (!keys) {
+        return JS_EXCEPTION;
+    }
+    for (uint32_t i = 0; i < keys->size (); i++) {
+        if (header_names_equal ((*keys)[i], *name)) {
+            return JS_NewInt32 (ctx, static_cast<int32_t> (i));
+        }
+    }
+    return JS_NewInt32 (ctx, -1);
 }
 
 // Postman spells this `add({ key, value })`; Bruno spells it `(name, value)`.
@@ -3311,10 +3526,29 @@ JSValue js_request_headers_remove (JSContext* ctx, JSValueConst this_val, int ar
 // they mutate an object nothing reads back - the same no-op that assignment
 // already is there, documented in both script docs.
 void install_header_methods (JSContext* ctx, JSValue headers, bool mutators) {
-    JS_DefinePropertyValueStr (ctx, headers, "get",
-    JS_NewCFunction (ctx, js_headers_get, "get", 1), HEADER_METHOD_FLAGS);
-    JS_DefinePropertyValueStr (ctx, headers, "has",
-    JS_NewCFunction (ctx, js_headers_has, "has", 1), HEADER_METHOD_FLAGS);
+    // The reads are eight of one shape, so they are a table and a loop - the
+    // idiom `build_query_object` uses for the same job further down. The three
+    // mutators are not: two of them share one implementation through a magic
+    // number, and spelling that in the table would cost more than it saves.
+    struct HeaderRead {
+        const char* name;
+        JSCFunction* fn;
+        int length;
+    };
+    static constexpr std::array<HeaderRead, 8> READS = {
+        HeaderRead{ "get", js_headers_get, 1 },
+        HeaderRead{ "has", js_headers_has, 1 },
+        HeaderRead{ "each", js_headers_each, 1 },
+        HeaderRead{ "all", js_headers_all, 0 },
+        HeaderRead{ "count", js_headers_count, 0 },
+        HeaderRead{ "toObject", js_headers_to_object, 0 },
+        HeaderRead{ "one", js_headers_one, 1 },
+        HeaderRead{ "indexOf", js_headers_index_of, 1 },
+    };
+    for (const auto& read : READS) {
+        JS_DefinePropertyValueStr (ctx, headers, read.name,
+        JS_NewCFunction (ctx, read.fn, read.name, read.length), HEADER_METHOD_FLAGS);
+    }
 
     if (!mutators) {
         return;

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -651,6 +651,21 @@ declare const pm: {
 			 */
 			add(...args: any[]): void;
 			/**
+			 * Every outgoing header as a { key, value }, in the object's own key order. A snapshot: adding a header afterwards does not change the array.
+			 */
+			all(): { key: string; value: string }[];
+			/**
+			 * How many headers the request will send - all().length without building the array.
+			 */
+			count(): number;
+			/**
+			 * Call fn for each outgoing header, with { key, value } as Postman does. The list is taken once, so removing a header from inside the callback does not shorten the walk.
+			 * 
+			 * Example:
+			 * pm.request.headers.each(h => console.log(h.key, h.value));
+			 */
+			each(fn: (header: { key: string; value: string }, index: number, all: { key: string; value: string }[]) => void, thisArg?: any): void;
+			/**
 			 * Read an outgoing header by name, case-insensitively - unlike indexing, which is case-sensitive. Returns undefined when it is absent.
 			 */
 			get(name: string): string | undefined;
@@ -659,9 +674,21 @@ declare const pm: {
 			 */
 			has(name: string, value?: string): boolean;
 			/**
+			 * Where the header sits in all(), case-insensitively, or -1 when it is absent. A { key } member from all() or one() is accepted in place of the name.
+			 */
+			indexOf(name: string): number;
+			/**
+			 * The header itself rather than its value, case-insensitively - undefined when it is absent. Its key is the spelling the request holds, which is what upsert() writes through.
+			 */
+			one(name: string): { key: string; value: string } | undefined;
+			/**
 			 * Remove a header from the outgoing request, including one the Auth tab applied. Case-insensitive, and removing an absent header is a no-op.
 			 */
 			remove(name: string): void;
+			/**
+			 * A plain { name: value } copy. Keys are lower-cased, as Postman's case-insensitive list does it, so toObject()['content-type'] reads the header whatever casing it was set with; pass a truthy second argument to keep the spelling. The copy is not the header set - writing to it sends nothing.
+			 */
+			toObject(excludeDisabled?: boolean, caseSensitive?: boolean): Record<string, string>;
 			/**
 			 * Add the header, replacing any existing one of that name whatever its casing. The pre-request equivalent of assigning to pm.request.headers[name], and the safe choice when you do not know whether the header is already there.
 			 */
@@ -835,10 +862,25 @@ declare const pm: {
 		 */
 		eventsTruncated: boolean | undefined;
 		/**
-		 * Response headers as key-value pairs, keyed by the lower-cased name the HTTP client parsed. Index it (pm.response.headers['content-type']) or use the case-insensitive get()/has() over it.
+		 * Response headers as key-value pairs, keyed by the lower-cased name the HTTP client parsed. Index it (pm.response.headers['content-type']), use the case-insensitive get()/has() over it, or walk it with each()/all()/toObject().
 		 */
 		headers: {
 			[key: string]: any;
+			/**
+			 * Every response header as a { key, value }, in the object's own key order. A name the server sent twice is one entry here, its values already folded with ', ' - the wire order and the duplicate are gone before a script sees them.
+			 */
+			all(): { key: string; value: string }[];
+			/**
+			 * How many headers the response carries - all().length without building the array.
+			 */
+			count(): number;
+			/**
+			 * Call fn for each response header, with { key, value } as Postman does. The list is taken once, so it is the set the call started with.
+			 * 
+			 * Example:
+			 * pm.response.headers.each(h => console.log(h.key, h.value));
+			 */
+			each(fn: (header: { key: string; value: string }, index: number, all: { key: string; value: string }[]) => void, thisArg?: any): void;
 			/**
 			 * Read a response header by name, case-insensitively. Returns undefined when the header is absent.
 			 * 
@@ -850,6 +892,18 @@ declare const pm: {
 			 * Whether the response carries a header of that name, case-insensitively. With a second argument, whether it also carries that exact value - the comparison is strict, so a number never matches the wire's string.
 			 */
 			has(name: string, value?: string): boolean;
+			/**
+			 * Where the header sits in all(), case-insensitively, or -1 when it is absent. A { key } member from all() or one() is accepted in place of the name.
+			 */
+			indexOf(name: string): number;
+			/**
+			 * The header itself rather than its value, case-insensitively - undefined when it is absent. get() is the value half of the same lookup.
+			 */
+			one(name: string): { key: string; value: string } | undefined;
+			/**
+			 * A plain { name: value } object. Keys are lower-cased, as Postman's case-insensitive list does it; pass a truthy second argument to keep the stored spelling. Postman's other two switches decide nothing here - these headers hold no duplicate and no empty name.
+			 */
+			toObject(excludeDisabled?: boolean, caseSensitive?: boolean): Record<string, string>;
 		};
 		/**
 		 * Parse and return the response body as JSON.

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -3553,6 +3553,192 @@ TEST_F (ScriptEngineTest, ResponseHeadersHaveNoMutators) {
     EXPECT_EQ (env["remove"].value, "undefined");
 }
 
+TEST_F (ScriptEngineTest, HeaderPropertyListReadsWalkTheResponseHeaders) {
+    auto result = engine.execute_test (R"JS(
+        var seen = [];
+        pm.response.headers.each(function (header) { seen.push(header.key + '=' + header.value); });
+        pm.environment.set('each', seen.join('|'));
+        pm.environment.set('all',
+            pm.response.headers.all().map(function (h) { return h.key; }).join(','));
+        pm.environment.set('count', String(pm.response.headers.count()));
+        pm.environment.set('toObject', JSON.stringify(pm.response.headers.toObject()));
+        pm.environment.set('one', JSON.stringify(pm.response.headers.one('CONTENT-TYPE')));
+        pm.environment.set('absent', String(pm.response.headers.one('X-Absent')));
+        pm.environment.set('indexOf', String(pm.response.headers.indexOf('x-request-id')));
+        pm.environment.set('absentIndex', String(pm.response.headers.indexOf('X-Absent')));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["each"].value, "Content-Type=application/json|X-Request-Id=abc123");
+    EXPECT_EQ (env["all"].value, "Content-Type,X-Request-Id");
+    EXPECT_EQ (env["count"].value, "2");
+    EXPECT_EQ (env["toObject"].value,
+    R"({"content-type":"application/json","x-request-id":"abc123"})");
+    // `one` answers with the header, `get` with its value - and both find it
+    // whatever casing they are asked in.
+    EXPECT_EQ (env["one"].value, R"({"key":"Content-Type","value":"application/json"})");
+    EXPECT_EQ (env["absent"].value, "undefined");
+    EXPECT_EQ (env["indexOf"].value, "1");
+    EXPECT_EQ (env["absentIndex"].value, "-1");
+}
+
+TEST_F (ScriptEngineTest, HeaderPropertyListReadsWalkTheRequestHeaders) {
+    // The same six over the object the write-back reads. Asked in the opposite
+    // casing to the response test - stored upper, queried lower - so the two
+    // together pin the match in both directions rather than one.
+    auto result = engine.execute_prerequest (R"JS(
+        var seen = [];
+        pm.request.headers.each(function (header) { seen.push(header.key + '=' + header.value); });
+        pm.environment.set('each', seen.join('|'));
+        pm.environment.set('all',
+            pm.request.headers.all().map(function (h) { return h.key; }).join(','));
+        pm.environment.set('count', String(pm.request.headers.count()));
+        pm.environment.set('toObject', JSON.stringify(pm.request.headers.toObject()));
+        pm.environment.set('one', JSON.stringify(pm.request.headers.one('authorization')));
+        pm.environment.set('absent', String(pm.request.headers.one('X-Absent')));
+        pm.environment.set('indexOf', String(pm.request.headers.indexOf('content-type')));
+        pm.environment.set('absentIndex', String(pm.request.headers.indexOf('X-Absent')));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["each"].value, "Authorization=Bearer token123|Content-Type=application/json");
+    EXPECT_EQ (env["all"].value, "Authorization,Content-Type");
+    EXPECT_EQ (env["count"].value, "2");
+    EXPECT_EQ (env["toObject"].value,
+    R"({"authorization":"Bearer token123","content-type":"application/json"})");
+    // The member's key is the spelling the request holds, which is what
+    // `upsert` writes through - not the spelling it was asked for.
+    EXPECT_EQ (env["one"].value, R"({"key":"Authorization","value":"Bearer token123"})");
+    EXPECT_EQ (env["absent"].value, "undefined");
+    EXPECT_EQ (env["indexOf"].value, "1");
+    EXPECT_EQ (env["absentIndex"].value, "-1");
+}
+
+TEST_F (ScriptEngineTest, HeaderToObjectLowerCasesUnlessAskedNotTo) {
+    // postman-collection indexes a header list case-insensitively, so its
+    // `toObject()` lower-cases every key and only `caseSensitive` keeps the
+    // spelling. Copying this object's own keys instead would read as the
+    // harmless choice: `pm.request.headers` keeps whatever the user typed, so
+    // `toObject()['content-type']` would answer undefined here against a
+    // request carrying `Content-Type`, and the value in Postman.
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('lowered', pm.request.headers.toObject()['content-type']);
+        pm.environment.set('kept',
+            JSON.stringify(Object.keys(pm.request.headers.toObject(false, true))));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["lowered"].value, "application/json");
+    EXPECT_EQ (env["kept"].value, R"(["Authorization","Content-Type"])");
+}
+
+TEST_F (ScriptEngineTest, HeaderEachPassesPostmansArgumentsAndThis) {
+    // postman-collection's `each` is `_.forEach(members, iterator.bind(context))`,
+    // so the callback is handed the member, its index and the whole list, and
+    // the optional second argument becomes its `this`.
+    auto result = engine.execute_test (R"JS(
+        var shape = [];
+        pm.response.headers.each(function (header, index, all) {
+            shape.push([index, header.key, all.length, this.tag].join(':'));
+        }, { tag: 'bound' });
+        pm.environment.set('shape', shape.join('|'));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["shape"].value, "0:Content-Type:2:bound|1:X-Request-Id:2:bound");
+}
+
+TEST_F (ScriptEngineTest, HeaderIndexOfTakesAMemberAsWellAsAName) {
+    // Postman finds a member by identity in its own list; the members here are
+    // built per call, so the object form is matched by its key - which answers
+    // the same for a member of this list, and -1 for anything else.
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('member',
+            String(pm.response.headers.indexOf(pm.response.headers.all()[1])));
+        pm.environment.set('foreign',
+            String(pm.response.headers.indexOf({ key: 'X-Absent', value: '1' })));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["member"].value, "1");
+    EXPECT_EQ (env["foreign"].value, "-1");
+}
+
+TEST_F (ScriptEngineTest, HeaderPropertyListReadsRefuseBadInput) {
+    auto result = engine.execute_test (R"JS(
+        function reason(fn) {
+            try { fn(); return 'no throw'; } catch (e) { return String(e.message || e); }
+        }
+        pm.environment.set('eachNoFn', reason(function () { pm.response.headers.each(); }));
+        pm.environment.set('eachNumber', reason(function () { pm.response.headers.each(42); }));
+        pm.environment.set('oneNumber', reason(function () { pm.response.headers.one(42); }));
+        pm.environment.set('indexNumber', reason(function () { pm.response.headers.indexOf(42); }));
+        pm.environment.set('detached', reason(function () {
+            var all = pm.response.headers.all;
+            all();
+        }));
+        pm.environment.set('fromCallback', reason(function () {
+            pm.response.headers.each(function () { throw new Error('from the callback'); });
+        }));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_NE (env["eachNoFn"].value.find ("needs a function"), std::string::npos)
+    << env["eachNoFn"].value;
+    EXPECT_NE (env["eachNumber"].value.find ("got number"), std::string::npos)
+    << env["eachNumber"].value;
+    EXPECT_NE (env["oneNumber"].value.find ("needs a header name string"), std::string::npos)
+    << env["oneNumber"].value;
+    EXPECT_NE (env["indexNumber"].value.find ("needs a header name string"), std::string::npos)
+    << env["indexNumber"].value;
+    EXPECT_NE (
+    env["detached"].value.find ("must be called on a headers object"), std::string::npos)
+    << env["detached"].value;
+    // A throw out of the callback is the script's own, reported as it stands
+    // rather than wrapped as an `each` failure.
+    EXPECT_EQ (env["fromCallback"].value, "from the callback");
+}
+
+TEST_F (ScriptEngineTest, PreRequestHeaderEachWalksTheSetItStartedWith) {
+    // The member list is built once, so a callback that removes the header it
+    // was handed does not shorten the walk under itself.
+    auto result = engine.execute_prerequest (R"JS(
+        var seen = [];
+        pm.request.headers.each(function (header) {
+            seen.push(header.key);
+            pm.request.headers.remove(header.key);
+        });
+        pm.environment.set('seen', seen.join(','));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["seen"].value, "Authorization,Content-Type");
+    EXPECT_TRUE (request.headers.empty ());
+}
+
+TEST_F (ScriptEngineTest, PreRequestPropertyListReadsStayOffTheWire) {
+    // They are non-enumerable like the first five, so the write-back - which
+    // reads own enumerable string properties as the outgoing header set - never
+    // sees a header whose value is `each`.
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('count', String(pm.request.headers.count()));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["count"].value, "2");
+    ASSERT_EQ (request.headers.size (), 2u);
+    EXPECT_TRUE (request.headers.contains ("Authorization"));
+    EXPECT_TRUE (request.headers.contains ("Content-Type"));
+}
+
 TEST_F (ScriptEngineTest, ResponseReasonReportsTheStatusText) {
     response.status_code = 404;
     response.status_text = "Not Found";

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -228,6 +228,42 @@ TEST_F (SendRequestTest, DeliversTheResponseToTheCallback) {
     EXPECT_EQ (server.hit_count (), 1);
 }
 
+TEST_F (SendRequestTest, TheCallbackResponseCarriesTheHeaderPropertyListReads) {
+    // The third header object. It is built by the same `install_header_methods`
+    // the two pm.* ones are, so this is the assertion that keeps that true
+    // rather than a second surface drifting behind.
+    SendRequestServer server;
+
+    auto result = run ("var seen = {}; "
+                       "pm.sendRequest('" +
+    server.url ("/token") +
+    "', function (err, res) { "
+    "  seen.count = res.headers.count(); "
+    "  seen.keys = res.headers.all().map(function (h) { return h.key; }); "
+    "  seen.type = res.headers.toObject()['content-type']; "
+    "  seen.one = res.headers.one('CONTENT-TYPE').value; "
+    "  seen.index = res.headers.indexOf('X-Absent'); "
+    "  seen.walked = []; "
+    "  res.headers.each(function (h) { seen.walked.push(h.key); }); "
+    "  seen.enumerated = Object.keys(res.headers).length; "
+    "}); "
+    "pm.test('reads', function () { "
+    "  pm.expect(seen.count > 0).to.equal(true); "
+    "  pm.expect(seen.keys.length).to.equal(seen.count); "
+    "  pm.expect(seen.walked.length).to.equal(seen.count); "
+    // The methods are non-enumerable here too, so enumerating the object sees
+    // the headers and nothing else - the guard the two pm.* objects have.
+    "  pm.expect(seen.enumerated).to.equal(seen.count); "
+    "  pm.expect(seen.type).to.equal('application/json'); "
+    "  pm.expect(seen.one).to.equal('application/json'); "
+    "  pm.expect(seen.index).to.equal(-1); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
 TEST_F (SendRequestTest, OptionsObjectCarriesMethodHeadersAndBody) {
     SendRequestServer server;
 


### PR DESCRIPTION
## Description

`pm.response.headers`, `pm.request.headers` and the `res.headers` a `pm.sendRequest` callback is handed carried point lookups only - `get` and `has`, plus the three mutators on the request object. Postman's header objects are PropertyLists, so `pm.response.headers.each(...)`, an everyday idiom in an imported script, threw on a line that reads nothing.

**Root cause and approach.** The three objects are all built by one function, `install_header_methods`, which installed five members and no iteration. So the whole of the fix is six read methods added there, ahead of the `mutators` gate - which is also why the sendRequest response gets them with no second implementation to keep in step. The alternative I rejected was implementing the reads per surface, or reaching into the C++ `Headers` map behind each: the JS object is authoritative once built (the request one is what the write-back reads, and `add`/`upsert`/`remove` mutate it), so a read that consulted the map would answer about a header set the script had already changed. Every read enumerates the object's own enumerable properties, which is what `get`/`has` already do.

Three places where I implemented more than the issue's text, each verified against postman-collection's `property-list.js` and `header.js` rather than from memory:

1. **`toObject()` lower-cases its keys.** The issue called it "already-plain enumeration made explicit", and that is wrong: Postman's `toObject` lower-cases whenever the list is indexed case-insensitively, and a header list always is. Copying the object's own keys reads as harmless and is not - `pm.request.headers` keeps whatever the user typed, so `toObject()['content-type']` would answer `undefined` here against a request carrying `Content-Type`, and the value in Postman. That is the silent-wrong-answer class #996 exists to close, so it follows Postman. `caseSensitive` (the second positional argument) keeps the stored spelling; `excludeDisabled` and the two switches not taken decide nothing here, and the docs say so rather than leaving it to be discovered.
2. **`each` passes `(member, index, all)` and binds an optional `thisArg`** - what `_.forEach(members, iterator.bind(context))` does. Passing the member alone was the smaller change and would have handed `undefined` to a script reading the index. The member list is built once, so a callback that removes the header it was just handed does not shorten the walk under itself.
3. **`indexOf` accepts a `{ key }` member as well as a name.** Postman finds a member by identity in its own list; the members here are built per call, so identity would answer `-1` for a member of the very list it came from. Matching the key agrees with Postman for that case and still answers `-1` for an object naming a header this list does not hold.

Two cleanups the change carried rather than left: `find_header_key` was a hand-rolled second copy of `js_own_enumerable_keys`, the enumeration primitive already in this file - it and all six reads now share `header_key_order`, so no two of them can disagree about what the object holds or in what order; and the eight reads install from a table rather than eight near-identical calls, following `build_query_object` further down the same file.

What the object still cannot report is unchanged and stays documented beside the new methods: `Headers` is a single-valued case-insensitive map, so a name the server sent twice arrived folded with `", "` and the wire order went with it. `all()` reports the map's key order and never a duplicate. **No engine `Headers` type change here** - that is flagged on #996 as needing an owner decision, and the acceptance criteria require it stay out.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

Additive only - every existing header call keeps its behaviour, and a header field literally named after one of the new methods still wins over it, as it already did for the other five.

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2612 passed, 0 failed** (2596 on the base commit; the change adds 9 tests, 16 counting the parameterized expansions). No pre-existing failures on the base commit.

`cd app && pnpm test` - **5780 passed** across 532 files. `pnpm type-check` - clean on all three projects. `clang-format-19 --dry-run -Werror` and `clang-tidy-19` - clean on every touched file. `mkdocs build --strict` - builds.

New engine tests:

- `HeaderPropertyListReadsWalkTheResponseHeaders` and `HeaderPropertyListReadsWalkTheRequestHeaders` - all six on each object. The two ask in opposite casings (upper query against stored `Content-Type`, lower query against stored `Authorization`) so between them the match is pinned in both directions.
- `SendRequestTest.TheCallbackResponseCarriesTheHeaderPropertyListReads` - all six on the third object, plus `Object.keys(res.headers).length === count()`, which is the non-enumerability guard that surface never had.
- `HeaderToObjectLowerCasesUnlessAskedNotTo` - the default and the `caseSensitive` escape.
- `HeaderEachPassesPostmansArgumentsAndThis` - the index, the list and the bound `this`.
- `PreRequestHeaderEachWalksTheSetItStartedWith` - removing each header from inside the callback still walks both.
- `HeaderIndexOfTakesAMemberAsWellAsAName` - a member from `all()`, and a foreign object answering -1.
- `HeaderPropertyListReadsRefuseBadInput` - each refusal by message, including a throw out of an `each` callback propagating as the script's own error rather than being wrapped.
- `PreRequestPropertyListReadsStayOffTheWire` - asserts the sent `Request::headers` holds exactly the two it started with, which is the issue's explicit ask and rules out all six names reaching the wire.

The pre-existing `HeaderMethodsAreInvisibleToEnumerationAndJson` is untouched and re-verifies the new six stayed non-enumerable; `ScriptCompletions.EveryPmMemberTheRuntimeBindsIsOffered` discovers them by construction and fails if a completion entry is missing.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Both docs move in the same commit (`docs/engine/scripting.md`, `docs/app/pm-api-compatibility.md`), and the checked-in typedefs are regenerated from the completion table rather than hand-edited. Every signature parsed - none fell back to `...args: any[]`.

### Reviewed and not changed

Two review findings I judged and left, so they are on the record rather than silently dropped:

- **`one()` answers `undefined` when the enumeration itself fails with a pending exception, where the other five propagate it.** It shares `find_header_key` with `get` and `has`, which have always read that as "absent". `one` and `get` are two halves of one lookup and disagreeing about it would be worse than the inconsistency; the path is unreachable outside OOM. Changing it means changing `find_header_key`'s contract for five callers, which is not this issue's.
- **`header_name_lowered` is another hand-rolled ASCII fold.** It is the 29th across 19 files, and the engine has no primitive for it. Converting them from under one caller is not this diff - filed as **#1060**, and the helper's comment names that issue rather than saying "later".

## Related Issues

Closes #1005

Sub-issue of #996. Prerequisites verified live rather than from the Sequencing snapshot: #997 and #991, the two the program says land early, are both closed; master's head was `7105525`. The region is disjoint from every other live claim - #999's PR #1054 is the expectation class, #994 is `setup_pm_info`, #1051 and #1007 are `request_composer.cpp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7nZb57Wiqe83deYk843nG)_