### PR TITLE
ci: route every doc page an app guard reads to the job that runs it - #1121

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -178,10 +178,10 @@ jobs:
               # bare one covers a root-level file, the `**/` one covers nested.
               - '!*.md'
               - '!**/*.md'
-            # The two pages `script-typedefs.docs-compile.test.ts` compiles.
-            # They are prose, so `!**/*.md` above rejects them and `code`
-            # rejects them twice over (`!docs/**` *and* `!**/*.md`) - and they
-            # are also app test *input*, in the same sense
+            # The pages under `docs/` that a suite in `app/` reads and asserts
+            # against. They are prose, so `!**/*.md` above rejects them and
+            # `code` rejects them twice over (`!docs/**` *and* `!**/*.md`) - and
+            # they are also app test *input*, in the same sense
             # `engine/tests/fixtures/script-typedefs.d.ts` is, so editing one
             # can turn `pnpm test` red exactly the way a source file can. A gate
             # whose own inputs cannot trigger it is #887's defect again (#1118),
@@ -190,13 +190,35 @@ jobs:
             # `some-with-excludes` is final, so a positive rule listed after
             # `!**/*.md` is dead - it cannot include back what a `!` rejected.
             #
-            # This list is not free-standing. `DOC_PATHS` in that test names the
-            # same two files, and `routes every page it compiles` there fails if
-            # the two lists disagree - adding a third page to the guard is red
-            # until it is routed here as well.
+            # Four guards contribute, not the one #1118 routed: the typedefs
+            # compile, plus the design-token, renderer-state and row-persistence
+            # doc guards #1121 found in the same shape. One list rather than four
+            # filters, because the job condition is the same OR for all of them
+            # and a second filter would be a second thing to forget. The name
+            # stays `app_doc_fixtures` - every page here is an app test fixture
+            # that happens to be prose, which is as true of eight pages as of two.
+            #
+            # Only the pages a guard actually reads are listed. Routing `docs/**`
+            # wholesale would be one line that cannot miss an input, and would
+            # run the four-runner app matrix on every prose edit in the
+            # repository - the cost `!**/*.md` exists to avoid.
+            #
+            # This list is not free-standing. `DOC_READING_GUARDS` in
+            # `app/src/lib/routed-docs.testkit.ts` names the same pages, and
+            # `routes every page a guard reads, and no other`
+            # (`app/src/lib/routed-docs.test.ts`) compares this block against the
+            # union of the four guards' lists - so adding a page to a guard is
+            # red until it is routed here, and routing a page no guard reads is
+            # red too.
             app_doc_fixtures:
               - 'docs/engine/scripting.md'
               - 'docs/app/pm-api-compatibility.md'
+              - 'docs/design-system.md'
+              - 'docs/app/state-management.md'
+              - 'docs/app/architecture.md'
+              - 'docs/app/api-integration.md'
+              - 'docs/app/data-driven-runs.md'
+              - 'docs/app/COMPONENTS.md'
             engine:
               - 'engine/**'
               - 'VERSION'
@@ -315,13 +337,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: changes
     # The second clause is the one job the doc fixtures need: this is where
-    # `pnpm test` runs, so it is where the guard that compiles them runs. It is
-    # an OR rather than another entry in `app` because `code` rejects a
-    # documentation path too, and `code && app` would answer false on the `code`
-    # half however the area filter were written. `quality` deliberately keeps
-    # the plain condition - eslint reads TS/TSX, prettier's domain is `app/` and
-    # tsc reads neither page, so nothing it runs can change colour over a
-    # Markdown edit.
+    # `pnpm test` runs, so it is where every guard that reads one of those pages
+    # runs. It is an OR rather than another entry in `app` because `code` rejects
+    # a documentation path too, and `code && app` would answer false on the
+    # `code` half however the area filter were written. `quality` deliberately
+    # keeps the plain condition - eslint reads TS/TSX, prettier's domain is
+    # `app/` and tsc reads none of those pages, so nothing it runs can change
+    # colour over a Markdown edit.
     if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.app_doc_fixtures == 'true'
     permissions:
       contents: read

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -222,6 +222,14 @@ loses the cascade - write the pair `bg-card surface-card`
 | `docs/app/file-name-conventions.md` | The naming conventions themselves                            |
 | `docs/app/building.md`              | App build steps or tooling                                   |
 
