### PR TITLE
docs(app): qualify the fifth mirror claim, above the isMidRunRefreshable tests - #1100

### DIFF
--- a/app/src/modules/request-builder/components/oauth2-load-test-coverage.test.ts
+++ b/app/src/modules/request-builder/components/oauth2-load-test-coverage.test.ts
@@ -91,7 +91,9 @@ describe("coverageState", () => {
 	});
 });
 
-// Mirrors plan_auth_refresh in the engine; a divergence here either promises a
+// Mirrors the config-and-token cases of the engine's plan_auth_refresh, not its
+// last one - isMidRunRefreshable's docstring holds the exact rule and how far it
+// mirrors the engine's. A divergence within those cases either promises a
 // refresh that never happens or blocks a run the engine could have carried.
 describe("isMidRunRefreshable", () => {
 	const clientCredentials = { grantType: "client_credentials" } as const;


### PR DESCRIPTION
## Description

`app/src/modules/request-builder/components/oauth2-load-test-coverage.test.ts:94-95` still stated the mirror claim unqualified - "Mirrors plan_auth_refresh in the engine" - directly above `describe("isMidRunRefreshable", ...)`, so it is the first thing the next person editing these tests reads.

Root cause and approach: #1076/#1093 established that the claim must never stand unqualified, because `isMidRunRefreshable` structurally *cannot* mirror `plan_auth_refresh`'s last case - the one that declines a refresh when a user-supplied `Authorization` header beat the token - since it is handed a config and a token and never headers. PR #1092 corrected four copies; this fifth survived because #1093's acceptance grep (`rg isMidRunRefreshable`) hits the `describe` line, not the comment above it. The fix reuses the two phrasings already shipped rather than inventing a fifth: the "config-and-token cases" scope from `oauth2-load-test-coverage.ts:50-53` plus `OAuth2LoadTestGuard.tsx:22-23`'s deferral to the docstring that holds the exact rule. The alternative I rejected was restating the header carve-out in full here - that is a third long-form copy of a rule that already has one authoritative statement, which is the same drift shape this issue exists to close.

Blast radius, swept at `e9c6f05`: `rg -n "plan_auth_refresh" app/ docs/` finds nine lines. Four are engine-side references to the function itself (`docs/engine/architecture.md`, `db-schema.md`) and do not claim a mirror; `docs/engine/api-reference.md:3582-3584`, `docs/app/api-integration.md:1198-1202`, `docs/app/COMPONENTS.md:260` and `oauth2-load-test-coverage.ts:50` all name the header exception already. Only the test comment was unqualified, so this diff is one file.

## Type of Change
- [x] Documentation update (comment-only)

## Testing

None run, deliberately, per the repo's verification-scaling rule: the diff is a four-line comment, so no test can go from green to red. The one check that could react is formatting, and it passes - `pnpm exec prettier --check src/modules/request-builder/components/oauth2-load-test-coverage.test.ts` from `app/`: "All matched files use Prettier code style!". The issue's Tests section says the same ("None to run - comment-only edit").

Acceptance criterion verified directly: `rg -n "plan_auth_refresh" app/ docs/` now shows only qualified copies (config-and-token wording, or an explicit deferral to the docstring).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable - not applicable, comment-only)
- [x] I have updated documentation (the comment edit is the change; the doc pages were corrected by #1092 and are untouched)

## Related Issues
Closes #1100

---
_Generated by [Claude Code](https://claude.ai/code/session_0141Ejz1f1m49YaRqANGw37c)_