### PR TITLE
fix(engine): a comparison stops at the read that threw, and status() stops truncating - #1048

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -431,9 +431,12 @@ reported unequal by `eql` rather than compared (their contents are not
 properties); `Date` compares by instant, `RegExp` by pattern; a cyclic value
 raises a `RangeError` after 64 levels rather than hanging. **A throw the
 comparison runs into is the verdict** (#1048) - a key, an array element or an
-array `length` behind a getter that throws, and an overridden `toJSON` /
-`toString` on the `Date` and `RegExp` sides, all reach the test as the script's
-own error rather than as a difference.
+array `length` behind a getter that throws, an overridden `toJSON` / `toString`
+on the `Date` and `RegExp` sides, and the values `include`, `oneOf`, `members`,
+`keys`, `property`, `empty` and `length` read before they compare, all reach the
+test as the script's own error rather than as a difference. Chai reports a
+difference for some of these, which under `.not` is a pass; a test that cannot
+read its subject has not passed.
 
 ### Response status classes (`pm.response.to.be`)
 

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -429,7 +429,11 @@ a typo, or a chai matcher Vayu lacks (`.finite`, `.sealed`, `.frozen`,
 `have.keys` asserts *exactly* those keys. `Map` / `Set` / typed arrays are
 reported unequal by `eql` rather than compared (their contents are not
 properties); `Date` compares by instant, `RegExp` by pattern; a cyclic value
-raises a `RangeError` after 64 levels rather than hanging.
+raises a `RangeError` after 64 levels rather than hanging. **A throw the
+comparison runs into is the verdict** (#1048) - a key, an array element or an
+array `length` behind a getter that throws, and an overridden `toJSON` /
+`toString` on the `Date` and `RegExp` sides, all reach the test as the script's
+own error rather than as a difference.
 
 ### Response status classes (`pm.response.to.be`)
 
@@ -459,6 +463,13 @@ for "the body contains `sub`" should become `.to.have.body(new RegExp(sub))`.
 `.have.jsonBody(path, value)` also started comparing `value`, which it used to
 accept and ignore - a script relying on the old no-op should not pass an
 argument it does not want checked.
+
+**`have.status` refuses a code that is not a whole finite number (#1048).**
+`status(200.5)` used to be truncated to `200` and pass against a 200; a
+fractional or `NaN` expectation is a mistake in the script text - no response
+can carry such a code - so it raises a `TypeError` naming what was written
+rather than a verdict naming the status that arrived. Postman would report a
+failure here too, so no assertion that passes there fails here.
 
 **Every other name under `pm.response.to` throws a `TypeError`** naming the
 chain - a misspelling, or an idiom Vayu does not implement such as the negated

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -187,13 +187,16 @@ Notes on the edges:
   keep their contents outside the property list, so two distinct ones report
   *not* equal rather than silently passing. `Date` compares by instant and
   `RegExp` by pattern.
-- **A throw reached through the comparison is the verdict.** A key, an array
-  element or an array `length` backed by a getter that throws is a read that did
-  not happen, so the error reaches the test instead of being reported as "these
-  differ" - which under `.not` would have been a pass. The same holds for the
-  rendering the `Date` and `RegExp` comparisons run: an overridden `toJSON` or
-  `toString` that throws used to leave both sides rendered as the empty string,
-  which compared *equal* (#1048).
+- **A throw reached through a comparison is the verdict** (#1048). A key, an
+  array element or an array `length` behind a getter that throws is a read that
+  did not happen, so the error reaches the test instead of being reported as
+  "these differ" - which under `.not` would have been a pass. That holds for the
+  reads an assertion makes before comparing, too: `include`, `oneOf`, `members`,
+  `keys`, `property` (its nested walk included), `empty` and `length` stop at the
+  read rather than answering about it. And for the rendering the `Date` and
+  `RegExp` comparisons run: an overridden `toJSON` or `toString` that throws used
+  to leave both sides rendered as the empty string, which compared *equal*. When
+  both sides throw, the first side's error is the one reported.
 - **A cycle fails loudly.** Deep equality gives up after 64 levels with a
   `RangeError` naming the cause.
 - **`eql` separates `+0` from `-0`; `equal` does not.** That is chai: `equal`

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -187,6 +187,13 @@ Notes on the edges:
   keep their contents outside the property list, so two distinct ones report
   *not* equal rather than silently passing. `Date` compares by instant and
   `RegExp` by pattern.
+- **A throw reached through the comparison is the verdict.** A key, an array
+  element or an array `length` backed by a getter that throws is a read that did
+  not happen, so the error reaches the test instead of being reported as "these
+  differ" - which under `.not` would have been a pass. The same holds for the
+  rendering the `Date` and `RegExp` comparisons run: an overridden `toJSON` or
+  `toString` that throws used to leave both sides rendered as the empty string,
+  which compared *equal* (#1048).
 - **A cycle fails loudly.** Deep equality gives up after 64 levels with a
   `RangeError` naming the cause.
 - **`eql` separates `+0` from `-0`; `equal` does not.** That is chai: `equal`
@@ -515,7 +522,11 @@ pm.response.to.have.jsonBody('data.id', 42);              // exists and deep-equ
 `have.status` means two different things depending on the argument's type: a
 number is the status code, a string is compared against the reason phrase
 `pm.response.reason()` answers. **`status('200')` fails** - a string is always
-a reason phrase to compare, never a code coerced to one.
+a reason phrase to compare, never a code coerced to one. **A number that is not
+a whole finite code is refused**, not truncated: `status(200.5)` used to compare
+as `200` and pass against a 200, and no response carries a fractional code, so
+the `TypeError` names what was written rather than reporting a verdict about the
+status that did arrive (#1048). `status(NaN)` is refused the same way.
 
 `have.header`'s second argument is compared strictly against the header as it
 arrived on the wire. `header('X-Count', 5)` fails rather than stringifying `5`

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -342,8 +342,9 @@ nlohmann::json get_script_completions () {
     { "detail", "pm.response.to.have.status(code: number | string)" },
     { "documentation",
     "Assert that the response has a specific HTTP status code, or - given a "
-    "string - the reason phrase pm.response.reason() "
-    "answers.\n\nExample:\npm.response.to.have.status(200);\npm.response.to."
+    "string - the reason phrase pm.response.reason() answers. A number that is "
+    "not a whole finite code is refused rather than truncated."
+    "\n\nExample:\npm.response.to.have.status(200);\npm.response.to."
     "have.status('OK');" },
     { "sortText", "1_pm_response_to_have_status" } });
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -995,12 +995,17 @@ int js_deep_equal (JSContext* ctx, JSValueConst a, JSValueConst b, int depth, De
     // have written - an own `toJSON`, an overridden `toString` - and both
     // renderers answer "" when that throws, leaving the exception pending. Two
     // empty renderings compare *equal*, so a pair of throwing Dates used to
-    // report a pass. Asking the context settles either branch: a comparison
-    // that ran script and left an error behind has no verdict to give.
+    // report a pass. Neither renderer reports failure, so the context is asked
+    // instead - and asked after each side, because `JS_Throw` replaces the
+    // pending exception, so rendering the second side over a first that threw
+    // would report b's error for a's read.
     if (tag == "[object Date]") {
         // JSON renders a Date as its ISO instant, which is the comparison chai
         // makes (and keeps millisecond resolution, unlike toString).
         const std::string a_json = js_to_json (ctx, a);
+        if (JS_HasException (ctx)) {
+            return -1;
+        }
         const std::string b_json = js_to_json (ctx, b);
         if (JS_HasException (ctx)) {
             return -1;
@@ -1009,6 +1014,9 @@ int js_deep_equal (JSContext* ctx, JSValueConst a, JSValueConst b, int depth, De
     }
     if (tag == "[object RegExp]") {
         const std::string a_source = js_to_string (ctx, a);
+        if (JS_HasException (ctx)) {
+            return -1;
+        }
         const std::string b_source = js_to_string (ctx, b);
         if (JS_HasException (ctx)) {
             return -1;
@@ -1501,9 +1509,17 @@ JSValue expect_include (JSContext* ctx, JSValueConst this_val, int argc, JSValue
         // `JS_ToCString` forms, under which every object member matched every
         // object needle - both render as "[object Object]".
         for (uint32_t i = 0; i < len && !includes; i++) {
-            JSValue elem = JS_GetPropertyUint32 (ctx, state->actual, i);
-            const int same = js_compare_for_chain (ctx, elem, argv[0], state->deep);
-            JS_FreeValue (ctx, elem);
+            // The reads a comparison is given are the comparison's own: an
+            // element behind a getter that throws is a read that did not
+            // happen. Handing the exception sentinel to `js_compare_for_chain`
+            // answers "not a member" about it, and under `.not` that is a pass.
+            // Same rule the deep compare states for its own reads.
+            ScopedValue elem (ctx, JS_GetPropertyUint32 (ctx, state->actual, i));
+            if (JS_IsException (elem.get ())) {
+                return JS_EXCEPTION;
+            }
+            const int same =
+            js_compare_for_chain (ctx, elem.get (), argv[0], state->deep);
             if (same < 0) {
                 return JS_EXCEPTION;
             }
@@ -1619,6 +1635,12 @@ JSValue expect_have_property (JSContext* ctx, JSValueConst this_val, int argc, J
         JSValue next = JS_GetPropertyStr (ctx, holder, segments[i].c_str ());
         JS_FreeValue (ctx, holder);
         holder = next;
+        // A segment behind a getter that throws is a walk that did not finish.
+        // The sentinel is not an object, so the loop would call it a missing
+        // property - and under `.not` that reads as a pass.
+        if (JS_IsException (holder)) {
+            return JS_EXCEPTION;
+        }
     }
 
     if (has_prop) {
@@ -1635,9 +1657,16 @@ JSValue expect_have_property (JSContext* ctx, JSValueConst this_val, int argc, J
     // the chain is `deep`, which is why this cannot stringify: two objects with
     // the same JSON are still different references.
     if (has_prop && argc >= 2) {
-        JSValue actual_val = JS_GetPropertyStr (ctx, holder, segments.back ().c_str ());
-        const int same = js_compare_for_chain (ctx, actual_val, argv[1], state->deep);
-        JS_FreeValue (ctx, actual_val);
+        // `JS_HasProperty` above does not run the getter, so this is the first
+        // read of the value - and the one the comparison is given.
+        ScopedValue actual_val (
+        ctx, JS_GetPropertyStr (ctx, holder, segments.back ().c_str ()));
+        if (JS_IsException (actual_val.get ())) {
+            JS_FreeValue (ctx, holder);
+            return JS_EXCEPTION;
+        }
+        const int same =
+        js_compare_for_chain (ctx, actual_val.get (), argv[1], state->deep);
         if (same < 0) {
             JS_FreeValue (ctx, holder);
             return JS_EXCEPTION;
@@ -1746,14 +1775,18 @@ JSValue expect_empty_getter (JSContext* ctx, JSValueConst this_val, int argc, JS
     } else if (JS_IsObject (state->actual)) {
         JSPropertyEnum* tab = nullptr;
         uint32_t count      = 0;
+        // The key list is what "empty" means for an object, and a proxy's
+        // ownKeys trap can refuse to produce it. Reporting "not empty" for a
+        // list that was never produced is a pass under `.not`.
         if (JS_GetOwnPropertyNames (ctx, &tab, &count, state->actual,
-            JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) == 0) {
-            is_empty = (count == 0);
-            for (uint32_t i = 0; i < count; i++) {
-                JS_FreeAtom (ctx, tab[i].atom);
-            }
-            js_free (ctx, tab);
+            JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) != 0) {
+            return JS_EXCEPTION;
         }
+        is_empty = (count == 0);
+        for (uint32_t i = 0; i < count; i++) {
+            JS_FreeAtom (ctx, tab[i].atom);
+        }
+        js_free (ctx, tab);
     }
 
     bool pass = state->negated ? !is_empty : is_empty;
@@ -1811,15 +1844,21 @@ JSValue expect_length (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
         return JS_ThrowInternalError (ctx, "Invalid expectation state");
     }
 
-    JSValue length_val = JS_GetPropertyStr (ctx, state->actual, "length");
-    if (JS_IsUndefined (length_val)) {
-        JS_FreeValue (ctx, length_val);
+    ScopedValue length_val (ctx, JS_GetPropertyStr (ctx, state->actual, "length"));
+    // A `length` the read could not produce is neither absent nor a number:
+    // the script's own error is the answer, not "requires a value with a
+    // length" and not a comparison against an uninitialised double.
+    if (JS_IsException (length_val.get ())) {
+        return JS_EXCEPTION;
+    }
+    if (JS_IsUndefined (length_val.get ())) {
         return JS_ThrowTypeError (ctx, "length() requires a value with a length");
     }
 
-    double actual_len, expected;
-    JS_ToFloat64 (ctx, &actual_len, length_val);
-    JS_FreeValue (ctx, length_val);
+    double actual_len = 0, expected = 0;
+    if (JS_ToFloat64 (ctx, &actual_len, length_val.get ()) < 0) {
+        return JS_EXCEPTION;
+    }
     if (JS_ToFloat64 (ctx, &expected, argv[0]) < 0) {
         return JS_ThrowTypeError (ctx, "length() requires a numeric argument");
     }
@@ -1946,10 +1985,14 @@ JSValue expect_one_of (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
 
     bool found = false;
     for (uint32_t i = 0; i < len && !found; i++) {
-        JSValue candidate = JS_GetPropertyUint32 (ctx, argv[0], i);
+        // Same rule as `include`: a candidate that could not be read is not a
+        // candidate the target failed to match.
+        ScopedValue candidate (ctx, JS_GetPropertyUint32 (ctx, argv[0], i));
+        if (JS_IsException (candidate.get ())) {
+            return JS_EXCEPTION;
+        }
         const int same =
-        js_compare_for_chain (ctx, state->actual, candidate, state->deep);
-        JS_FreeValue (ctx, candidate);
+        js_compare_for_chain (ctx, state->actual, candidate.get (), state->deep);
         if (same < 0) {
             return JS_EXCEPTION;
         }
@@ -1989,9 +2032,14 @@ JSValue expect_keys (JSContext* ctx, JSValueConst this_val, int argc, JSValueCon
         JS_ToUint32 (ctx, &len, length_val);
         JS_FreeValue (ctx, length_val);
         for (uint32_t i = 0; i < len; i++) {
-            JSValue key = JS_GetPropertyUint32 (ctx, argv[0], i);
-            expected.push_back (js_to_string (ctx, key));
-            JS_FreeValue (ctx, key);
+            // A name that could not be read is not a name: `js_to_string`
+            // answers "" for it, and an empty key would be compared against
+            // the target's real ones as though the script had asked for it.
+            ScopedValue key (ctx, JS_GetPropertyUint32 (ctx, argv[0], i));
+            if (JS_IsException (key.get ())) {
+                return JS_EXCEPTION;
+            }
+            expected.push_back (js_to_string (ctx, key.get ()));
         }
     } else {
         for (int i = 0; i < argc; i++) {
@@ -2051,17 +2099,24 @@ JSValue expect_members (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     bool matches = (actual_len == expected_len);
     std::vector<bool> claimed (actual_len, false);
     for (uint32_t i = 0; i < expected_len && matches; i++) {
-        JSValue wanted = JS_GetPropertyUint32 (ctx, argv[0], i);
-        bool paired    = false;
+        // Same rule as `include`: an element that could not be read is not an
+        // element that failed to pair.
+        ScopedValue wanted (ctx, JS_GetPropertyUint32 (ctx, argv[0], i));
+        if (JS_IsException (wanted.get ())) {
+            return JS_EXCEPTION;
+        }
+        bool paired = false;
         for (uint32_t j = 0; j < actual_len && !paired; j++) {
             if (claimed[j]) {
                 continue;
             }
-            JSValue candidate = JS_GetPropertyUint32 (ctx, state->actual, j);
-            const int same = js_compare_for_chain (ctx, candidate, wanted, state->deep);
-            JS_FreeValue (ctx, candidate);
+            ScopedValue candidate (ctx, JS_GetPropertyUint32 (ctx, state->actual, j));
+            if (JS_IsException (candidate.get ())) {
+                return JS_EXCEPTION;
+            }
+            const int same =
+            js_compare_for_chain (ctx, candidate.get (), wanted.get (), state->deep);
             if (same < 0) {
-                JS_FreeValue (ctx, wanted);
                 return JS_EXCEPTION;
             }
             if (same == 1) {
@@ -2069,7 +2124,6 @@ JSValue expect_members (JSContext* ctx, JSValueConst this_val, int argc, JSValue
                 paired     = true;
             }
         }
-        JS_FreeValue (ctx, wanted);
         matches = paired;
     }
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -25,6 +25,7 @@
 #include <cctype>
 #include <chrono>
 #include <cmath>
+#include <format>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -990,13 +991,29 @@ int js_deep_equal (JSContext* ctx, JSValueConst a, JSValueConst b, int depth, De
     if (tag != b_tag) {
         return 0;
     }
+    // Both branches below render each side through script the test author may
+    // have written - an own `toJSON`, an overridden `toString` - and both
+    // renderers answer "" when that throws, leaving the exception pending. Two
+    // empty renderings compare *equal*, so a pair of throwing Dates used to
+    // report a pass. Asking the context settles either branch: a comparison
+    // that ran script and left an error behind has no verdict to give.
     if (tag == "[object Date]") {
         // JSON renders a Date as its ISO instant, which is the comparison chai
         // makes (and keeps millisecond resolution, unlike toString).
-        return js_to_json (ctx, a) == js_to_json (ctx, b) ? 1 : 0;
+        const std::string a_json = js_to_json (ctx, a);
+        const std::string b_json = js_to_json (ctx, b);
+        if (JS_HasException (ctx)) {
+            return -1;
+        }
+        return a_json == b_json ? 1 : 0;
     }
     if (tag == "[object RegExp]") {
-        return js_to_string (ctx, a) == js_to_string (ctx, b) ? 1 : 0;
+        const std::string a_source = js_to_string (ctx, a);
+        const std::string b_source = js_to_string (ctx, b);
+        if (JS_HasException (ctx)) {
+            return -1;
+        }
+        return a_source == b_source ? 1 : 0;
     }
     if (tag != "[object Object]" && tag != "[object Array]" && tag != "[object Error]") {
         // Map, Set, typed arrays and the like hold their contents somewhere a
@@ -1006,25 +1023,45 @@ int js_deep_equal (JSContext* ctx, JSValueConst a, JSValueConst b, int depth, De
         return 0;
     }
 
+    // Every read below can run script: a getter the author wrote, or a Proxy
+    // trap - `IsArray` unwraps a proxy, so a proxy of an array reaches this
+    // branch and even its `length` goes through a trap. A read that throws
+    // leaves the exception pending and hands back the exception sentinel, which
+    // is neither a number nor an object, so comparing it reports an ordinary
+    // "not deeply equal" about a read that never happened - #959's shape, one
+    // level down. Each pair stops at the *first* side that throws, because
+    // reading the second would run more script and could replace the error the
+    // script author is owed.
     if (tag == "[object Array]") {
-        JSValue a_len_val = JS_GetPropertyStr (ctx, a, "length");
-        JSValue b_len_val = JS_GetPropertyStr (ctx, b, "length");
+        ScopedValue a_len_val (ctx, JS_GetPropertyStr (ctx, a, "length"));
+        if (JS_IsException (a_len_val.get ())) {
+            return -1;
+        }
+        ScopedValue b_len_val (ctx, JS_GetPropertyStr (ctx, b, "length"));
+        if (JS_IsException (b_len_val.get ())) {
+            return -1;
+        }
         uint32_t a_len = 0, b_len = 0;
-        JS_ToUint32 (ctx, &a_len, a_len_val);
-        JS_ToUint32 (ctx, &b_len, b_len_val);
-        JS_FreeValue (ctx, a_len_val);
-        JS_FreeValue (ctx, b_len_val);
+        if (JS_ToUint32 (ctx, &a_len, a_len_val.get ()) < 0 ||
+        JS_ToUint32 (ctx, &b_len, b_len_val.get ()) < 0) {
+            return -1;
+        }
         if (a_len != b_len) {
             return 0;
         }
         for (uint32_t i = 0; i < a_len; i++) {
-            JSValue a_elem = JS_GetPropertyUint32 (ctx, a, i);
-            JSValue b_elem = JS_GetPropertyUint32 (ctx, b, i);
+            ScopedValue a_elem (ctx, JS_GetPropertyUint32 (ctx, a, i));
+            if (JS_IsException (a_elem.get ())) {
+                return -1;
+            }
+            ScopedValue b_elem (ctx, JS_GetPropertyUint32 (ctx, b, i));
+            if (JS_IsException (b_elem.get ())) {
+                return -1;
+            }
             path.emplace_back (a_id, b_id);
-            const int same = js_deep_equal (ctx, a_elem, b_elem, depth + 1, path, zeros);
+            const int same =
+            js_deep_equal (ctx, a_elem.get (), b_elem.get (), depth + 1, path, zeros);
             path.pop_back ();
-            JS_FreeValue (ctx, a_elem);
-            JS_FreeValue (ctx, b_elem);
             if (same != 1) {
                 return same;
             }
@@ -1045,13 +1082,20 @@ int js_deep_equal (JSContext* ctx, JSValueConst a, JSValueConst b, int depth, De
         if (std::find (b_keys.begin (), b_keys.end (), key) == b_keys.end ()) {
             return 0;
         }
-        JSValue a_val = JS_GetPropertyStr (ctx, a, key.c_str ());
-        JSValue b_val = JS_GetPropertyStr (ctx, b, key.c_str ());
+        // Same rule as the array branch above: a key backed by a throwing
+        // getter is a read that did not happen, not a mismatch.
+        ScopedValue a_val (ctx, JS_GetPropertyStr (ctx, a, key.c_str ()));
+        if (JS_IsException (a_val.get ())) {
+            return -1;
+        }
+        ScopedValue b_val (ctx, JS_GetPropertyStr (ctx, b, key.c_str ()));
+        if (JS_IsException (b_val.get ())) {
+            return -1;
+        }
         path.emplace_back (a_id, b_id);
-        const int same = js_deep_equal (ctx, a_val, b_val, depth + 1, path, zeros);
+        const int same =
+        js_deep_equal (ctx, a_val.get (), b_val.get (), depth + 1, path, zeros);
         path.pop_back ();
-        JS_FreeValue (ctx, a_val);
-        JS_FreeValue (ctx, b_val);
         if (same != 1) {
             return same;
         }
@@ -2843,6 +2887,20 @@ std::string describe_body (const std::string& body) {
     return "'" + body.substr (0, cut) + "...' (" + std::to_string (body.size ()) + " bytes)";
 }
 
+// A number as a message quotes it back. `std::format` gives the shortest
+// spelling that round-trips (`200`, not `200.000000`; `200.5`, not
+// `200.500000`), and the three values it spells in C are given JavaScript's
+// names, because the script author is reading their own source back.
+std::string describe_number (double value) {
+    if (std::isnan (value)) {
+        return "NaN";
+    }
+    if (std::isinf (value)) {
+        return value > 0 ? "Infinity" : "-Infinity";
+    }
+    return std::format ("{}", value);
+}
+
 JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     if (argc < 1) {
         return JS_ThrowTypeError (ctx, "status() requires an expected status code");
@@ -2868,13 +2926,27 @@ JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc
         return JS_UNDEFINED;
     }
 
-    int32_t expected_status;
-    if (JS_ToInt32 (ctx, &expected_status, argv[0]) < 0) {
-        return JS_ThrowTypeError (ctx, "status() expects a number");
+    // A code is compared as the script wrote it. `JS_ToInt32` truncated toward
+    // zero, so `status(200.5)` compared as 200 and passed against a 200 - the
+    // same coercion the string arm above stopped making. No response can carry
+    // a fractional or non-finite code, so an assertion written that way is not
+    // a statement about the response at all; it is refused the way `body(5)` is
+    // rather than reported as a verdict, which would name the status the author
+    // got and leave the mistake in their own text unmentioned.
+    double expected_code = 0;
+    if (JS_ToFloat64 (ctx, &expected_code, argv[0]) < 0) {
+        // The conversion's own error - a Symbol, a `valueOf` that throws - is
+        // the script's, and QuickJS has already named it. A message of ours
+        // here would discard what the author actually wrote.
+        return JS_EXCEPTION;
+    }
+    if (!std::isfinite (expected_code) || std::trunc (expected_code) != expected_code) {
+        return JS_ThrowTypeError (ctx, "status() expects an integer status code, got %s",
+        describe_number (expected_code).c_str ());
     }
 
-    if (data->response->status_code != expected_status) {
-        std::string msg = "Expected status code " + std::to_string (expected_status) +
+    if (static_cast<double> (data->response->status_code) != expected_code) {
+        std::string msg = "Expected status code " + describe_number (expected_code) +
         " but got " + std::to_string (data->response->status_code);
         return throw_assertion_failure (ctx, msg);
     }

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -1145,7 +1145,7 @@ declare const pm: {
 				 */
 				jsonBody(path?: string, value?: unknown): void;
 				/**
-				 * Assert that the response has a specific HTTP status code, or - given a string - the reason phrase pm.response.reason() answers.
+				 * Assert that the response has a specific HTTP status code, or - given a string - the reason phrase pm.response.reason() answers. A number that is not a whole finite code is refused rather than truncated.
 				 * 
 				 * Example:
 				 * pm.response.to.have.status(200);

--- a/engine/tests/script_assertion_error_test.cpp
+++ b/engine/tests/script_assertion_error_test.cpp
@@ -244,6 +244,7 @@ TEST_F (AssertionErrorTest, AMisusedMatcherIsStillATypeError) {
         R"(pm.expect(1).to.be.instanceOf("Array"))",
         R"(pm.expect(1).to.throw())",
         R"(pm.response.to.have.status())",
+        R"(pm.response.to.have.status(200.5))",
         R"(pm.response.to.have.body(5))",
         R"(pm.response.to.have.body(null))",
     };

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1511,6 +1511,58 @@ TEST_F (ScriptEngineTest, DeepEqualPropagatesAThrowFromAMemberItReads) {
     }
 }
 
+// The audit the issue asked for: the same omission in the reads each assertion
+// helper makes *before* handing a value to the comparison. Every case below is
+// negated, because that is where the swallow paid out - "these differ" about a
+// read that never happened is a PASS under `.not`, which is a green test over a
+// broken object.
+TEST_F (ScriptEngineTest, AssertionHelpersPropagateAThrowFromTheReadsTheyCompare) {
+    auto result = engine.execute_test (R"(
+        function throwingElement() {
+            var arr = [];
+            Object.defineProperty(arr, 0, {
+                enumerable: true, get: function() { throw new Error("from the element"); }
+            });
+            return arr;
+        }
+        function throwingLength() {
+            return { get length () { throw new Error("from the length"); } };
+        }
+        function unlistableKeys() {
+            return new Proxy({}, {
+                ownKeys: function() { throw new Error("from the keys"); }
+            });
+        }
+        function throwingKey(message) {
+            return { get a () { throw new Error(message); } };
+        }
+
+        pm.test("include", function() { pm.expect(throwingElement()).to.not.include(1); });
+        pm.test("oneOf", function() { pm.expect(1).to.not.be.oneOf(throwingElement()); });
+        pm.test("members", function() { pm.expect(throwingElement()).to.not.have.members([1]); });
+        pm.test("keys", function() { pm.expect({a: 1}).to.not.have.keys(throwingElement()); });
+        pm.test("property value", function() {
+            pm.expect(throwingKey("from the property")).to.not.have.property("a", 1);
+        });
+        pm.test("nested walk", function() {
+            pm.expect(throwingKey("from the walk")).to.not.have.nested.property("a.b");
+        });
+        pm.test("empty", function() { pm.expect(unlistableKeys()).to.not.be.empty; });
+        pm.test("length", function() { pm.expect(throwingLength()).to.not.have.length(0); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 8u);
+    const std::array<const char*, 8> expected = { "from the element",
+        "from the element", "from the element", "from the element",
+        "from the property", "from the walk", "from the keys", "from the length" };
+    for (size_t i = 0; i < result.tests.size (); i++) {
+        EXPECT_FALSE (result.tests[i].passed) << result.tests[i].name;
+        EXPECT_NE (result.tests[i].error_message.find (expected.at (i)), std::string::npos)
+        << result.tests[i].name << ": " << result.tests[i].error_message;
+    }
+}
+
 // A Date and a RegExp are compared through their own rendering, and both
 // renderers answer "" when the script they run throws. Two empty renderings
 // compare *equal*, so this pair used to PASS - the dangerous direction, and
@@ -1519,14 +1571,14 @@ TEST_F (ScriptEngineTest, DeepEqualDoesNotPassAPairItCouldNotRender) {
     auto result = engine.execute_test (R"(
         pm.test("dates", function() {
             var a = new Date(0), b = new Date(5);
-            a.toJSON = function() { throw new Error("from toJSON"); };
-            b.toJSON = function() { throw new Error("from toJSON"); };
+            a.toJSON = function() { throw new Error("from the first toJSON"); };
+            b.toJSON = function() { throw new Error("from the second toJSON"); };
             pm.expect(a).to.eql(b);
         });
         pm.test("regexps", function() {
             var a = /one/, b = /two/;
-            a.toString = function() { throw new Error("from toString"); };
-            b.toString = function() { throw new Error("from toString"); };
+            a.toString = function() { throw new Error("from the first toString"); };
+            b.toString = function() { throw new Error("from the second toString"); };
             pm.expect(a).to.eql(b);
         });
         pm.test("dates that render still compare", function() {
@@ -1539,11 +1591,15 @@ TEST_F (ScriptEngineTest, DeepEqualDoesNotPassAPairItCouldNotRender) {
     ASSERT_EQ (result.tests.size (), 3u);
     EXPECT_FALSE (result.tests[0].passed)
     << "two Dates that cannot be rendered are not equal Dates";
-    EXPECT_NE (result.tests[0].error_message.find ("from toJSON"), std::string::npos)
+    // The *first* side's error, because rendering the second over a throw
+    // replaces the pending exception with one about a read the author is not
+    // being told failed.
+    EXPECT_NE (result.tests[0].error_message.find ("from the first toJSON"), std::string::npos)
     << result.tests[0].error_message;
     EXPECT_FALSE (result.tests[1].passed)
     << "two RegExps that cannot be rendered are not equal RegExps";
-    EXPECT_NE (result.tests[1].error_message.find ("from toString"), std::string::npos)
+    EXPECT_NE (result.tests[1].error_message.find ("from the first toString"),
+    std::string::npos)
     << result.tests[1].error_message;
     EXPECT_TRUE (result.tests[2].passed) << result.tests[2].error_message;
 }

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1459,6 +1459,126 @@ TEST_F (ScriptEngineTest, ResponseToBeOkIsStatus200Only) {
 }
 
 // ============================================================================
+// Coercion leftovers of the #998 sweep (issue #1048)
+// ============================================================================
+//
+// Two reads the comparison path made without asking whether they had worked.
+// Every test below asserts both directions, so each is its own mutation check:
+// restore the unchecked read or the truncating conversion and the half that
+// must fail goes green.
+
+// A getter that throws is a read that did not happen. The exception sentinel it
+// hands back is neither a number nor an object, so the walk used to compare it
+// as an ordinary value and report "not deeply equal" - a verdict about a
+// comparison that never ran, with the script's own error left pending and
+// never shown. #959's shape, one level below where it was fixed.
+TEST_F (ScriptEngineTest, DeepEqualPropagatesAThrowFromAMemberItReads) {
+    response.body = R"({"id": {"x": 1}, "list": [1]})";
+
+    auto result = engine.execute_test (R"(
+        pm.test("object key", function() {
+            pm.expect({a: 1}).to.eql({ get a () { throw new Error("from the key"); } });
+        });
+        pm.test("array element", function() {
+            var arr = [];
+            Object.defineProperty(arr, 0, {
+                enumerable: true, get: function() { throw new Error("from the element"); }
+            });
+            pm.expect([1]).to.eql(arr);
+        });
+        pm.test("array length", function() {
+            var lying = new Proxy([1], {
+                get: function(target, key) {
+                    if (key === "length") { throw new Error("from the length"); }
+                    return target[key];
+                }
+            });
+            pm.expect([1]).to.eql(lying);
+        });
+        pm.test("through jsonBody", function() {
+            pm.response.to.have.jsonBody("id", { get x () { throw new Error("from jsonBody"); } });
+        });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    const std::array<const char*, 4> expected = { "from the key",
+        "from the element", "from the length", "from jsonBody" };
+    for (size_t i = 0; i < result.tests.size (); i++) {
+        EXPECT_FALSE (result.tests[i].passed) << result.tests[i].name;
+        EXPECT_NE (result.tests[i].error_message.find (expected.at (i)), std::string::npos)
+        << result.tests[i].name << ": " << result.tests[i].error_message;
+    }
+}
+
+// A Date and a RegExp are compared through their own rendering, and both
+// renderers answer "" when the script they run throws. Two empty renderings
+// compare *equal*, so this pair used to PASS - the dangerous direction, and
+// the one #996 exists to close.
+TEST_F (ScriptEngineTest, DeepEqualDoesNotPassAPairItCouldNotRender) {
+    auto result = engine.execute_test (R"(
+        pm.test("dates", function() {
+            var a = new Date(0), b = new Date(5);
+            a.toJSON = function() { throw new Error("from toJSON"); };
+            b.toJSON = function() { throw new Error("from toJSON"); };
+            pm.expect(a).to.eql(b);
+        });
+        pm.test("regexps", function() {
+            var a = /one/, b = /two/;
+            a.toString = function() { throw new Error("from toString"); };
+            b.toString = function() { throw new Error("from toString"); };
+            pm.expect(a).to.eql(b);
+        });
+        pm.test("dates that render still compare", function() {
+            pm.expect(new Date(0)).to.eql(new Date(0));
+            pm.expect(new Date(0)).to.not.eql(new Date(5));
+        });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 3u);
+    EXPECT_FALSE (result.tests[0].passed)
+    << "two Dates that cannot be rendered are not equal Dates";
+    EXPECT_NE (result.tests[0].error_message.find ("from toJSON"), std::string::npos)
+    << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed)
+    << "two RegExps that cannot be rendered are not equal RegExps";
+    EXPECT_NE (result.tests[1].error_message.find ("from toString"), std::string::npos)
+    << result.tests[1].error_message;
+    EXPECT_TRUE (result.tests[2].passed) << result.tests[2].error_message;
+}
+
+// `JS_ToInt32` truncated toward zero, so a fractional expectation compared as
+// its floor and `status(200.5)` passed against a 200. No response carries a
+// fractional code, so the assertion is a mistake in the script text and is
+// refused there - the same call `body(5)` gets - rather than reported as a
+// verdict about the status the author did get.
+TEST_F (ScriptEngineTest, ResponseStatusRefusesANonIntegerCode) {
+    auto result = engine.execute_test (R"(
+        pm.test("fractional", function() { pm.response.to.have.status(200.5); });
+        pm.test("not a number at all", function() { pm.response.to.have.status(NaN); });
+        pm.test("the code itself still passes", function() { pm.response.to.have.status(200); });
+        pm.test("another code still fails", function() { pm.response.to.have.status(201); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_FALSE (result.tests[0].passed)
+    << "200.5 must not be truncated into agreement with a 200";
+    EXPECT_NE (result.tests[0].error_message.find ("TypeError"), std::string::npos)
+    << result.tests[0].error_message;
+    EXPECT_NE (result.tests[0].error_message.find ("200.5"), std::string::npos)
+    << "the refusal must name what was written: " << result.tests[0].error_message;
+    EXPECT_FALSE (result.tests[1].passed);
+    EXPECT_NE (result.tests[1].error_message.find ("NaN"), std::string::npos)
+    << result.tests[1].error_message;
+    EXPECT_TRUE (result.tests[2].passed) << result.tests[2].error_message;
+    EXPECT_FALSE (result.tests[3].passed);
+    EXPECT_NE (result.tests[3].error_message.find ("201"), std::string::npos)
+    << result.tests[3].error_message;
+}
+
+// ============================================================================
 // pm.response.to.be Tests
 // ============================================================================
 //


### PR DESCRIPTION
## Description

Two coercion leftovers of the #998 sweep, plus the audit that issue asked for.

**Root cause, in one line:** the comparison path reported verdicts about reads that never happened. `js_deep_equal` read every own key, every array element and an array's `length` without asking whether the read had worked - a getter that throws hands back the exception sentinel, which is neither a number nor an object, so the walk compared it as an ordinary value and answered "not deeply equal" with the script's own error left pending and never shown. `to.have.status` had the mirror shape at the argument end: `JS_ToInt32` truncated, so `status(200.5)` compared as 200 and passed against a 200.

**Approach.** Each read stops at the *first* side that throws, because reading the second runs more script and can replace the error the author is owed (measured: with both sides throwing, the unfixed ordering reports the second error). `js_deep_equal` returns the `-1` its callers already handle; the helpers return `JS_EXCEPTION`. For the status arm the choice was **refuse**, not compare: no response carries a fractional or non-finite code, so an assertion written that way is not a statement about the response, and reporting "expected 200.5, got 200" would name the status the author did get and leave the mistake in their own text unmentioned. Postman fails such an assertion too, so nothing that passes there fails here.

**The alternative I rejected:** comparing the fractional code exactly (chai-postman's literal verdict). It gives the same pass/fail for every script - both always fail - and a strictly worse message, so the only thing it buys is a verdict where a `TypeError` names the bug. `body(5)` is refused on the same reasoning, one function away.

**The audit widened the diff, deliberately.** The issue's fix pathway says to audit the other reads in the comparison helpers, and it found the same swallow in `include`, `oneOf`, `members`, `keys`, `property` (its nested walk and its value read), `empty` and `length` - all reachable from ordinary script (`Object.defineProperty(arr, 0, {get(){throw}})`, or a proxy whose `ownKeys` refuses), and all paying out as a **PASS under `.not`**. Fixing `js_deep_equal` alone would have left `.property("a", 1)` swallowing, which reads as unfixed. The guards are one shape, copied from `expect_object_subset`, which already had it.

Two things deliberately **not** changed, both measured rather than assumed:

- The `length` reads behind a `JS_IsArray` guard. quickjs-ng's `JS_IsArray` does not unwrap a proxy - a proxy written for the test reached the *object* branch instead - so those branches see only genuine arrays, whose `length` is a data property that cannot throw. A guard there would be untestable. The one array `length` that can throw is the one `js_deep_equal` reaches through the class tag, which *does* unwrap; that one is guarded and tested.
- `js_class_tag`'s catch-and-fall-back, which the issue exempts by name.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

A script that today gets a wrong verdict will get an error or a refusal instead. That is the point of the change, and no script that was passing correctly changes behaviour.

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2685 passed, 0 failed** (four new tests, one of them extending the existing `AMisusedMatcherIsStillATypeError` list). `cd app && pnpm test` - **538 files / 5833 tests**, plus `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean; `mkdocs build --strict` clean; `clang-format-19` clean over the touched files and the pre-commit hook's `clang-tidy-19` pass clean. No pre-existing failures on the base commit.

Every new test asserts both directions, and each was mutation-checked by rebuilding against the reverted fix rather than by reasoning:

| Reverted | What went red |
|---|---|
| the `JS_IsException` checks in `js_deep_equal` | all four members of `DeepEqualPropagatesAThrowFromAMemberItReads` - the swallow reappears as `Expected {"a":1} to deeply equal [object Object]` |
| the `Date` / `RegExp` pending-exception check | `DeepEqualDoesNotPassAPairItCouldNotRender` **passes** - two unrenderable Dates compare equal, the false pass this fixes |
| the same check moved back after both sides | the same test, now surfacing `from the second toJSON` |
| the helper guards | seven of the eight cases in `AssertionHelpersPropagateAThrowFromTheReadsTheyCompare` report PASS |
| `JS_ToFloat64` + the integrality check | `ResponseStatusRefusesANonIntegerCode` - `status(200.5)` passes against a 200 |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs move in the same commits: `docs/engine/scripting.md` (the deep-equality rules and the `have.status` paragraph), `docs/app/pm-api-compatibility.md` (the throw rule beside the `eql` paragraph, the refusal beside the `#998` notes), the completion doc string in `engine/src/http/routes/scripting.cpp` and its generated `script-typedefs.d.ts` fixture. No app changes: the renderer treats an assertion's error as an opaque string, verified through `TestResult.error` to `TestResults.tsx`.

Two findings from the review pass were real and fixed rather than argued away - the Date/RegExp branches contradicting this diff's own "stop at the first throw" rule, and the helpers left out of the first commit. One was checked and discarded: a suggestion that `expect_include`'s and `expect_one_of`'s reads were already covered because they route through `js_compare_for_chain` - they are not, the read happens at the helper and the sentinel is what the comparison is handed, which is exactly what the new test proves.

## Related Issues
Closes #1048


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4C6Y35JDP6vfUk2Wx2upf)_