### PR TITLE
refactor(engine): look header names up on the Headers map instead of scanning it - #1127

### DIFF
--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -28,7 +28,6 @@
 #include "vayu/http/event_loop/curl_utils.hpp"
 #include "vayu/http/form_body.hpp"
 #include "vayu/http/status.hpp"
-#include "vayu/utils/ascii_case.hpp"
 
 #include <curl/curl.h>
 
@@ -203,21 +202,24 @@ size_t write_callback (char* ptr, size_t size, size_t nmemb, void* userdata) {
  * either way, because headers arrive before the first byte of body.
  */
 std::optional<unsigned long long> declared_content_length (const Headers& headers) {
-    for (const auto& [key, value] : headers) {
-        if (!vayu::utils::ascii_lower_equal (key, "content-length")) {
-            continue;
-        }
-        try {
-            size_t consumed                   = 0;
-            const unsigned long long declared = std::stoull (value, &consumed);
-            // A trailing-garbage or empty value is no declaration at all; the
-            // caller says so rather than reporting a number the server did not.
-            return consumed == value.size () ? std::optional{ declared } : std::nullopt;
-        } catch (const std::exception&) {
-            return std::nullopt;
-        }
+    // `Headers` orders by `CaseInsensitiveLess`, so this lookup already answers
+    // every casing the wire can spell the name in, and the map holds one value
+    // per name - there is no second `content-length` for a first-match rule to
+    // choose between.
+    const auto declaration = headers.find ("content-length");
+    if (declaration == headers.end ()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    const std::string& value = declaration->second;
+    try {
+        size_t consumed                   = 0;
+        const unsigned long long declared = std::stoull (value, &consumed);
+        // A trailing-garbage or empty value is no declaration at all; the
+        // caller says so rather than reporting a number the server did not.
+        return consumed == value.size () ? std::optional{ declared } : std::nullopt;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
 }
 
 /**

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -18,7 +18,6 @@
 #include "vayu/core/spec_binding.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/routes.hpp"
-#include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -143,13 +142,13 @@ const Result<Response>& result) {
         resp.error_message.empty () ? "connection error" : resp.error_message;
         return { 502, error_body (502, "Failed to fetch: " + detail) };
     }
-    std::string content_type = "application/octet-stream";
-    for (const auto& [key, value] : resp.headers) {
-        if (vayu::utils::ascii_lower_equal (key, "content-type")) {
-            content_type = value;
-            break;
-        }
-    }
+    // `Headers` compares without case, so one lookup covers every casing the
+    // upstream can have spelled the name in, and the map holds one value per
+    // name - there is no earlier duplicate this could be shadowing.
+    const auto declared            = resp.headers.find ("content-type");
+    const std::string content_type = declared == resp.headers.end () ?
+    std::string ("application/octet-stream") :
+    declared->second;
 
     return { 200, nlohmann::json{ { "content", resp.body }, { "contentType", content_type } } };
 }

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3313,21 +3313,17 @@ JSValue js_response_have_header (JSContext* ctx, JSValueConst this_val, int argc
 
     std::string header_name = js_to_string (ctx, argv[0]);
 
-    // Case-insensitive header lookup
-    bool found = false;
-    std::string found_value;
-    for (const auto& [key, value] : data->response->headers) {
-        if (vayu::utils::ascii_lower_equal (key, header_name)) {
-            found       = true;
-            found_value = value;
-            break;
-        }
-    }
-
-    if (!found) {
+    // `Headers` orders by `CaseInsensitiveLess`, so this lookup answers the
+    // case-insensitive match HTTP header names take - a script may ask for
+    // `content-type` against a `Content-Type` the wire sent. The map holds one
+    // value per name, so there is no earlier duplicate this could shadow.
+    const auto& headers = data->response->headers;
+    const auto found    = headers.find (header_name);
+    if (found == headers.end ()) {
         std::string msg = "Expected response to have header '" + header_name + "'";
         return throw_assertion_failure (ctx, msg);
     }
+    const std::string& found_value = found->second;
 
     // A header value is a string on the wire, and chai-postman compares the
     // expected value against it strictly. Coercing the expectation instead let

--- a/engine/tests/import_route_test.cpp
+++ b/engine/tests/import_route_test.cpp
@@ -66,6 +66,16 @@ class MockSpecServer {
             res.set_content (std::string (large_bytes, 'x'), "application/octet-stream");
         });
 
+        // The name spelled the way a server is free to send it. httplib
+        // supplies its own `Content-Type` only when the response carries none
+        // under any casing, so setting it here lower-cased is what reaches the
+        // wire - which is what makes the route's lookup a case-insensitive one
+        // to assert (#1127).
+        svr_.Get ("/lowercased-type", [] (const httplib::Request&, httplib::Response& res) {
+            res.body = R"({"openapi":"3.0.0"})";
+            res.set_header ("content-type", "application/json");
+        });
+
         // No Content-Length at all, so only the write callback can stop it.
         svr_.Get ("/chunked", [this] (const httplib::Request&, httplib::Response& res) {
             res.set_chunked_content_provider ("application/octet-stream",
@@ -143,6 +153,16 @@ TEST (ImportFetch, ProxiesSuccessfully) {
     vayu::http::routes::import_fetch (body, vayu::http::TransportPolicy{});
     EXPECT_EQ (status, 200);
     EXPECT_EQ (json["content"].get<std::string> (), R"({"openapi":"3.0.0"})");
+}
+
+TEST (ImportFetch, ReportsTheContentTypeWhateverCaseTheUpstreamSpelledIt) {
+    MockSpecServer mock;
+    auto [status, json] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/lowercased-type")), vayu::http::TransportPolicy{});
+    EXPECT_EQ (status, 200);
+    // A case-sensitive lookup would miss the header and report the
+    // `application/octet-stream` fallback instead.
+    EXPECT_EQ (json["contentType"].get<std::string> (), "application/json");
 }
 
 TEST (ImportFetch, ReturnsBadGatewayOnFetchFailure) {

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1802,6 +1802,27 @@ TEST_F (ScriptEngineTest, ResponseHeaderValueComparisonIsStrict) {
     EXPECT_TRUE (result.tests[3].passed) << result.tests[3].error_message;
 }
 
+// The name a script asks for and the name the wire sent are matched the way
+// HTTP matches header names - without case (#1127). The fixture stores
+// `Content-Type`; a script that asks in any other casing gets the same answer,
+// and its value comes back for the two-argument form.
+TEST_F (ScriptEngineTest, ResponseHeaderLookupIgnoresTheCaseTheWireUsed) {
+    auto result = engine.execute_test (R"(
+        pm.test("lower-cased name finds it", function() { pm.response.to.have.header("content-type"); });
+        pm.test("upper-cased name carries its value", function() { pm.response.to.have.header("CONTENT-TYPE", "application/json"); });
+        pm.test("mixed-cased name carries its value", function() { pm.response.to.have.header("cOnTeNt-TyPe", "application/json"); });
+        pm.test("a name no casing can reach still fails", function() { pm.response.to.have.header("content-length"); });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 4u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[1].passed) << result.tests[1].error_message;
+    EXPECT_TRUE (result.tests[2].passed) << result.tests[2].error_message;
+    EXPECT_FALSE (result.tests[3].passed)
+    << "case-insensitive is not the same as matching anything";
+}
+
 TEST_F (ScriptEngineTest, HeadersHasChecksTheValueWhenItIsGivenOne) {
     response.headers["X-Count"] = "5";
 


### PR DESCRIPTION
## Description

Three sites walked a `vayu::Headers` map linearly to find one header by name, folding each key with `ascii_lower_equal` against a literal the map's own comparator already answers for. Each is now one `find` on the map.

**Root cause and approach.** `vayu::Headers` is `std::map<std::string, std::string, CaseInsensitiveLess>` - the comparator already owns the case-insensitivity rule, and the map already answers a lookup in `O(log n)`. The three loops restated that rule at the call site, which is the "hand-rolled copy of a primitive" shape `CLAUDE.md` names; after #1060 they were one `ascii_lower_equal` per header rather than two string copies, so the cost was small and the second statement of the rule was the part worth deleting. `engine/src/http/auth_resolver.cpp:165` was already doing it the right way, so this follows the existing precedent rather than inventing one. Verified before editing that all three containers really are `Headers` (`Response::headers`, `types.hpp:429`) and that first-match-and-break was not load-bearing: a `Headers` map cannot hold two keys differing only in case, so the loops had nothing to choose between - now said at each site instead of left for a reader to re-derive.

**Alternative rejected:** a shared `header_value_of(headers, name)` helper wrapping the `find`. Declined - it would be a second name for `std::map::find` with no rule of its own to hold, and the issue's own guidance is that the map is the primitive. The two structurally similar scans in `mock_server.cpp:270` (a `vector<pair>`) and `inbox.cpp:80` (a *plain*, case-sensitive `std::map`) are deliberately left alone: neither is a `Headers`, and a naive `find` on the second would silently become case-sensitive. Out of this issue's scope.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor with no behaviour change (`type:enhancement`)

## Testing

Local, on this branch:

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2798 tests, 2798 passed, 0 failed** (43.7s).
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19 -p build` over all five touched files - both clean.

Two new case-mismatch regression tests, one per path whose wire casing a test can control:

- `ScriptEngineTest.ResponseHeaderLookupIgnoresTheCaseTheWireUsed` - `pm.response.to.have.header` asked with `content-type` / `CONTENT-TYPE` / `cOnTeNt-TyPe` against the fixture's `Content-Type`, plus a name no casing can reach, so "case-insensitive" is not read as "matches anything".
- `ImportFetch.ReportsTheContentTypeWhateverCaseTheUpstreamSpelledIt` - a mock route that sets `content-type` lower-cased (httplib supplies its own only when the response carries none under any casing, so this is what reaches the wire).

**What these tests do and do not lock.** They fail under a *case-sensitive* lookup - checked, not assumed: with the import site mutated to `key == "Content-Type"` the new test fails on the `application/octet-stream` fallback, which is also what proves the mock really sends a lower-cased name rather than the test asserting a tautology. They would **not** fail if this diff were simply reverted: the old scans folded through `ascii_lower_equal` and were equally case-insensitive, so these guard the property, not the mechanism. That is deliberate - the property used to be stated at the call site and is now taken entirely from `CaseInsensitiveLess`, so a future change to the comparator or the container is exactly what they catch, and neither path had any case-mismatch coverage before.

The app side was not built or tested: no file under `app/` is touched, and the issue's "App changes" section is *None - engine-internal*.

**Deliberate deviation from the issue spec:** the issue asks for a case-mismatch case "through each of the three paths". `declared_content_length` has none. Its input is whatever the wire spelled, and httplib writes `Content-Length` itself for every response with a body (`res.set_header("Content-Length", ...)`, unconditional) - a lower-cased one pre-set by a test route reaches the wire as a *duplicate* header rather than replacing it, and the function lives in an anonymous namespace so it cannot be called directly either. Rather than build a raw-socket mock server for one assertion, the path keeps its existing coverage (`ReportsTheDeclaredTotalWhenTheServerDeclaresOne` / `ReportsNoTotalWhenTheServerDeclaresNone`), which the refactor leaves green.

Two now-unused `#include "vayu/utils/ascii_case.hpp"` lines went with the loops in `client.cpp` and `import.cpp`; `script_engine.cpp` still uses the helper elsewhere and keeps its include.

No docs changed: nothing describes these loops, and every doc sentence about header case-insensitivity (`docs/engine/scripting.md`, `docs/engine/api-reference.md:3566`) describes observable behaviour this preserves exactly.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - none needed, see above

## Related Issues

Closes #1127