### PR TITLE
docs(scripting): state the post-#1009 resolver contract everywhere it is described - #1052

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4916,8 +4916,8 @@ token that arrived as a *variable's value* binds like any other: a variable
 `endpoint` whose value is `/u/{{data.id}}` leaves `{{data.id}}` in the URL after
 composition - it is rescanned since issue #1009, but the `data.` namespace is
 deferred to bind time (issue #1007), so this token survives it - and the data
-pass then binds it. That is usable, and it is also why the
-no-data refusal below says "or from the variable value it was written into" -
+pass then binds it. That is usable, and it is also why the no-data refusal
+below says "or from the variable value it was written into" -
 the token it names may not appear anywhere in the request as you wrote it.
 
 **`{{$vu}}` and `{{$iteration}}` are the second reserved namespace** (issue

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4914,8 +4914,9 @@ through `pm.iterationData`, or through `pm.variables` for a bare name - see
 The pass runs over the **composed** text, not the text as it was authored, so a
 token that arrived as a *variable's value* binds like any other: a variable
 `endpoint` whose value is `/u/{{data.id}}` leaves `{{data.id}}` in the URL after
-composition (resolution is one pass and never rescans a substituted value), and
-the data pass then binds it. That is usable, and it is also why the
+composition - it is rescanned since issue #1009, but the `data.` namespace is
+deferred to bind time (issue #1007), so this token survives it - and the data
+pass then binds it. That is usable, and it is also why the
 no-data refusal below says "or from the variable value it was written into" -
 the token it names may not appear anywhere in the request as you wrote it.
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -449,12 +449,13 @@ ids, and returns the execute-ready payload that `POST /execute` and `POST
 - builds the effective variable map (globals < collection chain root→leaf <
   environment, enabled definitions only) and interpolates `{{variables}}` into
   the URL, header keys/values, body content/fields, and the auth block -
-  single-pass, raw stored strings, unknown plain names to `""`, unknown
-  `$names` kept braced, dynamic variables (`{{$guid}}`, …) generated per
-  occurrence - unless the caller asked for them to be deferred
-  (`deferDynamicVariables`), which a composition made for a *run* does, so the
-  run generates a fresh value per iteration instead of repeating one (issue
-  #995);
+  raw stored strings, an unknown name kept braced whether or not it is a
+  `$name` (issue #1009), a substituted value that carries tokens of its own
+  resolved through them to a bound of 8 levels, dynamic variables
+  (`{{$guid}}`, …) generated per occurrence - unless the caller asked for them
+  to be deferred (`deferDynamicVariables`), which a composition made for a
+  *run* does, so the run generates a fresh value per iteration instead of
+  repeating one (issue #995);
 - resolves `inherit` auth by walking the collection ancestor chain leaf→root
   (an explicit `noauth` terminates the walk, `none` is stepped over), and
   resolves variables inside the winning block **before** any OAuth 2.0 cache

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -825,11 +825,12 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
 
 - **Variables** - the engine resolves URL, headers, and body with the app's
   precedence (environment > collection chain, leaf→root > globals; enabled
-  only; unknown → empty string; dynamic variables like `{{$guid}}` generated
-  per occurrence). MCP hands it raw strings and checks the allowlist against
-  the **composed** host. `start_load_run` composes for a *run*, like the app,
-  so the `{{$guid}}` family is deferred and the engine generates a fresh value
-  per iteration rather than repeating one across them (issue #995); see
+  only; an unknown name keeps its braces, issue #1009; dynamic variables like
+  `{{$guid}}` generated per occurrence). MCP hands it raw strings and checks
+  the allowlist against the **composed** host. `start_load_run` composes for a
+  *run*, like the app, so the `{{$guid}}` family is deferred and the engine
+  generates a fresh value per iteration rather than repeating one across them
+  (issue #995); see
   [variable resolution](../app/variable-resolution.md#dynamic-variables).
 - **Auth** - `run_collection_smoke` composes each saved request by id, so its
   stored auth applies (`inherit` resolved against the collection chain);

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1308,7 +1308,7 @@ choose where the value is stored.
 ```
 
 **`pm.variables.replaceIn(template)`** - Postman's `{{name}}` interpolation of
-an arbitrary string - runs the same single-pass resolver `POST /compose` uses
+an arbitrary string - runs the same resolver `POST /compose` uses
 (`request_composer.cpp::resolve_template`), over the script's scopes in
 `pm.variables`' precedence, at **call time** - so a variable the script set a
 line earlier resolves, unlike `{{}}` in the URL, which was composed before the

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -279,7 +279,8 @@ struct ScenarioLimits {
  * Everything resolution needs beyond the `scenario` block itself.
  *
  * `environment_id` is not part of the block: it is the *run's* environment, and
- * composition needs it or every `{{env var}}` in the plan resolves to "".
+ * composition needs it or every `{{env var}}` in the plan keeps its braces
+ * (issue #1009) instead of resolving.
  */
 struct ScenarioResolveOptions {
     std::string environment_id;

--- a/engine/include/vayu/http/request_composer.hpp
+++ b/engine/include/vayu/http/request_composer.hpp
@@ -41,7 +41,8 @@
  *    "" (D17, enforced by `vayu::json::parse_variables`)
  *  - a user-defined variable named `$guid` beats the generator, and each
  *    generator runs once per `{{...}}` occurrence
- *  - single pass, no recursion: a value containing `{{other}}` stays literal
+ *  - a value containing `{{other}}` is resolved through it too (issue #1009),
+ *    under the cycle rule and depth bound `substitute_tokens` states below
  *  - the raw stored string is substituted, never the typed value
  *  - `noauth` on a collection terminates the inherit walk, `none` does not
  *  - auth is resolved *before* any OAuth 2.0 cache key is computed (the key

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -6556,11 +6556,16 @@ JSValue js_pm_variables_to_object (JSContext* ctx, JSValueConst this_val, int ar
 // This is the sanctioned way to `{{...}}` inside a script. Script *text* is
 // never interpolated (issue #226, D16: a rewrite cannot tell code from a
 // string literal, and splicing variable values into source is an injection);
-// replaceIn keeps values as data - the same single-pass resolver the engine's
-// POST /compose uses (`resolve_template`), so the semantics are identical:
-// a bound row's column wins over the scopes (issue #1007), scopes win over
-// generators, a dynamic `{{$guid}}` generates per occurrence, an unknown
-// `$name` keeps its braces, an ordinary unknown name becomes "".
+// replaceIn keeps values as data - the same resolver the engine's POST
+// /compose uses (`resolve_template`), so the semantics are identical: the
+// `{{$vu}}`/`{{$iteration}}` identity answers ahead of every scope (issue
+// #1088), a bound row's column wins over the scopes (issue #1007), scopes
+// win over generators, a dynamic `{{$guid}}` generates per occurrence, and
+// a name nothing answers keeps its braces - an unknown `$name` and an
+// ordinary unknown name alike (issue #1009). A substituted value that
+// carries tokens of its own is resolved through them in turn, bounded by
+// `MAX_NESTED_RESOLUTIONS` (`request_composer.cpp`) and by a cycle rule
+// that leaves a name already being expanded written as it stands.
 //
 // Two deliberate differences from compose-time resolution, both consequences
 // of *when* this runs:

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -68,11 +68,11 @@ TEST (ScenarioDataNamespaceTest, ComposingLeavesADataTokenWrittenAsItStands) {
 TEST (ScenarioDataNamespaceTest, ADataTokenWrittenIntoAVariableValueStillBinds) {
     // The data pass scans the *composed* text, not the authored text, so a
     // token that arrived as a variable's value is bound like any other. It
-    // follows from two rules that are each pinned elsewhere - composition is
-    // one pass, so `{{host}}`'s value is never rescanned for variables, and the
-    // data pass runs afterwards over what composition produced - but the
-    // combination is what a user relies on and nothing asserted it (issue #595,
-    // item 3).
+    // follows from two rules that are each pinned elsewhere - composition does
+    // rescan `{{endpoint}}`'s value (issue #1009) but defers the `data.`
+    // namespace, so the token survives it, and the data pass runs afterwards
+    // over what composition produced - but the combination is what a user
+    // relies on and nothing asserted it (issue #595, item 3).
     vayu::http::VariableValues vars{ { "endpoint", "/u/{{data.id}}" } };
     const auto composed =
     vayu::http::resolve_template ("https://api.test{{endpoint}}", vars);
@@ -463,8 +463,10 @@ TEST (ScenarioDataBindTest, ARequestWithNoTokensIsUnchanged) {
 }
 
 TEST (ScenarioDataBindTest, ASubstitutedValueIsNeverRescanned) {
-    // One pass, exactly as `resolve_template` promises: a cell whose text looks
-    // like a token is data, not an instruction.
+    // One pass, as the data pass promises: it joins the parts a row was split
+    // into and never re-reads what it wrote, where `resolve_template` has
+    // followed a substituted value's own tokens since issue #1009. A cell
+    // whose text looks like a token is data, not an instruction.
     auto request = request_with_url ("https://api.test/{{data.a}}");
     const auto result =
     bind_data_row (request, json::parse (R"({"a":"{{data.b}}","b":"no"})"), 0);

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -416,7 +416,8 @@ TEST_F (ScenarioPlanTest, AStepWithoutAGeneratorCarriesAnEmptyTemplate) {
 
 TEST_F (ScenarioPlanTest, StepsResolveAgainstTheRunsEnvironment) {
     // Without the run's environmentId reaching composition, every {{env var}}
-    // in the plan silently resolves to "" - the failure this guards.
+    // in the plan silently keeps its braces (issue #1009) instead of
+    // resolving - the failure this guards.
     seed_collection ("col", "");
     seed_request ("req", "col", 0, "https://{{host}}/ping");
     seed_environment ("env", R"({"host":{"value":"api.example.test"}})");


### PR DESCRIPTION
## Description

`pm.variables.replaceIn`'s contract comment (`engine/src/runtime/script_engine.cpp`, now `:6559-6568`) described `resolve_template` as it behaved **before** #1009: "the same single-pass resolver... an ordinary unknown name becomes `""`". Both halves are wrong today, and this is the one place a reader goes to learn `replaceIn`'s rules from the code.

**Root cause and approach.** The comment's own argument is still right - `replaceIn` inherits whatever the shared resolver does - so what rotted is the *description of the resolver*, in three ways: #1009 made an unknown ordinary name keep its braces (`request_composer.cpp:615-621`) and made a substituted value's own tokens resolve recursively under a cycle rule and `MAX_NESTED_RESOLUTIONS` (8), and #1088 made `{{$vu}}`/`{{$iteration}}` answer ahead of every scope. Verified that `replaceIn` really does inherit all three: `resolve_script_template` calls the same `vayu::http::resolve_template` / `resolve_template_with_data` and always passes `script_identity (data)`, and `identity_value` is checked before `lookup_variable` - and, in the row arm, before the row's own column read - in both resolver arms.

**Corrected the claim, not the page.** A repo-wide sweep for the pre-#1009 rule turned up seven more surviving copies beyond the two anchors the issue names:

| Surface | What it said |
|---|---|
| `docs/engine/scripting.md` | "the same **single-pass** resolver" (the one-word fix the issue asks for) |
| `docs/engine/architecture.md` | "single-pass, ... unknown plain names to `\"\"`" - both stale claims in one line |
| `docs/engine/mcp.md` | "unknown → empty string", stated outright |
| `docs/engine/api-reference.md` | a still-correct conclusion by a now-wrong route - see below |
| `engine/include/vayu/http/request_composer.hpp:44` | "single pass, no recursion", contradicting the same header's own `substitute_tokens` doc at `:198-204` |
| `engine/include/vayu/core/scenario_plan.hpp:282` | an unresolved `{{env var}}` "resolves to `\"\"`" |
| `engine/tests/scenario_plan_test.cpp:418` | the direct test-side twin of the `scenario_plan.hpp` line above |
| `engine/tests/scenario_data_test.cpp:71`, `:467` | one stale reason, one misattributed - see below |

The `api-reference.md` one is the subtle case and worth calling out: it says `{{data.id}}` inside a variable's value survives composition *because* "resolution is one pass and never rescans a substituted value". The conclusion holds, the reason no longer does - the value **is** rescanned since #1009; the token survives because the `data.` namespace is deliberately deferred to bind time (#1007). A right answer resting on a wrong rule is the version of this defect that outlives greps, so it is reworded rather than left. `scenario_data_test.cpp:71` carried that identical construction (and named `{{host}}` where the test binds `{{endpoint}}`); `:467` credited its one-pass behaviour to `resolve_template`, when `bind_data_row` in fact goes through `apply_iteration_template`'s `TemplateJoiner` - the function that genuinely does not re-read what it wrote.

**Alternative rejected.** Restating the depth bound as the literal "8" in the `script_engine.cpp` comment - this repo's recorded drift shape is a number in prose drifting from the thing it counts (the reason #1108 exists), so the comment names `MAX_NESTED_RESOLUTIONS` and where it lives instead. `architecture.md` keeps "8 levels" because that is the wording `request_composer.hpp:199` and `variable-resolution.md:489` already use, and inventing a third phrasing there would be the worse trade.

**Deliberate deviation from the issue spec.** The issue's AC2 scopes the sweep to "`script_engine.cpp` or the docs"; the two `.hpp` comments and the three test comments are outside that literal wording. All five state the identical pre-#1009 rule, `request_composer.hpp:44` self-contradicts its own file, and `scenario_plan_test.cpp:418` is the direct twin of a line this PR fixes in `scenario_plan.hpp` - fixing the header and leaving its test asserting the opposite reads worse than having fixed neither. All are comment-only edits with no behavioural reach; **no assertion was changed**.

`docs/app/variable-resolution.md` was verified already correct and left untouched, as the issue directs. Its "single pass" phrasing at `:492` is the amortized sense - "a value holding no `{{` costs one search" - and directly follows an accurate description of the bounded, cycle-guarded walk, so it is not the stale claim.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Comments and Markdown only - **no code changes and no assertion changes** - so per the repo's verification-scaling rule no local suite could change colour, and none was run by hand beyond the guard noted below.

Locally, before pushing:

- `mkdocs build --strict -f .github/mkdocs.yml` - passes (4 of the 5 touched docs pages are link-bearing).
- `clang-format-19 --dry-run -Werror` on all five touched engine files - clean, exit 0.
- `pnpm vitest run src/hooks/script-typedefs.docs-compile.test.ts` - **1 file, 2 tests passed**. Run by hand deliberately: this PR edits `docs/engine/scripting.md`, one of that guard's two declared inputs, and CI **skips** the app jobs on it - the routing gap filed as #1118, observed again on this PR's own check run (`App on ubuntu-latest`: `skipped`).

CI on the head commit then went further than the local scaling rule required, because the second commit touches `engine/tests/*.cpp` and so routes to the engine tree: **`Engine on ubuntu-latest`, `Engine on macos-latest` and `Engine on windows-latest` all built the engine and ran the full C++ suite green**, alongside `Engine formatting`. So the three edited test comments are confirmed to compile and their tests to pass unchanged, on all three platforms.

The behaviour these comments describe is already pinned by #1009's tests in `request_composer_test.cpp` and #1088's identity tests in `script_engine_test.cpp`; this change adds no behaviour to cover.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - n/a, comment/docs only
- [x] I have updated documentation

## Related Issues

Closes #1052

This drains the `script_engine.cpp` serial slot of the #996 program - #1000 (PR #1117) and #1003 (PR #1110) both merged - which unblocks #1060, whose lower-casing sweep was waiting for the slot.