### PR TITLE
docs(app): pm.expect.fail aborts outside a test, as an assertion - #1113

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -479,8 +479,10 @@ a typo, or a chai matcher Vayu lacks (`.finite`, `.sealed`, `.frozen`,
 
 **`pm.expect.fail([message])` throws that same `AssertionError` on demand**
 (issue #1004), defaulting to chai's own `expect.fail()` text. Inside a
-`pm.test` it fails that test; outside one it is the difference between an
-assertion and an error, since a thrown `Error` there aborts the script.
+`pm.test` it fails that test; outside one it aborts the script, the way any
+uncaught throw does. What it changes there is the shape of the verdict, not
+whether the script stops: the run is reported as a failed assertion carrying
+this message, rather than as the `TypeError` a misuse reports.
 chai's `fail(actual, expected, message, operator)` form is **not** supported -
 this `AssertionError` has nowhere to carry the two compared values, so a second
 argument is refused by name rather than `actual` being reported as the failure


### PR DESCRIPTION
## Description

`docs/app/pm-api-compatibility.md` described `pm.expect.fail` outside a `pm.test` as "the difference between an assertion and an error, since a thrown `Error` there aborts the script" - setting the two against each other and attaching the abort to the thrown `Error` alone. Nothing in the sentence is literally false, which is why #1098 treated the passage as the accurate reference and left it alone, but a reader who takes the contrast at face value concludes the assertion side does not abort. It does: `js_pm_expect_fail` (`engine/src/runtime/script_engine.cpp`) returns `throw_assertion_failure` unconditionally, and `PmExpectFailOutsideATestIsAnAssertionError` asserts `result.success == false`.

**Plan.** Root cause is the ambiguity the false statements #1112 removed were derived from, left standing as the fourth surface after that PR corrected the other three. The fix is to reword the second sentence so the abort attaches to both sides and the difference is named as the *shape of the verdict*, reusing `docs/engine/scripting.md`'s settled wording verbatim rather than inventing a fourth phrasing - which is the issue's second acceptance criterion, and this repo's repeated defect is precisely a describing sentence that outlives what it describes (#1099, #1100, #1098). The alternative I rejected was a lighter touch - splicing "both abort" into the existing contrast while keeping its "assertion vs error" framing. That keeps the fourth phrasing alive and leaves the next reader to reconcile four descriptions of one behaviour, which is the cost that filed this issue in the first place. The lead clause (`throws that same AssertionError on demand`) and the four-argument-form half are correct and untouched, per the issue.

A sweep of every surface describing `pm.expect.fail` (engine C++ comments and completion strings, the generated `script-typedefs.d.ts`, `docs/engine/scripting.md`, the gtest comments, and the app renderer / MCP / CLI trees) found this page to be the only one still carrying the construction, and no surface at all in the MCP or CLI trees - so the issue's third acceptance criterion is met by this one edit. Scope is one Markdown paragraph. No engine, app or test changes; the three surfaces #1112 corrected were verified to still agree at this branch's base and were deliberately not re-touched.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Prose between fenced blocks, on a published docs page - so the checks that could plausibly change colour are the docs build and the docs-compile guard, and both were run:

- `python -m mkdocs build --strict -f .github/mkdocs.yml` - **built in 4.08s, no warnings promoted to errors** (no link, anchor or nav change, but the page is published and `--strict` is the gate on docs PRs).
- `cd app && pnpm vitest run src/hooks/script-typedefs.docs-compile.test.ts` - **2 tests, 2 passed**. This test compiles the fenced `javascript` blocks of this file against `engine/tests/fixtures/script-typedefs.d.ts`; the edit is prose between blocks and no fence was touched, so its input is unchanged - run to prove that, not because a change was expected.

Not run, deliberately, per `CLAUDE.md`'s "scale the verification to what the change could actually break": no engine rebuild and no `ctest` / full app suite. A Markdown paragraph cannot move a C++ or renderer test from green to red, and the generated typedef fixture is emitted from `get_script_completions()`, not from this page. No pre-existing failures observed.

Prettier was not run: the repo-root `.prettierignore` keeps prettier's domain to `app/`, and this file is outside it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none: a docs-prose edit with no behaviour to lock, and the behaviour itself is already locked by `PmExpectFailOutsideATestIsAnAssertionError`
- [x] I have updated documentation - the documentation *is* the change

## Related Issues
Closes #1113