### PR TITLE
docs: carry the unreconciled-benchmark caveat onto the README headline - #1099

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The HTTP core is a multi-worker libcurl event loop in C++23, isolated from the E
 
 Vayu **matches `wrk` and edges past `vegeta`** - all three converge on the same ~57k system throughput ceiling, and at that ceiling the machine is still 79% idle, so it is the target saturating, not the client. Full methodology, the concurrency sweep, the `workers` A/B, tuning notes, and a one-command reproduction script are in **[Engine Benchmarks](https://athrvk.github.io/vayu/engine/benchmarks/)**.
 
+One caveat, carried over from the benchmarks page: an earlier 2026-07 CLI session measured the opposite curve shape - Vayu at **66%** of `wrk` at this same concurrency 64 - and the two measurements have not been reconciled. The 105% above is the newer of the two, not a settled result; the gap is too large to be run-to-run noise, so one of them is not measuring what it claims. Read both before quoting either: [prior results (2026-07, CLI, unreconciled)](https://athrvk.github.io/vayu/engine/benchmarks/#prior-results-2026-07-cli-unreconciled).
+
 **And from the UI, not just the CLI.** A 60-second run started from the app's own Load Test panel sustained **51,922 req/s - 3,115,391 requests, zero errors, zero dropped**, p50 1.20 ms / p99 1.52 ms, with the charts streaming live throughout:
 
 ![In-app load test sustaining 51,922 req/s over 60 seconds with 3,115,391 requests and a 0.0% error rate](docs/images/vayu-loadtest4.png)


### PR DESCRIPTION
## Description

`README.md:45-51` carried the 105%-of-`wrk` throughput table with no caveat and no link, while `docs/compare/vayu-vs-k6.md:64-70` - corrected by PR #1078 for #986 - has carried the unreconciled-measurement note since. Root cause: #986 scoped its sweep to the docs pages, and the front page was never in the list, so the correction landed everywhere except where most readers are (repo landing view, npm page).

The fix repeats `vayu-vs-k6.md:64-70`'s wording **verbatim** rather than writing a third phrasing, changing only the link target: README is outside the MkDocs build, so the relative `../engine/benchmarks.md#...` path used in the docs tree would not resolve on GitHub or npm, and the absolute published URL `https://athrvk.github.io/vayu/engine/benchmarks/#prior-results-2026-07-cli-unreconciled` is used instead. The anchor was verified to resolve on the live site. Alternative rejected: a shorter README-only summary of the discrepancy ("an earlier run measured lower, see benchmarks"). It would have been a fourth phrasing of a claim this repo has already had to re-sweep twice, and it would have dropped the two numbers (66% vs 105%) that are the reason the caveat exists.

Placement is after the interpretation paragraph and before the in-app-run paragraph, mirroring where `vayu-vs-k6.md` puts it relative to its own table.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

None run, and none apply. Per CLAUDE.md's verification-scaling rule this is a repo-root Markdown edit outside `app/` and outside the MkDocs site: no build, no engine suite, no app suite, and `mkdocs build --strict` does not read README. The one external fact the edit asserts - that the published anchor exists - was checked by fetching the [live benchmarks page](https://athrvk.github.io/vayu/engine/benchmarks/) and confirming the `#prior-results-2026-07-cli-unreconciled` heading resolves. The added paragraph was diffed against `vayu-vs-k6.md:64-70` and is identical modulo whitespace and the link target. The file was not reflowed (prettier's domain is `app/` only); the diff is 2 added lines.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, prose-only
- [x] I have updated documentation - the doc edit is the change

## Notes for review

Blast-radius sweep (`rg -n "105%|unreconciled|66%|56,880|54,280"`) found no other surface stating the **ratio** without the caveat - README was the last one, as #1099 says. It did find four surfaces stating the same head-to-head parity as settled without the ratio and without a caveat: `docs/index.md:374`, `docs/compare/vayu-vs-bruno.md:50-51`, `docs/compare/vayu-vs-jmeter.md:55-56`, and this file's own summary bullet at `README.md:5`. Those are outside #1099's scope (it names `README.md:45-51` as the one surviving copy of the headline) and are not touched here; they are filed as #1126, which is sequenced after this PR.

## Related Issues
Closes #1099