### PR TITLE
docs(app): isMidRunRefreshable mirrors the config-and-token cases, not all of them - #1076, #1093

### DIFF
--- a/app/src/modules/request-builder/components/OAuth2LoadTestGuard.tsx
+++ b/app/src/modules/request-builder/components/OAuth2LoadTestGuard.tsx
@@ -19,8 +19,8 @@
  *   - stale-but-coverable  → offer Refresh (a fresh token gives a full window)
  *   - longer-than-lifetime → block, with an explicit "start anyway" override
  *
- * Which case applies is `isMidRunRefreshable`, which mirrors the engine's own
- * rule; see oauth2-load-test-coverage.ts.
+ * Which case applies is `isMidRunRefreshable`, whose docstring holds the exact
+ * rule and how far it mirrors the engine's; see oauth2-load-test-coverage.ts.
  *
  * Reports whether the Start button should be gated via onGateChange.
  */

--- a/app/src/modules/request-builder/components/oauth2-load-test-coverage.ts
+++ b/app/src/modules/request-builder/components/oauth2-load-test-coverage.ts
@@ -47,9 +47,20 @@ export type CoverageState =
 /**
  * Whether the engine will keep this credential current for the whole run.
  *
- * Mirrors `plan_auth_refresh` (engine/src/http/auth_resolver.cpp) case for
- * case - the guard must not promise a refresh the engine will not perform, and
- * must not block a run the engine can carry. Change one, change both.
+ * Mirrors the config-and-token cases of `plan_auth_refresh`
+ * (engine/src/http/auth_resolver.cpp) - the guard must not promise a refresh
+ * the engine will not perform, and must not block a run the engine can carry.
+ * Change one, change both.
+ *
+ * It cannot mirror that function's last case, which plans a refresh only for a
+ * run whose `Authorization` header is the token's own value, and declines when
+ * a user-supplied header beat the token to it - swapping the token under that
+ * header would change nothing on the wire. This decision is made before a
+ * request is composed and is handed a config and a token, never headers, so
+ * that case is outside its inputs. The gap leans the safe way: it takes a
+ * user-supplied `Authorization` header to reach, and such a run is
+ * authenticated by that header rather than by this token, which makes the
+ * coverage question moot. Covering it would be a signature change.
  */
 export function isMidRunRefreshable(
 	config: Pick<OAuth2Config, "grantType" | "tokenPlacement" | "autoRefreshToken">,

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1196,8 +1196,10 @@ means the run could never refresh (no OAuth 2.0 auth, a non-expiring or
 query-placed token, `autoRefreshToken: false`, or an older sidecar); present
 with an empty `refreshes` means it was watched and never needed to. The same
 eligibility rule decides whether `OAuth2LoadTestGuard` still blocks a run
-longer than its token - `isMidRunRefreshable` mirrors the engine's
-`plan_auth_refresh`, and the two must change together.
+longer than its token - `isMidRunRefreshable` mirrors the config-and-token
+cases of the engine's `plan_auth_refresh`, not its last one, a user-supplied
+`Authorization` header that beats the token and that the guard is never handed
+the headers to see. The two must change together.
 
 ### Load Test Execution
 


### PR DESCRIPTION
## Description

Every prose statement of the `isMidRunRefreshable` / `plan_auth_refresh` mirror now names the one case the guard cannot host. There were four; two were corrected in #986's PR, and this takes the other two.

**Root cause and approach.** `plan_auth_refresh` ends on a case the guard has no way to evaluate: it hands back a plan only when the request is already sending the token's own `Authorization` header, and declines when a user-supplied header beat the token to it, because swapping the token under that header would change nothing on the wire (`auth_resolver.cpp:161-168`). `isMidRunRefreshable` takes a config and a token and nothing else, at its sole call site (`OAuth2LoadTestGuard.tsx:72`) or anywhere else, so it is never handed headers to inspect. The four config-and-token cases do match one for one; the fifth is invisible to it. The fix is what the claim says: name the cases it mirrors, name the carve-out as outside its inputs with the reason, and keep the "change one, change both" instruction, which is the part worth having. **The alternative I rejected** was widening `isMidRunRefreshable`'s signature to take the composed request's headers so the mirror becomes literal. That is a behaviour change dressed as a comment fix, and it buys nothing: the gap leans the safe way. It takes a user-supplied `Authorization` header to reach, and such a run is authenticated by that header rather than by the OAuth 2.0 token at all - `resolve_oauth2` never places the token on the wire in that case - so the coverage question the guard is asking is moot exactly where it diverges.

Verified against live code before writing: every anchor still reads as the issues describe at `d1ea585`.

Three sites, one per commit:

| Site | Was | Is |
|---|---|---|
| `oauth2-load-test-coverage.ts:49` (#1076) | "Mirrors `plan_auth_refresh` **case for case**" | The config-and-token cases, plus the carve-out named with its reason |
| `docs/app/api-integration.md:1199` (#1093) | "mirrors the engine's `plan_auth_refresh`, and the two must change together" | `COMPONENTS.md`'s wording, rather than a fifth spelling of the rule |
| `OAuth2LoadTestGuard.tsx:22` (#1093) | "which mirrors the engine's own rule" | Defers to the docstring that holds the exact rule instead of restating it |

The third is the shape worth noting: a file-header comment's job is to point at the decision, not to keep a fourth copy of it in sync. `rg isMidRunRefreshable` now returns the code, four qualified prose copies, and nothing else.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Comments and one published page. No behaviour change, no signature change, no test change.

## Testing

Scaled to a comment-and-docs edit, per CLAUDE.md's verification-scaling rule - no test could go from green to red here, so no suite was run beyond the touched files' own:

- `npx vitest run src/modules/request-builder/components/oauth2-load-test-coverage.test.ts` - **15 passed** (the four config-and-token cases stay covered at `:96-127`; none of them moved).
- `mkdocs build --strict -f .github/mkdocs.yml` - **clean**, for the `api-integration.md` edit, since a broken relative link there is a build failure.
- `npx prettier --check` and `npx eslint` on both touched TypeScript files - clean.

No engine build, no `ctest`, no full app suite: nothing outside these comment blocks moved. No pre-existing failures were encountered.

The docstring's factual claims were checked line by line against `plan_auth_refresh`, `resolve_oauth2` and the call site, which is where the substance of this PR actually lives. Two things that turned up, both worth recording:

1. **My first draft had the header carve-out backwards** - it read as though the engine declines when the request *does* send the token's header, when the code declines in the opposite case. Caught and fixed before the commit; the wording in the diff is the corrected one.
2. **The "header absent" branch of that carve-out is unreachable for OAuth 2.0.** `resolve_oauth2` sets `Authorization` whenever the request does not already carry one (`:100-103`), and `walk_auth_credentials` excludes oauth2 from deferral (`auth_resolver.hpp:93-97`), so by the time `plan_auth_refresh` runs the header is always present. That is why the wording names the user-supplied header as *the* reason rather than one of two - it is the whole reachable reason, not a simplification.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable; comments with no behaviour behind them, and the function's cases are already covered
- [x] I have updated documentation - the docs half moves in the same commit as the source comment it belongs to

## Related Issues

Closes #1076
Closes #1093

One thing checked and deliberately left out, since it is a different claim from the one these issues name: the engine reads its token from the DB during request build, while the guard is handed a `CoverageToken` from a query that can have gone stale while the load-test dialog sat open. The branching logic mirrors; the token's freshness does not. No statement in the repo currently claims otherwise, so there is nothing to correct - say the word if it is worth writing down and I will file it.