### PR TITLE
feat(engine): pm.request.body as Postman's RequestBody object - #1003

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -85,7 +85,8 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			'pm.request.url.query.get("page")',
 			'pm.request.url.query.upsert({ key: "page", value: 2 })',
 			'pm.request.url = "https://api.example.com/v2/users"',
-			"pm.request.body = JSON.stringify({ n: 2 })",
+			"pm.request.body.raw = JSON.stringify({ n: 2 })",
+			'pm.request.body.mode === "urlencoded"',
 			"pm.sendRequest(url, (err, res) => { ... })",
 			"pm.info.requestName",
 		],
@@ -111,6 +112,17 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 				<code className={CODE_CLASS}>typeof</code>. Edit a member -{" "}
 				<code className={CODE_CLASS}>path.push</code>,{" "}
 				<code className={CODE_CLASS}>query.add</code> - or assign a whole URL string.
+			</>,
+			<>
+				<code className={CODE_CLASS}>body</code> is Postman&apos;s RequestBody object -{" "}
+				<code className={CODE_CLASS}>mode</code>, <code className={CODE_CLASS}>raw</code>,{" "}
+				<code className={CODE_CLASS}>urlencoded</code> and{" "}
+				<code className={CODE_CLASS}>formdata</code> - and still reads as the body string
+				everywhere except <code className={CODE_CLASS}>===</code>,{" "}
+				<code className={CODE_CLASS}>typeof</code> and a header value, which needs{" "}
+				<code className={CODE_CLASS}>String(pm.request.body)</code>. Assign{" "}
+				<code className={CODE_CLASS}>raw</code> or the whole body; the field lists are
+				read-only.
 			</>,
 			<>
 				Indexing is case-sensitive in JS: use the exact name (

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -871,9 +871,10 @@ pm.request.body = JSON.stringify({ n: 2 });
   engine applied.
 - **The script wins over engine-applied auth.** `build_request` resolves auth into the
   request before the script runs, so a script-set `Authorization` replaces the resolved one.
-- **A value the engine cannot send is refused, not coerced.** `method`/`body` must be
-  strings (`method` one of the seven verbs); a header value may be a string, number or
-  boolean. Anything else rejects the whole write-back - all or nothing - and surfaces as
+- **A value the engine cannot send is refused, not coerced.** `method` must be a string
+  (one of the seven verbs); `body` must be a string or the `RequestBody` object
+  `pm.request.body` itself holds; a header value may be a string, number or boolean.
+  Anything else rejects the whole write-back - all or nothing - and surfaces as
   `preScriptError`, which the response pane's Console tab shows. `url` is refused a step
   earlier: assigning anything that is not a URL string throws at the assignment, so the
   script author is told which line was wrong rather than reading it off the write-back.
@@ -891,16 +892,17 @@ pm.request.body = JSON.stringify({ n: 2 });
   query carries Postman's `PropertyList` writers - `add`, `upsert`, `remove`,
   `clear`. A URL nobody edited is sent as the exact bytes it arrived as, because
   the parts are recomposed only when a member actually changed.
-- **`body` is a string for every mode, including the two that store fields.** A
-  `x-www-form-urlencoded` or `form-data` body reads as its **enabled** fields encoded
-  `key=value&…` rather than as `""` - the empty string a `content`-only read used to give,
-  which no script could tell apart from a request with no body. For urlencoded that string
-  *is* the wire body and an assignment parses back into the fields; for `form-data` it is a
-  rendering of the parts, because the multipart bytes carry a boundary libcurl generates at
-  transfer time - so an assignment there is **refused with a named error** rather than
-  written to a body the transfer layer would ignore. Full table in
+- **`body` is Postman's `RequestBody` object, not a string** (#1003 - the same trade
+  #991 made for the URL). `mode` (`urlencoded` / `formdata` / `raw` - every other content
+  mode reads `raw`), `raw`, and the `urlencoded` / `formdata` field lists, plus `length`,
+  all read-only; assigning the whole body, or `.raw`, is the one write and is unchanged
+  from what shipped. It still behaves as a string in every context JavaScript allows -
+  concatenation, template literals, `==`, `String.prototype` methods, `JSON.stringify`,
+  `.length` - and three things changed: `===`, `typeof`, and assigning it straight into a
+  header value, refused the same way `pm.request.url` already is. The full surface and the
+  migration note are in
   [scripting.md](../engine/scripting.md#request-object-pmrequest). Reading a form body
-  never rewrites it: an unchanged string means untouched.
+  never rewrites it: an unchanged value means untouched.
 - **Setting a variable now re-renders whatever composition left unresolved.**
   `{{…}}` placeholders are still resolved at **compose time** (`POST /compose`,
   engine-side since #226) before the pre-request script runs - #226's decision

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -762,9 +762,13 @@ otherwise re-add. A file part carries no `value` at all, rather than the `""`
 an empty text field would hold - an empty string there would read as a text
 field that happens to be empty - and never the local path.
 
-Both lists are **read-only**, and so are `.mode` and `.length`: assigning one,
-or `push`ing into one, throws naming the member. Assign `pm.request.body` or
-`.raw` to change what is sent, or edit the request's form fields directly.
+Both lists are **read-only**, and so are `.mode` and `.length`. Assigning any of
+the four throws naming the member, and so does `push`ing into a list, which is
+frozen. Writing to a field *inside* an entry is the one edit that does not throw
+- a frozen object drops a write silently in non-strict code, which is
+JavaScript's own rule rather than one this surface adds - and it reaches nothing
+either way. Assign `pm.request.body` or `.raw` to change what is sent, or edit
+the request's form fields directly.
 
 Reading a form body never rewrites it. The write-back reads `body` off the
 script's object whether or not the script assigned it, so an **unchanged**

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -667,7 +667,7 @@ Access request data:
 pm.request.method            // HTTP method (string)
 pm.request.url               // Full URL (Postman Url object - see below)
 pm.request.headers           // Request headers (object, with the methods below)
-pm.request.body              // Request body (string, if any)
+pm.request.body              // Request body (Postman RequestBody object, if any - see below)
 ```
 
 **`headers` is a different set in each hook, and that is the point.** A
@@ -699,11 +699,36 @@ Four consequences worth knowing:
   cookie surface, and the response's raw view is the full wire frame (which also
   carries libcurl's own `Accept`, `Host` and `Content-Length`).
 
-`body` is a string for every mode, including the two whose content is a list of
-fields rather than text. A form body reads as its **enabled** fields encoded
-`key=value&…`:
+`pm.request.body` is Postman's `RequestBody` object (issue #1003), present only
+when the request has a body: a bodyless request still defines no `body`
+property at all, so `typeof pm.request.body === 'undefined'` still separates
+"no body" from "a body that happens to be empty", exactly as it did when this
+was a string.
 
-| Body mode | What `pm.request.body` reads | Assigning a string |
+```javascript
+pm.request.body.mode         // 'urlencoded' | 'formdata' | 'raw'
+pm.request.body.raw          // the body as a string, for every mode
+pm.request.body.urlencoded   // [{key, value, disabled}, ...] or undefined
+pm.request.body.formdata     // [{key, value?, type, fileName?, disabled}, ...] or undefined
+pm.request.body.length       // the body string's own length
+```
+
+`.mode` reads `raw` for every content mode - `json`, `text`, `xml`, `binary`,
+`graphql` and `jsonrpc` all carry their body as one string, which is what `raw`
+means. Postman's own `graphql` and `file` modes are deliberately not answered:
+each promises a member this engine has nothing to fill it from - a stored
+GraphQL body may be an envelope or a bare document rather than Postman's
+`{query, variables}` pair, and a binary body carries bytes rather than the path
+`file.src` names - so answering the mode without the member it exists for would
+be a silent wrong answer (issue #1111 tracks filling them in).
+
+`.raw` is the string every mode reads as, including the two whose content is a
+list of fields rather than text - and it is defined for both of those, where
+Postman leaves it `undefined`, because a form body reading as nothing cannot be
+told apart from a request with no body (issue #411). A form body's `.raw` reads
+its **enabled** fields encoded `key=value&…`:
+
+| Body mode | What `.raw` reads | Assigning a string (or `.raw`) |
 |---|---|---|
 | `json` / `text` / `xml` / `graphql` / … | the content, as stored | replaces it |
 | `x-www-form-urlencoded` | the encoded fields - **exactly** the bytes sent | parses back into the fields |
@@ -726,10 +751,59 @@ refused there rather than accepted and then ignored by the transfer layer. To
 change a multipart body, edit the request's form fields; `delete pm.request.body`
 still drops it entirely.
 
+`.urlencoded` and `.formdata` are the two field lists, present only in their own
+mode and `undefined` in every other: `{ key, value, disabled }` per
+x-www-form-urlencoded pair, or `{ key, value?, type, fileName?, disabled }` per
+multipart part. Values are as the user wrote them, not percent-encoded - the
+encoding is `.raw`'s answer, so a signature built from these pairs would
+double-encode if this were encoded too. A disabled row is listed with
+`disabled: true` rather than omitted, so a script can see the row it would
+otherwise re-add. A file part carries no `value` at all, rather than the `""`
+an empty text field would hold - an empty string there would read as a text
+field that happens to be empty - and never the local path.
+
+Both lists are **read-only**, and so are `.mode` and `.length`: assigning one,
+or `push`ing into one, throws naming the member. Assign `pm.request.body` or
+`.raw` to change what is sent, or edit the request's form fields directly.
+
 Reading a form body never rewrites it. The write-back reads `body` off the
-script's object whether or not the script assigned it, so an **unchanged** string
-means untouched - without that, a script that only looked at the body would
-delete the disabled rows the encoded view leaves out.
+script's object whether or not the script assigned it, so an **unchanged**
+value means untouched - without that, a script that only looked at the body
+would delete the disabled rows the encoded view leaves out.
+
+### The body was a string too, and mostly still behaves as one
+
+This shape replaced a plain string (issue #1003: Postman compatibility over the
+shipped string shape, the same trade issue #991 made for the
+[URL](#url-parts-pmrequesturl)). The object keeps as much of the old behaviour
+as JavaScript allows - it carries its own `toString`, `valueOf`, `toJSON` and
+`Symbol.toPrimitive`, and inherits from `String.prototype`:
+
+```javascript
+'' + pm.request.body;                     // the body
+`${pm.request.body}`;                     // the body
+pm.request.body == 'plain text';          // compares as the body
+pm.request.body.startsWith('{');          // String methods work
+pm.request.body.length;                   // the body's own length
+JSON.stringify({ b: pm.request.body });   // embeds the body string
+```
+
+Three things did change, and no mitigation can fix them:
+
+| Was | Now | Use |
+|-----|-----|-----|
+| `pm.request.body === '...'` | `false` | `==`, or `.toString()` |
+| `typeof pm.request.body` | `'object'` | - |
+| `pm.request.headers['X-Body'] = pm.request.body` | refused | `pm.request.headers['X-Body'] = String(pm.request.body)` |
+
+The third is the same refusal `pm.request.url` already gets: a value the engine
+cannot send is refused rather than coerced, and an object is not a header
+value.
+
+`.length` is **not** one of them: it is defined on the object as the body's own
+length. Inheriting it from `String.prototype` - which is a String object
+holding `""` - would have answered `0` for a body that is not empty, and a
+plausible wrong number is worse than a break you can see.
 
 ### Mutating the request (pre-request scripts)
 
@@ -756,12 +830,14 @@ Rules worth knowing before you rely on them:
   sees the real `Authorization` header and can replace or remove it.
 - **A bad value is refused, not coerced.** `method` must be a string (one of the
   seven HTTP verbs), `url` a URL string (assigning anything else throws at the
-  assignment), header values must be strings,
-  numbers or booleans, and `body` must be a string. Anything else fails the
-  whole write-back - the request is sent unchanged and the reason is reported
-  as the pre-request script error, visible in the response pane's Console tab.
-  Assigning a string to a `form-data` body fails the same way, for the same
-  reason: a value the engine cannot send is refused rather than dropped.
+  assignment), header values must be strings, numbers or booleans, and `body`
+  must be a string or the `RequestBody` object `pm.request.body` itself holds -
+  handing the object straight back (`pm.request.body = pm.request.body`)
+  changes nothing. Anything else fails the whole write-back - the request is
+  sent unchanged and the reason is reported as the pre-request script error,
+  visible in the response pane's Console tab. Assigning a string to a
+  `form-data` body fails the same way, for the same reason: a value the engine
+  cannot send is refused rather than dropped.
 - **Setting a variable can re-render the URL, if composition left it
   unresolved.** `{{placeholders}}` are still resolved at compose time
   (`POST /compose`), strictly before any script runs (#226, D1 stands) - but a
@@ -1827,10 +1903,10 @@ parse - mutate - stringify. Anything derived from the body (a length, a digest,
 a checksum) has to be computed *after* the edit, or it describes the old one.
 
 ```javascript
-var body = JSON.parse(pm.request.body);
+var body = JSON.parse(pm.request.body.raw);
 body.metadata = { client: 'vayu', sentAt: new Date().toISOString() };
 delete body.debugOnly;
-pm.request.body = JSON.stringify(body);
+pm.request.body.raw = JSON.stringify(body);
 
 // Recomputed from the final body, not the original.
 pm.request.headers['Content-Length'] = String(pm.request.body.length);

--- a/engine/include/vayu/http/form_body.hpp
+++ b/engine/include/vayu/http/form_body.hpp
@@ -171,6 +171,23 @@ namespace vayu::http {
 [[nodiscard]] bool has_file_parts (const Body& body);
 
 /**
+ * @brief The filename the server is told a file part carries.
+ *
+ * `file_name` when the part declares one, else the basename of `src`, with
+ * separators for both platforms because the path is whatever the client on this
+ * machine wrote. It mirrors what the transfer setup hands libcurl
+ * (`curl_mime_filedata` declares the basename, an explicit `curl_mime_filename`
+ * overrides it), so nothing that shows a part can name one thing while the send
+ * names another.
+ *
+ * The path itself is deliberately not part of any answer built from this: it
+ * discloses this machine's layout to anything a script logs and adds nothing the
+ * request sends. `render_form_data_parts` and `pm.request.body.formdata` (issue
+ * #1003) are the two surfaces that show a part, and they show this.
+ */
+[[nodiscard]] std::string declared_file_name (const FormField& field);
+
+/**
  * @brief Why this body's file parts cannot be sent, if any of them cannot.
  *
  * A part with no `src` (a row authored but never pointed at a file, or one

--- a/engine/src/http/form_body.cpp
+++ b/engine/src/http/form_body.cpp
@@ -55,11 +55,11 @@ std::string percent_decode (std::string value) {
     return out;
 }
 
-// The filename the server is told this part carries. Mirrors what the transfer
-// setup hands libcurl (`curl_mime_filedata` declares the basename, an explicit
-// `curl_mime_filename` overrides it), so a rendering cannot name one thing while
-// the send names another. Separators for both platforms because the path is
-// whatever the client on this machine wrote.
+} // namespace
+
+// Declared in the header since issue #1003: `pm.request.body.formdata` names a
+// part the same way the rendering does, and a second copy of the rule would not
+// receive this one's fixes.
 std::string declared_file_name (const FormField& field) {
     if (!field.file_name.empty ()) {
         return field.file_name;
@@ -67,8 +67,6 @@ std::string declared_file_name (const FormField& field) {
     const auto slash = field.src.find_last_of ("/\\");
     return slash == std::string::npos ? field.src : field.src.substr (slash + 1);
 }
-
-} // namespace
 
 bool is_form_mode (BodyMode mode) {
     return mode == BodyMode::Form || mode == BodyMode::FormData;

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -800,17 +800,103 @@ nlohmann::json get_script_completions () {
     { "sortText", "1_pm_request_headers_index_of" } });
 
     completions.push_back ({ { "label", "pm.request.body" }, { "kind", KIND_FIELD },
-    { "insertText", "pm.request.body" }, { "detail", "string | undefined (writable pre-request)" },
+    { "insertText", "pm.request.body" }, { "detail", "string & object (writable pre-request)" },
     { "documentation",
-    "The request body as a string (if any). Assign a string to replace it, or "
-    "delete it to send none. A body set on a request that had none is sent as "
-    "raw text - set Content-Type yourself. A form body reads as its fields "
-    "encoded `key=value&...`: for x-www-form-urlencoded that is the exact wire "
-    "body and an assignment parses back into the fields, while for form-data "
-    "it "
-    "is a rendering of the parts (the multipart bytes carry a boundary that "
-    "does not exist until the send) and an assignment is refused." },
+    "The request body (if any), as Postman's RequestBody object: mode, raw, "
+    "and the urlencoded/formdata field lists.\n\nIt still behaves as the "
+    "string it used to be - concatenation, template literals, ==, the String "
+    "methods and .length all give the body - so `===` and `typeof` are two of "
+    "the three things that changed; the third is that assigning it straight to "
+    "a header value is refused, like pm.request.url. Assign a string (or "
+    "body.raw) to replace the body, or delete it to send none. A body set on a "
+    "request that had none is sent as raw text - set Content-Type yourself. A "
+    "form body reads as its fields encoded `key=value&...`: for "
+    "x-www-form-urlencoded that is the exact wire body and an assignment "
+    "parses back into the fields, while for form-data it is a rendering of the "
+    "parts (the multipart bytes carry a boundary that does not exist until the "
+    "send) and an assignment is refused." },
     { "sortText", "1_pm_request_body" } });
+
+    completions.push_back ({ { "label", "pm.request.body.mode" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.body.mode" }, { "detail", "string" },
+    { "documentation",
+    "Postman's mode name: \"urlencoded\", \"formdata\", or \"raw\" for every "
+    "content mode - json, text, xml, binary, graphql and jsonrpc all carry "
+    "their body as one string, which is what raw means. Read-only; the mode "
+    "follows the request's body type." },
+    { "sortText", "2_pm_request_body_mode" } });
+
+    completions.push_back ({ { "label", "pm.request.body.raw" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.body.raw" }, { "detail", "string" },
+    { "documentation",
+    "The body as a string - the same text pm.request.body itself reads as, so "
+    "JSON.parse(pm.request.body.raw) is the imported-script idiom that "
+    "works.\n\nDefined for every mode, where Postman leaves it undefined for "
+    "the two form ones: a form body reading as nothing cannot be told apart "
+    "from a request with no body. Assigning it is the same write as assigning "
+    "the body - it parses back into the fields for x-www-form-urlencoded, and "
+    "is refused for form-data." },
+    { "sortText", "2_pm_request_body_raw" } });
+
+    completions.push_back ({ { "label", "pm.request.body.urlencoded" },
+    { "kind", KIND_FIELD }, { "insertText", "pm.request.body.urlencoded" },
+    // `object[]`, the spelling `pm.response.events` already uses, because the
+    // declaration generator names a fixed vocabulary of types and renders
+    // anything else as `void` - which would make every use of this list an
+    // editor error on correct code. The entry shape is the first line of the
+    // documentation instead, where the popup shows it.
+    { "detail", "object[] | undefined" },
+    { "documentation",
+    "{ key, value, disabled } for each x-www-form-urlencoded pair, or "
+    "undefined in any other mode. Values "
+    "are as the user wrote them, not percent-encoded - the encoding is what "
+    "body.raw answers. Disabled rows are listed with disabled: true rather "
+    "than omitted, so a script can see the row it would otherwise re-add.\n\n"
+    "Read-only: edit the request's form fields, or assign body.raw." },
+    { "sortText", "2_pm_request_body_urlencoded" } });
+
+    completions.push_back ({ { "label", "pm.request.body.formdata" },
+    { "kind", KIND_FIELD }, { "insertText", "pm.request.body.formdata" },
+    // `object[]` for the reason the urlencoded row above gives.
+    { "detail", "object[] | undefined" },
+    { "documentation",
+    "{ key, value?, type, fileName?, disabled } for each multipart part, or "
+    "undefined in any other mode. A text part carries "
+    "type \"text\" and a value; a file part carries type \"file\" and the "
+    "fileName the server is told, with no value at all - an empty string there "
+    "would read as a text field that happens to be empty, and the local path "
+    "is never disclosed.\n\nRead-only: edit the request's form fields." },
+    { "sortText", "2_pm_request_body_formdata" } });
+
+    completions.push_back ({ { "label", "pm.request.body.length" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.request.body.length" }, { "detail", "number" },
+    { "documentation",
+    "The length of the body string - defined on the object rather than "
+    "inherited, so it is the body's own length and not the 0 that String's "
+    "prototype would have answered." },
+    { "sortText", "2_pm_request_body_length" } });
+
+    completions.push_back ({ { "label", "pm.request.body.toString" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.body.toString()" },
+    { "detail", "pm.request.body.toString(): string" },
+    { "documentation",
+    "The body as a string. The explicit spelling of what every string context "
+    "already does, and what `===` needs to keep comparing the way it did." },
+    { "sortText", "2_pm_request_body_toString" } });
+
+    completions.push_back ({ { "label", "pm.request.body.valueOf" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.body.valueOf()" },
+    { "detail", "pm.request.body.valueOf(): string" },
+    { "documentation", "The body as a string - what an arithmetic or == coercion reaches." },
+    { "sortText", "2_pm_request_body_valueOf" } });
+
+    completions.push_back ({ { "label", "pm.request.body.toJSON" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.request.body.toJSON()" },
+    { "detail", "pm.request.body.toJSON(): string" },
+    { "documentation",
+    "The body as a string - what JSON.stringify embeds, so an object holding "
+    "the body serialises as the body and not as its members." },
+    { "sortText", "2_pm_request_body_toJSON" } });
 
     // Snippets for the mutation patterns. Without these, `pm.request.` offers
     // only the four reads and the capability is invisible in the editor.
@@ -838,14 +924,17 @@ nlohmann::json get_script_completions () {
     { { "label", "pm.request.body = JSON.stringify(...) (rewrite the body)" },
     { "kind", KIND_SNIPPET },
     { "insertText",
-    "var body = JSON.parse(pm.request.body);\n${1:// body.field = \"value\";}\n"
-    "pm.request.body = JSON.stringify(body);" },
+    "var body = JSON.parse(pm.request.body.raw);\n${1:// body.field = "
+    "\"value\";}\n"
+    "pm.request.body.raw = JSON.stringify(body);" },
     { "insertTextRules", INSERT_AS_SNIPPET }, { "filterText", "pm.request.body rewrite json" },
     { "detail", "Parse, edit and re-serialise the body (pre-request)" },
     { "documentation",
     "The body is a string in and a string out, so a structural edit is "
-    "parse - mutate - stringify. Compute anything derived from the body after "
-    "this, or it describes the old one." },
+    "parse - mutate - stringify. `.raw` is the Postman spelling and leaves the "
+    "body object in place; assigning pm.request.body a string still works and "
+    "replaces it with that string. Compute anything derived from the body "
+    "after this, or it describes the old one." },
     { "sortText", "2_pm_request_body_rewrite" } });
 
     // ========================================

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -5768,8 +5768,17 @@ void setup_pm_request (JSContext* ctx, JSValue pm) {
         // `typeof pm.request.body` stays the way a script tells "no body" from
         // "a body that happens to be empty".
         if (data->request->body.mode != BodyMode::None) {
-            JS_SetPropertyStr (
-            ctx, request, "body", new_request_body (ctx, data->request->body));
+            JSValue body = new_request_body (ctx, data->request->body);
+            if (JS_IsException (body)) {
+                // Defining the exception sentinel as a property would make
+                // `pm.request.body` an object no read can touch. A request with
+                // no reachable body reads as one with no body, which is the
+                // failure this can degrade to honestly. Same guard, same
+                // reason, as install_request_url.
+                JS_FreeValue (ctx, body);
+            } else {
+                JS_SetPropertyStr (ctx, request, "body", body);
+            }
         }
     }
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -5484,7 +5484,7 @@ enum BodyMember : std::uint8_t {
  * and a `binary` body carries bytes rather than the path `file.src` names.
  * Answering the mode without the member it exists for would be a silent wrong
  * answer, which is the class this program closes rather than adds to; issue
- * #1110 tracks filling them in.
+ * #1111 tracks filling them in.
  */
 const char* postman_body_mode (BodyMode mode) {
     switch (mode) {

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -549,6 +549,68 @@ RequestUrlState* request_url_state (JSValueConst value) {
 }
 
 /**
+ * @brief What `pm.request.body` carries (issue #1003).
+ *
+ * `body` is the composed body, which is where the mode and the field lists are
+ * read from; `text` is the string view (`script_body_view`) the object answers
+ * every string context with, and the one thing the write-back reads back. A
+ * `.raw` assignment moves `text` and nothing else - the write-back applies it
+ * through the same rules a whole-string assignment goes through, so there is one
+ * definition of what assigning a body means rather than two.
+ */
+struct RequestBodyState {
+    Body body;
+    std::string text;
+};
+
+JSClassID request_body_class_id = 0;
+
+void request_body_finalizer (JSRuntime* rt, JSValue val) {
+    (void)rt;
+    delete static_cast<RequestBodyState*> (JS_GetOpaque (val, request_body_class_id));
+}
+
+// No gc_mark, for the reason the Url class gives: the state holds C++ values,
+// never a JSValue.
+JSClassDef request_body_class = { .class_name = "RequestBody",
+    .finalizer                                = request_body_finalizer,
+    .gc_mark                                  = nullptr,
+    .call                                     = nullptr,
+    .exotic                                   = nullptr };
+
+/// The state behind a RequestBody object, or nullptr for anything else - a real
+/// class test, for the reason `request_url_state` gives.
+RequestBodyState* request_body_state (JSValueConst value) {
+    return static_cast<RequestBodyState*> (JS_GetOpaque (value, request_body_class_id));
+}
+
+/**
+ * @brief The text an assertion should read a string-like target as.
+ *
+ * A JS string, and the two objects that replaced one on `pm.request`: the Url
+ * (#991) and the RequestBody (#1003). Both are documented as still behaving as
+ * the string they replaced, and `pm.expect(pm.request.url).to.include(...)` is
+ * the idiom in this repo's own docs and tests - a verdict that silently flipped
+ * to failing is the worst thing an assertion can do, so the two are named here
+ * rather than left to whichever branch an object falls into.
+ *
+ * Only these three. Coercing *any* object would make
+ * `pm.expect({}).to.include('object')` pass.
+ */
+std::optional<std::string> expect_string_like (JSContext* ctx, JSValueConst value) {
+    if (auto* url = request_url_state (value)) {
+        return request_url_current_text (ctx, value, *url);
+    }
+    if (auto* body = request_body_state (value)) {
+        return body->text;
+    }
+    if (JS_IsString (value)) {
+        return js_to_string (ctx, value);
+    }
+    return std::nullopt;
+}
+
+/**
  * @brief The URL a value carries, for the surfaces that used to require a
  *        string and are documented as taking `pm.request.url`.
  *
@@ -1520,19 +1582,13 @@ JSValue expect_include (JSContext* ctx, JSValueConst this_val, int argc, JSValue
 
     bool includes = false;
 
-    // A Url object takes the substring branch, not the "neither string nor
-    // array" one that answers false. `pm.expect(pm.request.url).to.include(...)`
-    // is the idiom in this repo's own docs and tests, and #991 turned its
-    // target from a string into an object - a verdict that silently flipped to
-    // failing is the worst thing an assertion can do.
-    RequestUrlState* url = request_url_state (state->actual);
-
-    if (JS_IsString (state->actual) || url != nullptr) {
-        const std::string str = url != nullptr ?
-        request_url_current_text (ctx, state->actual, *url) :
-        js_to_string (ctx, state->actual);
-        std::string substr    = js_to_string (ctx, argv[0]);
-        includes              = str.find (substr) != std::string::npos;
+    // A Url or RequestBody object takes the substring branch, not the "neither
+    // string nor array" one that answers false: both replaced a string on
+    // `pm.request` (#991, #1003) and both are documented as still reading as
+    // one. See `expect_string_like`.
+    if (auto text = expect_string_like (ctx, state->actual)) {
+        const std::string substr = js_to_string (ctx, argv[0]);
+        includes                 = text->find (substr) != std::string::npos;
     } else if (JS_IsArray (state->actual)) {
         JSValue length = JS_GetPropertyStr (ctx, state->actual, "length");
         uint32_t len;
@@ -5399,6 +5455,283 @@ void install_request_url (JSContext* ctx, JSValue request, const std::string& ur
     JS_FreeValue (ctx, url);
 }
 
+// ---------------------------------------------------------------------------
+// pm.request.body - Postman's RequestBody object (issue #1003)
+// ---------------------------------------------------------------------------
+
+/// Which member a bound accessor answers for.
+enum BodyMember : std::uint8_t {
+    BODY_MODE,
+    BODY_RAW,
+    BODY_URLENCODED,
+    BODY_FORMDATA,
+    BODY_LENGTH
+};
+
+/**
+ * @brief The Postman mode name this body reads as.
+ *
+ * Three names, because those are the three shapes a script can *act* on: a
+ * string it can parse, a pair list, and a multipart part list. Vayu's other
+ * content modes - `json`, `text`, `xml`, `binary`, `graphql`, `jsonrpc` - each
+ * carry their body as one string, which is what `raw` means, so a lifted
+ * `body.mode === 'raw'` guard answers true for every one of them.
+ *
+ * The two Postman modes deliberately not answered are `graphql` and `file`,
+ * because each promises a member this engine has nothing to fill it from: a
+ * `graphql` body is stored as one string that may be an envelope or a bare
+ * document (`graphql_body.hpp`), never as Postman's `{query, variables}` pair,
+ * and a `binary` body carries bytes rather than the path `file.src` names.
+ * Answering the mode without the member it exists for would be a silent wrong
+ * answer, which is the class this program closes rather than adds to; issue
+ * #1110 tracks filling them in.
+ */
+const char* postman_body_mode (BodyMode mode) {
+    switch (mode) {
+    case BodyMode::Form: return "urlencoded";
+    case BodyMode::FormData: return "formdata";
+    // `None` never reaches here: a bodyless request defines no `body` property
+    // at all, so no object is built for it. See setup_pm_request.
+    default: return "raw";
+    }
+}
+
+/// The member a magic stands for, for the refusal that has to name it.
+const char* body_member_name (int magic) {
+    switch (magic) {
+    case BODY_MODE: return "mode";
+    case BODY_RAW: return "raw";
+    case BODY_URLENCODED: return "urlencoded";
+    case BODY_FORMDATA: return "formdata";
+    default: return "length";
+    }
+}
+
+/// One form field as Postman presents it - a read-only view of a composed part.
+JSValue body_field_entry (JSContext* ctx, const FormField& field, bool multipart) {
+    JSValue entry     = JS_NewObject (ctx);
+    const auto define = [&] (const char* name, JSValue value) {
+        JS_DefinePropertyValueStr (ctx, entry, name, value, JS_PROP_ENUMERABLE);
+    };
+    const auto define_text = [&] (const char* name, const std::string& text) {
+        define (name, JS_NewStringLen (ctx, text.data (), text.size ()));
+    };
+    define_text ("key", field.key);
+    if (multipart && field.type == FormFieldType::File) {
+        // No `value` at all, rather than the `""` a file part's `value` holds:
+        // an empty string here reads as a text field that happens to be empty,
+        // which is the one distinction `render_form_data_parts` exists to keep
+        // (issue #411). What a script may see is the name the *server* is told,
+        // never the path - see `declared_file_name`.
+        define ("type", JS_NewString (ctx, "file"));
+        define_text ("fileName", vayu::http::declared_file_name (field));
+    } else {
+        define_text ("value", field.value);
+        if (multipart) {
+            define ("type", JS_NewString (ctx, "text"));
+        }
+    }
+    // Disabled rows are listed rather than dropped, unlike the string view: the
+    // list is what a script inspects the *request* with, and a row it cannot see
+    // is one it would re-add. The flag is what says the row is not sent.
+    define ("disabled", JS_NewBool (ctx, !field.enabled));
+    (void)JS_PreventExtensions (ctx, entry);
+    return entry;
+}
+
+/**
+ * @brief The read-only list `.urlencoded` / `.formdata` answer with.
+ *
+ * Not extensible, and its entries not writable, so `push`, `splice` and a field
+ * assignment throw instead of editing a list nothing reads back. #1003 keeps the
+ * write surface exactly as it shipped - a whole-body string, or `.raw` - and a
+ * list that quietly accepted edits would be the silent-wrong shape again.
+ */
+JSValue body_field_list (JSContext* ctx, const std::vector<FormField>& fields, bool multipart) {
+    JSValue list  = JS_NewArray (ctx);
+    uint32_t next = 0;
+    for (const auto& field : fields) {
+        JS_SetPropertyUint32 (ctx, list, next++, body_field_entry (ctx, field, multipart));
+    }
+    (void)JS_PreventExtensions (ctx, list);
+    return list;
+}
+
+/**
+ * The body as a string, and the single answer behind every string context.
+ *
+ * `toString`, `valueOf`, `toJSON` and `@@toPrimitive` all land here, for the
+ * reason `js_url_to_string` gives: concatenation, a template literal, `==`
+ * against a string, `JSON.stringify` and `String.prototype`'s generic methods
+ * keep behaving the way they did when this was a string.
+ */
+JSValue js_body_to_string (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = request_body_state (this_val);
+    if (!state) {
+        return JS_ThrowTypeError (ctx, "not a pm.request.body object");
+    }
+    return JS_NewStringLen (ctx, state->text.data (), state->text.size ());
+}
+
+JSValue js_body_member_get (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)argc;
+    (void)argv;
+    (void)func_data;
+    auto* state = request_body_state (this_val);
+    if (!state) {
+        return JS_ThrowTypeError (ctx, "not a pm.request.body object");
+    }
+    switch (magic) {
+    case BODY_MODE:
+        return JS_NewString (ctx, postman_body_mode (state->body.mode));
+    // `.raw` is the string view for **every** mode, where Postman leaves it
+    // undefined for the two form ones. That is the divergence #411 already
+    // decided: a form body reading as nothing is indistinguishable from a
+    // request with no body, and this object exists to add answers rather than
+    // take one back.
+    case BODY_RAW:
+        return JS_NewStringLen (ctx, state->text.data (), state->text.size ());
+    case BODY_URLENCODED:
+        return state->body.mode == BodyMode::Form ?
+        body_field_list (ctx, state->body.fields, /*multipart=*/false) :
+        JS_UNDEFINED;
+    case BODY_FORMDATA:
+        return state->body.mode == BodyMode::FormData ?
+        body_field_list (ctx, state->body.fields, /*multipart=*/true) :
+        JS_UNDEFINED;
+    // Defined rather than left to the prototype, for the reason #991 gives
+    // about the URL's: `String.prototype` is a String object holding `""`, so
+    // an inherited `length` answers 0 - a plausible number for a body that is
+    // not empty, and `docs/engine/scripting.md` sets Content-Length from it.
+    case BODY_LENGTH:
+        return JS_NewInt64 (ctx, static_cast<int64_t> (state->text.size ()));
+    default: return JS_UNDEFINED;
+    }
+}
+
+JSValue js_body_member_set (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)func_data;
+    auto* state = request_body_state (this_val);
+    if (!state) {
+        return JS_ThrowTypeError (ctx, "not a pm.request.body object");
+    }
+    if (magic != BODY_RAW) {
+        // The members that *describe* the body rather than carry it. Refused at
+        // the assignment rather than ignored: a script that set `.mode` or
+        // rebuilt `.urlencoded` would otherwise send the body it started with
+        // and be told nothing, which is the exact silent-wrong shape this
+        // program exists to close.
+        return JS_ThrowTypeError (ctx,
+        "pm.request.body.%s is read-only - assign pm.request.body or "
+        "pm.request.body.raw to change what is sent, or edit the request's "
+        "form "
+        "fields",
+        body_member_name (magic));
+    }
+    if (argc < 1 || !JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx, "pm.request.body.raw must be assigned a string, got %s",
+        argc > 0 ? js_type_name (ctx, argv[0]) : "no value");
+    }
+    // Only the view moves. What assigning a body *means* - the untouched rule,
+    // the urlencoded parse-back, the form-data refusal - is the write-back's,
+    // and is reached identically whether the script assigned `.raw` or the whole
+    // body. One definition, not two.
+    state->text = js_to_string (ctx, argv[0]);
+    return JS_UNDEFINED;
+}
+
+/**
+ * @brief A RequestBody object over @p body, with the Postman members on it.
+ *
+ * A plain property on `pm.request` rather than #991's accessor pair, and the one
+ * place this shape departs from that precedent. The URL needed an accessor so
+ * that `pm.request.url = x` left a Url object behind; for the body, a string
+ * assignment leaving a plain string *is* the shipped contract, and `null` and
+ * `delete` both mean "send no body" - an accessor would have to carry an
+ * emptied-state flag to keep saying so, machinery bought for a chained access
+ * nothing asks for.
+ */
+JSValue new_request_body (JSContext* ctx, const Body& body) {
+    JSValue object = JS_NewObjectClass (ctx, request_body_class_id);
+    if (JS_IsException (object)) {
+        return object;
+    }
+    auto* state = new RequestBodyState{ body, script_body_view (body) };
+    if (JS_SetOpaque (object, state) < 0) {
+        // The object is not of this class, so the finalizer will never run and
+        // nothing else would free the state.
+        delete state;
+        JS_FreeValue (ctx, object);
+        return JS_EXCEPTION;
+    }
+
+    // Defined rather than set, for the reason build_request_url_members gives:
+    // `String.prototype` is the prototype here, and `[[Set]]` consults it.
+    const auto define = [&] (const char* name, JSValue value) {
+        JS_DefinePropertyValueStr (ctx, object, name, value, JS_PROP_C_W_E);
+    };
+    define ("toString", JS_NewCFunction (ctx, js_body_to_string, "toString", 0));
+    define ("valueOf", JS_NewCFunction (ctx, js_body_to_string, "valueOf", 0));
+    define ("toJSON", JS_NewCFunction (ctx, js_body_to_string, "toJSON", 0));
+    JSAtom to_primitive = well_known_symbol_atom (ctx, "toPrimitive");
+    JS_DefinePropertyValue (ctx, object, to_primitive,
+    JS_NewCFunction (ctx, js_body_to_string, "[Symbol.toPrimitive]", 1),
+    JS_PROP_CONFIGURABLE);
+    JS_FreeAtom (ctx, to_primitive);
+
+    // Accessors, not values: a read is answered from the state, and a write
+    // reaches it or is refused by name. `this` carries the state, so the pair
+    // needs no bound data - and a getter pulled off the object and called on
+    // something else finds no state and throws rather than reading one.
+    const auto define_accessor = [&] (const char* name, int magic) {
+        JSAtom atom = JS_NewAtom (ctx, name);
+        JS_DefinePropertyGetSet (ctx, object, atom,
+        JS_NewCFunctionData (ctx, js_body_member_get, 0, magic, 0, nullptr),
+        JS_NewCFunctionData (ctx, js_body_member_set, 1, magic, 0, nullptr),
+        JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE);
+        JS_FreeAtom (ctx, atom);
+    };
+    define_accessor ("mode", BODY_MODE);
+    define_accessor ("raw", BODY_RAW);
+    define_accessor ("urlencoded", BODY_URLENCODED);
+    define_accessor ("formdata", BODY_FORMDATA);
+    define_accessor ("length", BODY_LENGTH);
+    return object;
+}
+
+/**
+ * @brief The body text a value carries, the sibling of `script_url_text`.
+ *
+ * A JS string is itself; a RequestBody object is the string view it holds, which
+ * a `.raw` assignment has already moved. Anything else is `nullopt`, and the
+ * caller says so in its own words.
+ *
+ * Deliberately *not* "any object, via toString": `pm.request.body = {}` would
+ * then become the string `[object Object]` and reach the wire, which is exactly
+ * the silent-wrong-request class this program exists to close.
+ */
+std::optional<std::string> script_body_text (JSContext* ctx, JSValueConst value) {
+    if (JS_IsString (value)) {
+        return js_to_string (ctx, value);
+    }
+    if (auto* state = request_body_state (value)) {
+        return state->text;
+    }
+    return std::nullopt;
+}
+
 void setup_pm_request (JSContext* ctx, JSValue pm) {
     auto* data = get_context_data (ctx);
 
@@ -5428,13 +5761,15 @@ void setup_pm_request (JSContext* ctx, JSValue pm) {
         }
         JS_SetPropertyStr (ctx, request, "headers", headers);
 
-        // pm.request.body - a string for every mode, including the two that
-        // carry their content in `fields`. A bodyless request still defines no
-        // property at all, so `typeof pm.request.body` stays the way a script
-        // tells "no body" from "a body that happens to be empty".
+        // pm.request.body - Postman's RequestBody object, not the string it used
+        // to be (issue #1003). It still *reads* as that string in every context
+        // JavaScript allows, and the string is still what an assignment means.
+        // A bodyless request defines no property at all, so
+        // `typeof pm.request.body` stays the way a script tells "no body" from
+        // "a body that happens to be empty".
         if (data->request->body.mode != BodyMode::None) {
-            const std::string view = script_body_view (data->request->body);
-            JS_SetPropertyStr (ctx, request, "body", JS_NewString (ctx, view.c_str ()));
+            JS_SetPropertyStr (
+            ctx, request, "body", new_request_body (ctx, data->request->body));
         }
     }
 
@@ -5660,8 +5995,11 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
     ScopedValue js_body (ctx, JS_GetPropertyStr (ctx, js_request.get (), "body"));
     if (JS_IsUndefined (js_body.get ()) || JS_IsNull (js_body.get ())) {
         staged.body = Body{};
-    } else if (JS_IsString (js_body.get ())) {
-        std::string body_text = js_to_string (ctx, js_body.get ());
+    } else if (auto staged_text = script_body_text (ctx, js_body.get ())) {
+        // Either shape: the RequestBody object `pm.request.body` normally holds,
+        // or a plain string, which is what an assignment leaves there. Both are
+        // the body as a string, and both mean the same thing from here on.
+        std::string body_text = std::move (*staged_text);
         // Every other member of pm.request is authoritative rather than a diff:
         // whatever the object holds is what is sent. `body` cannot be read that
         // way for a form mode, because the string the script was handed is a
@@ -5703,7 +6041,8 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
             }
         }
     } else {
-        return "pm.request.body must be a string, got " +
+        return "pm.request.body must be a string or a request body object, "
+               "got " +
         std::string (js_type_name (ctx, js_body.get ()));
     }
 
