### PR TITLE
feat(app): the script surfaces learn that a bound row answers bare column names - #1063, #1075, #1077

### DIFF
--- a/app/src/hooks/data-column-completion.test.tsx
+++ b/app/src/hooks/data-column-completion.test.tsx
@@ -251,3 +251,51 @@ describe('`pm.variables.get("` in a script', () => {
 		expect(column!.filterText).toBe("{{email}}");
 	});
 });
+
+/**
+ * Which spelling each mode offers (issue #1077).
+ *
+ * `replaceIn` resolves `{{data.email}}` and `{{email}}` from the same row, so
+ * offering one of the two would be the gap #1063 closed, one call over. A name
+ * argument is the opposite case: `pm.variables.get("data.email")` reads no
+ * column, so the prefixed spelling there would teach a call that returns
+ * `undefined`.
+ */
+describe("the two column spellings, per accessor mode", () => {
+	it("offers the prefixed spelling to replaceIn, beside the bare one", () => {
+		contract.current = declared;
+		const suggestions = inScript('pm.variables.replaceIn("{{');
+		const prefixed = suggestions.find((s) => s.label === "data.email");
+		expect(prefixed, "replaceIn resolves {{data.email}} from the bound row").toBeTruthy();
+		expect(prefixed!.insertText).toBe("{{data.email}}");
+	});
+
+	it("labels the two spellings so picking one is deliberate", () => {
+		contract.current = declared;
+		const suggestions = inScript('pm.variables.replaceIn("{{');
+		const prefixed = suggestions.find((s) => s.label === "data.email")!;
+		const bare = suggestions.find((s) => s.label === "email")!;
+		expect(prefixed.detail).not.toBe(bare.detail);
+		expect(bare.detail).toMatch(/bare/i);
+	});
+
+	it("withholds the prefixed spelling from a name argument, which cannot read it", () => {
+		/*
+		 * The mutation check for the rule above: applying the fix to both modes
+		 * is the obvious wrong version of it, and this is the only case that
+		 * fails when it is.
+		 */
+		contract.current = declared;
+		expect(inScript('pm.variables.get("').map((s) => s.label)).not.toContain("data.email");
+		expect(inScript("pm.variables.has('").map((s) => s.label)).not.toContain("data.email");
+	});
+
+	it("does not say (bare) where only one spelling is offered", () => {
+		// The word tells two adjacent entries apart; in a list with one entry
+		// per column it names a contrast that list does not contain.
+		contract.current = declared;
+		const bare = inScript('pm.variables.get("').find((s) => s.label === "email")!;
+		expect(bare.detail).not.toMatch(/bare/i);
+		expect(bare.detail).toContain("Checkout flow");
+	});
+});

--- a/app/src/hooks/data-column-completion.test.tsx
+++ b/app/src/hooks/data-column-completion.test.tsx
@@ -191,13 +191,63 @@ describe('`pm.iterationData.get("` in a script', () => {
 		expect(inScript('pm.iterationData.get("')).toEqual([]);
 	});
 
-	it("does not bleed into a variable accessor, whose names are a different set", () => {
+	it("does not bleed into a single-scope accessor, whose names are a different set", () => {
 		contract.current = declared;
 		// `pm.environment.get("email")` reads the environment; a column offered
 		// there is a name that returns `undefined` at run time.
 		expect(inScript('pm.environment.get("')).toEqual([]);
-		// `replaceIn` interpolates variables, and the data pass is a different
-		// pass over the composed request - a column is not one of its names.
-		expect(inScript('pm.variables.replaceIn("{{').map((s) => s.label)).not.toContain("email");
+		expect(inScript("pm.globals.get('")).toEqual([]);
+		expect(inScript('pm.collectionVariables.get("')).toEqual([]);
+	});
+});
+
+/**
+ * The merged accessor's list is the union of both sources (issue #1063).
+ *
+ * `pm.variables` is the one accessor that reads a bound row's bare column names
+ * *and* the three scopes (issue #1007), so a column is genuinely one of the
+ * names it can return - and it was the only such name the list withheld, which
+ * makes a declared column something you have to already know to use.
+ */
+describe('`pm.variables.get("` in a script', () => {
+	it("offers the declared columns, which the call really can return", () => {
+		contract.current = declared;
+		expect(inScript('pm.variables.get("').map((s) => s.label)).toEqual(["id", "email"]);
+	});
+
+	it("offers them to `.has` and to a guarded call too", () => {
+		contract.current = declared;
+		expect(inScript("pm.variables.has('").map((s) => s.label)).toEqual(["id", "email"]);
+		expect(inScript('pm.variables?.get("').map((s) => s.label)).toEqual(["id", "email"]);
+	});
+
+	it("inserts a bare name - the argument is a name, not a template", () => {
+		contract.current = declared;
+		const column = inScript('pm.variables.get("').find((s) => s.label === "email")!;
+		expect(column.insertText).toBe("email");
+		expect(column.detail).toContain("Checkout flow");
+	});
+
+	it("offers nothing extra when the chain declares no contract", () => {
+		contract.current = undefined;
+		expect(inScript('pm.variables.get("')).toEqual([]);
+	});
+
+	/*
+	 * `replaceIn` resolves a bare `{{email}}` from the bound row through the same
+	 * `resolve_template_with_data` the merged `get` reads (issue #1007), so its
+	 * list carries the columns too - as tokens, because that argument is a
+	 * template. This case asserted the opposite until #1063: it was written at
+	 * #600, when the row answered only `{{data.*}}` and a bare column really was
+	 * not one of `replaceIn`'s names.
+	 */
+	it("offers them to replaceIn as tokens, which is what that argument takes", () => {
+		contract.current = declared;
+		const column = inScript('pm.variables.replaceIn("{{').find((s) => s.label === "email");
+		expect(column, "replaceIn resolves a bare column from the bound row").toBeTruthy();
+		// Braces on both, the way every other entry in *this* list spells them -
+		// they share one `wrap`, so a column cannot drift from a variable here.
+		expect(column!.insertText).toBe("{{email}}");
+		expect(column!.filterText).toBe("{{email}}");
 	});
 });

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -40,6 +40,11 @@
  * tokens are validated against, so what an editor offers and what the builder
  * paints green cannot disagree.
  *
+ * **`pm.variables` completes both** (issue #1063). It is the one accessor that
+ * reads a bound row's bare column names *and* the three scopes (issue #1007),
+ * so its list is the union - a column offered there is a name the call really
+ * can return, which is the rule every other list here already follows.
+ *
  * Call once (in App). A completion provider is global per language, so a single
  * registration covers every script editor instance. The same shape as
  * `useScriptCompletionProvider` and `useVariableCompletionProvider` beside it.
@@ -61,6 +66,13 @@ const CLOSE_BRACES = "}}";
 
 /** The resolver's own precedence, so the winning definition sorts first. */
 const SCOPE_ORDER: Record<string, number> = { environment: 0, collection: 1, global: 2 };
+
+/**
+ * Columns sort after every scope and before the generators, the same grouping
+ * the body editor's list uses - so a column never displaces a name the call
+ * resolves today, and the two lists order the same things the same way.
+ */
+const DATA_SORT_GROUP = 7;
 
 /** Sorts after every scope above, so a generator never outranks a real variable. */
 const DYNAMIC_SORT_GROUP = 8;
@@ -152,6 +164,47 @@ export function useScriptVariableCompletionProvider() {
 						filterText: wrap(name),
 						range,
 					}));
