### PR TITLE
feat(engine): bind {{$vu}} in a credential - defer for the token carried, not the rows the run has - #1055

### DIFF
--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -159,13 +159,17 @@ same counter the data-row cursor claims from, so iteration *i* binds row
 *i % rows* and a script cannot be told it is on iteration 3 while holding row
 1's values.
 
-**Credentials are the one place they do not bind.** A `{{$vu}}` in a basic-auth
-username or a bearer token goes out written as it stands: a credential is
-encoded when the request is built, and the deferral that lets a *row* reach one
-first happens only in a run that has rows - so binding the identity there would
-work in a data-driven run and silently not in every other. #1055 tracks lifting
-that. Everywhere else binds: the URL, header names and values, the body and
-both halves of every form field, each escaped for the document it lands in.
+**Every bindable field binds, credentials included** (issue #1055): the URL,
+header names and values, the body and both halves of every form field, each
+escaped for the document it lands in - and a basic-auth username, a bearer
+token or an api key. A credential is encoded when the request is built, so one
+carrying either name defers that build and is bound before `apply_auth`
+encodes it, which is the same order a `{{data.*}}` credential has always taken.
+A run does not need a data set for it: the identity comes from the iteration
+rather than from a row, so `user-{{$vu}}` binds on a plain load run exactly as
+it does on a data-driven one. OAuth 2.0 is the exception, and it is refused by
+name rather than sent wrong - its token is acquired once, before any iteration
+exists.
 
 ### D18 - a bound row's bare column names outrank the environment (issue #1007)
 
@@ -672,8 +676,11 @@ still generates at composition - `POST /compose` defers only when the caller
 asks. And a generator inside an **auth credential** is still generated once, at
 composition: `apply_auth` encodes a credential when the request is built - basic
 auth collapses into one base64 value - so a token left for the bind would go out
-as base64 of its own text. That exception is the deferral issue #1055 carries,
-and it is the same reason a credential does not carry `{{$vu}}` either.
+as base64 of its own text. A `{{$vu}}` in a credential is no longer the same
+case: a credential carrying one defers the build and binds before `apply_auth`
+runs (issue #1055), where a generator has nothing to wait for - its value is
+knowable at composition, so deferring it would buy a different id per iteration
+rather than a correct one.
 
 ### The engine copy of the table
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3801,8 +3801,11 @@ and is never re-resolved - see [POST /execute](#post-execute) and
   either way, so it keeps its braces - issue #186), and a generator inside the
   **auth block** is generated here even when the field is true, because
   `apply_auth` encodes a credential when the request is built and a token left
-  for the bind would go out as base64 of its own text (the deferral issue #1055
-  carries). A scenario plan's steps are composed with it internally, so a
+  for the bind would go out as base64 of its own text. That is a generator's
+  case alone: a credential carrying a `{{data.*}}` or a `{{$vu}}` defers the
+  whole build and is bound before the encoding (issue #1055), where a generator
+  has nothing to wait for. A scenario plan's steps are composed with it
+  internally, so a
   collection run needs no field at all.
 
 - **`requestId`** composes the stored request wholesale: URL, flattened enabled
@@ -4900,9 +4903,12 @@ iterations, whatever the concurrency), and `{{$iteration}}` is that user's
 plain `POST /execute`. A variable named `$vu` does not answer for the identity,
 for the reason a variable named `data.id` does not answer for the column, and
 `{{$vus}}` is an ordinary unknown `$name` that keeps its braces. They bind
-everywhere a `data.*` token does **except the credential fields**: a credential
-is encoded at build time and the deferral that lets a row reach one first
-happens only in a run that has rows (issue #1055).
+everywhere a `data.*` token does, **credential fields included** (issue #1055):
+a credential carrying either name defers its build and is bound before
+`apply_auth` encodes it, on every run shape rather than only on one carrying
+rows, because the identity comes from the iteration rather than from a row. An
+OAuth 2.0 config is the exception and is refused by name - its token is acquired
+before any iteration exists.
 
 **A run binds only what it was given rows for.** A `POST /runs` carrying
 `scenario.data` binds per iteration, one carrying the top-level

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -396,11 +396,16 @@ applied to the outgoing request rather than being left to the UI. This lives in
 - **`auth_resolver`** (`apply_auth` / `preflight_auth` / `plan_auth_refresh`) - a
   typed `Auth` variant with an exhaustive per-mode handler: bearer/basic/api-key
   are injected inline; `oauth2` delegates to the token client. A user-supplied
-  `Authorization` header always wins. A scenario step whose credentials carry a
-  `{{data.*}}` token is the one case auth is *not* resolved into the plan: the
-  row has to be bound before the credential is encoded, so the step keeps its
-  typed `Auth` and applies it per iteration
+  `Authorization` header always wins. Credentials carrying a `{{data.*}}` or a
+  `{{$vu}}` / `{{$iteration}}` token are the one case auth is *not* resolved
+  into the plan: the value has to be bound before the credential is encoded, so
+  the step keeps its typed `Auth` and applies it per iteration
   (`bind_step_auth`, see [Scenario runs](api-reference.md#scenario-runs)).
+  **What is deferred is decided by the credentials, not by the run's shape**
+  (issue #1055): a build defers because these credentials carry a token, so a
+  run with no data set at all still binds `user-{{$vu}}`. An OAuth 2.0 config
+  carrying either kind is refused by name instead - its token is acquired once,
+  before any iteration exists, so no bind can reach it.
   `plan_auth_refresh` decides afterwards
   whether the credential a *load* run just resolved can be kept current past its
   expiry - see the run lifecycle below.
@@ -939,9 +944,13 @@ row exists - and the executor is the only thing that differs.
   single request has no sequence for an iteration to span, so the unit of a claim
   is the request. The templates are split once, when the run's one request is
   built (`RunContext::load_template`), the credentials defer exactly as a step's do,
-  and every retained result carries its `dataRowIndex`. **A run without rows
-  carries no set at all**, which is the throughput guard stated structurally: the
-  strategies test one pointer and otherwise submit the shared request they always
+  and every retained result carries its `dataRowIndex`. The credential half is
+  split onto `RunContext::load_auth` rather than onto the row set (issue #1055),
+  for the reason the request's template is: a credential carrying `{{$vu}}`
+  defers on a run that has no rows, so a set that exists only where rows do is
+  the wrong place to keep it. **A run without rows carries no set at all**, which
+  is the throughput guard stated structurally: the strategies test one pointer
+  and two empty templates, and otherwise submit the shared request they always
   did. The validation, the binder and the escaping are the scenario path's own
   functions rather than copies - `read_data_rows` and `bind_iteration`.
 - **The iteration's identity binds beside its row** (issue #994). `{{$vu}}` and

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -44,30 +44,48 @@ struct RunContext; // Forward declaration
  *
  * The request's own bindable fields are **not** here: they are split off the
  * built request onto `RunContext::load_template`, because a run with no rows at
- * all still binds its `{{$vu}}` / `{{$iteration}}` identity (issue #994). This
- * carries what only a data set has.
+ * all still binds its `{{$vu}}` / `{{$iteration}}` identity (issue #994). Nor
+ * are the credentials, for the same reason and since issue #1055 - see
+ * @ref LoadAuthPlan. This carries what only a data set has: the rows, and the
+ * bare names they answer.
  */
 struct LoadDataSet {
     /// The validated rows, in payload order. Never empty - a present-but-empty
     /// `data` array is refused by the route, and a run without rows carries no
     /// set at all.
     std::vector<nlohmann::json> rows;
-    /**
-     * The parsed auth, read only when @ref credentials is non-empty - which is
-     * exactly when the request's build was deferred and carries no credential
-     * until a row reaches it. `NoAuth` for every run whose auth the build
-     * applied.
-     */
-    vayu::http::Auth auth;
-    /// The credentials split around their `{{data.column}}` tokens; empty when
-    /// none carries one.
-    StepDataTemplate credentials;
     /// The bare column names @ref rows can bind (issue #1007), read off the
     /// rows once by `core::bound_columns_of`. It is what the run's split is
     /// told, so a bare `{{username}}` this set answers is bound per iteration
     /// rather than sent as the literal token - and a run without rows carries
     /// no set at all, so it is told nothing and splits as it always did.
     vayu::http::BoundColumnNames bound_columns;
+};
+
+/**
+ * How a *single-request* load run resolves its credentials (issue #1055).
+ *
+ * Beside @ref LoadDataSet rather than inside it, for the reason
+ * `RunContext::load_template` is: a credential carrying `{{$vu}}` defers on a
+ * run that has no rows at all, so a set that only exists when rows do cannot be
+ * where this lives. That was the whole of the old rule - deferral keyed to the
+ * run's shape rather than to what the credentials carry - and it is what made
+ * an identity token in a credential go out written as it stood.
+ *
+ * Empty credentials are the ordinary run, whose auth the build resolves once as
+ * it always did.
+ */
+struct LoadAuthPlan {
+    /**
+     * The parsed auth, read only when @ref credentials is non-empty - which is
+     * exactly when the request's build was deferred and carries no credential
+     * until the bind reaches it. `NoAuth` for every run whose auth the build
+     * applied.
+     */
+    vayu::http::Auth auth;
+    /// The credentials split around their `{{data.column}}` and
+    /// `{{$vu}}` / `{{$iteration}}` tokens; empty when none carries one.
+    StepDataTemplate credentials;
 
     /// What `build_request` must be told: the credentials are bound after the
     /// build, so an auth carrying a token must not be encoded during it.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -332,6 +332,23 @@ struct RunContext {
      */
     StepDataTemplate load_template;
 
+    /**
+     * How a *single-request* load run's credentials resolve (issue #1055) - the
+     * parsed auth and its split, read once off the payload before the run
+     * starts.
+     *
+     * **Empty credentials for every run whose auth the build resolved**, which
+     * is the same structural guard @ref load_template is: the strategies test
+     * `empty()` and otherwise submit the shared request they always did.
+     *
+     * Beside @ref load_data rather than inside it, because a credential
+     * carrying the identity defers on a run that has no rows at all - the set
+     * exists only where rows do, so a set is the wrong place to keep what every
+     * run shape can carry. Written once by `start_run`, read on the run's
+     * worker thread afterwards.
+     */
+    LoadAuthPlan load_auth;
+
     // Real-time counters (also tracked by MetricsCollector, but kept for backward compat)
     std::atomic<size_t> requests_sent{ 0 }; // Number of requests submitted to event loop
     std::atomic<size_t> requests_expected{ 0 }; // Total expected requests for this run
@@ -927,13 +944,20 @@ class RunManager {
      *             a run started with the raw payload alone would be trusting a
      *             check nobody ran. Null for a scenario run, whose rows travel
      *             on @p scenario.
+     * @param auth_plan How this run's credentials resolve (issue #1055), read
+     *             off the same payload by the same route. Passed beside @p data
+     *             rather than inside it because a credential carrying the
+     *             identity defers on a run that has no rows at all; default for
+     *             a run whose credentials carry no token, which is the build
+     *             resolving its auth once exactly as it always did.
      */
     bool start_run (const std::string& run_id,
     const nlohmann::json& config,
     vayu::db::Database& db,
     bool verbose,
     std::shared_ptr<const ScenarioExecution> scenario = nullptr,
-    std::unique_ptr<LoadDataSet> data                 = nullptr);
+    std::unique_ptr<LoadDataSet> data                 = nullptr,
+    LoadAuthPlan auth_plan                            = {});
 
     /**
      * @brief Start a scenario run: the same lifecycle, a different executor.

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -375,18 +375,22 @@ const StepDataTemplate& tmpl,
 const IterationBinding& binding);
 
 /**
- * Split @p auth's credential strings around their `{{data.column}}` tokens.
+ * Split @p auth's credential strings around their `{{data.column}}` tokens and
+ * their `{{$vu}}` / `{{$iteration}}` identity (issue #1055).
  *
- * **The data namespace only**: a credential carrying `{{$vu}}` - or a
- * `{{$guid}}`, which composition generates into a credential rather than
- * deferring (issue #995) - is deliberately not split here (issue #994).
- * Deferring a build is what lets a row reach a
- * credential before `apply_auth` encodes it, and a build is deferred only for a
- * run that *has* rows - so an identity token in a credential would bind in a
- * data-driven run and go out base64-encoded as written in every other, which is
- * a rule nobody could hold in their head. It goes out written as it stands in
- * both, loudly, and the identity binds the request rather than its credentials
- * (issue #1055 carries the deferral change that would lift this).
+ * **Both namespaces the bind can answer, and only those.** A `{{$guid}}` is not
+ * one of them: composition generates a generator inside the auth block rather
+ * than deferring it (issue #995), so none survives into a credential to be
+ * split, and one kept here would defer a build for a token that is already a
+ * value.
+ *
+ * The identity used to be excluded, because deferring a build was what let a
+ * row reach a credential and a build was deferred only for a run that *had*
+ * rows - so splitting it out would have bound `{{$vu}}` in a data-driven run
+ * and sent it base64-encoded as written in every other, which is a rule nobody
+ * could hold in their head. What changed is the deferral, not this: a build is
+ * deferred for the credentials that carry a token rather than for the runs that
+ * carry rows, so one rule now holds on every run shape.
  *
  * The same splitter the request walk drives, over `walk_auth_credentials`
  * instead of `walk_bindable_fields` - one field list per walk, and the join
@@ -412,19 +416,25 @@ const IterationBinding& binding);
 const vayu::http::BoundColumnNames& bound_columns = {});
 
 /**
- * Join @p tmpl's credentials against @p row, in place on @p auth.
+ * Join @p tmpl's credentials against @p binding, in place on @p auth.
  *
  * @p auth must be the parsed auth @p tmpl was split from, for the same reason
  * `apply_iteration_template` needs the request it was split from: a credential is
  * addressed by its position in the walk.
+ *
+ * The whole @ref IterationBinding rather than a row, and for the reason that
+ * type exists: a credential carrying `{{data.user}}` beside `{{$vu}}` is joined
+ * once, from both sources at once. A null row is not an error here - it is a run
+ * with no set at all, which answers the identity and refuses a data token by
+ * name (issue #1055).
  */
 [[nodiscard]] DataBindResult apply_auth_data_template (vayu::http::Auth& auth,
 const StepDataTemplate& tmpl,
-const nlohmann::json& row,
-size_t row_index);
+const IterationBinding& binding);
 
 /**
- * Bind @p auth's credentials against @p row and apply the result to @p request.
+ * Bind @p auth's credentials against @p binding and apply the result to
+ * @p request.
  *
  * The whole deferred-credential sequence in one place - join, then apply - for
  * every caller that built its request with `http::AuthResolution::Defer`. Both
@@ -444,14 +454,13 @@ size_t row_index);
  * deferred a build must only have done so for a non-empty template.
  *
  * No database handle reaches `apply_auth`: oauth2 is the only mode that needs
- * one, and an oauth2 config carrying a data token is refused before any build
- * is deferred (@ref first_oauth2_data_token).
+ * one, and an oauth2 config carrying a token this would defer for is refused
+ * before any build is deferred (@ref first_oauth2_deferrable_token).
  */
 [[nodiscard]] DataBindResult bind_auth_row (vayu::Request& request,
 vayu::http::Auth auth,
 const StepDataTemplate& tmpl,
-const nlohmann::json& row,
-size_t row_index);
+const IterationBinding& binding);
 
 /**
  * One iteration's whole bind, in the order that makes it correct: @p fields
@@ -470,8 +479,8 @@ size_t row_index);
  * it unconditionally. @p auth is only read when @p credentials is non-empty,
  * which is exactly when the request's build was deferred; a caller whose auth
  * was applied at build time passes its `NoAuth` and pays nothing. The
- * credentials are joined against @p binding's row alone - see
- * `tokenize_auth_fields` for why the identity stops at the request.
+ * credentials are joined against the whole of @p binding - its row where the
+ * run has one, and its identity, which every run has (issue #1055).
  *
  * On failure @p request is left partially bound and must not be sent - see
  * `apply_iteration_template`, whose rule this inherits.
@@ -483,8 +492,14 @@ const StepDataTemplate& credentials,
 const IterationBinding& binding);
 
 /**
- * The first data token in any string of @p value, recursively, written back
- * with its braces - or `nullopt` when it carries none.
+ * The first token a deferred credential could bind - a `{{data.column}}` or a
+ * `{{$vu}}` / `{{$iteration}}` identity - in any string of @p value,
+ * recursively, written back with its braces, or `nullopt` when it carries none.
+ *
+ * The same namespaces `tokenize_auth_fields` splits for, because this is the
+ * refusal that stands where that split cannot be honoured: a block deferral
+ * does not reach must refuse every token deferral would otherwise have bound,
+ * or the two disagree about which tokens mean anything (issue #1055).
  *
  * @p bound_columns extends the scan to the bare spelling (issue #1007), for the
  * same reason the bind reads it: a run's column reaching a block that cannot
@@ -496,26 +511,30 @@ const IterationBinding& binding);
  * is resolved. Object *keys* are not scanned - a column name where a config key
  * belongs is not a placement anyone means.
  */
-[[nodiscard]] std::optional<std::string> first_data_token_in (const nlohmann::json& value,
+[[nodiscard]] std::optional<std::string> first_deferrable_token_in (const nlohmann::json& value,
 const vayu::http::BoundColumnNames& bound_columns = {});
 
 /**
- * The first `{{data.column}}` in @p auth's OAuth 2.0 configuration, or
- * `nullopt` - for any other mode as well as for an oauth2 config carrying none.
+ * The first `{{data.column}}` or `{{$vu}}` / `{{$iteration}}` in @p auth's
+ * OAuth 2.0 configuration, or `nullopt` - for any other mode as well as for an
+ * oauth2 config carrying none.
  *
  * **OAuth 2.0 is the one mode deferral cannot serve**, and this is the check
  * that says so, for both callers that defer. Its token is acquired against the
  * token endpoint once - when a plan is resolved, or before a single send leaves
  * - so there is no later moment at which a row could reach the acquisition, the
  * way binding a credential before `apply_auth` encodes it reaches every other
- * mode. Refused by name rather than sent to the token endpoint as the literal
- * token text.
+ * mode. The identity is refused for the same reason and not a weaker one: it is
+ * known per iteration, and the acquisition happens before any iteration exists
+ * (issue #1055). Refused by name rather than sent to the token endpoint as the
+ * literal token text.
  *
  * Every other mode's credentials are walked by `walk_auth_credentials` and
  * bound; an oauth2 config is deliberately absent from that walk, which is why
  * it needs this second, config-shaped scan.
  */
-[[nodiscard]] std::optional<std::string> first_oauth2_data_token (const vayu::http::Auth& auth,
+[[nodiscard]] std::optional<std::string> first_oauth2_deferrable_token (
+const vayu::http::Auth& auth,
 const vayu::http::BoundColumnNames& bound_columns = {});
 
 /**

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -101,9 +101,11 @@ struct ScenarioStep {
     ///
     /// **Non-empty means this step's auth was deferred**: `request` carries no
     /// credential yet, and an executor must call `bind_step_auth` before
-    /// sending or the request goes out unauthenticated. Deferral only ever
-    /// happens in a run that has rows - a data token with no data set is
-    /// refused when the plan resolves - so an executor always has a row for it.
+    /// sending or the request goes out unauthenticated. An executor does *not*
+    /// always have a row for it: since issue #1055 a credential carrying only
+    /// the `{{$vu}}` / `{{$iteration}}` identity defers too, and the identity
+    /// needs no data set. A data token with no data set is still refused when
+    /// the plan resolves, so a row is there whenever a token wants one.
     StepDataTemplate auth_template{};
 };
 

--- a/engine/include/vayu/http/request_builder.hpp
+++ b/engine/include/vayu/http/request_builder.hpp
@@ -27,8 +27,12 @@ namespace vayu::http {
  * *before* they are encoded: a `{{data.column}}` token inside a credential has
  * to carry its row's value before `apply_auth` base64-encodes a username and
  * password into one header, because after that it is unreadable and would go
- * out as base64 of the literal token text (issue #591). Such a caller parses
- * the auth itself, joins it against the row and applies it afterwards -
+ * out as base64 of the literal token text (issue #591). The `{{$vu}}` /
+ * `{{$iteration}}` identity is deferred for the same reason and on the same
+ * rule (issue #1055): what decides a deferral is the token the credentials
+ * carry, never the shape of the run, so a caller with no data set at all still
+ * defers for an identity token and binds it per iteration. Such a caller parses
+ * the auth itself, joins it against the iteration and applies it afterwards -
  * `vayu::core::bind_auth_row` is that step, and it is the only correct way to
  * finish a deferred build. A `Defer` whose auth is never applied sends an
  * unauthenticated request.

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -926,7 +926,8 @@ DataRow read_data_row (const nlohmann::json& json, size_t max_bytes);
  * build, byte for byte as it did before this existed.
  *
  * `ok == false` carries the 400 the route answers with. There is one: an
- * OAuth 2.0 config carrying a data token, which no deferral can serve.
+ * OAuth 2.0 config carrying a token deferral would otherwise bind, which no
+ * deferral can serve.
  */
 struct SendRowAuth {
     bool ok = true;
@@ -947,10 +948,12 @@ struct SendRowAuth {
  * `vayu::core::bind_auth_row` is the half that happens after, and the two are
  * split exactly there because `build_request` sits between them.
  *
- * @p has_row is false for an ordinary send, which returns `Apply` with an empty
- * template and no refusal: without a row there is nothing to bind a token
- * against, so a `{{data.*}}` in a credential keeps today's goes-out-literal
- * behaviour rather than becoming a new refusal this endpoint never had.
+ * An ordinary send - a credential spelling no token at all - returns `Apply`
+ * with an empty template and no refusal, having parsed nothing. Whether the
+ * send carries a *row* is deliberately not asked (issue #1055): a credential
+ * carrying only the `{{$vu}}` / `{{$iteration}}` identity is bindable without
+ * one, and a `{{data.*}}` that does need a row is refused by name at the bind,
+ * the way the same token in the URL already was.
  *
  * @p bound_columns are the bare names the row can bind (issue #1007), so a
  * credential written `{{username}}` is deferred and joined against the row the
@@ -962,7 +965,6 @@ struct SendRowAuth {
  * drive it directly, matching the suite's other route-core tests.
  */
 SendRowAuth plan_send_row_auth (const nlohmann::json& json,
-bool has_row,
 const vayu::http::BoundColumnNames& bound_columns = {});
 
 /**
@@ -981,6 +983,12 @@ struct LoadDataRows {
     bool ok = true;
     std::string error;
     std::unique_ptr<vayu::core::LoadDataSet> set;
+    /// How this run's credentials resolve (issue #1055), read off the same
+    /// payload. Carried beside @ref set rather than inside it because a
+    /// credential spelling `{{$vu}}` defers on a run that has no rows at all;
+    /// default - and so `Apply` - for a scenario run, whose steps resolved
+    /// their own auth when the plan did.
+    vayu::core::LoadAuthPlan auth;
 };
 
 /**

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -351,10 +351,10 @@ const ResultAnnotations& annotations) {
 
 /**
  * Bind this submission's row - where the run has one - and its identity into
- * @p request, through the one binder both load paths drive.
+ * @p request and its credentials, through the one binder both load paths drive.
  *
- * Reached only for a run whose request carries a reserved token: the caller
- * keeps the token-free path clear of all of this.
+ * Reached only for a run carrying a reserved token in its request or its
+ * credentials: the caller keeps the token-free path clear of all of this.
  */
 DataBindResult bind_submission (vayu::Request& request,
 const RunContext& context,
@@ -368,14 +368,11 @@ const ResultAnnotations& annotations) {
         "a run carrying rows claims one per submission")),
         annotations.data_row_index.value_or (0),
         IterationIdentity{ SOLE_VIRTUAL_USER, iteration } };
-    // The auth halves are the data set's, and empty for a run without one: a
-    // credential deliberately does not carry the identity, which is the rule
-    // `tokenize_auth_fields` records.
-    static const vayu::http::Auth NO_AUTH{};
-    static const StepDataTemplate NO_CREDENTIALS{};
+    // The auth halves are the run's own, not the data set's: a credential
+    // carrying the identity defers on a run that has no set at all (issue
+    // #1055), and both are empty for a run whose auth the build resolved.
     return bind_iteration (request, context.load_template,
-    data == nullptr ? NO_AUTH : data->auth,
-    data == nullptr ? NO_CREDENTIALS : data->credentials, binding);
+    context.load_auth.auth, context.load_auth.credentials, binding);
 }
 
 /**
@@ -388,10 +385,10 @@ const ResultAnnotations& annotations) {
  * instead of the one whose lambda remembered them - and so does the
  * mid-run credential swap, which two of the four used to miss.
  *
- * **A run carrying neither takes the path it always did**: one null test and
- * one `empty()` test, then the same submit of the same shared request. No copy
- * and no bind - the throughput guard #992 states, kept structurally rather than
- * by measurement alone. What it does pay is the cursor increment below, which is
+ * **A run carrying none of them takes the path it always did**: one null test
+ * and two `empty()` tests, then the same submit of the same shared request. No
+ * copy and no bind - the throughput guard #992 states, kept structurally rather
+ * than by measurement alone. What it does pay is the cursor increment below, which is
  * one unsynchronised `size_t` on the sole producer thread and is what lets
  * every load run - not only the ones spelling a token - tell a deferred script
  * which iteration a sampled response was sent in.
@@ -409,7 +406,12 @@ SubmissionRequest& live) {
         std::optional<size_t> (iteration % data->rows.size ()),
         std::nullopt, iteration, SOLE_VIRTUAL_USER };
 
-    if (data == nullptr && context->load_template.empty ()) {
+    // The credentials are tested beside the request's own template because they
+    // are a third thing a submission can have to bind (issue #1055) - a run
+    // whose *only* token sits in a credential has no rows and an empty request
+    // template, and skipping the bind here would send it unauthenticated.
+    if (data == nullptr && context->load_template.empty () &&
+    context->load_auth.credentials.empty ()) {
         submit_to_loop (context, db, live.current (), annotations);
         return;
     }

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -980,7 +980,8 @@ const nlohmann::json& config,
 vayu::db::Database& db,
 bool verbose,
 std::shared_ptr<const ScenarioExecution> scenario,
-std::unique_ptr<LoadDataSet> data) {
+std::unique_ptr<LoadDataSet> data,
+LoadAuthPlan auth_plan) {
     return spawn_run (run_id, config, db, [&] (const std::shared_ptr<RunContext>& context) {
         // Set before either thread starts: the worker reads it to choose an
         // executor, and a later write would race the run it is meant to shape.
@@ -988,6 +989,9 @@ std::unique_ptr<LoadDataSet> data) {
         // Same rule, same moment: the worker splits this set's request template
         // before its first submission and every strategy reads it after.
         context->load_data = std::move (data);
+        // And the credential plan beside it, which `build_load_request` reads
+        // to decide whether the build resolves this run's auth at all.
+        context->load_auth = std::move (auth_plan);
         // Spawn metrics collection thread first - it is NOT detached and is
         // joined by the worker thread below.
         context->metrics_thread =
@@ -1118,15 +1122,18 @@ vayu::Request& request) {
     if (context->scenario) {
         return true;
     }
-    // Credentials carrying a `{{data.column}}` are the one case the build
-    // leaves alone: the row has to reach them before `apply_auth` base64s them
-    // out of reach (issue #591), so a run with rows tells the build to defer
-    // and `bind_iteration` applies them per submission. Every other run
+    // Credentials carrying a token are the one case the build leaves alone: the
+    // value has to reach them before `apply_auth` base64s them out of reach
+    // (issue #591), so a run whose credentials carry one tells the build to
+    // defer and `bind_iteration` applies them per submission. Every other run
     // resolves its auth here exactly as it always did.
-    const auto auth_resolution = context->load_data ?
-    context->load_data->auth_resolution () :
-    vayu::http::AuthResolution::Apply;
-    auto built = vayu::http::build_request (config, db_ptr, timeout_ms, auth_resolution);
+    //
+    // Asked of the credentials rather than of the run's rows (issue #1055):
+    // `{{$vu}}` binds off the iteration, so a run sent without `data` at all
+    // defers for it too. Keying this on whether the run had rows is what used
+    // to send an identity token in a credential base64-encoded as written.
+    auto built = vayu::http::build_request (
+    config, db_ptr, timeout_ms, context->load_auth.auth_resolution ());
     if (!built.ok) {
         vayu::utils::log_error (built.parse_failed ?
         std::string ("Load test: invalid request format") :

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -479,6 +479,20 @@ bool keeps_reserved_namespace (const std::string& name) {
     vayu::http::is_generator_variable_name (name);
 }
 
+/// Every kind of token a *credential* is split for (issue #1055): the row's
+/// columns and the iteration identity, which are the two the bind can answer
+/// once the build has been deferred.
+///
+/// A generator is deliberately not here, which is the one way this differs from
+/// `keeps_reserved_namespace`: composition generates a `{{$guid}}` inside the
+/// auth block rather than deferring it (issue #995), so no generator token
+/// survives into a credential for a split to find - and one kept here would
+/// defer a build for a token that is already a value.
+bool keeps_deferrable_credential_namespace (const std::string& name) {
+    return vayu::http::is_data_variable_name (name) ||
+    vayu::http::is_identity_variable_name (name);
+}
+
 /**
  * Split each visited field around the reserved tokens of one namespace, keeping
  * only the fields that carry one.
@@ -883,11 +897,10 @@ const vayu::http::BoundColumnNames& bound_columns) {
 
 StepDataTemplate tokenize_auth_fields (const vayu::http::Auth& auth,
 const vayu::http::BoundColumnNames& bound_columns) {
-    // The data namespace alone here - see the header for why a credential does
-    // not carry the identity. A bare column *is* the data namespace in its
-    // other spelling (issue #1007), so it is split here: a credential written
-    // `{{username}}` binds from the row exactly as `{{data.username}}` does.
-    FieldSplitter splitter (vayu::http::is_data_variable_name, bound_columns);
+    // A bare column *is* the data namespace in its other spelling (issue
+    // #1007), so it is split here: a credential written `{{username}}` binds
+    // from the row exactly as `{{data.username}}` does.
+    FieldSplitter splitter (keeps_deferrable_credential_namespace, bound_columns);
     vayu::http::walk_auth_credentials (auth,
     [&splitter] (const std::string& field, vayu::http::CredentialDestination destination) {
         splitter (field, credential_context (destination));
@@ -897,12 +910,10 @@ const vayu::http::BoundColumnNames& bound_columns) {
 
 DataBindResult apply_auth_data_template (vayu::http::Auth& auth,
 const StepDataTemplate& tmpl,
-const nlohmann::json& row,
-size_t row_index) {
+const IterationBinding& binding) {
     if (tmpl.empty ()) {
         return DataBindResult{ true, {} };
     }
-    const IterationBinding binding{ &row, row_index, IterationIdentity{} };
     TemplateJoiner joiner (tmpl, binding);
     // A bearer token and an api key sent in a header are header text, so a line
     // break in the cell behind one forges a header exactly as it would in
@@ -926,31 +937,24 @@ const IterationBinding& binding) {
     if (credentials.empty ()) {
         return DataBindResult{ true, {} };
     }
-    if (binding.row == nullptr) {
-        // Unreachable through either executor - a build is deferred only for a
-        // run that has rows - and a refusal rather than an assumption, because
-        // the alternative is sending base64 of the literal token text, which is
-        // the failure the deferral exists to remove and the one that hides.
-        return DataBindResult{ false,
-            "this request's credentials carry a data token, but the run has no "
-            "data set to bind them from" };
-    }
     // The credentials second, which is the whole reason this order lives in one
-    // place - see the header.
-    return bind_auth_row (request, auth, credentials, *binding.row, binding.row_index);
+    // place - see the header. A run with no set at all reaches this with a null
+    // row and is not refused here: the credentials may carry the identity
+    // alone, which needs no row (issue #1055), and a data token that does need
+    // one is refused by the join itself, naming the token the way it names one
+    // in a request field.
+    return bind_auth_row (request, auth, credentials, binding);
 }
 
 DataBindResult bind_auth_row (vayu::Request& request,
 vayu::http::Auth auth,
 const StepDataTemplate& tmpl,
-const nlohmann::json& row,
-size_t row_index) {
+const IterationBinding& binding) {
     if (tmpl.empty ()) {
         return DataBindResult{ true, {} };
     }
 
-    if (auto bound = apply_auth_data_template (auth, tmpl, row, row_index);
-    !bound.ok) {
+    if (auto bound = apply_auth_data_template (auth, tmpl, binding); !bound.ok) {
         return bound;
     }
 
@@ -962,12 +966,12 @@ size_t row_index) {
     return DataBindResult{ true, {} };
 }
 
-std::optional<std::string> first_data_token_in (const nlohmann::json& value,
+std::optional<std::string> first_deferrable_token_in (const nlohmann::json& value,
 const vayu::http::BoundColumnNames& bound_columns) {
     if (value.is_string ()) {
         const auto split = vayu::http::split_tokens (
         value.get<std::string> (), [&bound_columns] (const std::string& name) {
-            return vayu::http::is_data_variable_name (name) ||
+            return keeps_deferrable_credential_namespace (name) ||
             vayu::http::is_bound_column_name (name, bound_columns);
         });
         if (split.names.empty ()) {
@@ -977,7 +981,7 @@ const vayu::http::BoundColumnNames& bound_columns) {
     }
     if (value.is_object () || value.is_array ()) {
         for (const auto& child : value) {
-            if (auto found = first_data_token_in (child, bound_columns)) {
+            if (auto found = first_deferrable_token_in (child, bound_columns)) {
                 return found;
             }
         }
@@ -985,13 +989,13 @@ const vayu::http::BoundColumnNames& bound_columns) {
     return std::nullopt;
 }
 
-std::optional<std::string> first_oauth2_data_token (const vayu::http::Auth& auth,
+std::optional<std::string> first_oauth2_deferrable_token (const vayu::http::Auth& auth,
 const vayu::http::BoundColumnNames& bound_columns) {
     const auto* oauth2 = std::get_if<vayu::http::OAuth2Auth> (&auth);
     if (oauth2 == nullptr) {
         return std::nullopt;
     }
-    return first_data_token_in (oauth2->config, bound_columns);
+    return first_deferrable_token_in (oauth2->config, bound_columns);
 }
 
 DataBindResult apply_iteration_template (vayu::Request& request,

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -406,12 +406,12 @@ ScenarioPlan& plan) {
     // mean a network round trip per virtual user per iteration. Refused by
     // name in both directions, with or without a data set, rather than sent
     // to the token endpoint as the literal token text.
-    if (auto token = first_oauth2_data_token (parsed_auth, bound_columns)) {
+    if (auto token = first_oauth2_deferrable_token (parsed_auth, bound_columns)) {
         return (describe_step (index, row) + " carries " + *token +
         " in its OAuth 2.0 configuration. That token is acquired once, "
-        "when the run is planned, so a data column can never reach it - "
-        "use a static credential there, or move the data token into the "
-        "request itself.");
+        "when the run is planned, so neither a data column nor the "
+        "iteration identity can ever reach it - use a static credential "
+        "there, or move the token into the request itself.");
     }
 
     // Deferred through the builder's own option rather than by hiding the

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -469,9 +469,13 @@ ScenarioPlan& plan) {
     step.stored_url     = row.url;
     step.spec_operation = row.spec_operation.value_or (std::string ());
     step.data_template  = std::move (data_template);
-    // Only ever reached with rows behind it: the refusal above returns for
-    // a credential token in a run that has no data set, so a deferred step
-    // cannot arrive at an executor with no row to bind.
+    // A deferred step reaches an executor with a row behind it whenever it
+    // needs one: the refusal above returns for a credential carrying a *data*
+    // token in a run with no set. It does not for one carrying only the
+    // `{{$vu}}` / `{{$iteration}}` identity (issue #1055), which is deliberate
+    // and is why `first_data_token` is the scan there rather than the whole
+    // template - the identity binds off the iteration, so that step is
+    // perfectly runnable with no rows at all and must not be refused.
     if (!auth_template.empty ()) {
         step.auth          = parsed_auth;
         step.auth_template = std::move (auth_template);

--- a/engine/src/http/request_builder.cpp
+++ b/engine/src/http/request_builder.cpp
@@ -29,8 +29,9 @@ AuthResolution auth_resolution) {
     out.request            = parsed.value ();
     out.request.timeout_ms = timeout_ms;
 
-    // Deferred: the caller holds credentials that must bind a data row before
-    // they are encoded, and applies the auth itself once they have. Left
+    // Deferred: the caller holds credentials that must bind a data row or the
+    // iteration identity before they are encoded, and applies the auth itself
+    // once they have. Left
     // untouched here rather than applied-then-rewritten, because `apply_auth`
     // is not reversible - a base64 `Authorization` value cannot be un-collapsed
     // back into the username and password a row was meant to fill.

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -385,26 +385,28 @@ DataRow read_data_row (const nlohmann::json& json, size_t max_bytes) {
  * contract and for why the ordinary send is untouched.
  */
 SendRowAuth plan_send_row_auth (const nlohmann::json& json,
-bool has_row,
 const vayu::http::BoundColumnNames& bound_columns) {
     SendRowAuth out;
-    if (!has_row) {
-        // Not merely the same answer as an unbindable payload's - deliberately
-        // not parsing at all. `parse_auth` warns on an unresolved `inherit`,
-        // and on this path the build is about to parse the very same block; a
-        // second parse would double every such warning on the ordinary send.
+    const auto auth_json = json.value ("auth", nlohmann::json ());
+    // Asked of the payload's own JSON before anything is parsed, and this is
+    // why: `parse_auth` warns on an unresolved `inherit`, and the build is
+    // about to parse the very same block, so a second parse would double every
+    // such warning on the ordinary send. A block spelling no token at all -
+    // which is every ordinary send - is answered here, unparsed, exactly as the
+    // `has_row` test used to answer it (issue #1055).
+    if (!vayu::core::first_deferrable_token_in (auth_json, bound_columns)) {
         return out;
     }
-    out.auth = vayu::http::parse_auth (json.value ("auth", nlohmann::json ()));
+    out.auth = vayu::http::parse_auth (auth_json);
 
-    if (auto token = vayu::core::first_oauth2_data_token (out.auth, bound_columns)) {
+    if (auto token = vayu::core::first_oauth2_deferrable_token (out.auth, bound_columns)) {
         out.ok    = false;
         out.error = "Auth credentials carry " + *token +
-        " in an OAuth 2.0 configuration, and no row can reach it: the token is "
-        "acquired against the token endpoint before the request is sent, not "
-        "written into the request the way every other credential is. Use a "
-        "static credential there, or move the data token into the request "
-        "itself.";
+        " in an OAuth 2.0 configuration, and nothing can reach it: the "
+        "token is acquired against the token endpoint before the request "
+        "is sent, not written into the request the way every other "
+        "credential is. Use a static credential there, or move the token "
+        "into the request itself.";
         return out;
     }
 
@@ -425,17 +427,15 @@ LoadDataRows read_load_data_set (const nlohmann::json& json,
 const vayu::core::ScenarioLimits& limits,
 bool is_scenario) {
     LoadDataRows out;
-    const auto field = json.find ("data");
-    if (field == json.end () || field->is_null ()) {
-        return out;
-    }
+    const auto field       = json.find ("data");
+    const bool carries_set = field != json.end () && !field->is_null ();
 
     // A collection run states its rows inside the block that names the
     // collection, and the two are bound differently - one row per iteration
     // shared by every step there, one per submission here. Refused rather than
     // silently ignored: a caller that sent rows and had them dropped would read
     // a run of literal `{{data.*}}` tokens as the feature working.
-    if (is_scenario) {
+    if (carries_set && is_scenario) {
         out.ok    = false;
         out.error = "'data' is the single-request form of a data set. A "
                     "collection run states its rows as 'scenario.data', where "
@@ -444,30 +444,49 @@ bool is_scenario) {
         return out;
     }
 
-    auto set = std::make_unique<vayu::core::LoadDataSet> ();
-    // The same reader the scenario block goes through, so the two shapes cannot
-    // come to disagree about what a row is or which limit refuses it.
-    if (auto reason = vayu::core::read_data_rows (*field, limits, "data", set->rows)) {
-        out.ok    = false;
-        out.error = *reason;
+    std::unique_ptr<vayu::core::LoadDataSet> set;
+    if (carries_set) {
+        set = std::make_unique<vayu::core::LoadDataSet> ();
+        // The same reader the scenario block goes through, so the two shapes
+        // cannot come to disagree about what a row is or which limit refuses
+        // it.
+        if (auto reason =
+            vayu::core::read_data_rows (*field, limits, "data", set->rows)) {
+            out.ok    = false;
+            out.error = *reason;
+            return out;
+        }
+        set->bound_columns = vayu::core::bound_columns_of (set->rows);
+    }
+
+    // A scenario load run's credentials are its steps', resolved when the plan
+    // was: there is no single request here whose build could defer, and asking
+    // would refuse a top-level oauth2 block no step uses.
+    if (is_scenario) {
+        out.set = std::move (set);
         return out;
     }
 
     // How the credentials resolve, decided here because it is the *build* that
     // would otherwise encode them out of reach - the same call, and the same
     // reasoning, as a send that carries one row (issue #642). The refusal it
-    // can carry is an oauth2 config with a data token, which no deferral can
-    // serve.
-    set->bound_columns = vayu::core::bound_columns_of (set->rows);
-    auto row_auth = plan_send_row_auth (json, /*has_row=*/true, set->bound_columns);
+    // can carry is an oauth2 config carrying a token deferral would bind, which
+    // no deferral can serve.
+    //
+    // Asked of every run rather than only of one carrying rows (issue #1055):
+    // a credential spelling `{{$vu}}` defers without a set behind it, and it is
+    // this call that finds out. A run whose credentials spell no token parses
+    // nothing here and resolves its auth in the build, as it always did.
+    auto row_auth = plan_send_row_auth (
+    json, set ? set->bound_columns : vayu::http::BoundColumnNames{});
     if (!row_auth.ok) {
         out.ok    = false;
         out.error = std::move (row_auth.error);
         return out;
     }
-    set->auth        = std::move (row_auth.auth);
-    set->credentials = std::move (row_auth.credentials);
-    out.set          = std::move (set);
+    out.auth.auth        = std::move (row_auth.auth);
+    out.auth.credentials = std::move (row_auth.credentials);
+    out.set              = std::move (set);
     return out;
 }
 
@@ -1072,7 +1091,7 @@ read_execute_payload (RouteContext& ctx, const httplib::Request& req, ExecutePay
     const auto row_columns = data_row.value ?
     vayu::core::bound_columns_of (*data_row.value) :
     vayu::http::BoundColumnNames{};
-    auto row_auth = plan_send_row_auth (json, data_row.value.has_value (), row_columns);
+    auto row_auth          = plan_send_row_auth (json, row_columns);
     if (!row_auth.ok) {
         vayu::utils::log_warning ("POST /execute - " + row_auth.error);
         return row_auth.error;
@@ -1108,16 +1127,15 @@ read_execute_payload (RouteContext& ctx, const httplib::Request& req, ExecutePay
     // load run's.
     const vayu::core::IterationBinding binding{ data_row.value ? &*data_row.value : nullptr,
         /*row_index=*/0, vayu::core::IterationIdentity{} };
-    auto bound = vayu::core::apply_iteration_template (built.request,
-    vayu::core::tokenize_bindable_fields (built.request), binding);
-    if (bound.ok && data_row.value) {
-        // Then the credentials the build deferred, in the order the
-        // scenario executors bind theirs: the row reaches them before
-        // `apply_auth` encodes them onto the request. A no-op for the
-        // ordinary send, whose auth the build already applied.
-        bound = vayu::core::bind_auth_row (
-        built.request, row_auth.auth, row_auth.credentials, *data_row.value, 0);
-    }
+    // Both halves through the one binder both load paths drive, rather than the
+    // two calls and the row test this used to spell itself: the order is the
+    // whole of what makes a deferred credential correct, and a second copy of
+    // it here would be a copy that stops receiving that one's fixes. The
+    // credentials half is a no-op for the ordinary send, whose auth the build
+    // already applied.
+    auto bound = vayu::core::bind_iteration (built.request,
+    vayu::core::tokenize_bindable_fields (built.request), row_auth.auth,
+    row_auth.credentials, binding);
     if (!bound.ok) {
         vayu::utils::log_warning ("POST /execute - " + bound.error);
         return bound.error;
@@ -1872,7 +1890,8 @@ httplib::Response& res) {
     ctx.run_manager.start_scenario_run (
     run_id, json, scenario_execution, ctx.db, ctx.cookie_jar, ctx.verbose) :
     ctx.run_manager.start_run (run_id, json, ctx.db, ctx.verbose,
-    is_scenario_load ? scenario_execution : nullptr, std::move (load_data.set));
+    is_scenario_load ? scenario_execution : nullptr, std::move (load_data.set),
+    std::move (load_data.auth));
     if (!started) {
         send_error (res, 503, "Engine is shutting down");
         return;

--- a/engine/tests/load_data_test.cpp
+++ b/engine/tests/load_data_test.cpp
@@ -179,13 +179,14 @@ class LoadDataTest : public ::testing::Test {
         auto read = read_load_data_set (payload, stock_limits (), /*is_scenario=*/false);
         ASSERT_TRUE (read.ok) << read.error;
 
-        auto built = vayu::http::build_request (payload, db_.get (), /*timeout_ms=*/5000,
-        read.set ? read.set->auth_resolution () : vayu::http::AuthResolution::Apply);
+        auto built = vayu::http::build_request (
+        payload, db_.get (), /*timeout_ms=*/5000, read.auth.auth_resolution ());
         ASSERT_TRUE (built.ok) << built.error_message;
 
         auto context =
         std::make_shared<vayu::core::RunContext> ("test-load-data", payload);
         context->load_data = std::move (read.set);
+        context->load_auth = std::move (read.auth);
         context->load_template = vayu::core::tokenize_bindable_fields (built.request);
         vayu::http::EventLoopConfig loop_config;
         loop_config.max_concurrent = 100;
@@ -258,7 +259,7 @@ TEST (ReadLoadDataSet, RowsAreKeptInPayloadOrder) {
     ASSERT_EQ (read.set->rows.size (), 2u);
     EXPECT_EQ (read.set->rows[0]["id"], "a");
     EXPECT_EQ (read.set->rows[1]["id"], "b");
-    EXPECT_EQ (read.set->auth_resolution (), vayu::http::AuthResolution::Apply)
+    EXPECT_EQ (read.auth.auth_resolution (), vayu::http::AuthResolution::Apply)
     << "static credentials must still be applied by the build, exactly as they "
        "were before rows existed";
 }
@@ -332,8 +333,8 @@ TEST (ReadLoadDataSet, CredentialsCarryingATokenDeferTheBuild) {
     const auto read = read_load_data_set (payload, stock_limits (), false);
     ASSERT_TRUE (read.ok) << read.error;
     ASSERT_NE (read.set, nullptr);
-    EXPECT_FALSE (read.set->credentials.empty ());
-    EXPECT_EQ (read.set->auth_resolution (), vayu::http::AuthResolution::Defer)
+    EXPECT_FALSE (read.auth.credentials.empty ());
+    EXPECT_EQ (read.auth.auth_resolution (), vayu::http::AuthResolution::Defer)
     << "a credential carrying a row value must not be encoded by the build - "
        "after `apply_auth` the token is base64 of its own literal text";
 }

--- a/engine/tests/load_identity_test.cpp
+++ b/engine/tests/load_identity_test.cpp
@@ -52,6 +52,7 @@
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/encoding.hpp"
 
 namespace {
 
@@ -85,11 +86,11 @@ class RecordingServer {
         // readable off the wire rather than inferred from a counter the test
         // also owns.
         svr.Get (R"(/i/(.*))", [this] (const httplib::Request& req, httplib::Response& res) {
-            record ("/i/" + req.matches[1].str ());
+            record (req, "/i/" + req.matches[1].str ());
             res.set_content ("{}", "application/json");
         });
-        svr.Get ("/plain", [this] (const httplib::Request&, httplib::Response& res) {
-            record ("/plain");
+        svr.Get ("/plain", [this] (const httplib::Request& req, httplib::Response& res) {
+            record (req, "/plain");
             res.set_content ("{}", "application/json");
         });
 
@@ -117,10 +118,20 @@ class RecordingServer {
         return paths_;
     }
 
+    /// Every `Authorization` answered, in arrival order. Read off the wire for
+    /// the reason `load_data_test.cpp`'s listener is: a credential is only
+    /// correct once `apply_auth` has encoded it, and base64 is where a bind in
+    /// the wrong order hides.
+    [[nodiscard]] std::vector<std::string> authorizations () const {
+        std::lock_guard<std::mutex> lock (paths_mtx_);
+        return authorizations_;
+    }
+
     private:
-    void record (const std::string& path) {
+    void record (const httplib::Request& req, const std::string& path) {
         std::lock_guard<std::mutex> lock (paths_mtx_);
         paths_.push_back (path);
+        authorizations_.push_back (req.get_header_value ("Authorization"));
     }
 
     httplib::Server svr;
@@ -128,6 +139,7 @@ class RecordingServer {
     int port = 0;
     mutable std::mutex paths_mtx_;
     std::vector<std::string> paths_;
+    std::vector<std::string> authorizations_;
 };
 
 constexpr const char* TEST_DB_PATH = "test_load_identity.db";
@@ -166,13 +178,14 @@ class LoadIdentityTest : public ::testing::Test {
         payload, stock_limits (), /*is_scenario=*/false);
         ASSERT_TRUE (read.ok) << read.error;
 
-        auto built = vayu::http::build_request (payload, db_.get (), /*timeout_ms=*/5000,
-        read.set ? read.set->auth_resolution () : vayu::http::AuthResolution::Apply);
+        auto built = vayu::http::build_request (
+        payload, db_.get (), /*timeout_ms=*/5000, read.auth.auth_resolution ());
         ASSERT_TRUE (built.ok) << built.error_message;
 
         auto context =
         std::make_shared<vayu::core::RunContext> ("test-load-identity", payload);
         context->load_data     = std::move (read.set);
+        context->load_auth     = std::move (read.auth);
         context->load_template = tokenize_bindable_fields (built.request);
         context->test_script   = payload.value ("tests", std::string ());
         vayu::http::EventLoopConfig loop_config;
@@ -403,6 +416,78 @@ TEST_F (LoadIdentityTest, ARunWithoutTheTokensCarriesAnEmptyTemplate) {
     << "a request naming neither token must leave nothing for the executor to "
        "walk per submission";
     EXPECT_EQ (server.paths ().size (), 2u);
+}
+
+// ============================================================================
+// The identity inside a credential (issue #1055)
+// ============================================================================
+
+// The headline: a basic-auth username carrying `{{$vu}}` on a run with **no
+// data set at all**. Read base64-decoded off the wire, because that encoding is
+// exactly what used to hide the literal token text going out.
+TEST_F (LoadIdentityTest, ACredentialBindsTheIdentityOnARunWithNoDataSet) {
+    RecordingServer server;
+    json payload    = iterations_payload (server.url ("/plain"), 3);
+    payload["auth"] = { { "mode", "basic" },
+        { "username", "user-{{$iteration}}" }, { "password", "pw" } };
+
+    run (payload);
+
+    std::vector<std::string> sent = server.authorizations ();
+    std::sort (sent.begin (), sent.end ());
+    ASSERT_EQ (sent.size (), 3u);
+    for (size_t i = 0; i < sent.size (); ++i) {
+        EXPECT_EQ (sent[i],
+        "Basic " + vayu::utils::base64_encode ("user-" + std::to_string (i) + ":pw"))
+        << "iteration "
+        << i << " must reach the wire bound, on a run that carries no rows to defer for";
+    }
+}
+
+// The other half of the same rule, and the one the old behaviour got right by
+// accident: a run whose credentials carry no token must still resolve its auth
+// in the build. Asserted rather than assumed, because this is the throughput
+// guard - a run that started deferring here would pay `apply_auth` per
+// submission for nothing.
+TEST_F (LoadIdentityTest, StaticCredentialsStillResolveInTheBuild) {
+    RecordingServer server;
+    json payload = iterations_payload (server.url ("/plain"), 2);
+    payload["auth"] = { { "mode", "basic" }, { "username", "ada" }, { "password", "pw" } };
+
+    run (payload);
+
+    EXPECT_TRUE (context_->load_auth.credentials.empty ())
+    << "credentials naming no token must leave nothing for the executor to "
+       "join";
+    EXPECT_EQ (context_->load_auth.auth_resolution (), vayu::http::AuthResolution::Apply);
+    EXPECT_TRUE (context_->load_template.empty ());
+
+    const auto sent = server.authorizations ();
+    ASSERT_EQ (sent.size (), 2u);
+    for (const auto& authorization : sent) {
+        EXPECT_EQ (authorization, "Basic " + vayu::utils::base64_encode ("ada:pw"))
+        << "the build's own encoding must still be what goes out";
+    }
+}
+
+// An identity token in an oauth2 config is refused by name, for the reason a
+// data column is: the token is acquired against the token endpoint once, before
+// any iteration exists, so no bind can ever reach it.
+TEST_F (LoadIdentityTest, AnIdentityTokenInAnOAuth2ConfigIsRefusedByName) {
+    const json payload = { { "url", "https://example.test/" },
+        { "auth",
+        { { "mode", "oauth2" },
+        { "config",
+        { { "grantType", "client_credentials" }, { "clientId", "client-{{$vu}}" },
+        { "tokenUrl", "https://issuer.example/token" } } } } } };
+
+    const auto read = vayu::http::routes::read_load_data_set (payload, stock_limits (),
+    /*is_scenario=*/false);
+
+    EXPECT_FALSE (read.ok);
+    EXPECT_NE (read.error.find ("{{$vu}}"), std::string::npos)
+    << "the refusal must name the token that cannot be served: " << read.error;
+    EXPECT_NE (read.error.find ("OAuth 2.0"), std::string::npos) << read.error;
 }
 
 // What a deferred `tests` script is told about the response it is grading. Both

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -989,8 +989,10 @@ namespace {
 vayu::core::DataBindResult
 bind_auth (vayu::Request& request, const json& auth, const json& row, size_t row_index) {
     const auto parsed = vayu::http::parse_auth (auth);
+    const vayu::core::IterationBinding binding{ &row, row_index,
+        vayu::core::IterationIdentity{} };
     return vayu::core::bind_auth_row (
-    request, parsed, vayu::core::tokenize_auth_fields (parsed), row, row_index);
+    request, parsed, vayu::core::tokenize_auth_fields (parsed), binding);
 }
 
 } // namespace

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -989,6 +989,42 @@ TEST_F (ScenarioLoadTest, ACredentialsFileBindsPerIterationOnTheWire) {
     "Basic " + vayu::utils::base64_encode ("bob:pw1") }));
 }
 
+// The same bind on a collection run that carries **no data set at all** (issue
+// #1055). This is the run shape the old rule could not serve: deferral was
+// keyed to the run having rows, so a step's `{{$vu}}` credential went out
+// base64-encoded as written. Two virtual users, so the assertion is about each
+// binding its *own* number rather than both binding `1` - which is what a bind
+// that dropped the caller's identity would produce.
+TEST_F (ScenarioLoadTest, AStepCredentialBindsTheIdentityWithNoDataSet) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/echo") });
+    with_deferred_auth (execution,
+    json{ { "mode", "basic" }, { "username", "user-{{$vu}}" }, { "password", "pw" } });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 2 }, { "vus", 2 } };
+    run (config, execution);
+
+    std::vector<std::string> sent;
+    for (const auto& hit : server.hits_for ("/echo")) {
+        sent.push_back (hit.authorization);
+    }
+    std::sort (sent.begin (), sent.end ());
+    ASSERT_FALSE (sent.empty ()) << "no step reached the wire";
+    for (const auto& authorization : sent) {
+        EXPECT_NE (authorization.find ("Basic "), std::string::npos) << authorization;
+    }
+    // Every credential that left carries a bound number rather than the token
+    // text, and the set of numbers is the set of users that sent.
+    for (const auto& authorization : sent) {
+        EXPECT_EQ (authorization.find ("{{$vu}}"), std::string::npos)
+        << "the token text reached the wire base64-encoded as written: " << authorization;
+    }
+    EXPECT_TRUE (std::find (sent.begin (), sent.end (),
+                 "Basic " + vayu::utils::base64_encode ("user-1:pw")) != sent.end ())
+    << "virtual user 1 must authenticate as itself";
+}
+
 // The credential half of the failure path: a column the row does not carry ends
 // the step before the send, exactly as one in the URL does - never a request
 // with a blank password.

--- a/engine/tests/send_with_row_test.cpp
+++ b/engine/tests/send_with_row_test.cpp
@@ -65,6 +65,7 @@
 namespace {
 
 using nlohmann::json;
+using vayu::core::apply_auth_data_template;
 using vayu::core::bind_auth_row;
 using vayu::core::bind_data_row;
 using vayu::http::routes::plan_send_row_auth;
@@ -163,7 +164,7 @@ TEST (SendWithRowAuth, StaticCredentialsResolveInTheBuild) {
     const json payload{ { "auth",
     { { "mode", "basic" }, { "username", "ada" }, { "password", "s3cret" } } } };
 
-    const auto plan = plan_send_row_auth (payload, true);
+    const auto plan = plan_send_row_auth (payload);
     EXPECT_TRUE (plan.ok);
     EXPECT_TRUE (plan.credentials.empty ());
     EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
@@ -172,7 +173,7 @@ TEST (SendWithRowAuth, StaticCredentialsResolveInTheBuild) {
 TEST (SendWithRowAuth, AbsentAuthResolvesInTheBuild) {
     for (const auto& payload :
     { json{ { "url", "http://x/" } }, json{ { "auth", nullptr } } }) {
-        const auto plan = plan_send_row_auth (payload, true);
+        const auto plan = plan_send_row_auth (payload);
         EXPECT_TRUE (plan.ok);
         EXPECT_TRUE (plan.credentials.empty ());
         EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
@@ -186,25 +187,59 @@ TEST (SendWithRowAuth, CredentialTokenDefersTheAuth) {
     const json payload{ { "auth",
     { { "mode", "basic" }, { "username", "{{data.user}}" }, { "password", "s3cret" } } } };
 
-    const auto plan = plan_send_row_auth (payload, true);
+    const auto plan = plan_send_row_auth (payload);
     ASSERT_TRUE (plan.ok);
     EXPECT_FALSE (plan.credentials.empty ());
     EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Defer);
     EXPECT_EQ (plan.credentials.first_data_token ().value_or (""), "{{data.user}}");
 }
 
-/// Without a row there is nothing to bind against, so the token keeps the
-/// behaviour it has always had here rather than becoming a refusal or a
-/// deferral that never applies - a deferred build whose auth is never applied
-/// would send the request unauthenticated.
-TEST (SendWithRowAuth, NoRowNeverDefers) {
+/// A data token with no row defers and is then **refused by name** at the bind
+/// (issue #1055), which is what the same token in the URL has always done. It
+/// used to be answered here, unparsed, as `Apply` - so the credential went out
+/// as base64 of its own literal text while the URL beside it was a 400.
+///
+/// The deferral is safe precisely because the bind is unconditional: a deferred
+/// build whose auth was never applied would send the request unauthenticated,
+/// so the refusal below is what stands in place of that.
+TEST (SendWithRowAuth, ADataTokenWithNoRowDefersAndIsRefusedByName) {
     const json payload{ { "auth",
     { { "mode", "basic" }, { "username", "{{data.user}}" }, { "password", "s3cret" } } } };
 
-    const auto plan = plan_send_row_auth (payload, false);
-    EXPECT_TRUE (plan.ok);
-    EXPECT_TRUE (plan.credentials.empty ());
-    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
+    const auto plan = plan_send_row_auth (payload);
+    ASSERT_TRUE (plan.ok) << plan.error;
+    EXPECT_FALSE (plan.credentials.empty ());
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Defer);
+
+    vayu::Request request;
+    const vayu::core::IterationBinding no_row{ nullptr, 0, vayu::core::IterationIdentity{} };
+    const auto bound = bind_auth_row (request, plan.auth, plan.credentials, no_row);
+    EXPECT_FALSE (bound.ok) << "a credential naming a column no row can answer "
+                               "must be refused, never sent as its own text";
+    EXPECT_NE (bound.error.find ("{{data.user}}"), std::string::npos) << bound.error;
+}
+
+/// The identity needs no row at all, which is the whole of issue #1055: a
+/// single send is a run of one, so `{{$vu}}` answers `1` here rather than
+/// reaching the wire base64-encoded as written.
+TEST (SendWithRowAuth, AnIdentityTokenDefersWithNoRowAndBindsToTheRunOfOne) {
+    const json payload{ { "auth",
+    { { "mode", "basic" }, { "username", "user-{{$vu}}" }, { "password", "s3cret" } } } };
+
+    const auto plan = plan_send_row_auth (payload);
+    ASSERT_TRUE (plan.ok) << plan.error;
+    EXPECT_FALSE (plan.credentials.empty ())
+    << "an identity token in a credential must defer the build";
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Defer);
+
+    vayu::Request request;
+    const vayu::core::IterationBinding no_row{ nullptr, 0, vayu::core::IterationIdentity{} };
+    auto auth = plan.auth;
+    const auto bound = apply_auth_data_template (auth, plan.credentials, no_row);
+    ASSERT_TRUE (bound.ok) << bound.error;
+    const auto* basic = std::get_if<vayu::http::BasicAuth> (&auth);
+    ASSERT_NE (basic, nullptr);
+    EXPECT_EQ (basic->username, "user-1");
 }
 
 /// An ordinary `{{user}}` is not a data token - it is a variable composition
@@ -212,7 +247,7 @@ TEST (SendWithRowAuth, NoRowNeverDefers) {
 TEST (SendWithRowAuth, OrdinaryVariableIsNotADataToken) {
     const json payload{ { "auth", { { "mode", "bearer" }, { "token", "{{apiToken}}" } } } };
 
-    const auto plan = plan_send_row_auth (payload, true);
+    const auto plan = plan_send_row_auth (payload);
     EXPECT_TRUE (plan.ok);
     EXPECT_TRUE (plan.credentials.empty ());
     EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
@@ -228,7 +263,7 @@ TEST (SendWithRowAuth, Oauth2DataTokenIsRefusedByName) {
     { { "grantType", "client_credentials" }, { "clientId", "{{data.client}}" },
     { "tokenUrl", "https://issuer.example/token" } } } } } };
 
-    const auto plan = plan_send_row_auth (payload, true);
+    const auto plan = plan_send_row_auth (payload);
     ASSERT_FALSE (plan.ok);
     EXPECT_NE (plan.error.find ("{{data.client}}"), std::string::npos);
     EXPECT_NE (plan.error.find ("OAuth 2.0"), std::string::npos);
@@ -242,7 +277,7 @@ TEST (SendWithRowAuth, Oauth2DataTokenIsRefusedByName) {
 /// endpoint as the literal text `{{client}}`, which is the silent wrong request
 /// the prefixed spelling has been refused for since #591.
 ///
-/// Mutation-check: drop `bound_columns` from `first_oauth2_data_token` and this
+/// Mutation-check: drop `bound_columns` from `first_oauth2_deferrable_token` and this
 /// send is accepted.
 TEST (SendWithRowAuth, ABoundColumnInAnOauth2ConfigIsRefusedToo) {
     const json payload{ { "auth",
@@ -251,7 +286,7 @@ TEST (SendWithRowAuth, ABoundColumnInAnOauth2ConfigIsRefusedToo) {
     { { "grantType", "client_credentials" }, { "clientId", "{{client}}" },
     { "tokenUrl", "https://issuer.example/token" } } } } } };
 
-    const auto plan = plan_send_row_auth (payload, true, { "client" });
+    const auto plan = plan_send_row_auth (payload, { "client" });
     ASSERT_FALSE (plan.ok);
     EXPECT_NE (plan.error.find ("{{client}}"), std::string::npos) << plan.error;
     EXPECT_NE (plan.error.find ("OAuth 2.0"), std::string::npos) << plan.error;
@@ -259,7 +294,7 @@ TEST (SendWithRowAuth, ABoundColumnInAnOauth2ConfigIsRefusedToo) {
     // And the same config with no row bound to that name is untouched: the
     // refusal is about a column reaching a block that cannot defer, not about
     // every `{{name}}` in an oauth2 config.
-    const auto unbound = plan_send_row_auth (payload, true);
+    const auto unbound = plan_send_row_auth (payload);
     EXPECT_TRUE (unbound.ok) << unbound.error;
 }
 
@@ -272,7 +307,7 @@ TEST (SendWithRowAuth, Oauth2WithoutADataTokenIsNotRefused) {
     { { "grantType", "client_credentials" }, { "clientId", "static-client" },
     { "tokenUrl", "https://issuer.example/token" } } } } } };
 
-    const auto plan = plan_send_row_auth (payload, true);
+    const auto plan = plan_send_row_auth (payload);
     EXPECT_TRUE (plan.ok);
     EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
 }
@@ -329,7 +364,7 @@ class SendWithRowTest : public ::testing::Test {
     static RowSend build_with_row (const json& payload, const json& row) {
         RowSend out;
 
-        const auto plan = plan_send_row_auth (payload, true);
+        const auto plan = plan_send_row_auth (payload);
         if (!plan.ok) {
             return RowSend{ false, plan.error, {} };
         }
@@ -342,7 +377,9 @@ class SendWithRowTest : public ::testing::Test {
 
         auto bound = bind_data_row (out.request, row, 0);
         if (bound.ok) {
-            bound = bind_auth_row (out.request, plan.auth, plan.credentials, row, 0);
+            const vayu::core::IterationBinding binding{ &row, 0,
+                vayu::core::IterationIdentity{} };
+            bound = bind_auth_row (out.request, plan.auth, plan.credentials, binding);
         }
         out.ok    = bound.ok;
         out.error = bound.error;


### PR DESCRIPTION
## Description

A basic-auth username of `user-{{$vu}}` was base64-encoded with the token text still in it and went out that way. Loud by #186's rule, but not what the author asked for.

**Root cause.** A credential is encoded when the request is built, so a value reaches one only if the build was deferred (#591) - and a build was deferred only for a run carrying `data` rows, because rows were the case deferral was added for. `tokenize_auth_fields` enforced that by refusing the identity namespace outright, so "do these credentials carry an identity token" was a question the code could not ask.

**Approach.** The deferral moves rather than the split: a build defers for the credentials that carry a token instead of for the runs that carry rows, so one rule holds on every run shape. Three sites decided it; two spelled it as the run's shape (`build_load_request` asked whether the run had a `LoadDataSet`; `plan_send_row_auth` returned before parsing unless the send had a row). The third, `resolve_step`, already asked the template, which is why the scenario path needed nothing but the wider split.

**The alternative I rejected**, and why: splitting the identity out of `tokenize_auth_fields` and leaving the deferral keyed to rows. That is the smaller diff and it is the one the old code comment explicitly warned against - it would bind `{{$vu}}` in a data-driven run and silently not in any other. One rule that is wrong everywhere beats two that differ by whether a data file happens to be attached.

Most of this is deletion. `TemplateJoiner` already answers `{{$vu}}` from the binding's identity before it looks at the row, and already refuses a data token with no row by naming it - so `bind_auth_row` and `apply_auth_data_template` take the whole `IterationBinding` the request half takes, and `bind_iteration`'s eager null-row refusal goes: the join refuses the same case one layer down, naming the token the way it names one in a URL.

**The trap this had to disarm:** `apply_auth_data_template` built its own binding with a hardcoded `IterationIdentity{}`. Widening the split alone would have bound every virtual user's credential to `vu=1` - silently, and the same defect one layer over. That is what the wire tests below are shaped to catch.

The credentials leave `LoadDataSet` for `RunContext::load_auth`, following `load_template`, which left it in #994 for exactly this reason: a set that exists only where rows do cannot hold what a rowless run carries.

### Deliberate deviations from the issue spec

- **`POST /execute` gains a refusal it did not have.** A credential naming a column no row can answer is now refused by name rather than sent as its own text. The issue did not ask for this; it falls out of dropping the `has_row` gate, and it makes credentials behave exactly like request fields, which have refused that token on this endpoint all along. Removing the divergence seemed better than preserving it by special case. The auth block is scanned before anything is parsed, so an ordinary send still parses once and `parse_auth`'s `inherit` warning is not doubled - which is what the `has_row` early return was actually protecting.
- **`first_data_token_in` renamed to `first_deferrable_token_in`** (and its OAuth 2.0 wrapper with it). The scanned set changed, so the old name would describe it wrongly.
- **App changes: none, and the issue asked me to state the answer.** Credential inputs and the URL bar both render the same `VariableInput` and cannot paint differently. But *neither* paints `{{$vu}}` as a runtime token: `isIterationVariableName` appears in no rendering component, so the identity falls through to the "define a new variable" affordance - painted exactly like a typo. Pre-existing, not caused by this PR, newly consequential because the token now binds. Filed as **#1101** rather than widened into this diff.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2715 pass, 0 fail** (4 new). `cd app && pnpm test` (5966 pass) and `pnpm type-check` clean; no app files changed. `mkdocs build --strict` clean. clang-format 19 and clang-tidy clean on every touched file. No pre-existing failures observed on the base commit.

New tests, all mutation-checked by rebuilding with the fix reverted and observing the failure:

| Test | Pins | Reddens when |
|---|---|---|
| `LoadIdentityTest.ACredentialBindsTheIdentityOnARunWithNoDataSet` | a `user-{{$iteration}}` credential on a run with no rows, read base64-decoded off the wire | the credential predicate is reverted; the identity is hardcoded again; the credentials term is dropped from the submission guard |
| `LoadIdentityTest.StaticCredentialsStillResolveInTheBuild` | tokens-off still resolves at build time (`Apply`, empty templates) and the build's own encoding is what leaves | a run starts deferring when it should not |
| `LoadIdentityTest.AnIdentityTokenInAnOAuth2ConfigIsRefusedByName` | the refusal names `{{$vu}}` and OAuth 2.0 | the identity is dropped from the oauth2 scan |
| `ScenarioLoadTest.AStepCredentialBindsTheIdentityWithNoDataSet` | two virtual users, no data set, each authenticating as itself | the credential predicate is reverted |

`SendWithRowAuth.NoRowNeverDefers` pinned the old rule and is replaced by `ADataTokenWithNoRowDefersAndIsRefusedByName` and `AnIdentityTokenDefersWithNoRowAndBindsToTheRunOfOne`.

Worth noting which mutation each test catches: the hardcoded-identity mutation is caught *only* by the load-path wire test. A single send is vu 1, iteration 0, which is what the hardcoded default already returned - so the `/execute` test passes under it. That asymmetry is why the wire test is on a multi-iteration run.

### Throughput guard (#992)

The guard is structural first: a run with no rows, an empty request template and empty credentials takes the same submit of the same shared request - one null test and two `empty()` tests, no copy and no bind. `StaticCredentialsStillResolveInTheBuild` asserts that rather than the throughput.

Measured in `docs/engine/benchmarks.md`'s shape. Both binaries ran as idle daemons for the whole series with exactly one load run in flight at a time, so the arms interleave per round and rotate; `constant_concurrency`, c=32, 6 s per arm, 12 rounds, retention effectively off (sampling period 100000). Figures are the run report's own `throughput`.

| Arm | Median req/s | Mean | Min | Max |
|---|---|---|---|---|
| branch, static credentials (tokens off) | 19 104 | 19 103 | 17 944 | 20 625 |
| master, static credentials (tokens off) | 19 174 | 19 081 | 18 537 | 19 613 |
| branch, `user-{{$vu}}` (tokens on) | 18 329 | 18 500 | 17 628 | 19 653 |
| branch, static credentials again (null test) | 18 536 | 18 768 | 17 615 | 20 466 |

- **Tokens-off, branch against master: -0.36%** on medians.
- **Null test - the same branch binary in both arms: -2.97%.** That is the harness and the host, not code.
- **Tokens-on against tokens-off: -4.06%**, identical bytes on the wire (a single-request run's `{{$vu}}` is always 1), differing only in the join.

**Verdict: the tokens-off path is unchanged - its -0.36% is an order below the harness's own -2.97% null test - and the tokens-on cost is not resolvable on this host, being about a point above that floor.** The arms' min-max spans overlap heavily, so the tokens-on figure bounds the cost rather than measuring it. Same caveat as #994's section: this is a 4-core container running the Go mock server beside the engine, and a single arm's runs vary by more than either effect being looked for. The structural claim is what the guard rests on.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Two review passes ran over the diff, against the acceptance criteria and against `CLAUDE.md`. Three findings survived my own verification and are fixed in the second commit: `AuthResolution`'s own doc comment and `resolve_step`'s "only ever reached with rows behind it" both still stated the old rule, and nothing pinned the identity inside a *scenario* step's credentials. One finding I noted and did not act on: `read_load_data_set` gains a level of nesting, which is the direct consequence of a rowless run having to reach the auth plan instead of returning early - I judged the alternative (a second function over the same payload) worse.

## Related Issues

Closes #1055

Filed from this work: #1101 (the renderer paints `{{$vu}}` like a typo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL5vk3QRG8cmFv6kbKMemS)_