### PR TITLE
ci: route the two repository-root files the app suite reads - #1130

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,6 +63,7 @@ jobs:
       app: ${{ steps.area.outputs.app }}
       app_doc_fixtures: ${{ steps.area.outputs.app_doc_fixtures }}
       app_engine_inputs: ${{ steps.area.outputs.app_engine_inputs }}
+      app_root_inputs: ${{ steps.area.outputs.app_root_inputs }}
       engine: ${{ steps.area.outputs.engine }}
       installer: ${{ steps.area.outputs.installer }}
       build_script: ${{ steps.area.outputs.build_script }}
@@ -272,6 +273,38 @@ jobs:
               - 'engine/tests/fixtures/variable-resolution-conformance.json'
               - 'engine/tests/fixtures/set-cookie-conformance.json'
               - 'engine/tests/fixtures/import-conformance.json'
+            # The files at the repository root that a suite in `app/` reads.
+            # Same defect again, by a third route (#1130): each of these holds
+            # one half of a value the app cannot share a constant with - the
+            # macOS update command lives in `README.md` and in `updater.ts`, the
+            # Linux install layout in `install.sh` and in `appimage-stamp.ts` -
+            # and the guard that holds the two halves together runs only in the
+            # app job.
+            #
+            # Neither reaches it on its own. `README.md` is rejected by `!*.md`
+            # in `app` and twice over by `code` (`!*.md` *and* `!**/*.md`), so a
+            # README-only pull request runs **no job at all** and a reworded
+            # macOS section lands green. `install.sh` matches `installer` and
+            # `scripts`, never `app`, so an installer-only pull request runs the
+            # installer suite and shellcheck and skips the one guard that holds
+            # the Electron side to the shell's layout.
+            #
+            # Naming what this costs, as the block above does: a README-only
+            # pull request now runs the four-runner app matrix (~23 runner-
+            # minutes) where it previously ran nothing. That is the deliberate
+            # trade - the alternative is a guard that cannot fire on its own
+            # input - and it is bounded by how rare those pull requests are and
+            # by the list being two literal paths rather than a glob.
+            #
+            # Not free-standing either. `ROOT_READING_GUARDS` in
+            # `app/src/lib/routed-inputs.testkit.ts` names the same two files,
+            # and the table that holds the two lists above to their guards holds
+            # this one to its own - which is what #1122's generalisation bought:
+            # a third kind of input costs an entry, not a third copy of the
+            # assertions.
+            app_root_inputs:
+              - 'README.md'
+              - 'install.sh'
             engine:
               - 'engine/**'
               - 'VERSION'
