### PR TITLE
fix(app): the identity namespace paints as a run-time token - #1101

### DIFF
--- a/app/src/components/shared/VariableInput/RuntimeToken.tsx
+++ b/app/src/components/shared/VariableInput/RuntimeToken.tsx
@@ -7,20 +7,22 @@
 
 /**
  * A `{{token}}` whose value is produced at run time rather than stored in a
- * scope - `{{$guid}}`, which a generator invents per use, and `{{data.email}}`,
- * which a collection run binds from the iteration's row.
+ * scope - `{{$guid}}`, which a generator invents per use; `{{data.email}}`,
+ * which a collection run binds from the iteration's row; and `{{$vu}}` /
+ * `{{$iteration}}`, which the iteration that sends the request binds from the
+ * run itself (issue #1101).
  *
- * The sibling `EditableVariable` cannot serve either. It offers a popover for
- * viewing and editing a stored value, and neither of these has one: there is
+ * The sibling `EditableVariable` cannot serve any of them. It offers a popover for
+ * viewing and editing a stored value, and none of these has one: there is
  * nothing to edit, and any value it showed would be one it had just invented
  * rather than the one the request will carry. What it *would* do is worse -
  * a name no scope defines paints `text-destructive-text` with a "not defined"
  * tooltip, and offers to create the variable. For a generator that is exactly
- * backwards; for a `data.*` name the offer is a trap, since the namespace is
- * disjoint from the scopes and a variable of that name can never answer for the
- * column.
+ * backwards; for a `data.*` or identity name the offer is a trap, since both
+ * namespaces are disjoint from the scopes and a variable of that name can never
+ * answer for the column or the identity.
  *
- * One component for both, rather than one each: they differ only in the words
+ * One component for all three, rather than one each: they differ only in the words
  * of the tooltip, and a hand-rolled copy of a primitive does not receive the
  * primitive's fixes.
  *

--- a/app/src/components/shared/VariableInput/index.tsx
+++ b/app/src/components/shared/VariableInput/index.tsx
@@ -23,6 +23,12 @@
  * defines paints as a bound-column runtime token rather than an undefined
  * variable (issue #1007) - see the `boundColumn` check in
  * `renderOverlayContent` and `describeBareColumnToken`.
+ *
+ * `{{$vu}}` and `{{$iteration}}` paint as run-time tokens too (issue #1101):
+ * they address the reserved identity namespace, which no scope can answer, so
+ * the "not defined, click to create" treatment marked the one case that always
+ * works - and marked it identically to `{{$vus}}`, a typo that reaches the wire
+ * in braces.
  */
 
 import {
@@ -43,6 +49,7 @@ import { VARIABLE_PATTERN } from "@/constants/variables";
 import { variableCompletionContext } from "@/lib/variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 import { isDataVariableName } from "@/lib/variable-resolution";
+import { iterationVariable } from "@/lib/iteration-variables";
 import { describeDataToken, describeBareColumnToken } from "@/lib/data-contract";
 
 interface VariableInputProps {
@@ -431,6 +438,35 @@ export default function VariableInput({
 								description={data.description}
 								note={data.note}
 								tone={data.tone}
+							/>
+						</span>
+					);
+				}
+				/*
+				 * The identity namespace is reserved the same way (issue
+				 * #994), so it is decided in the same tier - before the
+				 * scopes, not beside the generator table below. The
+				 * difference is load-bearing: a scope that defines `$guid`
+				 * wins and takes the editable token, but `lookupVariable`
+				 * answers `$vu` ahead of every scope, so a variable someone
+				 * happens to name `$vu` shadows nothing and must not paint
+				 * as though it had. Nothing binds it until the iteration
+				 * that sends the request, which is what the note says.
+				 */
+				const identity = iterationVariable(seg.varName);
+				if (identity) {
+					return (
+						<span
+							key={`${i}-${seg.varName}`}
+							data-variable-token
+							data-runtime-token
+							{...tokenBounds}
+							style={{ pointerEvents: "auto" }} // See the data.* token above.
+						>
+							<RuntimeToken
+								name={identity.name}
+								description={identity.description}
+								note="not generated here"
 							/>
 						</span>
 					);

--- a/app/src/components/shared/VariableInput/iteration-variable-token.test.tsx
+++ b/app/src/components/shared/VariableInput/iteration-variable-token.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A `{{$vu}}` token must not be painted as an undefined variable (issue #1101).
+ *
+ * `EditableVariable` colours a name nothing defines with `text-destructive-text`
+ * and offers to create it. For the identity namespace that offer is a trap: the
+ * resolver answers `$vu` and `$iteration` ahead of every scope
+ * (`lookupVariable`), so a variable created with either name would never be
+ * consulted - and the token itself always binds, from the iteration that sends
+ * the request. The undefined paint marked the one case that cannot fail.
+ *
+ * The `{{$vus}}` case is the half that must not move: the names are matched
+ * exactly, so a near-miss is an ordinary unknown `$name` that reaches the wire
+ * in braces, and the undefined paint is how the reader spots it (issue #186).
+ *
+ * The shadowing case is the opposite of the generator one, which is why it is
+ * asserted rather than assumed: a workspace variable named `$guid` wins and
+ * takes the editable token, but one named `$vu` shadows nothing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import { variableSupportStub } from "@/test/variable-support";
+import type { ResolvedVariable } from "@/types";
+import VariableInput from "./index";
+
+const variables: Record<string, ResolvedVariable> = {};
+
+const scope = variableSupportStub(variables);
+
+function renderInput(value: string) {
+	const { container } = render(
+		<TooltipProvider delayDuration={0}>
+			<VariableInput value={value} onChange={() => {}} placeholder="URL" variables={scope} />
+		</TooltipProvider>
+	);
+	const overlay = container.querySelector('[aria-hidden="true"]');
+	expect(overlay).toBeTruthy();
+	return overlay as HTMLElement;
+}
+
+/** The hover Radix actually listens for on a tooltip trigger. */
+function hover(token: HTMLElement) {
+	const trigger = token.firstElementChild ?? token;
+	fireEvent.pointerMove(trigger, { pointerType: "mouse" });
+}
+
+describe.each(["$vu", "$iteration"])("an identity token in the overlay", (name) => {
+	it(`renders {{${name}}}`, () => {
+		// Guards the scan itself: an overlay that rendered nothing would pass
+		// every "does not contain" assertion below while checking nothing.
+		expect(renderInput(`https://x/y?u={{${name}}}`).textContent).toContain(`{{${name}}}`);
+	});
+
+	it(`paints {{${name}}} as a run-time token, not as unresolved`, () => {
+		const overlay = renderInput(`https://x/y?u={{${name}}}`);
+		const token = overlay.querySelector("[data-variable-token] span");
+		expect(token).toBeTruthy();
+		expect(token!.className).not.toContain("text-destructive-text");
+		expect(token!.className).toContain("text-muted-foreground");
+	});
+
+	it(`offers nothing to define for {{${name}}} - no scope can answer it`, () => {
+		/*
+		 * EditableVariable's trigger is the popover's, a `<span role="button">`
+		 * rather than a `<button>` so an inline token does not break the text
+		 * flow. The run-time token is a plain span, so the role is absent.
+		 */
+		expect(renderInput(`{{${name}}}`).querySelector('[role="button"]')).toBeNull();
+	});
+
+	it(`says when {{${name}}} is bound`, async () => {
+		const overlay = renderInput(`{{${name}}}`);
+
+		hover(overlay.querySelector<HTMLElement>("[data-runtime-token]")!);
+
+		const tooltip = await screen.findByRole("tooltip");
+		expect(tooltip).toHaveTextContent("bound per iteration by the run");
+		expect(tooltip).toHaveTextContent("not generated here");
+	});
+});
+
+describe("a near-miss of an identity name", () => {
+	it("keeps the editable token, so a typo stays marked undefined", () => {
+		const overlay = renderInput("{{$vus}}");
+		const token = overlay.querySelector("[data-variable-token] span");
+		expect(token).toBeTruthy();
+		expect(token!.className).not.toContain("text-muted-foreground");
+		expect(token!.className).toContain("text-destructive-text");
+	});
+});
+
+describe("a workspace variable named like an identity", () => {
+	it("shadows nothing - the token stays the run-time one", () => {
+		variables.$vu = { value: "pinned", scope: "global" };
+		try {
+			const overlay = renderInput("{{$vu}}");
+			const token = overlay.querySelector("[data-variable-token] span");
+			expect(token!.className).toContain("text-muted-foreground");
+			expect(overlay.querySelector('[role="button"]')).toBeNull();
+		} finally {
+			delete variables.$vu;
+		}
+	});
+});

--- a/app/src/lib/iteration-variables.test.ts
+++ b/app/src/lib/iteration-variables.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { ITERATION_VARIABLES, isIterationVariableName } from "./iteration-variables";
+import {
+	ITERATION_VARIABLES,
+	isIterationVariableName,
+	iterationVariable,
+} from "./iteration-variables";
 
 describe("ITERATION_VARIABLES", () => {
 	test("names exactly $vu and $iteration, with a non-empty description each", () => {
@@ -35,5 +39,20 @@ describe("isIterationVariableName", () => {
 		expect(isIterationVariableName("vu")).toBe(false);
 		expect(isIterationVariableName("$guid")).toBe(false);
 		expect(isIterationVariableName("")).toBe(false);
+	});
+});
+
+describe("iterationVariable", () => {
+	test("answers with the entry a surface can describe the token from", () => {
+		expect(iterationVariable("$vu")).toBe(ITERATION_VARIABLES[0]);
+		expect(iterationVariable("$iteration")).toBe(ITERATION_VARIABLES[1]);
+	});
+
+	test("agrees with isIterationVariableName on every name either is asked", () => {
+		// The two must never disagree: a surface that decides a name is reserved
+		// and then finds nothing to say about it has no token to paint.
+		for (const name of ["$vu", "$iteration", "$vus", "vu", "$guid", ""]) {
+			expect(iterationVariable(name) !== undefined).toBe(isIterationVariableName(name));
+		}
 	});
 });

--- a/app/src/lib/iteration-variables.ts
+++ b/app/src/lib/iteration-variables.ts
@@ -54,9 +54,19 @@ export const ITERATION_VARIABLES: readonly IterationVariable[] = [
 	},
 ] as const;
 
-const NAMES = new Set(ITERATION_VARIABLES.map((v) => v.name));
+const BY_NAME = new Map(ITERATION_VARIABLES.map((v) => [v.name, v]));
+
+/**
+ * The reserved name `name` addresses, or `undefined` - for a surface that needs
+ * the entry itself rather than the yes/no, `VariableInput`'s token paint being
+ * the one that does. One map behind both, so a surface cannot decide a name is
+ * reserved and then fail to find what it says.
+ */
+export function iterationVariable(name: string): IterationVariable | undefined {
+	return BY_NAME.get(name);
+}
 
 /** True for exactly `$vu` and `$iteration` - the reserved identity namespace. */
 export function isIterationVariableName(name: string): boolean {
-	return NAMES.has(name);
+	return BY_NAME.has(name);
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1342,15 +1342,23 @@ same reason - there is deliberately **no re-export shim** in
 scope; without one it is a plain text field, since a token would paint a name
 "not defined" and open an editor with nowhere to write.
 
-**A token has three states, and the overlay decides between them in the order
-`resolveTemplate` does** - reserved namespace first, then the scopes, then the
+**A token has four states, and the overlay decides between them in the order
+`resolveTemplate` does** - reserved namespaces first, then the scopes, then the
 generator table:
 
 | Token | Painted by | Looks like |
 |-------|-----------|------------|
 | `{{data.email}}` - the reserved `data.*` namespace (issue #402) | `RuntimeToken` | muted or amber, depending on the declared contract - see below |
+| `{{$vu}}`, `{{$iteration}}` - the reserved identity namespace (issues #994, #1101) | `RuntimeToken` | muted, "not generated here", no popover |
 | `{{merchantId}}` - a stored variable, or a name nothing defines | `EditableVariable` | accent when it resolves, **red** when it does not; hover reads, click edits or creates |
 | `{{$guid}}` - a generator | `RuntimeToken` | muted, "generated per use", no popover |
+
+The two reserved rows sit above the scopes for the same reason and the generator
+row below them for the opposite one: a scope that defines `$guid` wins and takes
+the editable token, while a variable named `data.email` or `$vu` answers for
+neither the column nor the identity, so it must not paint as though it had. The
+identity names are matched exactly, so `{{$vus}}` is an ordinary unknown `$name`
+and keeps the red paint that is how a typo is spotted (issue #186).
 
 **A `data.*` token has three states of its own** (issue #600), decided by
 `describeDataToken` against `VariableSupport.dataColumns` - the contract the
@@ -1428,13 +1436,14 @@ inside: `{{data.email}}` is one atom to everything that reads it, and a caret
 between its braces is how a keystroke corrupts the name.
 
 `EditableVariable` takes the scope as a **required** prop, because a token only
-renders where there is one. `RuntimeToken` serves both run-time cases - a value
-produced when the request is sent rather than stored anywhere - and is one
-component rather than two because they differ only in the words of the tooltip.
+renders where there is one. `RuntimeToken` serves all three run-time cases - a
+value produced when the request is sent rather than stored anywhere - and is one
+component rather than three because they differ only in the words of the tooltip.
 
-The namespace check comes **before** the scope lookup deliberately: `data.*` is
-disjoint from the tiers, so a variable someone happens to name `data.email`
-neither answers for the column nor may paint the token as though it had. Reading
+The namespace checks come **before** the scope lookup deliberately: `data.*` and
+the identity names are both disjoint from the tiers, so a variable someone
+happens to name `data.email` or `$vu` neither answers for the column or the
+identity nor may paint the token as though it had. Reading
 the scopes first would show a resolved token carrying a value the engine will
 never send. The same rule keeps the create offer out of `VariablePopover` for
 these names - a variable of that name can never resolve, so offering to make one

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1445,9 +1445,12 @@ the identity names are both disjoint from the tiers, so a variable someone
 happens to name `data.email` or `$vu` neither answers for the column or the
 identity nor may paint the token as though it had. Reading
 the scopes first would show a resolved token carrying a value the engine will
-never send. The same rule keeps the create offer out of `VariablePopover` for
-these names - a variable of that name can never resolve, so offering to make one
-is a dead end that leaves the token exactly as it was.
+never send. The create offer is out of reach for both - a variable of either
+name can never resolve, so offering to make one is a dead end that leaves the
+token exactly as it was - but by two different mechanisms: `VariablePopover`
+refuses it for a `data.*` name itself (`isDataVariableName`, `:217`), while an
+identity name never reaches the popover at all, the branch above returning
+before `EditableVariable` is rendered.
 
 **The popover names a bound row as the origin, above what it beat** (issue
 #1064). The token paint above is unchanged - a shadowed bare name still paints

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -142,6 +142,15 @@ it. That is the one thing these names exist to prevent. The two names are
 matched exactly, so `{{$vus}}` is an ordinary unknown `$name` and keeps its
 braces.
 
+**The UI paints them as their own state too** (issue #1101), for the reason the
+`data.*` paragraph above gives and one more. Until #1101 the builder rendered
+`{{$vu}}` red, hovered it to "not defined" and offered to create a variable of
+that name - the one offer that is guaranteed to change nothing, since the
+resolver answers the identity ahead of every scope. So they get the same muted
+`RuntimeToken` treatment, noted `not generated here` to tell them from the
+generator beside them, and no surface offers to create one. `{{$vus}}` keeps the
+red paint, which is what makes the near-miss visible.
+
 What they resolve to depends on the shape of the run, and every shape has an
 answer:
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -108,7 +108,7 @@ namespace being disjoint, can never answer for the column. So a `data.*` token
 gets the muted run-time treatment (`RuntimeToken`) and a tooltip naming the run's
 data file, and no surface offers to create one. See
 [COMPONENTS.md](COMPONENTS.md#shared-variable-input-componentssharedvariableinput)
-for the three token states.
+for the four token states.
 
 A **collection run** is the one place that reading is not left to the user: a
 run started without a data file whose plan still carries a `data.*` token is


### PR DESCRIPTION
## Description

`{{$vu}}` and `{{$iteration}}` fell through every branch of `VariableInput`'s token chain to `EditableVariable` with `resolved={false}` - red, hovered "not defined", offering to create a variable of that name. The root cause is a missing branch, not a wrong one: `isIterationVariableName` was imported in exactly one file (`variable-resolution.ts`, to *exclude* the names from scope lookup) and in no rendering component, so the identity table had a writer and no reader on the paint side. The consequence is the one the docs warn about for `data.*`: the offer to define `$vu` is guaranteed to change nothing, since `lookupVariable` answers the identity ahead of every scope, and a bound token was painted identically to `{{$vus}}` - a genuine typo that reaches the wire in braces, where the red paint is the whole way it is spotted (#186). Since #1055 the cost is highest exactly where the reader cannot check by eye: a bound credential is base64 by the time it is sent.

**Approach, and the alternative rejected.** A fourth branch in the same chain, rendering the existing `RuntimeToken` from `ITERATION_VARIABLES`' own description with the note `not generated here` - the phrasing already shipped in both Monaco completion providers, so no fourth vocabulary. The issue proposed placing it *after* the bound-column branch and before the generator lookup; that placement is rejected, and the branch sits with the `data.*` one, above the scope lookup. `COMPONENTS.md:1345` already states the rule the placement follows: the overlay decides in the order `resolveTemplate` does - reserved namespaces first, then the scopes, then the generator table. The generator branch is below the scopes because a variable named `$guid` genuinely wins there; the identity is the opposite case, so a branch placed after the scope-dependent checks would paint a workspace variable named `$vu` as a resolved accent token carrying a value the run will never send. That is not hypothetical - it is what the mutation check renders (`text-primary`) with the branch removed, and it is asserted as a test in its own right.

Also rejected: threading the run shape into the tooltip so it could say `1` / `0` for a plain Send. The component does not know the shape, and the issue explicitly holds that back as separate.

`iterationVariable(name)` joins `isIterationVariableName` on one map in `iteration-variables.ts`, rather than the component building a second membership answer from the same table - a surface must not be able to decide a name is reserved and then fail to find what it says.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run on this branch, app-only change so no engine build:

- `pnpm exec vitest run` - **546 files, 5982 tests, all passing** (0 failures, no pre-existing failures on this base).
- `pnpm type-check` - clean across renderer, electron and electron-tests.
- `pnpm lint` - clean at `--max-warnings 0`.
- `pnpm format:check` - clean.
- **Mutation check performed, not assumed**: with `iterationVariable(...)` forced to `undefined`, **7 of the 10 new cases fail**. The 3 that stay green are exactly the ones that must - the two "the overlay rendered something at all" guards and the `{{$vus}}` near-miss, which is the case that must not move.

New file `app/src/components/shared/VariableInput/iteration-variable-token.test.tsx` (10 cases): both identity names render the run-time pill and not the create-a-variable affordance, the tooltip names when they are bound, `{{$vus}}` still paints `text-destructive-text`, and a workspace variable named `$vu` shadows nothing - the inverse of `dynamic-variable-token.test.tsx`'s shadowing case, which is why it is asserted rather than assumed. `iteration-variables.test.ts` gains two cases pinning `iterationVariable` against `isIterationVariableName` so the pair cannot drift.

`mkdocs build --strict` was **not** run: mkdocs is not installed in this environment. The docs edits add no links, no headings and no anchors - only prose, one table row and a corrected sentence - so there is nothing for the strict build to resolve; CI's docs job covers it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the repo rule:
- `docs/app/COMPONENTS.md` - the token table gains the identity row and now says four states, plus the sentence explaining why the two reserved rows sit above the scopes and the generator row below them. `RuntimeToken` "serves both run-time cases" corrected to three.
- `docs/app/variable-resolution.md` - the `$vu`/`$iteration` section gains the UI-paint paragraph its `data.*` sibling (`:103-111`) already had; the page documented the resolver and autocomplete sides and was silent on the paint.
- `RuntimeToken.tsx`'s header enumerated its two run-time cases; a third exists now.

## Related Issues
Closes #1101

Verified against live code at master `07ccb59` before writing: every anchor in the issue's Problem section reproduces exactly (`:410-437`, `:448-470`, `:474-490`, `variable-resolution.ts:50` and `:223`). The one deviation from the issue's stated fix is the branch placement, argued above.

---
_Generated by [Claude Code](https://claude.ai/code/session_012jXkDCp92rnLbZm7SoY55T)_