### PR TITLE
fix(engine): refuse a header name that resolves to nothing - #1084

### DIFF
--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -549,6 +549,36 @@ send rather than a rejected payload. The pre-send gate is deliberately *not* the
 backstop here, and cannot be: by the time it sees a request the erased header is
 already missing, with nothing left to notice.
 
+### And the name that resolves to nothing (#1084)
+
+The same file holds a second rule about a header *name*, one step further along:
+a name that resolves to the empty string. `{{blank}}: acme` with `blank` holding
+`""` - which is what an enabled row with a blank value is, an ordinary value
+rather than an exotic one - leaves a key with nothing in it, and the line that
+reaches the wire is `": acme"`, under no name at all. A strict server answers
+`400` and the run reads as the endpoint being broken; a lenient one ignores the
+line, and the header being set is simply absent.
+
+So it gets the answer the two above get: a `400` with code `empty_header_name`,
+naming the name as written - which is all there is to name, since what it
+produced is nothing. The pre-send gate is no backstop for this one either, and
+for a sharper reason than before: it reads a header's text for the bytes that
+end a line early, and an absent name ends nothing, so a nameless line passes
+every check between composition and libcurl.
+
+One difference from the collision. That one is refused only where resolution
+made it, because two names typed side by side are two lines the author can see;
+composition refuses this one however the name got there, a name that is not
+there being nothing to see whoever wrote it. In practice both flattenings that
+feed composition drop such a row first - a stored request's headers, and the
+app's - so what that catches beyond a produced name is a payload built by hand.
+The three layers are the ones above: composition's `400`, the residual pass as a
+failed send, and `pm.sendRequest`, which met this first because a script writes
+header names of its own. The residual pass reads a name only where the name held
+a `{{token}}`, which is its reach for the collision rule too - a request posted
+already-resolved is composition's to refuse - and a name a data row binds is the
+one layer with no empty-name rule yet (#1095).
+
 ---
 
 ## Dynamic variables

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3883,6 +3883,27 @@ with specific codes:
   `INTERNAL_ERROR` carrying the message, exactly as the pre-send gate does,
   while a streaming send - which has not answered yet - is a `400` with this
   same code and fails its run row.
+- `400` `{"error": {"code": "empty_header_name", "message": "..."}}` - a header
+  name resolved to the empty string, so the line would go out under no name at
+  all. `{{blank}}: acme` with `blank` holding `""` is not a header the caller
+  can see: the name is a map key, the key is empty, and what libcurl is handed
+  is the line `": acme"`. Nothing further down refuses it - the pre-send gate
+  reads a header's text for the bytes that end a line early, and an absent name
+  ends nothing - so composition is where it is caught. The message names the
+  name as written, which is all there is to name; what it produced is nothing.
+
+  Refused however the name got there, unlike the collision above. A collision
+  has to be one resolution produced, because two names the caller typed are two
+  entries they can see; a name that is not there is nothing to see whoever wrote
+  it. Both flattenings that feed composition drop such a row before it arrives -
+  a stored request's headers and the app's - so what this catches beyond a
+  produced name is a payload built by hand. The execute-time residual pass
+  refuses it in the same words and under this same code, in each of the two
+  shapes it answers a refusal in (above), and reads a name only where the name
+  held a token - the reach it has for the collision rule too, a request posted
+  already-resolved being composition's to refuse. `pm.sendRequest` has refused
+  it since its own header names began resolving, with the call named in front of
+  the same wording.
 
 ### POST /execute
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -477,12 +477,17 @@ of every value that had an answer. The one thing this costs: an ad-hoc payload
 posted straight to `/execute` with a literal `{{...}}` in it is no longer
 inert - if the run's scopes define that name, the send now carries its value.
 A name nothing defines still goes out written as it stands, and the load path
-does not run this pass at all. The one thing the pass can *refuse* is a
-resolved header name landing on a name the request already carries (#1051):
-the map holds one value per name, so the send would go out a header short, and
-it is stopped instead - in composition's words, as a `statusCode: 0` response
-carrying the reason (a `400` on the streaming path, which has not answered
-yet). An unresolved `{"mode":"inherit"}` reaching an execution endpoint
+does not run this pass at all. What the pass can *refuse* is what resolving a
+header **name** can produce, both rules held in
+`engine/include/vayu/http/header_names.hpp`: a name landing on one the request
+already carries (#1051), where the map holds one value per name and the send
+would go out a header short; and a name landing on nothing at all (#1084),
+where what would go out is a `": value"` line no name owns. Either is stopped
+rather than sent - in composition's words and under composition's refusal
+code, as a `statusCode: 0` response carrying the reason (a `400` on the
+streaming path, which has not answered yet, which is why the refusal carries
+the code as well as the error). Both rules read a name only where the pass
+reads one: a name that arrives already resolved is composition's to refuse. An unresolved `{"mode":"inherit"}` reaching an execution endpoint
 is treated as no auth and logged as a **warning** - it means a client skipped
 composition.
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1225,7 +1225,10 @@ out. Names are compared without case, the way the header map keys them. A name
 that resolves to nothing at all is refused the same way, and it is the one thing
 resolution can produce that nothing further down the send would catch: the
 pre-send gate reads header text for the bytes that break a line, and what is
-left of an empty name is the line `: value`, which libcurl sends.
+left of an empty name is the line `: value`, which libcurl sends. This call met
+that rule first, a script writing header names of its own; since #1084
+composition and the execute-time residual pass refuse it in the same words, so
+one wording answers wherever a name is resolved.
 
 ```javascript
 pm.environment.set("tenant", "acme");

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -870,10 +870,18 @@ script and before the send (`resolve_residual_tokens`,
 `engine/src/http/request_exchange.cpp`) - a value compose already substituted
 is finished text and this pass does not revisit it, so nothing is resolved
 twice. **That pass can refuse** (#1051): a header name it resolves onto a name
-the request already carries would erase that header, so it returns a
-`vayu::Error` and the send does not happen - composition refuses the same
-collision with a `400`, in the same words, and `http/header_names.hpp` holds
-the rule. Two entry shapes: `requestId` (stored request; MCP uses
+the request already carries would erase that header, so it refuses and the send
+does not happen - composition refuses the same collision with a `400`, in the
+same words, and `http/header_names.hpp` holds the rule. **A name that resolves
+to nothing is refused beside it** (#1084), by both layers and in that file's
+one wording: what is left of an empty name is a `": value"` line no name owns,
+and the pre-send gate is no backstop for it - it reads header text for the
+bytes that end a line early, and an absent name ends nothing. The pass answers
+a `ResidualRefusal`, which carries the compose refusal code as well as the
+error, because the streaming send answers a `400` of its own and a code spelled
+at that call site is one that drifts from the rule it names. Both rules read a
+name only where this pass reads one, so a request posted already-resolved is
+composition's to refuse. Two entry shapes: `requestId` (stored request; MCP uses
 this, and gates its allowlist on the *composed* URL) and an inline `request`
 (+ `collectionId` scope; the renderer uses this because Send/replay execute
 *editor state*, which may be unsaved or detached). Inline over stored = the

--- a/engine/include/vayu/http/header_names.hpp
+++ b/engine/include/vayu/http/header_names.hpp
@@ -8,10 +8,16 @@
  */
 
 #include <string>
+#include <string_view>
 
 /**
  * @file header_names.hpp
- * @brief When two header names become one - one rule, one place.
+ * @brief What resolution can do to a header *name* - the rules, one place.
+ *
+ * Two of them, both about a name a variable produced rather than a name the
+ * author typed: two names that become one (below), and a name that becomes
+ * nothing at all (`describe_empty_header_name`). Neither is visible from the
+ * response, and neither is caught anywhere further down the send.
  *
  * A header name is substituted like any other field, and the map it lands in
  * holds one value per name. So two names that resolve alike do not both go out:
@@ -69,6 +75,32 @@
  * rule is enforced where the map is rebuilt rather than checked once before the
  * transfer: by the time the gate sees a request, the collision has already
  * happened and the erased header is simply not there to notice.
+ *
+ * ## The name that resolves to nothing
+ *
+ * `describe_empty_header_name` is the second rule, and it is the same argument
+ * one step further: `{{blank}}: acme` with `blank` empty is not a header the
+ * author can see either, and the gate is no backstop for it for the same reason
+ * - it reads header text for the bytes that break a line, and an empty name
+ * breaks nothing. What is left goes out as the line `": acme"`, under no name
+ * at all. The three layers that resolve a name refuse it: composition and the
+ * residual pass (issue #1084) and `pm.sendRequest` (issue #1067), which met it
+ * first because a script writes header names of its own.
+ *
+ * Unlike a collision, composition refuses this one however the name got there.
+ * A collision has to be one resolution produced, because two names the author
+ * typed are two lines they can see; a name that is not there is nothing to see
+ * whoever wrote it. In practice both flattenings that feed composition - the
+ * stored one and the renderer's - drop such a row before it arrives, so what
+ * that catches beyond a produced name is a caller that built the payload
+ * itself.
+ *
+ * The other two layers see less, and neither rule pretends otherwise: the
+ * residual pass reads a name only where the name held a `{{token}}`, so a
+ * payload posted straight to `POST /execute` carrying an already-empty name is
+ * composition's to refuse and this pass never looks at it - the same reach the
+ * collision rule has there - and a name bound from a data row has no rule of
+ * its own yet, where the collision rule does (issue #1095).
  */
 
 namespace vayu::http {
@@ -97,5 +129,27 @@ struct HeaderNameCollision {
  * were three. A layer may name itself in front of the wording, never inside it.
  */
 [[nodiscard]] std::string describe_header_name_collision (const HeaderNameCollision& collision);
+
+/**
+ * @brief The refusal a header name that resolved to nothing reads as.
+ *
+ * One wording for the same three layers, on the reasoning above: a caller
+ * meeting this at composition and again at execute time is meeting one rule,
+ * and three spellings of it would read as three. A layer may name itself in
+ * front of the wording, never inside it.
+ *
+ * @param written the name as the request carries it, before resolution. It is
+ *        the whole of what the message can name - what the name produced is
+ *        nothing, and `{{blank}}` is what the author has to go and look at.
+ */
+[[nodiscard]] std::string describe_empty_header_name (const std::string& written);
+
+/// The `POST /compose` refusal code each rule answers under, beside its wording
+/// for the same reason: a layer with no `400` of its own still names the rule by
+/// one - a streaming send reports the residual pass's refusal as a `400`, and a
+/// code spelled at that site is a code that drifts from the rule it names.
+inline constexpr std::string_view COLLIDING_HEADER_NAMES_CODE =
+"colliding_header_names";
+inline constexpr std::string_view EMPTY_HEADER_NAME_CODE = "empty_header_name";
 
 } // namespace vayu::http

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -262,6 +262,26 @@ struct ExchangeOutcome {
 };
 
 /**
+ * Why a residually-resolved request must not be sent, in the two shapes its two
+ * callers answer in.
+ *
+ * The pass serves a buffered send, which has a response to fill in, and a
+ * streaming one, which has not answered its route yet - so it carries both
+ * rather than making either caller derive the other's half from a message.
+ */
+struct ResidualRefusal {
+    /// The pre-send gate's shape, which every buffered driver already renders:
+    /// an `InternalError` carrying the reason, answered as a status-0 response
+    /// rather than a transfer.
+    vayu::Error error;
+    /// The `POST /compose` code for the same rule, for the streaming send's
+    /// `400`. It comes from the file that holds the rule
+    /// (`http/header_names.hpp`), so composition and this pass cannot name one
+    /// refusal two ways.
+    std::string code;
+};
+
+/**
  * Resolve the `{{tokens}}` composition left behind, against the variable state
  * a pre-request script has just written (issue #1008).
  *
@@ -291,17 +311,15 @@ struct ExchangeOutcome {
  * A request holding no `{{` at all - nearly all of them, composition having
  * resolved what it could - pays one search per field and nothing else.
  *
- * @return why this request must not be sent, if a resolved header name landed
- *         on one the request already carried (`http/header_names.hpp`, issue
- *         #1051) - the one thing this pass can produce that a send cannot
- *         survive, because the map holds one value per name and the header it
- *         replaced is simply gone. `std::nullopt` is the ordinary answer, the
- *         request resolved in place. The refusal is a `vayu::Error` rather than
- *         a status because this pass serves two callers with two different
- *         answers to give: the shape is the pre-send gate's, and each caller
- *         renders it the way it renders that one.
+ * @return why this request must not be sent, if resolving a header name
+ *         produced one the request already carried (`http/header_names.hpp`,
+ *         issue #1051) or no name at all (issue #1084) - the two things this
+ *         pass can produce that a send cannot survive, because the map holds
+ *         one value per name and what is left of an empty one is a `": value"`
+ *         line. `std::nullopt` is the ordinary answer, the request resolved in
+ *         place.
  */
-[[nodiscard]] std::optional<vayu::Error>
+[[nodiscard]] std::optional<ResidualRefusal>
 resolve_residual_tokens (vayu::Request& request, const ScriptVariableScopes& scopes);
 
 /**

--- a/engine/src/http/header_names.cpp
+++ b/engine/src/http/header_names.cpp
@@ -17,4 +17,11 @@ std::string describe_header_name_collision (const HeaderNameCollision& collision
     " sent with a header missing";
 }
 
+std::string describe_empty_header_name (const std::string& written) {
+    return "header \"" + written +
+    "\" resolves to an empty name"
+    " - what would go out is a \": value\" line no name owns, so the request is"
+    " refused rather than sent carrying a header the author cannot see";
+}
+
 } // namespace vayu::http

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -820,7 +820,7 @@ namespace {
 // Builds through routes.hpp's error_body so /compose carries the same nested
 // shape as every other route (issue #173 landed while #226 was in flight).
 std::pair<int, nlohmann::json>
-compose_error (int status, const char* code, const std::string& message) {
+compose_error (int status, std::string_view code, const std::string& message) {
     return { status, routes::error_body (status, message, code) };
 }
 
@@ -1021,6 +1021,8 @@ struct ResolvedHeaders {
     std::optional<HeaderTextRefusal> unspellable;
     /// Two names that resolved to one (#1051).
     std::optional<vayu::http::HeaderNameCollision> collision;
+    /// A name that resolved to nothing, as it was written (#1084).
+    std::optional<std::string> nameless;
 };
 
 /**
@@ -1051,6 +1053,11 @@ DynamicResolution dynamic) {
     for (const auto& [key, value] : headers.items ()) {
         const std::string name =
         resolve_header_template (key, vars, bound_columns, dynamic, out.unspellable);
+        if (name.empty () && !out.nameless) {
+            // However it got there, unlike a collision: a name that is not
+            // there is nothing the author can see, whoever wrote it.
+            out.nameless = key;
+        }
         const auto [taken, was_free] = produced.emplace (name, key);
         const bool resolution_made_it = name != key || taken->second != taken->first;
         if (!was_free && resolution_made_it && !out.collision) {
@@ -1072,8 +1079,9 @@ DynamicResolution dynamic) {
  * the one the author cannot see the result of: its text has a terminator and no
  * escape for it, so a substituted CR or LF ends the line rather than sitting in
  * it (`http/header_text.hpp`), and its name is a map key, so a substituted name
- * can quietly take another header's place (`http/header_names.hpp`). Both files
- * carry the rule and the layers that share it.
+ * can quietly take another header's place - or leave the line with no name at
+ * all (`http/header_names.hpp`). Both files carry the rules and the layers that
+ * share them.
  *
  * @return the refusal, or nothing.
  */
@@ -1100,8 +1108,15 @@ nlohmann::json& payload) {
             return compose_error (400, "unsendable_header",
             describe_header_text_refusal (*resolved.unspellable));
         }
+        // Before the collision, because it is the nearer fault: two names that
+        // both resolved to nothing collide on the empty name, and "they
+        // resolved alike" is not what the author needs to be told about them.
+        if (resolved.nameless) {
+            return compose_error (400, vayu::http::EMPTY_HEADER_NAME_CODE,
+            vayu::http::describe_empty_header_name (*resolved.nameless));
+        }
         if (resolved.collision) {
-            return compose_error (400, "colliding_header_names",
+            return compose_error (400, vayu::http::COLLIDING_HEADER_NAMES_CODE,
             vayu::http::describe_header_name_collision (*resolved.collision));
         }
         *headers = std::move (resolved.headers);

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -352,6 +352,13 @@ bool a_header_name_holds_a_token (const vayu::Headers& headers) {
     [] (const auto& entry) { return holds_a_token (entry.first); });
 }
 
+/// Both halves of a refusal from one wording: the pre-send gate's shape for the
+/// buffered send, and the rule's own `POST /compose` code for the streaming one.
+ResidualRefusal refusal_of (std::string reason, std::string_view code) {
+    return ResidualRefusal{ vayu::Error{ vayu::ErrorCode::InternalError, std::move (reason) },
+        std::string (code) };
+}
+
 /**
  * Rebuilt rather than edited in place, because a resolved name is a different
  * key. Values are copied rather than moved, so a refusal leaves the request as
@@ -367,11 +374,19 @@ bool a_header_name_holds_a_token (const vayu::Headers& headers) {
  * names without case already, so two names that survive untouched cannot have
  * been equal to begin with.
  *
- * @return the first collision, the headers left as they were; nothing, and the
+ * A name that resolves to *nothing* is refused here too (#1084), in that rule's
+ * one wording: it is the same shape of quiet wrong request with the erased
+ * header replaced by a `": value"` line no name owns, and this pass is the
+ * layer composition cannot stand in for - the name a script has just defined is
+ * one composition never saw. A name that arrives *already* empty holds no token
+ * and so is never walked here at all, which is this pass's reach for both rules
+ * alike: composition refuses that one (see issue #1095).
+ *
+ * @return the first refusal, the headers left as they were; nothing, and the
  *         map rebuilt, when every name is still its own.
  */
-std::optional<vayu::http::HeaderNameCollision>
-resolve_header_names (vayu::Headers& headers, const vayu::http::VariableValues& vars) {
+std::optional<ResidualRefusal> resolve_header_names (vayu::Headers& headers,
+const vayu::http::VariableValues& vars) {
     if (!a_header_name_holds_a_token (headers)) {
         return std::nullopt;
     }
@@ -382,10 +397,17 @@ resolve_header_names (vayu::Headers& headers, const vayu::http::VariableValues& 
     std::map<std::string, std::string, vayu::CaseInsensitiveLess> produced;
     for (const auto& [name, value] : headers) {
         std::string resolved_name = vayu::http::resolve_template (name, vars);
+        // Both refusals are reported with the map untouched: the caller refuses
+        // the send, so a half-rebuilt request is one nothing goes on to read.
+        if (resolved_name.empty ()) {
+            return refusal_of (vayu::http::describe_empty_header_name (name),
+            vayu::http::EMPTY_HEADER_NAME_CODE);
+        }
         if (const auto [taken, was_free] = produced.emplace (resolved_name, name); !was_free) {
-            // Reported with the map untouched: the caller refuses the send, so
-            // a half-rebuilt request is one nothing goes on to read.
-            return vayu::http::HeaderNameCollision{ name, taken->second, taken->first };
+            return refusal_of (
+            vayu::http::describe_header_name_collision (
+            vayu::http::HeaderNameCollision{ name, taken->second, taken->first }),
+            vayu::http::COLLIDING_HEADER_NAMES_CODE);
         }
         resolved[std::move (resolved_name)] = value;
     }
@@ -404,7 +426,7 @@ vayu::http::VariableValues values_from_scopes (const ScriptVariableScopes& scope
 
 } // namespace
 
-std::optional<vayu::Error> resolve_residual_tokens (vayu::Request& request,
+std::optional<ResidualRefusal> resolve_residual_tokens (vayu::Request& request,
 const ScriptVariableScopes& scopes) {
     auto targets             = resolvable_strings (request);
     const bool anything_left = a_header_name_holds_a_token (request.headers) ||
@@ -420,15 +442,15 @@ const ScriptVariableScopes& scopes) {
             *text = vayu::http::resolve_template (*text, vars);
         }
     }
-    // Last: it rebuilds the map the values `targets` points at live in.
-    if (auto collision = resolve_header_names (request.headers, vars)) {
-        // The shape the pre-send gate answers in, because this is a refusal of
-        // the same send and the drivers already render that one: an
-        // `InternalError` carrying the message, which each caller turns into a
-        // status-0 response rather than a transfer (see `validate_transferable`
-        // in `event_loop/curl_utils.cpp`).
-        return vayu::Error{ vayu::ErrorCode::InternalError,
-            vayu::http::describe_header_name_collision (*collision) };
+    // Last: it rebuilds the map the values `targets` points at live in. The
+    // refusal already carries the pre-send gate's shape, because this is a
+    // refusal of the same send and the drivers already render that one: an
+    // `InternalError` a buffered caller turns into a status-0 response rather
+    // than a transfer (see `validate_transferable` in
+    // `event_loop/curl_utils.cpp`), beside the code a streaming caller answers
+    // its still-open route with.
+    if (auto refusal = resolve_header_names (request.headers, vars)) {
+        return refusal;
     }
     return std::nullopt;
 }
@@ -501,7 +523,7 @@ bool verbose) {
         // the send that was to carry them. The test script still runs, and
         // reads a response reporting an error rather than a status - the
         // false-pass rule issue #180 exists for.
-        outcome.response = vayu::http::detail::error_response (*refusal);
+        outcome.response = vayu::http::detail::error_response (refusal->error);
         outcome.response.request_headers = outcome.request.headers;
     } else {
         vayu::http::ClientConfig config;

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1248,7 +1248,7 @@ DesignSend& send) {
  * as the stream.
  *
  * One helper for both refusals - the draining daemon's, and the header-name
- * collision the residual pass reports (#1051) - because they are the same three
+ * ones the residual pass reports (#1051, #1084) - because they are the same three
  * statements, and a second copy is one that stops receiving this one's fixes.
  */
 void refuse_stream_before_it_opens (RouteContext& ctx,
@@ -1338,11 +1338,13 @@ void run_streaming_execution (RouteContext& ctx, httplib::Response& res, DesignS
     // rather than through `execute_exchange`: a `{{token}}` the script has just
     // defined resolves before the stream opens.
     if (auto refusal = resolve_residual_tokens (send.request, scopes)) {
-        // The one thing that pass can refuse (issue #1051), in the same words
-        // the buffered send refuses it with; what differs is where the caller
-        // reads it, this route not having answered yet.
+        // What that pass can refuse (issues #1051 and #1084), in the same words
+        // the buffered send refuses it with and under the code composition
+        // refuses it under; what differs is where the caller reads it, this
+        // route not having answered yet. The code rides on the refusal because
+        // naming it here is how it would come to name the wrong rule.
         refuse_stream_before_it_opens (
-        ctx, res, run_id, 400, refusal->message, "colliding_header_names");
+        ctx, res, run_id, 400, refusal->error.message, refusal->code);
         return;
     }
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -6320,8 +6320,11 @@ std::optional<std::string> resolve_send_request_headers (JSContext* ctx, Headers
             // A name written empty is refused as the headers are read; one
             // *resolved* empty reaches nothing that would notice - the pre-send
             // gate reads header text for the bytes that break a line, and
-            // libcurl writes what is left as `": value"` and sends it.
-            return "pm.sendRequest header '" + name + "' resolves to an empty name";
+            // libcurl writes what is left as `": value"` and sends it. Since
+            // #1084 composition and the residual pass refuse it too, so the
+            // wording is `http/header_names.hpp`'s rather than this layer's -
+            // the same move the collision beside it already made.
+            return "pm.sendRequest: " + vayu::http::describe_empty_header_name (name);
         }
         if (const auto [taken, was_free] = produced.emplace (resolved_name, name); !was_free) {
             return "pm.sendRequest: " +

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -1222,6 +1222,68 @@ TEST_F (RequestComposerTest, TwoNamesTheAuthorTypedAreNotThisRefusal) {
     EXPECT_EQ (payload["headers"]["authorization"], "Bearer other");
 }
 
+// --- A header name that resolves to nothing (#1084) --------------------------
+//
+// The third thing a substituted header name can do, after erasing a header and
+// forging one: leave the line with no name at all. `{{blank}}: acme` with
+// `blank` empty is written into the payload under the key `""`, and nothing
+// further down looks - the pre-send gate reads header text for the bytes that
+// break a line, and an absent name breaks none, so libcurl appends what is left
+// as `": acme"` and sends it. See `http/header_names.hpp`.
+//
+// Mutation-check for the three below: drop the `nameless` check in
+// `resolve_compose_head` and the first two fail - the second on the code it
+// falls back to - while the third must keep passing, a name that resolves to a
+// name being nobody's refusal.
+
+TEST_F (RequestComposerTest, AHeaderNameResolvingToNothingIsRefused) {
+    // An enabled variable with a blank value, which is what the D17 rule stores
+    // for a row the author left empty - an ordinary value, not an exotic one.
+    seed_environment ("env_1", R"({"blank":{"value":"","enabled":true}})");
+    const json body        = { { "request",
+                               { { "method", "GET" }, { "url", "https://x.test/" },
+                               { "headers", { { "{{blank}}", "acme" } } } } },
+               { "environmentId", "env_1" } };
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+
+    EXPECT_EQ (status, 400) << payload.dump ();
+    EXPECT_EQ (payload["error"]["code"], "empty_header_name");
+    // The name as written is the whole of what the message can name: what it
+    // produced is nothing, and `{{blank}}` is what the author has to go to.
+    const auto message = payload["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("{{blank}}"), std::string::npos) << message;
+}
+
+// Two names that both resolve to nothing do collide - on the empty name - and
+// the collision is the further fault: what the author needs to be told is that
+// neither name arrived, not that the two agreed about it.
+TEST_F (RequestComposerTest, TwoNamesResolvingToNothingAreRefusedAsNameless) {
+    seed_environment ("env_1",
+    R"({"a":{"value":"","enabled":true},"b":{"value":"","enabled":true}})");
+    const json body        = { { "request",
+                               { { "method", "GET" }, { "url", "https://x.test/" },
+                               { "headers", { { "{{a}}", "acme" }, { "{{b}}", "legacy" } } } } },
+               { "environmentId", "env_1" } };
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+
+    EXPECT_EQ (status, 400) << payload.dump ();
+    EXPECT_EQ (payload["error"]["code"], "empty_header_name");
+}
+
+// The case the refusal leaves alone, and the reason it cannot be a check on the
+// name holding a token: a name a variable answers is composed as ever.
+TEST_F (RequestComposerTest, ANameThatResolvesToANameIsNotThisRefusal) {
+    seed_environment ("env_1", R"({"tenant_header":{"value":"X-Tenant","enabled":true}})");
+    const json body        = { { "request",
+                               { { "method", "GET" }, { "url", "https://x.test/" },
+                               { "headers", { { "{{tenant_header}}", "acme" } } } } },
+               { "environmentId", "env_1" } };
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+
+    ASSERT_EQ (status, 200) << payload.dump ();
+    EXPECT_EQ (payload["headers"]["X-Tenant"], "acme");
+}
+
 TEST_F (RequestComposerTest, UnknownScopeIdsDegradeToAnEmptyScope) {
     const json body = { { "request", { { "method", "GET" }, { "url", "https://x.test/{{missing}}" } } },
         { "collectionId", "col_missing" }, { "environmentId", "env_missing" } };

--- a/engine/tests/residual_token_test.cpp
+++ b/engine/tests/residual_token_test.cpp
@@ -305,10 +305,15 @@ TEST (ResidualTokens, ANameResolvingOntoAHeaderAlreadyThereIsRefused) {
     const auto refusal = resolve_residual_tokens (request, scopes);
 
     ASSERT_HAS_VALUE (refusal);
-    EXPECT_EQ (refusal->code, vayu::ErrorCode::InternalError);
-    EXPECT_NE (refusal->message.find ("{{header_name}}"), std::string::npos)
-    << refusal->message;
-    EXPECT_NE (refusal->message.find ("X-Tenant"), std::string::npos) << refusal->message;
+    EXPECT_EQ (refusal->error.code, vayu::ErrorCode::InternalError);
+    // The code composition refuses the same rule under, so the streaming send -
+    // which answers a `400` rather than a status-0 response - names one rule the
+    // one way (#1084).
+    EXPECT_EQ (refusal->code, "colliding_header_names");
+    EXPECT_NE (refusal->error.message.find ("{{header_name}}"), std::string::npos)
+    << refusal->error.message;
+    EXPECT_NE (refusal->error.message.find ("X-Tenant"), std::string::npos)
+    << refusal->error.message;
 }
 
 /// Refused with the request as it was found: the caller stops the send, and a
@@ -354,6 +359,50 @@ TEST (ResidualTokens, ANameResolvingToItsOwnHeaderIsNotACollision) {
     EXPECT_EQ (request.headers["X-Tenant"], "acme");
     EXPECT_EQ (request.headers["X-Other"], "kept");
     EXPECT_EQ (request.headers.count ("{{header_name}}"), 0u);
+}
+
+// --- a name that resolves to nothing (#1084) ---------------------------------
+//
+// The second rule `http/header_names.hpp` holds, met here for the reason the
+// collision above is: a name a pre-request script has just emptied is one
+// composition never saw. What a send would carry is the line `": acme"`, under
+// no name at all, and nothing between here and the wire looks at a name that is
+// not there.
+//
+// Mutation-check for the two below: drop the empty check in
+// `resolve_header_names` and the first fails on the refusal it no longer gets,
+// the second on the nameless header the rebuild then leaves behind.
+
+TEST (ResidualTokens, ANameResolvingToNothingIsRefused) {
+    vayu::Request request;
+    request.url                        = "https://api.example.com/x";
+    request.headers["{{header_name}}"] = "acme";
+
+    auto scopes        = environment_with ("header_name", "");
+    const auto refusal = resolve_residual_tokens (request, scopes);
+
+    ASSERT_HAS_VALUE (refusal);
+    EXPECT_EQ (refusal->error.code, vayu::ErrorCode::InternalError);
+    EXPECT_EQ (refusal->code, "empty_header_name");
+    EXPECT_NE (refusal->error.message.find ("{{header_name}}"), std::string::npos)
+    << refusal->error.message;
+}
+
+/// Refused with the request as it was found, for the reason a refused collision
+/// is: the caller stops the send, and a half-rebuilt map is one nothing should
+/// go on to read.
+TEST (ResidualTokens, ARefusedEmptyNameLeavesTheHeadersAlone) {
+    vayu::Request request;
+    request.url                        = "https://api.example.com/x";
+    request.headers["{{header_name}}"] = "acme";
+    request.headers["X-Other"]         = "kept";
+    const vayu::Request before         = request;
+
+    auto scopes = environment_with ("header_name", "");
+    EXPECT_TRUE (resolve_residual_tokens (request, scopes));
+
+    EXPECT_EQ (request.headers, before.headers);
+    EXPECT_EQ (request.headers.count (""), 0u);
 }
 
 // --- the exchange, on the wire -----------------------------------------------


### PR DESCRIPTION
## Description

A header name *written* empty never reaches the wire - both flattenings that feed composition drop the row. A name that *becomes* empty did: `{{blank}}: acme` with `blank` holding `""` composed into the key `""`, and nothing downstream looked, so libcurl was handed the line `": acme"` and sent it - a line the author did not write, under a name they cannot see, with a value they did mean.

**Root cause.** The rule that would catch it does not exist in the two composition-side layers. `resolve_header_block` writes `out.headers[name]` with `name` empty and `resolve_header_names` does the same into a `Headers` map; below them, `line_fault` reports only CR/LF and NUL - all `find`-shaped, so an empty string is clean - and `build_request_header_list` gates on the *value* alone before writing `key + ": " + value`. The pre-send gate is structurally no backstop: it reads a header's text for the bytes that end a line early, and an absent name ends nothing.

**Approach.** Both layers refuse it, each in the shape it already refuses a header in: composition a `400` with a new `empty_header_name` code beside `unsendable_header` and `colliding_header_names`, the residual pass a refusal the send does not survive. The wording is one function in `http/header_names.hpp` beside `describe_header_name_collision`, and `pm.sendRequest` - which met this first, in #1067 - reads it there now instead of spelling its own, so acceptance criterion 3 holds across three layers rather than two. The refusal *codes* moved into that file with the wording, because tracing the consumers turned up a defect the fix would otherwise have introduced: the streaming send reports the residual pass's refusal as a `400` of its own and spelled `"colliding_header_names"` at the call site, so a second refusal reason would have been reported under the first one's name. The pass now answers a `ResidualRefusal` carrying the code beside the error, and the streaming site reads it.

**The alternative I rejected**, and why: refusing only a name *resolution emptied*, mirroring the collision rule's "only the ones resolution produced" test. That distinction earns its place for a collision - two names typed side by side are two lines the author can see, and the later-wins rule is visible in the editor - but a name that is not there is nothing to see whoever wrote it, so the condition would buy a branch and leave a hand-built payload sending `": value"`. Composition therefore refuses an empty composed name however it got there.

**What this deliberately does not cover**, filed as #1095 rather than widened into here: a data row that binds a header name to `""` (the bind-time layer has the collision rule but no empty-name rule, and the load path runs no residual pass), and the residual pass's own reach - it is gated by "does this name hold a token", which is its reach for the collision rule too, so a payload posted straight to `POST /execute` already carrying an empty key is composition's to refuse. The docs now state that reach instead of implying more.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2715 tests, 2715 passed, 0 failed** (2710 before; 5 added). No pre-existing failures on this base (`8d952ca`). `clang-format` 19 clean over every touched file; `clang-tidy` 19 over the changed translation units reports nothing but the local build's GCC-PCH notice.

Five new tests, all mutation-checked by actually removing each guard, rebuilding and re-running:

- `request_composer_test.cpp` - `AHeaderNameResolvingToNothingIsRefused` (400 + code + `{{blank}}` named), `TwoNamesResolvingToNothingAreRefusedAsNameless` (two names resolving alike *to nothing* answer the nearer fault, not the collision), `ANameThatResolvesToANameIsNotThisRefusal` (the untouched case).
- `residual_token_test.cpp` - `ANameResolvingToNothingIsRefused` (refusal shape, and the compose code the streaming send answers with), `ARefusedEmptyNameLeavesTheHeadersAlone`.

With the composition guard removed the first test answers `200` and the second falls back to `colliding_header_names`; with the residual guard removed both residual tests fail and the request is left carrying `("", "acme")` - the malformed line itself. The control stayed green throughout. `SendRequestTest.AHeaderNameResolvingToNothingIsRefused` still passes on the shared wording.

Not run, with reason: the app suite (no `app/` file changed - the issue specifies no app changes, and tracing the consumers confirmed no renderer, MCP or CLI surface switches on a compose refusal code; the message passes through generically). `mkdocs build --strict` (mkdocs is not installed in this environment) - the docs changes add no page, link or nav entry, only prose and one new `###` heading.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/api-reference.md` (the `POST /compose` refusal list gains the code), `docs/app/variable-resolution.md` (a rule beside the #738 and #1051 ones), `docs/engine/scripting.md` (the `pm.sendRequest` paragraph, now one of three layers), `docs/engine/architecture.md` (its "the one thing the pass can refuse" sentence was made false by this change), `engine/CLAUDE.md`, and `header_names.hpp`'s own doc block.

## Related Issues

Closes #1084. Defers the two uncovered layers to #1095.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFtBek3VYSUC3RuDkVwnxQ)_