### PR TITLE
feat(engine): cookie API completion - getAll, Date expires, cookie-bearing callbacks - #1002

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -26,7 +26,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
-| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear(url?)`, see below |
+| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()`, `.each(fn)`, `.all()`, `.count()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`getAll`/`set`/`unset`/`clear(url?)`, see below |
 | Response assertions | `pm.response.to.have.status(code \| reason)`, `.header(name[, value])`, `.body(expected)`, `.jsonBody(path?[, value])`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url` (Postman's `Url` object - `protocol`/`host`/`port`/`path`/`hash`/`query`, `getHost()`, `getPath()`, `getQueryString()`, `update()`), `.method`, `.headers`, `.body` |
 | Request headers     | `pm.request.headers.get(name)`, `.has(name[, value])`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
@@ -449,13 +449,25 @@ way on screen and another in a script.
 pm.cookies.get('session');   // value, or undefined
 pm.cookies.has('session');   // boolean
 pm.cookies.toObject();       // { session: 'abc' }
+pm.cookies.each(function (cookie) { /* ... */ });  // whole cookie objects
+pm.cookies.all();            // array of cookie objects
+pm.cookies.count();          // number
 ```
 
 The read half of Postman's `pm.cookies`, over a jar the engine keeps for
 design-mode requests: a `Set-Cookie` on one request is sent on the next one
 automatically. What these answer is matched against **this request's URL** -
 domain, path, `Secure` and expiry - so they report what will go on the wire and
-not everything stored.
+not everything stored. `each`, `all()` and `count()` are Postman's CookieList
+reads, over that same matched set, read fresh on every call.
+
+A cookie object - what `each`, `all()`, `jar().getAll()` and `jar().set`'s
+callback all hand back - carries `name` and `key` (same value, both spellings),
+`value`, `domain`, `path`, `secure`, `httpOnly`, `hostOnly`, `session`
+(booleans), and `expires` (a `Date`, or `null` for a session cookie). Postman's
+`maxAge` and its unmodelled `extensions` are not modelled - the jar does not
+keep them. Full field list in
+[scripting.md](../engine/scripting.md#the-cookie-jar-pmcookies).
 
 The write half is `pm.cookies.jar()`, Postman's own jar object:
 
@@ -463,14 +475,18 @@ The write half is `pm.cookies.jar()`, Postman's own jar object:
 const jar = pm.cookies.jar();
 jar.set(pm.request.url, { name: 'session', value: token });  // or (url, name, value)
 jar.get('https://api.example.com/', 'session');              // value, or undefined
+jar.getAll('https://api.example.com/');                      // every cookie that URL would carry
 jar.unset('https://api.example.com/', 'session');
 jar.clear('https://api.example.com/');                       // that URL's cookies
 jar.clear();                                                 // this environment's jar
 ```
 
-Every method is URL-scoped and takes an optional trailing `callback(err, value)`,
-invoked inline. A written cookie's `domain` and `path` default from the URL, and
-it is then matched by exactly the rules a received cookie is.
+Every method is URL-scoped and takes an optional trailing callback, invoked
+inline, that carries what the call did: `get` the value, `getAll` the array,
+`set` the **stored** cookie object (domain/path filled in from the URL), `unset`
+the removed name, `clear` nothing. Each is also the method's return value. A
+written cookie's `domain` and `path` default from the URL, and it is then
+matched by exactly the rules a received cookie is.
 
 Divergences from Postman:
 
@@ -486,14 +502,22 @@ Divergences from Postman:
   with no URL is Vayu's own** and empties this environment's jar, because the
   environment is Vayu's scope unit. A URL the engine cannot parse is refused
   rather than cleared as a wipe matching nothing.
-- **`expires` is seconds since the epoch**, not a date string.
+- **`getAll` and `pm.cookies.all()` return a plain array**, not Postman's
+  `CookieList` - the same divergence `pm.response.cookies` already makes, for
+  the same reason: an array is what every other cookie surface here, and a
+  plain `for (const c of ...)`, treats it as.
+- **`expires` takes a `Date`, a date string, or a whole number of seconds
+  since the epoch** - all three read the way the same script's own
+  `new Date(...)` would, since the Date and the string are parsed by QuickJS's
+  own `Date` rather than a parser written into the engine.
 - **Scope is the environment**, not the domain-with-permission model Postman
   uses. One jar per environment plus one for "no environment", in memory only,
   clearable in Settings → General → Cookies.
 - **`pm.sendRequest` shares the jar** with the request around it, so logging in
   from a pre-request script leaves the session where the real request finds it.
-- **Load runs have no jar**, and these throw there rather than answering
-  `undefined` - see [scripting.md](../engine/scripting.md#the-cookie-jar-pmcookies).
+- **Load runs have no jar**, and every read and write here throws there rather
+  than answering `undefined` - see
+  [scripting.md](../engine/scripting.md#the-cookie-jar-pmcookies).
 
 ---
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1020,12 +1020,41 @@ over it. Use `pm.variables.replaceIn(template)`.
 pm.cookies.get('session');      // value, or undefined
 pm.cookies.has('session');      // boolean
 pm.cookies.toObject();          // { session: 'abc' }
+pm.cookies.each(function (cookie) { console.log(cookie.name); });
+pm.cookies.all();               // array of cookie objects
+pm.cookies.count();             // number
 ```
 
 `pm.cookies` is what the engine is holding *for this request's URL* - matched on
 domain, path, `Secure` and expiry, exactly as it will be sent. It is what makes
 "log in once, reuse the session" work: a `Set-Cookie` on one request is carried
 to the next one automatically, with no header to set by hand.
+
+**`each`, `all()` and `count()`** are Postman's CookieList reads, over the same
+matched set `get`/`has`/`toObject` answer over - what this request's URL would
+carry. Each call reads the jar afresh, so a `jar().set` earlier in the script is
+visible by the time one of these runs. `each(fn, context?)` calls `fn` once per
+cookie with the whole cookie object (below), `context` becoming the iterator's
+`this`; a throw from `fn` - a failed `pm.expect` inside it, most likely - ends
+the walk and is the script's error rather than being swallowed. `all()` returns
+an array of cookie objects, `count()` the number of them.
+
+A cookie object - what `each`, `all()`, `jar().getAll()` (below) and
+`jar().set`'s callback all hand back - carries:
+
+| Field | Value |
+|-------|-------|
+| `name`, `key` | the cookie's name, under both spellings. Postman's `Cookie` calls it `key`; both are present, same value |
+| `value` | the cookie's value |
+| `domain`, `path` | where it is scoped |
+| `secure`, `httpOnly` | booleans |
+| `hostOnly` | `true` when the cookie answers for that host only, `false` when it answers for subdomains too |
+| `session` | `true` for a session cookie |
+| `expires` | a `Date`, or `null` for a session cookie |
+
+Postman's `maxAge` and its unmodelled `extensions` are deliberately absent: the
+jar does not keep them, and a field with nothing behind it is a value a script
+would read and act on.
 
 - **One jar per environment**, plus one for requests sent with no environment
   selected. A staging session therefore cannot ride along on a production call
@@ -1037,10 +1066,11 @@ to the next one automatically, with no header to set by hand.
 - **`pm.sendRequest` shares the jar** of the request it runs inside. A
   pre-request script that logs in through it leaves the session where the real
   request will find it.
-- **Load runs have no jar.** These three throw there rather than answering
-  `undefined`, which would read as "the cookie is gone". The jar is deliberately
-  off the load path: sharing one across the event loop's workers would put a
-  lock on the hot path, and a load run repeats a single request anyway.
+- **Load runs have no jar.** Every one of these reads throws there rather than
+  answering `undefined`, which would read as "the cookie is gone". The jar is
+  deliberately off the load path: sharing one across the event loop's workers
+  would put a lock on the hot path, and a load run repeats a single request
+  anyway.
 - **Writing goes through `jar()`**, below. There is deliberately no flat
   `pm.cookies.set(name, value)`: a written cookie needs a URL to take its
   domain and path from, which is exactly why Postman's write half hangs off
@@ -1057,18 +1087,32 @@ const jar = pm.cookies.jar();
 jar.set(pm.request.url, { name: 'session', value: token });
 jar.set(pm.request.url, 'session', token);            // the same, flat
 jar.get('https://api.example.com/', 'session');        // value, or undefined
+jar.getAll('https://api.example.com/');                 // every cookie that URL would carry
 jar.unset('https://api.example.com/', 'session');
 jar.clear('https://api.example.com/');                 // that URL's cookies
 jar.clear();                                           // this environment's jar
 ```
 
-Postman's jar object, whole. Every method is **URL-scoped** - it takes the URL
-the cookie belongs to rather than assuming this request's (`clear`'s URL is
-optional; see below) - and each accepts an
-optional trailing `callback(err, value)`, invoked inline the way
-[`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest)'s is,
-since the work has already happened by the time it is called. `get` also
-*returns* the value, which a synchronous implementation can do honestly.
+Postman's jar object, whole - **`getAll`** is new, Postman's "dump the session"
+read: every cookie a request to that URL would carry, as an array, whole. It is
+exactly what `get(url, name)` matches, without a name to narrow it - the same
+domain/path/`Secure`/expiry rules, the same per-environment jar, and a cookie
+this script has already staged with `set` is included. Every method is
+**URL-scoped** - it takes the URL the cookie belongs to rather than assuming
+this request's (`clear`'s URL is optional; see below) - and each accepts an
+optional trailing callback, invoked inline the way
+[`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest)'s is, since
+the work has already happened by the time it is called. What the callback
+carries, and what the call itself returns, is what that call did - there is no
+longer one shape for all five:
+
+| Method | Callback / return |
+|--------|--------------------|
+| `get(url, name)` | the value, or `undefined` |
+| `getAll(url)` | every matching cookie, as an array of cookie objects |
+| `set(url, cookie)` | the **stored** cookie object - the one thing this call knows and the script does not, since it carries the domain and path derived from the URL where `cookie` left them out |
+| `unset(url, name)` | the removed name |
+| `clear(url?)` | `undefined` - there is nothing left to describe |
 
 The cookie object needs `name` and `value`; everything else is optional and
 defaults from the URL:
@@ -1078,14 +1122,27 @@ defaults from the URL:
 | `domain` | the URL's host, host-only. A leading dot (`.example.com`) means subdomains too |
 | `path` | RFC 6265 default-path - the URL's path with its last segment removed, so `/v1/orders/42` gives `/v1/orders` |
 | `secure`, `httpOnly` | `false` |
-| `expires` | `0`, a session cookie. Otherwise **seconds since the epoch** - `Math.floor(date.getTime() / 1000)` |
+| `expires` | `0`, a session cookie. Otherwise a `Date`, a date string, or a whole number of seconds since the epoch |
+
+**`expires` takes three spellings**, matching Postman: a `Date`; a date string -
+anything JavaScript's own `Date.parse` accepts, an ISO 8601 or an HTTP date; or
+a whole number of seconds since the epoch, `0` still meaning a session cookie.
+The Date and the string are read by asking QuickJS's own `Date` (`getTime` and
+`Date.parse`) rather than a date parser written into the engine, so the answer
+here is the one the same script's own `new Date(s)` would give. Because a
+stored cookie reads back with `expires` as a `Date` (above), and `set` now
+takes a `Date`, a cookie can be read and written back with nothing to convert.
 
 Anything else is refused with an error rather than guessed at: a non-string
-`value`, a `secure: "yes"`, a date string in `expires`, a field carrying a tab
-or newline (the separators of the format the jar stores), or a URL that cannot
-be parsed. A cookie stored under the wrong domain reads as "the session did not
-stick" three requests later, which is a much worse afternoon than a thrown
-error.
+`value`, a `secure: "yes"`, a field carrying a tab or newline (the separators
+of the format the jar stores), or a URL that cannot be parsed. `expires` has
+its own refusals, loud ones: an Invalid Date, a string `Date.parse` cannot
+read, a **fractional** number of seconds - `date.getTime() / 1000` without the
+floor, which the message names both cures for (pass the `Date` itself, or keep
+the `Math.floor`) - a value before the epoch, and one further in the future than
+the jar can store. A cookie stored under the
+wrong domain reads as "the session did not stick" three requests later, which
+is a much worse afternoon than a thrown error.
 
 **A written cookie is matched by the same rules a received one is.** Setting it
 for one host does not send it to another, `/admin` does not reach `/`, and the

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -1074,14 +1074,44 @@ nlohmann::json get_script_completions () {
     "object." },
     { "sortText", "1_pm_cookies_to_object" } });
 
