### PR TITLE
fix(engine): the handler, not the clock, says a script timed out - #1073

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1279,7 +1279,10 @@ It is a subset of `pm.response` and has no `to.*` assertion chain.
   to whatever is left of the script's budget; without that, a 5s script calling
   `pm.sendRequest` at the default 30s request timeout would hold its thread for
   30s with no error and no way to interrupt it. When `scriptTimeout` is `0`
-  there is no budget and nothing to clamp to.
+  there is no budget and nothing to clamp to. A call made with the budget
+  already spent is refused by name - `pm.sendRequest was called with none of
+  the script's time budget left` - and that sentence is what the script's error
+  reports, since the handler never ran and so never stopped anything.
 - *A request cap.* One script execution may issue at most **10** requests, then
   throws. A load run's `tests` script runs once per *sampled* response, serially,
   on the run's worker thread, so an uncapped loop would turn post-run validation
@@ -2066,7 +2069,12 @@ The **language** is current; what is missing is the **host environment**:
   engine. Configurable via the `scriptTimeout` setting (milliseconds); `0` disables
   the limit. The deadline is checked *between bytecode operations*, so it cannot
   interrupt a blocking call - which is why `pm.sendRequest` clamps its own
-  timeout to the budget that is left rather than relying on it. A function an
+  timeout to the budget that is left rather than relying on it. **A script is
+  reported as timed out when the deadline actually stopped it**, not whenever
+  its error happens to land past the deadline: a script that throws its own
+  error at the buzzer reports *that* error, and `pm.sendRequest` refusing a
+  spent budget reports its own sentence rather than a generic timeout line.
+  A function an
   assertion calls - `pm.expect(fn).to.throw()`, `.to.satisfy(fn)` - is stopped
   by the same deadline, and that is **reported as the abort it is**, never as a
   satisfied assertion: the engine stopped `fn`, `fn` did not throw. Inside a

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -8232,11 +8232,15 @@ class ScriptEngine::Impl {
         if (JS_IsException (eval_result)) {
             JSValue exc    = JS_GetException (js_ctx);
             result.success = false;
-            // If the deadline interrupt fired, report a clear timeout message
-            // rather than QuickJS's raw "interrupted" InternalError.
-            auto* rt_state = static_cast<RuntimeState*> (JS_GetRuntimeOpaque (rt));
-            if (rt_state && rt_state->enabled &&
-            std::chrono::steady_clock::now () > rt_state->deadline) {
+            // Whether the deadline stopped this script is the interrupt
+            // handler's to answer, not the clock's - the same question #1056
+            // settled one layer down. An error that merely *lands* past the
+            // deadline is still that error: a script's own throw at the buzzer,
+            // and `pm.sendRequest` refusing a spent budget from a blocking C
+            // function the handler never gets to interrupt. Comparing the clock
+            // here replaced the sentence naming the fault with a timeout line
+            // the user could not act on.
+            if (script_deadline_expired (js_ctx)) {
                 result.error_message = "Script execution timed out after " +
                 std::to_string (config.timeout_ms) + "ms";
             } else {

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -3315,6 +3315,41 @@ TEST_F (ScriptEngineTest, SatisfyPredicatePastTheDeadlineAbortsTheScript) {
 #endif
 }
 
+// #1073. The message half of the same question the three tests above settled
+// for the verdict: `execute` asked the *clock* whether the deadline ended the
+// script, so an error that merely landed past it was relabelled a timeout and
+// the sentence naming the fault was discarded. Here the deadline has provably
+// passed and the handler stopped nothing since - the `arm` before the second
+// `.to.throw()` clears its record, which is what makes the top-level throw
+// below the only thing that ended this script.
+//
+// Mutation check: restore the `steady_clock::now () > deadline` comparison in
+// `Impl::execute` and this reddens on "Script execution timed out after 300ms".
+TEST_F (ScriptEngineTest, AnOwnThrowPastTheDeadlineKeepsItsOwnError) {
+#ifdef VAYU_HAS_QUICKJS
+    ScriptConfig cfg;
+    cfg.timeout_ms = 300;
+    ScriptEngine timeout_engine (cfg);
+
+    auto result = timeout_engine.execute_test (R"(
+        pm.test("spins past the deadline", function () {
+            pm.expect(function () { while (true) {} }).to.throw();
+        });
+        pm.expect(function () { throw new Error("caught by the matcher"); }).to.throw();
+        throw new Error("the script's own error");
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("the script's own error"), std::string::npos)
+    << "error was: " << result.error_message;
+    EXPECT_EQ (result.error_message.find ("timed out"), std::string::npos)
+    << "an ordinary throw was relabelled a timeout: " << result.error_message;
+#else
+    GTEST_SKIP () << "QuickJS not compiled in";
+#endif
+}
+
 // timeout_ms == 0 disables the wall-clock limit (escape hatch); a bounded loop
 // still completes normally with no false timeout.
 TEST_F (ScriptEngineTest, ZeroTimeoutDisablesLimit) {

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -864,6 +864,31 @@ TEST_F (SendRequestTest, ASpentBudgetDoesNotIssueAnUnboundedRequest) {
     << "an exhausted budget still issued an unbounded request";
 }
 
+// #1073. The refusal above is thrown from a *blocking C function*, which the
+// interrupt handler never gets to stop - so the script ends with the deadline
+// passed and nothing interrupted, which is the shape `Impl::execute` used to
+// read off the clock and answer "Script execution timed out after 300ms". The
+// budget fact is already in this sentence; substituting the generic line threw
+// away the only part that tells the user which call refused and why.
+//
+// The first request spends the budget deterministically rather than relying on
+// setup latency: /slow holds its connection for SLOW_MS, the clamp bounds it to
+// what is left, and it returns to the callback as an error with the deadline
+// behind it. Mutation check: restore the clock comparison in `Impl::execute`
+// and this reddens on the timeout line.
+TEST_F (SendRequestTest, ASpentBudgetRefusalReachesTheScriptErrorByName) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest('" + server.url ("/slow") + "', function () {}); " +
+    "pm.sendRequest('" + server.url ("/slow") + "', function () {});",
+    /*timeout_ms=*/300);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (
+    result.error_message.find ("none of the script's time budget left"), std::string::npos)
+    << "the refusal was replaced by a guessed timeout: " << result.error_message;
+}
+
 // Turning the budget off entirely (timeout_ms == 0) must not be read as "no
 // time left" - there is simply nothing to clamp to.
 TEST_F (SendRequestTest, NoConfiguredBudgetMeansNoClamp) {


### PR DESCRIPTION
## Description

`ScriptEngine::Impl::execute` decided whether the exception that ended `JS_Eval` was the deadline by comparing the clock *after* the call had already returned. That is the same question #1056 settled one layer down - "was this exception the engine's abort or the script's own throw?" - answered the way #1056 rejected. Any error that merely **lands** past the deadline had its real message discarded and replaced with `Script execution timed out after Nms`.

**Root cause and approach.** #1056 built the primitive this wants: `RuntimeState::interrupted`, set by the interrupt handler when it stops a call, cleared per execution and per assertion call, read through `script_deadline_expired`. The handler is the only thing that knows *why* a call ended. `execute` now reads that flag instead of the clock, so the repo has one way to ask whether the deadline stopped something rather than two - one honest and one guessed. A script the handler actually stopped still reports the timeout, because the flag is set in that case.

The reachable case is `pm.sendRequest`'s budget clamp: it refuses a spent budget *by name*, and it throws from a blocking C function that QuickJS never interrupts (the handler only runs between bytecode operations - the clamp exists for exactly that reason). So the handler may never have fired, the deadline has nevertheless passed, and the specific, actionable sentence was replaced by the generic line.

**The alternative I rejected**, which the issue leaves open: having a blown budget with no interrupt still say the script was over its budget *in addition to* naming the error. The one case that actually reaches it - the `pm.sendRequest` refusal - already carries the budget fact in its own sentence, so the note would be redundant exactly where it is reachable; and deriving it anywhere else would mean asking the clock again, reintroducing the guess this PR removes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**100% tests passed, 0 tests failed out of 2756** (53.7s, `linux-dev`). No pre-existing failures to report - the suite was green on this commit end to end.

Two new gtests, and both mutation checks were **run rather than asserted**: the clock comparison was restored in `Impl::execute`, the engine rebuilt, and each test reddened on the substituted line -

```
[  FAILED  ] ScriptEngineTest.AnOwnThrowPastTheDeadlineKeepsItsOwnError
  an ordinary throw was relabelled a timeout: Script execution timed out after 300ms
[  FAILED  ] SendRequestTest.ASpentBudgetRefusalReachesTheScriptErrorByName
  the refusal was replaced by a guessed timeout: Script execution timed out after 300ms
```

- `ScriptEngineTest.AnOwnThrowPastTheDeadlineKeepsItsOwnError` - the deadline has provably passed and the handler stopped nothing since (the `arm` before the second `.to.throw()` clears its record), so the top-level throw is the only thing that ended the script. It must report **its own error**, and must not say "timed out".
- `SendRequestTest.ASpentBudgetRefusalReachesTheScriptErrorByName` - the issue's named reachable case, on the wire. The first request spends the budget deterministically (`/slow` holds its connection for 3s, the clamp bounds the request to what is left, and a curl timeout cannot return early) rather than relying on setup latency; the second is refused, and the refusal's own sentence must reach `error_message`.

The other side of the change is pinned by tests that already existed and must stay green - `InfiniteLoopTimesOut`, `ThrowMatcherAbortsWhenTheTargetOutlivesTheDeadline`, `SatisfyPredicatePastTheDeadlineAbortsTheScript`. All three interrupt a real busy-loop, so the handler genuinely fires and the flag is set; they passed under the mutation too, which is what makes them the *other* side rather than a restatement of the same one.

**Blast radius, traced rather than assumed.** Nothing string-matches this message. Every engine consumer either checks `.empty()` (`scenario_runner.cpp:82`) or concatenates the text through unchanged (`scenario_runner.cpp:101,112`, `run_manager.cpp:174`, `request_exchange.cpp:287`, and the one production JSON path, `build_script_result_node` in `routes/execution.cpp:743-747` → `preScriptError` / `postScriptError`). On the app side those wire fields are display-only (`execute-mapping.ts`, `restore-response.ts`, `response-store.ts`, `ScenarioStepCard.tsx`); no TypeScript matches on "timed out" against a script error. `TestResult::error_message` is a sibling field set inside `js_pm_test` and does not go through this branch at all, so `testResults[].error` is unaffected.

No app suites were run: the diff touches nothing under `app/`, so per the repo's verification-scaling rule no app test could change colour.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/scripting.md` gains the rule in both places that describe the deadline - the sandbox-limits bullet (a script is reported as timed out when the deadline actually stopped it, not whenever its error lands past it) and the `pm.sendRequest` bounds bullet (the spent-budget refusal is what the script's error reports). `docs/engine/api-reference.md` and `docs/app/pm-api-compatibility.md` were checked and need nothing: their timeout language is about HTTP transfers and about the clamp's bounds, never about the labelling rule.

## Related Issues

Closes #1073

Filed while tracing this change's blast radius, deliberately **not** folded in: #1106 - `vayu::json::serialize (const ScriptResult&)` is a second, divergent serializer of the script-result wire shape that nothing calls.