### PR TITLE
feat(engine): guarded VACUUM at startup returns freed pages to disk - #990

### DIFF
--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -107,6 +107,40 @@ endpoint reports it as a `recovery` node, absent on a clean start - see
 dismissible banner naming the database path and, when there is one, the
 quarantined file and the `.recover` command that reads it.
 
+### Reclaiming freed pages
+
+Deleting rows - a prune, a trash purge, the `metrics` drop - moves their pages to SQLite's
+freelist, where the engine reuses them and the filesystem never sees them again, so a workspace
+that once held weeks of heavy runs keeps that high-water mark forever. `Database::init()` ends
+with a guarded `VACUUM` that gives them back (issue #990).
+
+Guarded, because a `VACUUM` rewrites the whole database: it runs only when **both** thresholds are
+crossed - at least **25%** of the file's pages are free **and** they hold at least **10 MiB**
+(`VACUUM_MIN_FREELIST_PERCENT` / `VACUUM_MIN_RECLAIMABLE_BYTES`, compile-time, deliberately not
+configurable). The fraction alone would rewrite a nearly-empty workspace on every start; the byte
+floor alone would rewrite four gigabytes to win back eleven megabytes. Neither threshold crossed
+means the pass reads three PRAGMAs and returns.
+
+Three things worth knowing about where it sits:
+
+- **Last in `init()`**, after the run prune and the trash purge, so it sees the pages every sweep
+  freed rather than only the first one's.
+- **On a connection of its own**, like `POST /workspace/backup`'s `VACUUM INTO` - sqlite_orm
+  exposes no way to run these statements on the connection it holds. Nothing contends for it:
+  `init` runs before the HTTP listener starts, and the lock file has already refused a second
+  engine.
+- **The `VACUUM` is followed by a `wal_checkpoint(TRUNCATE)`.** Under WAL the rewritten image
+  lands in the `-wal` file and the database is not resized until a checkpoint copies it back, so
+  without it the pass would free every page it set out to and leave the file exactly as large as
+  it found it.
+
+The outcome is logged at info level (`Reclaimed N KB of freed database pages`), because the cost
+is paid on the startup path - `db.init()` returns before `/health` answers, and the app gives the
+engine 45 seconds to come up. A rewrite slow enough to matter is one this line explains.
+Best-effort like the sweeps before it: a failure is a warning, never a daemon that will not start.
+`auto_vacuum` was rejected as the alternative - switching an existing database's mode requires a
+full `VACUUM` anyway, and it changes page bookkeeping for every write thereafter.
+
 ---
 
 ## Tables
@@ -842,7 +876,8 @@ backlog cannot stall `/health`, SSE, or the runs poll. The cascade itself lives 
 is wired into both at once. `prune_runs_configured()` reads the two
 knobs (config, `data_retention`, defaults 200 / 30) and runs at **startup** (`Database::init`) and
 after a run reaches a **terminal** status (design mode's `store_result`, and the load-run
-completion/failure paths in `run_manager.cpp`).
+completion/failure paths in `run_manager.cpp`). What a prune frees is disk the file keeps until
+[Reclaiming freed pages](#reclaiming-freed-pages) gives it back.
 
 ---
 
@@ -976,8 +1011,8 @@ along with the `MetricName` enum and `db::Metric`. `sync_schema()` only syncs th
 storage still declares - it never drops one that was removed from it - so `Database::init()`
 issues an explicit `DROP TABLE IF EXISTS metrics`, and an upgraded database sheds the table and
 its rows on first start. The freed pages return to SQLite's freelist for reuse; the file itself
-does not shrink, because a `VACUUM` would rewrite the whole database under a write lock at
-startup.
+shrinks only when the guarded reclamation at the end of `Database::init()` decides they are worth
+a rewrite - see [Reclaiming freed pages](#reclaiming-freed-pages).
 
 ---
 

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -914,6 +914,26 @@ constexpr int MAX_BACKUPS_RETAINED = 5;
  * spares is reclaimed by the next one rather than kept.
  */
 constexpr int64_t SPEC_DOCUMENT_SWEEP_GRACE_MS = 600'000;
+/**
+ * Startup reclamation (issue #990): how much of the database must be free pages
+ * before the startup sweep rewrites it to return them to the filesystem.
+ *
+ * Deleting rows only moves their pages to SQLite's freelist, where they are
+ * reused but never given back, so a workspace that once held weeks of heavy
+ * runs keeps that high-water mark forever. A `VACUUM` gives it back and costs a
+ * rewrite of the whole file, which is why it is a threshold and not a policy.
+ */
+constexpr int VACUUM_MIN_FREELIST_PERCENT = 25;
+/**
+ * The second half of that threshold: how many bytes the free pages must hold.
+ *
+ * Both halves must be crossed, and each is what makes the other safe. The
+ * fraction alone rewrites a nearly-empty workspace on every start, since a
+ * database holding one collection is mostly freelist the moment anything is
+ * deleted from it. The byte floor alone rewrites four gigabytes to win back
+ * eleven megabytes.
+ */
+constexpr int64_t VACUUM_MIN_RECLAIMABLE_BYTES = 10LL * 1024 * 1024;
 } // namespace database
 } // namespace vayu::core::constants
 

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -814,6 +814,207 @@ const std::function<bool (const std::string&)>& probe) {
     }
 }
 
