### PR TITLE
docs(scripting): the ten pm-api-compatibility discrepancies, re-verified - #1011

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -480,7 +480,7 @@ the transfer failed, two fields naming why:
 | `errorMessage` | That failure's message |
 
 The two error fields are **absent** on a transfer that completed, rather than
-empty or `null` - the same absent-not-zeros rule `pm.response.events` follows -
+empty or `null` - the same absent-not-empty rule `pm.response.events` follows -
 so `if (pm.response.errorCode)` is the test, and reading `errorMessage` without
 it is a guess about a sibling field.
 

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -22,10 +22,10 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Group               | API                                                                              |
 | ------------------- | -------------------------------------------------------------------------------- |
 | Core                | `pm`, `pm.test(name, fn)` - in either script, each result naming the one that made it (see below), `pm.expect(value[, message])` - the message prefixes the failure, as in chai |
-| Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
+| Response            | `pm.response.code`, `.status`, `.responseTime`, `.responseTimeWire`, `.responseTimeQueueWait`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()`, plus `.errorCode` / `.errorMessage` on a transport failure, see below |
 | Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict; `.each(fn, thisArg?)`, `.all()`, `.count()`, `.toObject(excludeDisabled?, caseSensitive?)`, `.one(name)`, `.indexOf(name)` - the read half of a Postman `PropertyList`, see [Header methods](#header-methods) |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
-| Streamed events     | `pm.response.events` (array of `{ event, id, data }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
+| Streamed events     | `pm.response.events` (array of `{ event, id?, data, dataTruncated? }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
 | Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()`, `.each(fn)`, `.all()`, `.count()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`getAll`/`set`/`unset`/`clear(url?)`, see below |
 | Response assertions | `pm.response.to.have.status(code \| reason)`, `.header(name[, value])`, `.body(expected)`, `.jsonBody(path?[, value])`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url` (Postman's `Url` object - `protocol`/`host`/`port`/`path`/`hash`/`query`, `getHost()`, `getPath()`, `getQueryString()`, `update()`), `.method`, `.headers`, `.body` |
@@ -188,7 +188,7 @@ truthful value for it, so a script tests with `typeof` rather than assuming:
 | `eventName` | `"prerequest"` in the Pre-request tab, `"test"` in the Tests tab | Never, for a script Vayu runs - both hooks set it |
 | `iteration` | The 0-based pass this response was sent in - a collection run's pass, or the iteration a load run's sampled response carried | A single Send, which is one request rather than a pass of anything |
 | `vu` | The 1-based virtual user that sent it. Spans the concurrency in a collection load run; `1` everywhere else, because one request repeated is one user's iterations | A single Send |
-| `iterationCount` | How many passes that run will make | Anywhere but a collection run |
+| `iterationCount` | How many passes that run will make - a collection run's total, and `1` for a send that bound a row, which is row 0 of 1 | An ordinary Send, and a load run |
 
 ```javascript
 if (pm.info.eventName === "prerequest") {
@@ -197,9 +197,13 @@ if (pm.info.eventName === "prerequest") {
 console.log("running " + (pm.info.requestName || "an unnamed request"));
 ```
 
-`iterationCount` is set by the **collection runner and by nothing else**: a
-duration-bounded load run has no total to report, and a field readable from one
-mode and not another is worse than one that is never readable at all.
+`iterationCount` is set by the **collection runner, and by a send that bound a
+row**: the runner reports the run's total, and a send-with-row reports `1`,
+because that send is row 0 of 1 and it has said so about `iteration` already
+(`POST /execute`, on both the buffered and the streaming path). A **load run**
+is the mode that leaves it `undefined` - a duration-bounded run has no total to
+report, and a field readable from one load run and not another is worse than
+one that is never readable there at all.
 
 `iteration` and `vu` are reported by every run, load runs included (issue #994).
 That is not a reversal of issue #300's ruling but the case it excluded: what
@@ -293,9 +297,11 @@ in either spelling - the exported `[{ key, value }]` array or a plain object.
 `basic`, `bearer` and `apikey` are composed by the engine's own auth resolver,
 the same one `POST /execute` sends through, so an api key sent as a query
 parameter is percent-encoded onto the URL exactly as it would be on the main
-request and an `Authorization` header the script set itself still wins. Every
-other type - `oauth2` included, whose token acquisition needs a database this
-path deliberately does not carry - is refused by name rather than dropped, and so
+request and an `Authorization` header the script set itself still wins.
+`noauth` (spelled `none` too) is accepted and composes nothing, so a script can
+say this one request carries no credential rather than omitting the option.
+Every other type - `oauth2` included, whose token acquisition needs a database
+this path deliberately does not carry - is refused by name rather than dropped, and so
 is a type whose parameter block is absent or misspelled, since `basic` requires
 neither of its halves and would otherwise compose an empty credential and send
 it. A request that goes out unauthenticated because the sandbox skipped an option
@@ -447,8 +453,11 @@ a typo, or a chai matcher Vayu lacks (`.finite`, `.sealed`, `.frozen`,
 
 `have.keys` asserts *exactly* those keys. `Map` / `Set` / typed arrays are
 reported unequal by `eql` rather than compared (their contents are not
-properties); `Date` compares by instant, `RegExp` by pattern; a cyclic value
-raises a `RangeError` after 64 levels rather than hanging. **A throw the
+properties); `Date` compares by instant, `RegExp` by pattern; a cycle
+raises a `RangeError` **at the depth it closes** (#959), naming the pair of
+objects the walk met twice, and a merely very deep structure raises a different
+`RangeError` after 64 levels - a backstop with its own message, not the same
+finding reported late. **A throw the
 comparison runs into is the verdict** (#1048) - a key, an array element or an
 array `length` behind a getter that throws, an overridden `toJSON` / `toString`
 on the `Date` and `RegExp` sides, and the values `include`, `oneOf`, `members`,
@@ -456,6 +465,29 @@ on the `Date` and `RegExp` sides, and the values `include`, `oneOf`, `members`,
 test as the script's own error rather than as a difference. Chai reports a
 difference for some of these, which under `.not` is a pass; a test that cannot
 read its subject has not passed.
+
+### Response timings, and the two error fields
+
+Postman reports one duration; Vayu's response carries three numbers and, when
+the transfer failed, two fields naming why:
+
+| Property | What it is |
+|---|---|
+| `responseTime` | What the caller waited - submission to completion, queue wait included. This is the one Postman's `pm.response.responseTime` corresponds to |
+| `responseTimeWire` | The transfer itself, without the time the submission spent queued |
+| `responseTimeQueueWait` | `responseTime` minus `responseTimeWire`, clamped at zero - the generator-side overhead. Near zero on a single send, which has no generator queue to wait in |
+| `errorCode` | The transport failure's code (`TIMEOUT`, `CONNECTION_FAILED`, …), as `pm.sendRequest`'s `err.code` spells it |
+| `errorMessage` | That failure's message |
+
+The two error fields are **absent** on a transfer that completed, rather than
+empty or `null` - the same absent-not-zeros rule `pm.response.events` follows -
+so `if (pm.response.errorCode)` is the test, and reading `errorMessage` without
+it is a guess about a sibling field.
+
+The two extra timings are there because a load run's latency and the engine's
+own overhead are different questions: `responseTimeWire` is libcurl's view of
+the transfer, and the gap between the two is what the generator's queue cost.
+An assertion on `responseTime` under load is an assertion on both.
 
 ### Response status classes (`pm.response.to.be`)
 
@@ -482,6 +514,11 @@ match by reason phrase as well as by code; Vayu's stay code-only.
 **`have.body`'s substring form is gone (#998).** A string argument now has to
 equal the body exactly, not merely appear in it - `.to.have.body(sub)` written
 for "the body contains `sub`" should become `.to.have.body(new RegExp(sub))`.
+It takes chai-postman's three argument forms and no others: a string compares
+equal, a regular expression is run against the body with its own `test`, and a
+plain object is deep-equalled against the **parsed** body - which reports
+`Response body is not valid JSON` when the body does not parse. A number or a
+boolean is a `TypeError` naming what was passed, and the argument is required.
 `.have.jsonBody(path, value)` also started comparing `value`, which it used to
 accept and ignore - a script relying on the old no-op should not pass an
 argument it does not want checked.
@@ -522,6 +559,16 @@ a per-event callback to run in. A script sees the retained list, once.
 list is bounded by the engine's `sseMaxStoredEvents`, so a script that means to
 assert over the *whole* stream has to check `eventsTruncated` first; counting a
 prefix would otherwise report a wrong number with complete confidence.
+
+**A load run's deferred `tests` script reads the same three.** `POST /runs`
+with `"stream": true` samples its streaming responses the way it samples any
+other, and the deferred script replays against those samples - so the three
+properties mean there what they mean in design mode, with two differences. The
+list is rebuilt by reparsing the sample's stored body and is bounded by
+`sseMaxStoredEvents`, while `totalEvents` is the count taken off the wire, so
+it stays right about a stream the stored body is only a prefix of. And there is
+no per-sample end reason: whether a stream ended by a cap is a run-level fact,
+reported once as `stream.capped`.
 
 All three are **absent** on an ordinary response rather than empty, so
 `typeof pm.response.events === 'undefined'` distinguishes "not a stream" from "a
@@ -683,9 +730,10 @@ pm.iterationData.has('coupon');    // whether the row carries that column
 pm.iterationData.toObject();       // the whole row
 ```
 
-A collection run can be given rows - the app parses the CSV or JSON file and
-sends them inline on the run payload; the engine never opens a file. Row
-`i % rows` binds to iteration `i`, so `iterations` above the row count wraps.
+A collection run can be given rows - the app parses the CSV, TSV, JSON or
+JSONL file and sends them inline on the run payload; the engine never opens a
+file. Row `i % rows` binds to iteration `i`, so `iterations` above the row
+count wraps.
 
 A **single send** can bind one row as well: the request builder's Send-with-row
 caret and MCP's `run_request` both take one row on `POST /execute`, which is
@@ -962,7 +1010,8 @@ going unreported in exchange for not crying wolf on correct code.
 
 #### Every `pm.*` example on this page is compiled against those declarations
 
-`script-typedefs.docs-compile.test.ts` takes the 54 `pm.*` blocks in this page and
+`script-typedefs.docs-compile.test.ts` takes **every** ` ```javascript ` block that mentions
+`pm.` in this page and
 [`docs/engine/scripting.md`](../engine/scripting.md), compiles each against the generated
 `.d.ts`, and requires zero errors - with `SCRIPT_COMPILER_OPTIONS` and
 `SUPPRESSED_DIAGNOSTICS` read from `useScriptTypeDefinitions.ts` rather than restated, so
@@ -978,6 +1027,13 @@ for the regeneration command.
 
 A consequence worth knowing before editing either page: a `pm.*` example here is now
 **checked**, so an example that is wrong fails CI rather than misleading a reader.
+The corpus is whatever the two pages currently hold, and the guard beside the
+compile asserts a **floor** rather than a count, deliberately - an added or
+deleted example is an ordinary docs edit and must not fail an assertion in a
+`.test.ts`. Which is also why this page no longer states how large that corpus
+currently is: a count written into prose is a fact with nothing holding it
+true, and the one that used to sit here had drifted by a third. The figures in
+the `strictNullChecks` note below are dated for the same reason.
 
 #### Optional members, and why the editor states them without enforcing them
 
@@ -998,10 +1054,10 @@ type system enforces.
 That is a decision (#443), not an oversight, and `useScriptTypeDefinitions` now sets
 `strictNullChecks: false` explicitly rather than relying on the default, so a `strict:
 true` arriving through the spread of Monaco's existing options cannot turn it on as a side
-effect. It was taken on a count. Compiling **57 scripts** against the real generated
-declarations - the 54 `pm.*` examples in this page and
-[`docs/engine/scripting.md`](../engine/scripting.md), plus three realistic ones - turning
-the flag on adds **13 diagnostics**:
+effect. It was taken on a count, and the count is a **measurement from when the
+decision was made** rather than a live property of the corpus: compiling the
+**57 scripts** the two pages then held - 54 `pm.*` examples plus three realistic
+ones - with the flag on added **13 diagnostics**:
 
 | What | Count | Verdict |
 |------|------:|---------|
@@ -1056,4 +1112,4 @@ reference had drifted into claiming "No crypto, base64 or `URL` in the sandbox" 
 | Completion fetch + cache        | `app/src/queries/script-completions.ts`                                                                                                                 |
 | Monaco completion provider      | `app/src/hooks/useScriptCompletionProvider.ts`                                                                                                          |
 | Shared editor wrapper           | `app/src/components/ui/code-editor.tsx`                                                                                                                 |
-| Script editor panels            | `app/src/modules/request-builder/components/RequestTabs/panels/{Pre,Test}ScriptPanel.tsx`, `app/src/modules/collections/CollectionDetail/ScriptTab.tsx` |
+| Script editor panels            | `app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx` + `script-variants.tsx`, `app/src/modules/collections/CollectionDetail/ScriptTab.tsx` |

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -22,7 +22,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Group               | API                                                                              |
 | ------------------- | -------------------------------------------------------------------------------- |
 | Core                | `pm`, `pm.test(name, fn)` - in either script, each result naming the one that made it (see below), `pm.expect(value[, message])` - the message prefixes the failure, as in chai |
-| Response            | `pm.response.code`, `.status`, `.responseTime`, `.responseTimeWire`, `.responseTimeQueueWait`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()`, plus `.errorCode` / `.errorMessage` on a transport failure, see below |
+| Response            | `pm.response.code`, `.status`, `.responseTime`, `.responseTimeWire`, `.responseTimeQueueWait`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()`, plus `.errorCode` / `.errorMessage` on a transport failure - see [Response timings](#response-timings-and-the-two-error-fields) |
 | Response headers    | `pm.response.headers.get(name)`, `.has(name[, value])` - case-insensitive; the value compare is strict; `.each(fn, thisArg?)`, `.all()`, `.count()`, `.toObject(excludeDisabled?, caseSensitive?)`, `.one(name)`, `.indexOf(name)` - the read half of a Postman `PropertyList`, see [Header methods](#header-methods) |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Streamed events     | `pm.response.events` (array of `{ event, id?, data, dataTruncated? }`), `.totalEvents`, `.eventsTruncated` - a streaming request only, see below. **Vayu-specific** |
@@ -473,8 +473,8 @@ the transfer failed, two fields naming why:
 
 | Property | What it is |
 |---|---|
-| `responseTime` | What the caller waited - submission to completion, queue wait included. This is the one Postman's `pm.response.responseTime` corresponds to |
-| `responseTimeWire` | The transfer itself, without the time the submission spent queued |
+| `responseTime` | What the caller waited - submission to completion, queue wait included. The one a ported Postman script reads, since it is the one carrying Postman's name |
+| `responseTimeWire` | `CURLINFO_TOTAL_TIME`: DNS, connect, TLS, send and receive. What the server and the network cost, with none of Vayu's own queue in it |
 | `responseTimeQueueWait` | `responseTime` minus `responseTimeWire`, clamped at zero - the generator-side overhead. Near zero on a single send, which has no generator queue to wait in |
 | `errorCode` | The transport failure's code (`TIMEOUT`, `CONNECTION_FAILED`, …), as `pm.sendRequest`'s `err.code` spells it |
 | `errorMessage` | That failure's message |

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6732,7 +6732,7 @@ method's signature emptied by the `()` inside its own label, `pm.info.eventName`
 read as prose and typed `void`, and two `pm.expect` chains shorter than the
 documentation beside them.
 
-So the durable guard compiles the **54 `pm.*` code blocks** in
+So the durable guard compiles **every ` ```javascript ` block mentioning `pm.`** in
 [`scripting.md`](scripting.md) and
 [`pm-api-compatibility.md`](../app/pm-api-compatibility.md) against the real
 declarations and requires zero errors, with the app's own compiler options and

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -624,10 +624,11 @@ make the load-mode executor (a per-VU state machine) possible without SQLite on
 its hot path.
 
 **Data rows bind per iteration.** A `scenario.data` array - rows the app parsed
-from a CSV or JSON file, sent inline, because the sandbox has no filesystem and a
-user-supplied path would be a new trust boundary - binds row `i % rows` to
-iteration `i`, read by the run's scripts as `pm.iterationData`. The rows ride the
-`ScenarioExecution` the worker holds and are never persisted: the snapshot keeps
+from a CSV, TSV, JSON or JSONL file, sent inline, because the sandbox has no
+filesystem and a user-supplied path would be a new trust boundary - binds row
+`i % rows` to iteration `i`, read by the run's scripts as `pm.iterationData`.
+The rows ride the `ScenarioExecution` the worker holds and are never
+persisted: the snapshot keeps
 `dataRowCount`, and every step's stored row and `step` event keeps
 `dataRowIndex`, so which row a wrapped pass re-used stays answerable without
 storing the row itself.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -197,8 +197,11 @@ Notes on the edges:
   `RegExp` comparisons run: an overridden `toJSON` or `toString` that throws used
   to leave both sides rendered as the empty string, which compared *equal*. When
   both sides throw, the first side's error is the one reported.
-- **A cycle fails loudly.** Deep equality gives up after 64 levels with a
-  `RangeError` naming the cause.
+- **A cycle fails loudly, at the depth it closes** (#959). The walk carries the
+  pairs of objects it is already comparing, so meeting one twice is a
+  `RangeError` naming that repetition - not a wait for a depth limit to be
+  reached. The 64-level cap is still there behind it, with a message of its own,
+  as the backstop for a structure that is merely very deeply nested.
 - **`eql` separates `+0` from `-0`; `equal` does not.** That is chai: `equal`
   is `===`, under which the two zeros are one value, while `eql` is deep-eql,
   whose number rule is `x === y && (x !== 0 || 1/x === 1/y)`. The
@@ -935,9 +938,13 @@ is a statement rather than a placeholder: a single request repeated under load
 is one user's iterations however many are in flight, and so is a collection run
 in design mode. `undefined` on an ordinary Send, beside `iteration`.
 
-**`iterationCount` is set by the collection runner and by nothing else.** A
-duration-bounded load run has no iteration total to report, and a field readable
-from one mode and not another is worse than one that is never readable at all.
+**`iterationCount` is set by the collection runner, and by a send that bound a
+row.** The runner reports the run's total; a send-with-row reports `1`, since
+that send is row 0 of 1 and says so about `iteration` already (see
+[Data rows](#data-rows-pmiterationdata)). A **load run** is where it stays
+`undefined`: a duration-bounded run has no iteration total to report, and a
+field readable from one load run and not another is worse than one that is
+never readable there at all.
 
 ## Environment Variables (`pm.environment`)
 
@@ -1419,6 +1426,13 @@ made, and the next transfer of that execution carries it:
   finished and the write lands on the next one.
 - A `set` in a **post-request script** has no transfer left to ride, so it is
   applied to the jar when the script ends.
+
+`unset` and `clear` are staged by the same rule and on the same queue - the
+bullets say `set` because it is the one that reads as immediate, not because
+the other two are. So `jar.clear(url)` followed by `jar.getAll(url)` in one
+script sees the clear, because a read is answered over the staged writes as
+well as the jar; the stored jar itself is not emptied until that execution's
+next transfer carries the write.
 
 **`clear` has two forms.** `clear(url)` is Postman's: it removes every cookie a
 request to that URL would have carried - `unset` with no name to narrow it, and


### PR DESCRIPTION
## Description

The ten discrepancies #1011 lists in `docs/app/pm-api-compatibility.md`, each re-verified against the code at the merge base rather than against the issue's anchors - those were taken at `e5277b6` and have drifted by up to 214 lines, and four of the ten had been fixed in the meantime.

**Root cause and approach.** This page is hand-written prose about a runtime that has taken ~15 PRs since it was last swept, and its claims rot in three distinct ways: a claim that was true when written and the code outgrew (`iterationCount`, the cycle rule, the data-file formats), a surface that shipped without ever being declared here (the four response timing/error properties, `dataTruncated`, the load path for streamed events), and a pointer that rots silently because nothing reads it (a moved file path, a count no guard holds). So the fix is not "apply the issue's ten edits": it is to re-establish each of the ten against `d1ea585` first, correct the six that are still wrong, and record the four the intervening PRs already closed rather than write over their wording. **The alternative rejected** is item 8's option (ii), making the docs-compile guard assert an exact block count: the guard's own comment says the floor is deliberately loose so ordinary doc edits do not fail CI, and pinning it would turn every added example into a code change while only relocating staleness - from "never caught" to "caught on every docs commit" - rather than removing the prose/code coupling that caused it.

**Corrected (six):**

| # | What was wrong | Truth |
|---|---|---|
| 1 | "`iterationCount` is set by the collection runner **and by nothing else**" - in both docs, and `scripting.md` contradicted itself about it 600 lines later | A send that binds a row sets it to `1` too, on the buffered and the streaming path alike (`execution.cpp:1490`, `:1323`, `:1409`). A load run is the mode that leaves it `undefined` |
| 3 | The Response row omitted `responseTimeWire`, `responseTimeQueueWait`, `errorCode`, `errorMessage`; the streamed-event shape omitted `dataTruncated` | All five are bound (`script_engine.cpp:4288-4300`, `:4251`). Declared, with a short section on what the three timings mean apart and the absent-not-empty rule for the two error fields |
| 4 | "a cyclic value raises a `RangeError` after 64 levels" - in both docs, predating #959 | A cycle raises **at the depth it closes**, naming the repeated object pair (`:976`); the 64-level cap is a separate backstop with its own message (`:927`). `docs/engine/building.md:388-401` had the right account all along |
| 5 | "the app parses the CSV or JSON file" | CSV, TSV, JSON or JSONL (`app/src/services/data-files/index.ts:41`) |
| 6 | The streamed-events section described design mode only | A load run's deferred `tests` script reads the same three properties (`run_manager.cpp:136-155`), with the two differences `scripting.md` already states |
| 7 | `panels/{Pre,Test}ScriptPanel.tsx` | `panels/script/ScriptPanel.tsx` + `script-variants.tsx`. Every other path this page names was swept and exists |

**Item 8 decided rather than deferred.** The prose stops naming a live count - the pinned "54 blocks" had drifted to 72, a third, without the `> 40` floor ever noticing - and #443's "57 scripts / 13 diagnostics" is dated as the measurement it was rather than presented as a current property.

**Already fixed by intervening PRs, verified and left alone (four):** `have.body`'s semantics (#998 via #1049), the TypeError guarantee for unsupported chai members (#999 via #1054 - now true, the expect chain has its `exotic` hook at `script_engine.cpp:687`), and `sendRequest`'s `auth` plus interpolation (#1001 via #1066, whose old "does not interpolate" divergence row is gone from the page). Two of them left a residue this PR closes, both required by acceptance criterion 2: this page named only `have.body`'s string-exact change, not the object or wrong-type rules; and it implied `noauth` was refused alongside `oauth2` when it is accepted (`script_engine.cpp:6247`). One more in `scripting.md`: the cookie-jar staging section named only `set` where `unset` and `clear` stage identically - which is item 10's own `jar.clear(url)` subject.

**Two files beyond the issue's two, both the same defect one page over.** Sweeping `docs/` for the wording each corrected claim replaced is what separates fixing a page from fixing a claim, and it found two survivors: `docs/engine/architecture.md:627` carried the same "a CSV or JSON file", and `docs/engine/api-reference.md:6735` carried the same pinned "54 `pm.*` code blocks" *and* misdescribed what the guard selects. Both corrected here rather than left to rot for the same reason the ten exist.

**Filed, not folded in: #1096.** The `pm.info` entry in the completion table (`engine/src/http/routes/scripting.cpp:838-844`, and `engine/tests/fixtures/script-typedefs.d.ts:588` generated from it) still says `iteration` and `iterationCount` are the collection runner's alone and that a load run's Tests script "reads undefined for both" - which #994 made false about `iteration`, and which this page's own rule ("do not add a fourth place that lists `pm.*` names") makes the *most* user-facing copy: it is what Monaco shows on hover and what every MCP agent reads. Fixing it is an engine source change plus a fixture regeneration, outside a docs-only issue, so it is #1096 with the anchors and the regeneration command rather than a "later" in a comment.

Deliberate deviation from the issue spec: none, beyond item 8's decision above and the residual clauses, each argued where it lands.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Docs-only, so the verification is the two gates that can actually redden, plus a review round:

- `mkdocs build --strict -f .github/mkdocs.yml` - clean, and clean on the base commit too (run before touching anything, so the pass means something). It is what proves the one new heading's anchor resolves from the table row that now links it.
- `app/src/hooks/script-typedefs.docs-compile.test.ts` - **2 tests, both passing**. Not a formality: it reads both edited pages, extracts every ` ```javascript ` block mentioning `pm.`, and type-checks each against the generated `.d.ts`, so a docs edit is one of the few things that can fail it.
- Two independent reviews of the diff, one against the issue's acceptance criteria line by line and one against the repo's conventions. The first returned no findings, having re-derived every claim from the code itself (including counting the corpus with the test's own extraction logic: 72, matching). The second returned the three fixed above plus #1096; a fourth suggestion was discarded - it read `architecture.md` as an unexplained modification when it was this branch's own concurrent commit.

No engine build and no other suite: no source file is touched, so nothing else could change colour. No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, prose only; the existing docs-compile guard already covers both pages
- [x] I have updated documentation

## Related Issues
Closes #1011