### PR TITLE
refactor(engine): one ASCII lower-case fold, replacing the 29 hand-rolled copies - #1060

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -118,6 +118,28 @@ engine/
   `sockaddr_in*` off an `addrinfo`, a Windows function pointer off
   `GetProcAddress` - have no primitive to route through and the scan does not
   look at them.
+- **A case-insensitive comparison folds through one primitive** (#1060).
+  Lower-casing a string for a comparison had no primitive, so all 29 sites
+  across 19 files wrote it themselves in four spellings - and the copy that had
+  not received the others' fix passed a plain `char` to `::tolower`, which is
+  undefined for a byte above 127 where `char` is signed.
+  **`vayu::utils::ascii_lower`** (`utils/ascii_case.hpp`) is the fold, for a
+  character or a whole string, and **`ascii_lower_equal`** is the answer for
+  the callers that compare without building a lowered copy -
+  `vayu::CaseInsensitiveLess` included, whose ordering and whose `equal` were
+  two spellings of it before. ASCII is in the name because it is the contract:
+  every caller folds a header name, a scheme, a MIME type, a hostname or a
+  log-level word, all ASCII by their own specifications, and `std::tolower`
+  would answer for a byte above 127 out of whatever the process last set as its
+  C locale. The fold is a range test on the character, so nothing here calls
+  `std::tolower` at all and the exemption list is empty.
+  `tests/ascii_case_test.cpp` scans `engine/{src,include}` and names any file
+  that spells the fold itself, on the same reasoning as the two scans above. Its
+  matcher is its own rather than `source_scan.hpp`'s `names_call`, and that is
+  the point: the sites that were undefined wrote
+  `std::transform (b, e, b, ::tolower)`, passing the function rather than
+  calling it, so a guard that requires a `(` after the name reads the one
+  spelling worth catching as a clean tree.
 - **A class with a destructor states all five** (#945,
   `cppcoreguidelines-special-member-functions`). Writing one of the five and
   leaving the rest implicit is how a fixture that owns a listener and a thread

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -126,8 +126,10 @@ engine/
   **`vayu::utils::ascii_lower`** (`utils/ascii_case.hpp`) is the fold, for a
   character or a whole string, and **`ascii_lower_equal`** is the answer for
   the callers that compare without building a lowered copy -
-  `vayu::CaseInsensitiveLess` included, whose ordering and whose `equal` were
-  two spellings of it before. ASCII is in the name because it is the contract:
+  `vayu::CaseInsensitiveLess` included, whose `equal` used to derive an answer
+  from the ordering by comparing twice (`!less (a, b) && !less (b, a)`) and now
+  folds through the same helper in one pass. ASCII is in the name because it is
+  the contract:
   every caller folds a header name, a scheme, a MIME type, a hostname or a
   log-level word, all ASCII by their own specifications, and `std::tolower`
   would answer for a byte above 127 out of whatever the process last set as its

--- a/engine/include/vayu/core/load_pacing.hpp
+++ b/engine/include/vayu/core/load_pacing.hpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <string_view>
 
+#include "vayu/utils/ascii_case.hpp"
+
 namespace vayu::core {
 
 namespace detail {
@@ -72,10 +74,7 @@ namespace detail {
     while (split > 0 && std::isalpha (static_cast<unsigned char> (text[split - 1])) != 0)
         --split;
 
-    std::string unit;
-    for (char c : text.substr (split))
-        unit.push_back (
-        static_cast<char> (std::tolower (static_cast<unsigned char> (c))));
+    const std::string unit = vayu::utils::ascii_lower (text.substr (split));
 
     double multiplier = 0.0;
     if (unit.empty () || unit == "s")

--- a/engine/include/vayu/http/debug_redact.hpp
+++ b/engine/include/vayu/http/debug_redact.hpp
@@ -16,9 +16,10 @@
 
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <string>
 #include <string_view>
+
+#include "vayu/utils/ascii_case.hpp"
 
 namespace vayu::http::detail {
 
@@ -48,9 +49,7 @@ inline std::string redact_header_line (const std::string& line) {
     if (first == std::string::npos) {
         return line;
     }
-    name = name.substr (first, last - first + 1);
-    std::transform (name.begin (), name.end (), name.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+    name = vayu::utils::ascii_lower (name.substr (first, last - first + 1));
 
     const bool sensitive = std::any_of (kSensitive.begin (), kSensitive.end (),
     [&name] (std::string_view s) { return name == s; });

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -13,7 +13,6 @@
  */
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <map>
@@ -26,6 +25,10 @@
 // one needs; constants.hpp depends on nothing but the version string, so it
 // cannot cycle back here.
 #include "vayu/core/constants.hpp"
+
+// For `CaseInsensitiveLess`, whose fold is the engine's one ASCII fold. Depends
+// on nothing but the standard library, so it cannot cycle back here either.
+#include "vayu/utils/ascii_case.hpp"
 
 namespace vayu {
 
@@ -107,18 +110,19 @@ inline std::optional<HttpMethod> parse_method (const std::string& str) {
  */
 struct CaseInsensitiveLess {
     bool operator() (const std::string& a, const std::string& b) const {
-        return std::lexicographical_compare (a.begin (), a.end (), b.begin (),
-        b.end (), [] (unsigned char c1, unsigned char c2) {
-            return std::tolower (c1) < std::tolower (c2);
+        return std::lexicographical_compare (
+        a.begin (), a.end (), b.begin (), b.end (), [] (char c1, char c2) {
+            return utils::ascii_lower (c1) < utils::ascii_lower (c2);
         });
     }
 
     /// Header-name equality, for the callers that compare a name outside the
     /// map - the same rule the map's ordering already applies, rather than a
-    /// private lower-casing copy at each call site.
+    /// private lower-casing copy at each call site. Both halves fold through
+    /// `utils::ascii_lower` (#1060), so the map's ordering and this answer
+    /// cannot come to disagree about what two names being the same means.
     static bool equal (const std::string& a, const std::string& b) {
-        const CaseInsensitiveLess less;
-        return !less (a, b) && !less (b, a);
+        return utils::ascii_lower_equal (a, b);
     }
 };
 

--- a/engine/include/vayu/utils/ascii_case.hpp
+++ b/engine/include/vayu/utils/ascii_case.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file utils/ascii_case.hpp
+ * @brief The engine's one ASCII lower-case fold (issue #1060).
+ *
+ * Twenty-nine sites across nineteen files each wrote the fold themselves, in
+ * four spellings: a `std::transform` with a `std::tolower` lambda, the same
+ * with an uncast `::tolower`, a hand-written loop over the string, and a
+ * per-character equality predicate that never builds a lowered string at all.
+ * Nothing about any of them was wrong on the ASCII input every caller has,
+ * which is why they accumulated rather than being noticed - but one of them
+ * was wrong on any other input, and that is the shape this repo names: a
+ * hand-rolled copy of a primitive does not receive the primitive's fixes. The
+ * uncast pair passed a plain `char` to `::tolower`, and a `char` holding a
+ * byte above 127 is negative where `char` is signed, which is undefined
+ * behaviour the other twenty-seven sites cast for.
+ *
+ * ASCII is in the name because it is the contract, not an omission. Every
+ * caller folds a header name, a URL scheme, a MIME type, a hostname or a
+ * log-level word - all ASCII by their own specifications - and a locale-aware
+ * fold would be the wrong answer for each: `std::tolower` reads the global C
+ * locale, so what it does to a byte above 127 is whatever the last caller of
+ * `std::setlocale` in the process decided. Folding the twenty-six letters and
+ * leaving every other byte exactly as it was is the rule all twenty-nine sites
+ * were written to have, and it is a rule that needs no `unsigned char` cast to
+ * state, because it never reaches a function that has one as a precondition.
+ *
+ * Three entry points, because the call sites ask three questions: a character
+ * (a comparator, and the two loops that build a string a byte at a time), a
+ * whole string (the majority), and whether two strings match with neither
+ * lowered copy built (`vayu::CaseInsensitiveLess`, and the four sites that
+ * compared header names by hand). They agree by construction - the string and
+ * the comparison are both written in terms of the character fold.
+ */
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+namespace vayu::utils {
+
+/**
+ * @brief @p c lowered if it is an ASCII upper-case letter, unchanged otherwise.
+ *
+ * The range test is written on the `char` itself rather than on an
+ * `unsigned char` cast of it, and that is what makes the byte above 127 safe
+ * on both signings: where `char` is signed such a byte is negative and fails
+ * `c >= 'A'`; where it is unsigned it exceeds `'Z'` and fails `c <= 'Z'`.
+ * Either way it comes back as it went in.
+ */
+constexpr char ascii_lower (char c) {
+    return (c >= 'A' && c <= 'Z') ? static_cast<char> (c - 'A' + 'a') : c;
+}
+
+/**
+ * @brief @p text with every ASCII upper-case letter lowered.
+ *
+ * One allocation, which is the one the callers already made: each of them
+ * built the string it was about to fold. A caller that only wants to know
+ * whether two strings match wants `ascii_lower_equal` instead, which builds
+ * nothing.
+ */
+inline std::string ascii_lower (std::string_view text) {
+    std::string lowered (text);
+    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
+    [] (char c) { return ascii_lower (c); });
+    return lowered;
+}
+
+/**
+ * @brief Whether @p a and @p b are the same string under the ASCII fold.
+ *
+ * The comparison neither lowers nor allocates: it is the answer the four
+ * header-name comparisons here were reaching for when they wrote a
+ * per-character predicate, and the answer `vayu::CaseInsensitiveLess::equal`
+ * gives the callers that compare a name outside the `Headers` map.
+ */
+inline bool ascii_lower_equal (std::string_view a, std::string_view b) {
+    return a.size () == b.size () &&
+    std::equal (a.begin (), a.end (), b.begin (),
+    [] (char l, char r) { return ascii_lower (l) == ascii_lower (r); });
+}
+
+} // namespace vayu::utils

--- a/engine/src/core/import_document.cpp
+++ b/engine/src/core/import_document.cpp
@@ -25,6 +25,7 @@
 
 #include "vayu/core/openapi_document.hpp"
 #include "vayu/core/path_template.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 #include <algorithm>
 #include <array>
@@ -271,7 +272,8 @@ json with_required_content_type (json headers, const json& body) {
         return headers;
     }
     for (const json& header : headers) {
-        const std::string key = walk::lower (header.at ("key").get<std::string> ());
+        const std::string key =
+        vayu::utils::ascii_lower (header.at ("key").get<std::string> ());
         const size_t begin        = key.find_first_not_of (" \t\n\r\f\v");
         const std::string trimmed = begin == std::string::npos ?
         std::string () :
@@ -979,7 +981,7 @@ json pm_examples (const json* item, PostmanCounts& counts) {
         const json* name = prop (saved, "name");
         std::string content_type;
         for (const json& header : headers) {
-            if (walk::lower (header.at ("key").get<std::string> ()) == "content-type") {
+            if (vayu::utils::ascii_lower (header.at ("key").get<std::string> ()) == "content-type") {
                 content_type = header.at ("value").get<std::string> ();
                 break;
             }
@@ -1276,7 +1278,7 @@ json insomnia_bearer (const json* auth) {
     prefix                  = begin == std::string::npos ?
                      std::string () :
                      prefix.substr (begin, prefix.find_last_not_of (" \t\n\r\f\v") - begin + 1);
-    if (!prefix.empty () && walk::lower (prefix) != "bearer") {
+    if (!prefix.empty () && vayu::utils::ascii_lower (prefix) != "bearer") {
         std::string value = prefix + " " + token;
         const size_t last = value.find_last_not_of (" \t\n\r\f\v");
         value = last == std::string::npos ? std::string () : value.substr (0, last + 1);

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 
 #include "vayu/db/database.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 namespace vayu::core {
 
@@ -25,10 +26,8 @@ bool starts_with_ci (const std::string& text, std::string_view prefix) {
     if (text.size () < prefix.size ()) {
         return false;
     }
-    return std::equal (prefix.begin (), prefix.end (), text.begin (), [] (char a, char b) {
-        return std::tolower (static_cast<unsigned char> (a)) ==
-        std::tolower (static_cast<unsigned char> (b));
-    });
+    return vayu::utils::ascii_lower_equal (
+    std::string_view (text).substr (0, prefix.size ()), prefix);
 }
 
 /** The scrape cadence, when the block names one of its own. */

--- a/engine/src/core/openapi_document.cpp
+++ b/engine/src/core/openapi_document.cpp
@@ -20,6 +20,7 @@
 #include "openapi_walk.hpp"
 
 #include "vayu/core/constants.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 #include <algorithm>
 #include <array>
@@ -48,7 +49,6 @@ namespace limits = vayu::core::constants::spec_document;
 // live in `openapi_walk.hpp` so `openapi_drafts.cpp` reads the *same* operations
 // this file indexes (issue #865).
 using walk::find_object;
-using walk::lower;
 using walk::resolve_single_hop;
 using walk::walk_operations;
 using walk::WalkedOperation;
@@ -826,8 +826,8 @@ const nlohmann::ordered_json& operation) {
             if (schema == media.value ().end () || !is_schema (*schema)) {
                 continue;
             }
-            declared.push_back (
-            declared_response (entry.key (), lower (media.key ()), *schema));
+            declared.push_back (declared_response (
+            entry.key (), vayu::utils::ascii_lower (media.key ()), *schema));
         }
     }
     return declared;
@@ -854,7 +854,7 @@ const nlohmann::ordered_json& operation) {
     if (produces != nullptr) {
         for (const auto& type : *produces) {
             if (type.is_string () && !type.get<std::string> ().empty ()) {
-                types.push_back (lower (type.get<std::string> ()));
+                types.push_back (vayu::utils::ascii_lower (type.get<std::string> ()));
             }
         }
     }

--- a/engine/src/core/openapi_drafts.cpp
+++ b/engine/src/core/openapi_drafts.cpp
@@ -38,6 +38,7 @@
 #include "openapi_walk.hpp"
 
 #include "vayu/core/path_template.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 #include <algorithm>
 #include <array>
@@ -445,7 +446,7 @@ ImportTally* tally) {
 /// Headers a request produces for itself rather than holding as a row: the
 /// `Authorization` its auth writes and the `Content-Type` its body names.
 bool is_self_produced_header (const std::string& name) {
-    const std::string lower = walk::lower (name);
+    const std::string lower = vayu::utils::ascii_lower (name);
     return lower == "authorization" || lower == "content-type";
 }
 
@@ -503,7 +504,7 @@ std::string path_folder_name (const std::string& path) {
         if (templated) {
             continue;
         }
-        if (is_version_segment (segment) || walk::lower (segment) == "api") {
+        if (is_version_segment (segment) || vayu::utils::ascii_lower (segment) == "api") {
             continue;
         }
         return segment;
@@ -886,7 +887,7 @@ std::string media_type (const json& value) {
         return {};
     }
     const size_t end = text.find_last_not_of (" \t\n\r\f\v");
-    return walk::lower (text.substr (begin, end - begin + 1));
+    return vayu::utils::ascii_lower (text.substr (begin, end - begin + 1));
 }
 
 /// The operation's `consumes`, falling back to the document's. Entries that are

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -19,6 +19,7 @@
 
 #include "vayu/core/constants.hpp"
 #include "vayu/core/operation_match.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 #include <algorithm>
 #include <array>
@@ -75,13 +76,6 @@ constexpr std::array<std::string_view, 8> PATH_ITEM_METHODS = { "get", "put",
 constexpr std::array<std::string_view, 2> NON_PARAMETER_HEADERS = {
     "authorization", "content-type"
 };
-
-std::string lower (std::string_view text) {
-    std::string out (text);
-    std::transform (out.begin (), out.end (), out.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return out;
-}
 
 std::string upper (std::string_view text) {
     std::string out (text);
@@ -440,10 +434,10 @@ void patch_parameters (Json& operation, const ExportRequest& entry, ExportNotes&
         } else {
             continue;
         }
-        const std::string wanted = lower (name);
+        const std::string wanted = vayu::utils::ascii_lower (name);
         const auto row           = std::find_if (
         rows->begin (), rows->end (), [&] (const ExportKeyValue& candidate) {
-            return lower (candidate.key) == wanted;
+            return vayu::utils::ascii_lower (candidate.key) == wanted;
         });
         if (row == rows->end () || row->value.empty ()) {
             continue;
@@ -825,7 +819,7 @@ Json operation_object (const ExportRequest& entry, const std::string& templated,
         }
     }
     for (const ExportKeyValue& row : entry.headers) {
-        const std::string key = lower (row.key);
+        const std::string key = vayu::utils::ascii_lower (row.key);
         if (row.key.empty () ||
         std::find (NON_PARAMETER_HEADERS.begin (), NON_PARAMETER_HEADERS.end (),
         key) != NON_PARAMETER_HEADERS.end ()) {
@@ -872,7 +866,7 @@ const std::vector<ExportRequest>& requests) {
             continue;
         }
         const std::string templated = path_template (*parts.path);
-        const std::string method    = lower (entry.method);
+        const std::string method    = vayu::utils::ascii_lower (entry.method);
         if (!claimed.insert (std::format ("{} {}", method, templated)).second) {
             // Two requests on the same method and path are one operation in a
             // document, and the second would silently replace the first.

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -925,7 +925,7 @@ std::string file_slug (const std::string& name) {
                 slug += '-';
             }
             pending_dash = false;
-            slug += static_cast<char> (std::tolower (c));
+            slug += vayu::utils::ascii_lower (raw);
         } else {
             pending_dash = true;
         }

--- a/engine/src/core/openapi_walk.hpp
+++ b/engine/src/core/openapi_walk.hpp
@@ -59,12 +59,6 @@ inline std::string upper (std::string value) {
     return value;
 }
 
-inline std::string lower (std::string value) {
-    std::transform (value.begin (), value.end (), value.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return value;
-}
-
 /// Which of the two formats Vayu imports a document claims to be. `None` is
 /// not an error - the document may be a perfectly good file that simply is not
 /// a contract, which is `NotASpecError` on the renderer side.

--- a/engine/src/core/sample_capture.cpp
+++ b/engine/src/core/sample_capture.cpp
@@ -12,6 +12,7 @@
 #include <cctype>
 #include <cstdint>
 
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/encoding.hpp"
 #include "vayu/utils/sha256.hpp"
 
@@ -95,10 +96,7 @@ std::string media_type (std::string_view content_type) {
         head.remove_suffix (1);
     }
 
-    std::string out (head);
-    std::transform (out.begin (), out.end (), out.begin (),
-    [] (unsigned char ch) { return static_cast<char> (std::tolower (ch)); });
-    return out;
+    return vayu::utils::ascii_lower (head);
 }
 
 bool looks_binary (std::string_view body, std::string_view content_type) {

--- a/engine/src/core/schema_validation.cpp
+++ b/engine/src/core/schema_validation.cpp
@@ -15,6 +15,7 @@
 
 #include "vayu/core/constants.hpp"
 #include "vayu/core/spec_coverage.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
@@ -32,12 +33,6 @@ namespace vayu::core {
 namespace {
 
 namespace limits = vayu::core::constants::schema_validation;
-
-std::string lower (std::string value) {
-    std::transform (value.begin (), value.end (), value.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return value;
-}
 
 std::string upper (std::string value) {
     std::transform (value.begin (), value.end (), value.begin (),
@@ -63,7 +58,8 @@ std::string trim (const std::string& value) {
  * rather than one normalised and one as-typed.
  */
 std::string media_type_of (const std::string& content_type) {
-    return lower (trim (content_type.substr (0, content_type.find (';'))));
+    return vayu::utils::ascii_lower (
+    trim (content_type.substr (0, content_type.find (';'))));
 }
 
 /// `METHOD path`, the second identity key - the spelling `OperationIndex` uses,
@@ -512,7 +508,8 @@ IndexedOperation& operation) {
         }
         DeclaredSchema declared;
         declared.status = response.value ("status", std::string ());
-        declared.content_type = lower (response.value ("contentType", std::string ()));
+        declared.content_type =
+        vayu::utils::ascii_lower (response.value ("contentType", std::string ()));
         auto schema = response.find ("schema");
         if (declared.status.empty () || declared.content_type.empty () ||
         schema == response.end ()) {

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -28,6 +28,7 @@
 #include "vayu/http/event_loop/curl_utils.hpp"
 #include "vayu/http/form_body.hpp"
 #include "vayu/http/status.hpp"
+#include "vayu/utils/ascii_case.hpp"
 
 #include <curl/curl.h>
 
@@ -203,10 +204,7 @@ size_t write_callback (char* ptr, size_t size, size_t nmemb, void* userdata) {
  */
 std::optional<unsigned long long> declared_content_length (const Headers& headers) {
     for (const auto& [key, value] : headers) {
-        std::string lower = key;
-        std::transform (lower.begin (), lower.end (), lower.begin (),
-        [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-        if (lower != "content-length") {
+        if (!vayu::utils::ascii_lower_equal (key, "content-length")) {
             continue;
         }
         try {

--- a/engine/src/http/cookie_jar.cpp
+++ b/engine/src/http/cookie_jar.cpp
@@ -17,10 +17,10 @@
 
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <ctime>
 #include <utility>
 
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/parse.hpp"
 
 namespace vayu::http {
@@ -34,10 +34,7 @@ constexpr size_t NETSCAPE_FIELDS            = 7;
 /// case-insensitive (RFC 6265 §5.1.2 lowercases before comparing). Cookie
 /// *names* are not - see find_cookie in script_engine.cpp.
 bool hosts_equal (std::string_view a, std::string_view b) {
-    return a.size () == b.size () &&
-    std::equal (a.begin (), a.end (), b.begin (), [] (unsigned char l, unsigned char r) {
-        return std::tolower (l) == std::tolower (r);
-    });
+    return vayu::utils::ascii_lower_equal (a, b);
 }
 
 /**

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -26,6 +26,7 @@
 #include "vayu/http/form_body.hpp"
 #include "vayu/http/header_text.hpp"
 #include "vayu/http/status.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/utils/parse.hpp"
 
@@ -378,10 +379,7 @@ void ingest_header_line (std::string_view line, Headers& headers) {
         return;
     }
 
-    std::string key (line.substr (0, colon_pos));
-    for (auto& c : key) {
-        c = static_cast<char> (std::tolower (static_cast<unsigned char> (c)));
-    }
+    std::string key = vayu::utils::ascii_lower (line.substr (0, colon_pos));
 
     auto value = line.substr (colon_pos + 1);
     while (!value.empty () && value.front () == ' ') {
@@ -700,10 +698,7 @@ bool tls_connection_never_answered (CURL* curl) {
     }
     // curl reports the scheme upper-cased; compared case-insensitively anyway,
     // because that is a presentation detail of one version.
-    std::string lowered (scheme);
-    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    if (lowered != "https") {
+    if (!vayu::utils::ascii_lower_equal (scheme, "https")) {
         return false;
     }
 

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -21,6 +21,7 @@
 #include "vayu/http/header_names.hpp"
 #include "vayu/http/header_text.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/reentrant.hpp"
@@ -171,12 +172,6 @@ constexpr auto JOB_TYPES = std::to_array<const char*> ({ "Liaison", "Manager",
 
 constexpr int SECONDS_PER_DAY = 24 * 60 * 60;
 
-std::string lower (std::string s) {
-    std::transform (s.begin (), s.end (), s.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return s;
-}
-
 std::string zero_padded (long long value, size_t width) {
     std::string out = std::to_string (value);
     if (out.size () < width) {
@@ -283,8 +278,8 @@ constexpr std::array<DynamicVariable, 39> DYNAMIC_VARIABLES = { {
 [] { return std::string (random_int (0, 1) == 1 ? "true" : "false"); } },
 { "$randomEmail",
 [] {
-    return lower (pick (FIRST_NAMES)) + "." + lower (pick (LAST_NAMES)) + "@" +
-    pick (DOMAINS);
+    return vayu::utils::ascii_lower (pick (FIRST_NAMES)) + "." +
+    vayu::utils::ascii_lower (pick (LAST_NAMES)) + "@" + pick (DOMAINS);
 } },
 { "$randomFirstName", [] { return std::string (pick (FIRST_NAMES)); } },
 { "$randomLastName", [] { return std::string (pick (LAST_NAMES)); } },
@@ -293,7 +288,10 @@ constexpr std::array<DynamicVariable, 39> DYNAMIC_VARIABLES = { {
 { "$randomCompanyName",
 [] { return std::string (pick (COMPANY_WORDS)) + " " + pick (COMPANY_SUFFIXES); } },
 { "$randomUrl",
-[] { return "https://" + lower (pick (COMPANY_WORDS)) + "." + pick (DOMAINS); } },
+[] {
+    return "https://" + vayu::utils::ascii_lower (pick (COMPANY_WORDS)) + "." +
+    pick (DOMAINS);
+} },
 { "$randomIP",
 [] {
     return std::to_string (random_int (0, 255)) + "." +
@@ -343,7 +341,9 @@ constexpr std::array<DynamicVariable, 39> DYNAMIC_VARIABLES = { {
 // generators already draw from, rather than Postman's live-looking `gracie.biz`
 // - a generated hostname reaches DNS the moment someone writes it into a URL.
 { "$randomDomainName",
-[] { return lower (pick (FIRST_NAMES)) + "." + pick (DOMAINS); } },
+[] {
+    return vayu::utils::ascii_lower (pick (FIRST_NAMES)) + "." + pick (DOMAINS);
+} },
 { "$randomAbbreviation", [] { return std::string (pick (ABBREVIATIONS)); } },
 { "$randomPrice",
 [] {

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -32,12 +32,11 @@
 
 #include "vayu/http/routes.hpp"
 #include "vayu/http/transport_policy.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <optional>
 #include <string>
 #include <utility>
@@ -74,14 +73,6 @@ RouteResult apply_port_field (const nlohmann::json& json, std::optional<int>& ou
     }
     out = json["port"].get<int> ();
     return {};
-}
-
-/// Hosts are stored lower-cased, so a match is a compare rather than a second
-/// case-folding rule at every read - see `ClientCertRule::host`.
-std::string lowered (std::string value) {
-    std::transform (value.begin (), value.end (), value.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return value;
 }
 
 /**
@@ -184,7 +175,9 @@ bool is_create) {
     if (auto outcome = apply_required_string_field (json, "host", c.host, is_create); !outcome) {
         return outcome;
     }
-    c.host = lowered (std::move (c.host));
+    // Hosts are stored lower-cased, so a match is a compare rather than a
+    // second case-folding rule at every read - see `ClientCertRule::host`.
+    c.host = vayu::utils::ascii_lower (c.host);
     if (auto outcome = apply_port_field (json, c.port, is_create); !outcome) {
         return outcome;
     }

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -18,13 +18,13 @@
 #include "vayu/core/spec_binding.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
 
 #include "vayu/core/run_manager.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -145,10 +145,7 @@ const Result<Response>& result) {
     }
     std::string content_type = "application/octet-stream";
     for (const auto& [key, value] : resp.headers) {
-        std::string lower = key;
-        std::transform (lower.begin (), lower.end (), lower.begin (),
-        [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-        if (lower == "content-type") {
+        if (vayu::utils::ascii_lower_equal (key, "content-type")) {
             content_type = value;
             break;
         }

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -18,6 +18,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/http/managed_listener.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
@@ -26,7 +27,6 @@
 #include <httplib.h>
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <cstddef>
 #include <expected>
@@ -40,12 +40,6 @@ namespace vayu::http {
 namespace constants = vayu::core::constants;
 
 namespace {
-
-std::string lower (std::string value) {
-    std::transform (value.begin (), value.end (), value.begin (),
-    [] (unsigned char ch) { return static_cast<char> (std::tolower (ch)); });
-    return value;
-}
 
 /// The engine's own listener answers on 9876; an inbox must not be told to
 /// fight it for the port, and 0 means "pick one".
@@ -85,7 +79,7 @@ std::string query_of (const std::string& target) {
 /// Read a canned response's content type without assuming the caller's casing.
 std::string content_type_of (const std::map<std::string, std::string>& headers) {
     for (const auto& [name, value] : headers) {
-        if (lower (name) == "content-type") {
+        if (vayu::utils::ascii_lower_equal (name, "content-type")) {
             return value;
         }
     }
@@ -490,7 +484,7 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
         res.status                     = canned.status;
         const std::string content_type = content_type_of (canned.headers);
         for (const auto& [name, value] : canned.headers) {
-            if (lower (name) != "content-type") {
+            if (!vayu::utils::ascii_lower_equal (name, "content-type")) {
                 res.set_header (name, value);
             }
         }

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -25,6 +25,7 @@
 #include "vayu/core/path_template.hpp"
 #include "vayu/http/managed_listener.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/invariant.hpp"
 #include "vayu/utils/logger.hpp"
@@ -37,7 +38,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <deque>
 #include <expected>
 #include <format>
@@ -262,13 +262,7 @@ std::vector<std::pair<std::string, std::string>> example_headers (const std::str
 }
 
 bool header_is (const std::string& name, const char* wanted) {
-    if (name.size () != std::strlen (wanted)) {
-        return false;
-    }
-    return std::equal (name.begin (), name.end (), wanted, [] (char a, char b) {
-        return std::tolower (static_cast<unsigned char> (a)) ==
-        std::tolower (static_cast<unsigned char> (b));
-    });
+    return vayu::utils::ascii_lower_equal (name, wanted);
 }
 
 /// The content type an example is served under: its denormalized column, then

--- a/engine/src/http/transport_policy.cpp
+++ b/engine/src/http/transport_policy.cpp
@@ -29,6 +29,7 @@
 #include <curl/curl.h>
 
 #include "vayu/db/database.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/logger.hpp"
 
 namespace vayu::http {
@@ -319,9 +320,7 @@ std::optional<std::string> proxy_url_rejection (std::string_view url) {
     const auto scheme_end      = url.find ("://");
     if (scheme_end != std::string_view::npos) {
         const std::string_view scheme = url.substr (0, scheme_end);
-        std::string lowered (scheme);
-        std::transform (lowered.begin (), lowered.end (), lowered.begin (),
-        [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+        const std::string lowered     = vayu::utils::ascii_lower (scheme);
         if (std::find (PROXY_SCHEMES.begin (), PROXY_SCHEMES.end (), lowered) ==
         PROXY_SCHEMES.end ()) {
             std::string allowed;
@@ -625,9 +624,7 @@ match_client_certificate (const TransportPolicy& policy, std::string_view host, 
         return nullptr;
     }
 
-    std::string wanted (host);
-    std::transform (wanted.begin (), wanted.end (), wanted.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+    std::string wanted = vayu::utils::ascii_lower (host);
 
     const ClientCertRule* best = nullptr;
     ClientCertRank best_rank;

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -45,6 +45,7 @@
 #include "vayu/http/set_cookie.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/http/url_parts.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/encoding.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/sha256.hpp"
@@ -274,9 +275,7 @@ JSValue cast_variable_to_jsvalue (JSContext* ctx, const Variable& var) {
     }
 
     if (type == "boolean") {
-        std::string lowered = var.value;
-        std::transform (lowered.begin (), lowered.end (), lowered.begin (),
-        [] (unsigned char c) { return std::tolower (c); });
+        std::string lowered = vayu::utils::ascii_lower (var.value);
         // Trim whitespace
         auto isspace_pred = [] (unsigned char c) { return std::isspace (c); };
         while (!lowered.empty () &&
@@ -1997,10 +1996,7 @@ JSValue expect_a (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst*
         type_name = "undefined";
     }
 
-    std::string expected = js_to_string (ctx, argv[0]);
-    for (auto& c : expected) {
-        c = static_cast<char> (std::tolower (static_cast<unsigned char> (c)));
-    }
+    const std::string expected = vayu::utils::ascii_lower (js_to_string (ctx, argv[0]));
 
     bool matches = (type_name == expected);
     bool pass    = state->negated ? !matches : matches;
@@ -3321,12 +3317,7 @@ JSValue js_response_have_header (JSContext* ctx, JSValueConst this_val, int argc
     bool found = false;
     std::string found_value;
     for (const auto& [key, value] : data->response->headers) {
-        std::string lower_key  = key;
-        std::string lower_name = header_name;
-        std::transform (lower_key.begin (), lower_key.end (), lower_key.begin (), ::tolower);
-        std::transform (
-        lower_name.begin (), lower_name.end (), lower_name.begin (), ::tolower);
-        if (lower_key == lower_name) {
+        if (vayu::utils::ascii_lower_equal (key, header_name)) {
             found       = true;
             found_value = value;
             break;
@@ -3795,24 +3786,6 @@ const std::string& value) {
     JS_NewString (ctx, value.c_str ()), JS_PROP_C_W_E);
 }
 
-/// A header name as a case-insensitive index keys it - which is the spelling
-/// Postman's `toObject()` hands back, and the only place here that needs one.
-/// The engine has no primitive for the fold and hand-rolls it 29 times; that is
-/// filed as #1060 rather than converted from under this one caller.
-std::string header_name_lowered (const std::string& name) {
-    std::string lowered = name;
-    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
-    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
-    return lowered;
-}
-
-bool header_names_equal (const std::string& a, const std::string& b) {
-    return a.size () == b.size () &&
-    std::equal (a.begin (), a.end (), b.begin (), [] (unsigned char c1, unsigned char c2) {
-        return std::tolower (c1) == std::tolower (c2);
-    });
-}
-
 // The own enumerable key naming `name`, spelled the way the object spells it.
 // HTTP header names are case-insensitive and JS object keys are not, so an
 // exact lookup would miss `Content-Type` on a response (whose keys the HTTP
@@ -3838,7 +3811,7 @@ find_header_key (JSContext* ctx, JSValueConst headers, const std::string& name) 
         return std::nullopt;
     }
     for (auto& key : *keys) {
-        if (header_names_equal (key, name)) {
+        if (vayu::utils::ascii_lower_equal (key, name)) {
             return std::move (key);
         }
     }
@@ -4089,7 +4062,9 @@ JSValue js_headers_to_object (JSContext* ctx, JSValueConst this_val, int argc, J
     JSValue out = JS_NewObject (ctx);
     for (const auto& key : *keys) {
         JSValue value = JS_GetPropertyStr (ctx, this_val, key.c_str ());
-        const std::string prop = case_sensitive ? key : header_name_lowered (key);
+        // A case-insensitive index is keyed by the folded name, which is the
+        // spelling Postman's `toObject()` hands back.
+        const std::string prop = case_sensitive ? key : vayu::utils::ascii_lower (key);
         JS_SetPropertyStr (ctx, out, prop.c_str (), value);
     }
     return out;
@@ -4134,7 +4109,7 @@ JSValue js_headers_index_of (JSContext* ctx, JSValueConst this_val, int argc, JS
         return JS_EXCEPTION;
     }
     for (uint32_t i = 0; i < keys->size (); i++) {
-        if (header_names_equal ((*keys)[i], *name)) {
+        if (vayu::utils::ascii_lower_equal ((*keys)[i], *name)) {
             return JS_NewInt32 (ctx, static_cast<int32_t> (i));
         }
     }
@@ -4339,7 +4314,7 @@ JSValue js_response_size (JSContext* ctx, JSValueConst this_val, int argc, JSVal
 constexpr int COOKIE_METHOD_FLAGS = JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE;
 
 // Cookie names are case-sensitive (RFC 6265 §4.1.1) - unlike header names, so
-// this is an exact match and not `header_names_equal`.
+// this is an exact match and not the ASCII fold header names compare under.
 //
 // The last definition wins: a response that sets the same name twice leaves the
 // later value in a browser's jar, so that is the one a script asking "what is

--- a/engine/src/utils/logger.cpp
+++ b/engine/src/utils/logger.cpp
@@ -8,7 +8,6 @@
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -18,6 +17,7 @@
 #include <vector>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/reentrant.hpp"
 
 namespace vayu::utils {
@@ -212,9 +212,7 @@ void Logger::ensure_log_directory () {
 }
 
 std::optional<Logger::Level> parse_log_level (std::string_view name) {
-    std::string lowered (name);
-    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
-    [] (unsigned char ch) { return static_cast<char> (std::tolower (ch)); });
+    std::string lowered = ascii_lower (name);
 
     if (lowered == "debug")
         return Logger::Level::DEBUG;

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -150,6 +150,7 @@ add_executable(vayu_tests
     schema_validation_test.cpp
     version_isolation_test.cpp
     reentrant_test.cpp
+    ascii_case_test.cpp
     logger_test.cpp
     ../src/http/routes/import.cpp
     ../src/http/routes/diagnostics.cpp

--- a/engine/tests/ascii_case_test.cpp
+++ b/engine/tests/ascii_case_test.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/ascii_case_test.cpp
+ * @brief `vayu::utils::ascii_lower` and `ascii_lower_equal` (issue #1060), and
+ *        the guard that keeps the fold they replaced out of `src` and
+ *        `include`.
+ *
+ * Two halves, because the defect has two.
+ *
+ * The behavioural half is the byte above 127. Twenty-seven of the twenty-nine
+ * hand-rolled folds cast to `unsigned char` before calling `std::tolower` and
+ * two did not, which is undefined where `char` is signed - and undefined is
+ * exactly what does not reproduce on demand, so what is pinned here is the
+ * rule that makes the question moot: the fold touches the twenty-six letters
+ * and returns every other byte as it went in, on either signing of `char`.
+ * `-funsigned-char` is a real build here (it is the default on ARM), so both
+ * halves of that sentence are asserted rather than one.
+ *
+ * The scanning half is for what no behavioural test can reach. A twenty-ninth
+ * copy added tomorrow works perfectly on the ASCII input every caller has;
+ * nothing fails, and the primitive's next fix simply does not reach it. What
+ * is testable is that `src` and `include` no longer name the call, which is
+ * also what holds an *untouched* file at zero once the lint gates have stopped
+ * looking at it (they lint only the files a change touches, #946). Reverting
+ * any one of the conversions fails the scan.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "source_scan.hpp"
+#include "vayu/types.hpp"
+#include "vayu/utils/ascii_case.hpp"
+
+namespace vayu::utils {
+namespace {
+
+TEST (AsciiLower, LowersTheTwentySixLettersAndNothingElse) {
+    EXPECT_EQ (ascii_lower ("CONTENT-TYPE"), "content-type");
+    EXPECT_EQ (ascii_lower ("Content-Type"), "content-type");
+
+    // Already lower is the common case at the call sites, and must be a
+    // faithful copy rather than a near one.
+    EXPECT_EQ (ascii_lower ("content-type"), "content-type");
+    EXPECT_EQ (ascii_lower (""), "");
+
+    // The neighbours of 'A'-'Z' in ASCII, which an off-by-one range test would
+    // fold: '@' is 'A' - 1 and '[' is 'Z' + 1.
+    EXPECT_EQ (ascii_lower ("@[`{ 0189_-."), "@[`{ 0189_-.");
+}
+
+/**
+ * The case the two uncast `::tolower` sites got wrong, and the reason the fold
+ * is spelled as a range test on the `char` rather than as a call taking an
+ * `unsigned char`: a byte above 127 is negative where `char` is signed, and
+ * passing it to `std::tolower` is undefined. Here it is simply not a letter.
+ */
+TEST (AsciiLower, LeavesAByteAbove127ExactlyAsItWas) {
+    const std::string utf8 = "caf\xC3\xA9-HEADER";
+    EXPECT_EQ (ascii_lower (utf8), "caf\xC3\xA9-header");
+
+    // Every byte from 0x80 up, none of which is a letter under this rule on
+    // either signing of `char`.
+    std::string high;
+    for (int byte = 0x80; byte <= 0xFF; ++byte) {
+        high.push_back (static_cast<char> (byte));
+    }
+    EXPECT_EQ (ascii_lower (high), high);
+}
+
+TEST (AsciiLower, TheCharacterFoldIsAConstantExpression) {
+    // The comparator in `types.hpp` calls it per character per lookup, so it
+    // has to be the cheap spelling as well as the correct one.
+    static_assert (ascii_lower ('A') == 'a');
+    static_assert (ascii_lower ('Z') == 'z');
+    static_assert (ascii_lower ('a') == 'a');
+    static_assert (ascii_lower ('7') == '7');
+    static_assert (ascii_lower ('@') == '@');
+    static_assert (ascii_lower ('[') == '[');
+    SUCCEED ();
+}
+
+TEST (AsciiLowerEqual, MatchesUnderTheFoldAndBuildsNothing) {
+    EXPECT_TRUE (ascii_lower_equal ("Authorization", "AUTHORIZATION"));
+    EXPECT_TRUE (ascii_lower_equal ("", ""));
+
+    EXPECT_FALSE (ascii_lower_equal ("authorization", "authorisation"));
+    EXPECT_FALSE (ascii_lower_equal ("auth", "authorization")); // a prefix is not a match
+    EXPECT_FALSE (ascii_lower_equal ("authorization", "auth"));
+
+    // Embedded NULs are compared, not treated as a terminator - the views
+    // carry their own length.
+    EXPECT_TRUE (
+    ascii_lower_equal (std::string_view ("A\0b", 3), std::string_view ("a\0B", 3)));
+    EXPECT_FALSE (
+    ascii_lower_equal (std::string_view ("a\0b", 3), std::string_view ("a", 1)));
+}
+
+/**
+ * The two answers `CaseInsensitiveLess` gives have to agree: `equal` is what
+ * callers ask outside the map and `operator()` is what the map itself orders
+ * by, and before #1060 they were two separate spellings of the fold. A byte
+ * above 127 is where a divergence would have shown first.
+ */
+TEST (CaseInsensitiveLess, TheOrderingAndTheEqualityAgree) {
+    const CaseInsensitiveLess less;
+
+    EXPECT_TRUE (CaseInsensitiveLess::equal ("Content-Type", "CONTENT-TYPE"));
+    EXPECT_FALSE (less ("Content-Type", "CONTENT-TYPE"));
+    EXPECT_FALSE (less ("CONTENT-TYPE", "Content-Type"));
+
+    EXPECT_FALSE (CaseInsensitiveLess::equal ("Accept", "Accept-Encoding"));
+    EXPECT_TRUE (less ("Accept", "Accept-Encoding"));
+
+    const std::string high  = "caf\xC3\xA9";
+    const std::string other = "caf\xC3\xA8";
+    EXPECT_TRUE (CaseInsensitiveLess::equal (high, high));
+    EXPECT_FALSE (CaseInsensitiveLess::equal (high, other));
+
+    // And the map keyed by it still treats a header name one way.
+    Headers headers;
+    headers["Content-Type"] = "application/json";
+    headers["CONTENT-TYPE"] = "text/plain";
+    EXPECT_EQ (headers.size (), 1u);
+    EXPECT_EQ (headers.at ("content-type"), "text/plain");
+}
+
+/// The one name the conversions replaced. `towlower` is deliberately not here:
+/// nothing in the engine has ever named it, and a guard is worth having for
+/// the spelling that actually accumulated.
+constexpr std::string_view kFoldCall = "tolower";
+
+/**
+ * @brief Whether @p code names `tolower` at all, called or not.
+ *
+ * `tests::names_call` is the wrong matcher here and the reason is the whole
+ * point of the issue: the two sites that were actually undefined spelled it
+ * `std::transform (b, e, b, ::tolower)`, passing the function rather than
+ * calling it, so the `(` that `names_call` requires after the name is not
+ * there. A guard built on it would have read the one spelling this fix exists
+ * for as a clean tree.
+ *
+ * Bounded on both sides like `names_call`, and for the same reason: without
+ * it `tolower_count` and any longer name containing this one would be
+ * reported, which would make the rule unstatable. Nothing narrower is needed -
+ * `std::` and `::` sit to the left of the name and do not interfere, and
+ * `towlower` does not contain it.
+ */
+bool names_fold (const std::string& code, std::string_view name) {
+    const auto is_identifier_char = [] (char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') || c == '_';
+    };
+
+    for (size_t at = code.find (name); at != std::string::npos;
+    at             = code.find (name, at + 1)) {
+        if (at > 0 && is_identifier_char (code[at - 1])) {
+            continue;
+        }
+        const size_t after = at + name.size ();
+        if (after < code.size () && is_identifier_char (code[after])) {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
+/// One file, one call, the shape `reentrant_test.cpp` settled on - `constexpr`
+/// arrays of views rather than the `std::vector<std::string>` they read more
+/// naturally as, because a namespace-scope container with a throwing
+/// constructor is a `cert-err58-cpp` finding.
+struct ExemptSite {
+    std::string_view file;
+    std::string_view call;
+};
+
+/// Empty, and that is the claim: the fold is written as a range test on the
+/// character, so even the primitive itself does not call `std::tolower`. A
+/// site that genuinely cannot route through `utils/ascii_case.hpp` belongs
+/// here with its reason beside it, not silenced at the line.
+constexpr std::array<ExemptSite, 0> kExempt = {};
+
+bool is_exempt (std::string_view file, std::string_view call) {
+    return std::any_of (kExempt.begin (), kExempt.end (), [&] (const ExemptSite& site) {
+        return site.file == file && site.call == call;
+    });
+}
+
+TEST (AsciiFold, TheEngineSourcesDoNotHandRollIt) {
+    const std::filesystem::path root{ VAYU_ENGINE_SOURCE_DIR };
+    size_t scanned_files = 0;
+    size_t scanned_bytes = 0;
+    std::vector<std::string> offenders;
+
+    for (const auto* directory : { "src", "include" }) {
+        const auto tree = root / directory;
+        ASSERT_TRUE (std::filesystem::is_directory (tree))
+        << tree.string () << " is not where the guard looks";
+
+        for (const auto& entry : std::filesystem::recursive_directory_iterator (tree)) {
+            const auto& path            = entry.path ();
+            const std::string extension = path.extension ().string ();
+            if (!entry.is_regular_file () || (extension != ".cpp" && extension != ".hpp")) {
+                continue;
+            }
+            const std::string relative =
+            std::filesystem::relative (path, root).generic_string ();
+
+            const std::string code = tests::strip_comments (tests::read_source (path));
+            ASSERT_FALSE (code.empty ()) << relative << " read as empty";
+            ++scanned_files;
+            scanned_bytes += code.size ();
+
+            if (is_exempt (relative, kFoldCall) || !names_fold (code, kFoldCall)) {
+                continue;
+            }
+            std::string offender = relative;
+            offender += " calls ";
+            offender += kFoldCall;
+            offenders.push_back (std::move (offender));
+        }
+    }
+
+    // A scan that read nothing passes forever, so it says what it read.
+    ASSERT_GT (scanned_files, 100u) << "the guard found almost no sources";
+    ASSERT_GT (scanned_bytes, 100'000u) << "the guard read empty sources";
+
+    std::string joined;
+    for (const auto& offender : offenders) {
+        if (!joined.empty ()) {
+            joined += "\n  ";
+        }
+        joined += offender;
+    }
+    EXPECT_TRUE (offenders.empty ())
+    << "a hand-rolled fold does not receive the primitive's fixes, and reads "
+       "the process's C locale for any byte above 127. Use "
+       "vayu/utils/ascii_case.hpp - ascii_lower for a character or a string, "
+       "ascii_lower_equal to compare without building one - or add the site "
+       "to kExempt with its reason. Offenders:\n  "
+    << joined;
+}
+
+/**
+ * The matcher still finds the call it should, and still ignores the longer
+ * names that contain it. Without this, an over-eager `strip_comments` or a
+ * broken boundary check would leave the guard above passing on a tree that had
+ * brought every copy back.
+ */
+TEST (AsciiFold, TheGuardSeesTheNameCalledOrPassed) {
+    EXPECT_TRUE (names_fold ("c = std::tolower (c);", kFoldCall));
+
+    // The spelling `tests::names_call` misses, and the one that was undefined:
+    // the function passed rather than called, so no `(` follows the name.
+    EXPECT_TRUE (names_fold ("std::transform (b, e, b, ::tolower);", kFoldCall));
+    EXPECT_FALSE (tests::names_call ("std::transform (b, e, b, ::tolower);", kFoldCall));
+
+    EXPECT_FALSE (names_fold ("x = ascii_lower (c);", kFoldCall));
+    EXPECT_FALSE (names_fold ("y = std::towlower (c);", kFoldCall));
+    EXPECT_FALSE (names_fold ("int tolower_count = 0;", kFoldCall));
+    EXPECT_FALSE (names_fold ("auto x = my_tolower (c);", kFoldCall));
+
+    // The prose in `ascii_case.hpp` names the call it replaced, so the guard
+    // has to read code and not comments or it could never be quieted.
+    EXPECT_FALSE (
+    names_fold (tests::strip_comments (
+                "// the sites that spelled std::tolower (c) themselves\n"),
+    kFoldCall));
+    EXPECT_TRUE (names_fold (
+    tests::strip_comments ("/* see above */ std::tolower (c);\n"), kFoldCall));
+}
+
+} // namespace
+} // namespace vayu::utils

--- a/engine/tests/ascii_case_test.cpp
+++ b/engine/tests/ascii_case_test.cpp
@@ -112,8 +112,10 @@ TEST (AsciiLowerEqual, MatchesUnderTheFoldAndBuildsNothing) {
 /**
  * The two answers `CaseInsensitiveLess` gives have to agree: `equal` is what
  * callers ask outside the map and `operator()` is what the map itself orders
- * by, and before #1060 they were two separate spellings of the fold. A byte
- * above 127 is where a divergence would have shown first.
+ * by. Before #1060 `equal` could not disagree because it *was* the ordering,
+ * asked twice (`!less (a, b) && !less (b, a)`); now the two are separate
+ * functions over the same fold, so agreeing is a property worth a test rather
+ * than a tautology. A byte above 127 is where a divergence would show first.
  */
 TEST (CaseInsensitiveLess, TheOrderingAndTheEqualityAgree) {
     const CaseInsensitiveLess less;


### PR DESCRIPTION
## Description

Lower-casing a string for a case-insensitive comparison had no primitive in the engine, so every site that needed one wrote the transform itself: **29 occurrences across 19 files, in four spellings**. Two of them - `js_response_have_header`'s `std::transform (b, e, b, ::tolower)` pair - had no `unsigned char` cast anywhere in them, so a header name carrying a byte above 127 passed a negative `char` to `::tolower`, which is undefined. The other 27 cast for exactly that reason. That is the shape `CLAUDE.md` names: a hand-rolled copy of a primitive does not receive the primitive's fixes.

**Root cause** is the missing primitive, not the two bad sites - fixing only those leaves 27 copies free to drift again. **The approach** is one header-only primitive in `vayu/utils/`, three entry points because the call sites ask three questions (a character, a whole string, and whether two strings match), plus a source scan so a 30th copy cannot land unnoticed. **The alternative I rejected** was making the fold take an `unsigned char` like `std::tolower` does, which is what the 27 correct sites did by hand: it keeps a precondition every caller has to remember. Writing the range test on the `char` itself removes the precondition instead - a byte above 127 is negative where `char` is signed and above `'Z'` where it is unsigned, so it fails the test and comes back untouched either way, with no cast at any call site.

`ascii_lower` also folds only the 26 letters, where `std::tolower` reads the process's C locale. Every caller here folds a header name, a scheme, a MIME type, a hostname or a log-level word - all ASCII by their own specifications - so this narrows what the fold can do rather than changing any answer it gives today. Nothing in the repository calls `setlocale`, so no current path was reading anything but the "C" locale anyway.

### What changed

- **`engine/include/vayu/utils/ascii_case.hpp`** (new, header-only like `parse.hpp` and `reentrant.hpp`): `ascii_lower (char)`, `ascii_lower (std::string_view)`, `ascii_lower_equal (std::string_view, std::string_view)`.
- **All 29 sites converted.** Seven file-local `lower` / `lowered` / `header_name_lowered` / `header_names_equal` helpers are **deleted** rather than respelled - a file-local copy of a primitive is the thing being removed.
- **`CaseInsensitiveLess`** (`types.hpp`) folds through the primitive in both halves. Its `equal` did not have a fold of its own before - it derived an answer from the ordering by comparing twice, `!less (a, b) && !less (b, a)` - and is now one `ascii_lower_equal` pass over the same helper the ordering uses.
- **`engine/tests/ascii_case_test.cpp`** (new): behaviour plus a source scan.
- **`engine/CLAUDE.md`**: the conventions bullet, beside the `byte_view` and `parse_number` entries that record the same kind of consolidation.

### Deliberate deviations from the issue spec

- The issue left "whether the scan should be enforced afterwards" open. It is enforced, following `reentrant_test.cpp` and `bounds_primitives_test.cpp`. **Its exemption list is empty** - because the fold is a range test rather than a call, even the primitive does not name `std::tolower`.
- The guard uses its own matcher instead of `source_scan.hpp`'s `names_call`, and that is load-bearing: `names_call` requires a `(` after the name, so it would have read `std::transform (b, e, b, ::tolower)` - the one spelling that was actually undefined - as a clean tree. The planted-positive test asserts both that `names_fold` sees it and that `names_call` does not. `character_cast_test.cpp` sets the precedent for a test-local matcher.
- `openapi_export.cpp`'s `file_slug` keeps its loop and takes the character overload: its fold is interleaved with an ASCII-alnum filter and dash collapsing, so the whole-string overload would not fit without restructuring logic the issue did not ask about.
- **Not done, filed instead:** #1127 (`client.cpp:208`, `import.cpp:150` and `js_response_have_header` hand-roll a linear scan over a `Headers` map that is *already* ordered case-insensitively) and #1128 (three sites re-declare that comparator inline instead of saying `vayu::Headers`). Both are adjacent to this diff and outside the issue, so they are follow-ups rather than scope creep here.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`python build.py -e -t` clean, then `ctest --preset linux-dev --output-on-failure`:

**2796 / 2796 passed, 0 failed** (46.7s) - 2789 pre-existing plus 7 new. Nothing in the suite fails on this branch, so there is no pre-existing failure to report.

The 7 new tests: the four cases the issue asks for (already-lower, mixed, a byte above 127 left alone, empty), the ASCII neighbours of `A`-`Z` (`@` is `'A' - 1`, `[` is `'Z' + 1`) that an off-by-one range test would fold, every byte from `0x80` to `0xFF` unchanged, the character fold as a constant expression, embedded NULs compared rather than terminating, `CaseInsensitiveLess`'s ordering and equality agreeing, the source scan, and the matcher's planted positive.

Mutation-checked rather than assumed: planting a file under `engine/src` that calls `std::tolower` fails `AsciiFold.TheEngineSourcesDoNotHandRollIt` naming that file; removing it passes again. The primitive was also compiled and run under `-funsigned-char` to prove the byte-above-127 rule holds on both signings of `char`, since ARM's default differs from x86's.

`clang-format-19 --style=file --dry-run -Werror` clean over every changed `.cpp`/`.hpp`. `clang-tidy-19 -p engine/build` clean on a sample of the changed translation units.

Not run, deliberately, per `CLAUDE.md`'s "scale the verification to what the change could break": the app suite. This is engine-internal and touches no app-visible behaviour - the issue's own "App changes: None" says the same.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1060