### PR TITLE
refactor(engine): name the header-name origins ledger, once - #1128

### DIFF
--- a/engine/include/vayu/http/header_names.hpp
+++ b/engine/include/vayu/http/header_names.hpp
@@ -7,8 +7,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <map>
 #include <string>
 #include <string_view>
+
+// For `Headers`, whose comparison `HeaderNameOrigins` is keyed by rather than
+// naming a second one of its own.
+#include "vayu/types.hpp"
 
 /**
  * @file header_names.hpp
@@ -130,6 +135,28 @@ struct HeaderNameCollision {
     /// The one name they both landed on.
     std::string produced;
 };
+
+/**
+ * @brief Each name resolution produced, against the name as written that
+ * produced it.
+ *
+ * What a layer rebuilding a header map keeps beside the map, because the
+ * rebuilt `Headers` remembers only the spelling that got there first and a
+ * collision has to be named with both. It is what makes `emplace` the whole of
+ * the detection: the name that fails to go in has already found the one it
+ * would have erased, and the value that was there says how that one was
+ * written.
+ *
+ * Keyed by `Headers`' own comparison rather than by a comparator named again
+ * here, because the collision this finds is the one *that* map will make - the
+ * two cannot come to disagree about which two names are one. It is deliberately
+ * not a `Headers` itself: its value is a header name, never a header value.
+ *
+ * The bind-time layer keeps none, and that is the distinction rather than an
+ * omission - its message names only the surviving key, which the rebuilt
+ * `Headers` already holds (`core/scenario_data.cpp`).
+ */
+using HeaderNameOrigins = std::map<std::string, std::string, Headers::key_compare>;
 
 /**
  * @brief The refusal a header-name collision reads as.

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -12,7 +12,6 @@
 #include <cctype>
 #include <chrono>
 #include <ctime>
-#include <map>
 #include <random>
 #include <regex>
 #include <string_view>
@@ -1071,12 +1070,13 @@ const VariableValues& vars,
 const BoundColumnNames& bound_columns,
 DynamicResolution dynamic) {
     ResolvedHeaders out;
-    // Each resolved name, against the name as written that produced it. The
-    // second half is what separates a collision resolution *made* from two
-    // names the author typed themselves: those are two lines they can see side
-    // by side, and composition has always let the later one win. This refusal
-    // is for the one that is invisible until the request comes back wrong.
-    std::map<std::string, std::string, vayu::CaseInsensitiveLess> produced;
+    // The written name it keeps is load-bearing here rather than only in the
+    // message: it is what separates a collision resolution *made* from two
+    // names the author typed themselves, which are two lines they can see side
+    // by side and which composition has always let the later one win. This
+    // refusal is for the one that is invisible until the request comes back
+    // wrong.
+    vayu::http::HeaderNameOrigins produced;
     for (const auto& [key, value] : headers.items ()) {
         const std::string name =
         resolve_header_template (key, vars, bound_columns, dynamic, out.unspellable);

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <map>
 #include <utility>
 
 #include "vayu/http/client.hpp"
@@ -412,10 +411,8 @@ const vayu::http::VariableValues& vars) {
         return std::nullopt;
     }
     vayu::Headers resolved;
-    // Each resolved name against the name as written that produced it, so a
-    // refusal can name both spellings - `resolved` alone remembers only the
-    // one that got there first.
-    std::map<std::string, std::string, vayu::CaseInsensitiveLess> produced;
+    // Kept beside `resolved` so a refusal can name both spellings.
+    vayu::http::HeaderNameOrigins produced;
     for (const auto& [name, value] : headers) {
         std::string resolved_name = vayu::http::resolve_template (name, vars);
         // Both refusals are reported with the map untouched: the caller refuses

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -7040,10 +7040,8 @@ resolve_send_request_text (JSContext* ctx, std::string& text, const std::string&
  */
 std::optional<std::string> resolve_send_request_headers (JSContext* ctx, Headers& headers) {
     Headers resolved;
-    // Each resolved name against the name as written that produced it, so a
-    // refusal can name both spellings - `resolved` alone remembers only the one
-    // that got there first.
-    std::map<std::string, std::string, vayu::CaseInsensitiveLess> produced;
+    // Kept beside `resolved` so a refusal can name both spellings.
+    vayu::http::HeaderNameOrigins produced;
     for (const auto& [name, value] : headers) {
         std::string resolved_name = name;
         if (auto reason = resolve_send_request_text (


### PR DESCRIPTION
## Description

The three sites #1128 names each spelled out `std::map<std::string, std::string, vayu::CaseInsensitiveLess> produced;` beside a header map they were rebuilding. Reading them is what decided the shape of the fix, and the issue asked for exactly that reading: **none of the three is a `Headers`**. The key is a produced header name; the value is *the name as written that produced it*, kept so a refusal can name both spellings, because the rebuilt `Headers` remembers only the one that got there first. Writing `vayu::Headers produced;` would have erased the distinction the alias exists to make - the issue's own escape hatch.

What the three *do* share with `Headers` is the comparison, and that half is worth pinning rather than restating: the collision they detect is the one the header map will make, so a comparator named separately at each site is three places that can come to disagree with it. So the fix is one alias, `vayu::http::HeaderNameOrigins`, in `http/header_names.hpp` - the header that already owns the collision rule and that all three sites already include - with its comparator taken from `Headers::key_compare` rather than spelled again. Its doc says what it is, why it is not a `Headers`, and why the fourth (bind-time) layer keeps no ledger at all: `core/scenario_data.cpp` names only the surviving key, which its rebuilt map already holds.

**Rejected alternative:** the issue's default, `vayu::Headers produced;` at all three. It is the smaller diff and it compiles, but it tells the next reader these are the request's headers when their values are header *names*, and it ties a ledger to a type whose future (multi-value, a different value type) is not the ledger's. The second alternative - leave the three long-hand and add a comment to each saying why they are not `Headers` - keeps three copies of one type, which is the thing this repo's "a hand-rolled copy does not receive the primitive's fixes" rule exists to remove; the comment is now the alias's doc, written once.

**Deliberate deviation from the issue spec:** the issue proposes substitution or a per-site comment; this adds a named alias instead. It serves the stated cost ("if the header map ever needs a different comparator ... `Headers` is the one line that says so and these three do not follow it") while keeping the distinction the issue itself asked to be checked for. Two smaller consequences of the change are in the diff: the two site comments that only restated what the type now says are trimmed to the one line they still add (`request_composer.cpp` keeps its sentence, because there the written half is *read* - it is what separates a collision resolution made from two names the author typed), and `<map>` goes with the last spelled-out map in `request_exchange.cpp` and `request_composer.cpp`.

No grep guard, per the issue - the spelling is a type, not a call.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor with no behaviour change

## Testing

Type-alias substitution with no behaviour change, so the build is the proof, per the issue. `HeaderNameOrigins` is the identical instantiation the three sites had (`Headers::key_compare` *is* `CaseInsensitiveLess`, `types.hpp:132`), so nothing about ordering or collision detection moves.

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2796/2796 passed, 0 failed** (38.6s). No test added or changed; none needed to change, which is the point of a type-alias substitution.
- `clang-format --dry-run -Werror` over the four touched files: the eight violations it reports in `request_composer.cpp` and `script_engine.cpp` are **pre-existing on `master`** - verified by running the same check against `origin/master`'s copies of both files, which report the same eight at the same places - and are the local-19.1.1-vs-CI continuation-line disagreement `engine/CLAUDE.md` documents. None is in a region this PR touches, so the files were deliberately not reformatted.

No app changes - engine-internal, as the issue says.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable, no behaviour change
- [x] I have updated documentation - the alias carries its own; no doc under `docs/` or in either `CLAUDE.md` describes these declarations, only the behavioural rule they implement, which is unchanged

### Acceptance criterion

The issue's criterion is `rg -n "CaseInsensitiveLess" engine/ -g '!vendor'` returning only `types.hpp`. That snapshot predates #1124: `CaseInsensitiveLess::equal` is now the deliberate shared spelling for comparing a name outside a map, so the grep also returns `utils/ascii_case.hpp` (a doc reference), `tests/ascii_case_test.cpp` (the comparator's own tests), `src/http/event_loop/curl_utils.cpp` (an `::equal` call) and `engine/CLAUDE.md`. Against the criterion's intent - no site re-spells the header map's type - it is met: after this PR **nothing outside `types.hpp` declares a map with that comparator**, and the new alias does not name it at all.

## Related Issues
Closes #1128