+
+				/*
+				 * Declared columns, blended into the merged accessor and nowhere
+				 * else (issue #1063). A bound row answers bare column names
+				 * through `pm.variables` above every scope (issue #1007), so a
+				 * column is one of the names that call can return - and it was
+				 * the one such name the list never offered, which makes it a
+				 * column you have to already know to use.
+				 *
+				 * The single-scope accessors never see the row, and
+				 * `pm.iterationData` answered from the branch above, so neither
+				 * reaches here. `replaceIn` does, and belongs:
+				 * `resolve_template_with_data` resolves a bare `{{email}}` from
+				 * the row for it too, so leaving it out would take a condition
+				 * written only to preserve the gap.
+				 *
+				 * The columns come from the contract rather than from `variables`
+				 * because the namespace is disjoint from the scopes - no variable
+				 * can carry one. A name that is both a column and a variable is
+				 * offered twice on purpose: the row wins while one is bound and
+				 * the scope answers when none is, and a single entry would have
+				 * to hide one of those.
+				 */
+				if (context.scope === "all") {
+					for (const column of dataColumns?.columns ?? []) {
+						suggestions.push({
+							label: column,
+							// `Field`, not `Variable`: the icon is the only thing in
+							// the list saying this is a column of a run's row rather
+							// than a name some scope defines.
+							kind: monaco.languages.CompletionItemKind.Field,
+							insertText: wrap(column),
+							detail: `Data column - ${dataColumns?.collectionName}`,
+							documentation:
+								"Bound per iteration by a collection run's data file. A bound row answers this name above every scope; with no row bound, the scopes answer it.",
+							sortText: `${DATA_SORT_GROUP}${column}`,
+							filterText: wrap(column),
+							range,
+						});
+					}
+				}
 
 				/*
 				 * Generators only exist during interpolation, so they belong to

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -58,6 +58,7 @@ import { useActiveCollectionId } from "./useActiveCollectionId";
 import { useDataContract } from "./useDataContract";
 import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
+import { DATA_NAMESPACE_PREFIX } from "@/lib/variable-resolution";
 
 /** Script editors mount with language="javascript". */
 const SCRIPT_LANGUAGE = "javascript";
