### PR TITLE
docs(engine): the ctype narrowing race survives httplib's thread_local regex - #967

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -302,9 +302,9 @@ difference is worth keeping straight:
   `crypto/hashtable/hashtable.c` entry is this kind.
 - **A real race in code that is not ours.** `std::ctype<char>::narrow` fills a
   mutable cache on the process-wide locale without synchronization, and
-  cpp-httplib reaches it by building a `std::regex` per response. That is a
-  genuine race; it simply has no engine frame anywhere in the stack and cannot
-  be fixed from here. Tracked in #967.
+  cpp-httplib reaches it by constructing a `std::regex` to parse a status line.
+  That is a genuine race; it simply has no engine frame anywhere in the stack
+  and cannot be fixed from here. Tracked in #967.
 
 **Never suppress engine code.** A finding in `engine/src` or `engine/include` is
 the thing the run exists to surface. Every entry must carry the report it
@@ -376,10 +376,18 @@ tracking issue.
   propagating the exception. See [Cycle detection, not a depth
   cap](#cycle-detection-not-a-depth-cap) below.
 - **#967** - a data race in libstdc++'s locale narrowing cache, reached through
-  the `std::regex` cpp-httplib builds per response in `parse_status_line`. No
-  engine frame anywhere in the stack, so it is **suppressed** in `tsan.supp`
-  with its trace and that issue number. It only became visible once #957 was
-  fixed - before that the crash masked it.
+  the `std::regex` cpp-httplib constructs in `parse_status_line`. No engine
+  frame anywhere in the stack, so it is **suppressed** in `tsan.supp` with its
+  trace and that issue number. It only became visible once #957 was fixed -
+  before that the crash masked it. **Still open, and re-measured at `3d2a6a7`
+  rather than assumed:** cpp-httplib 0.53.0 made that regex `thread_local`, so
+  the window is one construction per thread instead of one per response, but
+  deleting the entry and running `ctest --preset linux-tsan` still fails
+  `TransportPolicyPaths.LoadRunTraversesManualProxy` on the race - twice out of
+  two runs, both sides of the report being pool threads parsing their first
+  response - against 2796/2796 with the entry in place. That test alone
+  reproduces it 10 times out of 10, which is the cheap way to re-measure this
+  one. What is left is upstream in libstdc++.
 
 The matrix has therefore paid for itself twice over: two engine-side defects
 found and fixed, one of them a race the ordinary suite is structurally unable

--- a/engine/sanitizers/tsan.supp
+++ b/engine/sanitizers/tsan.supp
@@ -49,13 +49,16 @@
 race:crypto/hashtable/hashtable.c
 
 # WARNING: ThreadSanitizer: data race
-#   Read of size 1 by thread T8 (mutexes: write M0):
+#   Read of size 1 by thread T5 (mutexes: write M0):
 #     #0 std::ctype<char>::narrow(char, char) const
 #          /usr/include/c++/13/bits/locale_facets.h:941
 #     #1 std::__detail::_Scanner<char>::_M_scan_normal()
 #          /usr/include/c++/13/bits/regex_scanner.tcc:100
+#     #6 std::basic_regex<char>::basic_regex(char const*, ...)
 #     #7 httplib::detail::parse_status_line(...)
 #     #8 httplib::ClientImpl::read_response_line(...) httplib.h:13856
+#   Previous write of size 1 by thread T7 (mutexes: write M1): the same
+#   stack, on another thread of the same httplib pool.
 #   SUMMARY: data race in std::ctype<char>::narrow(char, char) const
 #
 # libstdc++'s narrowing cache, not anything this repository wrote. `narrow`
@@ -63,8 +66,13 @@ race:crypto/hashtable/hashtable.c
 # (`_M_narrow[]` plus its `_M_narrow_ok` flag) and fills it without
 # synchronization; two threads that both construct a std::regex race on that
 # fill. The facet is the process-wide classic locale, so every thread shares
-# it. httplib builds a std::regex per response in `parse_status_line`, which
-# is why concurrent HTTP clients reach it and nothing else does.
+# it. httplib constructs that regex in `parse_status_line`, which is why
+# concurrent HTTP clients reach it and nothing else does.
+#
+# Since cpp-httplib 0.53.0 that regex is `thread_local`, so the window is one
+# construction per thread rather than one per response. Narrower, not closed:
+# both sides of the report above are threads of one httplib pool parsing their
+# *first* response, which a suite that stands up mock servers produces readily.
 #
 # Cannot be fixed here on either side: the racing write is in libstdc++'s
 # headers, and the caller is header-only third-party code. No engine frame
@@ -73,11 +81,21 @@ race:crypto/hashtable/hashtable.c
 #
 # Tracked in #967. It is a real report rather than an artifact of missing
 # instrumentation, so unlike the OpenSSL entry above it is worth an upstream
-# fix; the practical remedies are upstream (libstdc++ synchronising the cache,
-# or httplib hoisting its regex to a function-local static).
+# fix. One remedy is left and it is libstdc++'s: synchronise or eagerly fill
+# the cache. The other was httplib hoisting its regex out of the per-response
+# path, and upstream has landed it - see the paragraph above.
 #
 # Seen on: linux-tsan, TransportPolicyPaths.LoadRunTraversesManualProxy, gcc 13
 # / libtsan 2. Only became visible once #957 was fixed - before that every test
 # that opens a socket segfaulted inside the sanitizer runtime and never got far
 # enough to report anything.
+#
+# Whether it still fires is a measurement, not an argument: delete the line
+# below and run `ctest --preset linux-tsan`. Done at 3d2a6a7 (2026-08-29, gcc
+# 13.3.0 / libtsan 2, cpp-httplib 0.53.0) - 2795/2796 on both runs, failing
+# that one test both times, against 2796/2796 with the line in place. Unlike
+# the OpenSSL entry above, this one reproduces on the test alone: 10 of 10
+# `./vayu_tests --gtest_filter=TransportPolicyPaths.LoadRunTraversesManualProxy`
+# raced without the line, 10 of 10 passed with it. That is the cheap way to
+# re-measure it; the suite run is only needed to confirm nothing else moved.
 race:std::ctype<char>::narrow


### PR DESCRIPTION
## Description

#967 named an empirical re-check as its cheap next step, and this ran it.

**Root cause of the ambiguity the issue recorded**: cpp-httplib 0.53.0 hoisted the status-line `std::regex` in `parse_status_line` to a `thread_local` (`httplib.h:7803`), which is essentially the remedy the suppression's own comment asked upstream for. That changed the window from one regex construction per response to one per thread, so whether the `std::ctype` narrowing entry in `tsan.supp` was still earning its place stopped being answerable from the source and became a measurement.

**Approach**: measure it. Delete the entry, run the suite, read the answer, then correct the record either way. The alternative I rejected was reasoning from the `thread_local` to a conclusion - either "the window is one-per-thread, that is small enough, delete the suppression" or "it is still theoretically open, leave everything alone". Both are arguments; a race that fires is a fact, and the file's own header says an entry is justified by a captured report. The measurement decided against deleting, so the entry stays and what its comment claims about the mechanism is what changes.

**The measurement** (this container: gcc 13.3.0, libtsan 2, cpp-httplib 0.53.0, `linux-tsan`, `ctest` at the preset's `-j2`):

| Run | `TSAN_OPTIONS` suppressions | Result |
|-----|------------------------------|--------|
| 1 | `tsan.supp` minus the ctype entry | **2795/2796** - `TransportPolicyPaths.LoadRunTraversesManualProxy` failed on the race |
| 2 | same | **2795/2796** - same test, same race |
| 3 (control) | the checked-in `tsan.supp` | **2796/2796**, zero ThreadSanitizer reports |

And on that one test alone, which is the cheap way to re-measure it: **10 of 10 raced without the entry, 10 of 10 passed with it.** So unlike the OpenSSL entry beside it - justified by a captured trace because six runs of its test never reproduced it - this one has a repeatable before/after, and the comment now says so.

The report is the same one the issue captured, and its two sides say why the `thread_local` did not close it: T5 reading and T7 writing the same byte of `_M_narrow[]`, both through `basic_regex`'s constructor under `parse_status_line`, on two threads of one httplib pool reaching their *first* forwarded response.

So: the suppression stays, #967 stays open tracking the one remaining remedy (libstdc++ synchronising or eagerly filling the narrow cache), and this PR fixes what is now provably wrong in the two files that describe it - "httplib builds a std::regex per response", and the remedy list that still asks upstream for the hoist it has already landed. The re-check and its one-test command are recorded next to the entry so the next reader does not spend a suite run learning the same thing.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `ctest --preset linux-tsan --output-on-failure` x3, as tabled above: **2796 tests**, 2795 passing without the entry (twice), 2796 passing with it.
- `./build-tsan/vayu_tests --gtest_filter=TransportPolicyPaths.LoadRunTraversesManualProxy` x20: 10 runs without the entry (all raced), 10 with it (all passed).
- Engine built at `cmake --preset linux-tsan -DVAYU_BUILD_TESTS=ON`; `TSAN_OPTIONS` byte-identical to `sanitizers.yml`'s (`halt_on_error=1:second_deadlock_stack=1:suppressions=...`).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.
- No other suite run, deliberately: the diff is a comment block and Markdown prose, so nothing could go from green to red. Per `CLAUDE.md`, scale the verification to what the change could break.
- No pre-existing failures on the base commit: the control run is `3d2a6a7` plus this branch's comment-only diff and is 2796/2796.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable; the suite run *is* the evidence, and there is nothing here a test could assert. There is no source-scanning guard over `sanitizers/*.supp` to extend either (checked).
- [x] I have updated documentation - `docs/engine/building.md` in the same commit, both places it describes this entry.

## Related Issues

Refs #967 - deliberately not `Closes`. The issue's criterion for closing is the entry going away, and the measurement says it should not: remedy 1 (libstdc++) is still open, so the issue stays as its tracking record, now with the re-check recorded rather than pending.