### PR TITLE
docs(engine): the collision rule is enforced in four layers, not three - #1108

### DIFF
--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -556,12 +556,14 @@ what this refuses is the collision that is invisible until the request comes
 back wrong. The distinction is the one [data-driven
 runs](./data-driven-runs.md) already draw for a bound row.
 
-The rule has three layers too, one definition
+The rule is layered too, one definition
 (`engine/include/vayu/http/header_names.hpp`): the bind-time one naming the
-column and the row, composition's `400`, and the execute-time residual pass -
-which rebuilds the same map after a pre-request script has run, and so can meet
-a collision composition never saw. It refuses in the same words, as a failed
-send rather than a rejected payload. The pre-send gate is deliberately *not* the
+column and the row, composition's `400`, the execute-time residual pass - which
+rebuilds the same map after a pre-request script has run, and so can meet a
+collision composition never saw, refusing in the same words as a failed send
+rather than a rejected payload - and a script's own `pm.sendRequest` (#1067),
+which builds a map of its own and throws those same words with the call named in
+front of them. The pre-send gate is deliberately *not* the
 backstop here, and cannot be: by the time it sees a request the erased header is
 already missing, with nothing left to notice.
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3885,7 +3885,9 @@ with specific codes:
   a buffered send answers `statusCode: 0` with an `errorCode` of
   `INTERNAL_ERROR` carrying the message, exactly as the pre-send gate does,
   while a streaming send - which has not answered yet - is a `400` with this