+    // Postman's CookieList reads. Where get/has/toObject answer about a name
+    // or a value, these hand back whole cookies - what a script needs to see
+    // the domain, path or expiry it is actually holding.
+    completions.push_back ({ { "label", "pm.cookies.each" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.each((${1:cookie}) => {\n\t$0\n})" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.cookies.each(fn: Function, context?: any): void" },
+    { "documentation",
+    "Call fn once per stored cookie that would be sent to this URL, with the "
+    "whole cookie: { name, key, value, domain, path, secure, httpOnly, "
+    "hostOnly, session, expires }. A throw from fn ends the walk and is the "
+    "script's error.\n\nExample:\npm.cookies.each(c => "
+    "console.log(c.name, c.domain));" },
+    { "sortText", "1_pm_cookies_each" } });
+
+    completions.push_back ({ { "label", "pm.cookies.all" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.all()" }, { "detail", "pm.cookies.all(): object[]" },
+    { "documentation",
+    "Every stored cookie that would be sent to this URL, whole, as an array. "
+    "Where toObject() answers with names and values alone, these carry the "
+    "domain, path, secure, httpOnly, hostOnly, session and expires the jar "
+    "holds." },
+    { "sortText", "1_pm_cookies_all" } });
+
+    completions.push_back ({ { "label", "pm.cookies.count" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.count()" }, { "detail", "pm.cookies.count(): number" },
+    { "documentation", "How many stored cookies would be sent to this URL." },
+    { "sortText", "1_pm_cookies_count" } });
+
     // pm.cookies.jar() - the write half (#337). Offered one level deeper than
     // the flat reads because every method is URL-scoped: the URL is what a
     // written cookie's domain and path come from.
     completions.push_back ({ { "label", "pm.cookies.jar" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.cookies.jar()" }, { "detail", "pm.cookies.jar(): object" },
     { "documentation",
-    "Postman's cookie jar object - the write half, plus a URL-scoped read. "
-    "get(url, name), set(url, cookie), unset(url, name) and clear(url) all "
+    "Postman's cookie jar object - the write half, plus two URL-scoped reads. "
+    "get(url, name), getAll(url), set(url, cookie), unset(url, name) and "
+    "clear(url) all "
     "take the URL the cookie belongs to rather than assuming this request's; "
     "clear() with no URL empties this environment's jar.\n\nA "
     "write is applied after the transfer it was made before, so the request "
@@ -1102,15 +1132,32 @@ nlohmann::json get_script_completions () {
     "callback as (null, value)." },
     { "sortText", "1_pm_cookies_jar_get" } });
 
+    completions.push_back ({ { "label", "pm.cookies.jar().getAll" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.jar().getAll(\"${1:https://api.example.com}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.cookies.jar().getAll(url: string, callback?: Function): object[]" },
+    { "documentation",
+    "Every stored cookie that would be sent to that URL, whole - the same "
+    "matching get() makes, without a name to narrow it, and cookies this "
+    "script has just set are included. Each carries { name, key, value, "
+    "domain, path, secure, httpOnly, hostOnly, session, expires }. The array "
+    "is returned and also handed to the optional callback as (null, "
+    "cookies).\n\nExample:\nconst jar = pm.cookies.jar();\nfor (const c of "
+    "jar.getAll(pm.request.url)) console.log(c.name, c.path);" },
+    { "sortText", "1_pm_cookies_jar_get_all" } });
+
     completions.push_back ({ { "label", "pm.cookies.jar().set" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.cookies.jar().set(\"${1:https://api.example.com}\", { name: \"${2:session}\", value: ${3:token} })" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.cookies.jar().set(url: string, cookie: object | string, value?: string | Function, callback?: Function): void" },
+    { "detail", "pm.cookies.jar().set(url: string, cookie: object | string, value?: string | Function, callback?: Function): object" },
     { "documentation",
     "Store a cookie for that URL. The cookie object needs name and value; "
-    "domain, path, secure, httpOnly and expires (seconds since the epoch, 0 "
-    "for a session cookie) are optional and default from the URL. "
-    "set(url, name, value) is accepted too.\n\nThe cookie is matched by the "
+    "domain, path, secure, httpOnly and expires are optional and default from "
+    "the URL. expires takes a Date, a date string Date.parse accepts, or a "
+    "whole number of seconds since the epoch - 0 for a session cookie. "
+    "set(url, name, value) is accepted too.\n\nThe stored cookie is returned "
+    "and handed to the optional callback as (null, cookie), carrying the "
+    "domain and path it took from the URL.\n\nThe cookie is matched by the "
     "same rules a received one is, so setting it for one host does not send "
     "it to another." },
     { "sortText", "1_pm_cookies_jar_set" } });
@@ -1118,10 +1165,11 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.cookies.jar().unset" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.cookies.jar().unset(\"${1:https://api.example.com}\", \"${2:session}\")" },
     { "insertTextRules", INSERT_AS_SNIPPET },
-    { "detail", "pm.cookies.jar().unset(url: string, name: string, callback?: Function): void" },
+    { "detail", "pm.cookies.jar().unset(url: string, name: string, callback?: Function): string" },
     { "documentation",
     "Remove the cookies of that name the URL would have carried. Cookies of "
-    "the same name stored for another host or path are left alone." },
+    "the same name stored for another host or path are left alone. The removed "
+    "name is returned and handed to the optional callback as (null, name)." },
     { "sortText", "1_pm_cookies_jar_unset" } });
 
     completions.push_back ({ { "label", "pm.cookies.jar().clear" },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -5691,6 +5691,61 @@ find_jar_cookie (const std::vector<vayu::http::JarCookie>& cookies, const std::s
     return best;
 }
 
+// A stored cookie as the object Postman's Cookie is - everything the jar keeps
+// and nothing it does not. `maxAge` and the unmodelled extensions Postman
+// carries have no field behind them here, and inventing one would hand a script
+// a value it could read and act on.
+JSValue create_jar_cookie_object (JSContext* ctx, const vayu::http::JarCookie& cookie) {
+    JSValue obj = JS_NewObject (ctx);
+    if (JS_IsException (obj)) {
+        return obj;
+    }
+    JS_SetPropertyStr (ctx, obj, "name", JS_NewString (ctx, cookie.name.c_str ()));
+    // Postman's Cookie spells the name `key` and keeps `name` beside it. A
+    // script imported from there reads either, and the one that answered
+    // undefined would do it silently.
+    JS_SetPropertyStr (ctx, obj, "key", JS_NewString (ctx, cookie.name.c_str ()));
+    JS_SetPropertyStr (ctx, obj, "value", JS_NewString (ctx, cookie.value.c_str ()));
+    JS_SetPropertyStr (ctx, obj, "domain", JS_NewString (ctx, cookie.domain.c_str ()));
+    JS_SetPropertyStr (ctx, obj, "path", JS_NewString (ctx, cookie.path.c_str ()));
+    JS_SetPropertyStr (ctx, obj, "secure", JS_NewBool (ctx, cookie.secure));
+    JS_SetPropertyStr (ctx, obj, "httpOnly", JS_NewBool (ctx, cookie.http_only));
+    // The jar stores "does this answer for subdomains too"; Postman states the
+    // same fact the other way round, and a script tests hostOnly.
+    JS_SetPropertyStr (ctx, obj, "hostOnly", JS_NewBool (ctx, !cookie.include_subdomains));
+    // A session cookie has no expiry rather than one at the epoch, so `expires`
+    // is null there and `session` is what says which. Otherwise it is the Date
+    // Postman's Cookie carries - and the Date jar().set now takes, so a cookie
+    // read here can be written back without converting it.
+    const bool session = cookie.expires == 0;
+    JS_SetPropertyStr (ctx, obj, "session", JS_NewBool (ctx, session));
+    JS_SetPropertyStr (ctx, obj, "expires",
+    session ? JS_NULL : JS_NewDate (ctx, static_cast<double> (cookie.expires) * 1000.0));
+    return obj;
+}
+
+// The matched cookies as a plain array. Postman hands back a CookieList, whose
+// reads are the ones pm.cookies itself carries; an array is what both this
+// engine's other cookie surface (pm.response.cookies) and every `for (const c
+// of ...)` in an imported script treat it as.
+JSValue create_jar_cookie_list (JSContext* ctx,
+const std::vector<vayu::http::JarCookie>& cookies) {
+    JSValue list = JS_NewArray (ctx);
+    if (JS_IsException (list)) {
+        return list;
+    }
+    uint32_t index = 0;
+    for (const auto& cookie : cookies) {
+        JSValue entry = create_jar_cookie_object (ctx, cookie);
+        if (JS_IsException (entry)) {
+            JS_FreeValue (ctx, list);
+            return JS_EXCEPTION;
+        }
+        JS_SetPropertyUint32 (ctx, list, index++, entry);
+    }
+    return list;
+}
+
 JSValue js_jar_cookies_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
     auto name = read_cookie_name_arg (ctx, "get", argc, argv);
@@ -5736,6 +5791,61 @@ JSValue js_jar_cookies_to_object (JSContext* ctx, JSValueConst this_val, int arg
         JS_NewString (ctx, chosen->value.c_str ()));
     }
     return obj;
+}
+
+// The three PropertyList reads Postman's CookieList carries. They answer over
+// the same matched set get/has/toObject answer over, read afresh per call: the
+// flat pm.cookies is an accessor onto a jar a jar().set can change mid-script,
+// so a list built once and kept would answer with the set as it was.
+JSValue js_jar_cookies_all (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto cookies = jar_cookies_from_context (ctx, "all");
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    return create_jar_cookie_list (ctx, *cookies);
+}
+
+JSValue js_jar_cookies_count (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto cookies = jar_cookies_from_context (ctx, "count");
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    return JS_NewInt64 (ctx, static_cast<int64_t> (cookies->size ()));
+}
+
+JSValue js_jar_cookies_each (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1 || !JS_IsFunction (ctx, argv[0])) {
+        return JS_ThrowTypeError (ctx, "pm.cookies.each(fn) needs a function, got %s",
+        argc < 1 ? "no argument" : js_type_name (ctx, argv[0]));
+    }
+    auto cookies = jar_cookies_from_context (ctx, "each");
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    // PropertyList.each takes the iterator's `this` as its second argument.
+    JSValue receiver = argc > 1 ? argv[1] : JS_UNDEFINED;
+    for (const auto& cookie : *cookies) {
+        ScopedValue entry (ctx, create_jar_cookie_object (ctx, cookie));
+        if (JS_IsException (entry.get ())) {
+            return JS_EXCEPTION;
+        }
+        JSValue args[1] = { entry.get () };
+        // A throw from the iterator - a failed pm.expect inside it, most
+        // likely - is the script's error and ends the walk, rather than being
+        // swallowed to finish iterating.
+        ScopedValue ret (ctx, JS_Call (ctx, argv[0], receiver, 1, args));
+        if (JS_IsException (ret.get ())) {
+            return JS_EXCEPTION;
+        }
+    }
+    return JS_UNDEFINED;
 }
 
 // ----------------------------------------------------------------------------
@@ -5796,6 +5906,102 @@ bool url_arg = false) {
         return std::nullopt;
     }
     return text;
+}
+
+// Milliseconds since the epoch out of a JS value that is either a Date or the
+// result of Date.parse, or nullopt for an Invalid Date. Any pending exception
+// is cleared: this reports its outcome as a refusal reason, which the caller
+// throws, and a second exception left standing behind that one would be the
+// error a script sees.
+std::optional<double> js_epoch_milliseconds (JSContext* ctx, JSValue millis) {
+    ScopedValue held (ctx, millis);
+    if (JS_IsException (held.get ())) {
+        JS_FreeValue (ctx, JS_GetException (ctx));
+        return std::nullopt;
+    }
+    double value = 0;
+    if (JS_ToFloat64 (ctx, &value, held.get ()) < 0) {
+        JS_FreeValue (ctx, JS_GetException (ctx));
+        return std::nullopt;
+    }
+    // An Invalid Date - `new Date("not a date")` - is NaN rather than a throw.
+    return std::isfinite (value) ? std::optional<double> (value) : std::nullopt;
+}
+
+// What a script wrote in `expires`, as the seconds since the epoch the jar
+// stores. Three spellings, because Postman takes all three: a number of
+// seconds, a Date, and a date string.
+//
+// The Date and the string are read by asking QuickJS's own Date - `getTime`
+// and `Date.parse` - rather than parsing text here. A date parser beside the
+// language's own would answer differently from the `new Date(s)` the same
+// script can write two lines up, and the disagreement would show as a cookie
+// that expires in 1970 and is simply never sent again.
+std::optional<std::string>
+read_expires_seconds (JSContext* ctx, JSValueConst value, int64_t& out) {
+    const std::string prefix = "pm.cookies.jar().set cookie.expires ";
+    // Every arm below either returns a reason or sets this, so the checks
+    // after them read a value all three agree on rather than three copies.
+    double seconds = 0;
+
+    if (JS_IsNumber (value)) {
+        double written = 0;
+        if (JS_ToFloat64 (ctx, &written, value) < 0 || !std::isfinite (written)) {
+            JS_FreeValue (ctx, JS_GetException (ctx));
+            return prefix + "must be a finite number of seconds since the epoch";
+        }
+        // A number is seconds exactly as written, and a fractional one is
+        // refused rather than truncated: `getTime() / 1000` without the floor
+        // is the shape it arrives in, and this surface refuses everywhere else
+        // it cannot be sure. The message names both cures.
+        if (written != std::floor (written)) {
+            return prefix +
+            "is not a whole number of seconds; pass a Date, or "
+            "Math.floor(date.getTime() / 1000)";
+        }
+        seconds = written;
+    } else if (JS_IsDate (value)) {
+        // Not JS_ToFloat64 on the Date itself: its @@toPrimitive takes the
+        // default hint as "string", so a Date coerces to NaN rather than to
+        // its time. getTime is what the script would have called.
+        ScopedValue get_time (ctx, JS_GetPropertyStr (ctx, value, "getTime"));
+        const auto millis = js_epoch_milliseconds (
+        ctx, JS_Call (ctx, get_time.get (), value, 0, nullptr));
+        if (!millis) {
+            return prefix + "is an Invalid Date";
+        }
+        seconds = std::floor (*millis / 1000.0);
+    } else if (JS_IsString (value)) {
+        const std::string text = js_to_string (ctx, value);
+        ScopedValue global (ctx, JS_GetGlobalObject (ctx));
+        ScopedValue date (ctx, JS_GetPropertyStr (ctx, global.get (), "Date"));
+        ScopedValue parse (ctx, JS_GetPropertyStr (ctx, date.get (), "parse"));
+        ScopedValue arg (ctx, JS_NewString (ctx, text.c_str ()));
+        JSValue args[1]   = { arg.get () };
+        const auto millis = js_epoch_milliseconds (
+        ctx, JS_Call (ctx, parse.get (), date.get (), 1, args));
+        if (!millis) {
+            return prefix + "is not a date this engine can read: \"" + text +
+            "\". Date.parse must accept it - an ISO 8601 or HTTP date does.";
+        }
+        seconds = std::floor (*millis / 1000.0);
+    } else {
+        return prefix +
+        "must be a number of seconds since the epoch, a Date, "
+        "or a date string, got " +
+        std::string (js_type_name (ctx, value));
+    }
+
+    if (seconds < 0) {
+        return prefix + "must not be before the epoch; 0 means a session cookie";
+    }
+    // The jar stores an int64_t, and a double past its range converts as
+    // undefined behaviour rather than as a large number.
+    if (seconds > static_cast<double> (std::numeric_limits<int64_t>::max ())) {
+        return prefix + "is further in the future than the jar can store";
+    }
+    out = static_cast<int64_t> (seconds);
+    return std::nullopt;
 }
 
 // `set`'s cookie object: `{ name, value, domain?, path?, secure?, httpOnly?,