@@ -7988,9 +8327,13 @@ void setup_pm_object (JSContext* ctx) {
     // through `ToString(this)`, which the object's own `@@toPrimitive` answers
     // with the URL. What it does not restore is `.length` - an own property of
     // a real string, and one of the three breaks #991 documents.
+    // `pm.request.body` inherits from it for the same reason (issue #1003), so
+    // the first call gets a reference of its own - `JS_SetClassProto` takes
+    // ownership of the value it is given.
     JSValue string_ctor  = JS_GetPropertyStr (ctx, global, "String");
     JSValue string_proto = JS_GetPropertyStr (ctx, string_ctor, "prototype");
     JS_FreeValue (ctx, string_ctor);
+    JS_SetClassProto (ctx, request_body_class_id, JS_DupValue (ctx, string_proto));
     JS_SetClassProto (ctx, request_url_class_id, string_proto);
 
     // pm.test()
@@ -8133,6 +8476,12 @@ class ScriptEngine::Impl {
             JS_NewClassID (rt, &request_url_class_id);
         }
         JS_NewClass (rt, request_url_class_id, &request_url_class);
+
+        // Register the pm.request.body class - same story, same prototype.
+        if (request_body_class_id == 0) {
+            JS_NewClassID (rt, &request_body_class_id);
+        }
+        JS_NewClass (rt, request_body_class_id, &request_body_class);
 
         JSContext* ctx = JS_NewContext (rt);
         if (ctx) {

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(vayu_tests
     jsonrpc_body_test.cpp
     url_parts_test.cpp
     script_request_url_test.cpp
+    script_request_body_test.cpp
     xml_body_test.cpp
     stats_route_test.cpp
     execution_timeout_test.cpp

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -854,9 +854,51 @@ declare const pm: {
 	 */
 	request: {
 		/**
-		 * The request body as a string (if any). Assign a string to replace it, or delete it to send none. A body set on a request that had none is sent as raw text - set Content-Type yourself. A form body reads as its fields encoded `key=value&...`: for x-www-form-urlencoded that is the exact wire body and an assignment parses back into the fields, while for form-data it is a rendering of the parts (the multipart bytes carry a boundary that does not exist until the send) and an assignment is refused.
+		 * The request body (if any), as Postman's RequestBody object: mode, raw, and the urlencoded/formdata field lists.
+		 * 
+		 * It still behaves as the string it used to be - concatenation, template literals, ==, the String methods and .length all give the body - so `===` and `typeof` are two of the three things that changed; the third is that assigning it straight to a header value is refused, like pm.request.url. Assign a string (or body.raw) to replace the body, or delete it to send none. A body set on a request that had none is sent as raw text - set Content-Type yourself. A form body reads as its fields encoded `key=value&...`: for x-www-form-urlencoded that is the exact wire body and an assignment parses back into the fields, while for form-data it is a rendering of the parts (the multipart bytes carry a boundary that does not exist until the send) and an assignment is refused.
 		 */
-		body: string | undefined;
+		get body(): string & {
+			/**
+			 * { key, value?, type, fileName?, disabled } for each multipart part, or undefined in any other mode. A text part carries type "text" and a value; a file part carries type "file" and the fileName the server is told, with no value at all - an empty string there would read as a text field that happens to be empty, and the local path is never disclosed.
+			 * 
+			 * Read-only: edit the request's form fields.
+			 */
+			formdata: { [key: string]: any }[] | undefined;
+			/**
+			 * The length of the body string - defined on the object rather than inherited, so it is the body's own length and not the 0 that String's prototype would have answered.
+			 */
+			length: number;
+			/**
+			 * Postman's mode name: "urlencoded", "formdata", or "raw" for every content mode - json, text, xml, binary, graphql and jsonrpc all carry their body as one string, which is what raw means. Read-only; the mode follows the request's body type.
+			 */
+			mode: string;
+			/**
+			 * The body as a string - the same text pm.request.body itself reads as, so JSON.parse(pm.request.body.raw) is the imported-script idiom that works.
+			 * 
+			 * Defined for every mode, where Postman leaves it undefined for the two form ones: a form body reading as nothing cannot be told apart from a request with no body. Assigning it is the same write as assigning the body - it parses back into the fields for x-www-form-urlencoded, and is refused for form-data.
+			 */
+			raw: string;
+			/**
+			 * The body as a string - what JSON.stringify embeds, so an object holding the body serialises as the body and not as its members.
+			 */
+			toJSON(): string;
+			/**
+			 * The body as a string. The explicit spelling of what every string context already does, and what `===` needs to keep comparing the way it did.
+			 */
+			toString(): string;
+			/**
+			 * { key, value, disabled } for each x-www-form-urlencoded pair, or undefined in any other mode. Values are as the user wrote them, not percent-encoded - the encoding is what body.raw answers. Disabled rows are listed with disabled: true rather than omitted, so a script can see the row it would otherwise re-add.
+			 * 
+			 * Read-only: edit the request's form fields, or assign body.raw.
+			 */
+			urlencoded: { [key: string]: any }[] | undefined;
+			/**
+			 * The body as a string - what an arithmetic or == coercion reaches.
+			 */
+			valueOf(): string;
+		};
+		set body(value: string);
 		/**
 		 * Request headers as key-value pairs. The object is authoritative: the set it holds at the end is the set that is sent, so delete removes a header. Names are case-sensitive here (use 'Authorization', not 'authorization'), and values must be a string, number or boolean.
 		 */

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -120,7 +120,7 @@ TEST (ScriptCompletions, TheMutationSnippetsAreOfferedAndReachable) {
         } else if (insert.rfind ("pm.request.headers[", 0) == 0) {
             has_set_header = true;
             EXPECT_NE (match.find ("pm.request.headers"), std::string::npos) << match;
-        } else if (insert.find ("pm.request.body = JSON.stringify") != std::string::npos) {
+        } else if (insert.find ("pm.request.body.raw = JSON.stringify") != std::string::npos) {
             has_body_rewrite = true;
             EXPECT_NE (match.find ("pm.request.body"), std::string::npos) << match;
         }

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -2545,7 +2545,7 @@ TEST_F (ScriptEngineTest, ScriptReadsAUrlencodedBodyAsTheStringThatGoesOnTheWire
     request.body = urlencoded_body ();
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2559,7 +2559,7 @@ TEST_F (ScriptEngineTest, ScriptReadsAFormDataBodyAsItsFieldsRatherThanEmpty) {
     request.body = form_data_body ();
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
         pm.request.headers['X-Body-Empty'] = String(pm.request.body === '');
     )JS",
     request, env);
@@ -2576,7 +2576,7 @@ TEST_F (ScriptEngineTest, ScriptReadingAFormBodySeesOnlyTheEnabledFields) {
     request.body.fields = { { "kept", "1", true }, { "off", "2", false } };
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2605,7 +2605,7 @@ TEST_F (ScriptEngineTest, ScriptOnlyReadingAFormBodyLeavesItsFieldsAlone) {
     request.body.fields = { { "kept", "1", true }, { "off", "2", false } };
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2648,7 +2648,7 @@ TEST_F (ScriptEngineTest, ScriptWritingBackAnUnchangedUrlencodedBodyChangesNothi
     const Body before = request.body;
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.body = pm.request.body;
+        pm.request.body = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2708,7 +2708,7 @@ TEST_F (ScriptEngineTest, ScriptTellsAFilePartFromAnEmptyTextField) {
     request.body = form_data_body_with_a_file ("/home/ada/portrait.png");
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2723,7 +2723,7 @@ TEST_F (ScriptEngineTest, ScriptTellsAFilePartFromAnEmptyTextField) {
     text_request.body.fields = { { "caption", "my avatar", true }, { "avatar", "", true } };
 
     auto text_result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     text_request, env);
 
@@ -2754,7 +2754,7 @@ TEST_F (ScriptEngineTest, ReadingABodyWithAFilePartRewritesNothing) {
     const Body before = request.body;
 
     auto result = engine.execute_prerequest (R"JS(
-        pm.request.headers['X-Seen-Body'] = pm.request.body;
+        pm.request.headers['X-Seen-Body'] = String(pm.request.body);
     )JS",
     request, env);
 
@@ -2806,7 +2806,7 @@ TEST_F (ScriptEngineTest, TestScriptReadsAFormBodyToo) {
 
     auto result = engine.execute_test (R"JS(
         pm.test('body is visible', function () {
-            if (pm.request.body !== 'grant_type=client_credentials&scope=read%20write') {
+            if (String(pm.request.body) !== 'grant_type=client_credentials&scope=read%20write') {
                 throw new Error('got: ' + pm.request.body);
             }
         });

--- a/engine/tests/script_request_body_test.cpp
+++ b/engine/tests/script_request_body_test.cpp
@@ -1,0 +1,473 @@
+/**
+ * @file tests/script_request_body_test.cpp
+ * @brief `pm.request.body` as Postman's `RequestBody` object (issue #1003).
+ *
+ * The sibling of `script_request_url_test.cpp`, pinning the same trade for the
+ * same reason: Postman compatibility wins over the string shape the member had,
+ * and both halves of that trade have to hold at once.
+ *
+ * - the compatibility half - a lifted Postman script reading `body.mode`,
+ *   `body.raw`, `body.urlencoded` and `body.formdata` runs unmodified, and
+ *   `JSON.parse(pm.request.body.raw)` is the idiom that has to work;
+ * - the mitigation half - concatenation, template literals, `==`, the generic
+ *   `String.prototype` methods and `JSON.stringify` still behave as they did,
+ *   because a change that quietly broke every script treating the body as a
+ *   string would not be worth the compatibility it bought.
+ *
+ * The three things that genuinely changed - `===`, `typeof`, and assigning the
+ * body straight into a header value - are asserted **as** breaks, for the reason
+ * #991 gives: a documented break nothing pins comes back as an accident later,
+ * and the docs would then describe behaviour the engine no longer has.
+ *
+ * What this suite must *not* let move is the write surface, which #1003 keeps
+ * exactly as it shipped: a whole-string assignment, the untouched rule that
+ * keeps a read-only script from rewriting a form body, the urlencoded
+ * parse-back, and the form-data refusal. Each is asserted here against the
+ * request that would be sent rather than against the JS object, because the
+ * object agreeing with itself proves nothing about the wire.
+ */
+
+#include "vayu/runtime/script_engine.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "vayu/types.hpp"
+
+using namespace vayu;
+using namespace vayu::runtime;
+
+namespace {
+
+#ifdef VAYU_HAS_QUICKJS
+
+Body json_body () {
+    Body body;
+    body.mode    = BodyMode::Json;
+    body.content = R"({"name":"Ada","count":2})";
+    return body;
+}
+
+Body urlencoded_body () {
+    Body body;
+    body.mode   = BodyMode::Form;
+    body.fields = { { "grant_type", "client_credentials", true },
+        { "scope", "read write", true }, { "legacy", "off", false } };
+    return body;
+}
+
+Body form_data_body () {
+    Body body;
+    body.mode = BodyMode::FormData;
+    body.fields.push_back ({ "name", "Ada", true });
+    FormField upload;
+    upload.key       = "avatar";
+    upload.type      = FormFieldType::File;
+    upload.src       = "/home/ada/pictures/portrait.png";
+    upload.file_name = "portrait.png";
+    body.fields.push_back (upload);
+    return body;
+}
+
+class ScriptRequestBodyTest : public ::testing::Test {
+    protected:
+    ScriptEngine engine;
+    Request request;
+    Response response;
+    Environment env;
+
+    void SetUp () override {
+        request.method       = HttpMethod::POST;
+        request.url          = "https://api.example.com/v2/users";
+        request.body         = json_body ();
+        response.status_code = 200;
+        response.status_text = "OK";
+        response.body        = "{}";
+    }
+
+    /// A single `pm.test` whose verdict is the assertion. The name is asserted
+    /// too, so a script that threw before reaching its test - which produces no
+    /// verdict at all - cannot read as a pass.
+    void expect_script_passes (const std::string& body) {
+        ScriptContext ctx;
+        ctx.request     = &request;
+        ctx.response    = &response;
+        ctx.environment = &env;
+        const ScriptResult result =
+        engine.execute ("pm.test('assertion', function () {\n" + body + "\n});", ctx);
+        // The script's own failure first: `success` is also false when a verdict
+        // failed, and reading that as a thrown error hides the assertion that
+        // actually went red.
+        ASSERT_TRUE (result.error_message.empty ()) << result.error_message;
+        ASSERT_EQ (result.tests.size (), 1u) << body;
+        EXPECT_EQ (result.tests[0].name, "assertion");
+        EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+        EXPECT_TRUE (result.success);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// The RequestBody read surface.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestBodyTest, AContentBodyReadsAsPostmansRawMode) {
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('raw');
+        pm.expect(pm.request.body.raw).to.equal('{"name":"Ada","count":2}');
+        pm.expect(pm.request.body.urlencoded).to.equal(undefined);
+        pm.expect(pm.request.body.formdata).to.equal(undefined);
+    )JS");
+}
+
+/**
+ * The idiom the issue exists for. It threw before #1003 - `.raw` was undefined,
+ * so `JSON.parse` was handed the string "undefined" - which is the loud half of
+ * the pair; the silent half is the `mode === 'raw'` guard above.
+ */
+TEST_F (ScriptRequestBodyTest, JsonParseOfRawIsTheImportedIdiomAndRoundTrips) {
+    expect_script_passes (R"JS(
+        var parsed = JSON.parse(pm.request.body.raw);
+        pm.expect(parsed.name).to.equal('Ada');
+        pm.expect(parsed.count).to.equal(2);
+    )JS");
+}
+
+/**
+ * Every content mode is `raw`, because each carries its body as one string.
+ * Asserted over all of them rather than one, since the mapping is a switch whose
+ * default arm is what answers for five of the six.
+ */
+TEST_F (ScriptRequestBodyTest, EveryContentModeAnswersRaw) {
+    for (const BodyMode mode : { BodyMode::Json, BodyMode::Text, BodyMode::Binary,
+         BodyMode::GraphQL, BodyMode::JsonRpc, BodyMode::Xml }) {
+        request.body.mode    = mode;
+        request.body.content = "payload";
+        expect_script_passes (R"JS(
+            pm.expect(pm.request.body.mode).to.equal('raw');
+            pm.expect(pm.request.body.raw).to.equal('payload');
+        )JS");
+    }
+}
+
+TEST_F (ScriptRequestBodyTest, AUrlencodedBodyReadsAsItsPairsWithTheDisabledRowFlagged) {
+    request.body = urlencoded_body ();
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('urlencoded');
+        var pairs = pm.request.body.urlencoded;
+        pm.expect(pairs.length).to.equal(3);
+        pm.expect(pairs[0].key).to.equal('grant_type');
+        pm.expect(pairs[0].value).to.equal('client_credentials');
+        pm.expect(pairs[0].disabled).to.equal(false);
+        // The value is the one the user wrote, not the percent-encoded wire
+        // form - the encoding is `.raw`'s answer, and a signature built from
+        // these pairs would double-encode if this were encoded too.
+        pm.expect(pairs[1].value).to.equal('read write');
+        // The disabled row is listed rather than dropped: the string view omits
+        // it, and a script that could not see it would re-add it.
+        pm.expect(pairs[2].key).to.equal('legacy');
+        pm.expect(pairs[2].disabled).to.equal(true);
+        pm.expect(pm.request.body.formdata).to.equal(undefined);
+    )JS");
+}
+
+/**
+ * `.raw` is the wire body for a urlencoded request, which is the one thing that
+ * separates this mode from form-data: the string parses straight back.
+ */
+TEST_F (ScriptRequestBodyTest, AUrlencodedBodysRawIsTheStringThatGoesOnTheWire) {
+    request.body = urlencoded_body ();
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.raw).to.equal(
+            'grant_type=client_credentials&scope=read%20write');
+    )JS");
+}
+
+TEST_F (ScriptRequestBodyTest, AFormDataBodyNamesItsFilePartAndNeverItsPath) {
+    request.body = form_data_body ();
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('formdata');
+        var parts = pm.request.body.formdata;
+        pm.expect(parts.length).to.equal(2);
+        pm.expect(parts[0].type).to.equal('text');
+        pm.expect(parts[0].value).to.equal('Ada');
+        pm.expect(parts[1].type).to.equal('file');
+        pm.expect(parts[1].fileName).to.equal('portrait.png');
+        // The two halves of issue #411's distinction, on the object this time:
+        // a file part carries no `value` at all, so it cannot be read as a text
+        // field that happens to be empty - and the local path is not disclosed.
+        pm.expect(parts[1].value).to.equal(undefined);
+        pm.expect(JSON.stringify(parts[1])).to.not.include('/home/ada');
+        pm.expect(pm.request.body.urlencoded).to.equal(undefined);
+    )JS");
+}
+
+TEST_F (ScriptRequestBodyTest, ABodylessRequestStillDefinesNoBodyAtAll) {
+    request.body = Body{};
+    expect_script_passes (R"JS(
+        pm.expect(typeof pm.request.body).to.equal('undefined');
+    )JS");
+}
+
+// ---------------------------------------------------------------------------
+// The string mitigations - what must NOT have changed.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestBodyTest, StillBehavesAsAStringInEveryContextItCan) {
+    request.body.content = "hello";
+    expect_script_passes (R"JS(
+        var body = pm.request.body;
+        pm.expect('' + body).to.equal('hello');
+        pm.expect(`${body}`).to.equal('hello');
+        pm.expect(body == 'hello').to.equal(true);
+        pm.expect(body.startsWith('he')).to.equal(true);
+        pm.expect(body.includes('ell')).to.equal(true);
+        pm.expect(body.slice(0, 2)).to.equal('he');
+        pm.expect(body.indexOf('llo')).to.equal(2);
+        pm.expect(body.split('l')[0]).to.equal('he');
+        pm.expect(body.toString()).to.equal('hello');
+        pm.expect(body.length).to.equal(5);
+        pm.expect(JSON.stringify({ b: body })).to.equal('{"b":"hello"}');
+    )JS");
+}
+
+// The repo's own docs and tests spell it this way, and the doc example that
+// signs a request reads `pm.request.body || ''` before joining.
+TEST_F (ScriptRequestBodyTest, ExpectIncludeAndTruthinessStillReadItAsAString) {
+    request.body.content = "hello";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body).to.include('ell');
+        pm.expect(pm.request.body).to.not.include('nowhere');
+        pm.expect([pm.request.body || ''].join('|')).to.equal('hello');
+    )JS");
+}
+
+/**
+ * A form body still reads as its fields rather than as `""` - the #411 decision
+ * this object had to keep, and the reason `.raw` answers for every mode where
+ * Postman leaves it undefined for the two form ones.
+ */
+TEST_F (ScriptRequestBodyTest, AFormBodyStillReadsAsItsFieldsInAStringContext) {
+    request.body = form_data_body ();
+    expect_script_passes (R"JS(
+        pm.expect('' + pm.request.body).to.equal('name=Ada&avatar=@portrait.png');
+        pm.expect(pm.request.body.raw).to.equal('name=Ada&avatar=@portrait.png');
+    )JS");
+}
+
+/**
+ * `.length` is an own property, not an inherited one - and that is the whole
+ * point of asserting it.
+ *
+ * `String.prototype` is a String exotic object holding "", so an object that
+ * only inherits from it answers `0` here. Deleting the own definition makes this
+ * test read 0 for a 24-character body, which is the silent wrong answer the
+ * object is built to avoid - and `docs/engine/scripting.md`'s worked example
+ * sets Content-Length from exactly this.
+ */
+TEST_F (ScriptRequestBodyTest, LengthIsTheBodysOwnLengthAndNotTheInheritedZero) {
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.length).to.equal(24);
+        pm.expect(pm.request.body.length).to.equal(pm.request.body.toString().length);
+    )JS");
+}
+
+/**
+ * The three documented breaks, asserted as breaks.
+ *
+ * The header one is the same refusal `pm.request.url` already gets: a value the
+ * engine cannot send is refused rather than coerced, and an object is not a
+ * header value. It is pinned here because it is the one break a script is likely
+ * to *hit* - `headers['X-Body'] = pm.request.body` reads as ordinary code.
+ */
+TEST_F (ScriptRequestBodyTest, TheDocumentedBreaksAreWhatTheDocsSay) {
+    request.body.content = "hello";
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body === 'hello').to.equal(false);
+        pm.expect(typeof pm.request.body).to.equal('object');
+    )JS");
+
+    request.body        = json_body ();
+    const Body before   = request.body;
+    const auto rejected = engine.execute_prerequest (R"JS(
+        pm.request.headers['X-Body'] = pm.request.body;
+    )JS",
+    request, env);
+    EXPECT_FALSE (rejected.success);
+    EXPECT_NE (rejected.error_message.find ("must be a string"), std::string::npos)
+    << rejected.error_message;
+    EXPECT_EQ (request.body.content, before.content)
+    << "a rejected write-back is all-or-nothing";
+}
+
+// ---------------------------------------------------------------------------
+// Writes - unchanged by #1003, and asserted against the request that is sent.
+// ---------------------------------------------------------------------------
+
+TEST_F (ScriptRequestBodyTest, AssigningRawReachesTheBodyThatIsSent) {
+    auto result = engine.execute_prerequest (R"JS(
+        var parsed = JSON.parse(pm.request.body.raw);
+        parsed.count = 7;
+        pm.request.body.raw = JSON.stringify(parsed);
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.body.mode, BodyMode::Json)
+    << "the mode is not the script's to change";
+    EXPECT_EQ (request.body.content, R"({"name":"Ada","count":7})");
+}
+
+TEST_F (ScriptRequestBodyTest, AssigningRawOnAUrlencodedBodyParsesBackIntoTheFields) {
+    request.body = urlencoded_body ();
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body.raw = pm.request.body.raw + '&audience=api';
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (request.body.fields.size (), 3u)
+    << "the disabled row is not in the wire string";
+    EXPECT_EQ (request.body.fields[2].key, "audience");
+    EXPECT_EQ (request.body.fields[2].value, "api");
+    EXPECT_TRUE (request.body.content.empty ())
+    << "exactly one of content and fields carries it";
+}
+
+TEST_F (ScriptRequestBodyTest, AssigningRawOnAFormDataBodyIsRefusedRatherThanDropped) {
+    request.body      = form_data_body ();
+    const Body before = request.body;
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body.raw = 'name=Grace';
+    )JS",
+    request, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("form-data"), std::string::npos)
+    << result.error_message;
+    ASSERT_EQ (request.body.fields.size (), before.fields.size ());
+    EXPECT_EQ (request.body.fields[1].src, before.fields[1].src)
+    << "the upload survives";
+}
+
+/// The shipped whole-string write, unchanged - the object is only a second way
+/// to reach it.
+TEST_F (ScriptRequestBodyTest, AssigningTheWholeBodyAsAStringStillWorks) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body = 'plain text';
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.body.content, "plain text");
+    EXPECT_EQ (request.body.mode, BodyMode::Json) << "an existing mode is kept";
+}
+
+/// Handing the object back where a string used to go is the shape a script that
+/// rebuilds `pm.request` wholesale produces, and the untouched rule has to see
+/// through it or every read-only script would rewrite its own form body.
+TEST_F (ScriptRequestBodyTest, AssigningTheObjectToItselfChangesNothing) {
+    request.body      = urlencoded_body ();
+    const Body before = request.body;
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body = pm.request.body;
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (request.body.fields.size (), before.fields.size ());
+    EXPECT_EQ (request.body.fields[2].key, "legacy");
+    EXPECT_FALSE (request.body.fields[2].enabled)
+    << "the disabled row is still disabled";
+}
+
+TEST_F (ScriptRequestBodyTest, DeletingTheBodyStillSendsNone) {
+    auto result = engine.execute_prerequest (R"JS(
+        delete pm.request.body;
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (request.body.mode, BodyMode::None);
+    EXPECT_TRUE (request.body.content.empty ());
+}
+
+/**
+ * The members that describe the body refuse a write instead of ignoring one.
+ *
+ * Each is checked against the request as well as the error, because "the script
+ * failed" and "the script failed *and changed nothing*" are different outcomes
+ * and only the second is the all-or-nothing rule the write-back promises.
+ */
+TEST_F (ScriptRequestBodyTest, TheDescribingMembersAreReadOnlyAndSaySo) {
+    for (const char* member : { "mode", "urlencoded", "formdata" }) {
+        request.body      = urlencoded_body ();
+        const Body before = request.body;
+
+        const std::string script = std::string ("pm.request.body.") + member + " = 'nonsense';";
+        auto result = engine.execute_prerequest (script, request, env);
+
+        EXPECT_FALSE (result.success) << member;
+        EXPECT_NE (result.error_message.find ("read-only"), std::string::npos)
+        << result.error_message;
+        EXPECT_NE (result.error_message.find (member), std::string::npos)
+        << result.error_message;
+        ASSERT_EQ (request.body.fields.size (), before.fields.size ()) << member;
+    }
+}
+
+/// A list that quietly grew would be a write nothing reads back, which is the
+/// defect class this program closes rather than adds to.
+TEST_F (ScriptRequestBodyTest, TheFieldListsRefuseAnEditRatherThanLoseIt) {
+    request.body      = urlencoded_body ();
+    const Body before = request.body;
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body.urlencoded.push({ key: 'audience', value: 'api' });
+    )JS",
+    request, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (request.body.fields.size (), before.fields.size ());
+}
+
+TEST_F (ScriptRequestBodyTest, AssigningRawSomethingThatIsNotAStringIsRefusedAtTheLine) {
+    const Body before = request.body;
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body.raw = { a: 1 };
+    )JS",
+    request, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("pm.request.body.raw"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (request.body.content, before.content);
+}
+
+/// A test script has no write-back, so what it does to the body is discarded -
+/// the same rule `pm.request.url` follows.
+TEST_F (ScriptRequestBodyTest, ATestScriptsWritesAreNotWrittenBack) {
+    const Body before = request.body;
+
+    auto result = engine.execute_test (R"JS(
+        pm.request.body.raw = 'ignored';
+        pm.test('read it back', function () {
+            pm.expect(pm.request.body.raw).to.equal('ignored');
+        });
+    )JS",
+    request, response, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (request.body.content, before.content)
+    << "the request that was sent is unchanged";
+}
+
+#endif // VAYU_HAS_QUICKJS
+
+} // namespace

