### PR TITLE
docs(app): data-driven-runs names {{$vu}}, {{$iteration}} and the per-iteration generators - #1109

### DIFF
--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -268,48 +268,49 @@ what they mean beside a bound row.
 user's iterations it is, 0-based. They are reserved names and not variables - a
 variable of either name does not answer for the identity - and they are
 substituted immediately before each send, so every iteration carries its own
-numbers. Neither needs a file: the identity comes from the iteration, so
-`user-{{$vu}}` binds on a load run with no rows at all. What each shape of run
-answers is tabulated under [`$vu` and `$iteration` are reserved
+numbers. Neither needs a file: the identity comes from the iteration rather than
+from a row, so both bind on a load run carrying no data at all. What each shape
+of run answers is tabulated under [`$vu` and `$iteration` are reserved
 too](variable-resolution.md#vu-and-iteration-are-reserved-too-for-the-same-reason);
 the shape to know here is that **a single request's load test is one user's
 iterations**, so `{{$vu}}` is `1` there and `{{$iteration}}` is the counter that
 varies - the same counter the row cursor claims from, so iteration `i` holds row
 `i % rows`. A script renders them with `pm.variables.replaceIn("{{$vu}}")`
 (issue #1057), which reads the identity the request beside it was bound with.
-Only those two spellings are reserved: `{{$vus}}` is an ordinary unknown name
-and is sent with its braces.
 
 **The `{{$guid}}` family generates per iteration** (issue #995). A run's request
-is composed once and then repeated, so a generator resolved at composition would
-put one id on every request of every user - the opposite of what a unique-id
-token is written for. Under a run the family is left written as it stands and a
-fresh value is generated per occurrence, immediately before each send: two
-`{{$guid}}` in one body are two different ids, on every iteration. A plain Send
-still generates once, because it composes once and sends once. The generators
-are listed in [the dynamic variables
-table](variable-resolution.md#dynamic-variables).
+is composed once and then repeated, so the generators are left written as they
+stand and a fresh value is produced per occurrence, immediately before each
+send: two `{{$guid}}` in one body are two different ids, on every iteration. A
+plain Send still generates at composition, because it composes once and sends
+once. Which names generate, and why a run defers them, is [the dynamic
+variables table](variable-resolution.md#dynamic-variables).
 
 **All three at once.** A collection load run of 20 users, driven by a
 `tokens.csv` of `user,token`, sending a request whose bearer token is
 `{{data.token}}`, whose `X-Client` header is `vu-{{$vu}}` and whose body carries
 `"requestId": "{{$guid}}"`:
 
-| Token            | Where its value comes from     | What it varies with                                 |
-| ---------------- | ------------------------------ | --------------------------------------------------- |
-| `{{data.token}}` | the row this iteration claimed | per iteration, off the shared cursor                |
+| Token            | Where its value comes from     | What it varies with                                  |
+| ---------------- | ------------------------------ | ---------------------------------------------------- |
+| `{{data.token}}` | the row this iteration claimed | per iteration, off the shared cursor                 |
 | `{{$vu}}`        | the user sending it            | per virtual user, the same across that user's passes |
-| `{{$guid}}`      | generated at the send          | per occurrence, per iteration                       |
+| `{{$guid}}`      | generated at the send          | per occurrence, per iteration                        |
 
-Credentials bind before they are encoded, so the `Authorization` header carries
-that row's token rather than base64 of the token's text - the rule [Send with a
-row](#send-with-a-row) states, and it holds for `{{$vu}}` and `{{$iteration}}`
-in a credential too (issue #1055). A **generator** in a credential is the
-exception: it is still resolved once, at composition, since a value left for the
-bind would go out as base64 of its own name - so write `{{$guid}}` into the body
-or a header rather than into a bearer token. OAuth 2.0 is outside all of it: its
-token is acquired once, before any iteration exists, so a row or an identity
-token in its config is refused by name rather than sent wrong.
+Write `user-{{$vu}}` into a basic-auth username instead of that header and it
+binds there too (issue #1055), even on a run with no data file at all: what
+defers a credential's build is the token the credential carries, not whether the
+run has rows to bind.
+
+Credentials bind before the request's auth is applied, so a row or an identity
+token reaches the credential itself rather than the header the credential is
+built into - the order [Send with a row](#send-with-a-row) describes. Basic
+auth is where the order shows, since it collapses username and password into one
+base64 value: a token still unbound by then would go out as base64 of its own
+text. That is also why a **generator** in a credential is resolved at
+composition rather than deferred like the rest - write `{{$guid}}` into the body
+or a header instead. OAuth 2.0 takes none of the three, for the reason that same
+section gives.
 
 This is also the answer when the file is smaller than the concurrency. Rows
 repeat once the cursor wraps, while `{{$vu}}` and `{{$iteration}}` together name

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -244,8 +244,9 @@ preview exists to remove.
 **A load run** binds rows differently: every virtual user claims rows from one
 shared cursor, so no two start on the same row while unclaimed rows remain, and
 the rows then repeat for as long as the duration lasts. Once they wrap, users do
-share rows - size the file to the concurrency if that matters. The row count
-says nothing about how long the run is.
+share rows - size the file to the concurrency if that matters, or reach for what
+[varies without a column](#what-varies-without-a-column). The row count says
+nothing about how long the run is.
 
 **A single request's load test** is that same cursor with one request where a
 collection run has a sequence: one row is claimed per request sent, in turn,
@@ -254,6 +255,65 @@ wrapping when the set runs out. So a 3-row file under a 6-request run sends rows
 many requests it sends, which is the load profile's job. Iterations is not
 defaulted from the row count here, unlike a collection run: a load profile
 already says how long the run is.
+
+## What varies without a column
+
+A file is one way to make iterations differ. A run has two more that need no
+column at all, and a data-driven load run usually wants all three at once.
+[Variable Resolution](variable-resolution.md) owns their rules; what follows is
+what they mean beside a bound row.
+
+**`{{$vu}}` and `{{$iteration}}` name the run rather than the row** (issue
+#994): which virtual user this request belongs to, 1-based, and which of that
+user's iterations it is, 0-based. They are reserved names and not variables - a
+variable of either name does not answer for the identity - and they are
+substituted immediately before each send, so every iteration carries its own
+numbers. Neither needs a file: the identity comes from the iteration, so
+`user-{{$vu}}` binds on a load run with no rows at all. What each shape of run
+answers is tabulated under [`$vu` and `$iteration` are reserved
+too](variable-resolution.md#vu-and-iteration-are-reserved-too-for-the-same-reason);
+the shape to know here is that **a single request's load test is one user's
+iterations**, so `{{$vu}}` is `1` there and `{{$iteration}}` is the counter that
+varies - the same counter the row cursor claims from, so iteration `i` holds row
+`i % rows`. A script renders them with `pm.variables.replaceIn("{{$vu}}")`
+(issue #1057), which reads the identity the request beside it was bound with.
+Only those two spellings are reserved: `{{$vus}}` is an ordinary unknown name
+and is sent with its braces.
+
+**The `{{$guid}}` family generates per iteration** (issue #995). A run's request
+is composed once and then repeated, so a generator resolved at composition would
+put one id on every request of every user - the opposite of what a unique-id
+token is written for. Under a run the family is left written as it stands and a
+fresh value is generated per occurrence, immediately before each send: two
+`{{$guid}}` in one body are two different ids, on every iteration. A plain Send
+still generates once, because it composes once and sends once. The generators
+are listed in [the dynamic variables
+table](variable-resolution.md#dynamic-variables).
+
+**All three at once.** A collection load run of 20 users, driven by a
+`tokens.csv` of `user,token`, sending a request whose bearer token is
+`{{data.token}}`, whose `X-Client` header is `vu-{{$vu}}` and whose body carries
+`"requestId": "{{$guid}}"`:
+
+| Token            | Where its value comes from     | What it varies with                                 |
+| ---------------- | ------------------------------ | --------------------------------------------------- |
+| `{{data.token}}` | the row this iteration claimed | per iteration, off the shared cursor                |
+| `{{$vu}}`        | the user sending it            | per virtual user, the same across that user's passes |
+| `{{$guid}}`      | generated at the send          | per occurrence, per iteration                       |
+
+Credentials bind before they are encoded, so the `Authorization` header carries
+that row's token rather than base64 of the token's text - the rule [Send with a
+row](#send-with-a-row) states, and it holds for `{{$vu}}` and `{{$iteration}}`
+in a credential too (issue #1055). A **generator** in a credential is the
+exception: it is still resolved once, at composition, since a value left for the
+bind would go out as base64 of its own name - so write `{{$guid}}` into the body
+or a header rather than into a bearer token. OAuth 2.0 is outside all of it: its
+token is acquired once, before any iteration exists, so a row or an identity
+token in its config is refused by name rather than sent wrong.
+
+This is also the answer when the file is smaller than the concurrency. Rows
+repeat once the cursor wraps, while `{{$vu}}` and `{{$iteration}}` together name
+each iteration of the run exactly once, and a generator is fresh at every send.
 
 ## Declaring the contract: the Data tab
 


### PR DESCRIPTION
## Description

`docs/app/data-driven-runs.md` is the entry page for the data-driven story, and it told only the rows half of it. The #992 program's three features all shipped - iteration identity (#994, #1057), per-iteration dynamic variables (#995), credential binding (#1055) - and each was documented where its mechanics live (`variable-resolution.md`, `docs/engine/scripting.md`), so this page never named two-thirds of the feature set it introduces. `rg -n '\$vu|\$iteration|\$guid|per.iteration'` against it returned nothing before this change.

**Plan.** The root cause is a wiring gap, not missing material: the mechanics have an owner, the entry page has no pointer. The fix is one new `## What varies without a column` section placed straight after `## How many iterations, and which row` (where row-to-VU binding is already established), naming all three mechanisms in this page's terms and linking `variable-resolution.md`'s owning sections for the rules - plus the combined walk-through the docs had nowhere: a collection load run with a bound dataset, `{{$vu}}`, `{{$guid}}` in the body, a table of what each token varies with, and the basic-auth username case for `{{$vu}}` in a credential. The alternative I rejected was restating the mechanics here (or adding a page for them): a second copy of the identity table and the generator list is exactly the drift shape this repo keeps hitting - #1099, #1100 and #1108 are all "the copy the last sweep missed" - so the section states what a data-driven reader needs and defers the rationale by link.

The section carries the shape caveats that separate right from nearly right, each verified against the engine rather than taken from prose:

- `{{$vu}}` is `1` on a single request's load test (one user's iterations), where `{{$iteration}}` is the counter that varies - and it is the same counter the row cursor claims from, so iteration `i` holds row `i % rows` (`load_strategy.cpp`, `submit_one_request`). The claim is deliberately **not** generalised to a collection load run, where rows come off a run-wide cursor (`scenario_load.cpp`) and a VU's iteration number is not a row index.
- Neither identity token needs a data file: a credential's build defers on what the credential carries, not on whether the run has rows (#1055).
- A plain Send still generates at composition; per-iteration generation is a run's behaviour.
- A generator inside a credential is still resolved at composition, while `{{$vu}}`/`{{$iteration}}` in a credential defer and bind. Conflating the two families here would have been wrong.
- OAuth 2.0 takes none of the three; the page's existing "Send with a row" section already owns that rule, so the new text links it rather than restating it.

One clause was also added to the existing load-run paragraph, pointing at the new section as the answer to a file smaller than the concurrency.

**Deliberate deviation from the issue spec.** The issue's suggested walk-through was "a single request with a bound dataset, `{{$vu}}` in a credential". A single request's load test always binds `SOLE_VIRTUAL_USER`, so `{{$vu}}` is pinned to `1` there and could not illustrate "what varies per VU". The walk-through is therefore a collection load run, which is the shape where `{{$vu}}` spans more than one user, and the `{{$vu}}`-in-a-credential case the issue asked for is shown right below the table as a basic-auth username.

**Review round (second commit).** Two review passes over the first commit found, and this PR fixes:

- The encoding rule was attached to the wrong credential: only basic auth base64-encodes (`engine/src/http/auth_resolver.cpp:221-225`); bearer and api key are written raw, so "a bearer token would go out as base64 of its own name" named the one credential its own mechanism does not describe.
- The `{{$vu}}`-in-a-credential case the issue asked for was asserted in prose but not shown; it is now a worked line under the table.
- Three sentences that restated `variable-resolution.md`'s rationale rather than pointing at it were trimmed, and the OAuth 2.0 rule became a link to this page's own section instead of a third copy of the same paragraph.
- The new table's third column was uneven against the page's other tables.

Findings noted and not acted on: the front-matter `description:` was left unchanged (the page's subject is still the file's contract, and the new section is what a data-driven run combines with), and the remaining definitional sentences about what `{{$vu}}`/`{{$iteration}}` and the generator family *are* stay in place - a link alone would leave the section unable to say what it is introducing.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `mkdocs build --strict -f .github/mkdocs.yml` - clean, before and after both commits (only the Material theme's own 2.0 banner, present at baseline). The new relative links render as `../variable-resolution/`, `../variable-resolution/#vu-and-iteration-are-reserved-too-for-the-same-reason` and `../variable-resolution/#dynamic-variables`, and the new `#what-varies-without-a-column` anchor exists in the built page.
- `cd app && pnpm vitest run src/modules/collections/row-persistence-claims.test.ts` - 4 passed, 1 file, on both commits. That suite reads this exact file and pins the `## What is stored` heading, the "binds into a request is stored with that request" phrasing and `maxRunsRetained`, none of which this diff touches.
- No engine or app suite run beyond that one: this is a Markdown-only change and nothing else could go from green to red (CLAUDE.md's "scale the verification to what the change could actually break").
- Acceptance criteria: `rg -c '\$vu' docs/app/data-driven-runs.md` -> non-empty, and the page now names all three mechanisms with working links.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - docs-only; the covering test is the existing docs-claim suite above
- [x] I have updated documentation

## Related Issues
Closes #1109