### PR TITLE
fix(app): resolve the Send-with-row preview against the bound row, in the builder and in the tab strip

### DIFF
--- a/app/src/components/layout/tab-descriptors.bound-row.test.tsx
+++ b/app/src/components/layout/tab-descriptors.bound-row.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A tab's label and its builder agreeing about a bound data row (issue #1074).
+ *
+ * #1062 gave every preview *inside* the request builder the picked row, and
+ * left this one behind: the strip labels every open tab from a single list-wide
+ * resolver - it has to know each label before it can decide how many fit - so it
+ * cannot take the row off the builder's context the way the URL bar does. A
+ * request with no name of its own therefore labelled its tab from the
+ * environment while the bar one row below showed the file's value.
+ *
+ * The slot the strip reads names its request, so the case that matters most is
+ * the third: a row bound for *another* request must not relabel this one.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const request = {
+	id: "req_a",
+	// No name of its own, so the label falls back to the resolved path - which
+	// is the only way a tab label reads a variable at all.
+	name: "",
+	method: "GET",
+	url: "https://api.test/u/{{username}}",
+};
+
+vi.mock("@/queries", () => ({
+	requestDetailOptions: (id: string | null) => ({
+		queryKey: ["request", id],
+		queryFn: async () => (id === request.id ? request : undefined),
+		initialData: id === request.id ? request : undefined,
+		enabled: false,
+	}),
+	runDetailOptions: (id: string | null) => ({
+		queryKey: ["run", id],
+		queryFn: async () => undefined,
+		initialData: undefined,
+		enabled: false,
+	}),
+	useCollectionsQuery: () => ({ data: [] }),
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useEnvironmentsQuery: () => ({
+		data: [
+			{
+				id: "env",
+				name: "Staging",
+				// The collision the row tier exists for.
+				variables: { username: { value: "from-the-environment", enabled: true } },
+			},
+		],
+	}),
+}));
+vi.mock("@/stores", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/stores")>()),
+	useSessionStore: () => ({ activeEnvironmentId: "env" }),
+}));
+
+const { useBoundRowStore } = await import("@/stores");
+const { useTabDescriptors } = await import("./tab-descriptors");
+
+const TABS = [{ id: "t1", type: "request" as const, entityId: "req_a" }];
+
+function labelOfRequestTab() {
+	const { result } = renderHook(() => useTabDescriptors(TABS), {
+		wrapper: ({ children }) => (
+			<QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+		),
+	});
+	return result.current[0].label;
+}
+
+beforeEach(() => {
+	useBoundRowStore.setState({ bound: null });
+});
+
+describe("a request tab's label while a row is bound", () => {
+	it("resolves from the environment when the builder is bound to no row", () => {
+		expect(labelOfRequestTab()).toBe("/u/from-the-environment");
+	});
+
+	it("resolves from the row once the builder is bound to one", () => {
+		useBoundRowStore.setState({
+			bound: { requestId: "req_a", row: { username: "ada" } },
+		});
+		expect(labelOfRequestTab()).toBe("/u/ada");
+	});
+
+	it("ignores a row bound for a different request", () => {
+		// The slot is one deep, so the check that it names *this* request is what
+		// keeps a pick made in another tab from relabelling this one.
+		useBoundRowStore.setState({
+			bound: { requestId: "req_b", row: { username: "ada" } },
+		});
+		expect(labelOfRequestTab()).toBe("/u/from-the-environment");
+	});
+});

--- a/app/src/components/layout/tab-descriptors.ts
+++ b/app/src/components/layout/tab-descriptors.ts
@@ -22,7 +22,7 @@ import { useQueries } from "@tanstack/react-query";
 import { requestDetailOptions, runDetailOptions, useCollectionsQuery } from "@/queries";
 import { useVariableResolver } from "@/hooks/useVariableResolver";
 import { DEFAULT_REQUEST_NAME } from "@/constants/request";
