### PR TITLE
ci: route the docs-compile guard's own inputs to the job that runs it - #1118

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -61,6 +61,7 @@ jobs:
     outputs:
       code: ${{ steps.code.outputs.code }}
       app: ${{ steps.area.outputs.app }}
+      app_doc_fixtures: ${{ steps.area.outputs.app_doc_fixtures }}
       engine: ${{ steps.area.outputs.engine }}
       installer: ${{ steps.area.outputs.installer }}
       build_script: ${{ steps.area.outputs.build_script }}
@@ -177,6 +178,25 @@ jobs:
               # bare one covers a root-level file, the `**/` one covers nested.
               - '!*.md'
               - '!**/*.md'
+            # The two pages `script-typedefs.docs-compile.test.ts` compiles.
+            # They are prose, so `!**/*.md` above rejects them and `code`
+            # rejects them twice over (`!docs/**` *and* `!**/*.md`) - and they
+            # are also app test *input*, in the same sense
+            # `engine/tests/fixtures/script-typedefs.d.ts` is, so editing one
+            # can turn `pnpm test` red exactly the way a source file can. A gate
+            # whose own inputs cannot trigger it is #887's defect again (#1118),
+            # so they get their own union, ORed into the `app` job's condition
+            # below. Not folded into `app` above: an exclusion in
+            # `some-with-excludes` is final, so a positive rule listed after
+            # `!**/*.md` is dead - it cannot include back what a `!` rejected.
+            #
+            # This list is not free-standing. `DOC_PATHS` in that test names the
+            # same two files, and `routes every page it compiles` there fails if
+            # the two lists disagree - adding a third page to the guard is red
+            # until it is routed here as well.
+            app_doc_fixtures:
+              - 'docs/engine/scripting.md'
+              - 'docs/app/pm-api-compatibility.md'
             engine:
               - 'engine/**'
               - 'VERSION'
@@ -214,7 +234,7 @@ jobs:
               - 'scripts/pre-commit'
               - '.github/workflows/pr-tests.yml'
 
-      # The routing, said out loud. Every job below is gated on these five
+      # The routing, said out loud. Every job below is gated on these six
       # booleans, and until this step existed the only way to answer "why did
       # the engine matrix run on a change that touched no engine source" was to
       # re-evaluate the globs by hand - which is how the doc-routing defect