@@ -5872,26 +6078,9 @@ read_jar_cookie_arg (JSContext* ctx, JSValueConst arg, vayu::http::JarCookie& ou
 
     ScopedValue js_expires (ctx, JS_GetPropertyStr (ctx, arg, "expires"));
     if (!JS_IsUndefined (js_expires.get ()) && !JS_IsNull (js_expires.get ())) {
-        // Seconds since the epoch, which is what the jar stores and what a
-        // Netscape line carries. A Date or a date string is refused with the
-        // conversion rather than guessed at, because guessing wrong writes a
-        // cookie that expires in 1970 and is simply never sent again.
-        if (!JS_IsNumber (js_expires.get ())) {
-            return "pm.cookies.jar().set cookie.expires must be a number of "
-                   "seconds since the epoch (use Math.floor(date.getTime() / "
-                   "1000)), got " +
-            std::string (js_type_name (ctx, js_expires.get ()));
+        if (auto reason = read_expires_seconds (ctx, js_expires.get (), out.expires)) {
+            return reason;
         }
-        int64_t seconds = 0;
-        if (JS_ToInt64 (ctx, &seconds, js_expires.get ()) < 0) {
-            return std::string ("pm.cookies.jar().set cookie.expires is not a "
-                                "whole number of seconds");
-        }
-        if (seconds < 0) {
-            return std::string ("pm.cookies.jar().set cookie.expires must not "
-                                "be negative; 0 means a session cookie");
-        }
-        out.expires = seconds;
     }
     return std::nullopt;
 }
@@ -5977,6 +6166,29 @@ JSValue js_jar_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueCons
     cookie ? JS_NewString (ctx, cookie->value.c_str ()) : JS_UNDEFINED);
 }
 
