### PR TITLE
fix(app): the variable popover names the bound data row as the origin - #1064

### DIFF
--- a/app/src/components/shared/VariableInput/EditableVariable.test.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.test.tsx
@@ -121,3 +121,92 @@ describe("secrets never appear on hover", () => {
 		expect(screen.getAllByText("Production").length).toBeGreaterThan(0);
 	});
 });
+
+/**
+ * Issue #1064. A bound row's column answers a bare name above every scope, and
+ * the popover was taught to say so - but hovering and clicking are two readings
+ * of the same token, and a tooltip still printing the environment's value made
+ * one token say two things about one send.
+ *
+ * The paint is deliberately unchanged (D18): a shadowed bare name keeps the
+ * variable's accent, and the explanation is what moves.
+ */
+describe("a bound row's column answers the token", () => {
+	const withRow = variableSupportStub(
+		{},
+		{
+			getVariableOrigins: () => [
+				{
+					scope: "environment",
+					sourceName: "Staging",
+					value: "staging@acme.io",
+					enabled: true,
+					winner: false,
+				},
+				{ scope: "row", value: "alice@acme.io", enabled: true, winner: true },
+			],
+		}
+	);
+
+	it("reads the row's cell on hover, not the definition it beat", () => {
+		/*
+		 * The mutation check: drop `boundRowValue` and the tooltip falls back to
+		 * the resolved branch, which prints "staging@acme.io" - the value the send
+		 * is not going to use, which is the whole defect.
+		 */
+		renderToken({ name: "email", value: "staging@acme.io", variables: withRow });
+		expect(screen.getAllByText("alice@acme.io").length).toBeGreaterThan(0);
+		expect(screen.queryByText("staging@acme.io")).not.toBeInTheDocument();
+		expect(screen.getAllByText("Bound row").length).toBeGreaterThan(0);
+	});
+
+	it("answers a name no scope defines rather than calling it undefined", () => {
+		const rowOnly = variableSupportStub(
+			{},
+			{
+				getVariableOrigins: () => [
+					{ scope: "row", value: "alice@acme.io", enabled: true, winner: true },
+				],
+			}
+		);
+		renderToken({ name: "email", value: "", resolved: false, variables: rowOnly });
+		expect(screen.queryByText("not defined")).not.toBeInTheDocument();
+		expect(screen.getAllByText("alice@acme.io").length).toBeGreaterThan(0);
+	});
+
+	it("leaves a token no row answers exactly as it was", () => {
+		// With no row origin the tooltip must be the one this file already pins,
+		// value and source name and all.
+		renderToken();
+		expect(screen.getAllByText("mrc_8813").length).toBeGreaterThan(0);
+		expect(screen.queryByText("Bound row")).not.toBeInTheDocument();
+	});
+
+	it("never lets a row's cell reveal a secret variable's value", () => {
+		// A cell is not a secret, but the variable it shadows may be - and the
+		// tooltip must still not print the secret it is standing in front of.
+		const shadowingSecret = variableSupportStub(
+			{},
+			{
+				getVariableOrigins: () => [
+					{
+						scope: "environment",
+						sourceName: "Prod",
+						value: "sk_live_abcdef",
+						secret: true,
+						enabled: true,
+						winner: false,
+					},
+					{ scope: "row", value: "alice@acme.io", enabled: true, winner: true },
+				],
+			}
+		);
+		renderToken({
+			name: "apiKey",
+			value: "sk_live_abcdef",
+			secret: true,
+			variables: shadowingSecret,
+		});
+		expect(document.body.textContent).not.toContain("sk_live_abcdef");
+	});
+});

