### PR TITLE
feat(engine): pm.sendRequest composes auth and resolves {{variables}} - #1001

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -222,10 +222,27 @@ Postman's `header` array of `{ key, value }` or a plain object under either
 `header` or `headers`; sending both spellings at once is refused rather than
 resolved by precedence.
 
-`{{variables}}` in a script-supplied URL are **not** resolved. Interpolation
-happens strictly before the pre-request script and a payload is resolved exactly
-once; a second pass inside the script would break that. Use
-`pm.variables.replaceIn(template)`.
+`{{variables}}` in the script-supplied URL, header values, a raw body and an
+`auth` credential **are** resolved, as the call is made (issue #1001) - so a
+value the same script set two lines earlier is visible, which is Postman's rule
+and the reason an imported token-refresh script works. This is not a second pass
+over the composed payload: those fields were composed once, before the script
+ran, and nothing here revisits them. A name nothing defines keeps its braces
+rather than becoming empty, as everywhere else. Header *names* are sent as
+written - two that resolve to one name are a collision rule composition owns
+(issue #1051), and a second answer to it invented here would be one more place
+for the two to drift.
+
+`auth` takes Postman's `{ type, <type>: params }` shape, with the parameter block
+in either spelling - the exported `[{ key, value }]` array or a plain object.
+`basic`, `bearer` and `apikey` are composed by the engine's own auth resolver,
+the same one `POST /execute` sends through, so an api key sent as a query
+parameter is percent-encoded onto the URL exactly as it would be on the main
+request and an `Authorization` header the script set itself still wins. Every
+other type - `oauth2` included, whose token acquisition needs a database this
+path deliberately does not carry - is refused by name rather than dropped: a
+request that goes out unauthenticated because the sandbox skipped an option is
+the same silent wrong request the body modes are refused to prevent.
 
 ### Hashing (`pm.crypto`) is Vayu's own name, and it is synchronous
 

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -240,9 +240,11 @@ the same one `POST /execute` sends through, so an api key sent as a query
 parameter is percent-encoded onto the URL exactly as it would be on the main
 request and an `Authorization` header the script set itself still wins. Every
 other type - `oauth2` included, whose token acquisition needs a database this
-path deliberately does not carry - is refused by name rather than dropped: a
-request that goes out unauthenticated because the sandbox skipped an option is
-the same silent wrong request the body modes are refused to prevent.
+path deliberately does not carry - is refused by name rather than dropped, and so
+is a type whose parameter block is absent or misspelled, since `basic` requires
+neither of its halves and would otherwise compose an empty credential and send
+it. A request that goes out unauthenticated because the sandbox skipped an option
+is the same silent wrong request the body modes are refused to prevent.
 
 ### Hashing (`pm.crypto`) is Vayu's own name, and it is synchronous
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -958,10 +958,11 @@ and must be a function.
 
 | Option | Shape |
 | ------ | ----- |
-| `url` | string, required. Postman's URL-object form is not accepted |
+| `url` | string, required, or `pm.request.url` - the Url object, so `pm.sendRequest(pm.request.url, cb)` reads as "send this again". A hand-built `{ host, path }` object is still not accepted |
 | `method` | string, default `GET`; case-insensitive, an unknown verb throws |
 | `header` / `headers` | `{ name: value }` or Postman's `[{ key, value }]`. Both names read; sending both at once throws |
 | `body` | a string, or `{ mode: 'raw', raw }`. Only `raw` - other modes throw |
+| `auth` | Postman's `{ type, <type>: params }`. `basic`, `bearer`, `apikey`, `noauth`; any other type throws |
 | `timeout` | milliseconds, clamped to the script's remaining budget (below) |
 
 **Synchronous, and callback-shaped for that reason.** The send blocks and the
@@ -1008,11 +1009,48 @@ so a streaming send's pre- and post-request scripts are governed by exactly the
 bit a buffered send's are (issue #653). Pressing Send with the **Event stream**
 setting on and off gives `pm.sendRequest` the same answer.
 
-**No `{{variable}}` resolution.** A script-supplied URL is sent as written.
-This request was never composed - it is a URL the script spelled, not a field
-of the request the engine resolved - so there is nothing here to have left a
-token behind, and the residual pass the main send makes (#1008) does not run
-over it. Use `pm.variables.replaceIn(template)`.
+**`{{variables}}` resolve as the call is made** (#1001). The URL, each header
+value, a raw body and each credential of an `auth` block are resolved once,
+against the three scopes and the bound data row exactly as
+`pm.variables.replaceIn` reads them - so a value this same script set two lines
+earlier is visible, which is Postman's rule and what makes an imported
+token-refresh script work. It is not a second pass over the composed request:
+that payload was resolved before the script ran and nothing here revisits it.
+A name nothing defines keeps its braces (#1009), and a `{{data.column}}` the
+bound row lacks throws naming the column, the same way `replaceIn` does.
+
+Header **names** are sent as written. Two names that resolve to one name are a
+collision rule composition owns (#1051); answering it a second way here is how
+the two would drift.
+
+```javascript
+pm.environment.set("tenant", "acme");
+pm.sendRequest(
+  {
+    url: "{{baseUrl}}/{{tenant}}/token",
+    method: "POST",
+    auth: { type: "basic", basic: { username: "{{id}}", password: "{{secret}}" } },
+  },
+  function (err, res) {
+    if (err) {
+      return;
+    }
+    pm.environment.set("token", res.json().access_token);
+  }
+);
+```
+
+**`auth` is composed, or refused by name.** The block takes Postman's
+`{ type, <type>: params }` shape, with the parameters in either spelling Postman
+writes - the exported `[{ key, value }]` array, or a plain object. `basic`,
+`bearer` and `apikey` (`in: 'header'` by default, `'query'` for a parameter) go
+through `vayu::http::apply_auth`, the engine's one auth composer, so the header
+or the percent-encoded query parameter is the one every other send would have
+written, and an `Authorization` header the script set itself still wins. Every
+other type throws naming it - `oauth2` included, because acquiring its token
+needs the database this path deliberately does not carry. Dropping the option
+would send an unauthenticated request that looks like the script's own mistake,
+which is the reason the body modes are refused too.
 
 ## The cookie jar (`pm.cookies`)
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1048,9 +1048,12 @@ through `vayu::http::apply_auth`, the engine's one auth composer, so the header
 or the percent-encoded query parameter is the one every other send would have
 written, and an `Authorization` header the script set itself still wins. Every
 other type throws naming it - `oauth2` included, because acquiring its token
-needs the database this path deliberately does not carry. Dropping the option
-would send an unauthenticated request that looks like the script's own mistake,
-which is the reason the body modes are refused too.
+needs the database this path deliberately does not carry. So does a type whose
+block is not there: `{ type: 'basic' }` with no `basic` beside it, or the key
+misspelled, is refused rather than composed as the empty credential `basic`'s two
+optional halves would otherwise make of it. Dropping the option would send an
+unauthenticated request that looks like the script's own mistake, which is the
+reason the body modes are refused too.
 
 ## The cookie jar (`pm.cookies`)
 

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -1009,7 +1009,10 @@ nlohmann::json get_script_completions () {
     { "insertTextRules", INSERT_AS_SNIPPET },
     { "detail",
     "pm.sendRequest(urlOrOptions: string | { url: string; method?: string; "
-    "header?: object; body?: string | { mode: 'raw'; raw: string }; timeout?: "
+    "header?: object; headers?: object; body?: string | { mode: 'raw'; raw: "
+    "string }; auth?: { type: string; basic?: object; bearer?: object; "
+    "apikey?: "
+    "object }; timeout?: "
     "number }, callback: (err: Error | null, res: any) => void): void" },
     { "documentation",
     "Send an auxiliary request - fetching a token in a pre-request script is "
@@ -1020,7 +1023,16 @@ nlohmann::json get_script_completions () {
     "Transport failures - refused, DNS, timeout - arrive as err with a .code; "
     "res is null then. res carries code, status, responseTime, headers.get() "
     "and json()/text() - a subset of pm.response, not the assertion "
-    "chain.\n\nBounded on purpose: the request's timeout is capped "
+    "chain.\n\nThe url may be a string or pm.request.url, and {{variables}} in "
+    "it, in header values, in a raw body and in auth credentials resolve as "
+    "the "
+    "call is made - so a value this script set two lines earlier is visible. "
+    "Header names are sent as written.\n\nauth takes Postman's { type, <type>: "
+    "params } shape in either spelling, and composes basic, bearer and apikey. "
+    "Any other type - oauth2 included - is refused by name rather than "
+    "dropped, "
+    "and an Authorization header the script set itself wins.\n\nBounded on "
+    "purpose: the request's timeout is capped "
     "at whatever is left of the script's own time budget, and one script may "
     "issue at most 10 requests. Both throw when exceeded.\n\n**Not available "
     "to agents.** Vayu's MCP target allowlist is checked before the engine is "

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -34,6 +35,7 @@
 #include <utility>
 #include <vector>
 
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/form_body.hpp"
 #include "vayu/http/request_composer.hpp"
@@ -5169,18 +5171,12 @@ std::string describe_iteration_columns (const nlohmann::json& row) {
     return out.empty () ? "none" : out;
 }
 
-JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    (void)this_val;
-    if (argc < 1 || !JS_IsString (argv[0])) {
-        return JS_ThrowTypeError (ctx,
-        "pm.variables.replaceIn expects a string, e.g. "
-        "pm.variables.replaceIn(\"{{$guid}}\")");
-    }
-
-    const std::string input = js_to_string (ctx, argv[0]);
+// Every name a script can see, folded weakest scope first so a stronger one
+// overwrites - the same walk toObject() does, and the same answer get() would
+// give per name. Read at call time rather than at bind time, which is what
+// makes a write earlier in the same script visible here.
+vayu::http::VariableValues visible_variable_values (JSContext* ctx) {
     vayu::http::VariableValues values;
-    // Weakest scope first so a stronger one overwrites - the same walk
-    // toObject() does, and the same answer get() would give per name.
     for (auto it = std::rbegin (variables_precedence);
     it != std::rend (variables_precedence); ++it) {
         merge_visible_variables (
@@ -5188,6 +5184,22 @@ JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int a
             values[key] = variable.value;
         });
     }
+    return values;
+}
+
+// One resolution of `input` against everything the script can see: the three
+// scopes as they stand now, plus the bound data row's columns when the run has
+// one. `pm.variables.replaceIn` and `pm.sendRequest` both resolve through this,
+// so a script cannot get one answer from the template it renders and another
+// from the request it sends.
+//
+// @param missing_column receives the {{data.column}} name the bound row does
+//        not carry, when that is why the resolution failed.
+// @return the resolved text, or nullopt when a column was named and missing.
+std::optional<std::string> resolve_script_template (JSContext* ctx,
+const std::string& input,
+std::string& missing_column) {
+    const vayu::http::VariableValues values = visible_variable_values (ctx);
 
     auto* data = get_context_data (ctx);
     if (data == nullptr || data->iteration_data == nullptr ||
@@ -5195,7 +5207,7 @@ JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int a
         // No row to resolve against, so the namespace stays written as it
         // stands - what composition does, and what lets one script run in both
         // a data-driven run and a plain send.
-        return JS_NewString (ctx, vayu::http::resolve_template (input, values).c_str ());
+        return vayu::http::resolve_template (input, values);
     }
 
     vayu::http::DataRowColumns row;
@@ -5204,18 +5216,45 @@ JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int a
     }
 
     std::optional<std::string> missing;
-    const std::string resolved =
+    std::string resolved =
     vayu::http::resolve_template_with_data (input, values, row, missing);
     if (missing) {
-        // The bind-time rule, in the shape a script can catch: naming the token
-        // and the columns the row does carry, because the mistake is almost
-        // always a spelling and the answer is in the second half.
-        return JS_ThrowTypeError (ctx,
-        "pm.variables.replaceIn: {{%s}} names a column this data row does not "
-        "have (columns: %s)",
-        missing->c_str (), describe_iteration_columns (*data->iteration_data).c_str ());
+        missing_column = *missing;
+        return std::nullopt;
     }
-    return JS_NewString (ctx, resolved.c_str ());
+    return resolved;
+}
+
+// The bind-time rule, in the shape a script can catch: naming the token and the
+// columns the row does carry, because the mistake is almost always a spelling
+// and the answer is in the second half. One message for both callers, since
+// they resolve through one function and so must fail the same way.
+std::string
+missing_column_message (JSContext* ctx, const std::string& what, const std::string& column) {
+    auto* data = get_context_data (ctx);
+    const std::string columns = (data != nullptr && data->iteration_data != nullptr &&
+                                data->iteration_data->is_object ()) ?
+    describe_iteration_columns (*data->iteration_data) :
+    std::string ("none");
+    return what + ": {{" + column +
+    "}} names a column this data row does not have (columns: " + columns + ")";
+}
+
+JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1 || !JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx,
+        "pm.variables.replaceIn expects a string, e.g. "
+        "pm.variables.replaceIn(\"{{$guid}}\")");
+    }
+
+    std::string missing;
+    auto resolved = resolve_script_template (ctx, js_to_string (ctx, argv[0]), missing);
+    if (!resolved) {
+        return JS_ThrowTypeError (ctx, "%s",
+        missing_column_message (ctx, "pm.variables.replaceIn", missing).c_str ());
+    }
+    return JS_NewString (ctx, resolved->c_str ());
 }
 
 // Postman's pm.variables.set writes to the *local* scope: alive for one
@@ -5351,10 +5390,226 @@ read_send_request_body (JSContext* ctx, JSValueConst value, Body& out) {
     return std::nullopt;
 }
 
+// One auth block's parameters, by name.
+using AuthParameters = std::map<std::string, std::string>;
+
+// Postman writes an auth block in two shapes and a script may hand over either:
+// `[{ key, value }]` as an exported collection carries it, or `{ name: value }`
+// as a script hand-writes it. Both are read, for the same reason the header
+// option reads both spellings - a parameter silently vanishing is a request
+// sent with the wrong credential.
+std::optional<std::string> read_auth_parameters (JSContext* ctx,
+JSValueConst block,
+const std::string& type,
+AuthParameters& out) {
+    const std::string where = "pm.sendRequest options.auth." + type;
+    if (JS_IsUndefined (block) || JS_IsNull (block)) {
+        return std::nullopt;
+    }
+    // A scalar the block's own value: `{ type: 'bearer', bearer: 'tok' }` is
+    // not a shape Postman writes, and reading it as a token would guess which
+    // parameter was meant.
+    if (!JS_IsObject (block) || JS_IsFunction (ctx, block)) {
+        return where + " must be an object or an array of { key, value } entries, got " +
+        std::string (js_type_name (ctx, block));
+    }
+
+    const auto read_value = [&] (JSValueConst value, const std::string& name,
+                            std::optional<std::string>& reason) -> std::optional<std::string> {
+        if (JS_IsUndefined (value) || JS_IsNull (value)) {
+            return std::nullopt;
+        }
+        if (!JS_IsString (value) && !JS_IsNumber (value) && !JS_IsBool (value)) {
+            reason = where + "." + name + " must be a string, got " +
+            std::string (js_type_name (ctx, value));
+            return std::nullopt;
+        }
+        return js_to_string (ctx, value);
+    };
+
+    std::optional<std::string> reason;
+    if (JS_IsArray (block)) {
+        int64_t length = 0;
+        if (JS_GetLength (ctx, block, &length) < 0) {
+            return where + " could not be enumerated";
+        }
+        for (int64_t i = 0; i < length; i++) {
+            ScopedValue entry (ctx, JS_GetPropertyInt64 (ctx, block, i));
+            if (!JS_IsObject (entry.get ()) || JS_IsArray (entry.get ())) {
+                return where + " entries must be { key, value } objects, got " +
+                std::string (js_type_name (ctx, entry.get ()));
+            }
+            ScopedValue key (ctx, JS_GetPropertyStr (ctx, entry.get (), "key"));
+            if (!JS_IsString (key.get ())) {
+                return where + " entries need a string 'key', got " +
+                std::string (js_type_name (ctx, key.get ()));
+            }
+            const std::string name = js_to_string (ctx, key.get ());
+            ScopedValue value (ctx, JS_GetPropertyStr (ctx, entry.get (), "value"));
+            if (auto text = read_value (value.get (), name, reason)) {
+                out[name] = std::move (*text);
+            }
+            if (reason) {
+                return reason;
+            }
+        }
+        return std::nullopt;
+    }
+
+    for (const char* name : { "token", "username", "password", "key", "value", "in" }) {
+        ScopedValue value (ctx, JS_GetPropertyStr (ctx, block, name));
+        if (auto text = read_value (value.get (), name, reason)) {
+            out[name] = std::move (*text);
+        }
+        if (reason) {
+            return reason;
+        }
+    }
+    return std::nullopt;
+}
+
+// pm.sendRequest's `auth`, in Postman's own shape: `{ type, <type>: params }`.
+//
+// The three types the engine can compose become its typed `Auth`, applied by
+// `vayu::http::apply_auth` - the same function every other send here composes
+// credentials with, because a second copy of "Basic " + base64 in the script
+// layer would not receive that one's fixes. Every other type is refused by
+// name: dropping the option sends an unauthenticated request that looks like
+// the script's own mistake, which is the silent wrong request the body modes
+// are refused to prevent.
+std::optional<std::string>
+read_send_request_auth (JSContext* ctx, JSValueConst value, vayu::http::Auth& out) {
+    if (JS_IsUndefined (value) || JS_IsNull (value)) {
+        return std::nullopt;
+    }
+    if (!JS_IsObject (value) || JS_IsArray (value) || JS_IsFunction (ctx, value)) {
+        return "pm.sendRequest options.auth must be an object like "
+               "{ type: 'bearer', bearer: { token: '...' } }, got " +
+        std::string (js_type_name (ctx, value));
+    }
+
+    ScopedValue js_type (ctx, JS_GetPropertyStr (ctx, value, "type"));
+    if (!JS_IsString (js_type.get ())) {
+        return "pm.sendRequest options.auth needs a string 'type' (basic, "
+               "bearer, apikey or noauth), got " +
+        std::string (js_type_name (ctx, js_type.get ()));
+    }
+
+    const std::string type = js_to_string (ctx, js_type.get ());
+    if (type == "noauth" || type == "none") {
+        out = vayu::http::NoAuth{};
+        return std::nullopt;
+    }
+    if (type != "basic" && type != "bearer" && type != "apikey") {
+        // oauth2 included, and deliberately: acquiring a token needs the
+        // database this path does not have, so composing it here would either
+        // reach for state the sandbox has no business holding or send the
+        // request with no token at all.
+        return "pm.sendRequest options.auth type \"" + type +
+        "\" is not supported - the sandbox composes basic, bearer and apikey. "
+        "Build the credential yourself and set the header; the request is "
+        "refused rather than sent unauthenticated.";
+    }
+
+    AuthParameters params;
+    ScopedValue block (ctx, JS_GetPropertyStr (ctx, value, type.c_str ()));
+    if (auto reason = read_auth_parameters (ctx, block.get (), type, params)) {
+        return reason;
+    }
+    const auto parameter = [&params] (const std::string& name) {
+        const auto it = params.find (name);
+        return it == params.end () ? std::string () : it->second;
+    };
+
+    if (type == "bearer") {
+        std::string token = parameter ("token");
+        if (token.empty ()) {
+            return std::string ("pm.sendRequest options.auth.bearer needs a "
+                                "'token' - an empty one would send the header "
+                                "with nothing after \"Bearer\"");
+        }
+        out = vayu::http::BearerAuth{ std::move (token) };
+        return std::nullopt;
+    }
+    if (type == "basic") {
+        // Neither half is required: Postman sends an empty username or password
+        // as the empty string, and the pair is base64-encoded either way.
+        out = vayu::http::BasicAuth{ parameter ("username"), parameter ("password") };
+        return std::nullopt;
+    }
+
+    const std::string in = parameter ("in");
+    if (!in.empty () && in != "header" && in != "query") {
+        return "pm.sendRequest options.auth.apikey.in must be 'header' or "
+               "'query' (got \"" +
+        in + "\")";
+    }
+    std::string key = parameter ("key");
+    if (key.empty ()) {
+        return std::string (
+        "pm.sendRequest options.auth.apikey needs a 'key' - "
+        "the header name, or query parameter name, the "
+        "value is sent under");
+    }
+    out = vayu::http::ApiKeyAuth{ std::move (key), parameter ("value"), in == "query" };
+    return std::nullopt;
+}
+
+// Every string pm.sendRequest was handed, resolved once against the scopes the
+// script can see: the URL, each header value, a raw body, and each credential
+// of an auth block. Postman resolves these, and until #1001 Vayu sent them as
+// written - so `pm.sendRequest("{{baseUrl}}/token", cb)` was a wrong request
+// sent silently rather than a refusal. Resolving here rather than at parse time
+// is what gives it Postman's mid-script visibility: a value the same script set
+// two lines earlier is in the scopes this reads.
+//
+// Header *names* are deliberately left as written. Two names that resolve to
+// one are a collision rule composition owns (#1051), and a second answer to it
+// invented here is how the two drift.
+std::optional<std::string>
+interpolate_send_request (JSContext* ctx, Request& request, vayu::http::Auth& auth) {
+    const auto resolve = [ctx] (std::string& text,
+                         const std::string& what) -> std::optional<std::string> {
+        std::string missing;
+        auto resolved = resolve_script_template (ctx, text, missing);
+        if (!resolved) {
+            return missing_column_message (ctx, "pm.sendRequest " + what, missing);
+        }
+        text = std::move (*resolved);
+        return std::nullopt;
+    };
+
+    if (auto reason = resolve (request.url, "options.url")) {
+        return reason;
+    }
+    for (auto& [name, value] : request.headers) {
+        if (auto reason = resolve (value, "header '" + name + "'")) {
+            return reason;
+        }
+    }
+    if (request.body.mode == BodyMode::Text) {
+        if (auto reason = resolve (request.body.content, "options.body")) {
+            return reason;
+        }
+    }
+
+    // Driven by the walk `apply_auth` shares, so a credential cannot be
+    // resolved in one place and applied from another.
+    std::optional<std::string> failure;
+    vayu::http::walk_auth_credentials (
+    auth, [&] (std::string& credential, vayu::http::CredentialDestination) {
+        if (failure) {
+            return;
+        }
+        failure = resolve (credential, "options.auth");
+    });
+    return failure;
+}
+
 // Translate pm.sendRequest's first argument into a Request.
 // @return why it was rejected, or nullopt when `out` is filled.
 std::optional<std::string>
-build_send_request (JSContext* ctx, JSValueConst arg, Request& out) {
+build_send_request (JSContext* ctx, JSValueConst arg, Request& out, vayu::http::Auth& auth) {
     // A Url object here is `pm.sendRequest(pm.request.url, cb)`, which #991
     // made the natural spelling of "send this request again" - it has to be
     // read before the options-object branch, or the Url object falls into it
@@ -5454,7 +5709,8 @@ build_send_request (JSContext* ctx, JSValueConst arg, Request& out) {
         std::min (ms, static_cast<double> (std::numeric_limits<int>::max ())));
     }
 
-    return std::nullopt;
+    ScopedValue js_auth (ctx, JS_GetPropertyStr (ctx, arg, "auth"));
+    return read_send_request_auth (ctx, js_auth.get (), auth);
 }
 
 // The response a pm.sendRequest callback receives.
@@ -5548,8 +5804,22 @@ JSValue js_pm_send_request (JSContext* ctx, JSValueConst this_val, int argc, JSV
     }
 
     Request request;
-    if (auto reason = build_send_request (ctx, argv[0], request)) {
+    vayu::http::Auth auth = vayu::http::NoAuth{};
+    if (auto reason = build_send_request (ctx, argv[0], request, auth)) {
         return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+    }
+    if (auto reason = interpolate_send_request (ctx, request, auth)) {
+        return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+    }
+    // The engine's own composition rather than a second copy of it: a header
+    // the script set still wins, and an api key sent as a query parameter is
+    // percent-encoded onto the URL exactly as every other send does it. `db` is
+    // null because the three types this path accepts need none - oauth2, the
+    // one that would, is refused by name while the options are read.
+    if (const auto applied = vayu::http::apply_auth (request, auth, nullptr);
+        !applied.ok) {
+        return JS_ThrowPlainError (ctx,
+        "pm.sendRequest could not apply options.auth: %s", applied.message.c_str ());
     }
 
     // The script's wall-clock budget is enforced by a QuickJS interrupt handler

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -5513,6 +5513,16 @@ read_send_request_auth (JSContext* ctx, JSValueConst value, vayu::http::Auth& ou
 
     AuthParameters params;
     ScopedValue block (ctx, JS_GetPropertyStr (ctx, value, type.c_str ()));
+    if (JS_IsUndefined (block.get ()) || JS_IsNull (block.get ())) {
+        // A type naming a block that is not there - `{ type: 'basic' }`, or the
+        // key misspelled - is refused rather than read as an empty credential.
+        // Basic is why this is checked here rather than left to the per-type
+        // reads below: neither of its halves is required, so an absent block
+        // would compose `Basic Og==` and send it, which is the silent wrong
+        // request in the one shape the required-field checks cannot see.
+        return "pm.sendRequest options.auth names type \"" + type +
+        "\" but carries no options.auth." + type + " block to read it from";
+    }
     if (auto reason = read_auth_parameters (ctx, block.get (), type, params)) {
         return reason;
     }
@@ -5817,7 +5827,7 @@ JSValue js_pm_send_request (JSContext* ctx, JSValueConst this_val, int argc, JSV
     // null because the three types this path accepts need none - oauth2, the
     // one that would, is refused by name while the options are read.
     if (const auto applied = vayu::http::apply_auth (request, auth, nullptr);
-        !applied.ok) {
+    !applied.ok) {
         return JS_ThrowPlainError (ctx,
         "pm.sendRequest could not apply options.auth: %s", applied.message.c_str ());
     }

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -1074,6 +1074,10 @@ declare const pm: {
 	 * 
 	 * The callback gets (err, res). Transport failures - refused, DNS, timeout - arrive as err with a .code; res is null then. res carries code, status, responseTime, headers.get() and json()/text() - a subset of pm.response, not the assertion chain.
 	 * 
+	 * The url may be a string or pm.request.url, and {{variables}} in it, in header values, in a raw body and in auth credentials resolve as the call is made - so a value this script set two lines earlier is visible. Header names are sent as written.
+	 * 
+	 * auth takes Postman's { type, <type>: params } shape in either spelling, and composes basic, bearer and apikey. Any other type - oauth2 included - is refused by name rather than dropped, and an Authorization header the script set itself wins.
+	 * 
 	 * Bounded on purpose: the request's timeout is capped at whatever is left of the script's own time budget, and one script may issue at most 10 requests. Both throw when exceeded.
 	 * 
 	 * **Not available to agents.** Vayu's MCP target allowlist is checked before the engine is called, so a request sent from inside a script would bypass it. When a run comes from the MCP server this throws instead of sending.
@@ -1084,7 +1088,7 @@ declare const pm: {
 	 *   pm.environment.set('token', res.json().access_token);
 	 * });
 	 */
-	sendRequest(urlOrOptions: string | { url: string; method?: string; header?: object; body?: string | { mode: 'raw'; raw: string }; timeout?: number }, callback: (err: Error | null, res: any) => void): void;
+	sendRequest(urlOrOptions: string | { url: string; method?: string; header?: object; headers?: object; body?: string | { mode: 'raw'; raw: string }; auth?: { type: string; basic?: object; bearer?: object; apikey?: object }; timeout?: number }, callback: (err: Error | null, res: any) => void): void;
 	/**
 	 * Define a test with assertions. The test name appears in results.
 	 * 

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -65,6 +65,12 @@ class SendRequestServer {
             echo["body"]   = req.body;
             echo["marker"] = req.get_header_value ("X-Marker");
             echo["type"]   = req.get_header_value ("Content-Type");
+            // The three an auth block can land in: the composed Authorization
+            // line, an api key's own header, and the target with its query,
+            // which is where an api key sent as a parameter shows up.
+            echo["auth"]   = req.get_header_value ("Authorization");
+            echo["apikey"] = req.get_header_value ("X-Api-Key");
+            echo["target"] = req.target;
             res.set_content (echo.dump (), "application/json");
         });
 
@@ -270,6 +276,218 @@ TEST_F (SendRequestTest, PostmanArrayHeaderFormIsAccepted) {
     EXPECT_TRUE (result.success) << result.error_message;
     ASSERT_EQ (result.tests.size (), 1u);
     EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// `pm.request.url` is a Url object since #991, and "send this request again" is
+// the idiom that reads it - so the whole-argument form has to take one. Pinned
+// here because nothing asserted it in either direction (issue #1001).
+TEST_F (SendRequestTest, PmRequestUrlIsAcceptedAsTheWholeArgument) {
+    SendRequestServer server;
+    request.url = server.url ("/token");
+
+    auto result = run ("var body = null; "
+                       "pm.sendRequest(pm.request.url, function (err, res) { "
+                       "  body = res.json(); "
+                       "}); "
+                       "pm.test('sent', function () { "
+                       "  pm.expect(body.access_token).to.equal('tok_123'); "
+                       "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (server.hit_count (), 1);
+}
+
+// ============================================================================
+// options.auth - composed by the engine's own resolver, refused by name where
+// it cannot be composed (issue #1001)
+// ============================================================================
+
+TEST_F (SendRequestTest, AuthBasicComposesTheAuthorizationHeader) {
+    SendRequestServer server;
+
+    auto result = run ("var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  auth: { type: 'basic', basic: { username: 'alice', password: 's3cret' } "
+    "} "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.auth).to.equal('Basic YWxpY2U6czNjcmV0'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// Postman's array spelling of the parameter block, and the token written as a
+// variable the same script set two lines earlier - the two halves an imported
+// token-refresh script depends on.
+TEST_F (SendRequestTest, AuthBearerReadsTheArrayFormAndResolvesTheToken) {
+    SendRequestServer server;
+
+    auto result = run ("pm.environment.set('tok', 'tok_123'); "
+                       "var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  auth: { type: 'bearer', bearer: [{ key: 'token', value: '{{tok}}' }] } "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.auth).to.equal('Bearer tok_123'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+TEST_F (SendRequestTest, AuthApiKeyGoesWhereItsInSays) {
+    SendRequestServer server;
+
+    auto result = run ("var header = null; var query = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  auth: { type: 'apikey', apikey: { key: 'X-Api-Key', value: 'k123' } } "
+    "}, function (err, res) { header = res.json(); }); "
+    "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  auth: { type: 'apikey', apikey: [{ key: 'key', value: 'api_key' }, "
+    "    { key: 'value', value: 'k123' }, { key: 'in', value: 'query' }] } "
+    "}, function (err, res) { query = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(header.apikey).to.equal('k123'); "
+    "  pm.expect(query.target.indexOf('api_key=k123') >= 0).to.equal(true); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// The engine's rule, reached rather than restated: a header the caller wrote
+// wins over the credential auth would compose into the same line.
+TEST_F (SendRequestTest, AHeaderTheScriptSetWinsOverTheAuthOption) {
+    SendRequestServer server;
+
+    auto result = run ("var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  header: { 'Authorization': 'Token abc' }, "
+    "  auth: { type: 'bearer', bearer: { token: 'tok_123' } } "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.auth).to.equal('Token abc'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// The silent drop this issue exists to close: before #1001 an `auth` block the
+// sandbox could not compose was ignored and the request went out
+// unauthenticated. Restore the drop and this reddens - the send succeeds.
+TEST_F (SendRequestTest, AnAuthTypeTheSandboxCannotComposeIsRefusedByName) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" + server.url ("/echo") +
+    "', method: 'POST', "
+    "  auth: { type: 'oauth2', oauth2: { accessToken: 'x' } } "
+    "}, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("oauth2"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0)
+    << "an auth block the sandbox cannot compose was dropped and the request "
+       "sent unauthenticated";
+}
+
+TEST_F (SendRequestTest, AnAuthBlockMissingItsCredentialIsRefused) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" + server.url ("/echo") +
+    "', method: 'POST', auth: { type: 'bearer', bearer: {} } "
+    "}, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("token"), std::string::npos) << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0);
+}
+
+// ============================================================================
+// {{variables}} in script-supplied strings (issue #1001)
+// ============================================================================
+
+TEST_F (SendRequestTest, ScriptSuppliedStringsResolveAsTheCallIsMade) {
+    SendRequestServer server;
+
+    auto result = run ("pm.environment.set('base', '" + server.url ("") +
+    "'); "
+    "pm.environment.set('marker', 'from-variable'); "
+    "pm.environment.set('payload', 'body-from-variable'); "
+    "var echo = null; "
+    "pm.sendRequest({ url: '{{base}}/echo', method: 'POST', "
+    "  header: { 'X-Marker': '{{marker}}' }, body: '{{payload}}' "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.marker).to.equal('from-variable'); "
+    "  pm.expect(echo.body).to.equal('body-from-variable'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (server.hit_count (), 1);
+}
+
+// #1009's pass-through rule, which this resolution inherits rather than
+// replaces: a name nothing defines keeps its braces instead of becoming empty.
+TEST_F (SendRequestTest, ANameNothingDefinesKeepsItsBraces) {
+    SendRequestServer server;
+
+    auto result = run ("var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', header: { 'X-Marker': '{{nothing_defines_this}}' } "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.marker).to.equal('{{nothing_defines_this}}'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// Resolution makes a variable's bytes header text, so the line-forging refusal
+// has to cover them - it does, because the send goes through the same
+// `validate_transferable` gate every other transfer does.
+TEST_F (SendRequestTest, AResolvedValueThatWouldForgeAHeaderIsRefused) {
+    SendRequestServer server;
+
+    auto result =
+    run ("pm.environment.set('marker', 'ok\\r\\nX-Injected: yes'); "
+         "var seen = ''; "
+         "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', header: { 'X-Marker': '{{marker}}' } "
+    "}, function (err) { seen = err ? err.message : ''; }); "
+    "pm.test('refused', function () { "
+    "  pm.expect(seen.indexOf('forging a header') >= 0).to.equal(true); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (server.hit_count (), 0);
 }
 
 // ============================================================================

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -358,11 +358,14 @@ TEST_F (SendRequestTest, AuthApiKeyGoesWhereItsInSays) {
     server.url ("/echo") +
     "', method: 'POST', "
     "  auth: { type: 'apikey', apikey: [{ key: 'key', value: 'api_key' }, "
-    "    { key: 'value', value: 'k123' }, { key: 'in', value: 'query' }] } "
+    "    { key: 'value', value: 'k 1&2' }, { key: 'in', value: 'query' }] } "
     "}, function (err, res) { query = res.json(); }); "
     "pm.test('sent', function () { "
     "  pm.expect(header.apikey).to.equal('k123'); "
-    "  pm.expect(query.target.indexOf('api_key=k123') >= 0).to.equal(true); "
+    // Percent-encoded by the same append_query_param every other send writes a
+    // query credential with - a raw '&' here would start a parameter of its own.
+    "  pm.expect(query.target.indexOf('api_key=k%201%262') >= "
+    "0).to.equal(true); "
     "});");
 
     EXPECT_TRUE (result.success) << result.error_message;
@@ -422,6 +425,23 @@ TEST_F (SendRequestTest, AnAuthBlockMissingItsCredentialIsRefused) {
     EXPECT_EQ (server.hit_count (), 0);
 }
 
+// Basic is the type with no required parameter - Postman sends an empty half as
+// the empty string - so a block that is not there at all has to be caught by
+// its absence, or a misspelled key composes `Basic Og==` and sends it.
+TEST_F (SendRequestTest, AnAuthTypeWithNoBlockToReadIsRefused) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" + server.url ("/echo") +
+    "', method: 'POST', auth: { type: 'basic', Basic: { username: 'alice' } } "
+    "}, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("no options.auth.basic block"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0)
+    << "a credential the script misspelled was sent as an empty one";
+}
+
 // ============================================================================
 // {{variables}} in script-supplied strings (issue #1001)
 // ============================================================================
@@ -433,19 +453,25 @@ TEST_F (SendRequestTest, ScriptSuppliedStringsResolveAsTheCallIsMade) {
     "'); "
     "pm.environment.set('marker', 'from-variable'); "
     "pm.environment.set('payload', 'body-from-variable'); "
-    "var echo = null; "
+    "var text = null; var raw = null; "
     "pm.sendRequest({ url: '{{base}}/echo', method: 'POST', "
     "  header: { 'X-Marker': '{{marker}}' }, body: '{{payload}}' "
-    "}, function (err, res) { echo = res.json(); }); "
+    "}, function (err, res) { text = res.json(); }); "
+    // The same body under Postman's object spelling, which is the shape an
+    // imported script carries.
+    "pm.sendRequest({ url: '{{base}}/echo', method: 'POST', "
+    "  body: { mode: 'raw', raw: '{{payload}}' } "
+    "}, function (err, res) { raw = res.json(); }); "
     "pm.test('sent', function () { "
-    "  pm.expect(echo.marker).to.equal('from-variable'); "
-    "  pm.expect(echo.body).to.equal('body-from-variable'); "
+    "  pm.expect(text.marker).to.equal('from-variable'); "
+    "  pm.expect(text.body).to.equal('body-from-variable'); "
+    "  pm.expect(raw.body).to.equal('body-from-variable'); "
     "});");
 
     EXPECT_TRUE (result.success) << result.error_message;
     ASSERT_EQ (result.tests.size (), 1u);
     EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
-    EXPECT_EQ (server.hit_count (), 1);
+    EXPECT_EQ (server.hit_count (), 2);
 }
 
 // #1009's pass-through rule, which this resolution inherits rather than
@@ -453,13 +479,18 @@ TEST_F (SendRequestTest, ScriptSuppliedStringsResolveAsTheCallIsMade) {
 TEST_F (SendRequestTest, ANameNothingDefinesKeepsItsBraces) {
     SendRequestServer server;
 
-    auto result = run ("var echo = null; "
+    // A defined name beside the undefined one, so this reddens if resolution
+    // stops running at all rather than only when the pass-through rule breaks.
+    auto result = run ("pm.environment.set('type', 'application/json'); "
+                       "var echo = null; "
                        "pm.sendRequest({ url: '" +
     server.url ("/echo") +
-    "', method: 'POST', header: { 'X-Marker': '{{nothing_defines_this}}' } "
+    "', method: 'POST', header: { 'X-Marker': '{{nothing_defines_this}}', "
+    "  'Content-Type': '{{type}}' } "
     "}, function (err, res) { echo = res.json(); }); "
     "pm.test('sent', function () { "
     "  pm.expect(echo.marker).to.equal('{{nothing_defines_this}}'); "
+    "  pm.expect(echo.type).to.equal('application/json'); "
     "});");
 
     EXPECT_TRUE (result.success) << result.error_message;


### PR DESCRIPTION
## Description

Three gaps an imported Postman script meets at `pm.sendRequest`, two of them the silent-wrong-request class #996 was opened for.

**The plan.** Root cause: `build_send_request` read five option keys and refused every unsupported field by name except `auth`, which it never looked for - so an imported token-refresh script sent an unauthenticated request and looked like it had worked; and script-supplied strings were sent as written, so `{{baseUrl}}/token` went out with its braces. The approach is to reach the engine's own machinery from the sandbox rather than grow a second copy of it: the auth block becomes `vayu::http::Auth` and is applied by `vayu::http::apply_auth` (the composer `POST /execute` sends through, so a header the script set still wins and a query api key is percent-encoded the one way this engine does it), and interpolation goes through the same `resolve_script_template` that `pm.variables.replaceIn` now calls, so the two cannot answer one name two ways. The alternative rejected: composing `"Basic " + base64` and scanning for `{{tokens}}` locally in `script_engine.cpp`, which is smaller to write and is exactly the hand-rolled copy that never receives the primitive's fixes - it would have missed the `Authorization`-already-set rule, the query percent-encoding, and #1009's pass-through rule.

**Deliberate deviations from the issue text, and why**

1. **The issue's third claim was already false.** It says a `Url`-object url throws; #991 made `pm.sendRequest(pm.request.url, cb)` work, and nothing asserted it in either direction. The code needed no change, so this PR pins it with a test and corrects `docs/engine/scripting.md`'s `url` row, which still claimed the opposite.
2. **`oauth2` is refused rather than composed**, though the engine supports it elsewhere: acquiring its token needs a `Database` this path deliberately does not carry, so the honest answer is a refusal naming the type, not a request sent with no token.
3. **Header *names* are not interpolated**, only values. Two names that resolve to one name are the collision rule #1051 is deciding right now; answering it a second way here is how the two would drift. Named in both docs.
4. **An auth type whose parameter block is absent is refused** (second commit, from the review pass). `basic` requires neither half, so `{ type: 'basic' }` with the key missing or misspelled composed `Basic Og==` and sent it - the same silent wrong request, in the one shape the per-type required-field checks cannot see.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2614 tests, 2614 passed, 0 failed**, up from 2603 on master (11 new).

- 11 new cases in `engine/tests/script_send_request_test.cpp`, every credential observed on the wire at the mock listener (`Authorization`, the api key's own header, the request target with its query) rather than engine-side.
- Mutation-checked: with the `auth` read and the interpolation pass reverted, 7 of them redden. The three that do not are contract pins rather than mutation tests, and two of those gained a second assertion in the follow-up commit so they now fail under a reverted build too.
- `pnpm vitest run src/hooks/script-typedefs.docs-compile.test.ts` - 2 passed (the guard that type-checks the docs' example blocks against the generated `.d.ts`).
- `mkdocs build --strict` clean; `scripts/pre-commit` (clang-format-19 + clang-tidy-19, whole file) clean on every touched source.
- No TypeScript changed, so `pnpm type-check` and the full app suite were not run. The issue's "App changes" section says none are needed, and the trace confirmed it: the app fetches its declarations from `GET /scripting/types` at runtime, so the completion table in `engine/src/http/routes/scripting.cpp` and the checked-in `engine/tests/fixtures/script-typedefs.d.ts` (regenerated with `VAYU_UPDATE_SCRIPT_TYPEDEFS=1`) are the whole of the client-visible surface, and both MCP scripting resources re-serve them unchanged.
- No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1001

---
_Generated by [Claude Code](https://claude.ai/code/session_019n42gHKuTw6CNRxUuBjg7W)_