+/**
+ * Open a second connection on the workspace database at @p path.
+ *
+ * Two statements the engine runs on the workspace - the backup's `VACUUM INTO`
+ * and the startup reclamation's `VACUUM` - cannot go through the connection
+ * every write is serialized on: sqlite_orm exposes no way to run a statement on
+ * the connection it holds. Both take one of these instead, so the flags and the
+ * busy timeout are decided once rather than per caller.
+ *
+ * @return the connection, or `nullptr` with @p error set to what SQLite
+ *         refused. The caller owns what it gets and closes it.
+ */
+sqlite3* open_workspace_connection (const std::string& path, std::string& error) {
+    sqlite3* connection = nullptr;
+    // Read-write rather than read-only: under WAL a reader still writes the
+    // `-shm` index, and a read-only open of a database whose WAL has not been
+    // checkpointed fails outright on a directory it cannot write.
+    if (sqlite3_open_v2 (path.c_str (), &connection, SQLITE_OPEN_READWRITE, nullptr) != SQLITE_OK) {
+        error = connection != nullptr ?
+        std::string (sqlite3_errmsg (connection)) :
+        std::string ("could not open the workspace database");
+        sqlite3_close (connection);
+        return nullptr;
+    }
+    sqlite3_busy_timeout (connection, vayu::core::constants::database::BUSY_TIMEOUT_MS);
+    return connection;
+}
+
+/** @brief What one startup reclamation pass decided and did (issue #990). */
+struct ReclaimOutcome {
+    /// Whether the rewrite ran. False with an empty `error` means the database
+    /// did not hold enough freed pages to be worth one.
+    bool ran = false;
+    /// The size of the database file before the pass, in bytes.
+    int64_t before_bytes = 0;
+    /// Its size after - equal to `before_bytes` when nothing ran, and negative
+    /// when the rewrite ran and the file could not be measured afterwards. The
+    /// three are different facts and the log says which one it is reporting.
+    int64_t after_bytes = 0;
+    /// What SQLite or the filesystem refused, or empty on success.
+    std::string error;
+};
+
+/**
+ * Read a PRAGMA that answers with one integer.
+ *
+ * @return the value, or nothing if SQLite would not answer - which is what
+ *         separates "this database has no free pages" from "we never found out",
+ *         and the two must not both read as zero.
+ *
+ * A refusal is written to @p error *here*, and only if it is still empty, so
+ * the message belongs to the read that failed and to the first one. Read back
+ * at the call site instead, `sqlite3_errmsg` would describe whichever statement
+ * ran last - which, after a later read succeeded, is "not an error".
+ */
+std::optional<int64_t>
+read_pragma_int (sqlite3* connection, const char* pragma, std::string& error) {
+    const auto record_failure = [&] {
+        if (error.empty ()) {
+            error = std::string (pragma) + ": " + sqlite3_errmsg (connection);
+        }
+    };
+    sqlite3_stmt* statement = nullptr;
+    if (sqlite3_prepare_v2 (connection, pragma, -1, &statement, nullptr) != SQLITE_OK) {
+        record_failure ();
+        return std::nullopt;
+    }
+    std::optional<int64_t> value;
+    if (sqlite3_step (statement) == SQLITE_ROW) {
+        value = sqlite3_column_int64 (statement, 0);
+    } else {
+        record_failure ();
+    }
+    sqlite3_finalize (statement);
+    return value;
+}
+
+/**
+ * Whether a database of @p pages pages of @p page_size bytes, @p freelist of
+ * them free, holds enough dead weight to be worth rewriting.
+ *
+ * Both thresholds must be crossed - see the two constants for why either alone
+ * is the wrong rule.
+ */
+bool worth_reclaiming (int64_t freelist, int64_t pages, int64_t page_size) {
+    if (freelist <= 0 || pages <= 0 || page_size <= 0) {
+        return false;
+    }
+    if (freelist * 100 < pages * vayu::core::constants::database::VACUUM_MIN_FREELIST_PERCENT) {
+        return false;
+    }
+    return freelist * page_size >= vayu::core::constants::database::VACUUM_MIN_RECLAIMABLE_BYTES;
+}
+
+/**
+ * The decision and the rewrite, on an already-open @p connection.
+ *
+ * Split from the function below so the connection is closed on exactly one
+ * path rather than on each of this one's four.
+ */
+ReclaimOutcome
+reclaim_on_connection (sqlite3* connection, const std::string& path, int64_t before_bytes) {
+    ReclaimOutcome outcome;
+    outcome.before_bytes = before_bytes;
+    outcome.after_bytes  = before_bytes;
+
+    std::string failure;
+    const std::optional<int64_t> freelist =
+    read_pragma_int (connection, "PRAGMA freelist_count", failure);
+    const std::optional<int64_t> pages =
+    read_pragma_int (connection, "PRAGMA page_count", failure);
+    const std::optional<int64_t> page_size =
+    read_pragma_int (connection, "PRAGMA page_size", failure);
+    if (!freelist.has_value () || !pages.has_value () || !page_size.has_value ()) {
+        outcome.error = failure;
+        return outcome;
+    }
+    if (!worth_reclaiming (*freelist, *pages, *page_size)) {
+        return outcome;
+    }
+
+    char* err_msg = nullptr;
+    if (sqlite3_exec (connection, "VACUUM", nullptr, nullptr, &err_msg) != SQLITE_OK) {
+        outcome.error = err_msg != nullptr ? std::string (err_msg) :
+                                             std::string (sqlite3_errmsg (connection));
+        sqlite3_free (err_msg);
+        return outcome;
+    }
+
+    // Under WAL the rewritten image lands in the `-wal` file and the database
+    // itself is not resized until a checkpoint copies it back, so without this
+    // the pass would free every page it set out to and leave the file exactly
+    // as large as it found it. Best-effort: a checkpoint that cannot truncate
+    // has still committed the rewrite, and the next one returns the space.
+    sqlite3_exec (connection, "PRAGMA wal_checkpoint(TRUNCATE)", nullptr, nullptr, nullptr);
+
+    outcome.ran = true;
+    std::error_code ec;
+    const auto after    = fs::file_size (path, ec);
+    outcome.after_bytes = ec ? -1 : static_cast<int64_t> (after);
+    return outcome;
+}
+
+/**
+ * Return the database's freed pages to the filesystem, if it holds enough of
+ * them to be worth the rewrite (issue #990).
+ *
+ * On a connection of its own, for the reason `open_workspace_connection` gives:
+ * sqlite_orm exposes no way to run a statement on the connection it holds, and
+ * neither `VACUUM` nor the three PRAGMAs this decides on are among the ones it
+ * wraps. That costs nothing here - the caller runs before the HTTP listener
+ * exists and the lock file has already refused a second engine, so this
+ * connection is the only one doing anything.
+ */
+ReclaimOutcome reclaim_freed_pages (const std::string& path) {
+    ReclaimOutcome outcome;
+    std::error_code ec;
+    const auto size = fs::file_size (path, ec);
+    if (ec) {
+        outcome.error = ec.message ();
+        return outcome;
+    }
+    outcome.before_bytes = static_cast<int64_t> (size);
+    outcome.after_bytes  = outcome.before_bytes;
+
+    sqlite3* connection = open_workspace_connection (path, outcome.error);
+    if (connection == nullptr) {
+        return outcome;
+    }
+
+    outcome = reclaim_on_connection (connection, path, outcome.before_bytes);
+    sqlite3_close (connection);
+    return outcome;
+}
+
+/** Report what the pass above did, at the level its outcome deserves. */
+void log_reclaim_outcome (const ReclaimOutcome& outcome) {
+    if (!outcome.error.empty ()) {
+        vayu::utils::log_warning (
+        "Startup database reclamation failed: " + outcome.error);
+        return;
+    }
+    if (!outcome.ran) {
+        vayu::utils::log_debug ("Database reclamation skipped: too few freed "
+                                "pages to be worth the rewrite");
+        return;
+    }
+    if (outcome.after_bytes < 0) {
+        vayu::utils::log_info ("Reclaimed the freed pages of a " +
+        std::to_string (outcome.before_bytes / 1024) +
+        " KB database; its size afterwards could not be read");
+        return;
+    }
+    const int64_t freed = outcome.after_bytes < outcome.before_bytes ?
+    outcome.before_bytes - outcome.after_bytes :
+    0;
+    vayu::utils::log_info ("Reclaimed " + std::to_string (freed / 1024) +
+    " KB of freed database pages (" + std::to_string (outcome.before_bytes / 1024) +
+    " KB -> " + std::to_string (outcome.after_bytes / 1024) + " KB)");
+}
+
 } // namespace
 
 Database::Database (const std::string& db_path) {
@@ -895,9 +1096,9 @@ void Database::init () {
     // were removed from it - so a database written by an engine before this
     // version keeps the table and its rows (~20/sec of load run) forever
     // otherwise. The pages return to SQLite's freelist for reuse rather than
-    // shrinking the file; a VACUUM to actually shrink it is deliberately not
-    // run here, since it rewrites the whole database while holding a write
-    // lock and startup is the worst possible moment to pay that.
+    // shrinking the file; what returns them to the filesystem is the guarded
+    // reclamation at the end of this function (issue #990), which is where the
+    // cost of a rewrite is decided rather than paid on every start.
     // Idempotent, so this stays rather than needing a one-shot migration flag.
     impl_->storage.drop_table_if_exists ("metrics");
 
@@ -996,6 +1197,29 @@ void Database::init () {
     } catch (const std::exception& e) {
         vayu::utils::log_warning (
         "Startup trash purge failed: " + std::string (e.what ()));
+    }
+
+    // Give the pages the sweeps above freed back to the filesystem (issue
+    // #990). Last of the startup passes, so it sees what every one of them
+    // freed rather than only the run prune's share, and guarded, because a
+    // rewrite of the whole database is not something to do on every start: a
+    // quarter of the file has to be free pages holding at least 10 MiB before
+    // this runs at all.
+    //
+    // The write lock it takes is the one the `metrics` drop above declines to
+    // pay, and what makes it payable here is that there is nothing waiting on
+    // it: `daemon.cpp` runs `init` before it starts the HTTP listener, and the
+    // lock file has already refused a second engine. The DB mutex this function
+    // holds throughout is held over the rewrite too, and for the same reason
+    // that costs nothing - there is no second caller yet to block. What it does
+    // cost is startup latency, which is why the outcome is logged: the app
+    // gives the engine 45 seconds to answer `/health`. Best-effort like the
+    // passes above - reclaiming disk must not be a daemon that will not start.
+    try {
+        log_reclaim_outcome (reclaim_freed_pages (impl_->opened_file));
+    } catch (const std::exception& e) {
+        vayu::utils::log_warning (
+        "Startup database reclamation failed: " + std::string (e.what ()));
     }
 }
 
@@ -2461,36 +2685,28 @@ bool is_backup_file_name (const std::string& name) {
  * @return an empty string on success, or what SQLite refused.
  *
  * On a connection of its own rather than the one every write is serialized
- * through. Two reasons, and they agree: sqlite_orm exposes no way to run a
- * statement on the connection it holds, and a `VACUUM INTO` of a large
- * workspace occupies its connection for as long as the copy takes - on the
- * shared one that is every other endpoint waiting behind a button someone
- * pressed. Under WAL a second reader sees every committed transaction and
- * blocks no writer, so the snapshot is consistent and costs the running engine
- * nothing but disk bandwidth.
+ * through - `open_workspace_connection` says why, and the startup reclamation
+ * takes one for the same reason. The second half of it is this function's
+ * alone: a `VACUUM INTO` of a large workspace occupies its connection for as
+ * long as the copy takes, and on the shared one that is every other endpoint
+ * waiting behind a button someone pressed. Under WAL a second reader sees every
+ * committed transaction and blocks no writer, so the snapshot is consistent and
+ * costs the running engine nothing but disk bandwidth.
  *
  * The destination is *bound*, not concatenated: a path is user data on every
  * platform and a quote in a directory name would otherwise be a SQL fragment.
  */
 std::string vacuum_into (const std::string& source, const std::string& destination) {
-    sqlite3* connection = nullptr;
-    // Read-write rather than read-only: under WAL a reader still writes the
-    // `-shm` index, and a read-only open of a database whose WAL has not been
-    // checkpointed fails outright on a directory it cannot write.
-    int rc = sqlite3_open_v2 (source.c_str (), &connection, SQLITE_OPEN_READWRITE, nullptr);
-    if (rc != SQLITE_OK) {
-        std::string message = connection != nullptr ?
-        std::string (sqlite3_errmsg (connection)) :
-        std::string ("could not open the workspace database");
-        sqlite3_close (connection);
+    std::string message;
+    sqlite3* connection = open_workspace_connection (source, message);
+    if (connection == nullptr) {
         return message;
     }
-    sqlite3_busy_timeout (connection, vayu::core::constants::database::BUSY_TIMEOUT_MS);
 
     sqlite3_stmt* statement = nullptr;
-    rc = sqlite3_prepare_v2 (connection, "VACUUM INTO ?", -1, &statement, nullptr);
+    int rc = sqlite3_prepare_v2 (connection, "VACUUM INTO ?", -1, &statement, nullptr);
     if (rc != SQLITE_OK) {
-        std::string message = sqlite3_errmsg (connection);
+        message = sqlite3_errmsg (connection);
         sqlite3_close (connection);
         return message;
     }
@@ -2499,7 +2715,6 @@ std::string vacuum_into (const std::string& source, const std::string& destinati
     // cannot quietly make the lifetime load-bearing.
     sqlite3_bind_text (statement, 1, destination.c_str (), -1, SQLITE_TRANSIENT);
 
-    std::string message;
     if (sqlite3_step (statement) != SQLITE_DONE) {
         message = sqlite3_errmsg (connection);
     }

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1516,6 +1516,114 @@ TEST_F (DatabaseTest, PruneRunsZeroLimitsDisableEachCap) {
 }
 
 // ============================================================================
+// Startup reclamation - freed pages return to the filesystem (issue #990)
+// ============================================================================
+
+namespace {
+
+// A run whose one result carries `body_bytes` of trace, so deleting it frees a
+// known and substantial number of pages rather than a handful.
+void seed_bulky_run (Database& db, const std::string& id, int64_t start_time, size_t body_bytes) {
+    vayu::db::Run run;
+    run.id              = id;
+    run.type            = vayu::RunType::Design;
+    run.status          = vayu::RunStatus::Completed;
+    run.start_time      = start_time;
+    run.config_snapshot = "{}";
+    db.create_run (run);
+
+    vayu::db::Result r;
+    r.run_id      = id;
+    r.timestamp   = start_time;
+    r.status_code = 200;
+    r.status_text = "OK";
+    r.latency_ms  = 1.0;
+    r.trace_data  = R"({"body":")" + std::string (body_bytes, 'x') + R"("})";
+    db.add_result (r);
+}
+
+constexpr size_t MIB = 1024 * 1024;
+
+int64_t database_file_size () {
+    std::error_code ec;
+    const auto size = std::filesystem::file_size (TEST_DB_PATH, ec);
+    return ec ? -1 : static_cast<int64_t> (size);
+}
+
+// Grow the database to `total_mib` one-MiB runs, then prune it down to `keep`
+// of them, and answer with the size the file reached. What the caller gets is a
+// database whose freelist holds `total_mib - keep` MiB.
+//
+// The runs are stamped from the wall clock rather than from a counter: the
+// startup prune this file's reclamation follows reads `runRetentionDays`, so
+// runs stamped in 1970 are all deleted by the *next* start and every case below
+// would be measuring an empty database.
+int64_t grow_then_prune (int total_mib, int keep) {
+    const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                        .count ();
+    Database db (TEST_DB_PATH);
+    db.init ();
+    for (int i = 1; i <= total_mib; ++i) {
+        seed_bulky_run (db, "bulk_" + std::to_string (i), now - int64_t{ i } * 1000, MIB);
+    }
+    db.prune_runs (keep, 0);
+    return database_file_size ();
+}
+
+// What a second start leaves the file at. The reclamation runs in `init`, so
+// every case below opens the database again rather than calling anything: what
+// is under test is what a start does.
+int64_t size_after_a_restart () {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+    return database_file_size ();
+}
+
+} // namespace
+
+TEST_F (DatabaseTest, StartupReclaimsAHeavilyPrunedDatabase) {
+    // 24 MiB down to one: past both thresholds, and by a wide enough margin
+    // that neither the page size nor the schema's own pages matter.
+    const int64_t grown = grow_then_prune (24, 1);
+    ASSERT_GT (grown, 12 * static_cast<int64_t> (MIB))
+    << "the seeded bodies never reached the file, so this proves nothing";
+
+    const int64_t reclaimed = size_after_a_restart ();
+    // Mutation check: take the reclamation back out of `init` and the file is
+    // still `grown` here.
+    EXPECT_LT (reclaimed, grown / 2)
+    << "the freed pages were not returned to the filesystem (" << grown
+    << " -> " << reclaimed << ")";
+}
+
+TEST_F (DatabaseTest, StartupLeavesADatabaseBelowTheByteFloorAlone) {
+    // 4 MiB down to one: nearly all freelist, so the *fraction* is crossed
+    // several times over and only the 10 MiB floor declines it.
+    const int64_t grown = grow_then_prune (4, 1);
+    ASSERT_GT (grown, 2 * static_cast<int64_t> (MIB));
+
+    // Never smaller - a rewrite would give back three of these four megabytes.
+    // Not byte-equal, because a start writes a page of its own.
+    // Mutation check: drop VACUUM_MIN_RECLAIMABLE_BYTES to zero and this reddens.
+    EXPECT_GE (size_after_a_restart (), grown)
+    << "a database holding less than the byte floor was rewritten anyway";
+}
+
+TEST_F (DatabaseTest, StartupLeavesADatabaseBelowTheFreelistFractionAlone) {
+    // 60 MiB down to 48: twelve of them freed, which is past the 10 MiB floor
+    // and a fifth of the file - so only the fraction declines it.
+    const int64_t grown = grow_then_prune (60, 48);
+    ASSERT_GT (grown, 55 * static_cast<int64_t> (MIB));
+
+    // Mutation check: drop VACUUM_MIN_FREELIST_PERCENT to zero and this reddens.
+    EXPECT_GE (size_after_a_restart (), grown)
+    << "a database whose freelist is under the fraction was rewritten anyway";
+}
+
+// ============================================================================
 // Metric ticks + the stored run summary (the wide-row time series)
 // ============================================================================
 

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1542,7 +1542,7 @@ void seed_bulky_run (Database& db, const std::string& id, int64_t start_time, si
     db.add_result (r);
 }
 
-constexpr size_t MIB = 1024 * 1024;
+constexpr size_t MIB = size_t{ 1024 } * 1024;
 
 int64_t database_file_size () {
     std::error_code ec;
@@ -1565,7 +1565,7 @@ int64_t grow_then_prune (int total_mib, int keep) {
     Database db (TEST_DB_PATH);
     db.init ();
     for (int i = 1; i <= total_mib; ++i) {
-        seed_bulky_run (db, "bulk_" + std::to_string (i), now - int64_t{ i } * 1000, MIB);
+        seed_bulky_run (db, "bulk_" + std::to_string (i), now - (int64_t{ i } * 1000), MIB);
     }
     db.prune_runs (keep, 0);
     return database_file_size ();


### PR DESCRIPTION
## Description

Deleting rows moves their pages to SQLite's freelist, where the engine reuses them and the filesystem never sees them again - so a workspace that once held weeks of heavy runs kept that high-water mark forever, whatever the run prune, the trash purge and the `metrics` drop freed. `Database::init()` now ends with a `VACUUM` that gives those pages back, guarded so a database with nothing worth reclaiming pays three PRAGMA reads and nothing else.

**Root cause, approach, and the alternative rejected.** Nothing in the engine ever ran a bare `VACUUM`, `PRAGMA auto_vacuum` or `incremental_vacuum` - the only `VACUUM` in `engine/src` is the backup's `VACUUM INTO`, which compacts a *copy* and leaves the live file alone. The one place that had considered it declined in a comment: a rewrite under a write lock, and "startup is the worst possible moment to pay that". That objection is what the fix had to answer rather than override, and it turns out not to hold *at this point in startup*: `daemon.cpp` runs `init()` before it starts the HTTP listener, and the lock file has already refused a second engine, so the write lock has nothing waiting behind it. So the pass sits at the end of `init()`, gated on both thresholds the issue recommends - at least 25% of the file's pages free **and** at least 10 MiB in them. Each threshold is what makes the other safe: the fraction alone rewrites a nearly-empty workspace on every start (a database holding one collection is mostly freelist the moment anything is deleted from it), the byte floor alone rewrites four gigabytes to win back eleven megabytes. The rejected alternative is `auto_vacuum`: switching an existing database's mode requires a full `VACUUM` anyway, and it then changes page bookkeeping for every write thereafter - a permanent per-write cost to avoid an occasional startup one.

**Three deliberate deviations from the issue text, all argued:**

1. **It runs last of the startup passes, not immediately after the prune.** The issue says "right there", after `prune_runs_configured()`. But `purge_expired_trash_configured()` (#988) runs after it and frees pages too, and a reclamation placed between them would give back the prune's share and leave the purge's for next time. Last is the only position that sees what every sweep freed.
2. **The `VACUUM` is followed by a `PRAGMA wal_checkpoint(TRUNCATE)`, which the issue does not mention.** Under WAL the rewritten image lands in the `-wal` file and the database is not resized until a checkpoint copies it back - so without it this pass frees every page it set out to and leaves the file *exactly as large as it found it*. That is not a theory: the first version of the test measured it. Best-effort, and stated as such at the site: a checkpoint that cannot truncate has still committed the rewrite, and the next one returns the space.
3. **The below-threshold tests assert the file does not shrink, not that it is byte-identical.** The issue asks for "no size change"; empirically a start writes a page of its own (196,608 -> 200,704 bytes, measured), so byte-equality is an assertion about `init()`'s other writes rather than about this pass. What each negative test pins instead is the threshold it is about, and the mutation checks below show it is the guard doing the declining.

**One repo-level tidy inside the diff, not beside it:** the backup's `vacuum_into` and this pass both need a second connection for a statement sqlite_orm cannot run on the connection it holds. That open / `busy_timeout` / close sequence is now `open_workspace_connection`, called by both, rather than written twice a thousand lines apart in one file.

**Two consumer-trace findings, one of which does not hold.** A trace of every surface that could see this suggested `WorkspaceBackupCard.tsx` displays a database-derived file size and would change. It does not: `VACUUM INTO` already writes a compacted copy, so the snapshot's `sizeBytes` was never a function of the live file's freelist. The second finding is real and is now written down: `db.init()` returns before `/health` answers and the app gives the engine **45 seconds** to come up (`ENGINE_HEALTH_MAX_ATTEMPTS` x `ENGINE_HEALTH_POLL_INTERVAL_MS`), so the rewrite is on that budget. The thresholds bound how *often* it runs, not how long one takes, which is exactly why the outcome is logged at info level - a slow start is explainable rather than mysterious. No app change; nothing reads the live file's size, and nothing parses engine startup logs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2606 engine tests, all green** (2603 before, three new). `mkdocs build --strict -f .github/mkdocs.yml` clean. `clang-format-19 --dry-run -Werror` clean over the whole of `engine/{src,include,tests}`; `clang-tidy-19` clean on both touched translation units. No pre-existing failures reproduced on the base commit. The app is untouched, so its suite was not run - no `app/` file is in this diff and no renderer, MCP or CLI surface reads the live database's size.

Three new cases in `db_test.cpp`, one per quadrant of the guard, each verified by reverting the thing it is supposed to pin:

| Test | Pins | Mutation check, run |
|------|------|---------------------|
| `StartupReclaimsAHeavilyPrunedDatabase` | 24 MiB pruned to one: both thresholds crossed, so the file shrinks past half | Reclamation call removed from `init()` -> **fails** (file stays at 25 MB) |
| `StartupLeavesADatabaseBelowTheByteFloorAlone` | 4 MiB pruned to one: ~95% free, under 10 MiB, so nothing runs | `VACUUM_MIN_RECLAIMABLE_BYTES` -> 0 -> **fails** |
| `StartupLeavesADatabaseBelowTheFreelistFractionAlone` | 60 MiB pruned to 48: 12 MiB free but a fifth of the file, so nothing runs | `VACUUM_MIN_FREELIST_PERCENT` -> 0 -> **fails** |

Each mutation was applied, rebuilt and run - the table records measured results, not expectations. The two negative cases are what makes the third mutation meaningful: with both thresholds zeroed they redden while the positive case stays green, which is the guard being the thing that declines rather than the pass being absent.

One flakiness guard worth naming: the seeded runs are stamped from the wall clock rather than from a counter. Stamped in 1970 they are all older than `runRetentionDays`, so the *next* start's prune deletes every one of them and each case ends up measuring an empty database - which is how the fraction test first passed for the wrong reason.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs move in the same commit: `docs/engine/db-schema.md` gains a **Reclaiming freed pages** section under the startup heading (thresholds and why both, the placement, the second connection, the checkpoint, the 45-second budget, the rejected `auto_vacuum`), the run-retention paragraph links to it, and the `metrics`-drop paragraph - which asserted as settled fact that the file "does not shrink, because a `VACUUM` would rewrite the whole database under a write lock at startup" - now says what actually happens. The code comment that made the same claim points at the pass instead.

## Related Issues
Closes #990

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn5BdHaf3yonsvTq1HM7fr)_