--- a/app/src/components/shared/VariableInput/EditableVariable.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.tsx
@@ -69,8 +69,20 @@ export default function EditableVariable({
 	variables,
 }: EditableVariableProps) {
 	const { getVariableOrigins, writableScopes } = variables;
+	const origins = getVariableOrigins(name);
 
 	const varInfo = resolved ? { value, scope: scope as VariableScope, secret, sourceName } : null;
+
+	/**
+	 * The bound row's answer, if it has one (issue #1064).
+	 *
+	 * Hovering reads and clicking edits, so the two must not read differently:
+	 * once the popover names the row as the origin, a tooltip still printing the
+	 * environment's value makes the same token say two things about one send.
+	 * Taken off the origins this component already fetches rather than through a
+	 * prop of its own, so there is one answer to "what wins" and not two.
+	 */
+	const boundRowValue = origins.find((o) => o.scope === "row")?.value;
 
 	const handleValueChange = onValueChange
 		? (varName: string, varValue: string, varScope: VariableScope) => {
@@ -108,7 +120,7 @@ export default function EditableVariable({
 			onValueChange={handleValueChange}
 			saveMode="auto"
 			disabled={disabled}
-			origins={getVariableOrigins(name)}
+			origins={origins}
 			writableScopes={writableScopes}
 			trigger={
 				/*
@@ -138,7 +150,21 @@ export default function EditableVariable({
 					 * already red when unresolved; the tooltip only has to say so.
 					 */}
 					<TooltipContent side="bottom" className="max-w-xs">
-						{!resolved ? (
+						{boundRowValue !== undefined ? (
+							/*
+							 * The row outranks every scope, so it is the answer whether or
+							 * not one of them also defines the name - which makes this the
+							 * first branch rather than a case inside the resolved one. A
+							 * cell is never a secret: it came from the picked file, not
+							 * from a stored variable someone marked.
+							 */
+							<span className="flex items-baseline gap-2">
+								<span className="break-all font-mono">
+									{boundRowValue || "empty"}
+								</span>
+								<TooltipHint className="shrink-0">Bound row</TooltipHint>
+							</span>
+						) : !resolved ? (
 							<span className="italic opacity-90">not defined</span>
 						) : (
 							<span className="flex items-baseline gap-2">

--- a/app/src/components/ui/variable-popover.test.tsx
+++ b/app/src/components/ui/variable-popover.test.tsx
@@ -356,6 +356,147 @@ describe("why this value won", () => {
 	});
 });
 
+/**
+ * Issue #1064. #1007 put a bound row's columns above every scope and #1062 made
+ * the *preview* say so, but the popover - the one surface whose entire job is
+ * "why is this the value" - still explained the environment's definition while
+ * the send was about to use the row's cell.
+ *
+ * The row is not a definition: nobody wrote it, nothing can edit it, and it
+ * disappears when the pick is dropped. So it is listed as the origin rather than
+ * replacing the editable field, which still holds the variable, because the
+ * variable is still the thing a reader can act on.
+ */
+describe("a bound data row outranks every definition", () => {
+	/** Lowest precedence first, as the resolver hands them over. */
+	const withRow: VariableOrigin[] = [
+		origin({ scope: "environment", sourceName: "Staging", value: "staging@acme.io" }),
+		origin({ scope: "row", value: "alice@acme.io", winner: true }),
+	];
+
+	it("names the row as the origin and strikes the definition it beat", () => {
+		renderPopover({ origins: withRow });
+		const panel = open();
+
+		expect(within(panel).getByText("bound data row")).toBeInTheDocument();
+		expect(within(panel).getByText("Bound row")).toBeInTheDocument();
+
+		/*
+		 * The mutation check. Drop the row origin from `ShadowedBy` - or let it
+		 * fall through to the ordinary loser list - and the row's cell either
+		 * vanishes or arrives struck through, which is the popover claiming the
+		 * send will not use the one value it will.
+		 */
+		const rowValue = within(panel).getByText("alice@acme.io");
+		expect(rowValue.className).not.toContain("line-through");
+
+		const beaten = within(panel).getByText("staging@acme.io");
+		expect(beaten.className).toContain("line-through");
+	});
+
+	it("says what the shadowed definition is still good for", () => {
+		// Not the `data.*` sentence: that one says defining a variable of this
+		// name would change nothing, which is false for a bare column.
+		renderPopover({ origins: withRow });
+		expect(
+			within(open()).getByText(/still resolves on a send that carries no row/)
+		).toBeInTheDocument();
+	});
+
+	it("reads exactly as it did before when no row is bound", () => {
+		// The tier is opt-in at the resolver, so a popover that never sees a row
+		// origin must be untouched by any of this.
+		renderPopover({
+			origins: [
+				origin({ scope: "environment", sourceName: "Staging", value: "x", winner: true }),
+				origin({ scope: "global", value: "http://localhost:8080" }),
+			],
+		});
+		const panel = open();
+		expect(within(panel).getByText("also defined")).toBeInTheDocument();
+		expect(within(panel).queryByText("bound data row")).not.toBeInTheDocument();
+		expect(within(panel).queryByText("Bound row")).not.toBeInTheDocument();
+	});
+
+	it("does not offer to create a variable as though the name were unanswered", () => {
+		/*
+		 * The realistic prop shape, and the one the first cut of this change
+		 * missed: `EditableVariable` always passes an `onValueChange` and a
+		 * `writableScopes` that has globals in it, so `canCreate` wins the render
+		 * ternary and the create form is what a reader actually sees. Creating is
+		 * still worth offering - the variable answers every row-less send - but a
+		 * form that says nothing about the row implies the token is unanswered,
+		 * which is the same wrong claim in a different shape.
+		 */
+		renderPopover({
+			name: "email",
+			varInfo: null,
+			resolved: false,
+			trigger: <span>{"{{email}}"}</span>,
+			writableScopes: ["global", "environment"],
+			origins: [origin({ scope: "row", value: "alice@acme.io", winner: true })],
+		});
+		const panel = open();
+		expect(within(panel).getByText("Create")).toBeInTheDocument();
+		expect(
+			within(panel).getByText(/The bound row already answers this name/)
+		).toBeInTheDocument();
+		expect(within(panel).getByText("alice@acme.io")).toBeInTheDocument();
+	});
+
+	it("does not chip a row-answered name as undefined", () => {
+		// The chip is a separate claim from the body text, and destructive red
+		// there says the same false thing: that this token reaches the server
+		// with its braces on.
+		renderPopover({
+			name: "email",
+			varInfo: null,
+			resolved: false,
+			trigger: <span>{"{{email}}"}</span>,
+			writableScopes: ["global"],
+			origins: [origin({ scope: "row", value: "alice@acme.io", winner: true })],
+		});
+		const panel = open();
+		expect(within(panel).queryByText("undefined")).not.toBeInTheDocument();
+		expect(within(panel).getByText("row")).toBeInTheDocument();
+	});
+
+	it("still chips a genuinely undefined name as undefined", () => {
+		// The mutation check for the pair above: with no row answering, the red
+		// chip is correct and must survive.
+		renderPopover({
+			name: "email",
+			varInfo: null,
+			resolved: false,
+			trigger: <span>{"{{email}}"}</span>,
+			writableScopes: ["global"],
+		});
+		const panel = open();
+		expect(within(panel).getByText("undefined")).toBeInTheDocument();
+		expect(within(panel).queryByText("row")).not.toBeInTheDocument();
+	});
+
+	it("stops calling a name the row answers an undefined variable", () => {
+		/*
+		 * The destructive red states a token that reaches the server with its
+		 * braces still on. A row carrying this column is precisely the case where
+		 * it does not - the file declared no such column, so the painter never
+		 * diverted it, and the popover was the only thing left saying anything.
+		 */
+		renderPopover({
+			name: "email",
+			varInfo: null,
+			resolved: false,
+			trigger: <span>{"{{email}}"}</span>,
+			origins: [origin({ scope: "row", value: "alice@acme.io", winner: true })],
+		});
+		const panel = open();
+		expect(within(panel).queryByText(/Variable not defined/)).not.toBeInTheDocument();
+		expect(within(panel).getByText(/Answered by the bound data row/)).toBeInTheDocument();
+		expect(within(panel).getByText(/carries no row/)).toBeInTheDocument();
+	});
+});
+
 describe("an Enter that only commits an IME buffer", () => {
 	it("saves on a plain Enter and not on a composition commit", () => {
 		// The keystroke an IME uses to commit its composition reaches the handler

--- a/app/src/components/ui/variable-popover.tsx
+++ b/app/src/components/ui/variable-popover.tsx
@@ -15,6 +15,12 @@
  *   undefined  a value field and a scope to create it in
  *   read-only  the value, when there is no way to change it from here
  *
+ * **A bound data row outranks all of them** (D18, issue #1007). While one is
+ * picked its column answers a bare name above every scope, so the popover names
+ * the row as the origin and strikes the definitions beneath it (issue #1064).
+ * Without that it explained, in full detail, a value the send was not going to
+ * use - the one question this popover exists to answer, answered wrongly.
+ *
  * **It used to show the value twice.** A "Current Value" block sat above an
  * "Edit Value" input holding the same string, each with its own label and its
  * own secret-reveal button - about 90px and two labels spent restating what the
@@ -65,6 +71,32 @@ const SCOPE_PREFERENCE: VariableScope[] = ["environment", "collection", "global"
  * inconsistent with the fixed eight-dot box that used to sit above it.
  */
 const SECRET_MASK = "••••••••";
+
+/**
+ * What a `"row"` origin calls itself. A row has no `sourceName` to give - it is
+ * the one row currently picked, not a file or an environment someone named.
+ */
+const BOUND_ROW_LABEL = "Bound row";
+
+/**
+ * The chip beside the name when there is no scope badge to show. Shared rather
+ * than spelled out per state: it was already written twice, and the third copy
+ * is where a shape or radius fix starts reaching only two of them.
+ */
+const NAME_CHIP =
+	"inline-flex h-[18px] items-center rounded-md border px-1.5 text-[10px] leading-none";
+
+/**
+ * The bare spelling's own sentence, and deliberately not the `data.*` one.
+ *
+ * `{{data.email}}` is disjoint from the scopes, so "defining one with this name
+ * would change nothing" is true of it. A bare `{{email}}` is not: defining that
+ * variable does something - it answers every send that carries no row - it just
+ * loses to the row while one is picked. Telling the reader it would change
+ * nothing would be false, which is why the two messages are two messages.
+ */
+const BOUND_ROW_NOTE =
+	"While a row is picked, its column answers this name. The definition above still resolves on a send that carries no row.";
 
 /** The eye that swaps a hidden secret field for an editable one. */
 function RevealButton({ revealed, onToggle }: { revealed: boolean; onToggle: () => void }) {
@@ -163,6 +195,16 @@ export function VariablePopover({
 	 * name as a prop and is reachable from any caller that renders a token.
 	 */
 	const isDataName = isDataVariableName(name);
+
+	/**
+	 * The bound row's answer for this name, if it has one (issue #1064).
+	 *
+	 * Read off `origins` rather than taken as a prop of its own: the resolver
+	 * already ranks the row against the definitions it beats, and a second
+	 * channel carrying the same fact is how the winner here and the winner there
+	 * come to disagree.
+	 */
+	const boundRowOrigin = origins?.find((o) => o.scope === "row");
 
 	// Creating is only offered where a write would land somewhere.
 	const creatableScopes = useMemo(
@@ -333,11 +375,31 @@ export function VariablePopover({
 									className="h-[18px] leading-none"
 								/>
 							) : isDataName ? (
-								<span className="inline-flex h-[18px] items-center rounded-md border border-muted-foreground/40 px-1.5 text-[10px] leading-none text-muted-foreground">
+								<span
+									className={cn(
+										NAME_CHIP,
+										"border-muted-foreground/40 text-muted-foreground"
+									)}
+								>
 									data
 								</span>
+							) : boundRowOrigin ? (
+								/*
+								 * Answered, so not "undefined" - and in the accent rather
+								 * than the destructive red, which states a token that will
+								 * reach the server with its braces still on. This one will
+								 * not: the row carries the column.
+								 */
+								<span className={cn(NAME_CHIP, "border-primary/40 text-primary")}>
+									row
+								</span>
 							) : (
-								<span className="inline-flex h-[18px] items-center rounded-md border border-destructive-text/40 px-1.5 text-[10px] leading-none text-destructive-text">
+								<span
+									className={cn(
+										NAME_CHIP,
+										"border-destructive-text/40 text-destructive-text"
+									)}
+								>
 									undefined
 								</span>
 							)}
@@ -518,11 +580,39 @@ export function VariablePopover({
 									Create
 								</Button>
 							</div>
+							{/*
+							 * A create offer must not imply the token is unanswered. The
+							 * row carries a column the declared contract does not, so the
+							 * painter never diverted this token and the send resolves it
+							 * anyway - creating a variable here is still worth doing, but
+							 * for the sends that carry no row, not for this one.
+							 */}
+							{boundRowOrigin && (
+								<p className="text-[10px] text-muted-foreground">
+									The bound row already answers this name with{" "}
+									<span className="font-mono">
+										{boundRowOrigin.value || "empty"}
+									</span>
+									. A variable created here answers a send that carries no row.
+								</p>
+							)}
 						</>
 					) : isDataName ? (
 						<div className="text-sm text-muted-foreground">
 							Bound per iteration by the run&rsquo;s data file. Not a variable -
 							defining one with this name would change nothing.
+						</div>
+					) : boundRowOrigin ? (
+						/*
+						 * Undefined everywhere, but the picked row carries the column, so
+						 * the send resolves it. "Variable not defined" in destructive red
+						 * is the one thing this must not say: the red states a token that
+						 * will reach the server with its braces on, and this one will not.
+						 */
+						<div className="text-sm text-muted-foreground">
+							Answered by the bound data row&rsquo;s{" "}
+							<span className="font-mono">{name}</span> column, not by a variable.
+							Defining one would answer a send that carries no row.
 						</div>
 					) : (
 						<div className="text-sm text-destructive-text">
@@ -537,53 +627,88 @@ export function VariablePopover({
 }
 
 /**
- * The definitions that did not win.
+ * One line of the "where could this have come from" list.
  *
- * Rendered only when there is more than one, so the ordinary case stays short.
- * Three row states, not two - a definition can lose by precedence *or* by being
- * switched off, and the second is the more common surprise: the value you set
- * is being skipped rather than missing. A list that only showed shadowing would
- * answer the easy question and stay silent on the hard one.
+ * Shared by the winning row and the definitions beneath it so the two cannot
+ * drift apart: the only difference between them is the strike-through, which is
+ * the whole message - a struck value is one the send will not use.
+ */
+function OriginRow({ origin, beaten }: { origin: VariableOrigin; beaten: boolean }) {
+	// A disabled definition is not competing at all, so it does not get a
+	// colour. The row gets the accent rather than a fourth scope colour: it is
+	// not a place a variable lives, it is the answer that is live right now, and
+	// the accent is what this app already paints a live answer in.
+	const dot = !origin.enabled
+		? "bg-subtle-foreground"
+		: origin.scope === "row"
+			? "bg-primary"
+			: VARIABLE_SCOPE_DOT[origin.scope];
+	const label =
+		origin.scope === "row" ? BOUND_ROW_LABEL : VARIABLE_SCOPE_CONFIG[origin.scope].full;
+
+	return (
+		<div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+			<span className={cn("size-[5px] shrink-0 rounded-full", dot)} />
+			<span className="shrink-0">{origin.sourceName ?? label}</span>
+			<span className={cn("truncate font-mono", beaten && "line-through opacity-60")}>
+				{origin.secret ? SECRET_MASK : origin.value || "empty"}
+			</span>
+			{!origin.enabled && (
+				<span className="ml-auto shrink-0 rounded-md border border-rule px-1 not-italic">
+					off
+				</span>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Where the value comes from, and what it beat.
+ *
+ * Rendered only when there is more than one answer, so the ordinary case stays
+ * short. Three row states, not two - a definition can lose by precedence *or* by
+ * being switched off, and the second is the more common surprise: the value you
+ * set is being skipped rather than missing. A list that only showed shadowing
+ * would answer the easy question and stay silent on the hard one.
+ *
+ * A bound row's cell is listed above them all, unstruck (issue #1064). Without
+ * it the popover explained a value the send would not use: the editable field at
+ * the top of the popover is the *variable*, which is still the thing you can
+ * change, while the row is what answers the name until the pick is dropped.
  */
 function ShadowedBy({ origins }: { origins?: VariableOrigin[] }) {
 	if (!origins || origins.length < 2) return null;
 
 	// Highest precedence first: reading down the list is reading the order the
 	// resolver rejected them in.
-	const others = [...origins].reverse().filter((o) => !o.winner);
+	const ranked = [...origins].reverse();
+	const row = ranked.find((o) => o.scope === "row");
+	const others = ranked.filter((o) => !o.winner && o.scope !== "row");
 	if (others.length === 0) return null;
 
 	return (
 		<div className="flex flex-col gap-0.5 border-t border-border pt-1.5">
+			{row && (
+				<>
+					<div className="text-[10px] uppercase tracking-wide text-subtle-foreground">
+						bound data row
+					</div>
+					<OriginRow origin={row} beaten={false} />
+				</>
+			)}
+			{/*
+			 * Still "also defined" with a row above, not "shadowed": the list holds
+			 * definitions that lost by precedence *and* ones that are switched off,
+			 * and an off definition is not shadowed by anything. The row block above
+			 * already says which answer wins.
+			 */}
 			<div className="text-[10px] uppercase tracking-wide text-subtle-foreground">
 				also defined
 			</div>
 			{others.map((o, i) => (
-				<div
-					key={`${o.scope}-${o.sourceId ?? "global"}-${i}`}
-					className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
-				>
-					<span
-						className={cn(
-							"size-[5px] shrink-0 rounded-full",
-							// A disabled definition is not competing at all, so it does
-							// not get the scope's colour.
-							o.enabled ? VARIABLE_SCOPE_DOT[o.scope] : "bg-subtle-foreground"
-						)}
-					/>
-					<span className="shrink-0">
-						{o.sourceName ?? VARIABLE_SCOPE_CONFIG[o.scope].full}
-					</span>
-					<span className="truncate font-mono line-through opacity-60">
-						{o.secret ? "••••••••" : o.value || "empty"}
-					</span>
-					{!o.enabled && (
-						<span className="ml-auto shrink-0 rounded-md border border-rule px-1 not-italic">
-							off
-						</span>
-					)}
-				</div>
+				<OriginRow key={`${o.scope}-${o.sourceId ?? "global"}-${i}`} origin={o} beaten />
 			))}
+			{row && <p className="text-[10px] text-muted-foreground">{BOUND_ROW_NOTE}</p>}
 		</div>
 	);
 }

--- a/app/src/hooks/useVariableResolver.origins.test.tsx
+++ b/app/src/hooks/useVariableResolver.origins.test.tsx
@@ -70,6 +70,7 @@ function setup(opts: {
 	envs?: Array<{ id: string; name: string; variables?: Record<string, unknown> }>;
 	activeCollectionId?: string | null;
 	activeEnvironmentId?: string | null;
+	boundRow?: Record<string, unknown>;
 }) {
 	globals.variables = opts.globalVars ?? {};
 	collections.length = 0;
@@ -83,7 +84,10 @@ function setup(opts: {
 	 * here and no writer anywhere.
 	 */
 	return renderHook(() =>
-		useVariableResolver({ collectionId: opts.activeCollectionId ?? undefined })
+		useVariableResolver({
+			collectionId: opts.activeCollectionId ?? undefined,
+			boundRow: opts.boundRow,
+		})
 	).result.current;
 }
 
@@ -275,5 +279,100 @@ describe("the definitions that lost", () => {
 			activeCollectionId: "c1",
 		});
 		expect(r.getVariableOrigins("host").map((o) => o.sourceName)).toEqual(["Acme"]);
+	});
+});
+
+/**
+ * Issue #1064. The bound row is a tier above every scope (D18, issue #1007),
+ * and until now `getVariableOrigins` could not say so - it was built from the
+ * scopes alone, so the popover reading it explained a definition the send was
+ * about to ignore.
+ *
+ * The row is layered on in `getVariableOrigins` rather than in the scope ladder
+ * underneath it, and the tests below pin both halves of that split: the origins
+ * list gains the row, and the resolved-variable map does not.
+ */
+describe("the bound row as an origin", () => {
+	it("puts the row above the environment and takes the win from it", () => {
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { email: v("staging@acme.io") } }],
+			activeEnvironmentId: "e1",
+			boundRow: { email: "alice@acme.io" },
+		});
+		const origins = r.getVariableOrigins("email");
+		expect(origins.map((o) => o.scope)).toEqual(["environment", "row"]);
+		expect(origins.find((o) => o.winner)?.value).toBe("alice@acme.io");
+		/*
+		 * The mutation check. Leave the environment's `winner` as the scope ladder
+		 * set it and two origins claim to have won at once - a list no reader can
+		 * render honestly, and the popover would go on striking the wrong one.
+		 */
+		expect(origins.filter((o) => o.winner)).toHaveLength(1);
+		expect(origins.find((o) => o.scope === "environment")?.winner).toBe(false);
+	});
+
+	it("answers a name no scope defines at all", () => {
+		const r = setup({ boundRow: { email: "alice@acme.io" } });
+		const origins = r.getVariableOrigins("email");
+		expect(origins).toHaveLength(1);
+		expect(origins[0]).toMatchObject({ scope: "row", value: "alice@acme.io", winner: true });
+	});
+
+	it("counts a column whose cell is empty as an answer", () => {
+		// `rowCells.get(name) === undefined` is the test, not truthiness: an empty
+		// cell binds, and binds to "". Read it as falsy and the popover explains
+		// the environment for a name the send will blank out.
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { email: v("staging@acme.io") } }],
+			activeEnvironmentId: "e1",
+			boundRow: { email: "" },
+		});
+		expect(r.getVariableOrigins("email").find((o) => o.winner)?.scope).toBe("row");
+	});
+
+	it("leaves a name the row has no column for alone", () => {
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { host: v("staging.acme.io") } }],
+			activeEnvironmentId: "e1",
+			boundRow: { email: "alice@acme.io" },
+		});
+		const origins = r.getVariableOrigins("host");
+		expect(origins.map((o) => o.scope)).toEqual(["environment"]);
+		expect(origins[0].winner).toBe(true);
+	});
+
+	it("gives the reserved data.* spelling no row origin", () => {
+		// The cells are keyed by bare column name, so `data.email` finds nothing
+		// here - which is what keeps its own terminal explanation correct.
+		const r = setup({ boundRow: { email: "alice@acme.io" } });
+		expect(r.getVariableOrigins("data.email")).toEqual([]);
+	});
+
+	it("keeps the row out of the resolved-variable map", () => {
+		/*
+		 * The split this change turns on. `getVariableOrigins` is display-only;
+		 * `getVariable` / `getAllVariables` feed the token painting and the
+		 * editable field, and a row folded into them would report a cell as the
+		 * variable's value and hand `ResolvedVariable` a scope nothing can write.
+		 */
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { email: v("staging@acme.io") } }],
+			activeEnvironmentId: "e1",
+			boundRow: { email: "alice@acme.io" },
+		});
+		expect(r.getVariable("email")?.value).toBe("staging@acme.io");
+		expect(r.getVariable("email")?.scope).toBe("environment");
+		// The preview, which is the row-aware surface, still binds the row.
+		expect(r.resolveString("{{email}}")).toBe("alice@acme.io");
+	});
+
+	it("has no row origins at all when no row is bound", () => {
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { email: v("staging@acme.io") } }],
+			activeEnvironmentId: "e1",
+		});
+		const origins = r.getVariableOrigins("email");
+		expect(origins.some((o) => o.scope === "row")).toBe(false);
+		expect(origins.find((o) => o.winner)?.scope).toBe("environment");
 	});
 });

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -31,13 +31,21 @@
  * and are held to the engine's behaviour by the shared conformance fixture, so
  * the preview cannot quietly drift from what actually gets sent.
  * `getVariableOrigins` keeps the definitions that lost so the UI can explain
- * the winner; execution has no use for losers, so the engine has no analogue.
+ * the winner - and, since issue #1064, the bound row above them, so the answer
+ * it gives is the one the send will use rather than the one the scopes settled
+ * on. Execution has no use for losers, so the engine has no analogue.
  */
 
 import { useMemo, useCallback } from "react";
 import { useGlobalsQuery, useCollectionsQuery, useEnvironmentsQuery } from "@/queries";
 import { useSessionStore } from "@/stores";
-import type { VariableValue, ResolvedVariable, VariableOrigin } from "@/types";
+import type {
+	VariableValue,
+	ResolvedVariable,
+	VariableOrigin,
+	ScopeVariableOrigin,
+	VariableScope,
+} from "@/types";
 import { castByType } from "@/lib/variable-cast";
 // The chain this hook used to build itself, guard and all - see tree-utils for
 // why every `parentId` walk in the renderer now comes from one place.
@@ -126,12 +134,12 @@ export function useVariableResolver(
 	 * definitions are in the list, "last" and "wins" are different things.
 	 */
 	const originsByName = useMemo(() => {
-		const result: Record<string, VariableOrigin[]> = {};
+		const result: Record<string, ScopeVariableOrigin[]> = {};
 
 		const push = (
 			name: string,
 			v: VariableValue,
-			scope: VariableOrigin["scope"],
+			scope: VariableScope,
 			source?: { id: string; name: string }
 		) => {
 			(result[name] ??= []).push({
@@ -229,11 +237,6 @@ export function useVariableResolver(
 		[variableMap]
 	);
 
-	const getVariableOrigins = useCallback(
-		(name: string): VariableOrigin[] => originsByName[name] ?? [],
-		[originsByName]
-	);
-
 	/**
 	 * The caller-wide bound row's cells as the text each substitutes, rendered
 	 * once rather than per token. Undefined - not an empty map - when no row is
@@ -244,6 +247,41 @@ export function useVariableResolver(
 	const rowCells = useMemo<DataRowCells | undefined>(
 		() => (boundRow ? cellsOf(boundRow) : undefined),
 		[boundRow]
+	);
+
+	/**
+	 * The scope ladder, plus the bound row on top of it (issue #1064).
+	 *
+	 * The row is layered on *here* rather than inside `originsByName`, and the
+	 * split is the point: `originsByName` is what `variableMap` resolves from, so
+	 * a row folded into it would make `getAllVariables` report a row's cell as
+	 * the variable's value and hand `ResolvedVariable` a scope nobody can write.
+	 * This function is display-only - nothing about execution reads it - which is
+	 * exactly the layer where "what will actually be sent" belongs.
+	 *
+	 * The row takes `winner` away from every definition beneath it, rather than
+	 * being appended beside a scope that still claims to have won. Two origins
+	 * flagged as the winner is a list that cannot be rendered honestly, and
+	 * `winner` means "what the send will use" to every reader of it.
+	 *
+	 * A `{{data.column}}` name never lands here: the cells are keyed by bare
+	 * column name, so the reserved spelling finds nothing and keeps the terminal
+	 * explanation it already had - which is correct for it, and wrong for a bare
+	 * name, since defining a variable of *that* name does something.
+	 */
+	const getVariableOrigins = useCallback(
+		(name: string): VariableOrigin[] => {
+			const defined: VariableOrigin[] = originsByName[name] ?? [];
+			// `get`, not a truthiness check: a column whose cell is empty still
+			// answers the name, and answers it with "".
+			const cell = rowCells?.get(name);
+			if (cell === undefined) return defined;
+			return [
+				...defined.map((o) => ({ ...o, winner: false })),
+				{ scope: "row" as const, value: cell, enabled: true, winner: true },
+			];
+		},
+		[originsByName, rowCells]
 	);
 
 	/**

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -735,6 +735,19 @@ export interface ResolvedVariable {
 }
 
 /**
+ * Where an answer for a name came from: one of the three writable scopes, or the
+ * bound data row - the tier above all of them (D18, issue #1007).
+ *
+ * Deliberately a second union rather than a fourth member of `VariableScope`.
+ * Every *write* path is typed on that union - `updateVariable`, the
+ * `writableScopes` a caller advertises, the popover's create picker - and a row
+ * is not somewhere a variable can be written. Widening `VariableScope` would
+ * have offered "Bound row" as a create target that silently no-ops, which is the
+ * defect the writable-scope list exists to prevent.
+ */
+export type VariableOriginScope = VariableScope | "row";
+
+/**
  * One definition of a variable name, at one scope.
  *
  * The resolver flattens every scope into a single winner, which is all execution
@@ -745,9 +758,15 @@ export interface ResolvedVariable {
  * one you expected.
  *
  * Disabled definitions are therefore kept here even though they never resolve.
+ *
+ * A `"row"` origin is not a definition at all - nobody wrote it and nothing can
+ * edit it - but it is an answer for the name, and the one the send will use, so
+ * it belongs in the list the UI reads to explain the winner. It is layered on by
+ * `getVariableOrigins`, never by the scope ladder itself; see
+ * `ScopeVariableOrigin`.
  */
 export interface VariableOrigin {
-	scope: VariableScope;
+	scope: VariableOriginScope;
 	/** Absent for `global`, as on ResolvedVariable. */
 	sourceId?: string;
 	sourceName?: string;
@@ -763,9 +782,22 @@ export interface VariableOrigin {
 	 *
 	 * Explicit rather than "the last one", because precedence order and win order
 	 * are not the same list once disabled definitions are included.
+	 *
+	 * "Winner" means what the send will use, not what the scope ladder settled
+	 * on, so a bound row's cell takes it away from every definition beneath.
 	 */
 	winner: boolean;
 }
+
+/**
+ * An origin that really is a stored definition, in a scope someone could edit.
+ *
+ * The scope ladder is built from these and `ResolvedVariable` is derived from
+ * them, which is what keeps `ResolvedVariable.scope` a `VariableScope`: a row
+ * has no scope to report, and a resolved variable that claimed one would be
+ * offering an uneditable tier to every write path that reads it.
+ */
+export type ScopeVariableOrigin = VariableOrigin & { scope: VariableScope };
 
 /**
  * Extended variable info for autocomplete and quick view.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1415,6 +1415,21 @@ never send. The same rule keeps the create offer out of `VariablePopover` for
 these names - a variable of that name can never resolve, so offering to make one
 is a dead end that leaves the token exactly as it was.
 
+**The popover names a bound row as the origin, above what it beat** (issue
+#1064). The token paint above is unchanged - a shadowed bare name still paints
+in the accent - but opening `VariablePopover` on one while a row is picked and
+its column answers the name now lists the row first, unstruck and labelled the
+origin, with the scope definitions it outranks struck beneath it.
+
+Hovering moved with it, and had to: hovering reads and clicking edits are two
+readings of one token, so a tooltip still printing the environment's value
+while the popover named the row would make a single token say two things about
+one send. `EditableVariable` takes the row's answer off the origins it already
+fetches - not a prop of its own, so there is one answer to "what wins" and not
+two - and shows it with a `Bound row` hint. A cell is never a secret, but a
+secret it shadows is still never printed. What did **not** move is the paint:
+the token's colour is decided as it always was.
+
 It sits beside `KeyValueEditor` rather than inside the request builder because
 every row of that table renders one: a shared table reaching into a feature
 module for its cell input is the same inversion one level down (issue #567).

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1663,8 +1663,10 @@ or collection the winning value came from (absent for `global`).
 
 `getVariableOrigins` returns **every** definition of a name, lowest precedence
 first, including disabled ones that never resolve. Display-only; the variable
-popover renders it as "also defined". See `docs/app/variable-resolution.md` for
-why the losers are kept and why the MCP copy is not given the same accessor.
+popover renders it as "also defined". Since issue #1064 it also carries the
+bound row on top when one answers the name, taking `winner` from whichever
+scope it beat. See `docs/app/variable-resolution.md` for why the losers are
+kept and why the MCP copy is not given the same accessor.
 
 ### `RequestBuilderContext` - variable members
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -232,14 +232,27 @@ A collection run, a load run and a scenario step still bind their row during
 the run itself, so nothing about them changes: this is the one caller, a
 single Send, that now happens to hold the row before the request goes out.
 
-**What is still not painted.** The token *state* `VariableInput` paints is
-unchanged: a bare name still paints as a bound column only where no scope
-defines it, and a shadowed bare name still paints - and explains itself in the
-popover - as the variable. So a picked row can now put its cell beside a token
-that still reads, and is still explained, as the environment's, with nothing
-on screen saying the column will win once a row binds. Reconciling the paint,
-and giving the popover a "bound data row" origin to explain it, is issue
-#1064's work, not done here.
+**The paint stays the accent; the popover now says why (issue #1064).** The
+token *state* `VariableInput` paints is unchanged: a bare name still paints as
+a bound column only where no scope defines it, and a shadowed bare name still
+paints as the variable, in the same accent it always has. That was the open
+question this section used to leave for later, and it has been decided rather
+than merely left open: the accent stays, and the explanation is what moves.
+Opening `VariablePopover` on a shadowed name while a row is picked now names
+the row as the origin - unstruck, above the definitions it beat, which render
+struck beneath it exactly as any other shadowed definition does - so the
+popover states plainly that the row's cell, not the environment's value, is
+what the send will use. The hover tooltip reads the same way, from the same
+origins list, because hovering and clicking are two readings of one token and a
+token that answers them differently is worse than one that answers both
+wrongly.
+
+A name that **no** scope defines but the row does is the same claim in the
+other direction, and it stops being reported as undefined: the destructive red
+states a token that reaches the server with its braces still on, and this one
+does not. The chip reads `row`, the popover names the column, and a create
+offer - still worth making, since the variable answers every row-less send -
+says what the row already answers rather than implying the token is unanswered.
 
 **What the tab strip shows, and how the row reaches it (issue #1074).** A tab's
 title resolves through one list-wide `useVariableResolver()` in
@@ -400,6 +413,16 @@ answering are exactly the ones a flat map destroys:
 The variable popover renders this as its "also defined" list. `VariableOrigin`
 carries `enabled` and an explicit `winner` flag - once disabled definitions are
 in the list, "last" and "wins" are different things.
+
+**Since issue #1064, the bound row is layered on top of this list, not into
+the scope ladder it is built from.** While a row is picked and its column
+answers the name, `getVariableOrigins` appends a `{ scope: "row" }` origin
+after the scope-derived ones and takes `winner` away from whichever of them
+had it - the row is what the send will use, so only it may claim the flag. The
+layering happens in this accessor alone: `originsByName`, the ladder
+`variableMap` and therefore `getVariable` / `getAllVariables` resolve from, is
+untouched, so a picked row still cannot make `ResolvedVariable.scope` report
+anything but a scope someone could actually write to.
 
 `ResolvedVariable.sourceId` / `sourceName` name the specific environment or
 collection the winning value came from (absent for `global`), so the popover can
@@ -830,3 +853,8 @@ the two lists never appear together.
 | `"global"`    | Came from globals              |
 | `"collection"`| Came from any collection layer |
 | `"environment"`| Came from the active environment |
+
+`VariableOrigin.scope` is wider - a `VariableOriginScope` (`VariableScope |
+"row"`) - because the origins list can also carry a bound row. It has no row in
+this table: nobody wrote a row's cell and nothing can edit it, so it is never a
+value `ResolvedVariable.scope` reports or a target `updateVariable` writes to.


### PR DESCRIPTION
## Description

#1007 put a bound row's bare column names above every scope, and #1062 made the *preview* say so. The popover - the one surface whose entire job is "why is this the value" - was still explaining the environment's definition while the send was about to use the row's cell.

**Root cause, and the plan.** The row signal from #1062 reached exactly `resolveString` / `resolveObject` and stopped there. `getVariableOrigins`, `getVariable` and `getAllVariables` all derive from `originsByName`, which is built from globals + collection chain + environment and nothing else, so no surface that explains a token could know a row was bound. The fix layers the row tier on inside `getVariableOrigins` - the display-only accessor - rather than into the scope ladder underneath it. **The alternative I rejected** was folding the row into `originsByName` itself, which is where it first looks like it belongs: it would have made `variableMap` resolve from it, so `getAllVariables` would report a row's cell as the variable's value and `ResolvedVariable.scope` would carry a tier nothing can write to, changing the token painting and every write path as a side effect of a display fix. The second rejected option was a separate `boundRow` prop threaded to the popover beside `origins`: that leaves the `winner` flag inside `origins` still pointing at the scope, so precedence would be decided in one place and re-derived in another - the shape `CLAUDE.md` names as this codebase's repeated defect.

Because the row wins, it takes `winner` from the definitions beneath it, and the popover's existing shadowed list then strikes them with no new rule. The row renders unstruck above them through the same `OriginRow` renderer.

**Deliberate deviations from the issue spec**, both argued rather than assumed:

1. **`VariableOrigin.scope` widens to a new `VariableOriginScope` union, not to a fourth `VariableScope`.** The issue says "give `VariableOrigin` a row-shaped case"; the narrow reading would be a fourth member of the existing union. Every *write* path is typed on `VariableScope` - `updateVariable`, the `writableScopes` a caller advertises, the popover's create picker - so a fourth member would have offered "Bound row" as a create target that silently no-ops, which is the exact defect the writable-scope list exists to prevent. `ScopeVariableOrigin` keeps the ladder honest so `ResolvedVariable.scope` stays writable.

2. **The scope covers three surfaces, not one.** The issue names the popover. Once the popover told the truth, the hover tooltip on the same token was still printing the environment's value - a disagreement this change would have *introduced*, since before it both were equally wrong. Hovering reads and clicking edits are two readings of one token, so `EditableVariable` now takes the row's answer off the origins it already fetches. The issue's own Tests section names `EditableVariable.test.tsx`, which is what pointed here.

3. **A name no scope defines but the row answers stops being reported as undefined** - in all three places that said so: the header chip, the body text, and the create offer. This state is reachable: the data contract is a collection's *declared* schema (`dataSchema.columns`), so a picked file can carry a column it does not list, and `VariableInput` only diverts *declared* columns to a `RuntimeToken`. Destructive red states a token that reaches the server with its braces still on, and this one does not. Creating is still offered there, because the variable answers every row-less send - it just no longer implies the token is unanswered.

**What did not change: the paint.** D18 left the shadowing paint state open and recommended "the variable's existing accent treatment plus a note, rather than a fourth colour". Taken as recommended - the token's colour is untouched, and the explanation is what moves. The row's dot in the origins list is `bg-primary`, the accent, for the same reason: a row is not a place a variable lives, it is the answer that is live right now.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Run in the main loop on this branch, all green:

- `cd app && pnpm test` - **545 files / 5924 tests passed** (5917 before this branch; 12 new tests across three files). The same suite was run on the base commit first and was green, so there are no pre-existing failures to report.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `cd app && pnpm lint` - clean, zero warnings.
- `cd app && pnpm format:check` - clean.
- `mkdocs build --strict` - clean.

No engine build or ctest run: the diff is `app/` and `docs/` only, and no engine test could change colour.

**Three mutation checks, each confirmed red and then restored** - not reasoned about, actually run:

| Reverted | Goes red |
|---|---|
| the `winner: false` re-flag in `getVariableOrigins` | `useVariableResolver.origins.test.tsx` - two origins claim the win at once |
| the row block in `ShadowedBy` (row falls through as an ordinary origin) | `variable-popover.test.tsx` - the row's cell vanishes or arrives struck |
| the `boundRowValue` lookup in `EditableVariable` | `EditableVariable.test.tsx` - the tooltip falls back to the beaten value |

Both directions are pinned throughout: every new behaviour has a companion case asserting the no-row path reads exactly as it does today, including "still chips a genuinely undefined name as undefined".

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Review findings, and what happened to each

Two read-only reviewers went over the diff. Three findings survived verification and are fixed above (the create-form gap, the red "undefined" header chip - which contradicted a claim my own code comment was making - and the tooltip disagreement). Two were checked and **discarded with reason**:

- *"`ShadowedBy` never renders when every scope definition is disabled, so the shadowed definition is dropped."* True, but not this diff's doing and not this diff's to fix: `ShadowedBy` has always been gated inside the resolved branch, and a name whose only definition is disabled has always shown no origin list, with or without a row. Filed as #1083 rather than widened into here.
- *"`ScopeVariableOrigin` may be decorative, and `sourceName ?? label` may be dead."* Both checked and neither holds - `ScopeVariableOrigin` types `originsByName` and is what keeps `ResolvedVariable.scope` narrow, and both sides of the `??` fire depending on the origin.

## Related Issues
Closes #1064