+// Postman's "dump the session" read: every cookie that URL would carry, rather
+// than the one that answers for a name. The same walk get() makes, without the
+// name to narrow it - so the matching, the staged writes it sees and the jar's
+// per-environment isolation are get()'s, not a second set of rules.
+JSValue js_jar_get_all (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto url = read_jar_string_arg (ctx, "getAll", "URL", 0, argc, argv, /*url_arg=*/true);
+    if (!url) {
+        return JS_EXCEPTION;
+    }
+    auto* data = jar_context (ctx, "jar().getAll");
+    if (!data) {
+        return JS_EXCEPTION;
+    }
+
+    const auto cookies = vayu::http::matching_in (staged_jar_lines (*data), *url);
+    JSValue list = create_jar_cookie_list (ctx, cookies);
+    if (JS_IsException (list)) {
+        return list;
+    }
+    return finish_jar_call (ctx, argc, argv, 1, list);
+}
+
 JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
     auto url = read_jar_string_arg (ctx, "set", "URL", 0, argc, argv, /*url_arg=*/true);
@@ -6027,7 +6239,11 @@ JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueCons
     }
     writes->push_back ({ vayu::http::CookieWrite::Kind::Set,
     vayu::http::format_cookie_line (*stored), {}, {} });
-    return finish_jar_call (ctx, argc, argv, callback_index, JS_UNDEFINED);
+    // Postman hands the callback the cookie it stored, which is the one thing
+    // this call knows and the script does not: the domain and path it took
+    // from the URL, where the object left them out.
+    return finish_jar_call (
+    ctx, argc, argv, callback_index, create_jar_cookie_object (ctx, *stored));
 }
 
 JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