@@ -186,9 +187,34 @@ export function useScriptVariableCompletionProvider() {
 				 * offered twice on purpose: the row wins while one is bound and
 				 * the scope answers when none is, and a single entry would have
 				 * to hide one of those.
+				 *
+				 * **Only `replaceIn` gets the prefixed spelling** (issue #1077), and
+				 * the asymmetry is the rule rather than an oversight: `replaceIn`
+				 * resolves `{{data.email}}` and `{{email}}` from the same row, so
+				 * withholding one of two spellings that work would be the same gap
+				 * this fixes; `pm.variables.get("data.email")` reads no column at
+				 * all, the namespace being disjoint from the scopes there, so
+				 * offering it in a name argument would teach a call that returns
+				 * `undefined`.
 				 */
 				if (context.scope === "all") {
 					for (const column of dataColumns?.columns ?? []) {
+						if (template) {
+							const prefixed = `${DATA_NAMESPACE_PREFIX}${column}`;
+							suggestions.push({
+								label: prefixed,
+								kind: monaco.languages.CompletionItemKind.Field,
+								insertText: wrap(prefixed),
+								detail: `Data column - ${dataColumns?.collectionName}`,
+								documentation:
+									"Bound per iteration by a collection run's data file. The prefixed spelling can never collide with a variable.",
+								// The same group as the bare spelling below, so one column's
+								// two entries sit together rather than scattering.
+								sortText: `${DATA_SORT_GROUP}${column}`,
+								filterText: wrap(prefixed),
+								range,
+							});
+						}
 						suggestions.push({
 							label: column,
 							// `Field`, not `Variable`: the icon is the only thing in
@@ -196,7 +222,15 @@ export function useScriptVariableCompletionProvider() {
 							// than a name some scope defines.
 							kind: monaco.languages.CompletionItemKind.Field,
 							insertText: wrap(column),
-							detail: `Data column - ${dataColumns?.collectionName}`,
+							/*
+							 * `(bare)` only where the prefixed entry is beside it: the
+							 * word exists to tell two adjacent spellings apart, and in
+							 * the `get` / `has` list - which offers one - it would draw
+							 * a contrast that list does not contain.
+							 */
+							detail: template
+								? `Data column (bare) - ${dataColumns?.collectionName}`
+								: `Data column - ${dataColumns?.collectionName}`,
 							documentation:
 								"Bound per iteration by a collection run's data file. A bound row answers this name above every scope; with no row bound, the scopes answer it.",
 							sortText: `${DATA_SORT_GROUP}${column}`,

--- a/app/src/lib/data-contract.ts
+++ b/app/src/lib/data-contract.ts
@@ -126,9 +126,26 @@ function describeDeclaredColumn(note: string): DataTokenDescription {
 }
 
 /**
- * What the token says about itself, given the contract in scope.
+ * Phase 1's neutral wording, for a column there is nothing to validate against.
  *
- * Three states, and the middle one is the reason the phase exists:
+ * One object rather than a literal in each caller: "no contract declared" is a
+ * single state, and two copies of its wording is how the surfaces start to
+ * disagree about what they are saying.
+ */
+const UNVALIDATED_COLUMN: DataTokenDescription = {
+	tone: "muted",
+	description: "Bound by the run's data file",
+	note: "per iteration",
+};
+
+/**
+ * What a **column name** says about itself, given the contract in scope - the
+ * three states below, decided without reference to how the name was spelled.
+ *
+ * Split out of `describeDataToken` because the `data.` prefix is a spelling and
+ * not a rule (issue #1063): `pm.iterationData.get("email")` names the column
+ * `{{data.email}}` names and reads the same row, so the two spellings must not
+ * each own a copy of "declared, undeclared, or no contract at all".
  *
  * - **No contract anywhere in the chain** - phase 1's neutral wording, kept
  *   exactly: nothing has been declared, so nothing can be validated, and a
@@ -136,21 +153,14 @@ function describeDeclaredColumn(note: string): DataTokenDescription {
  * - **A declared column** - informational, and the tooltip names the declaring
  *   collection so the reader knows which Data tab owns it.
  * - **A column no contract in scope declares** - warning. The run will send the
- *   braces literally unless the file happens to carry the column anyway, and
- *   the declared list is printed because the fix is nearly always a typo.
+ *   token literally unless the file happens to carry the column anyway, and the
+ *   declared list is printed because the fix is nearly always a typo.
  */
-export function describeDataToken(
-	name: string,
+export function describeColumnToken(
+	column: string,
 	contract: DataContractScope | null | undefined
 ): DataTokenDescription {
-	const column = dataColumnName(name);
-	if (!contract || !column) {
-		return {
-			tone: "muted",
-			description: "Bound by the run's data file",
-			note: "per iteration",
-		};
-	}
+	if (!contract) return UNVALIDATED_COLUMN;
 	if (contract.columns.includes(column)) {
 		return describeDeclaredColumn(`declared in ${contract.collectionName}`);
 	}
@@ -159,6 +169,22 @@ export function describeDataToken(
 		description: `Not a declared column of ${contract.collectionName}`,
 		note: `declared: ${columnList(contract.columns)}`,
 	};
+}
+
+/**
+ * What a `{{data.*}}` token says about itself, given the contract in scope -
+ * `describeColumnToken`'s three states, reached through the prefixed spelling.
+ *
+ * A name outside the namespace addresses no column, so it keeps the neutral
+ * wording rather than being validated against a list it does not belong to.
+ */
+export function describeDataToken(
+	name: string,
+	contract: DataContractScope | null | undefined
+): DataTokenDescription {
+	const column = dataColumnName(name);
+	if (!column) return UNVALIDATED_COLUMN;
+	return describeColumnToken(column, contract);
 }
 
 /**

--- a/app/src/lib/referenced-variables.test.ts
+++ b/app/src/lib/referenced-variables.test.ts
@@ -17,7 +17,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { referencedVariables } from "./referenced-variables";
+import { describeColumnReference, referencedVariables } from "./referenced-variables";
+import type { DataContractScope } from "@/types/domain";
 
 /** The names alone, for the cases that are about extraction and not syntax. */
 const names = (script: string) => referencedVariables(script).map((r) => r.name);
@@ -25,7 +26,7 @@ const names = (script: string) => referencedVariables(script).map((r) => r.name)
 describe("the pm API", () => {
 	it.each(["environment", "globals", "collectionVariables"])("reads pm.%s.get", (bucket) => {
 		expect(referencedVariables(`pm.${bucket}.get("token")`)).toEqual([
-			{ name: "token", via: "pm" },
+			{ name: "token", via: "pm", reads: "scope" },
 		]);
 	});
 
@@ -57,7 +58,7 @@ describe("the pm API", () => {
 describe("templates", () => {
 	it("reads a {{name}}, and says it arrived as a template", () => {
 		expect(referencedVariables('const u = "{{base_url}}/orders"')).toEqual([
-			{ name: "base_url", via: "template" },
+			{ name: "base_url", via: "template", reads: null },
 		]);
 	});
 
@@ -79,8 +80,8 @@ describe("the list the chips render", () => {
 	it("takes both syntaxes from one script", () => {
 		const script = 'pm.globals.get("run_id"); const u = "{{base_url}}";';
 		expect(referencedVariables(script)).toEqual([
-			{ name: "run_id", via: "pm" },
-			{ name: "base_url", via: "template" },
+			{ name: "run_id", via: "pm", reads: "scope" },
+			{ name: "base_url", via: "template", reads: null },
 		]);
 	});
 
@@ -92,14 +93,14 @@ describe("the list the chips render", () => {
 		 * win would report a resolving reference as inert.
 		 */
 		expect(referencedVariables('pm.environment.get("token") + "{{token}}"')).toEqual([
-			{ name: "token", via: "pm" },
+			{ name: "token", via: "pm", reads: "scope" },
 		]);
 	});
 
 	it("does not let a later template downgrade an earlier pm read", () => {
 		// The order-dependent half of the rule above: template first, pm second.
 		expect(referencedVariables('"{{token}}"; pm.globals.get("token");')).toEqual([
-			{ name: "token", via: "pm" },
+			{ name: "token", via: "pm", reads: "scope" },
 		]);
 	});
 
@@ -117,5 +118,148 @@ describe("the list the chips render", () => {
 
 	it("finds nothing in a script that references nothing", () => {
 		expect(referencedVariables("const x = 1;")).toEqual([]);
+	});
+});
+
+/**
+ * The two accessors the pattern left out entirely (issue #1063).
+ *
+ * Neither `pm.variables.get` nor `pm.iterationData.get` matched, so a name read
+ * through either was not painted wrongly - it was chipped nowhere at all, which
+ * is the failure no colour assertion can catch.
+ */
+describe("the accessors that can see a bound row", () => {
+	it("reads pm.variables.get, and records that the row answers first", () => {
+		expect(referencedVariables('pm.variables.get("email")')).toEqual([
+			{ name: "email", via: "pm", reads: "merged" },
+		]);
+	});
+
+	it("reads pm.iterationData.get, whose only source is the row", () => {
+		expect(referencedVariables('pm.iterationData.get("email")')).toEqual([
+			{ name: "email", via: "pm", reads: "row" },
+		]);
+	});
+
+	it("reads a guarded call, which is how pm.iterationData is actually written", () => {
+		// Its own documentation says to guard: the accessor is `undefined`
+		// outside a data-driven run, so `?.` is the spelling in real scripts and
+		// a pattern that missed it would miss most of them.
+		expect(referencedVariables("pm.iterationData?.get('email')")).toEqual([
+			{ name: "email", via: "pm", reads: "row" },
+		]);
+	});
+
+	it("keeps the row-reading claim when a scope accessor names it too", () => {
+		/*
+		 * One chip for one name, and it has to be the claim that can be about a
+		 * column. `pm.environment.get` cannot read the row whatever the
+		 * collection declares, so letting it win would paint a column read as an
+		 * undefined variable - the reading #604 removed from this row.
+		 */
+		expect(
+			referencedVariables('pm.environment.get("email"); pm.variables.get("email");')
+		).toEqual([{ name: "email", via: "pm", reads: "merged" }]);
+	});
+
+	it("does not let a scope accessor downgrade an earlier row read", () => {
+		// The order-dependent half: the row-reading call comes first this time.
+		expect(
+			referencedVariables('pm.variables.get("email"); pm.environment.get("email");')
+		).toEqual([{ name: "email", via: "pm", reads: "merged" }]);
+	});
+});
+
+/**
+ * Which references are column reads, which is what the chip colour turns on.
+ *
+ * The decision lives here rather than in the panel so both script surfaces read
+ * one answer, and so these edges are reachable without rendering anything.
+ */
+describe("what a reference says about itself as a column", () => {
+	const declared: DataContractScope = {
+		collectionId: "col-orders",
+		collectionName: "Orders",
+		columns: ["email"],
+	};
+	/** No scope defines anything, unless a case says otherwise. */
+	const definesNothing = () => false;
+	const first = (script: string) => referencedVariables(script)[0];
+
+	const describeFirst = (
+		script: string,
+		contract: DataContractScope | null | undefined,
+		definesVariable: (name: string) => boolean = definesNothing
+	) => describeColumnReference(first(script), contract, definesVariable);
+
+	describe("read through pm.iterationData, whose only source is the row", () => {
+		it("is a declared column of the contract in scope", () => {
+			expect(describeFirst('pm.iterationData.get("email")', declared)).toMatchObject({
+				tone: "muted",
+				note: "declared in Orders",
+			});
+		});
+
+		it("warns - never destructive - when the contract does not declare it", () => {
+			const { collectionName, collectionId } = declared;
+			const other = { collectionId, collectionName, columns: ["name"] };
+			expect(describeFirst('pm.iterationData.get("email")', other)).toMatchObject({
+				tone: "warning",
+				note: "declared: name",
+			});
+		});
+
+		it("is still a column with no contract in scope, not an undefined variable", () => {
+			/*
+			 * The case that has to answer rather than fall through: a column can
+			 * never be in `allVariables`, so a null here would hand the chip the
+			 * resolved/unresolved pair and paint every column read destructive red
+			 * - the reading issue #604 removed from this exact row.
+			 */
+			expect(describeFirst('pm.iterationData.get("email")', undefined)).toMatchObject({
+				tone: "muted",
+			});
+		});
+	});
+
+	describe("read through pm.variables, which reads the row and then the scopes", () => {
+		it("is a bound column when the contract declares it and no scope does", () => {
+			expect(describeFirst('pm.variables.get("email")', declared)).toMatchObject({
+				tone: "muted",
+				note: expect.stringContaining("bound row's column answers this name"),
+			});
+		});
+
+		it("stays the variable it also is when a scope defines the name", () => {
+			/*
+			 * The row does win at run time while one is bound (issue #1007), but
+			 * which of the two a surface should *paint* is issue #1064's question,
+			 * and the builder draws this same line for a bare `{{email}}` today.
+			 * Answering it differently here would make the two disagree.
+			 */
+			expect(describeFirst('pm.variables.get("email")', declared, (n) => n === "email")).toBe(
+				null
+			);
+		});
+
+		it("is an ordinary variable read when no contract declares the name", () => {
+			expect(describeFirst('pm.variables.get("token")', declared)).toBe(null);
+			expect(describeFirst('pm.variables.get("token")', undefined)).toBe(null);
+		});
+	});
+
+	it("is never a column read through an accessor that cannot see the row", () => {
+		// The negative half of the rule: `pm.environment.get("email")` reads the
+		// environment whatever the collection declares, so a column paint there
+		// would describe a read that cannot happen.
+		expect(describeFirst('pm.environment.get("email")', declared)).toBe(null);
+		expect(describeFirst('pm.globals.get("email")', declared)).toBe(null);
+		expect(describeFirst('pm.collectionVariables.get("email")', declared)).toBe(null);
+	});
+
+	it("is never a column read for a name the script only contains", () => {
+		// Nothing interpolates script text (decision D16), so a `{{email}}` here
+		// reads no column however the contract is written.
+		expect(describeFirst('const to = "{{email}}"', declared)).toBe(null);
 	});
 });

--- a/app/src/lib/referenced-variables.ts
+++ b/app/src/lib/referenced-variables.ts
@@ -25,12 +25,35 @@
  * The template matcher is the app's one `VARIABLE_PATTERN`; only `PM_GET` is
  * local, because nothing else looks for that syntax. Inner braces are excluded
  * by that pattern, so `{{a}}{{b}}` is two names and not one.
+ *
+ * **A reference carries what its accessor can see, not only how it was
+ * spelled** (issue #1063). `PM_GET` matched three accessors and left
+ * `pm.variables` and `pm.iterationData` out entirely, so a name read through
+ * either was not merely painted wrong - it was chipped nowhere at all, the
+ * quiet half of this repo's written-but-never-read defect. Since issue #1007 a
+ * bound row answers bare column names through `pm.variables`, which makes the
+ * accessor the difference between a column read and a variable read of the same
+ * name, so the syntax alone can no longer decide what a chip may claim.
  */
 
 import { VARIABLE_PATTERN } from "@/constants/variables";
+import {
+	describeBareColumnToken,
+	describeColumnToken,
+	type DataTokenDescription,
+} from "./data-contract";
+import type { DataContractScope } from "@/types/domain";
 
-/** `pm.environment.get("x")`, and the globals / collectionVariables siblings. */
-const PM_GET = /pm\.(?:environment|globals|collectionVariables)\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+/**
+ * `pm.<accessor>.get("x")`, for every accessor whose first argument is a name.
+ *
+ * Optional chaining counts as the dot it is, the same way `ACCESSOR_CALL` in
+ * `script-variable-completion.ts` reads it: `pm.iterationData` is `undefined`
+ * outside a data-driven run and its own documentation says to guard before
+ * calling, so `pm.iterationData?.get("x")` is how the call is actually written.
+ */
+const PM_GET =
+	/pm\??\.(environment|globals|collectionVariables|variables|iterationData)\??\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 
 /**
  * How a script named a variable.
@@ -42,6 +65,46 @@ const PM_GET = /pm\.(?:environment|globals|collectionVariables)\.get\s*\(\s*['"]
  *   script.
  */
 export type ReferenceSyntax = "pm" | "template";
+
+/**
+ * What the accessor that named it can actually see (issue #1063).
+ *
+ * The syntax alone stopped being enough once a bound data row began answering
+ * bare column names (issue #1007): `pm.environment.get("email")` and
+ * `pm.variables.get("email")` are the same syntax about the same name, and only
+ * the second one can be reading a column. A surface that paints them alike is
+ * guessing.
+ *
+ * - `scope` - `environment` / `globals` / `collectionVariables`. One scope, and
+ *   never the row, whatever the collection declares.
+ * - `merged` - `pm.variables`. The bound row's bare column names first, then the
+ *   three scopes (issue #1007), so this one is a column read *or* a variable
+ *   read and the name decides which.
+ * - `row` - `pm.iterationData`. The row and nothing but the row, so no answer
+ *   about the scopes says anything true about it.
+ */
+export type PmRead = "scope" | "merged" | "row";
+
+const PM_READ_BY_ACCESSOR: Record<string, PmRead> = {
+	environment: "scope",
+	globals: "scope",
+	collectionVariables: "scope",
+	variables: "merged",
+	iterationData: "row",
+};
+
+/**
+ * Which mention of a name outranks which, when a script writes it more than one
+ * way. Ascending, and the existing `pm`-beats-`template` rule is the bottom two
+ * rungs of it.
+ *
+ * Above them, an accessor that can see the row outranks one that cannot, for
+ * the same reason `pm` outranks `template`: it is the stronger claim about what
+ * the script reads, and the row shadowing a same-named variable is the fact an
+ * author most needs the chip to show. `row` tops `merged` because it reads
+ * nothing else, so the column reading is the only one it can have.
+ */
+const CLAIM_RANK: Record<string, number> = { template: 0, scope: 1, merged: 2, row: 3 };
 
 /**
  * What a `template` chip has to say for itself, in both script surfaces.
@@ -58,6 +121,8 @@ export const TEMPLATE_IN_SCRIPT_NOTE =
 export interface VariableReference {
 	name: string;
 	via: ReferenceSyntax;
+	/** What the accessor that named it reads; `null` for a `template` mention. */
+	reads: PmRead | null;
 }
 
 /**
@@ -74,15 +139,65 @@ export interface VariableReference {
  * pushes that name down the list even though it comes first in the file.
  */
 export function referencedVariables(script: string): VariableReference[] {
-	const byName = new Map<string, ReferenceSyntax>();
-	const add = (name: string, via: ReferenceSyntax) => {
+	const byName = new Map<string, VariableReference>();
+	const add = (name: string, via: ReferenceSyntax, reads: PmRead | null) => {
 		if (name.length === 0) return;
-		// `pm` wins over `template`, and a repeat never downgrades what is there.
-		if (via === "pm" || !byName.has(name)) byName.set(name, via);
+		const existing = byName.get(name);
+		// A repeat never downgrades what is there, so an equal claim keeps the
+		// first - which is also what holds this name's place in the row's order.
+		if (
+			existing &&
+			CLAIM_RANK[existing.reads ?? "template"] >= CLAIM_RANK[reads ?? "template"]
+		) {
+			return;
+		}
+		byName.set(name, { name, via, reads });
 	};
 
-	for (const match of script.matchAll(PM_GET)) add(match[1], "pm");
-	for (const match of script.matchAll(VARIABLE_PATTERN)) add(match[1].trim(), "template");
+	for (const match of script.matchAll(PM_GET)) {
+		add(match[2], "pm", PM_READ_BY_ACCESSOR[match[1]]);
+	}
+	for (const match of script.matchAll(VARIABLE_PATTERN)) add(match[1].trim(), "template", null);
 
-	return [...byName].map(([name, via]) => ({ name, via }));
+	return [...byName.values()];
+}
+
+/**
+ * What a reference says about itself *as a data column*, or null when it is not
+ * a column read and the caller's ordinary variable painting applies (#1063).
+ *
+ * Here rather than in the panels for the same reason `TEMPLATE_IN_SCRIPT_NOTE`
+ * is: the rule is one engine fact, and a surface holding its own copy is how
+ * two chips of the same name come to disagree. It takes a predicate rather than
+ * the resolver's map so it stays a pure join of "what did the script write" and
+ * "what does the contract declare".
+ *
+ * @param definesVariable whether any scope defines a variable of that name
+ */
+export function describeColumnReference(
+	reference: VariableReference,
+	contract: DataContractScope | null | undefined,
+	definesVariable: (name: string) => boolean
+): DataTokenDescription | null {
+	const { name, reads } = reference;
+
+	/*
+	 * `pm.iterationData` reads the row and nothing else, so every state it can
+	 * be in is a column state - including "no contract declared". Falling
+	 * through would hand it the resolved/unresolved pair, and a column can never
+	 * be in `allVariables`, so the answer would always be the destructive red
+	 * issue #604 removed from exactly this row.
+	 */
+	if (reads === "row") return describeColumnToken(name, contract);
+
+	/*
+	 * `pm.variables` reads the row first and the scopes after, so it is a column
+	 * read only while the name is a declared column that no scope answers -
+	 * the same line `VariableInput` draws for a bare `{{name}}` (issue #1007).
+	 * Where a scope does define it, the variable painting is still true and the
+	 * question of which one wins on screen belongs to #1064, not here.
+	 */
+	if (reads !== "merged" || !contract) return null;
+	if (!contract.columns.includes(name) || definesVariable(name)) return null;
+	return describeBareColumnToken(contract);
 }

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.autosave.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.autosave.test.tsx
@@ -50,6 +50,18 @@ vi.mock("@/queries/collections", () => ({
 }));
 
 /*
+ * The chip row reads the contract and the variables in scope (issue #1075).
+ * Nothing here is about chips - this file is the save behaviour - but the tab
+ * renders the row either way, and these hooks reach the query layer this file
+ * deliberately does not stand up.
+ */
+vi.mock("@/hooks", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/hooks")>()),
+	useDataContract: () => undefined,
+	useVariableResolver: () => ({ getAllVariables: () => ({}) }),
+}));
+
+/*
  * Monaco does not run in jsdom. The stub is a real focusable element inside the
  * editor's container, which is the part under test: the tab listens for
  * `focusout` on the container rather than on Monaco's own blur, so what has to

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
@@ -40,6 +40,24 @@ vi.mock("@/queries/collections", () => ({
 	useUpdateCollectionMutation: () => mutation,
 }));
 
+/**
+ * The contract in scope and the variables in scope, which the chips now read
+ * (issue #1075). Stubbed at the hook boundary rather than through the query
+ * layer for the reason this file's header gives: what these assert is the
+ * wiring, and standing up a real chain would be testing `useDataContract`
+ * and `useVariableResolver`, which have their own suites.
+ */
+const contract: { value: { collectionName: string; columns: string[] } | undefined } = {
+	value: undefined,
+};
+const variables: { value: Record<string, { value: string; scope: string }> } = { value: {} };
+
+vi.mock("@/hooks", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/hooks")>()),
+	useDataContract: () => contract.value,
+	useVariableResolver: () => ({ getAllVariables: () => variables.value }),
+}));
+
 // Monaco does not run in jsdom, and the editor is not what this guards.
 vi.mock("@/components/ui", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@/components/ui")>()),
@@ -72,6 +90,8 @@ function makeCollection(script: string): Collection {
 
 beforeEach(() => {
 	mutation.mutateAsync.mockClear();
+	contract.value = undefined;
+	variables.value = {};
 });
 
 describe.each(["pre", "post"] as const)("%s-request script tab", (kind) => {
@@ -126,5 +146,93 @@ describe.each(["pre", "post"] as const)("%s-request script tab", (kind) => {
 		render(<ScriptTab collection={makeCollection("console.log(1);")} kind={kind} />);
 
 		expect(screen.queryByText("Names mentioned:")).not.toBeInTheDocument();
+	});
+
+	/**
+	 * The column tones this tab did not have (issue #1075).
+	 *
+	 * The request panel got them at #604 and #1063; this one kept a two-way
+	 * ladder, so the same script pasted into a collection's tab instead of a
+	 * request's lost every column state - a flat accent chip that claims a
+	 * variable answers, for a name only a bound row can answer. The paint below
+	 * comes from `DATA_TOKEN_TONE_CLASS`, the one table both surfaces read, so
+	 * a column this tab calls declared is the one that panel calls declared.
+	 */
+	describe("a data column, by either spelling", () => {
+		const COLUMNS = [
+			'const a = "{{data.email}}";',
+			'const b = pm.variables.get("city");',
+			'const c = pm.iterationData.get("zip");',
+		].join("\n");
+
+		const chipFor = (container: HTMLElement, text: string) =>
+			[...container.querySelectorAll<HTMLElement>('[data-slot="badge"]')].find(
+				(el) => el.textContent === text
+			);
+
+		it("paints all three spellings as columns, never as the accent", () => {
+			contract.value = { collectionName: "Orders", columns: ["email", "city", "zip"] };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(COLUMNS)} kind={kind} />
+			);
+
+			for (const text of ["{{data.email}}", "city", "zip"]) {
+				const chip = chipFor(container, text);
+				expect(chip, `no chip for ${text}`).toBeTruthy();
+				expect(chip!.className).toContain("text-muted-foreground");
+				// The accent is the paint that said a variable answers this name.
+				expect(chip!.className).not.toContain("text-variable");
+			}
+		});
+
+		it("names the declaring collection, which is where the column changes", () => {
+			contract.value = { collectionName: "Orders", columns: ["email", "city", "zip"] };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(COLUMNS)} kind={kind} />
+			);
+
+			expect(chipFor(container, "zip")!.getAttribute("title")).toContain(
+				"declared in Orders"
+			);
+			expect(chipFor(container, "city")!.getAttribute("title")).toContain(
+				"bound row's column answers this name"
+			);
+		});
+
+		it("warns - amber, never destructive - for a column no contract declares", () => {
+			contract.value = { collectionName: "Orders", columns: ["email"] };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(COLUMNS)} kind={kind} />
+			);
+
+			const chip = chipFor(container, "zip")!;
+			expect(chip.className).toContain("text-warning-text");
+			expect(chip.className).not.toContain("bg-destructive");
+		});
+
+		it("leaves a pm.variables read as the variable a scope defines", () => {
+			// The same line the request panel draws, and `VariableInput` before
+			// it: which of the two wins on screen is issue #1064's question.
+			contract.value = { collectionName: "Orders", columns: ["email", "city", "zip"] };
+			variables.value = { city: { value: "Berlin", scope: "environment" } };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(COLUMNS)} kind={kind} />
+			);
+
+			expect(chipFor(container, "city")!.className).toContain("text-variable");
+			// The row's own accessor is unaffected: it reads no scope, so a
+			// variable of that name says nothing about it.
+			expect(chipFor(container, "zip")!.className).not.toContain("text-variable");
+		});
+
+		it("keeps the accent for an ordinary pm read, which is still a variable", () => {
+			// The case that proves the column branch did not swallow the old one.
+			contract.value = { collectionName: "Orders", columns: ["email"] };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(SCRIPT)} kind={kind} />
+			);
+
+			expect(chipFor(container, "auth_token")!.className).toContain("text-variable");
+		});
 	});
 });

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
@@ -210,6 +210,42 @@ describe.each(["pre", "post"] as const)("%s-request script tab", (kind) => {
 			expect(chip.className).not.toContain("bg-destructive");
 		});
 
+		it("stays a column with no contract in scope, not an undefined variable", () => {
+			/*
+			 * The third state, and the one that has to answer rather than fall
+			 * through: a column can never be in the scopes, so handing it the
+			 * ordinary pm paint would call every column read undefined - which is
+			 * the reading #604 removed. The request panel pins this too; both
+			 * surfaces need it, because either could regress alone.
+			 */
+			const { container } = render(
+				<ScriptTab collection={makeCollection(COLUMNS)} kind={kind} />
+			);
+
+			for (const text of ["{{data.email}}", "zip"]) {
+				const chip = chipFor(container, text);
+				expect(chip, `no chip for ${text}`).toBeTruthy();
+				expect(chip!.className).toContain("text-muted-foreground");
+				expect(chip!.className).not.toContain("text-variable");
+			}
+		});
+
+		it("does not tell a pm read that its characters reach the script verbatim", () => {
+			// The tooltip half of parity with the request panel: the interpolation
+			// note belongs to the spelling that is literal characters.
+			contract.value = { collectionName: "Orders", columns: ["email"] };
+			const { container } = render(
+				<ScriptTab
+					collection={makeCollection('pm.variables.get("data.email");')}
+					kind={kind}
+				/>
+			);
+
+			const title = chipFor(container, "data.email")!.getAttribute("title")!;
+			expect(title).toContain("declared in Orders");
+			expect(title).not.toContain("not interpolated");
+		});
+
 		it("leaves a pm.variables read as the variable a scope defines", () => {
 			// The same line the request panel draws, and `VariableInput` before
 			// it: which of the two wins on screen is issue #1064's question.

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -35,7 +35,16 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { Badge, Button, CodeEditor } from "@/components/ui";
 import { useDraftSaveContext, useEntityDraft } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
-import { referencedVariables, TEMPLATE_IN_SCRIPT_NOTE } from "@/lib/referenced-variables";
+import {
+	describeColumnReference,
+	referencedVariables,
+	TEMPLATE_IN_SCRIPT_NOTE,
+} from "@/lib/referenced-variables";
+import { describeDataToken } from "@/lib/data-contract";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import { isDataVariableName } from "@/lib/variable-resolution";
+import { useDataContract, useVariableResolver } from "@/hooks";
+import { cn } from "@/lib/utils";
 import type { Collection } from "@/types";
 import { InfoBanner, SaveFailed } from "./shared";
 
@@ -82,6 +91,17 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 	// it - the same two regexes, the same dedupe - so the empty-name filter that
 	// landed in the helper never reached the pre- and post-request tabs here.
 	const usedVars = useMemo(() => referencedVariables(script), [script]);
+
+	/*
+	 * The same two answers the request panel paints its chips from (issue #1075).
+	 * This tab had neither, so a column read here was a flat accent chip while
+	 * the identical script in a request said which contract declares the column
+	 * and whether it does - one script, two readings, decided by which screen it
+	 * was pasted into. The contract is the one in scope for *this* collection's
+	 * chain, which is the chain the engine hands a script running under it.
+	 */
+	const dataColumns = useDataContract(collection.id);
+	const { getAllVariables } = useVariableResolver({ collectionId: collection.id });
 
 	// Takes the text rather than reading the draft, so Clear can write the empty
 	// script on the same tick it sets it - `setScript` has not landed yet when
@@ -163,20 +183,54 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 			{usedVars.length > 0 && (
 				<div className="flex flex-wrap gap-1.5 items-center">
 					<span className="text-[11px] text-muted-foreground">Names mentioned:</span>
-					{usedVars.slice(0, 8).map(({ name, via }) => (
-						<Badge
-							key={name}
-							variant="chip"
-							className={
-								via === "pm"
-									? "font-mono text-[10px] bg-primary/10 text-variable border-0"
-									: "font-mono text-[10px] bg-muted text-muted-foreground border-0"
-							}
-							title={via === "pm" ? undefined : TEMPLATE_IN_SCRIPT_NOTE}
-						>
-							{via === "pm" ? name : `{{${name}}}`}
-						</Badge>
-					))}
+					{usedVars.slice(0, 8).map((reference) => {
+						const { name, via } = reference;
+						/*
+						 * A column, by either spelling, painted from the one table
+						 * `DATA_TOKEN_TONE_CLASS` - never the accent, which claims a
+						 * variable answers, and never destructive, which #604 removed
+						 * from this reading. The decision is `describeColumnReference`'s
+						 * so this tab reads the rule rather than owning a copy of it.
+						 */
+						const data = isDataVariableName(name)
+							? describeDataToken(name, dataColumns)
+							: describeColumnReference(reference, dataColumns, (candidate) =>
+									Boolean(getAllVariables()[candidate])
+								);
+						if (data) {
+							return (
+								<Badge
+									key={name}
+									variant="chip"
+									className={cn(
+										"font-mono text-[10px] bg-muted border-0",
+										DATA_TOKEN_TONE_CLASS[data.tone]
+									)}
+									title={
+										via === "template"
+											? `${data.description} - ${data.note} ${TEMPLATE_IN_SCRIPT_NOTE}`
+											: `${data.description} - ${data.note}`
+									}
+								>
+									{via === "pm" ? name : `{{${name}}}`}
+								</Badge>
+							);
+						}
+						return (
+							<Badge
+								key={name}
+								variant="chip"
+								className={
+									via === "pm"
+										? "font-mono text-[10px] bg-primary/10 text-variable border-0"
+										: "font-mono text-[10px] bg-muted text-muted-foreground border-0"
+								}
+								title={via === "pm" ? undefined : TEMPLATE_IN_SCRIPT_NOTE}
+							>
+								{via === "pm" ? name : `{{${name}}}`}
+							</Badge>
+						);
+					})}
 					{usedVars.length > 8 && (
 						<span className="text-[10px] text-muted-foreground">
 							+{usedVars.length - 8} more

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -102,6 +102,10 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 	 */
 	const dataColumns = useDataContract(collection.id);
 	const { getAllVariables } = useVariableResolver({ collectionId: collection.id });
+	// Once per render, not once per chip: `getAllVariables` spreads a fresh map
+	// on every call, so asking it inside the row would rebuild the scopes for
+	// each name in it.
+	const allVariables = getAllVariables();
 
 	// Takes the text rather than reading the draft, so Clear can write the empty
 	// script on the same tick it sets it - `setScript` has not landed yet when
@@ -195,7 +199,7 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 						const data = isDataVariableName(name)
 							? describeDataToken(name, dataColumns)
 							: describeColumnReference(reference, dataColumns, (candidate) =>
-									Boolean(getAllVariables()[candidate])
+									Boolean(allVariables[candidate])
 								);
 						if (data) {
 							return (

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
@@ -264,6 +264,23 @@ describe("a column read through pm, by its bare name", () => {
 		expect(chipFor(container, "city").className).toContain("text-muted-foreground");
 	});
 
+	it("does not tell a pm read that its characters reach the script verbatim", () => {
+		/*
+		 * A `data.*` name reached through `pm.*.get()` takes the column paint,
+		 * but not the interpolation note beside it: that note belongs to the
+		 * spelling that really is literal characters, and on a call it describes
+		 * something the author did not write. The collection tab draws the same
+		 * line (issue #1075), and the two must not answer this differently.
+		 */
+		script.value = 'const a = pm.variables.get("data.email");';
+		contract.value = { collectionName: "Orders", columns: ["email"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const title = chipFor(container, "data.email").getAttribute("title")!;
+		expect(title).toContain("declared in Orders");
+		expect(title).not.toContain("not interpolated");
+	});
+
 	it("keeps the destructive chip for a pm.variables read that names no column", () => {
 		// The merged accessor is still a variable read for every other name, and
 		// this is the case that proves the new branch did not swallow the old one.

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
@@ -50,6 +50,16 @@ const SCRIPT = [
 	'const u = "{{base_url}}/orders";',
 ].join("\n");
 
+/**
+ * The same column, reached through each accessor that can see the bound row
+ * (issue #1063). Separate from `SCRIPT` because these names must not disturb
+ * the three paints above, and because the chip row only chips the first five.
+ */
+const ROW_SCRIPT = [
+	'const a = pm.variables.get("email");',
+	'const b = pm.iterationData.get("city");',
+].join("\n");
+
 const contract: { value: { collectionName: string; columns: string[] } | undefined } = {
 	value: undefined,
 };
@@ -57,13 +67,22 @@ const contract: { value: { collectionName: string; columns: string[] } | undefin
 /** What `getAllVariables()` answers with - empty unless a case says otherwise. */
 const variables: { value: Record<string, { value: string; scope: string }> } = { value: {} };
 
+/** The script under the panel - `SCRIPT` unless a case swaps it. */
+const script = { value: SCRIPT };
+
 vi.mock("../../../context", () => ({
 	useRequestBuilderContext: () => ({
 		// `collectionId: null` keeps the inherited-scripts notice out of the tree,
 		// which would otherwise want a QueryClient. The contract this panel paints
 		// against arrives as `dataColumns`, already resolved by the provider, so
 		// the chain walk is not what these cases are about.
-		request: { preRequestScript: SCRIPT, testScript: SCRIPT, collectionId: null },
+		get request() {
+			return {
+				preRequestScript: script.value,
+				testScript: script.value,
+				collectionId: null,
+			};
+		},
 		updateField: () => {},
 		getAllVariables: () => variables.value,
 		get dataColumns() {
@@ -98,6 +117,7 @@ function chipFor(container: HTMLElement, name: string): HTMLElement {
 beforeEach(() => {
 	contract.value = undefined;
 	variables.value = {};
+	script.value = SCRIPT;
 });
 
 describe("a {{data.*}} name in the chip row", () => {
@@ -167,5 +187,89 @@ describe("a plain {{name}} the script only contains", () => {
 		const chip = chipFor(container, "{{base_url}}");
 		expect(chip.className).toContain("text-muted-foreground");
 		expect(chip.className).not.toContain("bg-secondary");
+	});
+});
+
+/**
+ * A bare column name, read through an accessor that sees the bound row
+ * (issue #1063).
+ *
+ * Both of these were chipped *nowhere at all* before: `referencedVariables`
+ * matched three accessors and neither of these was one, so the names a
+ * data-driven script actually reads were the ones the row stayed silent about.
+ * The paint they get now is the `{{data.*}}` paint, from the same table, because
+ * the spelling is the only thing that differed.
+ */
+describe("a column read through pm, by its bare name", () => {
+	beforeEach(() => {
+		script.value = ROW_SCRIPT;
+	});
+
+	it("chips a pm.variables read like the pm.iterationData read beside it", () => {
+		// The acceptance criterion itself: one column, two accessors, one paint.
+		contract.value = { collectionName: "Orders", columns: ["email", "city"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const merged = chipFor(container, "email");
+		const row = chipFor(container, "city");
+		expect(merged.className).toBe(row.className);
+		expect(merged.className).toContain("text-muted-foreground");
+		expect(merged.className).not.toContain("bg-destructive");
+	});
+
+	it("says the row is what answers the name, which is why it is not red", () => {
+		contract.value = { collectionName: "Orders", columns: ["email", "city"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		expect(chipFor(container, "email").getAttribute("title")).toContain(
+			"bound row's column answers this name"
+		);
+		expect(chipFor(container, "city").getAttribute("title")).toContain("declared in Orders");
+	});
+
+	it("warns - amber, not red - for a pm.iterationData read of an undeclared column", () => {
+		contract.value = { collectionName: "Orders", columns: ["email"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const chip = chipFor(container, "city");
+		expect(chip.className).toContain("text-warning-text");
+		expect(chip.className).not.toContain("bg-destructive");
+	});
+
+	it("never calls a pm.iterationData read undefined, with no contract in scope", () => {
+		/*
+		 * The state that has to be handled rather than fall through: a column can
+		 * never be in `allVariables`, so the resolved/unresolved pair answers
+		 * "destructive" for every column read - the #604 defect, arriving by a
+		 * second door.
+		 */
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		expect(chipFor(container, "city").className).not.toContain("bg-destructive");
+	});
+
+	it("leaves a pm.variables read painted as the variable a scope defines", () => {
+		/*
+		 * The row does win at run time while one is bound (issue #1007), but which
+		 * of the two the builder *paints* is issue #1064's question, and this
+		 * panel draws the line where `VariableInput` already draws it. The
+		 * `pm.iterationData` chip beside it is unaffected: that accessor reads no
+		 * scope, so a variable of the same name says nothing about it.
+		 */
+		contract.value = { collectionName: "Orders", columns: ["email", "city"] };
+		variables.value = { email: { value: "ops@example.com", scope: "environment" } };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		expect(chipFor(container, "email").className).toContain("bg-secondary");
+		expect(chipFor(container, "city").className).toContain("text-muted-foreground");
+	});
+
+	it("keeps the destructive chip for a pm.variables read that names no column", () => {
+		// The merged accessor is still a variable read for every other name, and
+		// this is the case that proves the new branch did not swallow the old one.
+		contract.value = { collectionName: "Orders", columns: ["city"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		expect(chipFor(container, "email").className).toContain("bg-destructive");
 	});
 });

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
@@ -123,7 +123,18 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 										"font-mono text-xs bg-muted",
 										DATA_TOKEN_TONE_CLASS[data.tone]
 									)}
-									title={`${data.description} - ${data.note} ${TEMPLATE_IN_SCRIPT_NOTE}`}
+									/*
+									 * The interpolation note belongs to the spelling
+									 * that is literal characters. A `data.*` name
+									 * read through `pm.*.get()` is a real call, so
+									 * telling its author the text reaches the script
+									 * verbatim describes something else entirely.
+									 */
+									title={
+										via === "template"
+											? `${data.description} - ${data.note} ${TEMPLATE_IN_SCRIPT_NOTE}`
+											: `${data.description} - ${data.note}`
+									}
 								>
 									{name}
 								</Badge>

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
@@ -25,7 +25,11 @@ import { useRequestBuilderContext } from "../../../../context";
 import InheritedScriptsNotice from "../InheritedScriptsNotice";
 import LegacyScriptNotice from "../LegacyScriptNotice";
 import { SCRIPT_VARIANTS, type ScriptVariant } from "./script-variants";
-import { referencedVariables, TEMPLATE_IN_SCRIPT_NOTE } from "@/lib/referenced-variables";
+import {
+	describeColumnReference,
+	referencedVariables,
+	TEMPLATE_IN_SCRIPT_NOTE,
+} from "@/lib/referenced-variables";
 import { describeDataToken } from "@/lib/data-contract";
 import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
 import { isDataVariableName } from "@/lib/variable-resolution";
@@ -94,7 +98,8 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 			{hasReferencedVars && (
 				<div className="flex flex-wrap items-center gap-2">
 					<span className="text-xs text-muted-foreground">Names mentioned:</span>
-					{usedVars.slice(0, CHIP_LIMIT).map(({ name, via }) => {
+					{usedVars.slice(0, CHIP_LIMIT).map((reference) => {
+						const { name, via } = reference;
 						/*
 						 * A `data.*` name is not a variable and never becomes one
 						 * (issue #604): the namespace is disjoint from the scopes,
@@ -119,6 +124,41 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 										DATA_TOKEN_TONE_CLASS[data.tone]
 									)}
 									title={`${data.description} - ${data.note} ${TEMPLATE_IN_SCRIPT_NOTE}`}
+								>
+									{name}
+								</Badge>
+							);
+						}
+						/*
+						 * A bare name a bound row answers (issue #1063). The same
+						 * two states as the `data.*` chip above and painted from
+						 * the same table, because `pm.iterationData.get("email")`
+						 * and `{{data.email}}` name one column and read one row -
+						 * a reader who has to learn two paints for that has been
+						 * told the spelling matters, and it does not.
+						 *
+						 * `pm.variables.get("email")` joins them only while the
+						 * name is a declared column no scope defines, which is
+						 * exactly the line `VariableInput` already draws for a
+						 * bare `{{email}}` in the URL bar. The decision itself is
+						 * `describeColumnReference`'s, so the two surfaces cannot
+						 * come to disagree about it.
+						 */
+						const column = describeColumnReference(
+							reference,
+							context.dataColumns,
+							(candidate) => Boolean(allVariables[candidate])
+						);
+						if (column) {
+							return (
+								<Badge
+									key={name}
+									variant="chip"
+									className={cn(
+										"font-mono text-xs bg-muted",
+										DATA_TOKEN_TONE_CLASS[column.tone]
+									)}
+									title={`${column.description} - ${column.note}`}
 								>
 									{name}
 								</Badge>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1385,10 +1385,28 @@ substitution that does not happen. `referencedVariables` (`lib/referenced-variab
 now returns each name with the syntax that found it - `pm` or `template` - and
 `pm` wins when a name is written both ways, because the script does read it.
 Template chips are muted, spelled `{{name}}`, and carry `TEMPLATE_IN_SCRIPT_NOTE`
-as their tooltip; `pm` chips keep the resolved/unresolved pair. The collection's
-Pre-request and Post-request tabs (`CollectionDetail/ScriptTab`) read the same
-helper and follow the same rule - they had also printed every name as `{{name}}`,
-including the ones the script reads through `pm`.
+as their tooltip; `pm` chips keep the resolved/unresolved pair, except for the
+column reads below. The collection's Pre-request and Post-request tabs
+(`CollectionDetail/ScriptTab`) read the same helper and split `pm` from
+`template` the same way - they had also printed every name as `{{name}}`,
+including the ones the script reads through `pm`. They do **not** paint the
+column tones: that half is the request panel's alone (issue #1075).
+
+**A reference carries what its accessor can see, not only how it was spelled**
+(issue #1063). `referencedVariables` matched three accessors and left
+`pm.variables` and `pm.iterationData` out, so a name read through either was
+chipped nowhere at all - the quiet half of the written-but-never-read defect,
+and the half no colour assertion catches. Each reference now also carries a
+`reads` of `scope`, `merged` or `row`, because since #1007 a bound row answers
+bare column names through `pm.variables`: the same name through
+`pm.environment.get` is a variable read and through `pm.variables.get` may be a
+column one, so the syntax alone can no longer decide what a chip may claim. The
+decision is `describeColumnReference`'s, beside the helper, and it resolves to
+`describeDataToken`'s own tones - a `row` read is a column in every state it can
+be in, including "no contract declared", while a `merged` read is a column only
+while the name is a declared column no scope defines, which is the line
+`VariableInput` already draws for a bare `{{email}}`. Everything else keeps the
+paint it had.
 
 **A run-time token receives pointer events; the overlay does not.** The overlay
 is `pointer-events: none` so clicks reach the transparent input underneath and

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1406,8 +1406,10 @@ and the half no colour assertion catches. Each reference now also carries a
 bare column names through `pm.variables`: the same name through
 `pm.environment.get` is a variable read and through `pm.variables.get` may be a
 column one, so the syntax alone can no longer decide what a chip may claim. The
-decision is `describeColumnReference`'s, beside the helper, and it resolves to
-`describeDataToken`'s own tones - a `row` read is a column in every state it can
+decision is `describeColumnReference`'s, beside the helper, and it answers with
+`describeColumnToken` - the same three states `describeDataToken` reaches for a
+`data.*` name, split out of it so the prefixed and bare spellings share one
+rule. A `row` read is a column in every state it can
 be in, including "no contract declared", while a `merged` read is a column only
 while the name is a declared column no scope defines, which is the line
 `VariableInput` already draws for a bare `{{email}}`. Everything else keeps the

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1389,8 +1389,13 @@ as their tooltip; `pm` chips keep the resolved/unresolved pair, except for the
 column reads below. The collection's Pre-request and Post-request tabs
 (`CollectionDetail/ScriptTab`) read the same helper and split `pm` from
 `template` the same way - they had also printed every name as `{{name}}`,
-including the ones the script reads through `pm`. They do **not** paint the
-column tones: that half is the request panel's alone (issue #1075).
+including the ones the script reads through `pm`. They paint the column tones
+too (issue #1075): that tab kept a two-way ladder through #604 and #1063, so
+the same script pasted into a collection's tab rather than a request's lost
+every column state, and a name only a bound row can answer got the accent that
+says a variable does. Both ladders read one `DATA_TOKEN_TONE_CLASS`, so a
+column one calls declared is the one the other calls declared - two consumers
+of one rule, not two copies of it.
 
 **A reference carries what its accessor can see, not only how it was spelled**
 (issue #1063). `referencedVariables` matched three accessors and left

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -737,7 +737,7 @@ list is deliberately *not* registered for `javascript`: braces are not the
 syntax in a script, so offering them there would teach the wrong thing. The
 names are the same names; only the place you type them differs.
 
-Three rules make the offered set match what the call can actually read:
+These rules make the offered set match what the call can actually read:
 
 - **The accessor picks the scope.** `pm.environment.get` lists environment
   variables only, because that is the one scope it reads - a collection

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -241,10 +241,16 @@ run with a mismatched file is still the user's to start. Declared columns are
 also completed: `{{data.` offers them in the request fields and the body editors,
 and `pm.iterationData.get("` offers them in the script editors (see below).
 
-The script panel's **"Referenced:" chips** read the same three states (issue
-#604). They used to paint a name red whenever no scope defined it, which for a
-`data.*` name is always - the reading that made a working column look broken in
-a row whose whole job is to say whether a name resolves.
+The script panel's **"Names mentioned:" chips** read the same three states
+(issue #604). They used to paint a name red whenever no scope defined it, which
+for a `data.*` name is always - the reading that made a working column look
+broken in a row whose whole job is to say whether a name resolves. A column
+reached by its **bare** name gets that same paint (issue #1063): a script reads
+one through `pm.iterationData.get("email")`, or through `pm.variables.get("email")`
+while no scope defines `email`, and both are the column `{{data.email}}` names.
+The accessor is what decides, not the spelling - `pm.environment.get("email")`
+cannot see the row whatever the collection declares, so it stays an ordinary
+variable chip.
 
 The **audit** in the Data tab is the same comparison in the other direction -
 the declared columns against the tokens the collection's requests actually
@@ -736,7 +742,8 @@ Three rules make the offered set match what the call can actually read:
 - **The accessor picks the scope.** `pm.environment.get` lists environment
   variables only, because that is the one scope it reads - a collection
   variable offered there would be a name that returns `undefined`. Only the
-  merged `pm.variables.get` lists all three.
+  merged `pm.variables.get` lists all three, and it alone also lists the
+  declared columns (below), because it alone reads both.
 - **Collection variables come from the active tab.** Collection scope is
   explicit-only (see *Collection scope is explicit only* above) and a Monaco
   completion provider is registered once per *language*, not per editor, so it
@@ -760,6 +767,18 @@ Three rules make the offered set match what the call can actually read:
   surface is `undefined` outside a data-driven run or a send-with-row, and its own documentation
   tells scripts to guard before calling. Nothing is offered when the chain
   declares no contract.
+- **`pm.variables` completes both, because it reads both.** A bound row answers
+  bare column names through the merged accessor, above every scope (issue
+  #1007), so the declared columns are blended into its list beside the
+  variables (issue #1063) - as bare names inside `get("…")` / `has("…")`, and
+  as `{{column}}` tokens inside `replaceIn`, which resolves them from the same
+  row. They carry the field icon and name their declaring collection, so a
+  column is distinguishable from a variable at a glance, and a name that is
+  both is offered twice on purpose: the row wins while one is bound and the
+  scope answers when none is. The single-scope accessors never see the row, so
+  no column is offered there. The prefixed `{{data.column}}` spelling is not in
+  this list: `pm.variables.get` does not read it at all, and it is completed
+  where its own accessor is.
 - **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
   template and interpolates it, so it gets brace-style completion including
   `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -776,9 +776,14 @@ Three rules make the offered set match what the call can actually read:
   column is distinguishable from a variable at a glance, and a name that is
   both is offered twice on purpose: the row wins while one is bound and the
   scope answers when none is. The single-scope accessors never see the row, so
-  no column is offered there. The prefixed `{{data.column}}` spelling is not in
-  this list: `pm.variables.get` does not read it at all, and it is completed
-  where its own accessor is.
+  no column is offered there. **The prefixed `{{data.column}}` spelling is
+  offered to `replaceIn` and to nothing else** (issue #1077): `replaceIn`
+  resolves both spellings from the same row, so withholding one of two that
+  work would be the same gap, while `pm.variables.get("data.email")` reads no
+  column at all - the namespace is disjoint from the scopes there - and
+  offering it in a name argument would teach a call that returns `undefined`.
+  The bare entry says `(bare)` only where the prefixed one sits beside it,
+  since that word exists to tell two adjacent spellings apart.
 - **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
   template and interpolates it, so it gets brace-style completion including
   `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no


### PR DESCRIPTION
## Description

Since #1007 a bound data row answers bare column names through `pm.variables.get` / `.has` / `.toObject`, above every scope. Three renderer surfaces still described the world before it.

**The plan.** The root cause is one fact arriving in the engine and never reaching the renderer: an accessor's *identity* became load-bearing, and the app was still keying off syntax. `pm.environment.get("email")` and `pm.variables.get("email")` are the same syntax about the same name, and only the second can be reading a column - so no surface that knows only "this was a `pm.*.get()`" can say anything true about it. The approach is therefore to carry what each accessor can **see** (`scope` / `merged` / `row`) on the reference itself, and to put the "is this a column read" decision in one pure function both script panels consume. The alternative I rejected was letting each panel test the name against the contract itself: it needs no new type and reads as less machinery, but it is precisely the shape of this repo's most-repeated defect - two surfaces owning one rule, drifting the moment one is fixed - and it cannot distinguish the accessors at all, so `pm.environment.get("email")` would have been painted as a column.

**The quiet half.** `PM_GET` matched three accessors and left `pm.variables` and `pm.iterationData` out entirely. So a name read through either was not painted *wrongly* - it was chipped **nowhere at all**, which is the failure no colour assertion catches.

**One anchor had drifted.** #1063 describes this as "the same gap `pm.iterationData.get` had before #600". Verified against live code: that accessor was never in the pattern either, so its criterion ("chipped like one read through `pm.iterationData.get`") was vacuous as written. Satisfying it non-vacuously required adding both accessors, which this does.

Folded in at the owner's request during the run, each claimed on its issue first:
- **#1075** - the collection script tab kept a two-way ladder, so the same script pasted there instead of into a request lost every column state.
- **#1077** - `replaceIn` resolves `{{data.email}}` and `{{email}}` from the same row, so offering one of two spellings that work was the same gap, one call over.

**Deliberate deviations from the issue text**, each with its reason:
- **#1063 named `variable-completion-scope.test.tsx`**; the cases went to `data-column-completion.test.tsx`. The named file mocks `useDataContract` to a constant `undefined` and its own comment defers columns to the file I used, which already has the mutable-contract fixture.
- **An existing assertion was overturned.** `data-column-completion.test.tsx` asserted `replaceIn` offers no column, with the reason "the data pass is a different pass over the composed request". That was true when written at #600 and is not true now: `resolve_template_with_data` (`engine/src/http/request_composer.cpp:640`) answers a bare `{{email}}` from `row.columns` above the scopes, and `pm.variables.replaceIn` routes through it. I checked the engine source rather than the docs before changing it.
- **#1075's "chip identically" is met for tone, not for markup.** The collection tab's chips are `text-[10px] border-0` and the request panel's are `text-xs`; that per-surface sizing predates this branch and I did not churn it. Both read one `DATA_TOKEN_TONE_CLASS`, so the state a column is in cannot differ between them.
- **#1075 floats merging the two ladders into one shared component.** Not taken: two consumers of one rule is what the repo asks for, and collapsing two panels is a change that should be justified on its own rather than ridden in beside a colour fix.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`pnpm test` **542 files / 5922 tests, all passing** (5879 on the base commit; +43). `pnpm lint`, `pnpm type-check` and `mkdocs build --strict` all clean. No engine code changed, so no ctest run - the one engine file I opened was read-only, to check the `replaceIn` claim above. No pre-existing failures encountered on the base commit.

Seven mutation checks, each failing exactly its intended cases and nothing else:

| Reverted | Fails |
|---|---|
| `PM_GET` back to three accessors | 17 |
| the completion blend | 4 |
| the `ScriptPanel` column branch | 5 |
| `row` reads falling through to the variable paint | 2 |
| the `definesVariable` guard | 2 |
| the prefixed spelling applied to *both* modes | 3 |
| the tooltip conditional | 1 |

The fifth and sixth are the ones worth naming: the `definesVariable` guard is the #1064 boundary, and "apply it to both modes" is the obvious wrong version of #1077, caught by the single case that asserts `pm.variables.get("` still withholds `data.email`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1063
Closes #1075
Closes #1077

Two boundaries left deliberately intact. Which of the row and the scope should *win* on screen when both answer a name is #1064's question - this draws the line where `VariableInput` already draws it rather than pre-empting it. And `#1062`'s preview resolution is untouched; that issue was claimed by a concurrent run and its files are disjoint from these.

---
_Generated by [Claude Code](https://claude.ai/code/session_014V4UNvAqVp2gAQoyT2yxxw)_