-import type { Tab } from "@/stores";
+import { boundRowFor, useBoundRowStore, type Tab } from "@/stores";
 
 /**
  * Extract a short display path from a request URL. URLs may contain
@@ -126,6 +126,14 @@ export function useTabDescriptors(tabs: Tab[]): TabDescriptor[] {
 	});
 	const { data: collections = [] } = useCollectionsQuery();
 	const { resolveString } = useVariableResolver();
+	/*
+	 * The row the open builder is bound to (issue #1074). One resolver serves the
+	 * whole list, so the row cannot be an option on it the way it is inside the
+	 * builder - it is passed per call instead, for the one tab it belongs to.
+	 * Null for every ordinary Send, which is the state this strip has always been
+	 * in.
+	 */
+	const bound = useBoundRowStore((s) => s.bound);
 
 	return tabs.map((tab, i) => {
 		const request = requests[i]?.data;
@@ -149,7 +157,10 @@ export function useTabDescriptors(tabs: Tab[]): TabDescriptor[] {
 			}
 			case "request": {
 				if (!request) return { label: "Request", title: "Request" };
-				const name = requestTabTitle(request.name, resolveString(request.url));
+				const name = requestTabTitle(
+					request.name,
+					resolveString(request.url, boundRowFor(bound, tab.entityId))
+				);
 				return {
 					label: name,
 					title: `${request.method} ${name}`,

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -68,7 +68,13 @@ interface UseVariableResolverOptions {
 }
 
 interface UseVariableResolverReturn {
-	resolveString: (input: string) => string;
+	/**
+	 * Resolve one string. `row` is for the caller that resolves for *several*
+	 * requests at once and so cannot name one row for the whole hook - the tab
+	 * strip, which labels every open tab from a single resolver (issue #1074).
+	 * It answers for that call only, and defaults to the `boundRow` option.
+	 */
+	resolveString: (input: string, row?: DataFileRow) => string;
 	resolveObject: <T>(obj: T) => T;
 	getVariable: (name: string) => ResolvedVariable | null;
 	getAllVariables: () => Record<string, ResolvedVariable>;
@@ -80,6 +86,14 @@ interface UseVariableResolverReturn {
 	 * `VariableOrigin` for why the losers are worth keeping.
 	 */
 	getVariableOrigins: (name: string) => VariableOrigin[];
+}
+
+/**
+ * A row as the text each of its cells substitutes - the one place a row is
+ * rendered, so the caller-wide row and a per-call one cannot render differently.
+ */
+function cellsOf(row: DataFileRow): DataRowCells {
+	return new Map(Object.entries(row).map(([column, cell]) => [column, renderDataValue(cell)]));
 }
 
 export function useVariableResolver(
@@ -221,21 +235,14 @@ export function useVariableResolver(
 	);
 
 	/**
-	 * The bound row's cells as the text each substitutes, rendered once rather
-	 * than per token. Undefined - not an empty map - when no row is bound, so
-	 * `resolveString` below can tell "no row" from "a row with no columns".
+	 * The caller-wide bound row's cells as the text each substitutes, rendered
+	 * once rather than per token. Undefined - not an empty map - when no row is
+	 * bound, so `resolveString` below can tell "no row" from "a row with no
+	 * columns".
 	 */
 	const boundRow = options?.boundRow;
 	const rowCells = useMemo<DataRowCells | undefined>(
-		() =>
-			boundRow
-				? new Map(
-						Object.entries(boundRow).map(([column, cell]) => [
-							column,
-							renderDataValue(cell),
-						])
-					)
-				: undefined,
+		() => (boundRow ? cellsOf(boundRow) : undefined),
 		[boundRow]
 	);
 
@@ -261,10 +268,13 @@ export function useVariableResolver(
 	 * one bind and the send would be a lie about the other one.
 	 */
 	const resolveString = useCallback(
-		(input: string): string =>
-			rowCells
-				? resolveTemplateWithRow(input, (name) => variableMap[name]?.value, rowCells)
-				: resolveTemplate(input, (name) => variableMap[name]?.value),
+		(input: string, row?: DataFileRow): string => {
+			const lookup = (name: string) => variableMap[name]?.value;
+			const cells = row ? cellsOf(row) : rowCells;
+			return cells
+				? resolveTemplateWithRow(input, lookup, cells)
+				: resolveTemplate(input, lookup);
+		},
 		[variableMap, rowCells]
 	);
 

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -11,9 +11,15 @@
  * Provides functions to resolve {{variables}} in strings using the current
  * variable context (globals, collection chain, active environment).
  *
- * Resolution priority (highest wins): Environment > Collection chain (leaf → root) > Global
+ * Resolution priority (highest wins): Bound data row (bare column names, only
+ * while one is picked) > Environment > Collection chain (leaf → root) > Global
  * Within the collection chain, variables closer to the leaf override those closer to the root.
  * Cached per (collectionId, environmentId) via useMemo.
+ *
+ * The row tier is the one a caller opts into with `boundRow` (issue #1062).
+ * Without it the preview is composition's, where a bound column keeps its
+ * braces for the per-row bind; with it the preview is composition *and* that
+ * bind, which is what a Send-with-row actually puts on the wire.
  *
  * A `{{$name}}` nothing defines is generated from the dynamic-variable table
  * (`lib/dynamic-variables.ts`) rather than looked up - see `resolveString`.
@@ -39,11 +45,26 @@ import { walkAncestors } from "@/modules/collections/tree-utils";
 import {
 	coerceVariableValue,
 	isEnabledDefinition,
+	renderDataValue,
 	resolveTemplate,
+	resolveTemplateWithRow,
+	type DataRowCells,
 } from "@/lib/variable-resolution";
+import type { DataFileRow } from "@/services/data-files";
 
 interface UseVariableResolverOptions {
 	collectionId?: string;
+	/**
+	 * The data row this preview is bound to, if one is picked (issue #1062).
+	 *
+	 * Only a Send-with-row has one. Composition never does - a payload is
+	 * composed once and a row is bound per iteration - so a caller without one
+	 * previews exactly what it always did, and the token a run will bind keeps
+	 * its braces. A caller *with* one previews the bind as well as the
+	 * composition, which is the whole difference: the row's cell answers a bare
+	 * column name above the environment, as it will on the wire.
+	 */
+	boundRow?: DataFileRow;
 }
 
 interface UseVariableResolverReturn {
@@ -200,6 +221,20 @@ export function useVariableResolver(
 	);
 
 	/**
+	 * The bound row's cells as the text each substitutes, rendered once rather
+	 * than per token. Undefined - not an empty map - when no row is bound, so
+	 * `resolveString` below can tell "no row" from "a row with no columns".
+	 */
+	const boundRow = options?.boundRow;
+	const rowCells = useMemo<DataRowCells | undefined>(
+		() =>
+			boundRow
+				? new Map(Object.entries(boundRow).map(([column, cell]) => [column, renderDataValue(cell)]))
+				: undefined,
+		[boundRow]
+	);
+
+	/**
 	 * Scopes first, then the dynamic-variable table.
 	 *
 	 * The order is the compatible one: a collection that already defines a
@@ -214,10 +249,18 @@ export function useVariableResolver(
 	 * it visible in the request, and `EditableVariable` keeps painting the token
 	 * as unresolved. Since issue #1009 an ordinary unknown name is the same
 	 * rule - the preview shows the token the engine will send.
+	 *
+	 * With a row bound the preview is the bind as well as the composition
+	 * (issue #1062): the row's cell answers a bare column name above every
+	 * scope, and `{{data.column}}` answers from the same row, because they are
+	 * one bind and the send would be a lie about the other one.
 	 */
 	const resolveString = useCallback(
-		(input: string): string => resolveTemplate(input, (name) => variableMap[name]?.value),
-		[variableMap]
+		(input: string): string =>
+			rowCells
+				? resolveTemplateWithRow(input, (name) => variableMap[name]?.value, rowCells)
+				: resolveTemplate(input, (name) => variableMap[name]?.value),
+		[variableMap, rowCells]
 	);
 
 	const resolveObject = useCallback(

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -229,7 +229,12 @@ export function useVariableResolver(
 	const rowCells = useMemo<DataRowCells | undefined>(
 		() =>
 			boundRow
-				? new Map(Object.entries(boundRow).map(([column, cell]) => [column, renderDataValue(cell)]))
+				? new Map(
+						Object.entries(boundRow).map(([column, cell]) => [
+							column,
+							renderDataValue(cell),
+						])
+					)
 				: undefined,
 		[boundRow]
 	);

--- a/app/src/lib/variable-resolution.row.test.ts
+++ b/app/src/lib/variable-resolution.row.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Resolution for the one preview that holds a row (issue #1062).
+ *
+ * `resolveTemplate` beside it previews *composition*, which never has a row: a
+ * payload is composed once and a row is bound per iteration, so both spellings
+ * of a data read keep their braces there. A Send-with-row is the other case -
+ * the row is already picked - and this is the engine's
+ * `resolve_template_with_data`, the shape `pm.variables.replaceIn` reaches for
+ * the same reason (issue #890).
+ *
+ * The cases that matter are the ones where the two disagree: a bare column name
+ * an environment variable also defines is the collision the tier order exists
+ * for, and it is exactly what the preview used to get wrong.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	renderDataValue,
+	resolveTemplate,
+	resolveTemplateWithRow,
+	type DataRowCells,
+} from "./variable-resolution";
+
+/** A scope lookup over a plain bag, the shape `useVariableResolver` passes. */
+const scopes =
+	(bag: Record<string, string>) =>
+	(name: string): string | undefined =>
+		bag[name];
+
+const row = (cells: Record<string, string>): DataRowCells => new Map(Object.entries(cells));
+
+describe("resolveTemplateWithRow", () => {
+	it("answers a bare column from the row, above an environment variable of the same name", () => {
+		const lookup = scopes({ username: "from-the-environment" });
+		expect(
+			resolveTemplateWithRow("https://api.test/u/{{username}}", lookup, row({ username: "ada" }))
+		).toBe("https://api.test/u/ada");
+		// The composition preview beside it, for contrast: no row, so the token
+		// is left for the bind - and without the row it would read the
+		// environment, which is the value the send never puts on the wire.
+		expect(resolveTemplate("https://api.test/u/{{username}}", lookup)).toBe(
+			"https://api.test/u/from-the-environment"
+		);
+	});
+
+	it("gives the bare spelling and {{data.column}} the same answer - they are one bind", () => {
+		const cells = row({ email: "ada@example.test" });
+		const lookup = scopes({ email: "from-the-environment" });
+		expect(resolveTemplateWithRow("{{email}}|{{data.email}}", lookup, cells)).toBe(
+			"ada@example.test|ada@example.test"
+		);
+	});
+
+	it("falls through to the scopes for a bare name the row does not carry", () => {
+		// Not a mistake about a column: an ordinary variable, which is what keeps
+		// one request previewing the same way with and without a row picked.
+		expect(
+			resolveTemplateWithRow("{{region}}/{{id}}", scopes({ region: "eu" }), row({ id: "7" }))
+		).toBe("eu/7");
+	});
+
+	it("leaves a data. name the row has no column for written as it stands", () => {
+		// The token says the value came from the file, so a name no column
+		// answers is a mistake about the column and an empty string hides it.
+		expect(resolveTemplateWithRow("{{data.missing}}", scopes({ missing: "x" }), row({ id: "7" }))).toBe(
+			"{{data.missing}}"
+		);
+	});
+
+	it("keeps an unknown bare name's braces, as resolution without a row does", () => {
+		expect(resolveTemplateWithRow("{{nowhere}}", scopes({}), row({ id: "7" }))).toBe("{{nowhere}}");
+	});
+
+	it("resolves a cell that carries tokens of its own through the same lookup", () => {
+		expect(
+			resolveTemplateWithRow("{{path}}", scopes({ host: "api.test" }), row({ path: "https://{{host}}/x" }))
+		).toBe("https://api.test/x");
+	});
+
+	it("lets a column named like a generator answer from the row", () => {
+		// The engine's order: the row is read before the generator table, so a
+		// dataset column spelled `$guid` is the row's, not a fresh id.
+		expect(resolveTemplateWithRow("{{$guid}}", scopes({}), row({ $guid: "from-the-row" }))).toBe(
+			"from-the-row"
+		);
+	});
+
+	it("lets a column named like the identity namespace answer from the row", () => {
+		// `$vu` is reserved against a *variable* answering for it, not against a
+		// column: `resolve_template_with_data` reads the row before it reaches
+		// the reserved check, and the preview reads it the same way.
+		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ $vu: "3" }))).toBe("3");
+	});
+
+	it("keeps the identity namespace deferred when the row has no such column", () => {
+		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ id: "7" }))).toBe("{{$vu}}");
+	});
+
+	it("leaves a cycle in a cell literal rather than expanding forever", () => {
+		// `a` (the row) spells `{{b}}`, `b` (a scope) spells `{{a}}` back: the
+		// innermost `a` is already being expanded, so its token stays written and
+		// the recursion ends there. A row cell joins the same cycle chain a scope
+		// value does, because both go through one substitution core.
+		expect(resolveTemplateWithRow("{{a}}", scopes({ b: "{{a}}" }), row({ a: "{{b}}" }))).toBe(
+			"{{a}}"
+		);
+	});
+});
+
+describe("renderDataValue", () => {
+	it("is byte-exact for a string, which is every CSV and TSV cell", () => {
+		expect(renderDataValue("ada@example.test")).toBe("ada@example.test");
+		expect(renderDataValue("")).toBe("");
+	});
+
+	it("spells a number or a boolean as JSON writes it", () => {
+		expect(renderDataValue(7)).toBe("7");
+		expect(renderDataValue(1.5)).toBe("1.5");
+		expect(renderDataValue(true)).toBe("true");
+	});
+
+	it("renders a null cell empty", () => {
+		// What the value *reads* as. The binder refuses a null cell outright, so
+		// this is never a value the wire sees.
+		expect(renderDataValue(null)).toBe("");
+		expect(renderDataValue(undefined)).toBe("");
+	});
+
+	it("renders an object or an array as compact JSON, so a nested cell can still be dropped into a body", () => {
+		expect(renderDataValue({ k: 1 })).toBe('{"k":1}');
+		expect(renderDataValue([1, "two"])).toBe('[1,"two"]');
+	});
+});

--- a/app/src/lib/variable-resolution.row.test.ts
+++ b/app/src/lib/variable-resolution.row.test.ts
@@ -41,7 +41,11 @@ describe("resolveTemplateWithRow", () => {
 	it("answers a bare column from the row, above an environment variable of the same name", () => {
 		const lookup = scopes({ username: "from-the-environment" });
 		expect(
-			resolveTemplateWithRow("https://api.test/u/{{username}}", lookup, row({ username: "ada" }))
+			resolveTemplateWithRow(
+				"https://api.test/u/{{username}}",
+				lookup,
+				row({ username: "ada" })
+			)
 		).toBe("https://api.test/u/ada");
 		// The composition preview beside it, for contrast: no row, so the token
 		// is left for the bind - and without the row it would read the
@@ -70,38 +74,48 @@ describe("resolveTemplateWithRow", () => {
 	it("leaves a data. name the row has no column for written as it stands", () => {
 		// The token says the value came from the file, so a name no column
 		// answers is a mistake about the column and an empty string hides it.
-		expect(resolveTemplateWithRow("{{data.missing}}", scopes({ missing: "x" }), row({ id: "7" }))).toBe(
-			"{{data.missing}}"
-		);
+		expect(
+			resolveTemplateWithRow("{{data.missing}}", scopes({ missing: "x" }), row({ id: "7" }))
+		).toBe("{{data.missing}}");
 	});
 
 	it("keeps an unknown bare name's braces, as resolution without a row does", () => {
-		expect(resolveTemplateWithRow("{{nowhere}}", scopes({}), row({ id: "7" }))).toBe("{{nowhere}}");
+		expect(resolveTemplateWithRow("{{nowhere}}", scopes({}), row({ id: "7" }))).toBe(
+			"{{nowhere}}"
+		);
 	});
 
 	it("resolves a cell that carries tokens of its own through the same lookup", () => {
 		expect(
-			resolveTemplateWithRow("{{path}}", scopes({ host: "api.test" }), row({ path: "https://{{host}}/x" }))
+			resolveTemplateWithRow(
+				"{{path}}",
+				scopes({ host: "api.test" }),
+				row({ path: "https://{{host}}/x" })
+			)
 		).toBe("https://api.test/x");
 	});
 
 	it("lets a column named like a generator answer from the row", () => {
 		// The engine's order: the row is read before the generator table, so a
 		// dataset column spelled `$guid` is the row's, not a fresh id.
-		expect(resolveTemplateWithRow("{{$guid}}", scopes({}), row({ $guid: "from-the-row" }))).toBe(
-			"from-the-row"
-		);
+		expect(
+			resolveTemplateWithRow("{{$guid}}", scopes({}), row({ $guid: "from-the-row" }))
+		).toBe("from-the-row");
 	});
 
 	it("lets a column named like the identity namespace answer from the row", () => {
 		// `$vu` is reserved against a *variable* answering for it, not against a
 		// column: `resolve_template_with_data` reads the row before it reaches
 		// the reserved check, and the preview reads it the same way.
-		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ $vu: "3" }))).toBe("3");
+		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ $vu: "3" }))).toBe(
+			"3"
+		);
 	});
 
 	it("keeps the identity namespace deferred when the row has no such column", () => {
-		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ id: "7" }))).toBe("{{$vu}}");
+		expect(resolveTemplateWithRow("{{$vu}}", scopes({ $vu: "9" }), row({ id: "7" }))).toBe(
+			"{{$vu}}"
+		);
 	});
 
 	it("leaves a cycle in a cell literal rather than expanding forever", () => {

--- a/app/src/lib/variable-resolution.ts
+++ b/app/src/lib/variable-resolution.ts
@@ -31,7 +31,9 @@
  *    bind - a variable defined with either name never answers for it
  *  - so does a bare name a bound data row will substitute (issue #1007) - the
  *    same deferral for the same reason, spelled the way Postman's data
- *    variables are
+ *    variables are. A caller that already holds the row is the one exception,
+ *    and it reads `resolveTemplateWithRow`: it previews the bind that follows
+ *    composition rather than composition alone (issue #1062)
  *  - a user-defined variable named `$guid` beats the generator; generators run
  *    once per occurrence
  *  - a value that itself holds `{{tokens}}` resolves through them, to a depth
@@ -140,8 +142,10 @@ export function dataColumnName(name: string): string | null {
  * stands.
  *
  * Empty is every resolution with no dataset behind it, which is every preview
- * this module serves today; the parameter exists so the preview cannot answer
- * the conformance fixture's cases differently from the engine.
+ * that composes without a row in hand; the parameter exists so the preview
+ * cannot answer the conformance fixture's cases differently from the engine. A
+ * preview that *has* the row reads `resolveTemplateWithRow` instead, which is
+ * the bind rather than the composition (issue #1062).
  */
 export type BoundColumnNames = ReadonlySet<string>;
 
@@ -157,27 +161,21 @@ const NO_BOUND_COLUMNS: BoundColumnNames = new Set<string>();
 const MAX_NESTED_RESOLUTIONS = 8;
 
 /**
- * Substitute `{{name}}` occurrences: the reserved `data.*` namespace and the
- * reserved `$vu` / `$iteration` identity namespace first, with `boundColumns`
- * beside them (all kept verbatim, issue #1007), then scopes, then the
- * dynamic-variable table. A defined name (even one spelled `$guid`) wins over
- * a generator; a name nothing answers keeps its braces, `$name` (issue #186)
- * and ordinary alike (issue #1009) - the token reaching the wire is what makes
- * the miss visible, where an empty string silently changed the request.
+ * Replace every `{{name}}` in @p input with what @p lookup answers for it, a
+ * name it answers `undefined` for keeping its braces.
+ *
+ * The engine's `substitute_tokens`, restated: the recursion and its bound live
+ * here and the tier order lives in the lookup, which is what lets one core
+ * serve both a composition preview (`resolveTemplate`) and a preview that holds
+ * the row (`resolveTemplateWithRow`) without either restating the other's
+ * nesting rules.
  *
  * A replacement that carries tokens of its own is resolved through the same
  * lookup, to `MAX_NESTED_RESOLUTIONS` levels, so a layered `{{baseUrl}}`
  * previews as the URL it spells. A name already being expanded is a cycle and
  * its token stays literal; the surrounding text is never rescanned.
- *
- * `boundColumns` defaults to empty, which is resolution as it was: every caller
- * with no dataset behind it resolves exactly the names it always did.
  */
-export function resolveTemplate(
-	input: string,
-	lookup: (name: string) => string | undefined,
-	boundColumns: BoundColumnNames = NO_BOUND_COLUMNS
-): string {
+function substituteTokens(input: string, lookup: (name: string) => string | undefined): string {
 	if (!input || typeof input !== "string") return input;
 	// The names currently being expanded, innermost last - the chain the cycle
 	// check reads, not a set of every name seen: `{{a}} {{a}}` side by side is
@@ -186,36 +184,8 @@ export function resolveTemplate(
 	const substitute = (text: string): string =>
 		text.replace(VARIABLE_PATTERN, (match, rawName: string) => {
 			const name = rawName.trim();
-			// Before the lookup, not after: the namespace is disjoint from the
-			// scopes, so a variable named `data.id` must not answer for the column.
-			// Only a scenario run's iteration can bind one, and the engine's
-			// composer leaves it written as it stands for exactly that reason.
-			if (isDataVariableName(name)) return match;
-			// Same reasoning, same placement: `$vu` / `$iteration` name the
-			// reserved identity namespace (issue #994), not a variable, so a
-			// scope definition of either must not answer here either. Only the
-			// iteration that sends binds them - the engine's composer leaves the
-			// token written as it stands for exactly that reason.
-			if (isIterationVariableName(name)) return match;
-			// Before the lookup for the opposite reason: this name is *not*
-			// disjoint from the scopes, and the row is the one that wins. Postman
-			// puts a data column above the environment, so a scope answering here
-			// would preview the value the row is there to replace - and ahead of
-			// the generator table too, so a column named `$guid` is deferred rather
-			// than generated. After the two reserved namespaces, as the engine
-			// orders them.
-			if (boundColumns.has(name)) return match;
 			if (expanding.includes(name)) return match;
-			const defined = lookup(name);
-			// The generator answers `null` for a name its table does not have,
-			// where a scope answers `undefined` - one shape here, so the miss is
-			// tested once rather than at each use below.
-			const value =
-				defined !== undefined
-					? defined
-					: isDynamicVariableName(name)
-						? (resolveDynamicVariable(name) ?? undefined)
-						: undefined;
+			const value = lookup(name);
 			if (value === undefined) return match;
 			if (!value.includes("{{") || expanding.length >= MAX_NESTED_RESOLUTIONS) return value;
 			expanding.push(name);
@@ -226,4 +196,128 @@ export function resolveTemplate(
 			}
 		});
 	return substitute(input);
+}
+
+/**
+ * One name's answer for a resolution with no row behind it - the engine's
+ * `lookup_variable`, tier for tier.
+ *
+ * `undefined` is "keeps its braces", which is every reserved or deferred name
+ * as well as every name nothing defines.
+ */
+function lookupVariable(
+	name: string,
+	lookup: (name: string) => string | undefined,
+	boundColumns: BoundColumnNames
+): string | undefined {
+	// Before the lookup, not after: the namespace is disjoint from the
+	// scopes, so a variable named `data.id` must not answer for the column.
+	// Only a scenario run's iteration can bind one, and the engine's
+	// composer leaves it written as it stands for exactly that reason.
+	if (isDataVariableName(name)) return undefined;
+	// Same reasoning, same placement: `$vu` / `$iteration` name the
+	// reserved identity namespace (issue #994), not a variable, so a
+	// scope definition of either must not answer here either. Only the
+	// iteration that sends binds them - the engine's composer leaves the
+	// token written as it stands for exactly that reason.
+	if (isIterationVariableName(name)) return undefined;
+	// Before the lookup for the opposite reason: this name is *not*
+	// disjoint from the scopes, and the row is the one that wins. Postman
+	// puts a data column above the environment, so a scope answering here
+	// would preview the value the row is there to replace - and ahead of
+	// the generator table too, so a column named `$guid` is deferred rather
+	// than generated. After the two reserved namespaces, as the engine
+	// orders them.
+	if (boundColumns.has(name)) return undefined;
+	const defined = lookup(name);
+	if (defined !== undefined) return defined;
+	// The generator answers `null` for a name its table does not have, where a
+	// scope answers `undefined` - one shape here, so the miss is tested once.
+	return isDynamicVariableName(name) ? (resolveDynamicVariable(name) ?? undefined) : undefined;
+}
+
+/**
+ * Substitute `{{name}}` occurrences: the reserved `data.*` namespace and the
+ * reserved `$vu` / `$iteration` identity namespace first, with `boundColumns`
+ * beside them (all kept verbatim, issue #1007), then scopes, then the
+ * dynamic-variable table. A defined name (even one spelled `$guid`) wins over
+ * a generator; a name nothing answers keeps its braces, `$name` (issue #186)
+ * and ordinary alike (issue #1009) - the token reaching the wire is what makes
+ * the miss visible, where an empty string silently changed the request.
+ *
+ * `boundColumns` defaults to empty, which is resolution as it was: every caller
+ * with no dataset behind it resolves exactly the names it always did.
+ */
+export function resolveTemplate(
+	input: string,
+	lookup: (name: string) => string | undefined,
+	boundColumns: BoundColumnNames = NO_BOUND_COLUMNS
+): string {
+	return substituteTokens(input, (name) => lookupVariable(name, lookup, boundColumns));
+}
+
+/**
+ * One row's cells, keyed by column name with no `data.` prefix, holding the
+ * text each substitutes - the engine's `DataRowColumns`.
+ */
+export type DataRowCells = ReadonlyMap<string, string>;
+
+/**
+ * Render one row value as the text a token substitutes - the engine's
+ * `render_data_value`, restated.
+ *
+ * A string is its own text: the CSV/TSV path produces only strings, so this is
+ * the ordinary case and it is byte-exact. A JSON or JSONL file may carry any
+ * type: numbers and booleans render as JSON writes them (`7`, `true`), `null`
+ * renders empty, and an object or array renders as compact JSON so a nested
+ * value can still be dropped into a body.
+ *
+ * A null cell never reaches a request through the binder - it is refused, for
+ * the same reason a missing column is - so the empty rendering is the answer to
+ * "what does this value say", not a value the wire ever sees.
+ */
+export function renderDataValue(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value === null || value === undefined) return "";
+	// Every other cell came out of a CSV, TSV, JSON or JSONL parse, so it is a
+	// number, a boolean, or a plain object or array - each of which `stringify`
+	// spells. Nothing a data file can hold makes it answer nothing.
+	return JSON.stringify(value);
+}
+
+/**
+ * Resolve @p input against a bound row as well as the scopes - the engine's
+ * `resolve_template_with_data`, restated for the preview that holds a row.
+ *
+ * Composition has no row: a payload is composed once and a row is bound per
+ * iteration, which is why `resolveTemplate` above leaves both spellings of a
+ * data read written as they stand. A Send-with-row's preview is the other case,
+ * the one the engine meets in `pm.variables.replaceIn` (issue #890) - the row
+ * is already picked, so the preview can show what the send will put on the wire
+ * rather than the token that stands in for it.
+ *
+ * The tiers, in the engine's order:
+ *  - `{{data.column}}` reads @p row, and a `data.` name the row has no column
+ *    for keeps its braces rather than emptying - the token says the value came
+ *    from the file, so a name no column answers is a mistake about the column
+ *    and the quiet answer hides it (the Data tab's column audit is what names
+ *    it, and `describeDataToken` is what paints it)
+ *  - a bare name the row carries reads the row too (issue #1007), above the
+ *    scopes, because that is where Postman puts a data variable
+ *  - every other bare name falls through to `lookupVariable` with no bound
+ *    columns: a name the row does not carry is an ordinary variable, not a
+ *    mistake about a column, which is what keeps one request previewing the
+ *    same way with and without a row picked
+ */
+export function resolveTemplateWithRow(
+	input: string,
+	lookup: (name: string) => string | undefined,
+	row: DataRowCells
+): string {
+	return substituteTokens(input, (name) => {
+		const column = dataColumnName(name);
+		if (column !== null) return row.get(column);
+		const cell = row.get(name);
+		return cell !== undefined ? cell : lookupVariable(name, lookup, NO_BOUND_COLUMNS);
+	});
 }

--- a/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
@@ -77,11 +77,20 @@ function ctx(canStartLoadTest: boolean, overrides: CtxOverrides = {}): RequestBu
 		getVariableOrigins: () => [],
 		updateVariable: vi.fn(),
 		writableScopes: [],
-		// Send-with-row's row cap. The bar reads it off the context rather than
-		// the config query precisely so this file can render without a
-		// `QueryClientProvider`; no case here declares a contract, so nothing
-		// measures anything against it.
-		dataFileMaxRows: 1000,
+		// Send-with-row's rows, held by the provider since issue #1062 so the
+		// preview can resolve against the picked one. No case here declares a
+		// contract, so the affordance is absent and nothing reads the rest.
+		sendWithRow: {
+			available: false,
+			contract: undefined,
+			fileName: undefined,
+			status: "idle",
+			parsed: null,
+			error: null,
+			load: vi.fn(),
+		},
+		lastRowIndex: null,
+		rememberRowIndex: vi.fn(),
 		executeRequest: vi.fn(async () => {}),
 		saveRequest: vi.fn(async () => {}),
 		startLoadTest: vi.fn(),

--- a/app/src/modules/request-builder/components/UrlBar/index.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/index.tsx
@@ -129,10 +129,10 @@ export default function UrlBar() {
 	const canBindRows = rows.available && !isStreaming;
 	useEffect(() => {
 		if (!dataRowTarget || dataRowTarget.requestId !== request.id) return;
+		rememberRowIndex(dataRowTarget.rowIndex);
 		/* eslint-disable-next-line react-hooks/set-state-in-effect -- the target
 		   is state handed over from a navigation, not derived from a prop: it
 		   arrives before this tab renders and is consumed once. */
-		rememberRowIndex(dataRowTarget.rowIndex);
 		if (canBindRows) setRowMenuOpen(true);
 		clearDataRowTarget();
 	}, [dataRowTarget, request.id, canBindRows, clearDataRowTarget, rememberRowIndex]);

--- a/app/src/modules/request-builder/components/UrlBar/index.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/index.tsx
@@ -49,7 +49,6 @@
 import { useEffect, useState } from "react";
 
 import { useRequestBuilderContext } from "../../context";
-import { useSendWithRow } from "../../hooks/useSendWithRow";
 import { useDashboardStore, useTabsStore } from "@/stores";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { formatChord, type Chord } from "@/lib/platform";
@@ -101,42 +100,12 @@ export default function UrlBar() {
 		executeRequest,
 		startLoadTest,
 		canStartLoadTest,
-		dataColumns,
-		dataFileMaxRows,
+		sendWithRow: rows,
+		lastRowIndex,
+		rememberRowIndex,
 	} = useRequestBuilderContext();
 	const isLoadTestRunning = useDashboardStore((s) => s.isStreaming);
 	const openTab = useTabsStore((s) => s.openTab);
-
-	/*
-	 * Send-with-row (issue #601): the rows this request could bind, and the one
-	 * it was last sent with.
-	 *
-	 * The index lives here, in plain state, because it is a property of *this
-	 * editing session* - "the row I am iterating on" - and not of the request.
-	 * Persisting it would point a saved number at a file whose rows are
-	 * deliberately not saved, so a later session would bind a different row
-	 * under the same index.
-	 *
-	 * Keyed by request, though (issue #659 item 1). Switching request tabs does
-	 * not remount this component - `Shell` renders `<RequestBuilder />` at the
-	 * same position for every request tab, so React keeps the instance and its
-	 * state - and a single number therefore followed the user from one request
-	 * to the next. The highlight, and the row a re-send would bind, belonged to
-	 * whichever request happened to pick one last. A map is the fix "per
-	 * request" always meant; it is still session-lived, and still thrown away
-	 * with the builder.
-	 */
-	const rows = useSendWithRow(dataColumns, dataFileMaxRows);
-	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
-	/*
-	 * An unsaved request has no id and cannot be switched away from and back to
-	 * as itself, so every one of them shares this key. They can never collide:
-	 * a request tab holds exactly one draft.
-	 */
-	const rowMemoryKey = request.id ?? "__unsaved__";
-	const lastRowIndex = rowIndexByRequest[rowMemoryKey] ?? null;
-	const rememberRowIndex = (index: number) =>
-		setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index }));
 
 	/*
 	 * A step of a collection run pointed here (issue #730): "Repro row 501"
@@ -163,13 +132,10 @@ export default function UrlBar() {
 		/* eslint-disable-next-line react-hooks/set-state-in-effect -- the target
 		   is state handed over from a navigation, not derived from a prop: it
 		   arrives before this tab renders and is consumed once. */
-		setRowIndexByRequest((previous) => ({
-			...previous,
-			[dataRowTarget.requestId]: dataRowTarget.rowIndex,
-		}));
+		rememberRowIndex(dataRowTarget.rowIndex);
 		if (canBindRows) setRowMenuOpen(true);
 		clearDataRowTarget();
-	}, [dataRowTarget, request.id, canBindRows, clearDataRowTarget]);
+	}, [dataRowTarget, request.id, canBindRows, clearDataRowTarget, rememberRowIndex]);
 
 	const canExecute = !isExecuting && request.url.trim().length > 0;
 	const viewRunningTest = () => openTab({ type: "dashboard", entityId: null });

--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -145,7 +145,8 @@ function Harness({
 	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
 	const rowMemoryKey = requestId ?? "__unsaved__";
 	const rememberRowIndex = useCallback(
-		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
+		(index: number) =>
+			setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
 		[rowMemoryKey]
 	);
 	return (
@@ -497,7 +498,11 @@ describe("the remembered row", () => {
 		const switchTo = (requestId: string) =>
 			rerender(
 				<TooltipProvider>
-					<Harness executeRequest={execute} dataColumns={CONTRACT} requestId={requestId} />
+					<Harness
+						executeRequest={execute}
+						dataColumns={CONTRACT}
+						requestId={requestId}
+					/>
 				</TooltipProvider>
 			);
 

--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -26,6 +26,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useCallback, useState } from "react";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 
 import { RequestBuilderContext } from "../../context";
@@ -35,6 +36,7 @@ import { emptyDrafts } from "../../utils/body-drafts";
 import { TooltipProvider } from "@/components/ui";
 import { useDataFileStore, useTabsStore } from "@/stores";
 import type { DataContractScope } from "@/types";
+import { useSendWithRow } from "../../hooks/useSendWithRow";
 import UrlBar from "./index";
 
 vi.mock("./MethodSelector", () => ({ default: () => null }));
@@ -55,9 +57,11 @@ function csvBytes(text = CSV): { bytes: Uint8Array; fileName: string } {
 
 function ctx(
 	executeRequest: RequestBuilderContextValue["executeRequest"],
-	dataColumns?: DataContractScope,
-	requestId: string | null = null,
-	dataFileMaxRows = 1000
+	dataColumns: DataContractScope | undefined,
+	requestId: string | null,
+	sendWithRow: RequestBuilderContextValue["sendWithRow"],
+	lastRowIndex: number | null,
+	rememberRowIndex: (index: number) => void
 ): RequestBuilderContextValue {
 	return {
 		request: {
@@ -95,12 +99,72 @@ function ctx(
 		updateVariable: vi.fn(),
 		writableScopes: [],
 		dataColumns,
-		dataFileMaxRows,
+		sendWithRow,
+		lastRowIndex,
+		rememberRowIndex,
 		executeRequest,
 		saveRequest: vi.fn(async () => {}),
 		startLoadTest: vi.fn(),
 		canStartLoadTest: true,
 	};
+}
+
+/**
+ * The provider's Send-with-row state, and nothing else it holds.
+ *
+ * The rows and the picked index moved onto the context in issue #1062, so the
+ * bar can no longer read them for itself - but the read they come from is the
+ * half of this file's gating that is worth exercising for real (a contract, a
+ * remembered location, an IPC read that may fail), so the harness drives the
+ * *actual* hook rather than handing the bar a fixed answer. What it restates of
+ * the provider is the two lines of index memory beside it, deliberately kept
+ * that small.
+ */
+function Harness({
+	executeRequest,
+	dataColumns,
+	requestId,
+	dataFileMaxRows = 1000,
+	overrides,
+}: {
+	executeRequest: RequestBuilderContextValue["executeRequest"];
+	dataColumns?: DataContractScope;
+	requestId: string | null;
+	dataFileMaxRows?: number;
+	overrides?: Partial<RequestBuilderContextValue>;
+}) {
+	const sendWithRow = useSendWithRow(dataColumns, dataFileMaxRows);
+	/*
+	 * Keyed by request exactly as the provider keys it (issue #659 item 1), so
+	 * the two cases below that switch request tabs still see what the bar sees.
+	 * The keying *rule* is the provider's and is pinned there, in
+	 * `RequestBuilderProvider.bound-row.test.tsx`; what these cases pin is that
+	 * the bar reads `lastRowIndex` off the context rather than remembering a
+	 * pick of its own.
+	 */
+	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
+	const rowMemoryKey = requestId ?? "__unsaved__";
+	const rememberRowIndex = useCallback(
+		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
+		[rowMemoryKey]
+	);
+	return (
+		<RequestBuilderContext.Provider
+			value={{
+				...ctx(
+					executeRequest,
+					dataColumns,
+					requestId,
+					sendWithRow,
+					rowIndexByRequest[rowMemoryKey] ?? null,
+					rememberRowIndex
+				),
+				...overrides,
+			}}
+		>
+			<UrlBar />
+		</RequestBuilderContext.Provider>
+	);
 }
 
 function renderBar(
@@ -111,11 +175,12 @@ function renderBar(
 ) {
 	return render(
 		<TooltipProvider>
-			<RequestBuilderContext.Provider
-				value={ctx(executeRequest, dataColumns, requestId, dataFileMaxRows)}
-			>
-				<UrlBar />
-			</RequestBuilderContext.Provider>
+			<Harness
+				executeRequest={executeRequest}
+				dataColumns={dataColumns}
+				requestId={requestId}
+				dataFileMaxRows={dataFileMaxRows}
+			/>
 		</TooltipProvider>
 	);
 }
@@ -317,17 +382,12 @@ describe("the caret's place in the attached group", () => {
 		rememberFile();
 		render(
 			<TooltipProvider>
-				<RequestBuilderContext.Provider
-					value={{
-						...ctx(
-							vi.fn(async () => {}),
-							CONTRACT
-						),
-						canStartLoadTest: false,
-					}}
-				>
-					<UrlBar />
-				</RequestBuilderContext.Provider>
+				<Harness
+					executeRequest={vi.fn(async () => {})}
+					dataColumns={CONTRACT}
+					requestId={null}
+					overrides={{ canStartLoadTest: false }}
+				/>
 			</TooltipProvider>
 		);
 		expect(caret()!.className).toContain("rounded-r-md");
@@ -344,17 +404,12 @@ describe("the caret's place in the attached group", () => {
 		rememberFile();
 		render(
 			<TooltipProvider>
-				<RequestBuilderContext.Provider
-					value={{
-						...ctx(
-							vi.fn(async () => {}),
-							CONTRACT
-						),
-						isStreaming: true,
-					}}
-				>
-					<UrlBar />
-				</RequestBuilderContext.Provider>
+				<Harness
+					executeRequest={vi.fn(async () => {})}
+					dataColumns={CONTRACT}
+					requestId={null}
+					overrides={{ isStreaming: true }}
+				/>
 			</TooltipProvider>
 		);
 		expect(caret()).toBeNull();
@@ -412,9 +467,7 @@ describe("the remembered row", () => {
 		// The tab switch: same mounted builder, different request.
 		rerender(
 			<TooltipProvider>
-				<RequestBuilderContext.Provider value={ctx(execute, CONTRACT, "req_b")}>
-					<UrlBar />
-				</RequestBuilderContext.Provider>
+				<Harness executeRequest={execute} dataColumns={CONTRACT} requestId="req_b" />
 			</TooltipProvider>
 		);
 
@@ -444,9 +497,7 @@ describe("the remembered row", () => {
 		const switchTo = (requestId: string) =>
 			rerender(
 				<TooltipProvider>
-					<RequestBuilderContext.Provider value={ctx(execute, CONTRACT, requestId)}>
-						<UrlBar />
-					</RequestBuilderContext.Provider>
+					<Harness executeRequest={execute} dataColumns={CONTRACT} requestId={requestId} />
 				</TooltipProvider>
 			);
 

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
@@ -56,7 +56,7 @@ vi.mock("@/hooks", async (importOriginal) => {
 	return { ...actual, useSaveManager: () => ({ saveStatus: "idle", isSaving: false }) };
 });
 
-const { useDataFileStore } = await import("@/stores");
+const { useDataFileStore, useBoundRowStore } = await import("@/stores");
 const { default: RequestBuilderProvider } = await import("./RequestBuilderProvider");
 const { useRequestBuilderContext } = await import("./RequestBuilderContext");
 
@@ -130,6 +130,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	useBoundRowStore.setState({ bound: null });
 	useDataFileStore.setState({ locations: {} });
 	Reflect.deleteProperty(window, "electronAPI");
 });
@@ -179,6 +180,31 @@ describe("the preview while a row is bound", () => {
 		// A name the row does not carry is an ordinary variable, not a mistake
 		// about a column.
 		expect(result.current.resolveString("{{nowhere}}")).toBe("{{nowhere}}");
+	});
+});
+
+describe("publishing the bound row for the tab strip", () => {
+	it("names the request the row is bound for", async () => {
+		// The strip labels every tab from one resolver and cannot reach into this
+		// provider, so the row travels through a store instead (issue #1074) - and
+		// it carries the request id, because a slot that did not could relabel the
+		// wrong tab.
+		const { result } = setup("req_a");
+		expect(useBoundRowStore.getState().bound).toBeNull();
+		await bindRow(result, 0);
+		expect(useBoundRowStore.getState().bound).toEqual({
+			requestId: "req_a",
+			row: { username: "ada", email: "ada@example.test" },
+		});
+	});
+
+	it("clears the slot when the builder goes away", async () => {
+		// The rows must never outlive the send that uses them, so an unmounted
+		// builder leaves nothing behind for the strip to label from.
+		const { result, unmount } = setup("req_a");
+		await bindRow(result, 0);
+		unmount();
+		expect(useBoundRowStore.getState().bound).toBeNull();
 	});
 });
 

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The preview and the send agreeing about a bound data row (issue #1062).
+ *
+ * #1007 wired the *payload* side of a Send-with-row - `composeForSend` sends
+ * the row's column names on `POST /compose`, so the engine defers a bare
+ * `{{username}}` and binds it from the row - and left the preview resolving
+ * with no row at all. The URL bar, the params and body previews and the
+ * resolved auth therefore showed the environment's value for a name the send
+ * answers from the file: a resolved token carrying a value the engine will
+ * never send, reached through the bare spelling.
+ *
+ * Driven through the real provider rather than a stub, because what is being
+ * checked is precisely the wiring between three things the provider is the only
+ * place to hold together: the picked row, the resolver, and the per-request
+ * memory of which row that is.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const globals = { variables: {} as Record<string, unknown> };
+const collections: Array<Record<string, unknown>> = [];
+const environments: Array<Record<string, unknown>> = [];
+const session = { activeEnvironmentId: null as string | null };
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: globals }),
+	useCollectionsQuery: () => ({ data: collections }),
+	useCollectionAncestors: () => [],
+	useEnvironmentsQuery: () => ({ data: environments }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: null, report: null, isLoading: false }),
+	// The row cap Send-with-row measures the declared file against; empty
+	// entries leave it on the seeds, which no case here comes near.
+	useConfigQuery: () => ({ data: { entries: [] } }),
+}));
+vi.mock("@/stores", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/stores")>()),
+	useSessionStore: () => session,
+	useResponseStore: () => ({ getResponse: () => null, setResponse: vi.fn() }),
+}));
+vi.mock("@/hooks", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/hooks")>();
+	return { ...actual, useSaveManager: () => ({ saveStatus: "idle", isSaving: false }) };
+});
+
+const { useDataFileStore } = await import("@/stores");
+const { default: RequestBuilderProvider } = await import("./RequestBuilderProvider");
+const { useRequestBuilderContext } = await import("./RequestBuilderContext");
+
+const COLLECTION_ID = "col-users";
+/** A row whose column names collide with the environment on purpose. */
+const CSV = "username,email\nada,ada@example.test\ngrace,grace@example.test\n";
+
+/** A collection declaring the contract, which is what puts columns in scope. */
+function declaringCollection() {
+	return {
+		id: COLLECTION_ID,
+		name: "Users",
+		dataSchema: { columns: ["username", "email"] },
+		variables: {},
+	};
+}
+
+/** The read IPC, answering with the CSV above. */
+function stubReadDataFile(text = CSV) {
+	const readDataFile = vi.fn(async () => ({
+		bytes: new TextEncoder().encode(text),
+		fileName: "users.csv",
+	}));
+	Object.defineProperty(window, "electronAPI", {
+		value: { readDataFile },
+		configurable: true,
+		writable: true,
+	});
+	return readDataFile;
+}
+
+function setup(requestId: string | null = "req_a") {
+	return renderHook(() => useRequestBuilderContext(), {
+		wrapper: ({ children }) => (
+			<RequestBuilderProvider collectionId={COLLECTION_ID} initialRequest={{ id: requestId }}>
+				{children}
+			</RequestBuilderProvider>
+		),
+	});
+}
+
+/** Read the declared file and pick one row, as the picker does. */
+async function bindRow(
+	result: { current: ReturnType<typeof useRequestBuilderContext> },
+	index: number
+) {
+	act(() => result.current.sendWithRow.load());
+	await waitFor(() => expect(result.current.sendWithRow.status).toBe("ready"));
+	act(() => result.current.rememberRowIndex(index));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	globals.variables = {};
+	collections.length = 0;
+	collections.push(declaringCollection());
+	environments.length = 0;
+	environments.push({
+		id: "env",
+		name: "Staging",
+		// The collision the tier order exists for: the environment defines the
+		// same name the dataset declares as a column.
+		variables: { username: { value: "from-the-environment", enabled: true } },
+	});
+	session.activeEnvironmentId = "env";
+	useDataFileStore.setState({ locations: {} });
+	useDataFileStore
+		.getState()
+		.setDataFile(COLLECTION_ID, { path: "/data/users.csv", fileName: "users.csv" });
+	stubReadDataFile();
+});
+
+afterEach(() => {
+	useDataFileStore.setState({ locations: {} });
+	Reflect.deleteProperty(window, "electronAPI");
+});
+
+describe("the preview while a row is bound", () => {
+	it("answers a bare column from the row rather than from the environment", async () => {
+		const { result } = setup();
+		// Before a row is picked the preview is composition's, and the
+		// environment answers - which is correct for a Send with no row.
+		expect(result.current.resolveString("https://api.test/u/{{username}}")).toBe(
+			"https://api.test/u/from-the-environment"
+		);
+
+		await bindRow(result, 0);
+
+		expect(result.current.resolveString("https://api.test/u/{{username}}")).toBe(
+			"https://api.test/u/ada"
+		);
+	});
+
+	it("gives the bare spelling and {{data.column}} the same answer", async () => {
+		// They are one bind, so a preview that answered them differently would be
+		// telling two stories about a single substitution.
+		const { result } = setup();
+		await bindRow(result, 1);
+		expect(result.current.resolveString("{{username}}|{{data.username}}")).toBe("grace|grace");
+	});
+
+	it("reaches the resolved-auth preview, which goes through resolveObject", async () => {
+		// A credential is the canonical data-driven field (issue #591), so the
+		// auth preview is the one that most needs the row - and it is resolved
+		// object-wise rather than string-wise, which is a second call site.
+		const { result } = setup();
+		act(() =>
+			result.current.setRequest({
+				...result.current.request,
+				auth: { mode: "bearer", token: "{{email}}" },
+			})
+		);
+		await bindRow(result, 0);
+		expect(result.current.resolvedAuth).toMatchObject({ token: "ada@example.test" });
+	});
+
+	it("leaves every other name resolving exactly as it did", async () => {
+		const { result } = setup();
+		await bindRow(result, 0);
+		// A name the row does not carry is an ordinary variable, not a mistake
+		// about a column.
+		expect(result.current.resolveString("{{nowhere}}")).toBe("{{nowhere}}");
+	});
+});
+
+describe("which row the preview is bound to", () => {
+	it("is none until the declared file has actually been read", () => {
+		// A "Repro row N" navigation (issue #730) sets the index before the picker
+		// has ever opened, so an index alone must not bind a preview.
+		const { result } = setup();
+		act(() => result.current.rememberRowIndex(1));
+		expect(result.current.resolveString("{{username}}")).toBe("from-the-environment");
+	});
+
+	it("is remembered per request, not per builder", async () => {
+		// One provider serves every request tab (`Shell` renders the builder at
+		// the same position), so a single number followed the user from one
+		// request to the next before issue #659 keyed it.
+		const { result, rerender } = setup("req_a");
+		await bindRow(result, 1);
+		expect(result.current.resolveString("{{username}}")).toBe("grace");
+
+		act(() => result.current.setRequest({ ...result.current.request, id: "req_b" }));
+		expect(result.current.resolveString("{{username}}")).toBe("from-the-environment");
+
+		act(() => result.current.setRequest({ ...result.current.request, id: "req_a" }));
+		rerender();
+		expect(result.current.resolveString("{{username}}")).toBe("grace");
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
@@ -174,6 +174,32 @@ describe("the preview while a row is bound", () => {
 		expect(result.current.resolvedAuth).toMatchObject({ token: "ada@example.test" });
 	});
 
+	it("un-binds when a Send carries no row", async () => {
+		// Send and the send chord both send *without* a row, so a pick left
+		// standing across one would put the row's value in every preview beside a
+		// request that had just gone out with the environment's - the same
+		// disagreement, arrived at from the other side.
+		const { result } = setup();
+		await bindRow(result, 0);
+		expect(result.current.resolveString("{{username}}")).toBe("ada");
+
+		await act(async () => {
+			await result.current.executeRequest();
+		});
+
+		expect(result.current.resolveString("{{username}}")).toBe("from-the-environment");
+		expect(useBoundRowStore.getState().bound).toBeNull();
+	});
+
+	it("stays bound when the Send carries the row", async () => {
+		const { result } = setup();
+		await bindRow(result, 0);
+		await act(async () => {
+			await result.current.executeRequest({ username: "ada" });
+		});
+		expect(result.current.resolveString("{{username}}")).toBe("ada");
+	});
+
 	it("leaves every other name resolving exactly as it did", async () => {
 		const { result } = setup();
 		await bindRow(result, 0);

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -365,7 +365,8 @@ export default function RequestBuilderProvider({
 	const rowMemoryKey = request.id ?? "__unsaved__";
 	const lastRowIndex = rowIndexByRequest[rowMemoryKey] ?? null;
 	const rememberRowIndex = useCallback(
-		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
+		(index: number) =>
+			setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
 		[rowMemoryKey]
 	);
 
@@ -379,7 +380,10 @@ export default function RequestBuilderProvider({
 	 * previewing the composition.
 	 */
 	const boundRow = useMemo(
-		() => (lastRowIndex === null ? undefined : (sendWithRow.parsed?.rows[lastRowIndex] ?? undefined)),
+		() =>
+			lastRowIndex === null
+				? undefined
+				: (sendWithRow.parsed?.rows[lastRowIndex] ?? undefined),
 		[lastRowIndex, sendWithRow.parsed]
 	);
 

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -374,6 +374,27 @@ export default function RequestBuilderProvider({
 			setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
 		[rowMemoryKey]
 	);
+	/*
+	 * A Send that carries no row leaves the request bound to none (issue #1062).
+	 *
+	 * Picking a row is not a setting, it is the row this request is being sent
+	 * with, and Send and the send chord both send *without* one - so a pick left
+	 * standing across a plain Send would put the row's value in every preview
+	 * beside a request that had just gone out with the environment's. That is the
+	 * disagreement this issue exists to end, arrived at from the other side. The
+	 * picker's own memory is what it always was in every other respect: it
+	 * survives a tab switch and a return (issue #659), because neither of those
+	 * is a send.
+	 */
+	const forgetRowIndex = useCallback(
+		() =>
+			setRowIndexByRequest((previous) => {
+				if (!(rowMemoryKey in previous)) return previous;
+				const { [rowMemoryKey]: _forgotten, ...rest } = previous;
+				return rest;
+			}),
+		[rowMemoryKey]
+	);
 
 	/**
 	 * The row the preview resolves against - the picked one, once the file it
@@ -807,6 +828,9 @@ export default function RequestBuilderProvider({
 	 */
 	const executeRequest = useCallback(
 		async (dataRow?: Record<string, unknown>) => {
+			// A Send with no row un-binds this request: the previews must describe
+			// the request that is going out, not the one the last pick described.
+			if (!dataRow) forgetRowIndex();
 			// Snapshot the request as it is at Send. If the user switches to another
 			// request before this resolves, the result must land on the request that
 			// actually ran - not on whatever is on screen when it finishes.
@@ -887,7 +911,7 @@ export default function RequestBuilderProvider({
 				}
 			}
 		},
-		[request, onExecute, onExecuteStream, storeSetResponse]
+		[request, onExecute, onExecuteStream, storeSetResponse, forgetRowIndex]
 	);
 
 	// Start load test

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -32,7 +32,12 @@ import {
 	useUpdateEnvironmentMutation,
 	useLastDesignRunQuery,
 } from "@/queries";
-import { useSessionStore, useResponseStore, useExecutionEventsStore } from "@/stores";
+import {
+	useSessionStore,
+	useResponseStore,
+	useExecutionEventsStore,
+	useBoundRowStore,
+} from "@/stores";
 import { useRevealStore, type OperationRevealCommand } from "@/lib/graphql/reveal-store";
 import { apiService } from "@/services";
 import { queryClient } from "@/lib/query-client";
@@ -386,6 +391,26 @@ export default function RequestBuilderProvider({
 				: (sendWithRow.parsed?.rows[lastRowIndex] ?? undefined),
 		[lastRowIndex, sendWithRow.parsed]
 	);
+
+	/*
+	 * Publish the bound row for the one preview surface that is not below this
+	 * provider: the tab strip (issue #1074). `useTabDescriptors` labels every
+	 * open tab from a single list-wide resolver, so it cannot take the row from
+	 * this context the way the bar and the panels do - and a tab labelled from
+	 * the environment while the bar beneath it shows the file's value is the same
+	 * one-bind-two-answers split #1062 closed everywhere else.
+	 *
+	 * Cleared on unmount as well as whenever there is no row, so the slot cannot
+	 * outlive the builder that justified it.
+	 */
+	const setBoundRow = useBoundRowStore((s) => s.setBoundRow);
+	const boundRequestId = request.id ?? null;
+	useEffect(() => {
+		setBoundRow(
+			boundRow && boundRequestId ? { requestId: boundRequestId, row: boundRow } : null
+		);
+		return () => setBoundRow(null);
+	}, [boundRow, boundRequestId, setBoundRow]);
 
 	// Variable resolution
 	const {

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -52,6 +52,7 @@ import { resolveAuthForSend } from "../utils/auth-resolution";
 import { createDefaultRequestState } from "../utils/request-state";
 import { responseFromRunResult } from "../utils/restore-response";
 import { useExecutionEvents } from "../hooks/useExecutionEvents";
+import { useSendWithRow } from "../hooks/useSendWithRow";
 
 interface RequestBuilderProviderProps {
 	children: ReactNode;
@@ -309,6 +310,79 @@ export default function RequestBuilderProvider({
 		autoAcceptRef.current = auto;
 	}, []);
 
+	const { data: collections = [] } = useCollectionsQuery();
+
+	/**
+	 * The data contract in scope (issue #600) - the nearest declared ancestor of
+	 * this request's collection, from the collections already loaded above.
+	 *
+	 * Resolved once here and carried on the context, so `VariableInput` and the
+	 * key/value rows can paint a `{{data.*}}` token against it without reaching
+	 * for the query cache themselves. Undefined is the ordinary state: most
+	 * collections declare nothing.
+	 */
+	const dataColumns = useMemo(
+		() => resolveDataContract(collectionId, collections) ?? undefined,
+		[collectionId, collections]
+	);
+
+	/*
+	 * Send-with-row (issue #601): the rows this request could bind, and the one
+	 * it was last sent with.
+	 *
+	 * Here rather than in `UrlBar`, where it started, because the *preview* needs
+	 * it as much as the picker does (issue #1062). A row reaching the engine
+	 * beside composition and never through it is what left the URL bar, the tab
+	 * title and the token painting previewing an environment value for a name the
+	 * send answers from the row. The provider already owns both of this hook's
+	 * inputs - the contract above and the row cap below - so lifting the state
+	 * here also takes two props off the context rather than adding any.
+	 *
+	 * The index is still session-lived and still not persisted: it is a property
+	 * of *this editing session* - "the row I am iterating on" - and not of the
+	 * request. Persisting it would point a saved number at a file whose rows are
+	 * deliberately not saved, so a later session would bind a different row under
+	 * the same index.
+	 *
+	 * Keyed by request, though (issue #659 item 1). Switching request tabs does
+	 * not remount the builder - `Shell` renders `<RequestBuilder />` at the same
+	 * position for every request tab, so React keeps the instance and its state -
+	 * and a single number therefore followed the user from one request to the
+	 * next.
+	 *
+	 * The row cap the declared file is measured against (issue #751) is read here
+	 * for the same reason the contract is resolved here: the config query is the
+	 * provider's to hold, not the URL bar's.
+	 */
+	const { maxRows: dataFileMaxRows } = useDataFileLimits();
+	const sendWithRow = useSendWithRow(dataColumns, dataFileMaxRows);
+	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
+	/*
+	 * An unsaved request has no id and cannot be switched away from and back to
+	 * as itself, so every one of them shares this key. They can never collide:
+	 * a request tab holds exactly one draft.
+	 */
+	const rowMemoryKey = request.id ?? "__unsaved__";
+	const lastRowIndex = rowIndexByRequest[rowMemoryKey] ?? null;
+	const rememberRowIndex = useCallback(
+		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
+		[rowMemoryKey]
+	);
+
+	/**
+	 * The row the preview resolves against - the picked one, once the file it
+	 * came from has actually been read.
+	 *
+	 * Null until then, including for an index restored from a "Repro row N"
+	 * navigation before the picker has opened: the index names a row the app has
+	 * not loaded, and previewing against a row nobody has is worse than
+	 * previewing the composition.
+	 */
+	const boundRow = useMemo(
+		() => (lastRowIndex === null ? undefined : (sendWithRow.parsed?.rows[lastRowIndex] ?? undefined)),
+		[lastRowIndex, sendWithRow.parsed]
+	);
+
 	// Variable resolution
 	const {
 		resolveString,
@@ -316,7 +390,7 @@ export default function RequestBuilderProvider({
 		getVariable: resolverGetVariable,
 		getAllVariables: resolverGetAllVariables,
 		getVariableOrigins,
-	} = useVariableResolver({ collectionId: collectionId || undefined });
+	} = useVariableResolver({ collectionId: collectionId || undefined, boundRow });
 
 	/**
 	 * The auth this request will actually send: `inherit` walked through the
@@ -339,7 +413,6 @@ export default function RequestBuilderProvider({
 	// Variable update mutations
 	const { activeEnvironmentId } = useSessionStore();
 	const { data: globalsData } = useGlobalsQuery();
-	const { data: collections = [] } = useCollectionsQuery();
 	const { data: environments = [] } = useEnvironmentsQuery();
 	const updateGlobalsMutation = useUpdateGlobalsMutation();
 	const updateCollectionMutation = useUpdateCollectionMutation();
@@ -597,27 +670,6 @@ export default function RequestBuilderProvider({
 	 * guard changes above, this list is the next thing in the file to change.
 	 * A caller that offers a scope not in here gets a silent no-op.
 	 */
-	/**
-	 * The data contract in scope (issue #600) - the nearest declared ancestor of
-	 * this request's collection, from the collections already loaded above.
-	 *
-	 * Resolved once here and carried on the context, so `VariableInput` and the
-	 * key/value rows can paint a `{{data.*}}` token against it without reaching
-	 * for the query cache themselves. Undefined is the ordinary state: most
-	 * collections declare nothing.
-	 */
-	const dataColumns = useMemo(
-		() => resolveDataContract(collectionId, collections) ?? undefined,
-		[collectionId, collections]
-	);
-
-	/*
-	 * The row cap Send-with-row measures the declared file against (issue #751),
-	 * read here for the same reason the contract is resolved here: the config
-	 * query is the provider's to hold, not the URL bar's.
-	 */
-	const { maxRows: dataFileMaxRows } = useDataFileLimits();
-
 	const writableScopes = useMemo((): VariableScope[] => {
 		const scopes: VariableScope[] = [];
 		if (globalsData?.variables) scopes.push("global");
@@ -854,7 +906,9 @@ export default function RequestBuilderProvider({
 			updateVariable,
 			writableScopes,
 			dataColumns,
-			dataFileMaxRows,
+			sendWithRow,
+			lastRowIndex,
+			rememberRowIndex,
 			executeRequest,
 			saveRequest,
 			startLoadTest,
@@ -894,7 +948,9 @@ export default function RequestBuilderProvider({
 			updateVariable,
 			writableScopes,
 			dataColumns,
-			dataFileMaxRows,
+			sendWithRow,
+			lastRowIndex,
+			rememberRowIndex,
 			executeRequest,
 			saveRequest,
 			startLoadTest,

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -20,6 +20,7 @@
 // Type-only, and therefore safe despite `body-drafts` importing `BodyMode` back
 // from here: `import type` is erased, so no runtime cycle exists.
 import type { BodyDrafts, VariablesDraft } from "./utils/body-drafts";
+import type { SendWithRowState } from "./hooks/useSendWithRow";
 import type {
 	BodyMode,
 	ConsoleLogEntry,
@@ -469,15 +470,22 @@ export interface RequestBuilderContextValue {
 	 */
 	dataColumns?: DataContractScope;
 	/**
-	 * The live `maxScenarioDataRows` a declared data file has to fit inside
-	 * (issue #751), for Send-with-row's re-read of it.
+	 * The rows a single Send can bind, for this request (issue #601).
 	 *
-	 * On the context for the same reason `dataColumns` is: it is the config
-	 * query's answer, and the UrlBar reading that query itself would make the
-	 * bar unrenderable without a `QueryClientProvider`. Never a constant -
-	 * raising the setting has to reach the next read without a restart.
+	 * Held by the provider rather than the URL bar since issue #1062, because the
+	 * preview needs the picked row as much as the picker does: the resolver that
+	 * paints the URL, the params and the body lives here, and a row it never sees
+	 * is a preview of the environment's value for a name the send answers from
+	 * the file. The file behind it is still read only when the picker opens.
 	 */
-	dataFileMaxRows: number;
+	sendWithRow: SendWithRowState;
+	/**
+	 * The row index this request was last sent with, or null - "the row I am
+	 * iterating on", session-lived and keyed per request (issues #601, #659).
+	 */
+	lastRowIndex: number | null;
+	/** Remember the row just picked, for the preview and the next Send. */
+	rememberRowIndex: (index: number) => void;
 
 	// Actions
 	/**

--- a/app/src/stores/bound-row-store.ts
+++ b/app/src/stores/bound-row-store.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Bound Row Store
+ *
+ * The one data row the open request builder is bound to, for the surfaces that
+ * preview a request from outside it (issue #1074).
+ *
+ * `RequestBuilderProvider` already holds the picked row and gives it to its own
+ * resolver, which is every preview *inside* the builder - the URL bar, the
+ * params and body, resolved auth (issue #1062). The tab strip is the surface
+ * that is not below it: `useTabDescriptors` labels every open tab from one
+ * list-wide resolver, because the strip has to know each label before it can
+ * decide how many fit and a hook inside a map is a variable number of hooks. It
+ * therefore cannot reach into the builder for the row, and without it a request
+ * with no name of its own labelled its tab from the environment while the bar
+ * one row below showed the file's value.
+ *
+ * **One slot, not a map.** The builder binds a row for the request it is
+ * showing, so that is the only request an on-screen preview can be bound for;
+ * publishing a row per remembered index would be publishing rows out of a file
+ * that is no longer the one loaded. Writing names the request, so a reader
+ * checks rather than assumes - a stale slot cannot silently relabel the next
+ * tab.
+ *
+ * **Never persisted, and cleared with the builder.** The rows themselves are
+ * the one thing in this feature that must never outlive the send that uses them
+ * (see `data-file-store`): a saved row would point at a file the app has not
+ * re-read, and a saved index at a row that is no longer the same one.
+ */
+
+import { create } from "zustand";
+
+import type { DataFileRow } from "@/services/data-files";
+
+/** The bound row, and which request it belongs to. */
+export interface BoundDataRow {
+	requestId: string;
+	row: DataFileRow;
+}
+
+interface BoundRowState {
+	/** The row the open builder is bound to, or null when it is bound to none. */
+	bound: BoundDataRow | null;
+	/**
+	 * Publish the row the builder is bound to, replacing whatever stood before.
+	 *
+	 * `null` is "bound to none" and is what an ordinary Send, an unsaved request
+	 * and an unmounting builder all write - so the slot cannot outlive the state
+	 * that justified it.
+	 */
+	setBoundRow: (bound: BoundDataRow | null) => void;
+}
+
+export const useBoundRowStore = create<BoundRowState>((set) => ({
+	bound: null,
+	setBoundRow: (bound) => set({ bound }),
+}));
+
+/**
+ * The row bound for @p requestId, or undefined - the read every consumer wants.
+ *
+ * Named here rather than compared at each call site: "is this slot this
+ * request's" is the check that keeps a stale publication from relabelling the
+ * wrong tab, and a copy of it in each reader is a copy that can be forgotten.
+ */
+export function boundRowFor(
+	bound: BoundDataRow | null,
+	requestId: string | null | undefined
+): DataFileRow | undefined {
+	if (!bound || !requestId) return undefined;
+	return bound.requestId === requestId ? bound.row : undefined;
+}

--- a/app/src/stores/index.ts
+++ b/app/src/stores/index.ts
@@ -15,6 +15,7 @@ export { useExecutionEventsStore } from "./execution-events-store";
 export { useImportModalStore } from "./import-modal-store";
 export { useSessionStore } from "./session-store";
 export { useDataFileStore, type DataFileLocation } from "./data-file-store";
+export { useBoundRowStore, boundRowFor, type BoundDataRow } from "./bound-row-store";
 export { useSpecFileStore, type SpecFileLocation } from "./spec-file-store";
 export { useSaveStore, type SaveStatus } from "./save-store";
 export { useResponseStore, type StoredResponse } from "./response-store";

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -250,11 +250,13 @@ on every tab the registry has entries for - request, collection and run. See
 
 ### Variable Resolution Flow
 
-Variables are resolved with priority: **Environment > Collection > Global**
+Variables are resolved with priority: **Bound data row (while one is picked) >
+Environment > Collection > Global**
 
 The **engine** owns resolution for anything that is sent (`POST /compose`). The
 renderer's `useVariableResolver()` is a preview of the same rules - tab titles,
-the variable popover, unresolved-token painting - pinned to the engine's by a
+the variable popover, unresolved-token painting, and, where a caller passes a
+picked row (`boundRow`), the bind itself - pinned to the engine's by a
 cross-language conformance fixture. See `variable-resolution.md`.
 
 1. `useVariableResolver()` fetches globals, collections, and environments

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1577,20 +1577,30 @@ const {
   getVariable: (name: string) => ResolvedVariable | null
   getAllVariables: () => Record<string, ResolvedVariable>
   getVariableOrigins: (name: string) => VariableOrigin[]
-} = useVariableResolver({ collectionId?: string });
+} = useVariableResolver({ collectionId?: string; boundRow?: DataFileRow });
 ```
 
 **Resolution Priority (highest to lowest):**
-1. Environment variables
-2. Collection variables
-3. Global variables
+1. Bound data row (bare column names) - only while `boundRow` is passed and a
+   row is actually picked (issue #1062)
+2. Environment variables
+3. Collection variables
+4. Global variables
 
 Collection scope comes from the `collectionId` option and nowhere else - a
 caller that passes none resolves against globals + environment. See
 `docs/app/variable-resolution.md` for why the session-store fallback was
 removed.
 
-**`collectionId` is the only option.** The environment is *not* passed in: the
+`boundRow` is optional and additive: without it `resolveString` /
+`resolveObject` resolve exactly as before (composition only, both a bound
+column and `{{data.column}}` deferred). With it, they resolve through
+`resolveTemplateWithRow` instead, so a bare bound column and `{{data.column}}`
+both read the row - the request builder's provider is the one caller that
+passes it, deriving it from the picked-row index. See
+`docs/app/variable-resolution.md` for the tier and its rules.
+
+**The environment is the one scope no option names.** It is *not* passed in: the
 hook reads `useSessionStore().activeEnvironmentId` itself, so every caller
 resolves against the environment the user has actually selected and no caller
 can scope a preview to a different one. This page documented an

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -347,6 +347,46 @@ main process - the renderer names no directory of its own, the same posture
 `dataFile:read` holds. It is normalized through **both** `migrate` and
 `merge`, for the reason spelled out for `data-file-store` above.
 
+#### `bound-row-store.ts` - The Row The Open Builder Is Bound To
+
+One slot: the data row a Send-with-row has picked, and the id of the request it
+was picked for (issue #1074).
+
+**State:**
+```typescript
+{
+  bound: { requestId: string; row: Record<string, unknown> } | null
+}
+```
+
+**Key Methods:**
+```typescript
+const setBoundRow = useBoundRowStore((s) => s.setBoundRow);
+setBoundRow({ requestId, row }); // or null for "bound to none"
+```
+
+**Persistence:** none, deliberately - see below.
+
+**Why a store at all.** `RequestBuilderProvider` already gives the picked row to
+its own resolver, which covers every preview inside the builder (issue #1062).
+The tab strip is the one that is not below it: `useTabDescriptors` labels every
+open tab from a single list-wide resolver, so it cannot take the row off the
+builder's context and, left alone, labelled a tab from the environment while the
+bar one row beneath it showed the file's value.
+
+**One slot, not a map, and it names its request.** The builder binds a row for
+the request it is showing, so that is the only request an on-screen preview can
+be bound for; a row per remembered index would be a row out of a file that is no
+longer the one loaded. Carrying the request id is what lets a reader check
+rather than assume, so a slot left standing cannot relabel the next tab -
+`boundRowFor(bound, requestId)` is that check, named once rather than repeated
+at each call site.
+
+**Never persisted, and cleared with the builder.** Rows are user data of unknown
+sensitivity and are persisted nowhere in Vayu, the same law `data-file-store`
+states above; the builder also clears the slot when it unmounts, so a row cannot
+outlive the send that justified it.
+
 #### `recovery-notice-store.ts` - Which Data-Loss Notice Was Already Seen
 
 One timestamp: the `at` of the startup-recovery record the user has already been
@@ -1578,6 +1618,10 @@ const {
   getAllVariables: () => Record<string, ResolvedVariable>
   getVariableOrigins: (name: string) => VariableOrigin[]
 } = useVariableResolver({ collectionId?: string; boundRow?: DataFileRow });
+
+// resolveString takes an optional per-call row (issue #1074), for the one
+// caller that resolves for several requests at once - the tab strip.
+resolveString(input: string, row?: DataFileRow): string
 ```
 
 **Resolution Priority (highest to lowest):**
@@ -1599,6 +1643,12 @@ column and `{{data.column}}` deferred). With it, they resolve through
 both read the row - the request builder's provider is the one caller that
 passes it, deriving it from the picked-row index. See
 `docs/app/variable-resolution.md` for the tier and its rules.
+
+`resolveString`'s second argument is the same row named per call instead of per
+hook. It exists for `useTabDescriptors`, which labels every open tab from a
+single resolver and therefore cannot name one row for the whole of it; it reads
+the row out of `useBoundRowStore` for the tab it is labelling. Both spellings
+render a row's cells through the same helper, so the two cannot disagree.
 
 **The environment is the one scope no option names.** It is *not* passed in: the
 hook reads `useSessionStore().activeEnvironmentId` itself, so every caller

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -233,14 +233,30 @@ on screen saying the column will win once a row binds. Reconciling the paint,
 and giving the popover a "bound data row" origin to explain it, is issue
 #1064's work, not done here.
 
-**What the tab strip still does not show.** A tab's title still resolves
-through one list-wide `useVariableResolver()` in
-`app/src/components/layout/tab-descriptors.ts`, shared by every open tab and
-carrying no row - a picked row is per-request builder state, and the list has
-no single request to bind it to. So the tab label keeps previewing
-composition alone even for the request whose own builder pane, open right
-beside it, is now showing the bind. Giving each tab its own row is issue
-#1074.
+**What the tab strip shows, and how the row reaches it (issue #1074).** A tab's
+title resolves through one list-wide `useVariableResolver()` in
+`app/src/components/layout/tab-descriptors.ts` - the strip has to know each
+label before it can decide how many fit, and a hook inside a map is a variable
+number of hooks - so the strip is the one preview surface that is not below the
+builder's provider and cannot take the row off its context. Left alone it
+labelled a tab from the environment while the bar one row beneath it showed the
+file's value, which is the same one-bind-two-answers split as above wearing a
+different coat.
+
+The row crosses that boundary through `bound-row-store.ts`: one slot, holding
+the row the open builder is bound to **and the id of the request it is bound
+for**. One slot rather than a map because the builder binds a row for the
+request it is showing, so that is the only request an on-screen preview can be
+bound for; publishing a row per remembered index would be publishing rows out of
+a file that is no longer the one loaded. The id is what makes a reader check
+rather than assume, so a slot left standing cannot relabel the next tab. It is
+never persisted and is cleared when the builder unmounts, on the rule the rows
+have carried since #601: they must not outlive the send that uses them.
+
+`resolveString` takes the row as an optional second argument for this one
+caller. Every other caller names its row once, as `useVariableResolver`'s
+`boundRow` option, because it resolves for a single request; the strip resolves
+for all of them at once and so has to say which row per call.
 
 ### Which contract answers for a request: nearest declared ancestor
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -210,6 +210,14 @@ preview line, the params and body previews, every key-value row, and resolved
 auth - above the environment, the tier this section names. That is what the
 send is about to put on the wire, not composition's guess at it.
 
+**A pick lasts until a Send that does not carry it.** Send and the send chord
+both send *without* a row, so the pick is cleared by one: a row left standing
+across a plain Send would put the file's value in every preview beside a request
+that had just gone out with the environment's, which is this same disagreement
+arrived at from the other side. Nothing else clears it - the picker's memory
+still survives a tab switch and a return (issue #659), because neither of those
+is a send.
+
 **Why the renderer can show this and composition cannot.** A plan is composed
 once, before any row exists to bind, so composition still defers both
 spellings exactly as above. The preview goes further only because it holds

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -203,18 +203,44 @@ so both spellings reach the same bind-time join and the same refusal rules.
 Nothing about the two rules can drift, because there is only the one path that
 substitutes either of them.
 
-**What the builder's preview does not show yet.** The request builder paints a
-bare `{{name}}` as a bound column only when *no* scope defines that name. Where
-a scope does define it, the token keeps painting as that variable and shows its
-value - which is right for a Send with no row, and wrong for the moment a run
-binds one, since the column outranks it. The preview resolver takes the bound
-columns (`resolveTemplate`'s third argument, pinned against the engine by the
-conformance fixture) but nothing passes them yet: no preview surface knows which
-row a run will bind. So a collision is *stated* rather than painted - the Data
-tab's column audit names any declared column that shares a name with a variable
-in scope, and says the column wins while a row is bound. Painting it in the
-builder is a design question of its own, tracked separately; nothing here reads
-a value the engine cannot send, it just does not yet show the one it will.
+**What the builder's preview shows now (issue #1062).** With a row picked, a
+Send previews the bind as well as the composition: a bare `{{username}}` and
+the reserved `{{data.username}}` both show the row's own cell - the URL bar's
+preview line, the params and body previews, every key-value row, and resolved
+auth - above the environment, the tier this section names. That is what the
+send is about to put on the wire, not composition's guess at it.
+
+**Why the renderer can show this and composition cannot.** A plan is composed
+once, before any row exists to bind, so composition still defers both
+spellings exactly as above. The preview goes further only because it holds
+something composition never does: the picked row itself, threaded from
+`RequestBuilderProvider`'s per-request row memory into
+`useVariableResolver({ boundRow })`. With it, `resolveString` reads
+`resolveTemplateWithRow` (`app/src/lib/variable-resolution.ts`) instead of
+`resolveTemplate` - a restatement of the engine's own
+`resolve_template_with_data`, the function `pm.variables.replaceIn` reaches
+for the same reason (issue #890), not a second rule invented for the preview.
+A collection run, a load run and a scenario step still bind their row during
+the run itself, so nothing about them changes: this is the one caller, a
+single Send, that now happens to hold the row before the request goes out.
+
+**What is still not painted.** The token *state* `VariableInput` paints is
+unchanged: a bare name still paints as a bound column only where no scope
+defines it, and a shadowed bare name still paints - and explains itself in the
+popover - as the variable. So a picked row can now put its cell beside a token
+that still reads, and is still explained, as the environment's, with nothing
+on screen saying the column will win once a row binds. Reconciling the paint,
+and giving the popover a "bound data row" origin to explain it, is issue
+#1064's work, not done here.
+
+**What the tab strip still does not show.** A tab's title still resolves
+through one list-wide `useVariableResolver()` in
+`app/src/components/layout/tab-descriptors.ts`, shared by every open tab and
+carrying no row - a picked row is per-request builder state, and the list has
+no single request to bind it to. So the tab label keeps previewing
+composition alone even for the request whose own builder pane, open right
+beside it, is now showing the bind. Giving each tab its own row is issue
+#1074.
 
 ### Which contract answers for a request: nearest declared ancestor
 


### PR DESCRIPTION
## Description

**Root cause.** #1007 gave `resolveTemplate` a `boundColumns` tier so the renderer's preview could match the engine's *composition*, and wired the row into `composeForSend`'s payload - but no preview surface ever learned which row a Send binds. The row lived in `UrlBar`'s local state and reached the engine *beside* composition, never *through* it, so `useVariableResolver` ran the no-dataset resolution and showed the environment's value for a bare name the send answers from the file.

**Approach.** The renderer holds the row, so the preview models the send end to end - composition *and* bind - rather than composition alone. `resolveTemplateWithRow` restates the engine's `vayu::http::resolve_template_with_data`, the one engine caller that also holds a row (`pm.variables.replaceIn`, #890): a bare name the row carries answers from the row above every scope, `{{data.column}}` answers from the same row, and a `data.` name the row has no column for keeps its braces rather than emptying. Both spellings are one bind, which is #1062's hard requirement. `resolveTemplate` is unchanged and still previews composition; the two now share one substitution core, exactly as the engine shares `substitute_tokens`. The row is lifted from `UrlBar` into `RequestBuilderProvider`, which already owned both of `useSendWithRow`'s inputs - so the lift *removes* `dataFileMaxRows` from the context rather than adding to it.

**The alternative I rejected**, and why: passing the row's *column names* as `resolveTemplate`'s third argument, so the preview shows a deferred `{{username}}`. It is smaller and pinned by the existing conformance fixture, and the issue's fix pathway reads that way. But it previews *composition* when the user has just picked a row: the preview would still not show what goes on the wire, which is what the issue's own decision point recommends against. The drift risk that made deferral attractive is answered differently - the new function is a restatement of a named engine function with a documented contract, not a rule invented for the preview, and the comments say which engine symbol each half mirrors.

### #1074, folded in

`useTabDescriptors` labels every open tab from a single list-wide resolver - the strip has to know each label before it can decide how many fit, and a hook inside a map is a variable number of hooks - so it is the one preview surface not below the builder's provider. A one-slot, never-persisted store (`bound-row-store.ts`) carries the row across that boundary, naming the request it belongs to so a stale slot cannot relabel the wrong tab, and cleared when the builder unmounts. `resolveString` gained an optional per-call row for that caller; every other caller names its row once as an option and is unchanged.

### One defect this branch's own review found

A pick was only ever *set*, never cleared - so a row picked once stayed bound to every preview in the builder, including across an ordinary Send, which carries no row at all. The previews then showed the file's value beside a request that had just gone out with the environment's: the same disagreement, reached from the other side. Send and the send chord now clear the pick; nothing else does, so the picker's memory still survives a tab switch and a return (#659), because neither of those is a send. It comes with the test that would have caught it.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Run on this branch, all green:

- `cd app && pnpm test` - **545 files, 5906 tests passed** (baseline on `d639497`: 542 files, 5879 tests - so +3 files, +27 tests, no pre-existing failures to note).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `cd app && pnpm lint` - clean (zero errors, zero warnings).
- `cd app && pnpm format:check` - clean. Only files this change touched were formatted; nothing outside `app/` was run through prettier.
- The engine was not built and `ctest` was not run: this branch touches no C++ and no engine test. `mkdocs build --strict` could not be run - mkdocs is not installed in this environment - so the docs edits were kept to prose under existing headings, with no heading renamed, moved, or removed and no new relative link added.

New tests, all mutation-checked:

- `app/src/lib/variable-resolution.row.test.ts` (14) - `resolveTemplateWithRow`'s tiers, including the two spellings agreeing, a bare name the row lacks falling through to the scopes, a missing `data.` column keeping its braces, a cell that carries tokens of its own, a column named like a generator or like `$vu`, and a cycle; plus `renderDataValue`'s four cell shapes.
- `app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx` (10) - through the *real* provider, which is the only place the picked row, the resolver and the per-request row memory meet. Reverting the `boundRow` wiring turns four red; the two that stay green are the no-row cases, which pin the unchanged behaviour. Reverting the un-bind turns the plain-Send case red.
- `app/src/components/layout/tab-descriptors.bound-row.test.tsx` (3) - the label from the environment with no row, from the row with one, and from the environment again for a row bound to a *different* request.
- `send-with-row.test.tsx` now renders through a harness that drives the real `useSendWithRow`, so its gating cases still exercise the data-file store and the IPC read after the state moved onto the context.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs move in the same commits as the code they describe: D18's "What the builder's preview does not show yet" paragraph in `docs/app/variable-resolution.md` is **rewritten**, not appended to, as #1062 requires; `docs/app/state-management.md` gains the `boundRow` option, the per-call row, and a `bound-row-store` section beside `data-file-store`, whose never-persist law it inherits; `docs/app/architecture.md`'s resolution-priority line, stale since #1007, now names the row tier. `docs/app/COMPONENTS.md` is deliberately untouched: token painting does not change here.

### Deliberate deviations from the issue spec

- **The preview shows the row's value, not the deferred token.** #1062 asks for this decision explicitly and recommends the value; the reasoning and the rejected alternative are above.
- **The conformance fixture is not extended.** The natural way to hold the new function to the engine would be `row` cases in `engine/tests/fixtures/variable-resolution-conformance.json`, but that fixture drives `resolve_template` on the engine side and the new cases would need a second driver against `resolve_template_with_data` - engine test work, where #1062's Sequencing says `app/` only. Left out rather than done halfway; worth a follow-up if you want the pin.
- **Token painting is untouched**, so while a row is bound a bare name a scope also defines still paints - and still explains itself in the popover - as that variable, with the row's value beside it. That gap is #1064's, and the doc says so rather than leaving it silent.

## Related Issues

Closes #1062
Closes #1074

---
_Generated by [Claude Code](https://claude.ai/code/session_012QMB3TYV7qfYtERF7tBMxU)_