### PR TITLE
fix(engine): pm.expect.fail outside a test aborts, as an assertion - #1098

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -120,7 +120,7 @@ try {
 
 **`pm.expect.fail([message])` fails on the spot**, as an assertion rather than
 as an error (issue #1004). It is chai's `expect.fail`, and it throws the same
-`AssertionError` every matcher throws - so *outside* a `pm.test` it aborts the
+`AssertionError` every matcher does - so *outside* a `pm.test` it aborts the
 script, the way any uncaught throw does. What it changes there is the shape of
 the verdict, not whether the script stops: the run is reported as a failed
 assertion carrying this message, rather than as the `TypeError` a misuse

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -119,9 +119,12 @@ try {
 ```
 
 **`pm.expect.fail([message])` fails on the spot**, as an assertion rather than
-as an error (issue #1004). It is chai's `expect.fail`, and the distinction is
-what it does *outside* a `pm.test`: a thrown `Error` there aborts the script,
-while this reports the same `AssertionError` every matcher reports.
+as an error (issue #1004). It is chai's `expect.fail`, and it throws the same
+`AssertionError` every matcher throws - so *outside* a `pm.test` it aborts the
+script, the way any uncaught throw does. What it changes there is the shape of
+the verdict, not whether the script stops: the run is reported as a failed
+assertion carrying this message, rather than as the `TypeError` a misuse
+reports.
 
 ```javascript
 pm.test('no branch reached the response', function() {

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -88,12 +88,12 @@ nlohmann::json get_script_completions () {
     { "detail", "pm.expect.fail(message?: string): never" },
     { "documentation",
     "Fail here, as an assertion rather than as an error.\n\nInside pm.test it "
-    "fails that test; outside one it records an assertion failure the way "
-    "every other matcher does, where a thrown Error would abort the "
-    "script.\n\nchai's fail(actual, expected, message, operator) form is not "
-    "supported - this AssertionError has nowhere to carry the two compared "
-    "values, so more than one argument is refused rather than read as the "
-    "message." },
+    "fails that test; outside one it aborts the script as a failed assertion "
+    "- an AssertionError carrying the message, rather than as the TypeError a "
+    "misuse reports.\n\nchai's fail(actual, expected, message, operator) form "
+    "is not supported - this AssertionError has nowhere to carry the two "
+    "compared values, so more than one argument is refused rather than read "
+    "as the message." },
     { "sortText", "0_pm_expect_fail" } });
 
     // ========================================

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3049,10 +3049,10 @@ JSValue js_pm_expect (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
  * @brief chai's `expect.fail([message])` - fail here, with this message.
  *
  * It is the one way a script states a failure *as an assertion* rather than as
- * an error: inside `pm.test` both fail the test, but at script level a thrown
- * `Error` aborts the script while this records what every other matcher
- * records. Reached as a property of the `pm.expect` function itself, which is
- * how chai spells it.
+ * an error: inside `pm.test` both fail the test, and at script level both abort
+ * - what differs is the shape the verdict carries, an `AssertionError` with
+ * this message rather than the `TypeError` a misuse reports. Reached as a
+ * property of the `pm.expect` function itself, which is how chai spells it.
  *
  * chai's four-argument form (`actual, expected, message, operator`) builds an
  * AssertionError carrying the two values it compared; this AssertionError has

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -710,7 +710,7 @@ declare const pm: {
 		/**
 		 * Fail here, as an assertion rather than as an error.
 		 * 
-		 * Inside pm.test it fails that test; outside one it records an assertion failure the way every other matcher does, where a thrown Error would abort the script.
+		 * Inside pm.test it fails that test; outside one it aborts the script as a failed assertion - an AssertionError carrying the message, rather than as the TypeError a misuse reports.
 		 * 
 		 * chai's fail(actual, expected, message, operator) form is not supported - this AssertionError has nowhere to carry the two compared values, so more than one argument is refused rather than read as the message.
 		 */


### PR DESCRIPTION
## Description

The `pm.expect.fail` completion `documentation` string said that outside a `pm.test` the call "records an assertion failure ... where a thrown `Error` would abort the script" - framing the distinction as abort-vs-record. That is not what ships. `js_pm_expect_fail` unconditionally returns `throw_assertion_failure`, which calls `JS_Throw`; there is no branch that asks whether it is inside a test. Outside one the throw propagates uncaught and aborts the script exactly as any other uncaught throw does - `PmExpectFailOutsideATestIsAnAssertionError` asserts `result.success == false`. What #1090 actually changed is the *shape* of the verdict: an `AssertionError` carrying the message, rather than a `TypeError`.

**Plan.** Root cause is a describing string that outlived the behaviour it describes; the fix is to reword it to what ships, in every place that states it, matching `docs/app/pm-api-compatibility.md`'s already-correct lead clause rather than inventing a fourth phrasing. The alternative I rejected was rewording only the two surfaces the issue names (the completion string and `scripting.md`) - that would have left the `js_pm_expect_fail` doc comment in `script_engine.cpp`, sitting directly above the implementation that contradicts it, still saying "this records what every other matcher records". That is the copy a maintainer trusts first, and leaving it is precisely the missed-copy pattern this repo keeps re-filing (#1099, #1100). It is also what the issue's own acceptance criterion requires: a literal three-file fix leaves a near-paraphrase of the false claim standing.

**Deviation from the issue spec, deliberate:** the issue lists three locations; this PR fixes four. The fourth is that `js_pm_expect_fail` doc comment - a comment-only edit, in a different region of the file from the `script_engine.cpp` serial-slot work.

The fixture `engine/tests/fixtures/script-typedefs.d.ts` is a generated artifact - `generate_script_typedefs()` reads the same `get_script_completions()` table, so the one string edit flows into it. Regenerated with the repo command, not by hand.

**Filed rather than folded in:** #1113, for `docs/app/pm-api-compatibility.md:478-479`. The issue named that file as the accurate reference and said to verify it without touching it, which this PR did. Verifying it is what surfaced that its second sentence still attaches "aborts the script" to a thrown `Error` alone - the same construction removed everywhere else here. Not a factual error (its lead clause, "throws that same `AssertionError` on demand", is right), so it is a follow-up, not a silent widening of this diff.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`master` moved under this branch while CI ran: #1110 (issue #1003) merged, touching the same four files, the generated fixture included. `origin/master` is merged in here (`641c2fb`) and everything below was re-run on the merged tree. The PR's own diff is unchanged by that merge - still 4 files, +17 / -14.

- `python build.py -e -t` - clean build on the merged tree.
- `ctest --preset linux-dev --output-on-failure` - **2779 tests, 2779 passed, 0 failed** (2756 before the merge; #1110 added the rest).
- `ScriptTypesTest.TheCheckedInDeclarationsMatchTheGenerator` passes on the merged tree, which is the load-bearing check here: both sides regenerated the same generated fixture, so a textual auto-merge of it proves nothing on its own. This test compares the checked-in file byte-for-byte against `generate_script_typedefs()`, so its passing is what says the merged fixture carries #1110's RequestBody entries *and* this PR's reworded string exactly as the generator emits them.
- `ctest --preset linux-dev -R "ScriptTypes|ScriptCompletions"` - 37/37 passed before the merge; covered by the full run after it.
- `cd app && pnpm vitest run src/hooks/script-typedefs.docs-compile.test.ts` - 2 passed; type-checks the fenced `javascript` blocks of `scripting.md` and `pm-api-compatibility.md` against the fixture.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `clang-format-19 --dry-run -Werror` on both edited `.cpp` files - clean.

CI was green on `23b3d8e` across the whole matrix (Engine and C++ Tests on ubuntu, macOS and Windows, plus `Engine formatting` and the CI gate) before the merge commit re-triggered it.

No pre-existing failures observed on the base commit.

Fixture regenerated with:
```
VAYU_UPDATE_SCRIPT_TYPEDEFS=1 ctest --preset linux-dev -R ScriptTypes
```

Two earlier red checks, for the record, neither a test failure on the current head: `f459800` is the checkpoint commit pushed before the fixture regeneration, so it failed exactly 1 of 2756 - the fixture comparison, fixed by `a9b93cb`. The `CI gate` red on `a9b93cb` is that run's `engine: cancelled`, GitHub superseding it when the next commit was pushed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none added: no behaviour changes, and the existing `ScriptTypes` fixture test already locks this string mutation-check style
- [x] I have updated documentation

## Related Issues
Closes #1098