+**A test that reads a page under `docs/` registers it in
+`src/lib/routed-docs.testkit.ts`.** CI routes only the pages named there, and
+every area filter excludes Markdown - so a guard whose page is unrouted never
+runs on the edit that breaks it, and fails later on an unrelated change to
+`app/` as if that change were the cause (#1118, #1121). That list and the
+`app_doc_fixtures` filter in `pr-tests.yml` are compared by
+`routed-docs.test.ts`, which fails if either side changes alone.
+
 Module READMEs carry the _why_ for their feature and are easy to miss:
 `app/src/modules/README.md`, plus one each for `welcome/`, `request-builder/`
 and `dashboard/`.

--- a/app/src/design-system-doc.test.ts
+++ b/app/src/design-system-doc.test.ts
@@ -23,10 +23,14 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { DOC_READING_GUARDS, fromRepoRoot } from "@/lib/routed-docs.testkit";
+
+/** Repository-relative, so CI can route the page this reads. See the testkit. */
+const [DESIGN_SYSTEM_DOC] = DOC_READING_GUARDS.designSystem.pages;
 
 const here = dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(join(here, "index.css"), "utf8");
-const doc = readFileSync(join(here, "..", "..", "docs", "design-system.md"), "utf8");
+const doc = readFileSync(fromRepoRoot(DESIGN_SYSTEM_DOC), "utf8");
 
 /** Every declared value for a token, anywhere in the stylesheet. */
 function declaredValues(): Map<string, Set<string>> {

--- a/app/src/hooks/script-typedefs.docs-compile.test.ts
+++ b/app/src/hooks/script-typedefs.docs-compile.test.ts
@@ -35,29 +35,20 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import ts from "typescript";
+import { DOC_READING_GUARDS, fromRepoRoot, repoRoot } from "@/lib/routed-docs.testkit";
 import { SCRIPT_COMPILER_OPTIONS, SUPPRESSED_DIAGNOSTICS } from "./useScriptTypeDefinitions";
-
-const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(here, "..", "..", "..");
 
 const DECLARATIONS_PATH = join(repoRoot, "engine", "tests", "fixtures", "script-typedefs.d.ts");
 
 /**
- * The two pages whose `pm.*` blocks are the contract, repository-relative and
- * POSIX-spelled: this is the form the workflow lists them in, and
- * `routes every page it compiles` below compares the two lists directly.
+ * The two pages whose `pm.*` blocks are the contract. They are held in the
+ * testkit with the other guards' pages, because the workflow filter that routes
+ * an edit to them back to this suite is compared against the union of all four
+ * (`routed-docs.test.ts`).
  */
-const DOC_PATHS_FROM_ROOT = ["docs/engine/scripting.md", "docs/app/pm-api-compatibility.md"];
-
-const DOC_PATHS = DOC_PATHS_FROM_ROOT.map((doc) => join(repoRoot, ...doc.split("/")));
-
-const WORKFLOW_PATH = join(repoRoot, ".github", "workflows", "pr-tests.yml");
-
-/** The filter in that workflow whose whole job is to route the pages above. */
-const ROUTING_FILTER = "app_doc_fixtures";
+const DOC_PATHS = DOC_READING_GUARDS.scriptTypedefs.pages.map(fromRepoRoot);
 
 interface DocBlock {
 	doc: string;
@@ -90,33 +81,6 @@ function extractPmBlocks(path: string): DocBlock[] {
 		start = -1;
 	}
 	return blocks;
-}
-
-/**
- * The paths the PR workflow's `app_doc_fixtures` filter routes to this suite.
- *
- * Read as text, not YAML: `app/` declares no YAML parser, and the block is a
- * flat list of single-quoted paths - the same shape every other guard in this
- * repository scans its input in. A line that is neither a comment nor a list
- * entry ends the filter, which is how the next filter's key stops the walk.
- */
-function routedDocPaths(workflow: string): string[] {
-	const lines = workflow.split("\n");
-	const key = lines.findIndex((line) => line.trim() === `${ROUTING_FILTER}:`);
-	if (key === -1) return [];
-
-	const keyIndent = lines[key].length - lines[key].trimStart().length;
-	const routed: string[] = [];
-	for (const line of lines.slice(key + 1)) {
-		const indent = line.length - line.trimStart().length;
-		if (indent <= keyIndent) break;
-		const trimmed = line.trim();
-		if (trimmed.startsWith("#")) continue;
-		const entry = /^- '(.+)'$/.exec(trimmed);
-		if (!entry) break;
-		routed.push(entry[1]);
-	}
-	return routed;
 }
 
 const SCRIPT_NAME = "/script.js";
@@ -233,33 +197,6 @@ describe("the documented pm.* examples compile against the generated declaration
 		expect(blocks.length).toBeGreaterThan(40);
 		expect(declarations).toContain("declare const pm: {");
 		expect(declarations.length).toBeGreaterThan(20000);
-	});
-
-	/*
-	 * The other way this suite checks nothing: it runs on no pull request that
-	 * edits its own inputs. Both pages are Markdown, which every area filter in
-	 * `pr-tests.yml` excludes, so until #1118 a doc example that stopped
-	 * type-checking landed green and the failure waited for the next change to
-	 * `app/`. The routing that fixes it is a list of the same two paths in a
-	 * different file, which is the drift this repository keeps paying for - so
-	 * the lists are compared rather than trusted, and adding a third page here
-	 * is red until it is routed there too.
-	 *
-	 * The three assertions are the three links in that wiring: the filter names
-	 * exactly these pages, the `changes` job exports it, and the job that runs
-	 * `pnpm test` reads it. A filter nothing reads would be this repository's
-	 * most repeated defect in the file that documents it.
-	 */
-	it("routes every page it compiles", () => {
-		const workflow = readFileSync(WORKFLOW_PATH, "utf8");
-		const routed = routedDocPaths(workflow);
-
-		expect(routed.length).toBeGreaterThan(0);
-		expect([...routed].sort()).toEqual([...DOC_PATHS_FROM_ROOT].sort());
-		expect(workflow).toContain(
-			`${ROUTING_FILTER}: \${{ steps.area.outputs.${ROUTING_FILTER} }}`
-		);
-		expect(workflow).toContain(`needs.changes.outputs.${ROUTING_FILTER} == 'true'`);
 	});
 
 	/*

--- a/app/src/lib/routed-docs.test.ts
+++ b/app/src/lib/routed-docs.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The wiring that makes a doc guard run on the doc it guards.
+ *
+ * Four suites under `app/` assert against pages in `docs/`, and every area
+ * filter in `pr-tests.yml` excludes Markdown - so a token value rewritten in
+ * `docs/design-system.md`, or a hook renamed out of `docs/app/state-management.md`,
+ * used to land green and fail on the next change to `app/` as if that change
+ * had caused it (#1118 for the first guard, #1121 for the rest).
+ *
+ * The fix is a list of paths in a workflow that must agree with a list of paths
+ * in TypeScript, which is the drift this repository keeps paying for. So the two
+ * are compared rather than trusted, in one place for all four guards: adding a
+ * page to `DOC_READING_GUARDS` is red until it is routed, and routing a page no
+ * guard reads is red too.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import {
+	DOC_READING_GUARDS,
+	ROUTED_DOC_PAGES,
+	ROUTING_FILTER,
+	WORKFLOW_PATH,
+	fromRepoRoot,
+	routedDocPaths,
+} from "./routed-docs.testkit";
+
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+describe("the docs the app suite reads", () => {
+	/*
+	 * A version of this that found no filter block, or no guards, would pass
+	 * forever while comparing nothing - the empty-string failure mode this
+	 * repository has already shipped once.
+	 */
+	it("has something to compare", () => {
+		expect(workflow.length).toBeGreaterThan(1000);
+		expect(Object.keys(DOC_READING_GUARDS).length).toBeGreaterThan(1);
+		expect(ROUTED_DOC_PAGES.length).toBeGreaterThan(1);
+		expect(routedDocPaths(workflow).length).toBeGreaterThan(0);
+	});
+
+	/*
+	 * The three links in the wiring: the filter names exactly the pages the
+	 * guards read, the `changes` job exports it, and the job that runs
+	 * `pnpm test` reads it. A filter nothing reads would be this repository's
+	 * most repeated defect in the file that documents it.
+	 */
+	it("routes every page a guard reads, and no other", () => {
+		expect([...routedDocPaths(workflow)].sort()).toEqual([...ROUTED_DOC_PAGES].sort());
+		expect(workflow).toContain(
+			`${ROUTING_FILTER}: \${{ steps.area.outputs.${ROUTING_FILTER} }}`
+		);
+		expect(workflow).toContain(`needs.changes.outputs.${ROUTING_FILTER} == 'true'`);
+	});
+
+	it("names pages that exist", () => {
+		for (const page of ROUTED_DOC_PAGES) {
+			expect(existsSync(fromRepoRoot(page)), page).toBe(true);
+		}
+	});
+
+	/*
+	 * The guards are named here so the entries cannot outlive them, and each is
+	 * required to import this module: a guard holding its own copy of the list
+	 * is exactly the drift the module exists to end, and it would be routed
+	 * correctly right up until someone edited one of the two copies.
+	 */
+	it("is the list its guards actually read", () => {
+		for (const [name, guard] of Object.entries(DOC_READING_GUARDS)) {
+			const path = fromRepoRoot(guard.test);
+			expect(existsSync(path), guard.test).toBe(true);
+			expect(readFileSync(path, "utf8"), name).toContain("routed-docs.testkit");
+			expect(guard.pages.length, name).toBeGreaterThan(0);
+		}
+	});
+});

