### PR TITLE
feat(engine): pm.request.body answers Postman's graphql mode - #1111

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -893,8 +893,9 @@ pm.request.body = JSON.stringify({ n: 2 });
   `clear`. A URL nobody edited is sent as the exact bytes it arrived as, because
   the parts are recomposed only when a member actually changed.
 - **`body` is Postman's `RequestBody` object, not a string** (#1003 - the same trade
-  #991 made for the URL). `mode` (`urlencoded` / `formdata` / `raw` - every other content
-  mode reads `raw`), `raw`, and the `urlencoded` / `formdata` field lists, plus `length`,
+  #991 made for the URL). `mode` (`urlencoded` / `formdata` / `graphql` / `raw` - every
+  other content mode reads `raw`), `raw`, the `urlencoded` / `formdata` field lists and the
+  `graphql` pair, plus `length`,
   all read-only; assigning the whole body, or `.raw`, is the one write and is unchanged
   from what shipped. It still behaves as a string in every context JavaScript allows -
   concatenation, template literals, `==`, `String.prototype` methods, `JSON.stringify`,
@@ -903,6 +904,24 @@ pm.request.body = JSON.stringify({ n: 2 });
   migration note are in
   [scripting.md](../engine/scripting.md#request-object-pmrequest). Reading a form body
   never rewrites it: an unchanged value means untouched.
+- **Four of Postman's five body modes are answered; `file` is not** (#1111). A
+  `graphql` body reads `mode === 'graphql'` and answers `body.graphql.query` /
+  `body.graphql.variables`, derived from the stored string by the classifier the
+  send itself uses. Two divergences inside that mode, both deliberate:
+  `variables` is the **JSON value** the envelope carries rather than the text of
+  Postman's variables editor, which Vayu never stored - so a lifted
+  `JSON.parse(pm.request.body.graphql.variables)` becomes a plain read - and a
+  body that is envelope-shaped but does not parse answers `undefined` rather
+  than a guessed pair, matching what the send does with it. `.raw` stays defined
+  here as it is for the form modes.
+
+    Postman's `file` mode is **not** answered, and a `binary` body reads `raw`.
+    That mode promises `file.src`, a path; a binary body here carries bytes, and
+    the only path this model holds belongs to a form-data file part, which is a
+    different mode and is deliberately never disclosed to a script (#411).
+    Reporting a path would be a change to how bodies are *stored*, not to what
+    scripts can read. Postman's `body.file` is therefore `undefined` here, and a
+    lifted `mode === 'file'` guard takes its false branch.
 - **Setting a variable now re-renders whatever composition left unresolved.**
   `{{…}}` placeholders are still resolved at **compose time** (`POST /compose`,
   engine-side since #226) before the pre-request script runs - #226's decision

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -706,21 +706,62 @@ property at all, so `typeof pm.request.body === 'undefined'` still separates
 was a string.
 
 ```javascript
-pm.request.body.mode         // 'urlencoded' | 'formdata' | 'raw'
+pm.request.body.mode         // 'urlencoded' | 'formdata' | 'graphql' | 'raw'
 pm.request.body.raw          // the body as a string, for every mode
 pm.request.body.urlencoded   // [{key, value, disabled}, ...] or undefined
 pm.request.body.formdata     // [{key, value?, type, fileName?, disabled}, ...] or undefined
+pm.request.body.graphql      // {query, variables?} or undefined
 pm.request.body.length       // the body string's own length
 ```
 
-`.mode` reads `raw` for every content mode - `json`, `text`, `xml`, `binary`,
-`graphql` and `jsonrpc` all carry their body as one string, which is what `raw`
-means. Postman's own `graphql` and `file` modes are deliberately not answered:
-each promises a member this engine has nothing to fill it from - a stored
-GraphQL body may be an envelope or a bare document rather than Postman's
-`{query, variables}` pair, and a binary body carries bytes rather than the path
-`file.src` names - so answering the mode without the member it exists for would
-be a silent wrong answer (issue #1111 tracks filling them in).
+`.mode` reads `raw` for every content mode without a Postman name of its own -
+`json`, `text`, `xml`, `binary` and `jsonrpc` all carry their body as one
+string, which is what `raw` means.
+
+Postman's fifth mode, `file`, is deliberately not answered: it promises
+`file.src`, a path, and a `binary` body here carries **bytes**. The only path
+this model holds belongs to a form-data file part, which is a different mode and
+is never disclosed to a script (issue #411). A `binary` body therefore reads
+`raw`, and that is a stated divergence rather than an omission - see
+[pm-api-compatibility.md](../app/pm-api-compatibility.md).
+
+### `graphql` bodies (issue #1111)
+
+`.mode` reads `graphql` for a GraphQL body, and `.graphql` answers Postman's
+`{query, variables}` pair. Vayu stores such a body as **one string** that is
+allowed to be either the `{"query": …}` envelope the request builder writes or
+the bare document an agent or a `curl` caller hands over; the pair is derived
+from that string by the same classifier the send itself goes through, so
+`.graphql.query` is the query that goes on the wire rather than a second reading
+of the same bytes.
+
+```javascript
+// An enveloped body answers its own members.
+pm.request.body.graphql.query        // 'query User($id: ID!) { user(id: $id) { name } }'
+pm.request.body.graphql.variables.id // '42'
+
+// A bare document answers as the query it would be wrapped and sent as.
+pm.request.body.graphql.query        // 'query User { user { name } }'
+```
+
+Three things worth knowing before scripting against it:
+
+- **`variables` is the JSON value the envelope carries**, where Postman's is the
+  *text* of its variables editor. Vayu never stored that text, and serializing
+  one here would invent whitespace and key order the user never wrote. Read it
+  as an object; a lifted `JSON.parse(…variables)` is the one call to change.
+- **A body that is envelope-shaped but does not parse answers `undefined`** - an
+  unresolved `{{token}}`, or a mistyped envelope. The send passes such a body
+  through untouched rather than wrapping something it could not read, and a pair
+  invented here would be the guess it refuses. `.raw` still carries the string.
+- **`.raw` stays the whole string in this mode too**, where Postman leaves it
+  undefined - the same divergence `.raw` already carries for the two form modes,
+  and for the same reason. Assigning `.raw` moves the pair with it.
+
+A lifted `pm.request.body.mode === 'raw'` guard over a GraphQL body took the
+true branch before this and takes the false one now. That is the break, and it
+is the compatible answer: Postman names this mode too, so a script written
+against Postman was already reading `graphql` there.
 
 `.raw` is the string every mode reads as, including the two whose content is a
 list of fields rather than text - and it is defined for both of those, where

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -803,7 +803,8 @@ nlohmann::json get_script_completions () {
     { "insertText", "pm.request.body" }, { "detail", "string & object (writable pre-request)" },
     { "documentation",
     "The request body (if any), as Postman's RequestBody object: mode, raw, "
-    "and the urlencoded/formdata field lists.\n\nIt still behaves as the "
+    "the urlencoded/formdata field lists and the graphql pair.\n\nIt still "
+    "behaves as the "
     "string it used to be - concatenation, template literals, ==, the String "
     "methods and .length all give the body - so `===` and `typeof` are two of "
     "the three things that changed; the third is that assigning it straight to "
@@ -820,10 +821,12 @@ nlohmann::json get_script_completions () {
     completions.push_back ({ { "label", "pm.request.body.mode" }, { "kind", KIND_FIELD },
     { "insertText", "pm.request.body.mode" }, { "detail", "string" },
     { "documentation",
-    "Postman's mode name: \"urlencoded\", \"formdata\", or \"raw\" for every "
-    "content mode - json, text, xml, binary, graphql and jsonrpc all carry "
-    "their body as one string, which is what raw means. Read-only; the mode "
-    "follows the request's body type." },
+    "Postman's mode name: \"urlencoded\", \"formdata\", \"graphql\", or "
+    "\"raw\" for every other content mode - json, text, xml, binary and "
+    "jsonrpc all carry their body as one string, which is what raw means. "
+    "Postman's fifth mode, \"file\", is never answered: it promises a path, "
+    "and a binary body here carries bytes. Read-only; the mode follows the "
+    "request's body type." },
     { "sortText", "2_pm_request_body_mode" } });
 
     completions.push_back ({ { "label", "pm.request.body.raw" }, { "kind", KIND_FIELD },
@@ -867,6 +870,25 @@ nlohmann::json get_script_completions () {
     "would read as a text field that happens to be empty, and the local path "
     "is never disclosed.\n\nRead-only: edit the request's form fields." },
     { "sortText", "2_pm_request_body_formdata" } });
+
+    completions.push_back ({ { "label", "pm.request.body.graphql" },
+    { "kind", KIND_FIELD }, { "insertText", "pm.request.body.graphql" },
+    // `object` for the reason the two list rows above give: the generator names
+    // a fixed vocabulary of types, so the member shape is prose here.
+    { "detail", "object | undefined" },
+    { "documentation",
+    "{ query, variables? } for a graphql body, or undefined in any other "
+    "mode. The pair is read off the same string body.raw answers with, "
+    "through the classifier the send itself uses: an enveloped body answers "
+    "its own query and variables, and a bare document answers as the query it "
+    "would be sent as.\n\nTwo things Postman spells differently: variables is "
+    "the JSON value the envelope carries, not the text of Postman's variables "
+    "editor, which Vayu never stored; and a body that is shaped like an "
+    "envelope but does not parse - an unresolved {{token}}, a typo - answers "
+    "undefined rather than a guessed pair, because that is the body the send "
+    "passes through untouched. body.raw still carries the string.\n\n"
+    "Read-only: assign body.raw to change what is sent." },
+    { "sortText", "2_pm_request_body_graphql" } });
 
     completions.push_back ({ { "label", "pm.request.body.length" }, { "kind", KIND_FIELD },
     { "insertText", "pm.request.body.length" }, { "detail", "number" },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -5594,14 +5594,11 @@ JSValue body_field_list (JSContext* ctx, const std::vector<FormField>& fields, b
  * An empty body answers `undefined` for the reason the header gives: empty in,
  * empty out, and `{query: ""}` would give a bodiless request a query.
  *
- * The members are read with QuickJS's own JSON parser rather than converted
- * from a second one, so `.graphql.variables` is exactly what a script writing
- * `JSON.parse(pm.request.body.raw).variables` would get. It is therefore the
- * JSON value the envelope carries, where Postman's is the *text* of its
- * variables editor - a divergence rather than an oversight: Vayu never stored
- * that text, and serializing one here would invent whitespace and key order the
- * user never wrote, which is the thing `graphql_wire_body` refuses to do at the
- * wire. `docs/app/pm-api-compatibility.md` states it.
+ * `variables` is the JSON value the envelope carries, where Postman's is the
+ * *text* of its variables editor - a divergence rather than an oversight: Vayu
+ * never stored that text, and serializing one here would invent whitespace and
+ * key order the user never wrote, which is the thing `graphql_wire_body`
+ * refuses to do at the wire. `docs/app/pm-api-compatibility.md` states it.
  */
 JSValue body_graphql_view (JSContext* ctx, const std::string& text) {
     if (text.empty ()) {
@@ -5619,12 +5616,28 @@ JSValue body_graphql_view (JSContext* ctx, const std::string& text) {
         define (document, "query", JS_NewStringLen (ctx, text.data (), text.size ()));
         return frozen (document);
     }
-    JSValue envelope =
-    JS_ParseJSON (ctx, text.c_str (), text.size (), "<pm.request.body.graphql>");
+    const auto document =
+    nlohmann::json::parse (text, nullptr, /*allow_exceptions=*/false);
+    if (document.is_discarded ()) {
+        // The classifier's object-shaped-but-unreadable case: it said envelope
+        // on the shape alone, and there is nothing under the shape to read.
+        return JS_UNDEFINED;
+    }
+    // QuickJS is handed what nlohmann *read*, never the bytes it read them from.
+    // The two are not the same grammar - a leading byte-order mark is nlohmann's
+    // to skip and `JSON.parse`'s to reject - so parsing the body twice lets the
+    // send carry a query this member answers `undefined` about. Only one reader
+    // of a body may have an opinion, and it is the one the send asks; the dump
+    // is a transport between them, not a second reading.
+    const std::string canonical =
+    document.dump (-1, ' ', false, nlohmann::json::error_handler_t::replace);
+    JSValue envelope = JS_ParseJSON (
+    ctx, canonical.c_str (), canonical.size (), "<pm.request.body.graphql>");
     if (JS_IsException (envelope)) {
-        // The classifier's object-shaped-but-unreadable case. Clear the parse
-        // error rather than letting it escape a getter: the body is not an error
-        // to read, it is one this object has no answer about.
+        // Not reachable through any body: `canonical` is what nlohmann just
+        // serialized, and `replace` leaves it valid JSON even for a lone UTF-8
+        // continuation byte. Handled rather than assumed, because the
+        // alternative is a parse error escaping a getter.
         JS_FreeValue (ctx, envelope);
         JSValue pending = JS_GetException (ctx);
         JS_FreeValue (ctx, pending);
@@ -5632,9 +5645,10 @@ JSValue body_graphql_view (JSContext* ctx, const std::string& text) {
     }
     JSValue query = JS_GetPropertyStr (ctx, envelope, "query");
     if (!JS_IsString (query)) {
-        // Reachable only where the two parsers read the same bytes differently
-        // - the classifier saw a string `query` and this one did not. Two
-        // readings is exactly the state that must not be guessed at.
+        // Also not reachable: the classifier returned true on a parse that was
+        // not discarded, which is exactly its "object with a string `query`"
+        // case, and the round trip above preserves the type. Restated as a
+        // guard rather than assumed, so the function stays total.
         JS_FreeValue (ctx, query);
         JS_FreeValue (ctx, envelope);
         return JS_UNDEFINED;

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -39,6 +39,7 @@
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/form_body.hpp"
+#include "vayu/http/graphql_body.hpp"
 #include "vayu/http/header_names.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/set_cookie.hpp"
@@ -5465,31 +5466,42 @@ enum BodyMember : std::uint8_t {
     BODY_RAW,
     BODY_URLENCODED,
     BODY_FORMDATA,
+    BODY_GRAPHQL,
     BODY_LENGTH
 };
 
 /**
  * @brief The Postman mode name this body reads as.
  *
- * Three names, because those are the three shapes a script can *act* on: a
- * string it can parse, a pair list, and a multipart part list. Vayu's other
- * content modes - `json`, `text`, `xml`, `binary`, `graphql`, `jsonrpc` - each
- * carry their body as one string, which is what `raw` means, so a lifted
+ * Four names, because those are the four shapes a script can *act* on: a string
+ * it can parse, a pair list, a multipart part list, and a GraphQL operation.
+ * Vayu's other content modes - `json`, `text`, `xml`, `binary`, `jsonrpc` -
+ * each carry their body as one string, which is what `raw` means, so a lifted
  * `body.mode === 'raw'` guard answers true for every one of them.
  *
- * The two Postman modes deliberately not answered are `graphql` and `file`,
- * because each promises a member this engine has nothing to fill it from: a
- * `graphql` body is stored as one string that may be an envelope or a bare
- * document (`graphql_body.hpp`), never as Postman's `{query, variables}` pair,
- * and a `binary` body carries bytes rather than the path `file.src` names.
+ * `graphql` was the third name for the whole of #1003, because Postman's mode
+ * promises a `{query, variables}` member and this engine stores a GraphQL body
+ * as one string that may be an envelope or a bare document. What #1111 found is
+ * that the pair is *derivable* from that string by a rule the engine already
+ * owns - `graphql_body.hpp`'s classifier, the one the send itself goes through
+ * - so the member has something to fill it from after all. See
+ * `body_graphql_view`.
+ *
+ * The one Postman mode still not answered is `file`, which promises `file.src`,
+ * a path. A `BodyMode::Binary` body carries *bytes* in `Body::content`; the only
+ * path in this model belongs to a form-data file part, is a different mode, and
+ * is deliberately never disclosed to a script (issue #411, `declared_file_name`).
  * Answering the mode without the member it exists for would be a silent wrong
- * answer, which is the class this program closes rather than adds to; issue
- * #1111 tracks filling them in.
+ * answer, which is the class this program closes rather than adds to, so
+ * `binary` reads `raw` and `docs/app/pm-api-compatibility.md` records it as a
+ * stated divergence. Reporting a path would be a *storage* change, not a
+ * scripting one, and wants its own issue if it is ever wanted.
  */
 const char* postman_body_mode (BodyMode mode) {
     switch (mode) {
     case BodyMode::Form: return "urlencoded";
     case BodyMode::FormData: return "formdata";
+    case BodyMode::GraphQL: return "graphql";
     // `None` never reaches here: a bodyless request defines no `body` property
     // at all, so no object is built for it. See setup_pm_request.
     default: return "raw";
@@ -5503,6 +5515,7 @@ const char* body_member_name (int magic) {
     case BODY_RAW: return "raw";
     case BODY_URLENCODED: return "urlencoded";
     case BODY_FORMDATA: return "formdata";
+    case BODY_GRAPHQL: return "graphql";
     default: return "length";
     }
 }
@@ -5558,6 +5571,89 @@ JSValue body_field_list (JSContext* ctx, const std::vector<FormField>& fields, b
 }
 
 /**
+ * @brief `.graphql` - Postman's `{query, variables}`, read off the one string.
+ *
+ * A GraphQL body is stored as one string that is allowed to be either the
+ * `{"query": ...}` envelope the request builder writes or the bare document an
+ * agent or a `curl` caller hands over, and `graphql_body.hpp` is what decides
+ * which. This asks *that* classifier rather than a second copy of the rule, so
+ * `.graphql.query` is the query the send would carry - a copy could call the
+ * same body an envelope here and a document at the wire, which is the one
+ * failure adding this member could introduce.
+ *
+ * Three answers, one per case the classifier separates:
+ *
+ * - A readable envelope: its own `query`, and `variables` when it carries them.
+ * - A bare document: `{query: <the document>}` - what wrapping it would send.
+ * - Object-shaped text that does not parse (an envelope whose `{{token}}` went
+ *   unresolved, or a mistyped one): **undefined**. `graphql_wire_body` passes
+ *   that through untouched rather than guessing at it, and any pair invented
+ *   here would be the guess it refuses. `.raw` still carries the string, so the
+ *   body is described as unreadable rather than hidden.
+ *
+ * An empty body answers `undefined` for the reason the header gives: empty in,
+ * empty out, and `{query: ""}` would give a bodiless request a query.
+ *
+ * The members are read with QuickJS's own JSON parser rather than converted
+ * from a second one, so `.graphql.variables` is exactly what a script writing
+ * `JSON.parse(pm.request.body.raw).variables` would get. It is therefore the
+ * JSON value the envelope carries, where Postman's is the *text* of its
+ * variables editor - a divergence rather than an oversight: Vayu never stored
+ * that text, and serializing one here would invent whitespace and key order the
+ * user never wrote, which is the thing `graphql_wire_body` refuses to do at the
+ * wire. `docs/app/pm-api-compatibility.md` states it.
+ */
+JSValue body_graphql_view (JSContext* ctx, const std::string& text) {
+    if (text.empty ()) {
+        return JS_UNDEFINED;
+    }
+    const auto define = [&] (JSValue object, const char* name, JSValue value) {
+        JS_DefinePropertyValueStr (ctx, object, name, value, JS_PROP_ENUMERABLE);
+    };
+    const auto frozen = [&] (JSValue object) {
+        (void)JS_PreventExtensions (ctx, object);
+        return object;
+    };
+    if (!vayu::http::graphql_body_is_enveloped (text)) {
+        JSValue document = JS_NewObject (ctx);
+        define (document, "query", JS_NewStringLen (ctx, text.data (), text.size ()));
+        return frozen (document);
+    }
+    JSValue envelope =
+    JS_ParseJSON (ctx, text.c_str (), text.size (), "<pm.request.body.graphql>");
+    if (JS_IsException (envelope)) {
+        // The classifier's object-shaped-but-unreadable case. Clear the parse
+        // error rather than letting it escape a getter: the body is not an error
+        // to read, it is one this object has no answer about.
+        JS_FreeValue (ctx, envelope);
+        JSValue pending = JS_GetException (ctx);
+        JS_FreeValue (ctx, pending);
+        return JS_UNDEFINED;
+    }
+    JSValue query = JS_GetPropertyStr (ctx, envelope, "query");
+    if (!JS_IsString (query)) {
+        // Reachable only where the two parsers read the same bytes differently
+        // - the classifier saw a string `query` and this one did not. Two
+        // readings is exactly the state that must not be guessed at.
+        JS_FreeValue (ctx, query);
+        JS_FreeValue (ctx, envelope);
+        return JS_UNDEFINED;
+    }
+    JSValue variables = JS_GetPropertyStr (ctx, envelope, "variables");
+    JSValue view      = JS_NewObject (ctx);
+    define (view, "query", query);
+    // Absent rather than `undefined`-valued, so `'variables' in body.graphql`
+    // answers what the envelope actually carries.
+    if (JS_IsUndefined (variables)) {
+        JS_FreeValue (ctx, variables);
+    } else {
+        define (view, "variables", variables);
+    }
+    JS_FreeValue (ctx, envelope);
+    return frozen (view);
+}
+
+/**
  * The body as a string, and the single answer behind every string context.
  *
  * `toString`, `valueOf`, `toJSON` and `@@toPrimitive` all land here, for the
@@ -5605,6 +5701,13 @@ JSValue* func_data) {
     case BODY_FORMDATA:
         return state->body.mode == BodyMode::FormData ?
         body_field_list (ctx, state->body.fields, /*multipart=*/true) :
+        JS_UNDEFINED;
+    // Read off `text` rather than `body.content`, so a script that assigned
+    // `.raw` reads the pair its *new* string carries. One string, one answer -
+    // the two disagreeing would be `.graphql` describing a body no longer sent.
+    case BODY_GRAPHQL:
+        return state->body.mode == BodyMode::GraphQL ?
+        body_graphql_view (ctx, state->text) :
         JS_UNDEFINED;
     // Defined rather than left to the prototype, for the reason #991 gives
     // about the URL's: `String.prototype` is a String object holding `""`, so
@@ -5707,6 +5810,7 @@ JSValue new_request_body (JSContext* ctx, const Body& body) {
     define_accessor ("raw", BODY_RAW);
     define_accessor ("urlencoded", BODY_URLENCODED);
     define_accessor ("formdata", BODY_FORMDATA);
+    define_accessor ("graphql", BODY_GRAPHQL);
     define_accessor ("length", BODY_LENGTH);
     return object;
 }

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -854,7 +854,7 @@ declare const pm: {
 	 */
 	request: {
 		/**
-		 * The request body (if any), as Postman's RequestBody object: mode, raw, and the urlencoded/formdata field lists.
+		 * The request body (if any), as Postman's RequestBody object: mode, raw, the urlencoded/formdata field lists and the graphql pair.
 		 * 
 		 * It still behaves as the string it used to be - concatenation, template literals, ==, the String methods and .length all give the body - so `===` and `typeof` are two of the three things that changed; the third is that assigning it straight to a header value is refused, like pm.request.url. Assign a string (or body.raw) to replace the body, or delete it to send none. A body set on a request that had none is sent as raw text - set Content-Type yourself. A form body reads as its fields encoded `key=value&...`: for x-www-form-urlencoded that is the exact wire body and an assignment parses back into the fields, while for form-data it is a rendering of the parts (the multipart bytes carry a boundary that does not exist until the send) and an assignment is refused.
 		 */
@@ -866,11 +866,19 @@ declare const pm: {
 			 */
 			formdata: { [key: string]: any }[] | undefined;
 			/**
+			 * { query, variables? } for a graphql body, or undefined in any other mode. The pair is read off the same string body.raw answers with, through the classifier the send itself uses: an enveloped body answers its own query and variables, and a bare document answers as the query it would be sent as.
+			 * 
+			 * Two things Postman spells differently: variables is the JSON value the envelope carries, not the text of Postman's variables editor, which Vayu never stored; and a body that is shaped like an envelope but does not parse - an unresolved {{token}}, a typo - answers undefined rather than a guessed pair, because that is the body the send passes through untouched. body.raw still carries the string.
+			 * 
+			 * Read-only: assign body.raw to change what is sent.
+			 */
+			graphql: { [key: string]: any } | undefined;
+			/**
 			 * The length of the body string - defined on the object rather than inherited, so it is the body's own length and not the 0 that String's prototype would have answered.
 			 */
 			length: number;
 			/**
-			 * Postman's mode name: "urlencoded", "formdata", or "raw" for every content mode - json, text, xml, binary, graphql and jsonrpc all carry their body as one string, which is what raw means. Read-only; the mode follows the request's body type.
+			 * Postman's mode name: "urlencoded", "formdata", "graphql", or "raw" for every other content mode - json, text, xml, binary and jsonrpc all carry their body as one string, which is what raw means. Postman's fifth mode, "file", is never answered: it promises a path, and a binary body here carries bytes. Read-only; the mode follows the request's body type.
 			 */
 			mode: string;
 			/**

--- a/engine/tests/script_request_body_test.cpp
+++ b/engine/tests/script_request_body_test.cpp
@@ -85,6 +85,12 @@ constexpr std::string_view GRAPHQL_DOCUMENT = "query User { user { name } }";
 /// Envelope-shaped, and not readable: the `{{token}}` that went unresolved.
 constexpr std::string_view GRAPHQL_UNRESOLVED = R"({"query":"{{savedQuery}},)";
 
+/// The same envelope behind a UTF-8 byte-order mark, which an editor or a
+/// PowerShell redirect can leave on a saved document. The classifier reads it
+/// and the send carries it, so the pair has to answer about it too.
+constexpr std::string_view GRAPHQL_BOM_ENVELOPE = "\xEF\xBB\xBF"
+                                                  R"({"query":"query Ping { ping }"})";
+
 Body graphql_body (std::string_view content) {
     Body body;
     body.mode    = BodyMode::GraphQL;
@@ -224,13 +230,20 @@ TEST_F (ScriptRequestBodyTest, ABareGraphqlDocumentReadsAsTheQueryItWouldBeSentA
 
 /**
  * The pin the member exists to keep: whatever `.graphql.query` answers is the
- * query `graphql_wire_body` would put on the wire, for both readable shapes.
+ * query `graphql_wire_body` would put on the wire, for every readable shape.
  * Reverting the classifier reuse - deriving the pair from a second local rule -
  * is what this fails on, since only the shared classifier decides the same way
  * the send does.
+ *
+ * The byte-order-marked envelope is here because it is the shape where reading
+ * the body *twice* stops being harmless: nlohmann skips a BOM and `JSON.parse`
+ * rejects one, so a version of this member that parsed the raw bytes with
+ * QuickJS answered `undefined` for a body the send carries intact. Handing
+ * QuickJS what nlohmann read is what this case fails without.
  */
 TEST_F (ScriptRequestBodyTest, TheQueryIsTheOneTheSendWouldCarry) {
-    for (const std::string_view content : { GRAPHQL_ENVELOPE, GRAPHQL_DOCUMENT }) {
+    for (const std::string_view content :
+    { GRAPHQL_ENVELOPE, GRAPHQL_DOCUMENT, GRAPHQL_BOM_ENVELOPE }) {
         request.body = graphql_body (content);
         expect_script_passes (
         "pm.expect(pm.request.body.graphql.query).to.equal(" +
@@ -307,6 +320,7 @@ TEST_F (ScriptRequestBodyTest, AUrlencodedBodyReadsAsItsPairsWithTheDisabledRowF
         pm.expect(pairs[2].key).to.equal('legacy');
         pm.expect(pairs[2].disabled).to.equal(true);
         pm.expect(pm.request.body.formdata).to.equal(undefined);
+        pm.expect(pm.request.body.graphql).to.equal(undefined);
     )JS");
 }
 
@@ -338,6 +352,7 @@ TEST_F (ScriptRequestBodyTest, AFormDataBodyNamesItsFilePartAndNeverItsPath) {
         pm.expect(parts[1].value).to.equal(undefined);
         pm.expect(JSON.stringify(parts[1])).to.not.include('/home/ada');
         pm.expect(pm.request.body.urlencoded).to.equal(undefined);
+        pm.expect(pm.request.body.graphql).to.equal(undefined);
     )JS");
 }
 

--- a/engine/tests/script_request_body_test.cpp
+++ b/engine/tests/script_request_body_test.cpp
@@ -32,7 +32,11 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <string_view>
 
+#include <nlohmann/json.hpp>
+
+#include "vayu/http/graphql_body.hpp"
 #include "vayu/types.hpp"
 
 using namespace vayu;
@@ -68,6 +72,37 @@ Body form_data_body () {
     upload.file_name = "portrait.png";
     body.fields.push_back (upload);
     return body;
+}
+
+/// The envelope the request builder writes, carrying variables and an operation
+/// name a server has agreed with its clients.
+constexpr std::string_view GRAPHQL_ENVELOPE =
+R"({"query":"query User($id: ID!) { user(id: $id) { name } }","operationName":"User","variables":{"id":"42"}})";
+
+/// The bare document an agent or a `curl` caller hands over.
+constexpr std::string_view GRAPHQL_DOCUMENT = "query User { user { name } }";
+
+/// Envelope-shaped, and not readable: the `{{token}}` that went unresolved.
+constexpr std::string_view GRAPHQL_UNRESOLVED = R"({"query":"{{savedQuery}},)";
+
+Body graphql_body (std::string_view content) {
+    Body body;
+    body.mode    = BodyMode::GraphQL;
+    body.content = content;
+    return body;
+}
+
+/// The query the send would carry, read back out of `graphql_wire_body`'s own
+/// answer rather than restated here. That is the whole point of the member: a
+/// `.graphql.query` disagreeing with this describes a request nothing sends.
+std::string wire_query (std::string_view content) {
+    const std::string wire = vayu::http::graphql_wire_body (std::string{ content });
+    return nlohmann::json::parse (wire).at ("query").get<std::string> ();
+}
+
+/// A C++ string as a JavaScript string literal, for a script built around one.
+std::string js_literal (const std::string& text) {
+    return nlohmann::json (text).dump ();
 }
 
 class ScriptRequestBodyTest : public ::testing::Test {
@@ -134,20 +169,124 @@ TEST_F (ScriptRequestBodyTest, JsonParseOfRawIsTheImportedIdiomAndRoundTrips) {
 }
 
 /**
- * Every content mode is `raw`, because each carries its body as one string.
- * Asserted over all of them rather than one, since the mapping is a switch whose
- * default arm is what answers for five of the six.
+ * Every content mode without a Postman name of its own is `raw`, because each
+ * carries its body as one string. Asserted over all of them rather than one,
+ * since the mapping is a switch whose default arm is what answers for them.
+ *
+ * `graphql` left this list in #1111, which is a *break* for a lifted
+ * `body.mode === 'raw'` guard over a GraphQL body - and the compatible answer,
+ * since Postman names that mode too. `binary` stays here: Postman's `file` mode
+ * promises the path `file.src`, and this one carries bytes.
  */
 TEST_F (ScriptRequestBodyTest, EveryContentModeAnswersRaw) {
-    for (const BodyMode mode : { BodyMode::Json, BodyMode::Text, BodyMode::Binary,
-         BodyMode::GraphQL, BodyMode::JsonRpc, BodyMode::Xml }) {
+    for (const BodyMode mode : { BodyMode::Json, BodyMode::Text,
+         BodyMode::Binary, BodyMode::JsonRpc, BodyMode::Xml }) {
         request.body.mode    = mode;
         request.body.content = "payload";
         expect_script_passes (R"JS(
             pm.expect(pm.request.body.mode).to.equal('raw');
             pm.expect(pm.request.body.raw).to.equal('payload');
+            pm.expect(pm.request.body.graphql).to.equal(undefined);
         )JS");
     }
+}
+
+// ---------------------------------------------------------------------------
+// The `graphql` mode and its pair (issue #1111).
+// ---------------------------------------------------------------------------
+
+/// The envelope case: the members are the envelope's own, not a re-derivation.
+TEST_F (ScriptRequestBodyTest, AGraphqlEnvelopeReadsAsItsQueryAndVariables) {
+    request.body = graphql_body (GRAPHQL_ENVELOPE);
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('graphql');
+        pm.expect(pm.request.body.graphql.query).to.equal(
+            'query User($id: ID!) { user(id: $id) { name } }');
+        pm.expect(pm.request.body.graphql.variables.id).to.equal('42');
+        pm.expect(pm.request.body.urlencoded).to.equal(undefined);
+        pm.expect(pm.request.body.formdata).to.equal(undefined);
+    )JS");
+}
+
+/**
+ * The bare document case. `query` is the document itself, because that is what
+ * the envelope the engine wraps it in carries - the point at which this member
+ * stops being a restatement of `.raw` and starts answering what is *sent*.
+ */
+TEST_F (ScriptRequestBodyTest, ABareGraphqlDocumentReadsAsTheQueryItWouldBeSentAs) {
+    request.body = graphql_body (GRAPHQL_DOCUMENT);
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('graphql');
+        pm.expect(pm.request.body.graphql.query).to.equal('query User { user { name } }');
+        pm.expect('variables' in pm.request.body.graphql).to.equal(false);
+    )JS");
+}
+
+/**
+ * The pin the member exists to keep: whatever `.graphql.query` answers is the
+ * query `graphql_wire_body` would put on the wire, for both readable shapes.
+ * Reverting the classifier reuse - deriving the pair from a second local rule -
+ * is what this fails on, since only the shared classifier decides the same way
+ * the send does.
+ */
+TEST_F (ScriptRequestBodyTest, TheQueryIsTheOneTheSendWouldCarry) {
+    for (const std::string_view content : { GRAPHQL_ENVELOPE, GRAPHQL_DOCUMENT }) {
+        request.body = graphql_body (content);
+        expect_script_passes (
+        "pm.expect(pm.request.body.graphql.query).to.equal(" +
+        js_literal (wire_query (content)) + ");");
+    }
+}
+
+/**
+ * Envelope-shaped and unreadable: an unresolved `{{token}}`, or a typo.
+ * `graphql_wire_body` passes such a body through untouched rather than wrapping
+ * something it failed to understand, so there is no pair to answer and none is
+ * invented. `.raw` still carries the string, which is what keeps the body
+ * described as unreadable rather than hidden.
+ */
+TEST_F (ScriptRequestBodyTest, AnUnreadableEnvelopeIsNotGuessedAt) {
+    request.body = graphql_body (GRAPHQL_UNRESOLVED);
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('graphql');
+        pm.expect(pm.request.body.graphql).to.equal(undefined);
+        pm.expect(pm.request.body.raw).to.include('{{savedQuery}}');
+    )JS");
+}
+
+/// An empty body has no query, and inventing one would give a bodiless request
+/// an operation - the rule `graphql_wire_body` states as empty in, empty out.
+TEST_F (ScriptRequestBodyTest, AnEmptyGraphqlBodyAnswersNoPair) {
+    request.body = graphql_body ("");
+    expect_script_passes (R"JS(
+        pm.expect(pm.request.body.mode).to.equal('graphql');
+        pm.expect(pm.request.body.graphql).to.equal(undefined);
+    )JS");
+}
+
+/**
+ * The pair is read off the string `.raw` answers with, so a script that rewrote
+ * the body reads the query it just wrote rather than the one it replaced.
+ */
+TEST_F (ScriptRequestBodyTest, AssigningRawMovesTheGraphqlPairWithIt) {
+    request.body = graphql_body (GRAPHQL_ENVELOPE);
+    expect_script_passes (R"JS(
+        pm.request.body.raw = 'query Rewritten { ping }';
+        pm.expect(pm.request.body.graphql.query).to.equal('query Rewritten { ping }');
+        pm.expect('variables' in pm.request.body.graphql).to.equal(false);
+    )JS");
+}
+
+/// Frozen like the field lists, and for the same reason: a write into the pair
+/// reaches nothing, so accepting one would be a write nothing reads back.
+TEST_F (ScriptRequestBodyTest, TheGraphqlPairIsFrozenLikeTheFieldLists) {
+    request.body = graphql_body (GRAPHQL_ENVELOPE);
+    expect_script_passes (R"JS(
+        var pair = pm.request.body.graphql;
+        try { pair.query = 'query Injected { ping }'; } catch (e) { /* strict mode */ }
+        pm.expect(pm.request.body.graphql.query).to.equal(
+            'query User($id: ID!) { user(id: $id) { name } }');
+    )JS");
 }
 
 TEST_F (ScriptRequestBodyTest, AUrlencodedBodyReadsAsItsPairsWithTheDisabledRowFlagged) {
@@ -403,7 +542,7 @@ TEST_F (ScriptRequestBodyTest, DeletingTheBodyStillSendsNone) {
  * and only the second is the all-or-nothing rule the write-back promises.
  */
 TEST_F (ScriptRequestBodyTest, TheDescribingMembersAreReadOnlyAndSaySo) {
-    for (const char* member : { "mode", "urlencoded", "formdata", "length" }) {
+    for (const char* member : { "mode", "urlencoded", "formdata", "graphql", "length" }) {
         request.body      = urlencoded_body ();
         const Body before = request.body;
 


### PR DESCRIPTION
## Description

`postman_body_mode` mapped Vayu's nine `BodyMode` values onto three of Postman's five names, because the two it left out each promise a member #1003 had nothing to fill from. For `graphql` that premise no longer holds: `graphql_body.hpp` already owns the classifier that decides whether the stored string is a `{"query": ...}` envelope or a bare document, and the send itself goes through it, so `{query, variables}` is derivable from the same rule the wire uses - no new storage, no second opinion about the same bytes. `.mode` now answers `graphql`, and a read-only `.graphql` member answers the pair, read off the string `.raw` shows (so a `.raw` assignment moves both) and classified by `graphql_body_is_enveloped` rather than a local copy; the envelope-shaped-but-unparseable body answers `undefined` rather than a guessed pair, matching what `graphql_wire_body` does with it. `file` stays unanswered and `binary` still reads `raw`, recorded in the compatibility doc as a stated divergence, because reporting `file.src` would be a change to how bodies are *stored* rather than to what scripts can read - the alternative the issue explicitly declines. The rejected approach was deriving the pair from a second local parse and classifier inside `script_engine.cpp`: a copy of that rule would let the same body read as an envelope to a script and a document to the send, which is the one failure adding this member could introduce.

Two deliberate divergences from Postman, both stated in the docs rather than left to be discovered:

- **`variables` is the JSON value the envelope carries**, where Postman's is the text of its variables editor. Vayu never stored that text, and serializing one here would invent whitespace and key order the user never wrote - the thing `graphql_wire_body` refuses to do at the wire. A lifted `JSON.parse(…variables)` becomes a plain read.
- **`.raw` stays defined in this mode**, where Postman leaves it undefined - the same divergence `.raw` already carries for the two form modes (#411), kept for consistency.

### What the review round changed

The first implementation single-sourced the *classification* and then read the envelope's members by parsing the same bytes a second time with QuickJS's `JSON.parse`. The two parsers are not the same grammar: nlohmann skips a leading UTF-8 byte-order mark and `JSON.parse` rejects one. So for `\xEF\xBB\xBF{"query":"…"}` - a BOM an editor or a PowerShell redirect leaves behind - the classifier read the envelope, the send carried it intact, and `.graphql` answered `undefined`. Verified by test before fixing, not reasoned about. `ca060df` hands QuickJS the document nlohmann *read* (re-dumped) instead of the bytes it read it from, so exactly one reader of a body has an opinion and it is the one the send asks; the byte-order-marked envelope is now a third case in `TheQueryIsTheOneTheSendWouldCarry`, and it fails on the previous implementation.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

Breaking: a lifted `pm.request.body.mode === 'raw'` guard over a GraphQL body took the true branch before this and takes the false one now. That is the *compatible* answer - Postman names this mode too, so a script written against Postman was already reading `graphql` there - and `EveryContentModeAnswersRaw` records the move rather than losing it.

## Testing

All run locally on this branch at `ca060df`, all green:

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **2786 tests run, 2786 passed, 0 failed.**
- `ctest --preset linux-dev -R ScriptRequestBody` - **30/30 passed**, of which 7 are new for this issue: `AGraphqlEnvelopeReadsAsItsQueryAndVariables`, `ABareGraphqlDocumentReadsAsTheQueryItWouldBeSentAs`, `TheQueryIsTheOneTheSendWouldCarry`, `AnUnreadableEnvelopeIsNotGuessedAt`, `AnEmptyGraphqlBodyAnswersNoPair`, `AssigningRawMovesTheGraphqlPairWithIt`, `TheGraphqlPairIsFrozenLikeTheFieldLists`.
- `cd app && pnpm test` - **546 files, 5982 tests, all passed** (includes `script-typedefs.docs-compile.test.ts`, which type-checks every `pm.*` block in the two changed docs against the regenerated declarations).
- `cd app && pnpm type-check` - clean on all three projects.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.
- `clang-format-19` over the touched engine sources; CI's `Engine formatting` job green.

`TheQueryIsTheOneTheSendWouldCarry` is the mutation-check that matters: it reads the expected query back out of `graphql_wire_body` itself rather than restating it, so both deriving the pair from a second local rule and reading the body with a second parser fail it.

No pre-existing failures were observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1111