### PR TITLE
refactor(engine): delete the uncalled, divergent ScriptResult serializer - #1106

### DIFF
--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -172,11 +172,6 @@ int indent = vayu::core::constants::json::DEFAULT_INDENT);
 [[nodiscard]] Json serialize (const Error& error);
 
 /**
- * @brief Serialize test results to JSON
- */
-[[nodiscard]] Json serialize (const ScriptResult& result);
-
-/**
  * @brief Pretty-print JSON with colors for terminal output
  */
 [[nodiscard]] std::string pretty_print (const Json& json, bool color = true);

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -1029,43 +1029,6 @@ Json serialize (const Error& error) {
 }
 
 // ============================================================================
-// Script Result Serialization
-// ============================================================================
-
-Json serialize (const ScriptResult& result) {
-    Json json;
-
-    json["success"] = result.success;
-
-    Json tests = Json::array ();
-    for (const auto& test : result.tests) {
-        Json test_json;
-        test_json["name"]   = test.name;
-        test_json["passed"] = test.passed;
-        if (!test.error_message.empty ()) {
-            test_json["error"] = test.error_message;
-        } else {
-            test_json["error"] = nullptr;
-        }
-        tests.push_back (test_json);
-    }
-    json["testResults"] = tests;
-
-    Json console = Json::array ();
-    for (const auto& entry : result.console_output) {
-        console.push_back (
-        { { "level", to_string (entry.level) }, { "message", entry.message } });
-    }
-    json["consoleOutput"] = console;
-
-    if (!result.error_message.empty ()) {
-        json["error"] = result.error_message;
-    }
-
-    return json;
-}
-
-// ============================================================================
 // Pretty Printing
 // ============================================================================
 


### PR DESCRIPTION
## Description

`vayu::json::serialize (const ScriptResult&)` (declared `engine/include/vayu/utils/json.hpp:177`, defined `engine/src/utils/json.cpp:1035-1064`) had no caller anywhere in `engine/src`, `engine/include`, `engine/tests`, `engine/vendor`, `scripts/` or the CMake files - the only one of that header's eleven `serialize` overloads with none. Every `vayu::json::serialize (x)` call site in the repo passes a `Request`, `Response`, `Error`, a `vayu::db` row or a raw `Json`; none passes a `ScriptResult`.

It also disagreed with the code that does the job - `build_script_result_node` (`engine/src/http/routes/execution.cpp:677-751`), reached from the live `POST /execute` body (`:1527` via `build_response_json`), the streaming post-script path (`:1442`) and a scenario step's trace (`core/scenario_runner.cpp:747`). The divergence is wider than #1106's table recorded:

| | `build_script_result_node` (shipped) | `serialize (const ScriptResult&)` (deleted) |
|---|---|---|
| script-level error | `preScriptError` / `postScriptError`, named by which script ran | one `error` key, with no way to say which |
| a passing test's error | key absent | `"error": null`, explicitly |
| console key | `consoleLogs`, each entry carrying `source` | `consoleOutput`, no `source` |
| assertions | both scripts' tests merged in execution order, each with `source` (#810) | one script's tests, unsourced |
| empty lists | key omitted | key written as `[]` |
| `success` | not on the node | written |

**Plan (root cause, approach, rejected alternative).** The root cause is a second, disagreeing definition of the script-result wire shape parked in the JSON header - the obvious place the next person adding a script-result surface would look - one call away from shipping a payload no existing client reads; the inverse of this repo's most-repeated defect (a reader nothing writes to, rather than a field nothing reads). The approach is the deletion alone: a serializer with no caller and a contract that contradicts the shipped one has nothing to preserve, and the build is what proves it was uncalled. The alternative rejected, per the issue's own recommendation, was folding in a shared `testResults` helper between the two writers - that would smuggle a refactor into a deletion, and after the deletion there is no duplication left to close, so no follow-up issue is filed: `build_script_result_node` is the sole writer of `testResults` / `consoleLogs` / `preScriptError` / `postScriptError`, and `consoleOutput` is now written by nothing at all.

Nothing on the wire changes, because nothing on the wire came from this function. The consumers that read those keys - `app/src/modules/request-builder/utils/restore-response.ts:110-124`, `execute-mapping.ts:205-207`, and MCP's `readTestVerdict` (`app/electron/mcp/tools.ts:2163`) - all read the HTTP response built by `build_response_json` / `build_script_result_node`, which this diff does not touch.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` - clean build, 12m34s, no warnings introduced. The build is what proves the overload was uncalled: a removed declaration is a compile error at any call site.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2779/2779 passed, 0 failed** (49.86s). No pre-existing failures to report.
- `clang-format-19 -style=file --dry-run -Werror` on both touched files - clean (the repo pins clang-format 19 exactly; an unpinned `clang-format` 18 on this image reports a spurious difference at `json.cpp:720` that 19 does not).

No tests added: deleting an uncalled function cannot change behaviour, and the existing `ScriptResultNode` tests in `engine/tests/execution_trace_test.cpp` already pin the shape that stays.

Verification scope, per CLAUDE.md's scaling rule: engine-only deletion, so the engine build and its suite; the app suite cannot change colour and was not run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable, see Testing
- [x] I have updated documentation - none needed: every doc statement of this shape (`docs/engine/api-reference.md:4042`, `:4251-4266`, `:4292-4303`, `docs/engine/scripting.md:43-44`, `:1992`, `docs/engine/mcp.md:1058`) describes `build_script_result_node`'s output, which stays; no doc anywhere describes the deleted overload's `success` / `consoleOutput` / explicit-`null` shape

## Related Issues
Closes #1106