--- a/app/src/lib/routed-docs.test.ts
+++ b/app/src/lib/routed-docs.test.ts
@@ -27,6 +27,8 @@ import {
 	DOC_READING_GUARDS,
 	ROUTED_DOC_PAGES,
 	ROUTING_FILTER,
+	TESTKIT_MODULE,
+	TESTKIT_PATH,
 	WORKFLOW_PATH,
 	fromRepoRoot,
 	routedDocPaths,
@@ -74,10 +76,12 @@ describe("the docs the app suite reads", () => {
 	 * correctly right up until someone edited one of the two copies.
 	 */
 	it("is the list its guards actually read", () => {
+		expect(existsSync(fromRepoRoot(TESTKIT_PATH)), TESTKIT_PATH).toBe(true);
+
 		for (const [name, guard] of Object.entries(DOC_READING_GUARDS)) {
 			const path = fromRepoRoot(guard.test);
 			expect(existsSync(path), guard.test).toBe(true);
-			expect(readFileSync(path, "utf8"), name).toContain("routed-docs.testkit");
+			expect(readFileSync(path, "utf8"), name).toContain(`from "${TESTKIT_MODULE}"`);
 			expect(guard.pages.length, name).toBeGreaterThan(0);
 		}
 	});

--- a/app/src/lib/routed-docs.testkit.ts
+++ b/app/src/lib/routed-docs.testkit.ts
@@ -42,6 +42,14 @@ export function fromRepoRoot(path: string): string {
 }
 
 /**
+ * This module, as a guard imports it and as the repository stores it.
+ * `routed-docs.test.ts` asserts both, so a rename that reaches three of the four
+ * guards cannot pass by leaving a stale name that still reads as a prefix.
+ */
+export const TESTKIT_MODULE = "@/lib/routed-docs.testkit";
+export const TESTKIT_PATH = "app/src/lib/routed-docs.testkit.ts";
+
+/**
  * Every guard that reads a page under `docs/`, with the pages it reads.
  *
  * `test` is the guard itself, repository-relative: `routed-docs.test.ts` asserts

--- a/app/src/lib/routed-docs.testkit.ts
+++ b/app/src/lib/routed-docs.testkit.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The pages under `docs/` that the app suite reads, and the CI filter that has
+ * to route them.
+ *
+ * Four guards assert against repository documentation, which makes each page
+ * they read a test input in the same sense a source file is: edit it and
+ * `pnpm test` can go red. Every area filter in `pr-tests.yml` excludes Markdown,
+ * so until #1118 none of those edits ran the job that would catch them - the
+ * failure surfaced on the next unrelated change under `app/`, attributed to that
+ * change. #1118 routed one guard's two pages; this module is #1121 doing the
+ * same for the other three, in one place rather than four.
+ *
+ * The lists live here, not in the guards, for the reason the routing exists at
+ * all: two copies of a path list drift. A guard imports the pages it reads, the
+ * workflow lists the union, and `routed-docs.test.ts` compares the two - so a
+ * page added to a guard is red until it is routed, and a page routed that no
+ * guard reads is red too.
+ */
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** The repository root. This file is `app/src/lib/`, so three levels up. */
+export const repoRoot = join(here, "..", "..", "..");
+
+/**
+ * A repository-relative, POSIX-spelled path as this machine spells it. The
+ * POSIX form is the one the workflow lists and the one these tests compare, so
+ * it is what the guards hold; only the read needs the native separator.
+ */
+export function fromRepoRoot(path: string): string {
+	return join(repoRoot, ...path.split("/"));
+}
+
+/**
+ * Every guard that reads a page under `docs/`, with the pages it reads.
+ *
+ * `test` is the guard itself, repository-relative: `routed-docs.test.ts` asserts
+ * each one exists and imports this module, so an entry cannot outlive the guard
+ * that justified it or quietly stop being the guard's own list.
+ *
+ * A fifth guard belongs here the day it is written - the union below is derived,
+ * so adding an entry is what asks CI to route its pages.
+ */
+export const DOC_READING_GUARDS = {
+	scriptTypedefs: {
+		test: "app/src/hooks/script-typedefs.docs-compile.test.ts",
+		pages: ["docs/engine/scripting.md", "docs/app/pm-api-compatibility.md"],
+	},
+	designSystem: {
+		test: "app/src/design-system-doc.test.ts",
+		pages: ["docs/design-system.md"],
+	},
+	rendererState: {
+		test: "app/src/state-management-doc.test.ts",
+		pages: [
+			"docs/app/state-management.md",
+			"docs/app/architecture.md",
+			"docs/app/api-integration.md",
+		],
+	},
+	rowPersistence: {
+		test: "app/src/modules/collections/row-persistence-claims.test.ts",
+		pages: ["docs/app/data-driven-runs.md", "docs/app/COMPONENTS.md"],
+	},
+} as const;
+
+/**
+ * The union of those pages, which is what the workflow filter must list. Derived
+ * rather than written out: a hand-kept union is the third copy of the same list.
+ */
+export const ROUTED_DOC_PAGES: readonly string[] = [
+	...new Set(Object.values(DOC_READING_GUARDS).flatMap((guard) => guard.pages)),
+];
+
+export const WORKFLOW_PATH = fromRepoRoot(".github/workflows/pr-tests.yml");
+
+/** The filter in that workflow whose whole job is to route the pages above. */
+export const ROUTING_FILTER = "app_doc_fixtures";
+
+/**
+ * The paths that filter routes to the job running `pnpm test`.
+ *
+ * Read as text, not YAML: `app/` declares no YAML parser, and the block is a
+ * flat list of single-quoted paths - the same shape every other guard in this
+ * repository scans its input in. A line that is neither a comment nor a list
+ * entry ends the filter, which is how the next filter's key stops the walk.
+ */
+export function routedDocPaths(workflow: string): string[] {
+	const lines = workflow.split("\n");
+	const key = lines.findIndex((line) => line.trim() === `${ROUTING_FILTER}:`);
+	if (key === -1) return [];
+
+	const keyIndent = lines[key].length - lines[key].trimStart().length;
+	const routed: string[] = [];
+	for (const line of lines.slice(key + 1)) {
+		const indent = line.length - line.trimStart().length;
+		if (indent <= keyIndent) break;
+		const trimmed = line.trim();
+		if (trimmed.startsWith("#")) continue;
+		const entry = /^- '(.+)'$/.exec(trimmed);
+		if (!entry) break;
+		routed.push(entry[1]);
+	}
+	return routed;
+}

--- a/app/src/modules/collections/row-persistence-claims.test.ts
+++ b/app/src/modules/collections/row-persistence-claims.test.ts
@@ -21,15 +21,20 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+import { DOC_READING_GUARDS, fromRepoRoot, repoRoot } from "@/lib/routed-docs.testkit";
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+/*
+ * The two doc pages are named through the testkit so CI routes an edit to them
+ * back to this suite. They stay literal keys below - the keys are what `RETIRED`
+ * points at, and a typo there should still be a type error.
+ */
+const [DATA_DRIVEN_RUNS_DOC, COMPONENTS_DOC] = DOC_READING_GUARDS.rowPersistence.pages;
 
 /** Every surface that told a user what happens to their data rows. */
 const SURFACES = {
-	"docs/app/data-driven-runs.md": join(repoRoot, "docs", "app", "data-driven-runs.md"),
-	"docs/app/COMPONENTS.md": join(repoRoot, "docs", "app", "COMPONENTS.md"),
+	[DATA_DRIVEN_RUNS_DOC]: fromRepoRoot(DATA_DRIVEN_RUNS_DOC),
+	[COMPONENTS_DOC]: fromRepoRoot(COMPONENTS_DOC),
 	"DataTab.tsx": join(
 		repoRoot,
 		"app",

--- a/app/src/state-management-doc.test.ts
+++ b/app/src/state-management-doc.test.ts
@@ -34,16 +34,12 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { DOC_READING_GUARDS, repoRoot } from "@/lib/routed-docs.testkit";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(here, "..", "..");
 
-/** The docs whose identifiers this guards. */
-const DOCS = [
-	"docs/app/state-management.md",
-	"docs/app/architecture.md",
-	"docs/app/api-integration.md",
-];
+/** The docs whose identifiers this guards, held where CI can route them. */
+const DOCS = DOC_READING_GUARDS.rendererState.pages;
 
 /**
  * Identifiers the docs name that are declared outside `app/src`, with the file


### PR DESCRIPTION
## Description

Four vitest suites under `app/` assert against pages in `docs/`. #1118 routed the two that `script-typedefs.docs-compile.test.ts` compiles; the other three read six more pages that no filter routes, so an edit to one landed green and failed on the next unrelated change under `app/`, attributed to that change.

**Plan.** Root cause is the one #1118 named, in the tests it did not: every area filter in `pr-tests.yml` excludes Markdown (`!**/*.md`, and `code` rejects `docs/**` twice over), so a doc page that is a test input reaches no job that runs `pnpm test`. The approach extends #1118's mechanism rather than inventing a second one - the six pages join the `app_doc_fixtures` filter, which becomes the union of what all four guards read - and moves the four path lists plus the single workflow scanner into `app/src/lib/routed-docs.testkit.ts`, so the generalised cross-check compares a *derived* union against the filter block. The alternative rejected is routing `docs/**` wholesale: one line that cannot miss an input, but it runs the four-runner app matrix on every prose edit in the repository, which is the cost the `.md` exclusions exist to avoid. The filter keeps its name - every page in it is an app test fixture that happens to be prose, as true of eight pages as of two - and its comment block now says what it is a union *of*.

Routed pages added: `docs/design-system.md`, `docs/app/state-management.md`, `docs/app/architecture.md`, `docs/app/api-integration.md`, `docs/app/data-driven-runs.md`, `docs/app/COMPONENTS.md`.

Deliberate deviation from the issue spec: none. The issue left "one filter or several" and "does the name widen" open; both are settled above, with the reasoning in the workflow's own comments, which is where that routing is documented.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **5986 tests across 547 files, all passing**, the four guards among them. `pnpm type-check`, `pnpm lint` (`--max-warnings 0`) and `pnpm format:check` all clean. No engine build: nothing here can change a C++ verdict.

The cross-check was mutation-checked in both directions, each mutation reverted after:

| Mutation | Result |
|---|---|
| Drop `docs/design-system.md` from the filter | `routes every page a guard reads, and no other` fails |
| Route a page no guard reads | same test fails |
| Add a page to a guard's list, leave the filter alone | same test fails |
| The `app` job's condition stops reading the filter | same test fails |
| The `changes` job stops exporting the filter | same test fails |
| A guard's import of the testkit is renamed | `is the list its guards actually read` fails |
| A guard drops the import and inlines its own path list | same test fails |

The second commit is one of those checks paying for itself: `toContain("routed-docs.testkit")` stayed green on a renamed import, because the new name had the old one as a prefix, so the assertion now pins the exact specifier.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: the filter block's comments in `.github/workflows/pr-tests.yml` and the `app` job's condition comment, which is where this routing rule is written down.

## Related Issues
Closes #1121