-  same code and fails its run row.
+  same code and fails its run row. A script's own `pm.sendRequest` refuses it
+  as well, with the call named in front of the same wording, because it too
+  rebuilds a header map and a resolved name is a different key (issue #1067).
 - `400` `{"error": {"code": "empty_header_name", "message": "..."}}` - a header
   name resolved to the empty string, so the line would go out under no name at
   all. `{{blank}}: acme` with `blank` holding `""` is not a header the caller

--- a/engine/include/vayu/http/header_names.hpp
+++ b/engine/include/vayu/http/header_names.hpp
@@ -52,8 +52,10 @@
  *
  * ## Where the rule is enforced
  *
- * Three layers, one rule, each naming what it alone knows - the shape
- * `header_text.hpp` describes for its own:
+ * One rule, enforced wherever a name is bound or resolved, each layer naming
+ * what it alone knows - the shape `header_text.hpp` describes for its own. The
+ * bullets are the count: a number spelled above them goes stale the next time a
+ * layer is added, as this one did when `pm.sendRequest` became the fourth.
  *
  * - **A bound data cell** (`core/scenario_data.cpp`, issue #732) refuses at
  *   bind time, naming the column and the row. It words its own message because
@@ -96,9 +98,11 @@
  * that catches beyond a produced name is a caller that built the payload
  * itself.
  *
- * **Every layer that can leave a header nameless refuses it** (issue #1095),
- * which is one layer more than the collision rule has and one reach wider at
- * the residual pass:
+ * **Every layer that can leave a header nameless refuses it** (issue #1095) -
+ * the same four the collision rule is enforced in. What differs is the wording
+ * and the reach rather than the count: all four spell this rule in the one
+ * wording below, where the collision rule's bind layer words its own, and the
+ * residual pass reads wider for this rule than it does for that one:
  *
  * - **A bound data cell** refuses it at bind time, in these words with the row
  *   in front of them - a blank cell is an ordinary thing for a data file to
@@ -145,10 +149,11 @@ struct HeaderNameCollision {
  * @brief The refusal a header name that resolved to nothing reads as.
  *
  * One wording for four layers - the three above and the bind, which is one more
- * than the collision rule reaches - on the same reasoning: a caller meeting this
- * at composition, again at execute time and again from a data row is meeting one
- * rule, and four spellings of it would read as four. A layer may name itself in
- * front of the wording, never inside it.
+ * than the *wording* above reaches, both rules being enforced in four - on the
+ * same reasoning: a caller meeting this at composition, again at execute time
+ * and again from a data row is meeting one rule, and four spellings of it would
+ * read as four. A layer may name itself in front of the wording, never inside
+ * it.
  *
  * @param written the name as the request carries it, before resolution. It is
  *        the whole of what the message can name - what the name produced is


### PR DESCRIPTION
## Description

`engine/include/vayu/http/header_names.hpp:55` opened the collision rule's "Where the rule is enforced" section with **"Three layers, one rule"** directly above **four** bullets - stale since #1067 added `pm.sendRequest` as the fourth, and the same file then used two different countings in adjacent sections without saying which was which.

**Plan.** Root cause: a count spelled in prose above a list, which drifts the moment a layer is added; the rule itself was never wrong, only the number in front of it. Verified against live code before writing (call sites, not the issue's snapshot): both rules are enforced in exactly **four** layers - bind (`core/scenario_data.cpp:1076-1082`), composition (`http/request_composer.cpp:1141-1148`), the residual pass (`http/request_exchange.cpp:423-432`) and `pm.sendRequest` (`runtime/script_engine.cpp:7061-7067`). What actually differs between them is the *wording*: the empty-name refusal is spelled by all four (composition and the residual pass verbatim, bind and `pm.sendRequest` wrapping it with the row or the call in front), while the collision rule's bind layer builds its own message (`describe_header_collision`, `scenario_data.cpp:251-258`) and so shares nothing. So the collision section drops its number and lets the bullets carry the count, and every remaining comparison says which counting it is using. The alternative - writing "four layers" in the prose - was rejected because it fixes today's number and leaves the same drift for the fifth layer; the issue asked for exactly that preference.

Changes:

1. `header_names.hpp:55` - the number is gone; the bullets are the count.
2. `header_names.hpp:99-105` - "one layer more than the collision rule has" was false under enforcement counting (four vs four) and true only of the wording. It now states that both rules are enforced in the same four layers and names what differs: this wording is shared by all four, the collision rule's bind layer words its own, and the residual pass reads wider for this rule.
3. `header_names.hpp:151-152` - `describe_empty_header_name`'s docstring said "one more than the collision rule reaches"; it now says one more than the *wording* reaches, with the enforcement count stated beside it.
4. `docs/app/variable-resolution.md:559` - the collision rule's layer enumeration omitted `pm.sendRequest`; it now lists all four, in the same shape the page already uses for the empty-name rule at `:591-600`.
5. `docs/engine/api-reference.md:3888` - **beyond the issue's literal criteria, deliberately.** Its `colliding_header_names` entry described composition, the bind-time refusal and the residual pass and stopped, while the sibling `empty_header_name` entry names `pm.sendRequest` and the bind. No count word, so it survives the issue's grep, but it is the same claim short of the same layer - and the issue asks for "a claim, not a page". One sentence, mirroring the sibling entry's own closing sentence.

Sweep result: no line in `engine/` or `docs/` still describes the collision rule short of a layer. The three surviving "three layers" matches are each a different rule (`variable-resolution.md:528` is the header-*text* forge rule; `:593` and `header_names.hpp:88` are the empty-name rule's three *resolving* layers, correctly excluding the bind) - all accurate, none touched. `docs/engine/architecture.md:488-500` describes the two rules' differing *reach* and states no layer count, so it needed nothing. The comments at `request_composer.cpp:1102-1112` and `script_engine.cpp:7022-7040` say "the three" of the wording-sharers, which stays true under the clarified counting.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Comment and prose only - no code path, so per `CLAUDE.md`'s "scale the verification to what the change could actually break" (and the issue's own Tests section) no engine or app suite was run: no test could change colour. What could break is the docs build, and it was run on the base commit and after each commit:

- `mkdocs build --strict -f .github/mkdocs.yml` - green on the base commit, green after commit 1 (4.79s) and after commit 2 (5.60s), no warnings.
- `clang-format --dry-run --Werror engine/include/vayu/http/header_names.hpp` - clean.
- Acceptance-criteria grep `rg -n "[Tt]hree layers" engine/ docs/`: no hit describes the collision rule.
- Two independent reviewers ran over the diff (acceptance criteria line by line, and repo conventions). The one surviving finding was the `api-reference.md` asymmetry, verified by hand and fixed as change 5 above.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, comment and prose only
- [x] I have updated documentation

## Related Issues
Closes #1108