### PR TITLE
feat(engine): pm.response.status is Postman's reason phrase - #1000

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -252,8 +252,12 @@ capability being off. `res` carries `code`, `status`, `responseTime`,
 `headers` with `get()`/`has()`/`each()`/`all()`/`count()`/`toObject()`/`one()`/
 `indexOf()` - the same read methods as `pm.response.headers` - `json()` and
 `text()`, a subset of `pm.response` with no assertion chain. `status` is the
-numeric code there too, so the two objects called a response do not disagree
-inside one sandbox.
+reason phrase there too, so the two objects called a response do not disagree
+inside one sandbox - `code` is the number on both. Both spellings changed
+together in #1000; a script reading `res.status` as a number wants `res.code`,
+and [the migration
+note](../engine/scripting.md#status-is-the-reason-phrase-code-is-the-number)
+names the one pattern that degrades silently.
 
 **It is bounded, and both bounds throw.** The request's timeout is clamped to
 whatever is left of the script's own time budget (`scriptTimeout`, 5s by
@@ -496,6 +500,22 @@ on the `Date` and `RegExp` sides, and the values `include`, `oneOf`, `members`,
 test as the script's own error rather than as a difference. Chai reports a
 difference for some of these, which under `.not` is a pass; a test that cannot
 read its subject has not passed.
+
+### `code` is the number, `status` is the reason phrase
+
+Postman splits the status line in two and Vayu answers the same split:
+`pm.response.code` is `200`, `pm.response.status` is `"OK"` - the phrase the
+status line carried, or the registered text for the code where the wire had
+none (HTTP/2 carries no phrase at all). `pm.response.reason()` answers the
+same string, and `pm.response.to.have.status(...)` compares a number against
+the code and a string against the phrase.
+
+Vayu spelled `status` as the number until #1000, so this is a break for a
+script written against the old spelling rather than against Postman.
+`docs/engine/scripting.md` carries [the migration
+note](../engine/scripting.md#status-is-the-reason-phrase-code-is-the-number),
+including the one legacy pattern - arithmetic on `status` - that goes on
+compiling, stops matching, and reports nothing.
 
 ### Response timings, and the two error fields
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -333,7 +333,7 @@ Access HTTP response data:
 
 ```javascript
 pm.response.code              // Status code (number, e.g., 200)
-pm.response.status            // Alias for code
+pm.response.status            // Reason phrase (string, e.g., 'OK') - see below
 pm.response.responseTime      // Perceived latency in ms (submit → completion).
                               // In load tests this includes generator-side
                               // queue wait. For pure server wire time, use
@@ -366,6 +366,38 @@ reached the script from a server carries neither.
 received it falls back to the canonical text for the code, so a client-side
 failure - vayu's synthetic status `0` - reads `"Error"` rather than an empty
 string. (Postman returns `null` in that case; vayu always returns a string.)
+
+### `status` is the reason phrase, `code` is the number
+
+Postman spells the two apart: `code` is the number and `status` is the phrase
+the status line carried. Vayu used to spell both as the number, so a lifted
+`if (res.status === 'OK')` guard was always false and
+`pm.expect(pm.response.status).to.eql('OK')` failed where Postman passes.
+`status` is now the phrase - the same string `reason()` answers, wire phrase
+where there was one and the registered text for the code where there was not -
+on **both** objects that carry a status: the response a post-request script
+reads, and the one a
+[`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest) callback
+receives. `code` is untouched on both.
+
+That is a break for a script written against vayu's old spelling:
+
+| Was | Reads now | Use instead |
+|---|---|---|
+| `pm.response.status` | `"OK"`, not `200` | `pm.response.code` |
+| `pm.expect(pm.response.status).to.equal(200)` | fails - the phrase is not the code | `pm.expect(pm.response.code).to.equal(200)` |
+| `if (pm.response.status >= 400)` | **never taken** - a phrase compares false against a number | `if (pm.response.code >= 400)` |
+| `res.status` in a `pm.sendRequest` callback | the phrase | `res.code` |
+
+The first two rows fail loudly: the comparison is always false, so the test
+that made it goes red and names itself. **The third does not.** A guard
+comparing `status` against a number is not an assertion, and JavaScript
+answers `false` for it rather than throwing, so the branch simply stops being
+entered and nothing reports that it stopped. Search a ported script for
+arithmetic on `status` before trusting a green run.
+
+`pm.response.to.have.status(...)` needs no migration - it has taken either
+form since it learned the reason phrase, and decides by the argument's type.
 
 `size()` counts the body the script can read through `text()`, so
 `size().body === pm.response.text().length` for an ASCII body. `size().header`
@@ -1348,7 +1380,7 @@ a `.code` (`CONNECTION_FAILED`, `DNS_ERROR`, `TIMEOUT`, …) and `res` null. The
 script's own mistakes throw out of the call instead: an unusable argument, an
 unsupported body mode, exceeding the request cap, and the capability being off.
 
-`res` carries `code`, `status` (the numeric code, as on `pm.response`),
+`res` carries `code`, `status` (the reason phrase, as on `pm.response`),
 `responseTime`, `headers` with `get()`/`has()`/`each()`/`all()`/`count()`/
 `toObject()`/`one()`/`indexOf()` - the same read methods documented under
 [Reading response headers](#reading-response-headers) - `json()` and `text()`.

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -112,8 +112,11 @@ nlohmann::json get_script_completions () {
     { "sortText", "1_pm_response_code" } });
 
     completions.push_back ({ { "label", "pm.response.status" }, { "kind", KIND_FIELD },
-    { "insertText", "pm.response.status" }, { "detail", "number" },
-    { "documentation", "The HTTP status code (alias for pm.response.code)." },
+    { "insertText", "pm.response.status" }, { "detail", "string" },
+    { "documentation",
+    "The status line's reason phrase ('OK', 'Not Found') - the same string "
+    "pm.response.reason() answers, and Postman's meaning for this name. The "
+    "number is pm.response.code." },
     { "sortText", "1_pm_response_status" } });
 
     completions.push_back ({ { "label", "pm.response.responseTime" }, { "kind", KIND_FIELD },
@@ -1287,7 +1290,8 @@ nlohmann::json get_script_completions () {
     "sendRequest returns. Postman's promise-returning overload is deliberately "
     "absent - it could only never resolve.\n\nThe callback gets (err, res). "
     "Transport failures - refused, DNS, timeout - arrive as err with a .code; "
-    "res is null then. res carries code, status, responseTime, headers.get() "
+    "res is null then. res carries code, status (the reason phrase, as on "
+    "pm.response - the number is code), responseTime, headers.get() "
     "and json()/text() - a subset of pm.response, not the assertion "
     "chain.\n\nThe url may be a string or pm.request.url, and {{variables}} in "
     "it, in header names and values, in a raw body and in auth credentials "

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -4573,9 +4573,12 @@ void setup_pm_response (JSContext* ctx, JSValue pm) {
         JS_SetPropertyStr (
         ctx, response, "code", JS_NewInt32 (ctx, data->response->status_code));
 
-        // pm.response.status (same as code for compatibility)
-        JS_SetPropertyStr (
-        ctx, response, "status", JS_NewInt32 (ctx, data->response->status_code));
+        // pm.response.status - Postman's reason phrase, not a second spelling
+        // of the code. Derived here rather than carried: the phrase is wanted
+        // only when a script reads it, and scripts run deferred on sampled
+        // responses, so nothing is added to the transfer path for it.
+        JS_SetPropertyStr (ctx, response, "status",
+        JS_NewString (ctx, response_reason_phrase (*data->response).c_str ()));
 
         // pm.response.responseTime - perceived latency (submit → completion),
         // includes generator-side queue wait. For pure server time, use
@@ -7123,16 +7126,19 @@ build_send_request (JSContext* ctx, JSValueConst arg, Request& out, vayu::http::
 // The response a pm.sendRequest callback receives.
 //
 // A deliberate subset of pm.response: code, status, responseTime, headers,
-// json() and text(). `status` is the numeric code, as it is on pm.response -
-// Postman spells the reason phrase there instead, but two objects called a
-// response inside one sandbox disagreeing about what `status` means is the
-// worse divergence. The body readers are the same two functions pm.response
-// installs, so the two cannot drift.
+// json() and text(). `status` is the reason phrase, as it is on pm.response -
+// which is Postman's contract and, since the two spellings moved together in
+// #1000, still leaves no room for two objects called a response inside one
+// sandbox to disagree about what `status` means. The phrase comes from the
+// same `response_reason_phrase` pm.response and `to.have.status` read, and
+// the body readers are the same two functions pm.response installs, so
+// neither answer can drift from its sibling.
 JSValue build_send_response (JSContext* ctx, const Response& response) {
     JSValue result = JS_NewObject (ctx);
 
     JS_SetPropertyStr (ctx, result, "code", JS_NewInt32 (ctx, response.status_code));
-    JS_SetPropertyStr (ctx, result, "status", JS_NewInt32 (ctx, response.status_code));
+    JS_SetPropertyStr (ctx, result, "status",
+    JS_NewString (ctx, response_reason_phrase (response).c_str ()));
     JS_SetPropertyStr (
     ctx, result, "responseTime", JS_NewFloat64 (ctx, response.timing.total_ms));
 

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -1192,9 +1192,9 @@ declare const pm: {
 		 */
 		size(): { body: number, header: number, total: number };
 		/**
-		 * The HTTP status code (alias for pm.response.code).
+		 * The status line's reason phrase ('OK', 'Not Found') - the same string pm.response.reason() answers, and Postman's meaning for this name. The number is pm.response.code.
 		 */
-		status: number;
+		status: string;
 		/**
 		 * Return the response body as a string.
 		 */
@@ -1384,7 +1384,7 @@ declare const pm: {
 	 * 
 	 * Synchronous despite the callback: the sandbox has no event loop, so the send blocks and the callback runs inline before sendRequest returns. Postman's promise-returning overload is deliberately absent - it could only never resolve.
 	 * 
-	 * The callback gets (err, res). Transport failures - refused, DNS, timeout - arrive as err with a .code; res is null then. res carries code, status, responseTime, headers.get() and json()/text() - a subset of pm.response, not the assertion chain.
+	 * The callback gets (err, res). Transport failures - refused, DNS, timeout - arrive as err with a .code; res is null then. res carries code, status (the reason phrase, as on pm.response - the number is code), responseTime, headers.get() and json()/text() - a subset of pm.response, not the assertion chain.
 	 * 
 	 * The url may be a string or pm.request.url, and {{variables}} in it, in header names and values, in a raw body and in auth credentials resolve as the call is made - so a value this script set two lines earlier is visible. Two header names that resolve to one name are refused rather than sent a header short, and a name resolving to nothing is refused too.
 	 * 

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1510,13 +1510,91 @@ TEST_F (ScriptEngineTest, ResponseStatusCode) {
             pm.expect(pm.response.code).to.equal(200);
         });
 
-        pm.test("Status is also available", function() {
-            pm.expect(pm.response.status).to.equal(200);
+        pm.test("Status is the reason phrase", function() {
+            pm.expect(pm.response.status).to.equal("OK");
         });
     )",
     request, response, env);
 
     EXPECT_TRUE (result.success);
+}
+
+// Postman splits the status line in two and a lifted script reads it that way:
+// `status` is the phrase, `code` the number. Vayu spelled both as the number
+// until #1000, so this pins the split rather than either half - a `status` that
+// went back to the code would still pass every assertion on `code`, and this is
+// what would notice.
+TEST_F (ScriptEngineTest, ResponseStatusIsThePhraseAndCodeIsTheNumber) {
+    response.status_code = 404;
+    response.status_text = "Not Found";
+
+    auto result = engine.execute_test (R"(
+        pm.test("phrase", function() { pm.expect(pm.response.status).to.equal("Not Found"); });
+        pm.test("a string, not a number", function() { pm.expect(typeof pm.response.status).to.equal("string"); });
+        pm.test("code stays the number", function() { pm.expect(pm.response.code).to.equal(404); });
+        pm.test("agrees with the reason accessor", function() { pm.expect(pm.response.status).to.equal(pm.response.reason()); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 4u);
+    for (const auto& test : result.tests) {
+        EXPECT_TRUE (test.passed) << test.name << ": " << test.error_message;
+    }
+}
+
+// The wire's own phrase wins where there was one - a server may word its status
+// line however it likes, and reporting the registered text instead would answer
+// about the code rather than about the response.
+TEST_F (ScriptEngineTest, ResponseStatusPrefersTheWirePhrase) {
+    response.status_code = 200;
+    response.status_text = "Totally Fine";
+
+    auto result = engine.execute_test (R"(
+        pm.test("the wire's wording", function() { pm.expect(pm.response.status).to.equal("Totally Fine"); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// HTTP/2 carries no reason phrase at all, so `status` falls back to the
+// registered text for the code rather than to an empty string - the same
+// fallback `reason()` and `to.have.status("...")` make, out of the one helper.
+// A client-side failure is the same fallback reached from vayu's synthetic 0,
+// which the canonical table spells "Error".
+TEST_F (ScriptEngineTest, ResponseStatusFallsBackToTheRegisteredPhrase) {
+    response.status_code = 503;
+    response.status_text.clear ();
+
+    auto result = engine.execute_test (R"(
+        pm.test("registered phrase", function() { pm.expect(pm.response.status).to.equal("Service Unavailable"); });
+        pm.test("and the assertion agrees", function() { pm.response.to.have.status("Service Unavailable"); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 2u);
+    for (const auto& test : result.tests) {
+        EXPECT_TRUE (test.passed) << test.name << ": " << test.error_message;
+    }
+
+    response.status_code = 0;
+    response.status_text.clear ();
+
+    auto failed = engine.execute_test (R"(
+        pm.test("synthetic status", function() { pm.expect(pm.response.status).to.equal("Error"); });
+        pm.test("synthetic code", function() { pm.expect(pm.response.code).to.equal(0); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (failed.success) << failed.error_message;
+    ASSERT_EQ (failed.tests.size (), 2u);
+    for (const auto& test : failed.tests) {
+        EXPECT_TRUE (test.passed) << test.name << ": " << test.error_message;
+    }
 }
 
 TEST_F (ScriptEngineTest, ResponseJson) {

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -230,7 +230,10 @@ TEST_F (SendRequestTest, DeliversTheResponseToTheCallback) {
     "pm.test('shape', function () { "
     "  pm.expect(seen.err).to.equal(null); "
     "  pm.expect(seen.code).to.equal(200); "
-    "  pm.expect(seen.status).to.equal(200); "
+    // The callback response spells the status line the way pm.response does
+    // since #1000: the phrase under `status`, the number under `code`. Two
+    // objects called a response inside one sandbox must not disagree.
+    "  pm.expect(seen.status).to.equal('OK'); "
     "  pm.expect(seen.token).to.equal('tok_123'); "
     "  pm.expect(seen.type).to.equal('application/json'); "
     "  pm.expect(seen.text.length > 0).to.equal(true); "


### PR DESCRIPTION
## Description

Postman splits the status line in two - `code` is the number, `status` is the reason phrase - and vayu spelled both as the number. A script lifted from Postman read the split wrong in silence: `if (res.status === 'OK')` was always false so its guard was skipped, and `pm.expect(pm.response.status).to.eql('OK')` failed where Postman passes.

**Root cause and approach.** The engine already had every part of the answer and only the binding was wrong. `response_reason_phrase` (`script_engine.cpp:3217`) has answered `reason()` and `to.have.status("OK")` since #1049 - wire phrase where the status line carried one, the registered `vayu::http::status_text` for the code where it did not - so `status` becomes a third reading of that one helper rather than a new derivation. Both spellings flip together: `pm.response.status` and the `pm.sendRequest` callback's `res.status`, with `code` untouched on both.

Flipping both is what keeps `build_send_response`'s standing rule true. That comment argued for the numeric spelling on the grounds that *"two objects called a response inside one sandbox disagreeing about what `status` means is the worse divergence"* - which is an argument about agreement, not about which of the two spellings they agree on. **The alternative I rejected** was flipping `pm.response.status` alone and leaving `sendRequest`'s `res.status` numeric: that is the smaller diff and the smaller break, but it manufactures exactly the intra-sandbox disagreement the existing design went out of its way to avoid, and it is not what #1000 specifies.

**The throughput guard the issue sets is met by construction.** Nothing is added to the transfer or completion path: the phrase is derived at script-bind time from `Response::status_text`, a field the response already carries, which `client.cpp` fills from the wire (or from the canonical table) as the transfer completes. The issue's open question - "does the engine already carry the wire phrase?" - is answered *yes*, so this is "existing capture, canonical fallback", not "canonical exclusively"; no new field, no per-response allocation, no hot-path presence.

`pm.response.to.have.status(...)` needed no change: it has taken a number or a phrase since #998/#1049 and decides by the argument's type. Acceptance criterion 3 was already satisfied by landed code.

**App changes:** none needed, and verified rather than assumed. Neither the renderer nor MCP holds a copy of the scripting surface - `useScriptTypeDefinitions.ts` and `useScriptCompletionProvider.ts` fetch the `.d.ts` and the completions from the engine, and `app/electron/mcp/resources.ts` re-serves the same two. The only app-shipped script snippets that touch the status use `pm.response.code` and `pm.response.to.have.status(200)`, neither of which changes. The many `response.status` reads under `app/src/modules/` are the REST layer's own numeric `status` field on `POST /execute` - a different field, deliberately untouched.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2782 tests, 2782 passing, 0 failing.** No pre-existing failures on this base (`01d70d3`).

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - green; the doc-compile guard type-checks every `pm.*` fenced block in both edited pages against the regenerated declarations.

Tests added or changed:

- `ResponseStatusCode` - the pin flips from `pm.response.status === 200` to `=== "OK"`, beside the unchanged assertion on `code`.
- `ResponseStatusIsThePhraseAndCodeIsTheNumber` (new) - the split itself: phrase, `typeof` string, `code` still `404`, and agreement with `reason()`. Mutation-checked - reverting the binding to `JS_NewInt32` fails three of its four cases, and it is what would notice a `status` that quietly went back to the code while every assertion on `code` still passed.
- `ResponseStatusPrefersTheWirePhrase` (new) - a server's own wording (`"Totally Fine"` on a 200) wins over the registered text.
- `ResponseStatusFallsBackToTheRegisteredPhrase` (new) - an empty `status_text` (HTTP/2 carries no phrase) reads `"Service Unavailable"` for a 503, agreeing with `to.have.status`; and vayu's synthetic `0` reads `"Error"`.
- `SendRequestTest.DeliversTheResponseToTheCallback` - the callback response's `status` pin flips to `'OK'` over a real wire.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1000

---

**Migration note** (for release-notes curation - this is a breaking change to a script-visible type):

`docs/engine/scripting.md` gains a `Was | Reads now | Use instead` subsection, on #1003's precedent, with `docs/app/pm-api-compatibility.md` cross-referencing it rather than duplicating the table. It names both legacy shapes honestly:

- **Loud.** `pm.response.status === 200` and `pm.expect(pm.response.status).to.equal(200)` become always-false, so the test that made them goes red and names itself. Use `pm.response.code`.
- **Silent.** `if (pm.response.status >= 400)` is not an assertion - JavaScript answers `false` rather than throwing, so the branch simply stops being entered and nothing reports that it stopped. The note says to search a ported script for arithmetic on `status` before trusting a green run.

The declarations fixture (`engine/tests/fixtures/script-typedefs.d.ts`) is regenerated with `VAYU_UPDATE_SCRIPT_TYPEDEFS=1`, not hand-edited; the diff is the three lines the completion table changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpjHMCMBzCbT13mocM9m7v)_