--- a/engine/tests/script_request_body_test.cpp
+++ b/engine/tests/script_request_body_test.cpp
@@ -403,7 +403,7 @@ TEST_F (ScriptRequestBodyTest, DeletingTheBodyStillSendsNone) {
  * and only the second is the all-or-nothing rule the write-back promises.
  */
 TEST_F (ScriptRequestBodyTest, TheDescribingMembersAreReadOnlyAndSaySo) {
-    for (const char* member : { "mode", "urlencoded", "formdata" }) {
+    for (const char* member : { "mode", "urlencoded", "formdata", "length" }) {
         request.body      = urlencoded_body ();
         const Body before = request.body;
 
@@ -432,6 +432,30 @@ TEST_F (ScriptRequestBodyTest, TheFieldListsRefuseAnEditRatherThanLoseIt) {
 
     EXPECT_FALSE (result.success);
     ASSERT_EQ (request.body.fields.size (), before.fields.size ());
+}
+
+/**
+ * The one edit that is dropped rather than refused, pinned so the docs describe
+ * what the engine does.
+ *
+ * The entries are frozen objects, and JavaScript's own rule for a write to a
+ * non-writable property in non-strict code is a silent no-op - not something
+ * this surface adds, and not something a C++ setter could change without giving
+ * every field of every entry an accessor. What matters is that the write
+ * reaches nothing: the request is sent with the fields it was composed with.
+ */
+TEST_F (ScriptRequestBodyTest, WritingIntoAFieldListEntryReachesNothing) {
+    request.body      = urlencoded_body ();
+    const Body before = request.body;
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.request.body.urlencoded[0].value = 'stolen';
+    )JS",
+    request, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (request.body.fields.size (), before.fields.size ());
+    EXPECT_EQ (request.body.fields[0].value, before.fields[0].value);
 }
 
 TEST_F (ScriptRequestBodyTest, AssigningRawSomethingThatIsNotAStringIsRefusedAtTheLine) {

--- a/engine/tests/script_request_body_test.cpp
+++ b/engine/tests/script_request_body_test.cpp
@@ -60,7 +60,7 @@ Body urlencoded_body () {
 Body form_data_body () {
     Body body;
     body.mode = BodyMode::FormData;
-    body.fields.push_back ({ "name", "Ada", true });
+    body.fields.emplace_back ("name", "Ada", true);
     FormField upload;
     upload.key       = "avatar";
     upload.type      = FormFieldType::File;


### PR DESCRIPTION
## Description

`pm.request.body` was bound as a plain JS string (`setup_pm_request`), so Postman's RequestBody surface was simply absent: a lifted `pm.request.body.mode === 'raw'` guard silently took the else branch (the silent-wrong half this program exists to close) and `JSON.parse(pm.request.body.raw)` was handed the string `"undefined"` (the loud half).

**The approach** mirrors #991's Url precedent exactly - a QuickJS class whose prototype is `String.prototype`, carrying its own `toString`/`valueOf`/`toJSON`/`@@toPrimitive` so every string context keeps answering with the body, with the Postman members defined on top. The write-back learns the same either-shape read `script_url_text` already applies to the URL, so the string path - the untouched rule, the urlencoded parse-back, the form-data refusal - is *reused byte for byte* rather than duplicated; `.raw` moves the string view and nothing else, so what assigning a body means has one definition and not two.

**The alternative rejected** was installing the body as #991's accessor pair. The URL needed one so `pm.request.url = x; pm.request.url.query.get(...)` keeps working. For the body, a string assignment leaving a plain string *is* the shipped contract, and `null` and `delete` both already mean "send no body" - an accessor would have to carry an emptied-state flag to keep saying so, machinery bought for a chained access nothing asks for.

## Type of Change
- [x] New feature
- [x] Breaking change (three breaks, each pinned as a break)

## Breaking changes

| Was | Now | Use |
|-----|-----|-----|
| `pm.request.body === 'x'` | `false` | `==`, or `.toString()` |
| `typeof pm.request.body` | `'object'` | - |
| `headers['X'] = pm.request.body` | refused | `String(pm.request.body)` |

The third is the refusal `pm.request.url` already gets: a header value the engine cannot send is refused rather than coerced. `.length` is **not** a break - it is defined on the object as the body's own length, because inheriting it from `String.prototype` (a String holding `""`) would answer `0`, and `docs/engine/scripting.md`'s worked example sets `Content-Length` from it. `pm.expect(pm.request.body).to.include(...)` is **not** a break either: that assertion answers `false` for anything that is neither a string nor an array, so it is taught about the new object beside the Url in one shared `expect_string_like` - a verdict silently flipping to failing is the worst thing an assertion can do.

## Deliberate deviations from the issue spec

- **`.mode` answers three names, not Postman's five.** `graphql` and `file` each promise a member this engine has nothing to fill from - a `graphql` body is one string that may be an envelope or a bare document (`graphql_body.hpp`), never `{query, variables}`; a `binary` body carries bytes rather than the path `file.src` names. Answering the mode without the member it exists for would be a silent wrong answer, so every content mode reads as `raw`. Filed as **#1111** rather than left as a "later".
- **`.raw` answers for every mode**, where Postman leaves it `undefined` for the two form ones. That is #411's decision kept: a form body reading as nothing cannot be told apart from a request with no body.
- **`.formdata` file parts carry `fileName`, not Postman's `src`.** The local path is never disclosed (#411). `declared_file_name` was promoted out of `form_body.cpp` into the header so the object and the string rendering cannot name a part differently.
- **The two lists are declared `object[] | undefined` in the typedefs**, the spelling `pm.response.events` already uses, with the entry shape as the first line of the documentation. The declaration generator names a fixed vocabulary of types and renders anything outside it as `void` - the first regeneration produced exactly that, which would have made every use of these lists an editor error on correct code.
- **A write into a list entry is dropped, not refused.** The entries are frozen objects and JavaScript's own rule for a write to a non-writable property in non-strict code is a silent no-op. The docs say so and a test pins it; making it loud would mean an accessor on every field of every entry.

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2779 tests, 2779 passed, 0 failed.**

`cd app && pnpm test` - **546 files, 5982 tests, all passing.** `pnpm type-check`, `pnpm lint`, `pnpm format:check` all clean. `mkdocs build --strict -f .github/mkdocs.yml` clean.

New: `engine/tests/script_request_body_test.cpp`, 24 tests mirroring `script_request_url_test.cpp`'s shape - the read surface per mode, the `JSON.parse(body.raw)` idiom, the string mitigations, the three breaks as breaks, and the write surface asserted against the request that would be sent rather than against the JS object, because the object agreeing with itself proves nothing about the wire.

Existing tests updated where they read the body through the `===` path: seven `pm.request.headers['X-Seen-Body'] = pm.request.body` probes became `String(...)`, and `TestScriptReadsAFormBodyToo`'s `!==` likewise. No pre-existing failures on the base commit.

A review pass over the full diff found three things, all fixed in `22f036f`: the exception sentinel from `new_request_body` could have been defined as a property; `.length`'s read-only refusal had no test; and the docs claimed a list-entry write throws when it is dropped. One finding was discarded with reason - that `AssigningTheWholeBodyAsAStringStillWorks` and `ABodylessRequestStillDefinesNoBodyAtAll` lock invariants that predate this change rather than the change itself. That is deliberate and is what the suite header calls the mitigation half: #991's suite pins the same shape for the same reason.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1003
Defers to #1111 (Postman's `graphql` and `file` modes)