### PR TITLE
fix(app): the variable popover lists a definition that is switched off - #1083

### DIFF
--- a/app/src/components/ui/variable-popover.test.tsx
+++ b/app/src/components/ui/variable-popover.test.tsx
@@ -357,6 +357,112 @@ describe("why this value won", () => {
 });
 
 /**
+ * Issue #1083. The list above exists for exactly one question - "why is this not
+ * the value I set?" - and could not reach the shape that asks it loudest.
+ *
+ * A name whose *only* definition is switched off has no winner, so it does not
+ * resolve, so it arrived in the create branch: offered a form to define a name
+ * that is already defined and one toggle from answering, with nothing on screen
+ * saying so. Acting on that offer writes a second definition which shadows
+ * nothing and leaves the first one off.
+ */
+describe("a name whose only definition is switched off", () => {
+	const onlyDisabled: VariableOrigin[] = [
+		origin({ scope: "environment", sourceName: "Staging", value: "env-token", enabled: false }),
+	];
+
+	it("lists that definition, with its off badge, where nothing is writable", () => {
+		// Mutation check: put `ShadowedBy` back inside the resolved branch, or
+		// restore the `origins.length < 2` gate, and all three of these vanish.
+		renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: [],
+			origins: onlyDisabled,
+		});
+		const panel = open();
+		expect(within(panel).getByText("also defined")).toBeInTheDocument();
+		expect(within(panel).getByText("env-token")).toBeInTheDocument();
+		expect(within(panel).getByText("off")).toBeInTheDocument();
+	});
+
+	it("says the definitions are off rather than telling you to go and define it", () => {
+		renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: [],
+			origins: onlyDisabled,
+		});
+		const panel = open();
+		expect(within(panel).getByText(/every definition is switched off/)).toBeInTheDocument();
+		expect(within(panel).queryByText(/Variable not defined/)).not.toBeInTheDocument();
+	});
+
+	it("still offers to create, and says what the offer is doing", () => {
+		// The offer stays: this popover writes values, not enabled flags, so it
+		// cannot present the switch that would be the better answer. What it can
+		// stop doing is offering in silence.
+		renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global"],
+			origins: onlyDisabled,
+		});
+		const panel = open();
+		expect(within(panel).getByRole("button", { name: "Create" })).toBeInTheDocument();
+		expect(within(panel).getByText(/already defined below, switched off/)).toBeInTheDocument();
+		expect(within(panel).getByText("off")).toBeInTheDocument();
+	});
+
+	it("counts them when there is more than one", () => {
+		renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global"],
+			origins: [
+				origin({ scope: "global", value: "global-token", enabled: false }),
+				...onlyDisabled,
+			],
+		});
+		const panel = open();
+		expect(within(panel).getByText(/already defined 2 times below/)).toBeInTheDocument();
+		expect(within(panel).getByText("global-token")).toBeInTheDocument();
+		expect(within(panel).getByText("env-token")).toBeInTheDocument();
+	});
+
+	it("does not promise a row-less send a definition that is switched off", () => {
+		/*
+		 * The list reaching the unresolved states brought the bound-row note with
+		 * it, into a state it had never been drawn in: "the definition above still
+		 * resolves on a send that carries no row" is the one thing an off
+		 * definition does not do. Dropping the pick here leaves the token red, and
+		 * that is what the reader needs to be told.
+		 */
+		renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: [],
+			origins: [...onlyDisabled, origin({ scope: "row", value: "row-token", winner: true })],
+		});
+		const panel = open();
+		expect(
+			within(panel).getByText(/a send that carries no row resolves nothing/)
+		).toBeInTheDocument();
+		expect(within(panel).queryByText(/still resolves on a send/)).not.toBeInTheDocument();
+	});
+
+	it("shows no list for a name nothing defines anywhere", () => {
+		// The companion to the first case: the gate moved from counting entries
+		// to asking whether any of them is not the winner, and a name with no
+		// entries at all must still say nothing rather than draw an empty list.
+		renderPopover({ varInfo: null, resolved: false, writableScopes: ["global"], origins: [] });
+		const panel = open();
+		expect(within(panel).queryByText("also defined")).not.toBeInTheDocument();
+		expect(within(panel).getByRole("button", { name: "Create" })).toBeInTheDocument();
+	});
+});
+
+/**
  * Issue #1064. #1007 put a bound row's columns above every scope and #1062 made
  * the *preview* say so, but the popover - the one surface whose entire job is
  * "why is this the value" - still explained the environment's definition while

--- a/app/src/components/ui/variable-popover.tsx
+++ b/app/src/components/ui/variable-popover.tsx
@@ -21,6 +21,13 @@
  * Without that it explained, in full detail, a value the send was not going to
  * use - the one question this popover exists to answer, answered wrongly.
  *
+ * **Not resolving is not the same as not being defined** (issue #1083). A name
+ * whose every definition is switched off has no winner, so it arrives here
+ * unresolved and used to be offered a form to create what it already has. The
+ * list of definitions is drawn under every state rather than under the resolved
+ * one alone, because "the value you set is being skipped" is the question it was
+ * added to answer and that is the state which asks it.
+ *
  * **It used to show the value twice.** A "Current Value" block sat above an
  * "Edit Value" input holding the same string, each with its own label and its
  * own secret-reveal button - about 90px and two labels spent restating what the
@@ -98,6 +105,18 @@ const NAME_CHIP =
 const BOUND_ROW_NOTE =
 	"While a row is picked, its column answers this name. The definition above still resolves on a send that carries no row.";
 
+/**
+ * The same note when every definition under the row is switched off.
+ *
+ * `BOUND_ROW_NOTE` cannot be reused there: "still resolves on a send that
+ * carries no row" is precisely what an off definition does not do, and the row
+ * would be reassuring the reader about a fallback they do not have. Drop the
+ * row and the token goes red - which is the thing worth saying, and only became
+ * sayable when the list stopped being drawn for won names alone (issue #1083).
+ */
+const BOUND_ROW_NOTE_ALL_OFF =
+	"While a row is picked, its column answers this name. Every definition below is switched off, so a send that carries no row resolves nothing.";
+
 /** The eye that swaps a hidden secret field for an editable one. */
 function RevealButton({ revealed, onToggle }: { revealed: boolean; onToggle: () => void }) {
 	return (
@@ -129,8 +148,9 @@ export interface VariablePopoverProps {
 	triggerClassName?: string;
 	/**
 	 * Every definition of this name, lowest precedence first, disabled ones
-	 * included. Rendered only when there is more than one, which is when the
-	 * question "why is this the value?" has a non-obvious answer.
+	 * included. Rendered whenever it holds a definition the popover is not
+	 * already showing - which is when the question "why is this the value?" has
+	 * a non-obvious answer, whether or not the name resolves (issue #1083).
 	 */
 	origins?: VariableOrigin[];
 	/**
@@ -205,6 +225,20 @@ export function VariablePopover({
 	 * come to disagree.
 	 */
 	const boundRowOrigin = origins?.find((o) => o.scope === "row");
+
+	/**
+	 * The definitions this name has that are switched off (issue #1083).
+	 *
+	 * A name resolves exactly when some definition is enabled, so a name that
+	 * does not resolve and still has definitions is one whose every definition
+	 * is off - the shape the origin list was built for and the one it could not
+	 * reach, because the list only rendered where the name had already won.
+	 *
+	 * Filtered on `enabled` rather than inferred from `resolved`: the two arrive
+	 * as separate props, and a list that describes itself cannot be wrong about
+	 * what it holds.
+	 */
+	const switchedOffDefinitions = (origins ?? []).filter((o) => o.scope !== "row" && !o.enabled);
 
 	// Creating is only offered where a write would land somewhere.
 	const creatableScopes = useMemo(
@@ -525,8 +559,6 @@ export function VariablePopover({
 									</Button>
 								</div>
 							)}
-
-							<ShadowedBy origins={origins} />
 						</>
 					) : canCreate ? (
 						<>
@@ -596,6 +628,25 @@ export function VariablePopover({
 									. A variable created here answers a send that carries no row.
 								</p>
 							)}
+							{/*
+							 * The create offer stays, and says what it is doing (issue
+							 * #1083). Replacing it with a switch would be the closer
+							 * answer, and this popover cannot give it: it writes values
+							 * through `onValueChange`, which carries no enabled flag, so
+							 * the toggle lives in the variables editor. Offering to
+							 * create in silence is the part that misleads - the reader
+							 * is one toggle away from a value and is being handed a
+							 * form that adds a second definition instead.
+							 */}
+							{switchedOffDefinitions.length > 0 && (
+								<p className="text-[10px] text-muted-foreground">
+									{switchedOffDefinitions.length === 1
+										? "This name is already defined below, switched off."
+										: `This name is already defined ${switchedOffDefinitions.length} times below, every one switched off.`}{" "}
+									Switching one back on answers the token; creating here adds
+									another definition and leaves it off.
+								</p>
+							)}
 						</>
 					) : isDataName ? (
 						<div className="text-sm text-muted-foreground">
@@ -614,12 +665,36 @@ export function VariablePopover({
 							<span className="font-mono">{name}</span> column, not by a variable.
 							Defining one would answer a send that carries no row.
 						</div>
+					) : switchedOffDefinitions.length > 0 ? (
+						/*
+						 * Defined, and still red: the token does not resolve, so the red
+						 * is honest. What was not honest is the sentence - "not defined"
+						 * printed directly above a list showing where it is defined, with
+						 * an `off` badge on it, tells the reader to go and do the one
+						 * thing they have already done (issue #1083).
+						 */
+						<div className="text-sm text-destructive-text">
+							Defined, but every definition is switched off, so this token does not
+							resolve.
+						</div>
 					) : (
 						<div className="text-sm text-destructive-text">
 							Variable not defined. Define it in Globals, an Environment, or
 							Collection variables.
 						</div>
 					)}
+					{/*
+					 * Outside the branch chain, because "where could this have come
+					 * from" is the same question in every state above, and the state
+					 * most likely to raise it - a name whose only definition is switched
+					 * off - is one of the ones that could not ask it (issue #1083).
+					 *
+					 * `data.*` is the exception rather than an oversight: the reserved
+					 * namespace is disjoint from the scopes, so a definition of that
+					 * name never answers for the column and listing it would say it
+					 * might.
+					 */}
+					{!isDataName && <ShadowedBy origins={origins} />}
 				</div>
 			</PopoverContent>
 		</Popover>
@@ -665,11 +740,19 @@ function OriginRow({ origin, beaten }: { origin: VariableOrigin; beaten: boolean
 /**
  * Where the value comes from, and what it beat.
  *
- * Rendered only when there is more than one answer, so the ordinary case stays
- * short. Three row states, not two - a definition can lose by precedence *or* by
- * being switched off, and the second is the more common surprise: the value you
- * set is being skipped rather than missing. A list that only showed shadowing
- * would answer the easy question and stay silent on the hard one.
+ * Rendered when the list holds a definition the popover is not already showing,
+ * so the ordinary case stays short: a name with one definition that wins has
+ * nothing to add - the field above it *is* that definition - and lists nothing.
+ * Three row states, not two - a definition can lose by precedence *or* by being
+ * switched off, and the second is the more common surprise: the value you set is
+ * being skipped rather than missing. A list that only showed shadowing would
+ * answer the easy question and stay silent on the hard one.
+ *
+ * The gate used to be `origins.length < 2`, which reached the same answer for a
+ * winner and the wrong one for a name whose *only* definition is switched off:
+ * one entry, nothing above it showing that entry, and the list suppressed
+ * anyway (issue #1083). Counting entries was standing in for the question the
+ * next line actually asks - is any of them not the winner.
  *
  * A bound row's cell is listed above them all, unstruck (issue #1064). Without
  * it the popover explained a value the send would not use: the editable field at
@@ -677,7 +760,7 @@ function OriginRow({ origin, beaten }: { origin: VariableOrigin; beaten: boolean
  * change, while the row is what answers the name until the pick is dropped.
  */
 function ShadowedBy({ origins }: { origins?: VariableOrigin[] }) {
-	if (!origins || origins.length < 2) return null;
+	if (!origins || origins.length === 0) return null;
 
 	// Highest precedence first: reading down the list is reading the order the
 	// resolver rejected them in.
@@ -708,7 +791,11 @@ function ShadowedBy({ origins }: { origins?: VariableOrigin[] }) {
 			{others.map((o, i) => (
 				<OriginRow key={`${o.scope}-${o.sourceId ?? "global"}-${i}`} origin={o} beaten />
 			))}
-			{row && <p className="text-[10px] text-muted-foreground">{BOUND_ROW_NOTE}</p>}
+			{row && (
+				<p className="text-[10px] text-muted-foreground">
+					{others.some((o) => o.enabled) ? BOUND_ROW_NOTE : BOUND_ROW_NOTE_ALL_OFF}
+				</p>
+			)}
 		</div>
 	);
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1455,6 +1455,26 @@ two - and shows it with a `Bound row` hint. A cell is never a secret, but a
 secret it shadows is still never printed. What did **not** move is the paint:
 the token's colour is decided as it always was.
 
+**The list of definitions is drawn under every state, not only the resolved
+one** (issue #1083). A name whose every definition is switched off has no
+winner, so it does not resolve and reached the popover's undefined states - and
+the list was rendered inside the resolved branch alone, so the case it was added
+for could not display it. The reader was offered a form to create a name that
+already existed and was one toggle from answering. The list now sits outside the
+branch chain, gated on holding a definition the popover is not already showing
+rather than on a count of entries, and the two undefined states say what it
+means: the create offer notes that the name is defined below and switched off,
+and the red sentence reads "defined, but every definition is switched off"
+instead of telling the reader to go and define it. The red itself stays - the
+token genuinely does not resolve. `data.*` is the one state with no list, for
+the same disjointness reason it has no create offer.
+
+Reaching the list into those states also reached the bound-row note into them,
+and it could not be carried over as written: "the definition above still
+resolves on a send that carries no row" is exactly what a switched-off
+definition does not do, so a row shadowing only off definitions gets the other
+sentence - dropping the pick there resolves nothing.
+
 It sits beside `KeyValueEditor` rather than inside the request builder because
 every row of that table renders one: a shared table reaching into a feature
 module for its cell input is the same inversion one level down (issue #567).


### PR DESCRIPTION
## Description

**Root cause.** `ShadowedBy` had exactly one call site, inside the popover's `resolved && varInfo` branch, and independently guarded itself on `origins.length < 2`. A name whose only definition is switched off has no winner - `variableMap` skips a list with no winner - so it does not resolve, `varInfo` is null, and it took the `canCreate` branch. The reader was offered a form to create a name that already existed and was one toggle from answering, with nothing on screen saying so; acting on the offer writes a second definition that shadows nothing and leaves the first one off. So the case `ShadowedBy`'s own doc comment says it exists for ("the value you set is being skipped rather than missing") was the one case it could not display. Neither gate was a recorded decision - `getVariableOrigins`' contract in `docs/app/variable-resolution.md` argues the opposite, naming a disabled definition as "the more common surprise" the accessor exists to surface.

**Approach.** Reach, not new rendering. The single `ShadowedBy` call moves outside the branch chain, so "where could this have come from" is answerable in every state except `data.*` - disjoint from the scopes, so listing a definition there would say it might answer for the column. Its gate stops counting entries and asks the question the next line already asked: is any of them not the winner. That leaves a resolved single definition listing nothing, exactly as before (its one origin *is* the field above), and lets a single disabled one list. `EditableVariable` already passes `origins` for every token, resolved or not, so nothing new is plumbed and no resolver changes.

**The one decision the issue asked to be made explicit:** the create offer stays. Replacing it with something that names the switch would be the closer answer, and this popover cannot give it - it writes values through `onValueChange`, which carries no enabled flag, so the toggle lives in the variables editor. What it stops doing is offering in silence: it now says the name is defined below and switched off. Stated in the code at the branch, not only here.

**Alternative rejected:** passing the disabled definitions in as a new prop from `EditableVariable`. The origins already arrive; a second channel carrying the same fact is how the winner here and the winner there come to disagree - the argument this file already makes for `boundRowOrigin` in #1064.

**Deliberate additions beyond the literal acceptance criteria**, both entailed by rendering the list in those states rather than tacked on:
- The sentence shown when nothing is writable moves from "Variable not defined. Define it in Globals..." to "Defined, but every definition is switched off". Leaving it would print "not defined" directly above a list showing where it is defined, with an `off` badge on it. The red itself stays - the token genuinely does not resolve.
- The bound-row note reached a state it had never been drawn in. "The definition above still resolves on a send that carries no row" is precisely what an off definition does not do, so a row shadowing only off definitions gets a sentence saying that dropping the pick resolves nothing. Found by review, not by the tests I wrote first.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green:

- **545 test files, 5973 tests passed** (was 5967; +6 in `variable-popover.test.tsx`).
- type-check clean across all three projects (renderer, electron, electron-tests); ESLint clean at `--max-warnings 0`; prettier clean.

Six new cases in `variable-popover.test.tsx`, mutation-checked in all three directions:
- restoring `origins.length < 2` reddens 2,
- putting the `ShadowedBy` call back inside the resolved branch reddens 3,
- pinning the bound-row note to its old text reddens 1.

Both directions covered as the issue asked: a name nothing defines anywhere still shows no list, so the gate was not simply removed. Engine untouched, so no engine build or ctest run - per CLAUDE.md, this is scaled to what the change could break. `mkdocs build --strict` was not run: mkdocs is not installed in this container, and the docs edit is prose inside an existing section with no new page, link or anchor.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs moved in the same commit: `docs/app/COMPONENTS.md`'s `VariablePopover` paragraph, since the branch structure changed. `docs/app/variable-resolution.md` deliberately did **not** move - the resolver, `getVariableOrigins`' contract and the precedence order are untouched, and the issue scoped that file to "only if the contract moves, which it should not."

Two review findings discarded with reason: that `switchedOffDefinitions` and `ShadowedBy`'s internal `others` compute overlapping subsets (they serve different purposes - one drives the sentence, the other the rows and their order, and consolidating would couple them), and that the new create-offer note lacks the row caveat its sibling carries (the sibling note renders directly above it in that state and already says the row answers now).

## Related Issues
Closes #1083