### PR TITLE
fix(engine): refuse a header name a row binds away, and read every name for it - #1095

### DIFF
--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -577,10 +577,21 @@ feed composition drop such a row first - a stored request's headers, and the
 app's - so what that catches beyond a produced name is a payload built by hand.
 The three layers are the ones above: composition's `400`, the residual pass as a
 failed send, and `pm.sendRequest`, which met this first because a script writes
-header names of its own. The residual pass reads a name only where the name held
-a `{{token}}`, which is its reach for the collision rule too - a request posted
-already-resolved is composition's to refuse - and a name a data row binds is the
-one layer with no empty-name rule yet (#1095).
+header names of its own.
+
+**A fourth binds rather than resolves** (#1095): a data row whose header-name
+column is blank - `{{data.header_name}}: acme` against a row that has nothing in
+that column - is refused at bind time, in the same wording with the row in front
+of it, and the load path needs that layer because it runs no residual pass over
+what it binds. A name a bind only *shortens* is not this rule: `X-{{data.h}}`
+with a blank cell binds to `X-`, which is a name a request can carry.
+
+And the residual pass reads **every** header name for this rule (#1095), not
+only the ones that still held a `{{token}}` - so a name a script has just
+emptied, and an empty key in a payload posted straight to `POST /execute`, are
+refused there rather than sent. The collision rule keeps the narrower reach and
+loses nothing by it: a request that arrives already resolved cannot carry a
+collision to find, since two names that are already equal are already one key.
 
 ---
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3899,11 +3899,16 @@ with specific codes:
   a stored request's headers and the app's - so what this catches beyond a
   produced name is a payload built by hand. The execute-time residual pass
   refuses it in the same words and under this same code, in each of the two
-  shapes it answers a refusal in (above), and reads a name only where the name
-  held a token - the reach it has for the collision rule too, a request posted
-  already-resolved being composition's to refuse. `pm.sendRequest` has refused
-  it since its own header names began resolving, with the call named in front of
-  the same wording.
+  shapes it answers a refusal in (above), and for this rule it reads **every**
+  header name rather than only the ones still holding a token (issue #1095) - so
+  a name a pre-request script has just emptied and an empty key posted straight
+  to `POST /execute` are refused there as well. The collision rule keeps the
+  narrower reach and loses nothing by it: a request that arrives already
+  resolved cannot carry a collision, two names that are already equal being
+  already one key. `pm.sendRequest` has refused it since its own header names
+  began resolving, with the call named in front of the same wording, and a data
+  row that binds a name away is refused at bind time with the row in front of it
+  (see [Scenario runs](#scenario-runs)).
 
 ### POST /execute
 
@@ -4091,7 +4096,7 @@ Refused with a **400**, before any run row exists and with nothing sent:
 | `data` is not an object | `'data' must be an object of name/value pairs (got array). A single send binds one row; a set of rows is a collection run.` |
 | over the byte cap | `'data' is N bytes, over the limit of M (raise the 'maxScenarioDataBytes' setting to allow more)` |
 | a token names a column the row lacks | the binder's own sentence, naming the token, the row and the row's columns |
-| a `null` cell, a header collision, an unwritable XML placement | the binder's own sentence - identical to a run's, see [Scenario runs](#scenario-runs) |
+| a `null` cell, a header collision, a header name bound to nothing, an unwritable XML placement | the binder's own sentence - identical to a run's, see [Scenario runs](#scenario-runs) |
 | an OAuth 2.0 config carries a `{{data.*}}` token | `Auth credentials carry {{data.client}} in an OAuth 2.0 configuration, and no row can reach it: ...` |
 
 **Credentials bind here too** (issue #642). A `{{data.user}}` in a basic-auth
@@ -5045,6 +5050,17 @@ produced and the row. Note this is deliberately *not* composition's duplicate
 rule, which is last-wins: a duplicate there is two headers the author typed and
 can see, while this one exists only for the rows that produce it.
 
+**A header name a row binds to nothing** errors the same way (issue #1095), and
+is reported ahead of a collision when a row does both - two names that bind to
+nothing collide on a name neither of them has, which is not what the file's
+author needs to be told. `{{data.header_name}}: acme` whose cell is blank would
+otherwise send the line `": acme"`, under a name nobody wrote and with a value
+they did mean, once per iteration. The message is the one every layer that can
+leave a header nameless shares, with the row in front of it; the column is
+inside the header as written, where that wording names it. A name a bind merely
+*shortens* is not this rule - `X-{{data.h}}` with a blank cell binds to `X-`,
+which is a name a request can carry.
+
 A cell that is present but **`null`** errors the same way, naming the token and
 the row. It is the same failure one type down - the token says the value comes
 from the file and the file says there is none - and writing `""` for it would
@@ -5198,8 +5214,8 @@ knob.
   step**: nothing is sent, the step's `errors` count in the breakdown moves, and
   the run's error list carries an entry with `error_type: "data_binding_failed"`
   naming the token, the row and the row's columns. It is never substituted with
-  an empty string. A `null` cell and two headers binding to one name fail the
-  same step the same way.
+  an empty string. A `null` cell, two headers binding to one name, and a header
+  name a row binds to nothing fail the same step the same way.
 
   Every retained result carries **`dataRowIndex`** on its `trace`, which is how
   a failure is attributed to a row when no per-step `results` rows exist. Absent

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -486,8 +486,13 @@ where what would go out is a `": value"` line no name owns. Either is stopped
 rather than sent - in composition's words and under composition's refusal
 code, as a `statusCode: 0` response carrying the reason (a `400` on the
 streaming path, which has not answered yet, which is why the refusal carries
-the code as well as the error). Both rules read a name only where the pass
-reads one: a name that arrives already resolved is composition's to refuse. An unresolved `{"mode":"inherit"}` reaching an execution endpoint
+the code as well as the error). The two rules read a name over different
+reaches, decided rather than inherited (#1095): the empty-name rule reads
+**every** header name, so a name a script has just emptied and an empty key
+posted straight to `POST /execute` are refused here too, while the collision
+rule reads only the names that still held a token - a request that arrives
+already resolved cannot carry a collision to find, two names that are already
+equal being already one key. An unresolved `{"mode":"inherit"}` reaching an execution endpoint
 is treated as no auth and logged as a **warning** - it means a client skipped
 composition.
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -879,9 +879,16 @@ and the pre-send gate is no backstop for it - it reads header text for the
 bytes that end a line early, and an absent name ends nothing. The pass answers
 a `ResidualRefusal`, which carries the compose refusal code as well as the
 error, because the streaming send answers a `400` of its own and a code spelled
-at that call site is one that drifts from the rule it names. Both rules read a
-name only where this pass reads one, so a request posted already-resolved is
-composition's to refuse. Two entry shapes: `requestId` (stored request; MCP uses
+at that call site is one that drifts from the rule it names. **The two rules
+read different reaches, decided in #1095**: the empty-name rule reads every
+header name, so a name a script has just emptied and an empty key posted
+straight to `POST /execute` are refused here too, while the collision rule reads
+only the names that still held a token - a request that arrives already resolved
+cannot carry a collision to find, two names that are already equal being already
+one key. **A fourth layer *binds* a name** rather than resolving one: a data row
+whose header-name column is blank is refused at bind time
+(`core/scenario_data.cpp`), which the load path needs because it runs no
+residual pass over what it binds. Two entry shapes: `requestId` (stored request; MCP uses
 this, and gates its allowlist on the *composed* URL) and an inline `request`
 (+ `collectionId` scope; the renderer uses this because Send/replay execute
 *editor state*, which may be unsaved or detached). Inline over stored = the

--- a/engine/include/vayu/http/header_names.hpp
+++ b/engine/include/vayu/http/header_names.hpp
@@ -144,9 +144,10 @@ struct HeaderNameCollision {
 /**
  * @brief The refusal a header name that resolved to nothing reads as.
  *
- * One wording for the same three layers, on the reasoning above: a caller
- * meeting this at composition and again at execute time is meeting one rule,
- * and three spellings of it would read as three. A layer may name itself in
+ * One wording for four layers - the three above and the bind, which is one more
+ * than the collision rule reaches - on the same reasoning: a caller meeting this
+ * at composition, again at execute time and again from a data row is meeting one
+ * rule, and four spellings of it would read as four. A layer may name itself in
  * front of the wording, never inside it.
  *
  * @param written the name as the request carries it, before resolution. It is

--- a/engine/include/vayu/http/header_names.hpp
+++ b/engine/include/vayu/http/header_names.hpp
@@ -83,9 +83,10 @@
  * author can see either, and the gate is no backstop for it for the same reason
  * - it reads header text for the bytes that break a line, and an empty name
  * breaks nothing. What is left goes out as the line `": acme"`, under no name
- * at all. The three layers that resolve a name refuse it: composition and the
+ * at all. The three layers that resolve a name refuse it - composition and the
  * residual pass (issue #1084) and `pm.sendRequest` (issue #1067), which met it
- * first because a script writes header names of its own.
+ * first because a script writes header names of its own - and so does the one
+ * that *binds* a name from a data row (issue #1095, below).
  *
  * Unlike a collision, composition refuses this one however the name got there.
  * A collision has to be one resolution produced, because two names the author
@@ -95,12 +96,22 @@
  * that catches beyond a produced name is a caller that built the payload
  * itself.
  *
- * The other two layers see less, and neither rule pretends otherwise: the
- * residual pass reads a name only where the name held a `{{token}}`, so a
- * payload posted straight to `POST /execute` carrying an already-empty name is
- * composition's to refuse and this pass never looks at it - the same reach the
- * collision rule has there - and a name bound from a data row has no rule of
- * its own yet, where the collision rule does (issue #1095).
+ * **Every layer that can leave a header nameless refuses it** (issue #1095),
+ * which is one layer more than the collision rule has and one reach wider at
+ * the residual pass:
+ *
+ * - **A bound data cell** refuses it at bind time, in these words with the row
+ *   in front of them - a blank cell is an ordinary thing for a data file to
+ *   hold, and the load path runs no residual pass, so this is the layer or
+ *   nothing. It words the *collision* itself, because that message has to name
+ *   what the bound name collided with; this one has only the row to add.
+ * - **The residual pass** reads every name for this rule rather than only the
+ *   templated ones, so a name a script has just emptied and a payload posted
+ *   straight to `POST /execute` carrying an empty key are both refused. The
+ *   collision rule keeps the narrower reach and loses nothing by it: a request
+ *   that arrives already resolved cannot carry a collision to find, since
+ *   `Headers` holds one value per name and compares without case, so two names
+ *   that are already equal are already one.
  */
 
 namespace vayu::http {
@@ -141,6 +152,9 @@ struct HeaderNameCollision {
  * @param written the name as the request carries it, before resolution. It is
  *        the whole of what the message can name - what the name produced is
  *        nothing, and `{{blank}}` is what the author has to go and look at.
+ *        Empty for a name that arrived with nothing in it rather than resolving
+ *        to nothing, which is a subject with no spelling to quote and so the
+ *        one thing the wording says differently.
  */
 [[nodiscard]] std::string describe_empty_header_name (const std::string& written);
 

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -17,6 +17,9 @@
 #include <variant>
 
 #include "vayu/http/graphql_body.hpp"
+// `describe_empty_header_name` - the wording every layer that can leave a
+// header nameless shares, this one included (issue #1095).
+#include "vayu/http/header_names.hpp"
 // `ends_a_header_line` - the same rule the composer and the pre-send gate
 // apply, so a bound cell and a substituted variable cannot drift apart on what
 // a header may hold.
@@ -122,6 +125,27 @@ struct HeaderCollision {
 };
 
 /**
+ * What a bind did to the header map that leaves it not a request.
+ *
+ * Both are the same shape of quiet wrong request - a header the author did not
+ * write, under a name they cannot see - and both are the row's fault rather
+ * than the request's, which is why the walk reports them and the caller, which
+ * holds the row, words them.
+ */
+struct HeaderFaults {
+    /// A name a row bound to *nothing*, as the request carries it (issue
+    /// #1095). Held beside the collision rather than folded into it because it
+    /// is a different sentence, and reported ahead of it: two names that both
+    /// bind to nothing do collide, on a name neither of them has, and "they
+    /// bound alike" is not what the author needs to be told about them - the
+    /// order composition already answers these two in
+    /// (`http/request_composer.cpp`).
+    std::optional<std::string> emptied;
+    /// Two names that became one (issue #732).
+    std::optional<HeaderCollision> collision;
+};
+
+/**
  * The one list of strings a data row binds: URL, header names and values, raw
  * body, and both halves of every form field.
  *
@@ -138,14 +162,16 @@ struct HeaderCollision {
  * Each field is visited with the context it sits in, so the splitter can decide
  * a token's encoding from the same walk that hands out its position.
  *
- * Returns the first header collision the rebuild produced, for the caller to
- * refuse the bind over; `nullopt` for the ordinary walk. Only a *bind* can
- * produce one - `request.headers` is already a case-insensitive map, so its own
- * keys are unique - which is why a split never reports one.
+ * Returns the first fault of each kind the rebuild produced, for the caller to
+ * refuse the bind over; an empty @ref HeaderFaults for the ordinary walk. Only
+ * a *bind* can produce either, and that is why the split ignores what it
+ * reports: `request.headers` compares without case already, so two of its own
+ * keys cannot collide, and a name that is empty before any row is bound into it
+ * is one no row emptied - it is composition's to refuse, and composition does.
  */
 template <typename Visit>
-std::optional<HeaderCollision> walk_bindable_fields (vayu::Request& request, Visit&& visit) {
-    std::optional<HeaderCollision> collision;
+HeaderFaults walk_bindable_fields (vayu::Request& request, Visit&& visit) {
+    HeaderFaults faults;
 
     visit (request.url, FieldContext::Plain);
 
@@ -156,6 +182,14 @@ std::optional<HeaderCollision> walk_bindable_fields (vayu::Request& request, Vis
             std::string bound_value = value;
             visit (bound_name, FieldContext::Header);
             visit (bound_value, FieldContext::Header);
+            // Recorded before the collision below, on the reasoning in
+            // `HeaderFaults`. A name bound to nothing is still emplaced: what
+            // the walk owes its caller is the field count, and refusing here
+            // would make that depend on a row's contents exactly as an early
+            // return would.
+            if (bound_name.empty () && !faults.emptied) {
+                faults.emptied = name;
+            }
             // A plain `emplace` is first-wins and silent, and a dropped header
             // is exactly the quiet wrong request this namespace exists to
             // remove - worse than most, because the collision belongs to the
@@ -169,11 +203,11 @@ std::optional<HeaderCollision> walk_bindable_fields (vayu::Request& request, Vis
             // on a row's contents.
             auto [existing, inserted] =
             rebound.emplace (std::move (bound_name), std::move (bound_value));
-            if (!inserted && !collision) {
+            if (!inserted && !faults.collision) {
                 // `bound_name` was consumed by the failed emplace; the key that
                 // won says what it collided with, and says it in the spelling
                 // that survives.
-                collision = HeaderCollision{ name, existing->first };
+                faults.collision = HeaderCollision{ name, existing->first };
             }
         }
         request.headers = std::move (rebound);
@@ -188,7 +222,28 @@ std::optional<HeaderCollision> walk_bindable_fields (vayu::Request& request, Vis
         visit (field.value, FieldContext::Plain);
     }
 
-    return collision;
+    return faults;
+}
+
+/**
+ * The refusal a header name a row bound to nothing reads as (issue #1095).
+ *
+ * The row goes in front and the rule's own words follow, which is the shape
+ * `http/header_names.hpp` asks every layer that meets this rule for: a caller
+ * refused at composition and again at bind time is being refused over one rule,
+ * and two spellings of it would read as two. What this layer adds is the only
+ * thing the shared wording cannot know - which row bound the name away - and
+ * the column is inside the header as written, where that wording names it.
+ *
+ * The collision beside it words itself instead, and the difference is not an
+ * inconsistency: that message has to name what the bound name *collided with*,
+ * which is a fact about this request's other headers rather than about the
+ * rule.
+ */
+std::string describe_empty_bound_header_name (const std::string& written,
+const IterationBinding& binding) {
+    return "binding against " + bound_subject (binding) + ": " +
+    vayu::http::describe_empty_header_name (written);
 }
 
 /// The refusal a header collision reads as, in the same shape as the missing-
@@ -872,8 +927,9 @@ const vayu::http::BoundColumnNames& bound_columns) {
     // trade.
     vayu::Request scratch = request;
     FieldSplitter splitter (keeps_reserved_namespace, bound_columns);
-    // The collision the walk can report is a bind-time fault only: a split
-    // rewrites nothing, so the header map is rebuilt from its own unique keys.
+    // The faults the walk can report are bind-time ones only: a split rewrites
+    // nothing, so the header map is rebuilt from its own keys - which are
+    // unique, and empty only if they already were.
     (void)walk_bindable_fields (
     scratch, [&splitter] (const std::string& field, FieldContext context) {
         splitter (field, context);
@@ -1001,20 +1057,25 @@ const IterationBinding& binding) {
         return DataBindResult{ true, {} };
     }
     TemplateJoiner joiner (tmpl, binding);
-    auto collision = walk_bindable_fields (
+    HeaderFaults faults = walk_bindable_fields (
     request, [&joiner] (std::string& field, FieldContext context) {
         joiner (field, context);
     });
     DataBindResult result = joiner.result ();
     // A join failure is checked first because it is the earlier and more
     // specific fault: the joiner stops rewriting once it records one, so a
-    // collision seen after it is an artefact of a half-bound walk rather than
-    // anything the request actually says.
+    // header fault seen after it is an artefact of a half-bound walk rather
+    // than anything the request actually says.
     if (!result.ok) {
         return result;
     }
-    if (collision) {
-        return DataBindResult{ false, describe_header_collision (*collision, binding) };
+    if (faults.emptied) {
+        return DataBindResult{ false,
+            describe_empty_bound_header_name (*faults.emptied, binding) };
+    }
+    if (faults.collision) {
+        return DataBindResult{ false,
+            describe_header_collision (*faults.collision, binding) };
     }
     return result;
 }

--- a/engine/src/http/header_names.cpp
+++ b/engine/src/http/header_names.cpp
@@ -18,8 +18,14 @@ std::string describe_header_name_collision (const HeaderNameCollision& collision
 }
 
 std::string describe_empty_header_name (const std::string& written) {
-    return "header \"" + written +
-    "\" resolves to an empty name"
+    // A name that arrives already empty has no spelling to quote back, and
+    // `header "" resolves to an empty name` reads as a resolution that did not
+    // happen. Only the subject changes: the rest is the rule, word for word,
+    // which is the whole reason every layer reads it from here.
+    const std::string subject = written.empty () ?
+    std::string ("a header carries no name at all") :
+    "header \"" + written + "\" resolves to an empty name";
+    return subject +
     " - what would go out is a \": value\" line no name owns, so the request is"
     " refused rather than sent carrying a header the author cannot see";
 }

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -347,9 +347,29 @@ std::vector<std::string*> resolvable_strings (vayu::Request& request) {
     return targets;
 }
 
-bool a_header_name_holds_a_token (const vayu::Headers& headers) {
-    return std::any_of (headers.begin (), headers.end (),
-    [] (const auto& entry) { return holds_a_token (entry.first); });
+/**
+ * Whether the name map has to be read at all: a name still holding a token,
+ * which the walk below resolves, or a name that is already nothing, which it
+ * refuses.
+ *
+ * The second half is what widens this pass past the tokens (issue #1095). The
+ * gate exists so an ordinary request pays one search per field and no more, and
+ * asking whether a name is empty beside that search costs a compare on a map
+ * the search already walks - which buys the one thing a token search cannot
+ * see: a header a *script* has just left nameless, and a payload posted
+ * straight to `POST /execute` carrying an empty key. Neither is a name this
+ * pass resolved, and both are a `": value"` line going out under no name.
+ *
+ * The collision rule does not widen with it, and that is not the two rules
+ * drifting: a request that arrives already resolved cannot carry a collision to
+ * find, because `Headers` holds one value per name and compares without case,
+ * so two names that are already equal are already one. There is nothing there
+ * to see, where an empty name is in plain sight.
+ */
+bool a_header_name_needs_reading (const vayu::Headers& headers) {
+    return std::any_of (headers.begin (), headers.end (), [] (const auto& entry) {
+        return entry.first.empty () || holds_a_token (entry.first);
+    });
 }
 
 /// Both halves of a refusal from one wording: the pre-send gate's shape for the
@@ -378,16 +398,17 @@ ResidualRefusal refusal_of (std::string reason, std::string_view code) {
  * one wording: it is the same shape of quiet wrong request with the erased
  * header replaced by a `": value"` line no name owns, and this pass is the
  * layer composition cannot stand in for - the name a script has just defined is
- * one composition never saw. A name that arrives *already* empty holds no token
- * and so is never walked here at all, which is this pass's reach for both rules
- * alike: composition refuses that one (see issue #1095).
+ * one composition never saw. Since #1095 that rule reaches a name which arrives
+ * *already* empty as well, holding no token for the gate to find - see
+ * `a_header_name_needs_reading` for why this rule widened there and the
+ * collision rule did not.
  *
  * @return the first refusal, the headers left as they were; nothing, and the
  *         map rebuilt, when every name is still its own.
  */
 std::optional<ResidualRefusal> resolve_header_names (vayu::Headers& headers,
 const vayu::http::VariableValues& vars) {
-    if (!a_header_name_holds_a_token (headers)) {
+    if (!a_header_name_needs_reading (headers)) {
         return std::nullopt;
     }
     vayu::Headers resolved;
@@ -429,7 +450,7 @@ vayu::http::VariableValues values_from_scopes (const ScriptVariableScopes& scope
 std::optional<ResidualRefusal> resolve_residual_tokens (vayu::Request& request,
 const ScriptVariableScopes& scopes) {
     auto targets             = resolvable_strings (request);
-    const bool anything_left = a_header_name_holds_a_token (request.headers) ||
+    const bool anything_left = a_header_name_needs_reading (request.headers) ||
     std::any_of (targets.begin (), targets.end (),
     [] (const std::string* text) { return holds_a_token (*text); });
     if (!anything_left) {

--- a/engine/tests/residual_token_test.cpp
+++ b/engine/tests/residual_token_test.cpp
@@ -405,6 +405,55 @@ TEST (ResidualTokens, ARefusedEmptyNameLeavesTheHeadersAlone) {
     EXPECT_EQ (request.headers.count (""), 0u);
 }
 
+// --- a name that arrives already empty (#1095) -------------------------------
+//
+// The reach the two rules do not share. A name holding no token is one this
+// pass used to skip, so a script writing `pm.request.headers[""] = "acme"` and a
+// payload posted straight to `POST /execute` with an empty key both sent the
+// `": acme"` line the rule above exists to stop - the pre-send gate is no
+// backstop for it, since an absent name ends no line. The collision rule stays
+// where it was and loses nothing: two names that are already equal are already
+// one key, so there is no collision left to find in a request that arrives
+// resolved.
+//
+// Mutation-check for the two below: drop `entry.first.empty ()` from
+// `a_header_name_needs_reading` and the first fails on the refusal it no longer
+// gets, the second on the send it then allows.
+
+TEST (ResidualTokens, ANameThatArrivesAlreadyEmptyIsRefused) {
+    vayu::Request request;
+    request.url             = "https://api.example.com/x";
+    request.headers[""]     = "acme";
+    request.headers["Host"] = "api.example.com";
+
+    ScriptVariableScopes scopes;
+    const auto refusal = resolve_residual_tokens (request, scopes);
+
+    ASSERT_HAS_VALUE (refusal);
+    EXPECT_EQ (refusal->error.code, vayu::ErrorCode::InternalError);
+    EXPECT_EQ (refusal->code, "empty_header_name");
+    // No spelling to quote back, so the message says the subject rather than
+    // naming it - the one thing the shared wording says differently.
+    EXPECT_NE (refusal->error.message.find ("no name at all"), std::string::npos)
+    << refusal->error.message;
+    EXPECT_EQ (refusal->error.message.find ("resolves to an empty name"), std::string::npos)
+    << refusal->error.message;
+}
+
+/// The gate still answers "nothing to read" for the request that has neither, so
+/// the ordinary send pays the compare and no walk.
+TEST (ResidualTokens, ARequestWithNeitherATokenNorAnEmptyNameIsUntouched) {
+    vayu::Request request;
+    request.url                      = "https://api.example.com/x";
+    request.headers["Authorization"] = "Bearer real";
+    const vayu::Request before       = request;
+
+    ScriptVariableScopes scopes;
+    EXPECT_FALSE (resolve_residual_tokens (request, scopes));
+    EXPECT_EQ (request.headers, before.headers);
+    EXPECT_EQ (request.url, before.url);
+}
+
 // --- the exchange, on the wire -----------------------------------------------
 
 class ResidualTokenExchangeTest : public ::testing::Test {

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -239,6 +239,62 @@ TEST (ScenarioDataHeaderCollisionTest, HeadersThatStayDistinctStillBind) {
 }
 
 // ---------------------------------------------------------------------------
+// A header name a row binds to nothing (issue #1095)
+// ---------------------------------------------------------------------------
+//
+// The sibling of the collision above and the more reachable of the two: a blank
+// cell is an ordinary thing for a data file to hold, and this is the layer or
+// nothing - the load path runs no residual pass over what it binds, and the
+// pre-send gate reads a name for the bytes that end a line, which an absent
+// name does not have.
+//
+// Mutation-check for the three below: drop the `bound_name.empty ()` record in
+// `walk_bindable_fields` and the first two read `ok`, with the request carrying
+// the `": acme"` line each of them exists to stop.
+
+TEST (ScenarioDataEmptyHeaderNameTest, ABoundNameEmptiedByTheRowRefusesTheRow) {
+    auto request                  = request_with_url ("https://api.test/");
+    request.headers["{{data.h}}"] = "acme";
+
+    const auto result = bind_data_row (request, json::parse (R"({"h":""})"), 3);
+
+    EXPECT_FALSE (result.ok);
+    // Enough to fix the file without guessing: the header as written - which is
+    // where the column is named - and the row that emptied it.
+    EXPECT_NE (result.error.find ("{{data.h}}"), std::string::npos) << result.error;
+    EXPECT_NE (result.error.find ("row 3"), std::string::npos) << result.error;
+}
+
+TEST (ScenarioDataEmptyHeaderNameTest, TwoNamesEmptiedByTheRowAreRefusedAsNameless) {
+    // Both bind to the empty name, so they also collide - on a name neither of
+    // them has. The nearer fault is the one the author needs, which is the
+    // order composition answers these two in as well.
+    auto request                  = request_with_url ("https://api.test/");
+    request.headers["{{data.a}}"] = "first";
+    request.headers["{{data.b}}"] = "second";
+
+    const auto result = bind_data_row (request, json::parse (R"({"a":"","b":""})"), 0);
+
+    EXPECT_FALSE (result.ok);
+    EXPECT_NE (result.error.find ("empty name"), std::string::npos) << result.error;
+    EXPECT_EQ (result.error.find ("already resolves to"), std::string::npos)
+    << result.error;
+}
+
+TEST (ScenarioDataEmptyHeaderNameTest, ABlankCellThatLeavesTheNameANameStillBinds) {
+    // The rule is about the name the bind produced, not about the cell: `X-`
+    // is a header name a request can carry, so this is an ordinary bind and
+    // refusing it would be a rule nobody asked for.
+    auto request                    = request_with_url ("https://api.test/");
+    request.headers["X-{{data.h}}"] = "acme";
+
+    const auto result = bind_data_row (request, json::parse (R"({"h":""})"), 0);
+
+    ASSERT_TRUE (result.ok) << result.error;
+    EXPECT_EQ (request.headers.at ("X-"), "acme");
+}
+
+// ---------------------------------------------------------------------------
 // A cell that would end the header line it is bound into (issue #732)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

The two layers #1084 left. Both send the same line - `": acme"`, under a name the author did not write, with a value they did mean.

**Root cause, path 1.** `walk_bindable_fields` (`core/scenario_data.cpp`) rebuilds `request.headers` from the data row and refuses a collision (#732); nothing there asked whether the bound name was empty, so `{{data.header_name}}: acme` against a row whose cell is blank rebuilt as `("", "acme")` and the load run sent it once per iteration. It is the more reachable of the two - a blank cell in a data file is ordinary - and it is this layer or nothing: the load path runs no residual pass over what it binds, and the pre-send gate reads a name for the bytes that end a line early, which an absent name does not have.

**Root cause, path 2.** The residual pass read a header name only where the name still held a `{{token}}`, so a name that arrived *already* empty was never walked. `deserialize_request` (`utils/json.cpp:927-930`) copies a payload's header keys verbatim, so an empty key posted straight to `POST /execute` reached the wire - and so did one a pre-request script wrote, which is the case this pass exists for.

**Approach.** Path 1 gets the rule in the shape that layer already refuses a header in: the walk records the emptied name beside the collision and finishes as before (what it owes its caller is the field count, which an early return would make depend on a row's contents), and the caller - which holds the row - words the refusal as the row in front of `describe_empty_header_name`, the wording every layer that can leave a header nameless shares. It is reported *ahead* of a collision when a row does both, on the reasoning composition already answers these two in: two names that bind to nothing collide on a name neither of them has.

Path 2 was a decision rather than a patch, and it is taken rather than restated: the pass now reads **every** header name for the empty-name rule. The gate exists so an ordinary request pays one search per field, and asking whether a name is empty beside that search costs a compare on a map the search already walks - which buys the two cases a token search cannot see. The collision rule keeps the narrower reach and loses nothing by it: a request that arrives already resolved cannot carry a collision to find, since `Headers` holds one value per name and compares without case, so two names that are already equal are already one key. That asymmetry is why one rule widened and the other did not, and it is now written where the rules are rather than left to be derived.

`describe_empty_header_name` gained the one thing it could not say: a name that arrives already empty has no spelling to quote back, and `header "" resolves to an empty name` reads as a resolution that did not happen. Only the subject changes; the rule is word for word.

**The alternative I rejected**, and why: leaving path 2 as documented reach - the header's own doc block, `architecture.md` and `api-reference.md` all stated the limit already, so acceptance criterion 2 could have been met by prose alone. Two things decided against it. The limit was inherited from the collision rule, where it costs nothing because there is genuinely nothing to see; for an empty name there is something to see, in plain sight, for one compare. And the case it leaves open is not only a hand-built payload: `pm.request.headers[""] = "acme"` in a pre-request script is exactly the kind of name this pass was added to catch.

**Deliberately not covered**: a bind that only *shortens* a name. `X-{{data.h}}` with a blank cell binds to `X-`, which is a name a request can carry, so refusing it would be a rule the issue did not ask for. It is pinned by a test rather than left implicit.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2749 tests, 2749 passed, 0 failed**. No pre-existing failures on this base (`d9c6341`). `clang-format` 19.1.1 clean over every touched file, and checked to have reflowed nothing outside the lines this change edits.

Five new tests. Three assert a guard and were mutation-checked by removing that guard, rebuilding and re-running; two are controls, which must keep passing under the same mutation and did.

- `scenario_data_test.cpp` - `ABoundNameEmptiedByTheRowRefusesTheRow` (refused, naming the header as written and the row), `TwoNamesEmptiedByTheRowAreRefusedAsNameless` (the nearer fault, not the collision), and the control `ABlankCellThatLeavesTheNameANameStillBinds` (`X-{{data.h}}` -> `X-` still binds).
- `residual_token_test.cpp` - `ANameThatArrivesAlreadyEmptyIsRefused` (refusal shape, the compose code the streaming send answers with, and the no-spelling wording), and the control `ARequestWithNeitherATokenNorAnEmptyNameIsUntouched` (the fast path still short-circuits).

Measured, not assumed: with the `bound_name.empty ()` record dropped from `walk_bindable_fields`, the first two fail and the control passes; with `entry.first.empty ()` dropped from `a_header_name_needs_reading`, `ANameThatArrivesAlreadyEmptyIsRefused` fails and the other 17 `ResidualTokens` cases pass. Both guards restored, full suite re-run green.

Not run, with reason: the app suite and `pnpm type-check` (no `app/` file changed - the issue specifies no app changes, and tracing every consumer confirmed it: nothing in the renderer, MCP or the CLI branches on a bind refusal's code or text, they show a count or the sentence verbatim). `mkdocs build --strict` (mkdocs is not installed here) - the docs changes add no page, link, nav entry or heading, and CI's docs build is green on this branch.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/api-reference.md` (the scenario-run and scenario-load refusal lists, the single-send refusal table, and the `empty_header_name` code's stated reach), `docs/engine/architecture.md`, `docs/app/variable-resolution.md`, `engine/CLAUDE.md`, and `http/header_names.hpp`'s own rule block - each of which carried the `#1095` forward reference this closes. A second commit fixes one the first missed: `describe_empty_header_name`'s own docstring still said "the same three layers", which is the exact shape of stale line this issue was filed over.

## Related Issues

Closes #1095.