@@ -294,7 +314,15 @@ jobs:
     name: App on ${{ matrix.os }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
     runs-on: ${{ matrix.os }}
     needs: changes
-    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true'
+    # The second clause is the one job the doc fixtures need: this is where
+    # `pnpm test` runs, so it is where the guard that compiles them runs. It is
+    # an OR rather than another entry in `app` because `code` rejects a
+    # documentation path too, and `code && app` would answer false on the `code`
+    # half however the area filter were written. `quality` deliberately keeps
+    # the plain condition - eslint reads TS/TSX, prettier's domain is `app/` and
+    # tsc reads neither page, so nothing it runs can change colour over a
+    # Markdown edit.
+    if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.app_doc_fixtures == 'true'
     permissions:
       contents: read
     strategy:

--- a/app/src/hooks/script-typedefs.docs-compile.test.ts
+++ b/app/src/hooks/script-typedefs.docs-compile.test.ts
@@ -45,11 +45,19 @@ const repoRoot = join(here, "..", "..", "..");
 
 const DECLARATIONS_PATH = join(repoRoot, "engine", "tests", "fixtures", "script-typedefs.d.ts");
 
-/** The two pages whose `pm.*` blocks are the contract. */
-const DOC_PATHS = [
-	join(repoRoot, "docs", "engine", "scripting.md"),
-	join(repoRoot, "docs", "app", "pm-api-compatibility.md"),
-];
+/**
+ * The two pages whose `pm.*` blocks are the contract, repository-relative and
+ * POSIX-spelled: this is the form the workflow lists them in, and
+ * `routes every page it compiles` below compares the two lists directly.
+ */
+const DOC_PATHS_FROM_ROOT = ["docs/engine/scripting.md", "docs/app/pm-api-compatibility.md"];
+
+const DOC_PATHS = DOC_PATHS_FROM_ROOT.map((doc) => join(repoRoot, ...doc.split("/")));
+
+const WORKFLOW_PATH = join(repoRoot, ".github", "workflows", "pr-tests.yml");
+
+/** The filter in that workflow whose whole job is to route the pages above. */
+const ROUTING_FILTER = "app_doc_fixtures";
 
 interface DocBlock {
 	doc: string;
@@ -82,6 +90,33 @@ function extractPmBlocks(path: string): DocBlock[] {
 		start = -1;
 	}
 	return blocks;
+}
+
+/**
+ * The paths the PR workflow's `app_doc_fixtures` filter routes to this suite.
+ *
+ * Read as text, not YAML: `app/` declares no YAML parser, and the block is a
+ * flat list of single-quoted paths - the same shape every other guard in this
+ * repository scans its input in. A line that is neither a comment nor a list
+ * entry ends the filter, which is how the next filter's key stops the walk.
+ */
+function routedDocPaths(workflow: string): string[] {
+	const lines = workflow.split("\n");
+	const key = lines.findIndex((line) => line.trim() === `${ROUTING_FILTER}:`);
+	if (key === -1) return [];
+
+	const keyIndent = lines[key].length - lines[key].trimStart().length;
+	const routed: string[] = [];
+	for (const line of lines.slice(key + 1)) {
+		const indent = line.length - line.trimStart().length;
+		if (indent <= keyIndent) break;
+		const trimmed = line.trim();
+		if (trimmed.startsWith("#")) continue;
+		const entry = /^- '(.+)'$/.exec(trimmed);
+		if (!entry) break;
+		routed.push(entry[1]);
+	}
+	return routed;
 }
 
 const SCRIPT_NAME = "/script.js";
@@ -198,6 +233,33 @@ describe("the documented pm.* examples compile against the generated declaration
 		expect(blocks.length).toBeGreaterThan(40);
 		expect(declarations).toContain("declare const pm: {");
 		expect(declarations.length).toBeGreaterThan(20000);
+	});
+
+	/*
+	 * The other way this suite checks nothing: it runs on no pull request that
+	 * edits its own inputs. Both pages are Markdown, which every area filter in
+	 * `pr-tests.yml` excludes, so until #1118 a doc example that stopped
+	 * type-checking landed green and the failure waited for the next change to
+	 * `app/`. The routing that fixes it is a list of the same two paths in a
+	 * different file, which is the drift this repository keeps paying for - so
+	 * the lists are compared rather than trusted, and adding a third page here
+	 * is red until it is routed there too.
+	 *
+	 * The three assertions are the three links in that wiring: the filter names
+	 * exactly these pages, the `changes` job exports it, and the job that runs
+	 * `pnpm test` reads it. A filter nothing reads would be this repository's
+	 * most repeated defect in the file that documents it.
+	 */
+	it("routes every page it compiles", () => {
+		const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+		const routed = routedDocPaths(workflow);
+
+		expect(routed.length).toBeGreaterThan(0);
+		expect([...routed].sort()).toEqual([...DOC_PATHS_FROM_ROOT].sort());
+		expect(workflow).toContain(
+			`${ROUTING_FILTER}: \${{ steps.area.outputs.${ROUTING_FILTER} }}`
+		);
+		expect(workflow).toContain(`needs.changes.outputs.${ROUTING_FILTER} == 'true'`);
 	});
 
 	/*


### PR DESCRIPTION
## Description

`app/src/hooks/script-typedefs.docs-compile.test.ts` compiles every fenced `pm.*` block in `docs/engine/scripting.md` and `docs/app/pm-api-compatibility.md`, and until now neither page could trigger it: both are Markdown, so the `app` area filter's `!**/*.md` rejects them and `code` rejects them twice over (`!docs/**` *and* `!**/*.md`). A doc example that stopped type-checking - a renamed member, a changed type - landed green and waited for the next change under `app/`. It is #887's defect one layer up: a gate whose own inputs cannot reach it.

**Plan, and the alternative rejected.** The issue proposed re-including the two paths in the `app` filter after its `!` lines. Verified against `dorny/paths-filter@v4`'s source, that fix would be dead code: under `some-with-excludes` the evaluator returns `false` the moment any exclude pattern matches, walking every rule item, so rule order carries no meaning and "an exclusion is final" (README). It would also be insufficient even if it worked, because every app job ANDs `code`, which rejects a documentation path however the area filter is written. So the two pages get their own union filter, `app_doc_fixtures` - no exclusions, hence no interaction with the quantifier - ORed into the condition of the one job that runs `pnpm test`. `quality` deliberately keeps the plain condition: eslint reads TS/TSX, prettier's domain is `app/`, and tsc reads neither page, so nothing it runs can change colour over a Markdown edit. Not `docs/**` wholesale, per the issue.

The routing list and the guard's `DOC_PATHS` are two spellings of one thing, which is this repository's standing drift shape, so they are compared rather than trusted: the test's new case fails if a page it compiles is unrouted, if the filter is not exported as a job output, or if no job condition reads it. That last assertion is the "written but never read" check applied to the fix itself.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `cd app && pnpm test` - **546 files, 5983 tests, all passed** (the three in this guard included).
- `pnpm type-check` - clean across all three tsc projects. `pnpm lint` - clean. `pnpm format:check` - clean.
- Mutation-checked both directions, against the real workflow file: dropping `docs/app/pm-api-compatibility.md` from the filter fails the new case on the list comparison (`expected [ 'docs/engine/scripting.md' ] to deeply equal [ …(2) ]`), and deleting the `|| needs.changes.outputs.app_doc_fixtures == 'true'` clause fails it on the wiring assertion. Restored after each; tree verified clean.
- The workflow was parsed with `yaml.safe_load` to confirm the filter block, the new `changes` output and both job conditions are structurally what they read as - and this PR's own `Detect changes` job then proved it live: `app_doc_fixtures: false` here (correct, this PR touches neither page), output set, app job still routed by the `code && app` clause.
- No engine build or ctest run: nothing in this diff can change a C++ verdict (repo verification-scaling rule).

Acceptance criterion 1 is exercised by the *next* docs-only pull request rather than by this one - this PR edits `.github/workflows/pr-tests.yml`, which routes to every area on purpose, so the app job here would run regardless and cannot demonstrate the fix. Criterion 2 is unchanged behaviour: no other Markdown path was added to any filter.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Documentation is the filter block's own comments, which is where the `.md` exclusion's reasoning lives; they now say why these two files are exempt from it. No page under `docs/` describes the area filters, so nothing there went stale.

## Related Issues

Closes #1118

Enumerating every `app/` test that reads a file outside `app/` turned up the same defect in two other shapes, both left out of this diff deliberately and filed instead of fixed here:

- #1121 - three more app guards read pages under `docs/` that no filter routes (`design-system-doc.test.ts`, `state-management-doc.test.ts`, `row-persistence-claims.test.ts`).
- #1122 - the app-side engine-parity and conformance guards run on the `app` filter alone, so an engine-only change runs ctest and skips the app tests that check the engine.