@@ -6047,9 +6263,12 @@ JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     if (!writes) {
         return JS_EXCEPTION;
     }
-    writes->push_back ({ vayu::http::CookieWrite::Kind::Unset, {},
-    std::move (*url), std::move (*name) });
-    return finish_jar_call (ctx, argc, argv, 2, JS_UNDEFINED);
+    writes->push_back (
+    { vayu::http::CookieWrite::Kind::Unset, {}, std::move (*url), *name });
+    // The removed name, where set hands back the stored cookie. There is no
+    // cookie left to describe, and Postman's own callback carries nothing at
+    // all here - a name is the most this can honestly report.
+    return finish_jar_call (ctx, argc, argv, 2, JS_NewString (ctx, name->c_str ()));
 }
 
 JSValue js_jar_clear (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
@@ -6111,6 +6330,8 @@ JSValue js_cookies_jar (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     (void)argv;
     JSValue jar = JS_NewObject (ctx);
     JS_SetPropertyStr (ctx, jar, "get", JS_NewCFunction (ctx, js_jar_get, "get", 3));
+    JS_SetPropertyStr (
+    ctx, jar, "getAll", JS_NewCFunction (ctx, js_jar_get_all, "getAll", 2));
     JS_SetPropertyStr (ctx, jar, "set", JS_NewCFunction (ctx, js_jar_set, "set", 4));
     JS_SetPropertyStr (ctx, jar, "unset", JS_NewCFunction (ctx, js_jar_unset, "unset", 3));
     JS_SetPropertyStr (ctx, jar, "clear", JS_NewCFunction (ctx, js_jar_clear, "clear", 2));
@@ -6127,6 +6348,12 @@ void setup_pm_cookies (JSContext* ctx, JSValue pm) {
     ctx, cookies, "has", JS_NewCFunction (ctx, js_jar_cookies_has, "has", 1));
     JS_SetPropertyStr (ctx, cookies, "toObject",
     JS_NewCFunction (ctx, js_jar_cookies_to_object, "toObject", 0));
+    JS_SetPropertyStr (
+    ctx, cookies, "each", JS_NewCFunction (ctx, js_jar_cookies_each, "each", 2));
+    JS_SetPropertyStr (
+    ctx, cookies, "all", JS_NewCFunction (ctx, js_jar_cookies_all, "all", 0));
+    JS_SetPropertyStr (ctx, cookies, "count",
+    JS_NewCFunction (ctx, js_jar_cookies_count, "count", 0));
     JS_SetPropertyStr (
     ctx, cookies, "jar", JS_NewCFunction (ctx, js_cookies_jar, "jar", 0));
     JS_SetPropertyStr (ctx, pm, "cookies", cookies);

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -464,6 +464,96 @@ TEST (CookieJarScript, PmCookiesReadsTheJarForTheRequestsUrl) {
     EXPECT_EQ (env["absent"].value, "undefined");
 }
 
+TEST (CookieJarScript, PmCookiesReadsWholeCookiesThroughEachAllAndCount) {
+    // get/has/toObject answer about a name or a value; these hand back the
+    // cookie, which is the only way a script sees the domain, path or expiry
+    // it is actually holding. They read the same matched set, so a cookie for
+    // another host stays out of all three.
+    CookieJar jar;
+    jar.store ("env_a",
+    { netscape_line ("example.com", "FALSE", "/", "FALSE",
+      std::to_string (FAR_FUTURE), "session", "abc"),
+    netscape_line ("example.com", "FALSE", "/admin", "FALSE",
+    std::to_string (FAR_FUTURE), "admin", "xyz"),
+    netscape_line ("other.example", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "elsewhere", "no") });
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request = get_request ("http://example.com/admin/users");
+    vayu::Response response;
+    vayu::Environment env;
+
+    vayu::runtime::ScriptContext ctx;
+    ctx.request      = &request;
+    ctx.response     = &response;
+    ctx.environment  = &env;
+    ctx.cookie_jar   = &jar;
+    ctx.cookie_scope = "env_a";
+
+    auto result = engine.execute (
+    "pm.environment.set('count', String(pm.cookies.count()));"
+    "pm.environment.set('all', pm.cookies.all().map(c => "
+    "c.name).sort().join(','));"
+    "const seen = [];"
+    "pm.cookies.each(c => seen.push(c.name + '@' + c.path));"
+    "pm.environment.set('each', seen.sort().join(','));"
+    "const one = pm.cookies.all().find(c => c.name === 'session');"
+    "pm.environment.set('shape', [one.key, one.value, one.domain, one.path, "
+    "one.secure, one.httpOnly, one.hostOnly, one.session, "
+    "one.expires.getTime() / 1000].join('|'));"
+    // The reads arrive; the flat writers deliberately do not, since a written
+    // cookie needs a URL to take its domain and path from. Both docs say so,
+    // and nothing said it here until the reads made this object worth adding
+    // to by hand.
+    "pm.environment.set('writers', ['set', 'unset', 'clear']"
+    "  .filter(m => typeof pm.cookies[m] !== 'undefined').join(','));",
+    ctx);
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["count"].value, "2")
+    << "the other host's cookie was counted";
+    EXPECT_EQ (env["all"].value, "admin,session");
+    EXPECT_EQ (env["each"].value, "admin@/admin,session@/");
+    // `key` is Postman's spelling of the name, and `expires` is the Date its
+    // Cookie carries - both read by an imported script, and both silently
+    // undefined before this.
+    EXPECT_EQ (env["shape"].value,
+    "session|abc|example.com|/|false|false|true|false|" + std::to_string (FAR_FUTURE));
+    EXPECT_EQ (env["writers"].value, "")
+    << "a flat writer both docs call absent is reachable from a script";
+}
+
+TEST (CookieJarScript, PmCookiesEachReportsAThrowFromItsIterator) {
+    // A failed pm.expect inside the iterator is the script's verdict. Swallowed
+    // to finish the walk, it would be a test that passed by not being run.
+    CookieJar jar;
+    jar.store ("env_a",
+    { netscape_line ("example.com", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "session", "abc") });
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request = get_request ("http://example.com/users");
+    vayu::Response response;
+    vayu::Environment env;
+
+    vayu::runtime::ScriptContext ctx;
+    ctx.request      = &request;
+    ctx.response     = &response;
+    ctx.environment  = &env;
+    ctx.cookie_jar   = &jar;
+    ctx.cookie_scope = "env_a";
+
+    auto thrown = engine.execute (
+    "pm.cookies.each(() => { throw new Error('from the iterator'); });", ctx);
+    EXPECT_FALSE (thrown.success);
+    EXPECT_NE (thrown.error_message.find ("from the iterator"), std::string::npos)
+    << thrown.error_message;
+
+    auto no_function = engine.execute ("pm.cookies.each('nope');", ctx);
+    EXPECT_FALSE (no_function.success);
+    EXPECT_NE (no_function.error_message.find ("needs a function"), std::string::npos)
+    << no_function.error_message;
+}
+
 TEST (CookieJarScript, PmCookiesSaysWhyWhenThereIsNoJar) {
     // A load run's test scripts land here. An empty answer would read as "the
     // cookie is gone" and send someone hunting the wrong bug.
@@ -627,6 +717,68 @@ TEST (CookieJarWrite, ACookieAScriptSetIsOnTheWireOfTheRequestItWasSetFor) {
     // now makes about the two features meeting.
     EXPECT_NE (sent.raw_request.find ("session=written"), std::string::npos)
     << "the raw-request view did not show the written cookie; got: " << sent.raw_request;
+}
+
+TEST (CookieJarWrite, JarGetAllAnswersEveryCookieTheUrlWouldCarry) {
+    // The same walk get() makes, without a name to narrow it - so it sees a
+    // cookie this script has just staged, and does not see one stored for
+    // another host.
+    CookieJar jar;
+    jar.store ("env_a",
+    { netscape_line ("example.com", "FALSE", "/", "FALSE",
+      std::to_string (FAR_FUTURE), "session", "abc"),
+    netscape_line ("other.example", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "elsewhere", "no") });
+    vayu::Environment env;
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "const jar = pm.cookies.jar();"
+    "jar.set('http://example.com/', { name: 'fresh', value: 'v' });"
+    "const all = jar.getAll('http://example.com/');"
+    "pm.environment.set('names', all.map(c => c.name).sort().join(','));"
+    "jar.getAll('http://example.com/', (err, cookies) => {"
+    "  pm.environment.set('cb', String(err) + ':' + cookies.length);"
+    "});"
+    "pm.environment.set('elsewhere', "
+    "String(jar.getAll('http://other.example/').map(c => c.name).join(',')));",
+    "http://example.com/users", env);
+
+    ASSERT_EQ (error, "");
+    EXPECT_EQ (env["names"].value, "fresh,session")
+    << "getAll did not see the cookie staged two lines above it";
+    EXPECT_EQ (env["cb"].value, "null:2");
+    EXPECT_EQ (env["elsewhere"].value, "elsewhere")
+    << "getAll answered with cookies the URL would not have carried";
+}
+
+TEST (CookieJarWrite, TheWriteCallbacksCarryWhatTheCallStored) {
+    // Postman's (error, cookie). The stored cookie is the one thing the call
+    // knows and the script does not: the domain and path it took from the URL
+    // where the object left them out.
+    CookieJar jar;
+    vayu::Environment env;
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "const jar = pm.cookies.jar();"
+    "const stored = jar.set('http://example.com/v1/orders/42', "
+    "  { name: 'session', value: 'abc' }, (err, cookie) => {"
+    "    pm.environment.set('set_cb', "
+    "      [String(err), cookie.name, cookie.domain, cookie.path].join('|'));"
+    "  });"
+    "pm.environment.set('set_ret', "
+    "  [stored.key, stored.value, String(stored.session)].join('|'));"
+    "const removed = jar.unset('http://example.com/', 'session', (err, name) "
+    "=> {"
+    "  pm.environment.set('unset_cb', String(err) + '|' + name);"
+    "});"
+    "pm.environment.set('unset_ret', removed);",
+    "http://example.com/users", env);
+
+    ASSERT_EQ (error, "");
+    EXPECT_EQ (env["set_cb"].value, "null|session|example.com|/v1/orders");
+    EXPECT_EQ (env["set_ret"].value, "session|abc|true");
+    EXPECT_EQ (env["unset_cb"].value, "null|session");
+    EXPECT_EQ (env["unset_ret"].value, "session");
 }
 
 TEST (CookieJarWrite, TheFlatPostmanSpellingSetsTheSameCookie) {
@@ -954,9 +1106,12 @@ TEST (CookieJarWrite, BadInputIsRefusedLoudlyRatherThanStoredWrong) {
     { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
       "'v', secure: 'yes' });",
     "true or false" },
+    // A date string is accepted now (see ExpiresTakesADateADateStringOrWholeSeconds);
+    // one Date.parse cannot read still is not, because the alternative is a
+    // cookie that expires in 1970 and is simply never sent again.
     { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
-      "'v', expires: '2030' });",
-    "seconds since the epoch" },
+      "'v', expires: 'the day after tomorrow' });",
+    "not a date this engine can read" },
     // A tab is the Netscape line's own separator: stored, the cookie would
     // be unreadable on the next parse and would simply vanish.
     { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
@@ -980,6 +1135,74 @@ TEST (CookieJarWrite, BadInputIsRefusedLoudlyRatherThanStoredWrong) {
     }
     EXPECT_TRUE (jar.snapshot ().empty ())
     << "a refused write was stored anyway";
+}
+
+TEST (CookieJarWriteValue, ExpiresTakesADateADateStringOrWholeSeconds) {
+    // One instant, three spellings. They must agree: a script writing a Date
+    // and a script writing Math.floor(t / 1000) are describing the same
+    // expiry, and a jar that stored them differently would expire one session
+    // and not the other. The Date and the string are read by QuickJS's own
+    // Date, so they answer as the script's own `new Date(s)` would.
+    CookieJar jar;
+    vayu::Environment env;
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "const url = 'http://example.com/';"
+    "const when = new Date(Date.UTC(2100, 0, 1, 0, 0, 0));"
+    "const jar = pm.cookies.jar();"
+    "jar.set(url, { name: 'a', value: '1', expires: when });"
+    "jar.set(url, { name: 'b', value: '1', expires: '2100-01-01T00:00:00Z' });"
+    "jar.set(url, { name: 'c', value: '1', expires: "
+    "  Math.floor(when.getTime() / 1000) });"
+    "const seen = {};"
+    "for (const c of jar.getAll(url)) seen[c.name] = "
+    "String(c.expires.getTime() / 1000);"
+    "pm.environment.set('a', seen.a);"
+    "pm.environment.set('b', seen.b);"
+    "pm.environment.set('c', seen.c);",
+    "http://example.com/users", env);
+
+    ASSERT_EQ (error, "");
+    EXPECT_EQ (env["a"].value, std::to_string (FAR_FUTURE));
+    EXPECT_EQ (env["b"].value, env["a"].value)
+    << "a date string disagreed with the Date";
+    EXPECT_EQ (env["c"].value, env["a"].value)
+    << "seconds disagreed with the Date";
+}
+
+TEST (CookieJarWriteValue, AnExpiresThatNamesNoInstantIsRefusedRatherThanStored) {
+    CookieJar jar;
+    vayu::Environment env;
+
+    struct Case {
+        const char* expires;
+        const char* expected;
+    };
+    const auto cases = std::to_array<Case> ({
+    { "new Date('nope')", "Invalid Date" },
+    { "'the day after tomorrow'", "not a date this engine can read" },
+    // `getTime() / 1000` without the floor. Truncated silently it would be a
+    // whole second off in a surface that otherwise refuses rather than
+    // guesses; the message names both cures.
+    { "new Date(Date.UTC(2100, 0, 1, 0, 0, 0, 500)).getTime() / 1000", "not a whole number of seconds" },
+    { "true", "a Date, or a date string" },
+    { "-1", "before the epoch" },
+    { "1e30", "further in the future than the jar can store" },
+    });
+
+    for (const auto& one : cases) {
+        vayu::Environment scratch = env;
+        const std::string script =
+        std::string ("pm.cookies.jar().set('http://example.com/', { name: 'n', "
+                     "value: 'v', expires: ") +
+        one.expires + " });";
+        const std::string error =
+        apply_after_script (jar, "env_a", script, "http://example.com/users", scratch);
+        EXPECT_NE (error.find (one.expected), std::string::npos)
+        << "script: " << script << "\ngot: " << error;
+    }
+    EXPECT_TRUE (jar.snapshot ().empty ())
+    << "a refused expiry was stored anyway";
 }
 
 TEST (CookieJarWrite, TheWriteHalfSaysWhyWhenThereIsNoJarAndWhenThereIsNowhereToApply) {

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -356,6 +356,21 @@ declare const pm: {
 	 */
 	cookies: {
 		/**
+		 * Every stored cookie that would be sent to this URL, whole, as an array. Where toObject() answers with names and values alone, these carry the domain, path, secure, httpOnly, hostOnly, session and expires the jar holds.
+		 */
+		all(): object[];
+		/**
+		 * How many stored cookies would be sent to this URL.
+		 */
+		count(): number;
+		/**
+		 * Call fn once per stored cookie that would be sent to this URL, with the whole cookie: { name, key, value, domain, path, secure, httpOnly, hostOnly, session, expires }. A throw from fn ends the walk and is the script's error.
+		 * 
+		 * Example:
+		 * pm.cookies.each(c => console.log(c.name, c.domain));
+		 */
+		each(fn: Function, context?: any): void;
+		/**
 		 * The value of a stored cookie that would be sent to this URL, or undefined when the jar holds none of that name for it. Cookie names are case-sensitive. When the jar holds the name on more than one path, the longest matching path answers - the value the server reads first.
 		 * 
 		 * Example:
@@ -367,7 +382,7 @@ declare const pm: {
 		 */
 		has(name: string): boolean;
 		/**
-		 * Postman's cookie jar object - the write half, plus a URL-scoped read. get(url, name), set(url, cookie), unset(url, name) and clear(url) all take the URL the cookie belongs to rather than assuming this request's; clear() with no URL empties this environment's jar.
+		 * Postman's cookie jar object - the write half, plus two URL-scoped reads. get(url, name), getAll(url), set(url, cookie), unset(url, name) and clear(url) all take the URL the cookie belongs to rather than assuming this request's; clear() with no URL empties this environment's jar.
 		 * 
 		 * A write is applied after the transfer it was made before, so the request that follows carries it and the jar keeps it.
 		 * 
@@ -384,15 +399,25 @@ declare const pm: {
 			 */
 			get(url: string, name: string, callback?: Function): string | undefined;
 			/**
-			 * Store a cookie for that URL. The cookie object needs name and value; domain, path, secure, httpOnly and expires (seconds since the epoch, 0 for a session cookie) are optional and default from the URL. set(url, name, value) is accepted too.
+			 * Every stored cookie that would be sent to that URL, whole - the same matching get() makes, without a name to narrow it, and cookies this script has just set are included. Each carries { name, key, value, domain, path, secure, httpOnly, hostOnly, session, expires }. The array is returned and also handed to the optional callback as (null, cookies).
+			 * 
+			 * Example:
+			 * const jar = pm.cookies.jar();
+			 * for (const c of jar.getAll(pm.request.url)) console.log(c.name, c.path);
+			 */
+			getAll(url: string, callback?: Function): object[];
+			/**
+			 * Store a cookie for that URL. The cookie object needs name and value; domain, path, secure, httpOnly and expires are optional and default from the URL. expires takes a Date, a date string Date.parse accepts, or a whole number of seconds since the epoch - 0 for a session cookie. set(url, name, value) is accepted too.
+			 * 
+			 * The stored cookie is returned and handed to the optional callback as (null, cookie), carrying the domain and path it took from the URL.
 			 * 
 			 * The cookie is matched by the same rules a received one is, so setting it for one host does not send it to another.
 			 */
-			set(url: string, cookie: object | string, value?: string | Function, callback?: Function): void;
+			set(url: string, cookie: object | string, value?: string | Function, callback?: Function): object;
 			/**
-			 * Remove the cookies of that name the URL would have carried. Cookies of the same name stored for another host or path are left alone.
+			 * Remove the cookies of that name the URL would have carried. Cookies of the same name stored for another host or path are left alone. The removed name is returned and handed to the optional callback as (null, name).
 			 */
-			unset(url: string, name: string, callback?: Function): void;
+			unset(url: string, name: string, callback?: Function): string;
 		};
 		/**
 		 * Every stored cookie that would be sent to this URL, as a name-to-value object.

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -317,15 +317,17 @@ TEST (ScriptTypesTest, ACallInsideALabelDoesNotEmptyTheSignature) {
     EXPECT_TRUE (contains (dts,
     "get(url: string, name: string, callback?: "
     "Function): string | undefined;"));
-    EXPECT_TRUE (contains (dts, "unset(url: string, name: string, callback?: Function): void;"));
+    EXPECT_TRUE (contains (dts, "getAll(url: string, callback?: Function): object[];"));
+    EXPECT_TRUE (contains (dts, "unset(url: string, name: string, callback?: Function): string;"));
     EXPECT_TRUE (contains (dts, "clear(url?: string, callback?: Function): void;"));
     // The flat `set(url, name, value)` form the docs also show has to fit the
     // one signature the table can express.
     EXPECT_TRUE (contains (dts,
     "set(url: string, cookie: object | string, "
-    "value?: string | Function, callback?: Function): void;"));
+    "value?: string | Function, callback?: Function): object;"));
     EXPECT_FALSE (contains (dts, "get(): void;"));
     EXPECT_FALSE (contains (dts, "set(): void;"));
+    EXPECT_FALSE (contains (dts, "getAll(): void;"));
 }
 
 // A closed set of strings is a type, and `field_type` called it prose. So


### PR DESCRIPTION
## Description

The cookie surface was built write-first (#337) and read-narrow: the jar object carried only the four methods that issue needed, the flat `pm.cookies` is a plain accessor rather than Postman's CookieList, and both `expires` and the write callbacks were narrowed to what the jar's Netscape storage keeps. Each narrowing was right at the time; each is now a place where an imported Postman script either throws or silently reads `undefined`. The fix widens all four to Postman's shapes **without touching the storage layer**: `getAll` is `jar().get`'s own `matching_in` walk with the name filter dropped, so it inherits the RFC 6265 matching, the staged-write visibility and the per-environment isolation rather than re-deriving them; `expires` accepts a Date or a date string by asking QuickJS's own `Date` (`getTime` and `Date.parse`); the callbacks hand back the cookie the method already computed. **The alternative rejected:** making the flat `pm.cookies` an actual array-like CookieList the way `pm.response.cookies` is. It would match Postman more completely, but `pm.cookies` is a live accessor whose contents change with each staged write, and the response list is frozen at first read *deliberately*, for caching - freezing this one would answer with a stale set after a `jar().set`. `each`/`all`/`count` read through the accessor on every call instead.

Four things worth your eye:

1. **`expires` reuses the language's own date parser, not a new one.** There is no HTTP-date parser anywhere in `engine/src/` - `cookie_jar.hpp` hands the whole job to libcurl on purpose, and says why in the sentence this repo quotes elsewhere ("a hand-rolled copy of a primitive does not receive the primitive's fixes"). So the Date and the string go through `getTime` and `Date.parse`, which makes the answer here the one the same script's own `new Date(s)` gives. A second parser in C++ is how those two start to disagree.
2. **A fractional number of seconds is now refused rather than truncated** - a deliberate acceptance-to-refusal flip, in code this diff already had open. The block's own error message claimed to refuse one, and could not: `JS_ToInt64` truncates rather than failing, so that branch had never been reachable. `getTime() / 1000` without the floor is the shape it arrives in; the message names both cures.
3. **The read and the write now speak the same unit.** A cookie reads back with `expires` as a `Date` and `set` takes one, so a cookie can be read and written back with nothing to convert - a round trip that only exists because both halves land together.
4. **`key` is present beside `name`, and `each` takes Postman's `context`.** Postman's `Cookie` spells the name `key`; a script reading `.key` and getting `undefined` is the silent-wrong class this program exists to close. Both are the Postman shape done to spec rather than surface beyond the issue.

One deliberate deviation from the issue's sketch: it describes `getAll`'s callback as receiving `(null, [{name, value, domain, path, ...}])` and leaves the field set open. The objects carry `name`, `key`, `value`, `domain`, `path`, `secure`, `httpOnly`, `hostOnly`, `session` and `expires`. Postman's `maxAge` and its unmodelled `extensions` are deliberately absent - the jar does not keep them, and a field with nothing behind it is a value a script would read and act on. Both docs say so.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2609 passed, 0 failed**. `cd app && pnpm test`: **5780 passed** (532 files), including the docs-compile guard that type-checks the new `pm.*` doc examples against the regenerated typedefs. `pnpm type-check` clean on all three projects. `clang-format-19 --dry-run -Werror` clean on every touched source; `clang-tidy-19` clean on all four (the only hits are PCH noise from linting a GCC-built tree, and a pre-existing `performance-enum-size` in `include/vayu/db/database.hpp`, which this diff does not touch).

Five new tests, all mutation-checked - revert the line each pins and it reddens:

- `PmCookiesReadsWholeCookiesThroughEachAllAndCount` - the three reads over a jar holding a `/` cookie, an `/admin` cookie and another host's; asserts every field of the cookie object, and that the flat writers both docs call absent are still unreachable.
- `PmCookiesEachReportsAThrowFromItsIterator` - a throw from the iterator ends the walk and is the script's error, not something swallowed to finish iterating. Also the non-function argument.
- `JarGetAllAnswersEveryCookieTheUrlWouldCarry` - sees a cookie staged two lines above it, does not see another host's, and the `(null, cookies)` callback.
- `TheWriteCallbacksCarryWhatTheCallStored` - `set`'s callback gets the stored cookie with the domain and path derived from `/v1/orders/42`; `unset`'s gets the removed name; both are the return value too.
- `ExpiresTakesADateADateStringOrWholeSeconds` and `AnExpiresThatNamesNoInstantIsRefusedRatherThanStored` - one instant in three spellings agreeing exactly, and six refusals beside it.

One existing test case changed rather than added to: `BadInputIsRefusedLoudlyRatherThanStoredWrong` pinned `expires: '2030'` as refused. That string is now accepted - `Date.parse` reads it - which is the acceptance criterion, so the case moved to `'the day after tomorrow'`, which `Date.parse` still cannot read. `ScriptTypesTest.ACallInsideALabelDoesNotEmptyTheSignature` pins the jar signatures by exact text and was updated for the three that changed return type, with `getAll` added to what it guards.

No pre-existing failures on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

App changes: none, as the issue states - confirmed rather than assumed by a consumer trace. The renderer's Monaco completion provider and its type-definition hook are pure consumers of `GET /scripting/completions` and `GET /scripting/types`, and both MCP scripting resources re-serve the engine's own table, so the completion entries and the regenerated `engine/tests/fixtures/script-typedefs.d.ts` are the whole of the client-visible move.

## Related Issues
Closes #1002

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8Noi5hkwkcqS6VumoXDBw)_