@@ -389,18 +422,20 @@ jobs:
     name: App on ${{ matrix.os }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
     runs-on: ${{ matrix.os }}
     needs: changes
-    # The second and third clauses are the one job those inputs need: this is
-    # where `pnpm test` runs, so it is where every guard that reads one of those
-    # files runs. The doc clause is an OR rather than another entry in `app`
-    # because `code` rejects a documentation path too, and `code && app` would
-    # answer false on the `code` half however the area filter were written. The
-    # engine clause could have been ANDed with `code` - every path it lists is
-    # source or fixture, never Markdown, so `code` is true whenever it is - and
-    # is left bare to read as the clause beside it. `quality` deliberately keeps
-    # the plain condition: eslint reads TS/TSX, prettier's domain is `app/` and
-    # tsc reads none of these files, so nothing it runs can change colour over
-    # an edit to one.
-    if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.app_doc_fixtures == 'true' || needs.changes.outputs.app_engine_inputs == 'true'
+    # The second, third and fourth clauses are the one job those inputs need:
+    # this is where `pnpm test` runs, so it is where every guard that reads one
+    # of those files runs. The doc clause is an OR rather than another entry in
+    # `app` because `code` rejects a documentation path too, and `code && app`
+    # would answer false on the `code` half however the area filter were
+    # written. The engine clause could have been ANDed with `code` - every path
+    # it lists is source or fixture, never Markdown, so `code` is true whenever
+    # it is - and is left bare to read as the clause beside it. The root clause
+    # must be bare: half of it is `README.md`, which `code` rejects, so an AND
+    # there would restore exactly the hole it closes. `quality` deliberately
+    # keeps the plain condition: eslint reads TS/TSX, prettier's domain is
+    # `app/` and tsc reads none of these files, so nothing it runs can change
+    # colour over an edit to one.
+    if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.app_doc_fixtures == 'true' || needs.changes.outputs.app_engine_inputs == 'true' || needs.changes.outputs.app_root_inputs == 'true'
     permissions:
       contents: read
     strategy:

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -224,16 +224,17 @@ loses the cascade - write the pair `bg-card surface-card`
 
 **A test that reads a file outside `app/` registers it in
 `src/lib/routed-inputs.testkit.ts`** - a page under `docs/` in
-`DOC_READING_GUARDS`, an engine source or fixture in `ENGINE_READING_GUARDS`.
-CI routes only the paths named there: every area filter excludes Markdown, and
-`app` matches nothing under `engine/` - so a guard whose input is unrouted never
-runs on the edit that breaks it, and fails later on an unrelated change to
-`app/` as if that change were the cause (#1118, #1121 for the docs, #1122 for
-the engine). Those lists and the `app_doc_fixtures` / `app_engine_inputs`
-filters in `pr-tests.yml` are compared by `routed-inputs.test.ts`, which fails
-if either side changes alone. Take the path from the registry rather than
-spelling it again in the guard - a second copy is the drift the registry exists
-to end.
+`DOC_READING_GUARDS`, an engine source or fixture in `ENGINE_READING_GUARDS`, a
+repository-root file in `ROOT_READING_GUARDS`. CI routes only the paths named
+there: every area filter excludes Markdown, `app` matches nothing under
+`engine/`, and `install.sh` belongs to the installer's filters alone - so a
+guard whose input is unrouted never runs on the edit that breaks it, and fails
+later on an unrelated change to `app/` as if that change were the cause (#1118,
+#1121 for the docs, #1122 for the engine, #1130 for the root). Those lists and
+the `app_doc_fixtures` / `app_engine_inputs` / `app_root_inputs` filters in
+`pr-tests.yml` are compared by `routed-inputs.test.ts`, which fails if either
+side changes alone. Take the path from the registry rather than spelling it
+again in the guard - a second copy is the drift the registry exists to end.
 
 Module READMEs carry the _why_ for their feature and are easy to miss:
 `app/src/modules/README.md`, plus one each for `welcome/`, `request-builder/`

--- a/app/electron/appimage-stamp.layout.test.ts
+++ b/app/electron/appimage-stamp.layout.test.ts
@@ -24,12 +24,11 @@
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { ROOT_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
 import { resolveStampPath } from "./appimage-stamp.js";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const installer = readFileSync(join(here, "..", "..", "install.sh"), "utf8");
+const [installerPath] = ROOT_READING_GUARDS.appImageLayout.paths.map(fromRepoRoot);
+const installer = readFileSync(installerPath, "utf8");
 
 /** The right-hand side of a top-level assignment in install.sh. */
 function shellValue(name: string): string {

--- a/app/electron/updater.test.ts
+++ b/app/electron/updater.test.ts
@@ -21,10 +21,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-
-const here = dirname(fileURLToPath(import.meta.url));
+import { ROOT_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
 
 type Handler = (arg: unknown) => void;
 
@@ -376,7 +373,8 @@ describe("the macOS update instruction", () => {
 	// README. When the installer moved to the docs site the README was updated
 	// and this string was not, because it is assembled from a template literal
 	// that no `raw.githubusercontent.com/athrvk` grep can see.
-	const readme = readFileSync(join(here, "..", "..", "README.md"), "utf8");
+	const [readmePath] = ROOT_READING_GUARDS.macUpdateCommand.paths.map(fromRepoRoot);
+	const readme = readFileSync(readmePath, "utf8");
 	const documented = readme.match(/^bash -c "\$\(curl -fsSL \S+install\.sh\)"$/m)?.[0];
 
 	it("finds a command in the README to compare against", () => {

--- a/app/src/lib/routed-inputs.testkit.ts
+++ b/app/src/lib/routed-inputs.testkit.ts
@@ -10,13 +10,14 @@
  * have to route them.
  *
  * Guards under `app/` assert against files the app does not own - pages under
- * `docs/`, sources and fixtures under `engine/` - which makes each of those
- * files a test input in the same sense a source file under `app/src` is: edit
- * it and `pnpm test` can go red. The area filters in `pr-tests.yml` route on
- * `app/**` and exclude Markdown, so until #1118 none of those edits ran the job
- * that would catch them: the failure surfaced on the next unrelated change
- * under `app/`, attributed to that change. #1118 routed one guard's two pages,
- * #1121 the other doc guards', #1122 the engine half.
+ * `docs/`, sources and fixtures under `engine/`, files at the repository root -
+ * which makes each of those files a test input in the same sense a source file
+ * under `app/src` is: edit it and `pnpm test` can go red. The area filters in
+ * `pr-tests.yml` route on `app/**` and exclude Markdown, so until #1118 none of
+ * those edits ran the job that would catch them: the failure surfaced on the
+ * next unrelated change under `app/`, attributed to that change. #1118 routed
+ * one guard's two pages, #1121 the other doc guards', #1122 the engine half,
+ * #1130 the two root files.
  *
  * The lists live here, not in the guards, for the reason the routing exists at
  * all: two copies of a path list drift. A guard imports the paths it reads, the
@@ -176,6 +177,32 @@ export const ENGINE_READING_GUARDS = {
 	},
 } as const satisfies Record<string, ReadingGuard>;
 
+/**
+ * Every guard that reads a file at the repository root, with the files it reads.
+ *
+ * The third route to the same defect (#1130). These two are neither prose the
+ * `app` filter excludes nor engine sources it never matched: `README.md` is
+ * rejected by `!*.md` *and* twice over by `code`, so a README-only pull request
+ * runs no job at all, and `install.sh` matches `installer` and `scripts` - which
+ * run the installer suite and shellcheck, and not the one guard holding the
+ * Electron side to the shell's layout.
+ *
+ * Both guards exist because a value lives in two places that cannot share a
+ * constant: the macOS update command in the README and in `updater.ts`, the
+ * Linux install layout in `install.sh` and in `appimage-stamp.ts`. Routing them
+ * is what makes the edit to the copy outside `app/` run the guard.
+ */
+export const ROOT_READING_GUARDS = {
+	macUpdateCommand: {
+		reader: "app/electron/updater.test.ts",
+		paths: ["README.md"],
+	},
+	appImageLayout: {
+		reader: "app/electron/appimage-stamp.layout.test.ts",
+		paths: ["install.sh"],
+	},
+} as const satisfies Record<string, ReadingGuard>;
+
 function union(guards: Record<string, ReadingGuard>): readonly string[] {
 	return [...new Set(Object.values(guards).flatMap((guard) => guard.paths))];
 }
@@ -186,19 +213,22 @@ function union(guards: Record<string, ReadingGuard>): readonly string[] {
  */
 export const ROUTED_DOC_PAGES = union(DOC_READING_GUARDS);
 export const ROUTED_ENGINE_PATHS = union(ENGINE_READING_GUARDS);
+export const ROUTED_ROOT_PATHS = union(ROOT_READING_GUARDS);
 
 export const WORKFLOW_PATH = fromRepoRoot(".github/workflows/pr-tests.yml");
 
 /**
  * The filters in that workflow whose whole job is to route the paths above, and
- * the guards each one answers for. One table rather than two comparisons: the
+ * the guards each one answers for. One table rather than three comparisons: the
  * engine half arrived a fix later than the doc half (#1122 after #1118 and
- * #1121), and a third kind of input should cost an entry here, not a fourth
- * copy of the same assertions.
+ * #1121) and the root half later still (#1130), and the table is what made the
+ * third kind of input cost an entry here rather than a third copy of the same
+ * assertions.
  */
 export const ROUTED_INPUTS = [
 	{ filter: "app_doc_fixtures", guards: DOC_READING_GUARDS, routed: ROUTED_DOC_PAGES },
 	{ filter: "app_engine_inputs", guards: ENGINE_READING_GUARDS, routed: ROUTED_ENGINE_PATHS },
+	{ filter: "app_root_inputs", guards: ROOT_READING_GUARDS, routed: ROUTED_ROOT_PATHS },
 ] as const;
 
 /**


### PR DESCRIPTION
## Description

Two guards under `app/` read a file at the repository root, and no filter in `pr-tests.yml` routes either to the job that runs them - the third route of the defect #1118 and #1122 fixed: a gate whose own inputs cannot trigger it, so the failure surfaces on the next unrelated change under `app/` and is attributed to that change.

- `app/electron/updater.test.ts` pins the macOS update command against `README.md`. `README.md` matches `!*.md` in the `app` filter and is rejected twice over by `code`, so a README-only pull request runs **no job at all** and a reworded macOS section lands green.
- `app/electron/appimage-stamp.layout.test.ts` holds `resolveStampPath` to `install.sh`'s own `LINUX_DATA_HOME` expansion. `install.sh` matches `installer` and `scripts`, never `app`, so an installer-only pull request runs the installer suite and shellcheck and skips the one guard holding the Electron side to the shell's layout.

**Root cause and approach.** Both are the same wiring gap, and #1122 (PR #1129) already generalised the machinery for it: `routed-inputs.testkit.ts` holds one registry per kind of input, `ROUTED_INPUTS` is the table `routed-inputs.test.ts` walks, and adding a kind is meant to cost an entry rather than a third copy of the assertions. So this adds `ROOT_READING_GUARDS` (README.md, install.sh), a third `ROUTED_INPUTS` row, and an `app_root_inputs` filter exported from the `changes` job and ORed into the `App on ${{ matrix.os }}` condition. Both guards now take their path from the registry instead of spelling their own `join(here, "..", "..", ...)` chain. The new clause is bare rather than ANDed with `code` - unlike the engine clause beside it, half of this list is `README.md`, which `code` rejects, so an AND would restore exactly the hole it closes.

**The alternative rejected:** folding the two paths into the `app` filter itself. That cannot work for `README.md` - `dorny/paths-filter`'s `some-with-excludes` treats an exclusion as final, so a positive rule listed after `!**/*.md` is dead - and it would have been the fourth place this repo learned that. A second alternative, leaving `install.sh` to the `installer` filter and gating the app job on it, was rejected as routing a whole area's worth of pull requests for one guard.

**The cost, stated deliberately:** a README-only pull request now runs the four-runner app matrix (~23 runner-minutes) where it previously ran nothing. That is the trade this issue asks for - the alternative is a guard that cannot fire on its own input - and it is bounded by two literal paths rather than a glob. The workflow comment says so beside the filter.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **547 files, 5994 tests, all passing**. No pre-existing failures.
- `pnpm type-check` (three tsc projects), `pnpm lint` (zero warnings), `pnpm format:check` - all clean.
- **Mutation-checked both ways**, as the issue asks: dropping `'install.sh'` from the new filter turns `routed-inputs.test.ts` red (1 failed / 11 passed); dropping the `|| needs.changes.outputs.app_root_inputs == 'true'` clause from the app job's condition turns it red the same way; restoring both returns 12 passed.
- The workflow was parsed as YAML and the `filters:` block re-parsed to confirm `app_root_inputs` resolves to exactly `['README.md', 'install.sh']`, is exported from `changes.outputs`, and is read by the `app` job's `if:`.
- Acceptance criterion 3 surveyed exhaustively: every `readFileSync` in `app/electron` and `app/src` test files was traced to the path it reads. These two were the only unrouted readers of a file outside `app/`; every other outside-`app/` reader already goes through the registry, and `routed-inputs.test.ts`'s own read of `pr-tests.yml` is routed by the `app` filter listing that file directly.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no new test code needed by design; the third `ROUTED_INPUTS` entry is picked up by the existing table walk, which is what #1122's generalisation was for
- [x] I have updated documentation - `app/CLAUDE.md`'s registration rule now names three registries and three filters, in the same commit

## Related Issues
Closes #1130

---
_Generated by [Claude Code](https://claude.ai/code/session_019jc3bEgaGAYdjh8xJMXP3u)_