### PR TITLE
fix(app): load the window alongside the engine, not behind it - #1144

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -46,8 +46,29 @@ export const MCP_PATH = "/mcp";
 export const MCP_ENDPOINT_URL = `http://${MCP_HOST}:${MCP_PORT}${MCP_PATH}`;
 
 // Engine lifecycle
-export const ENGINE_HEALTH_MAX_ATTEMPTS = 90;
-export const ENGINE_HEALTH_POLL_INTERVAL_MS = 500;
+/**
+ * How long the readiness poll waits for a freshly spawned engine to answer
+ * `/health` before it stops watching and leaves the engine to the renderer.
+ *
+ * Budget of *waiting*, not wall clock: the probes themselves are not charged
+ * against it, exactly as the attempt count it replaces was not. The engine's
+ * own startup housekeeping is priced against this number - see
+ * `reclaim_freed_pages` in `engine/src/db/database.cpp`.
+ */
+export const ENGINE_HEALTH_POLL_BUDGET_MS = 45000;
+/**
+ * First gap between health probes, doubling to `ENGINE_HEALTH_POLL_MAX_INTERVAL_MS`.
+ *
+ * A flat 500ms was the entire startup cost of a healthy engine: the first probe
+ * necessarily misses (nothing can be listening microseconds after `spawn()`
+ * returns), so every launch paid one full quantum before the second probe could
+ * succeed. Ramping spends that budget where the engine actually comes up -
+ * within tens of milliseconds - while still backing off to a cheap poll for the
+ * cold-cache, large-history case that needs the seconds.
+ */
+export const ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS = 50;
+/** Ceiling the ramped poll interval doubles up to. */
+export const ENGINE_HEALTH_POLL_MAX_INTERVAL_MS = 500;
 export const ENGINE_HEALTH_REQUEST_TIMEOUT_MS = 2000;
 export const ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS = 2000;
 export const ENGINE_GRACEFUL_EXIT_TIMEOUT_MS = 5000;

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -18,7 +18,7 @@ import {
 } from "electron";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import { EngineSidecar } from "./sidecar.js";
+import { EngineSidecar, EngineNotReadyError } from "./sidecar.js";
 import { resolveAppPaths } from "./app-paths.js";
 import { readDataFile } from "./data-file.js";
 import { readSpecFile } from "./spec-file.js";
@@ -535,6 +535,16 @@ async function startEngine() {
 		await engineSidecar.start();
 		console.log("[Main] Engine started successfully at", engineSidecar.getApiUrl());
 	} catch (error) {
+		// A slow engine is not a failed one, and it is not ours to kill. The
+		// process is alive and still working through its startup housekeeping; the
+		// window is up, the renderer is showing the disconnected state, and its
+		// health poll adopts the engine the moment it answers. Quitting here ended
+		// launches that were about to succeed.
+		if (error instanceof EngineNotReadyError) {
+			console.warn(`[Main] ${error.message}; leaving it to the renderer's health poll.`);
+			return;
+		}
+
 		console.error("[Main] Failed to start engine:", error);
 		// Show error dialog to user
 		const { dialog } = await import("electron");
@@ -948,22 +958,32 @@ app.whenReady().then(async () => {
 	// One registration for the process, ahead of any window - see the function.
 	installThemeBridge();
 
-	// Start the engine
-	await startEngine();
-
-	// Then create the window. Nothing below this line may sit between the engine
-	// and the window: the MCP server used to, and because it reads a config file
-	// at that point, a corrupt one left the app with a headless engine and no
-	// window at all. MCP is an optional convenience with no UI depending on it,
-	// so it starts after everything the user can see is up and wired.
+	// The window first, and the engine alongside it. The renderer does not need
+	// the engine to boot - its health query polls `/health` over HTTP and simply
+	// retries, and the Dock renders the disconnected state until it answers - so
+	// nothing was gained by making the user watch an empty screen for the length
+	// of the handshake. What was lost was everything: `db.init()` runs orphan
+	// reconciliation, inbox cleanup and a page-reclaim rewrite before the engine
+	// listens at all, and that whole window was blank screen.
+	//
+	// Nothing may sit between here and the engine that can fail on its own: the
+	// MCP server used to, and because it reads a config file at that point, a
+	// corrupt one left the app with a headless engine and no window. MCP is an
+	// optional convenience with no UI depending on it, so it still starts after
+	// everything the user can see is up and wired.
 	createWindow();
 
-	// Bridge the OS proxy into the engine (#708). *After* the window, and fire
-	// and forget, for the reason the line above states: nothing may sit between
-	// the engine and the window, and this is one more thing that talks to the
-	// engine at startup. It never throws and never blocks on the network - the
-	// resolution is local to Chromium - so the window has its proxy row a
-	// moment later, and the settings screen refreshes it on arrival anyway.
+	// Awaited, not fired and forgotten: the proxy bridge below talks to the
+	// engine, and the updater and MCP both read state the engine owns. The window
+	// is already loading throughout, which was the point.
+	await startEngine();
+
+	// Bridge the OS proxy into the engine (#708). Fire and forget: it never
+	// throws and never blocks on the network - the resolution is local to
+	// Chromium - so the window has its proxy row a moment later, and the settings
+	// screen refreshes it on arrival anyway. A slow engine is why this is not
+	// awaited: `startEngine` above returns without one, and the settings refresh
+	// is the backstop for the row this call then fails to fill.
 	void refreshSystemProxy(proxyResolution());
 
 	// Waking on a different network is the common way a laptop's proxy changes

--- a/app/electron/sidecar.test.ts
+++ b/app/electron/sidecar.test.ts
@@ -57,8 +57,14 @@ vi.mock("electron", () => ({
 	},
 }));
 
-import { EngineSidecar, type SidecarSystem } from "./sidecar";
-import { ENGINE_LOCK_FILE, ENGINE_PORT_RELEASE_DELAY_MS } from "./constants";
+import { EngineSidecar, EngineNotReadyError, type SidecarSystem } from "./sidecar";
+import {
+	ENGINE_HEALTH_POLL_BUDGET_MS,
+	ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS,
+	ENGINE_HEALTH_POLL_MAX_INTERVAL_MS,
+	ENGINE_LOCK_FILE,
+	ENGINE_PORT_RELEASE_DELAY_MS,
+} from "./constants";
 
 const TEST_PORT = 39876;
 const ADOPTED_PID = 4242;
@@ -398,9 +404,72 @@ describe("EngineSidecar - an engine that dies at spawn", () => {
 		spawnsAndDies(state, system, () => {});
 		const sidecar = new EngineSidecar(TEST_PORT, system);
 
-		await expect(sidecar.start()).rejects.toThrow(/failed to start within 45 seconds/);
+		await expect(sidecar.start()).rejects.toThrow(EngineNotReadyError);
 		// The early exit must not have shortened the wait for a live engine.
 		expect(vi.mocked(system.probeHealth).mock.calls.length).toBeGreaterThan(50);
+	});
+
+	it("separates a slow engine from a dead one by error type, not by message", async () => {
+		// The launch path branches on this distinction to decide whether to quit,
+		// so the two failures must not be one type: a dead engine is fatal, a slow
+		// one is the renderer's problem and the app stays up (see main.ts).
+		const slow = fakeSystem();
+		spawnsAndDies(slow.state, slow.system, () => {});
+		await expect(new EngineSidecar(TEST_PORT, slow.system).start()).rejects.toBeInstanceOf(
+			EngineNotReadyError
+		);
+
+		const dead = fakeSystem();
+		spawnsAndDies(dead.state, dead.system, (child) => {
+			queueMicrotask(() => child.emit("exit", 127, null));
+		});
+		await expect(new EngineSidecar(TEST_PORT, dead.system).start()).rejects.not.toBeInstanceOf(
+			EngineNotReadyError
+		);
+	});
+
+	it("ramps the health poll so a fast engine is not held for a full quantum", async () => {
+		const { system, state } = fakeSystem();
+		spawnsAndDies(state, system, () => {});
+		// The engine comes up during the first gap between probes. The probe
+		// before it cannot succeed - nothing is listening microseconds after
+		// spawn() returns - which is exactly why a flat interval made its own
+		// length the floor on every healthy launch.
+		vi.mocked(system.sleep).mockImplementation(async () => {
+			state.healthy = true;
+		});
+
+		await new EngineSidecar(TEST_PORT, system).start();
+
+		// The one sleep it paid is the ramp's first step, not the 500ms ceiling.
+		// Revert the ramp and this reads 500.
+		expect(vi.mocked(system.sleep).mock.calls).toEqual([
+			[ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS],
+		]);
+		expect(ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS).toBeLessThan(
+			ENGINE_HEALTH_POLL_MAX_INTERVAL_MS
+		);
+	});
+
+	it("doubles the poll interval up to the ceiling and spends the whole budget", async () => {
+		const { system, state } = fakeSystem();
+		spawnsAndDies(state, system, () => {});
+
+		await expect(new EngineSidecar(TEST_PORT, system).start()).rejects.toBeInstanceOf(
+			EngineNotReadyError
+		);
+
+		const slept = vi.mocked(system.sleep).mock.calls.map(([ms]) => ms as number);
+		expect(slept.slice(0, 4)).toEqual([50, 100, 200, 400]);
+		expect(slept.every((ms) => ms <= ENGINE_HEALTH_POLL_MAX_INTERVAL_MS)).toBe(true);
+		expect(slept[slept.length - 1]).toBe(ENGINE_HEALTH_POLL_MAX_INTERVAL_MS);
+		// The ceiling the engine's own startup housekeeping is priced against is
+		// unchanged by the ramp: it is a budget of waiting, not an attempt count.
+		const total = slept.reduce((sum, ms) => sum + ms, 0);
+		expect(total).toBeGreaterThanOrEqual(ENGINE_HEALTH_POLL_BUDGET_MS);
+		expect(total).toBeLessThan(
+			ENGINE_HEALTH_POLL_BUDGET_MS + ENGINE_HEALTH_POLL_MAX_INTERVAL_MS
+		);
 	});
 });
 

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -18,8 +18,9 @@ import net from "net";
 import {
 	ENGINE_PORT,
 	ENGINE_LOCK_FILE,
-	ENGINE_HEALTH_MAX_ATTEMPTS,
-	ENGINE_HEALTH_POLL_INTERVAL_MS,
+	ENGINE_HEALTH_POLL_BUDGET_MS,
+	ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS,
+	ENGINE_HEALTH_POLL_MAX_INTERVAL_MS,
 	ENGINE_HEALTH_REQUEST_TIMEOUT_MS,
 	ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS,
 	ENGINE_GRACEFUL_EXIT_TIMEOUT_MS,
@@ -306,6 +307,22 @@ type SpawnFailure =
 	| { kind: "exit"; code: number | null; signal: NodeJS.Signals | null; stderr: string[] }
 	| { kind: "error"; message: string };
 
+/**
+ * Raised when the readiness budget is spent but the engine is still alive.
+ *
+ * Distinct from every other start failure because it is the one that is not a
+ * failure of the engine: a large run history, a cold disk or an antivirus scan
+ * can push `db.init()` past the budget on a machine where the engine then comes
+ * up perfectly well. The launch path treats it as "not yet", not as "never" -
+ * quitting here killed engines that were seconds from answering.
+ */
+export class EngineNotReadyError extends Error {
+	constructor(budgetMs: number) {
+		super(`Engine did not answer /health within ${budgetMs / 1000} seconds`);
+		this.name = "EngineNotReadyError";
+	}
+}
+
 /** The user-facing half of a `SpawnFailure`; ends up in a `showErrorBox`. */
 function describeSpawnFailure(failure: SpawnFailure): string {
 	if (failure.kind === "error") {
@@ -590,9 +607,23 @@ export class EngineSidecar {
 	 * `spawnFailure` reports what the child we just spawned did instead of coming
 	 * up, and is the loop's early exit: polling out the remaining attempts against
 	 * a process that has already gone only delays the error the user needs.
+	 *
+	 * The gap between probes ramps rather than sitting flat, because the first
+	 * probe cannot succeed - nothing is listening microseconds after `spawn()`
+	 * returns - so a flat interval made its own length the floor on every healthy
+	 * launch. Spending the budget as `ENGINE_HEALTH_POLL_BUDGET_MS` of accumulated
+	 * waiting rather than as a fixed attempt count keeps that ceiling exactly
+	 * where the engine's own startup housekeeping is priced against it, while
+	 * letting the early attempts be cheap.
+	 *
+	 * Throws `EngineNotReadyError` when the budget is spent and the child is
+	 * still alive; the caller decides what a slow engine costs.
 	 */
 	private async waitForEngine(spawnFailure: () => SpawnFailure | null): Promise<void> {
-		for (let i = 0; i < ENGINE_HEALTH_MAX_ATTEMPTS; i++) {
+		let waited = 0;
+		let interval = ENGINE_HEALTH_POLL_INITIAL_INTERVAL_MS;
+
+		for (;;) {
 			// A quit arriving mid-startup must not be held for the rest of the
 			// ceiling: the child is already tracked, so the quit path kills it and
 			// this loop's only remaining job is to stop waiting.
@@ -611,11 +642,14 @@ export class EngineSidecar {
 				return;
 			}
 
-			await this.system.sleep(ENGINE_HEALTH_POLL_INTERVAL_MS);
-		}
+			if (waited >= ENGINE_HEALTH_POLL_BUDGET_MS) {
+				throw new EngineNotReadyError(ENGINE_HEALTH_POLL_BUDGET_MS);
+			}
 
-		const ceilingSeconds = (ENGINE_HEALTH_MAX_ATTEMPTS * ENGINE_HEALTH_POLL_INTERVAL_MS) / 1000;
-		throw new Error(`Engine failed to start within ${ceilingSeconds} seconds`);
+			await this.system.sleep(interval);
+			waited += interval;
+			interval = Math.min(interval * 2, ENGINE_HEALTH_POLL_MAX_INTERVAL_MS);
+		}
 	}
 
 	/** Throw if the app is shutting down, so no caller spawns into a quit. */

--- a/app/electron/startup-order.test.ts
+++ b/app/electron/startup-order.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * First paint does not wait on the engine (issue #1144).
+ *
+ * The window used to be created only after the sidecar's `/health` handshake
+ * resolved, which put the engine's entire startup - `db.init()`'s orphan
+ * reconciliation, inbox cleanup and page-reclaim rewrite, all of it before the
+ * engine listens at all - in front of a blank screen, for up to the 45-second
+ * readiness budget. The renderer never needed it: it polls `/health` over HTTP
+ * itself and renders the disconnected state until one answers.
+ *
+ * `main.ts` creates windows and starts the engine at import time, so the wiring
+ * itself can only be read - the same characterization approach
+ * `renderer-recovery.test.ts` and `quit-shutdown.test.ts` take to main.ts's own
+ * sequencing. The behaviour underneath is driven for real in `sidecar.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts"), "utf8");
+
+describe("startup ordering", () => {
+	it("creates the window before it waits on the engine", () => {
+		// One tab of indent is the `whenReady` handler's own call. The other,
+		// deeper-indented one is the macOS activate handler rebuilding a closed
+		// window, which runs long after startup and says nothing about ordering.
+		const windowAt = main.indexOf("\n\tcreateWindow();");
+		const engineAt = main.indexOf("\n\tawait startEngine();");
+
+		expect(windowAt).toBeGreaterThan(-1);
+		expect(engineAt).toBeGreaterThan(-1);
+		expect(windowAt).toBeLessThan(engineAt);
+	});
+
+	it("still starts MCP after the window, which is why the ordering rule existed", () => {
+		// MCP reads a config file, and a corrupt one once left the app with a
+		// headless engine and no window at all. Overlapping the engine with the
+		// window does not license overlapping this too.
+		const windowAt = main.indexOf("\n\tcreateWindow();");
+		// One tab again: `startMcp` is also called by the MCP enable/disable IPC
+		// handler, which says nothing about startup ordering.
+		const mcpAt = main.indexOf("\n\tawait startMcp();");
+
+		expect(mcpAt).toBeGreaterThan(-1);
+		expect(mcpAt).toBeGreaterThan(windowAt);
+	});
+
+	it("does not quit the app for an engine that is merely slow", () => {
+		// The whole point of the split: `EngineNotReadyError` returns, everything
+		// else still reaches the dialog and the quit below it.
+		const notReadyAt = main.indexOf("error instanceof EngineNotReadyError");
+		const quitAt = main.indexOf("app.quit();", notReadyAt);
+
+		expect(notReadyAt).toBeGreaterThan(-1);
+		expect(quitAt).toBeGreaterThan(notReadyAt);
+		// The early return sits between the two, so a slow engine never reaches
+		// the quit. Revert it and this window contains no `return`.
+		expect(main.slice(notReadyAt, quitAt)).toContain("return;");
+	});
+});

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -94,6 +94,19 @@ export const TIMING = {
 	HEALTH_CHECK_INTERVAL_MS: 30_000,
 
 	/**
+	 * Engine health poll interval while the engine is *not* answering.
+	 *
+	 * The window now loads alongside the engine rather than after it, so the
+	 * first seconds of an ordinary launch are spent disconnected and the poll
+	 * that ends that state is on the startup path. At the 30s cadence a launch
+	 * could sit disconnected for half a minute after the engine was already
+	 * serving. Disconnected is an abnormal state the user wants left, and a
+	 * refused connection to a closed localhost port costs almost nothing, so it
+	 * is polled hard and only until it answers.
+	 */
+	HEALTH_RECONNECT_POLL_INTERVAL_MS: 1_000,
+
+	/**
 	 * How often the two local-service lists (webhook inboxes, OAuth issuers) are
 	 * re-read.
 	 *

--- a/app/src/queries/health.test.ts
+++ b/app/src/queries/health.test.ts
@@ -21,11 +21,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const getHealth = vi.fn();
 vi.mock("@/services/api", () => ({ apiService: { getHealth: () => getHealth() } }));
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
-import { useHealthQuery } from "./health";
+import { useHealthQuery, healthPollIntervalMs } from "./health";
 import { useEngineStore } from "@/stores";
+import { TIMING } from "@/config/timing";
 import type { EngineRecovery } from "@/types/domain";
 
 const RECOVERY: EngineRecovery = {
@@ -43,6 +44,9 @@ function wrapper({ children }: { children: ReactNode }) {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// Implementation too, not just the call record: a queued `…Once` rejection
+	// left behind by a case that ended early is a failure in the next test.
+	getHealth.mockReset();
 	useEngineStore.setState({ isEngineConnected: false, engineError: null, recovery: null });
 });
 
@@ -71,5 +75,84 @@ describe("useHealthQuery", () => {
 
 		await waitFor(() => expect(useEngineStore.getState().isEngineConnected).toBe(true));
 		expect(useEngineStore.getState().recovery).toBeNull();
+	});
+});
+
+/**
+ * The window now loads while the engine is still starting, so "the engine is
+ * not there yet" is an ordinary launch rather than only a crash. Two things
+ * have to be true for that to be an improvement instead of a regression: the
+ * poll that ends the disconnected state has to be quick, and the queries that
+ * gave up during it have to be told to try again. Nothing else in the app
+ * notices a late engine - every other query settles after two retries, and
+ * `refetchOnReconnect` fires on the browser's online/offline event, which
+ * localhost never changes.
+ */
+describe("useHealthQuery - an engine that arrives after the window", () => {
+	function makeClient() {
+		// `retry` is set by the hook itself, so it cannot be turned off here - but
+		// the delay between those retries can, and the default backoff is longer
+		// than `waitFor` will wait for the error state it produces.
+		return new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+	}
+
+	function wrapperFor(client: QueryClient) {
+		return function Wrapper({ children }: { children: ReactNode }) {
+			return createElement(QueryClientProvider, { client }, children);
+		};
+	}
+
+	it("refetches everything once the engine answers after a failed poll", async () => {
+		const client = makeClient();
+		const invalidate = vi.spyOn(client, "invalidateQueries");
+		// Twice: the hook sets `retry: 1`, so one rejection is absorbed by the
+		// retry and never reaches an error state.
+		getHealth
+			.mockRejectedValueOnce(new Error("Network error: fetch failed"))
+			.mockRejectedValueOnce(new Error("Network error: fetch failed"));
+		getHealth.mockResolvedValue({ status: "ok", version: "1.0.0", workers: 8 });
+
+		const { result } = renderHook(() => useHealthQuery(), { wrapper: wrapperFor(client) });
+		// The query's own state, not the store's: the store starts disconnected,
+		// so waiting on it would pass before the poll had failed at all.
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(useEngineStore.getState().engineError).toContain("Network error");
+		expect(invalidate).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		await waitFor(() => expect(useEngineStore.getState().isEngineConnected).toBe(true));
+		expect(invalidate).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not refetch on a launch where no poll ever failed", async () => {
+		// The engine coming up is not by itself news: on an ordinary launch every
+		// query is already in flight, and invalidating here would be a second
+		// boot's worth of requests for nothing.
+		const client = makeClient();
+		const invalidate = vi.spyOn(client, "invalidateQueries");
+		getHealth.mockResolvedValue({ status: "ok", version: "1.0.0", workers: 8 });
+
+		const { result } = renderHook(() => useHealthQuery(), { wrapper: wrapperFor(client) });
+		await waitFor(() => expect(useEngineStore.getState().isEngineConnected).toBe(true));
+
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		expect(invalidate).not.toHaveBeenCalled();
+	});
+
+	it("polls hard while disconnected and cheaply once connected", () => {
+		expect(healthPollIntervalMs("error")).toBe(TIMING.HEALTH_RECONNECT_POLL_INTERVAL_MS);
+		expect(healthPollIntervalMs("success")).toBe(TIMING.HEALTH_CHECK_INTERVAL_MS);
+		expect(healthPollIntervalMs("pending")).toBe(TIMING.HEALTH_CHECK_INTERVAL_MS);
+		// The whole point of the fast branch: a launch must not sit disconnected
+		// for the connected cadence after the engine is already serving.
+		expect(TIMING.HEALTH_RECONNECT_POLL_INTERVAL_MS).toBeLessThan(
+			TIMING.HEALTH_CHECK_INTERVAL_MS
+		);
 	});
 });

--- a/app/src/queries/health.ts
+++ b/app/src/queries/health.ts
@@ -11,12 +11,27 @@
  * TanStack Query hook for engine health check with automatic polling.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
 import { useEngineStore } from "@/stores";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { TIMING } from "@/config/timing";
+
+/**
+ * How hard to poll `/health`, given how the last poll went.
+ *
+ * Two speeds, because the disconnected state is no longer only an engine that
+ * crashed: the window now loads while the engine is still starting, so the
+ * first seconds of an ordinary launch are spent here and the poll that ends
+ * them is on the startup path. Extracted so both branches are assertable
+ * without driving a timer.
+ */
+export function healthPollIntervalMs(status: "error" | "pending" | "success"): number {
+	return status === "error"
+		? TIMING.HEALTH_RECONNECT_POLL_INTERVAL_MS
+		: TIMING.HEALTH_CHECK_INTERVAL_MS;
+}
 
 /**
  * Engine health check with automatic polling
@@ -24,11 +39,24 @@ import { TIMING } from "@/config/timing";
  */
 export function useHealthQuery() {
 	const { setEngineConnected, setEngineError, setEngineRecovery } = useEngineStore();
+	const queryClient = useQueryClient();
+
+	/**
+	 * Set by a poll that failed, cleared by the recovery it earns.
+	 *
+	 * An engine that answers is not by itself news - on an ordinary launch every
+	 * query is already in flight and refetching them all would be a second boot's
+	 * worth of requests for nothing. Only a health poll that actually failed
+	 * means there are queries out there holding an error the engine has since
+	 * stopped deserving.
+	 */
+	const sawDisconnect = useRef(false);
 
 	const query = useQuery({
 		queryKey: queryKeys.health.status(),
 		queryFn: () => apiService.getHealth(),
-		refetchInterval: TIMING.HEALTH_CHECK_INTERVAL_MS,
+		// Hard while it is not answering, cheap once it is.
+		refetchInterval: (q) => healthPollIntervalMs(q.state.status),
 		retry: 1,
 		// Don't show stale data for health checks
 		staleTime: 0,
@@ -44,7 +72,23 @@ export function useHealthQuery() {
 			// what its own startup did, including a different engine answering
 			// on the port after a restart.
 			setEngineRecovery(query.data.recovery ?? null);
+
+			// Nothing else in the app notices an engine that arrives late. Every
+			// other query gives up after `shouldRetryQuery`'s two attempts, and a
+			// connection refused by a port nothing is listening on is a plain
+			// `Error`, not an `ApiError` - so collections, runs and config settle
+			// into an error state that no interval revisits. `refetchOnReconnect`
+			// does not cover this: it fires on the browser's online/offline event,
+			// which localhost never changes. Since the window now loads while the
+			// engine is still starting, that state is reachable on an ordinary
+			// launch rather than only on an engine crash. Same move the manual
+			// restart makes (`useEngineRestart`), for the same reason.
+			if (sawDisconnect.current) {
+				sawDisconnect.current = false;
+				void queryClient.invalidateQueries();
+			}
 		} else if (query.isError) {
+			sawDisconnect.current = true;
 			setEngineConnected(false);
 			const errorMessage =
 				query.error instanceof Error ? query.error.message : "Cannot connect to engine";
@@ -58,6 +102,7 @@ export function useHealthQuery() {
 		setEngineConnected,
 		setEngineError,
 		setEngineRecovery,
+		queryClient,
 	]);
 
 	return query;

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1360,11 +1360,24 @@ offset 0 and duplicate every tick already plotted.
 
 ### Health Checking
 
-The app polls `/health` endpoint to verify engine connectivity:
+The app polls `/health` endpoint to verify engine connectivity, at one of two
+speeds depending on whether the last poll succeeded:
 
 ```typescript
-useHealthQuery() // Polls every TIMING.HEALTH_CHECK_INTERVAL_MS (30s)
+useHealthQuery() // TIMING.HEALTH_RECONNECT_POLL_INTERVAL_MS (1s) while erroring,
+                 // TIMING.HEALTH_CHECK_INTERVAL_MS (30s) once connected
 ```
+
+The window loads alongside the engine rather than after it, so an ordinary
+launch spends its first seconds disconnected; polling that state at the 30s
+cadence could leave a launch reading disconnected for half a minute after the
+engine was already serving. A poll that succeeds right after one that failed
+also triggers `queryClient.invalidateQueries()` once - collections, runs and
+config gave up after two retries while the engine was down, a connection
+refused by a closed port is a plain `Error` rather than an `ApiError`, and
+`refetchOnReconnect` only fires on the browser's online/offline event, which
+localhost never changes - so nothing else would ever revisit their error state
+once the engine came back.
 
 **Health Response:**
 ```typescript
@@ -1397,8 +1410,11 @@ than being announced as whichever branch came last.
 ### Engine Startup
 
 The Electron main process (`electron/sidecar.ts`) manages engine lifecycle:
-- Spawns engine process on app start
-- Monitors health via `/health` endpoint
+- Spawns engine process on app start, alongside creating the window rather than
+  before it - first paint does not wait on the engine
+- Monitors health via `/health` endpoint, on a ramped poll that leaves a
+  live-but-slow engine to the renderer's own health poll instead of quitting
+  the app
 - Handles graceful shutdown on app quit
 
 ## Best Practices

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -89,10 +89,14 @@ The `EngineSidecar` class manages the C++ engine process:
 
 - **Binary Resolution**: Locates the engine binary (dev vs production paths)
 - **Process Management**: Spawns, monitors, and terminates the engine process
-- **Health Checking**: Polls `/health` endpoint to verify engine readiness, and
-  gives up the moment the spawned child exits rather than polling out the
-  45-second ceiling against a dead port. The failure carries the exit
-  code/signal and the engine's last stderr lines
+- **Health Checking**: Polls `/health` on a ramped interval - 50ms doubling to a
+  500ms ceiling - so a healthy engine is caught in tens of milliseconds instead
+  of paying a flat poll quantum, while the 45-second budget it spends against a
+  live child is unchanged. It still gives up the moment the spawned child exits
+  rather than spending the rest of that budget against a dead port, and that
+  failure carries the exit code/signal and the engine's last stderr lines. A
+  child still alive when the budget runs out raises `EngineNotReadyError`
+  instead, which the launch path treats as "not yet" rather than as fatal
 - **Build guidance**: A missing binary names `python build.py -e` and
   `docs/building.md` - the single build entry point, not per-platform scripts
 - **Port Management**: Checks if port 9876 is available or if engine is already running

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,9 @@ See [Engine API Reference](engine/api-reference.md) for complete endpoint docume
 
 The Engine runs as a separate process managed by the Electron main process:
 
-1. **Engine Startup**: Electron spawns the `vayu-engine` binary on app launch
+1. **Engine Startup**: Electron spawns the `vayu-engine` binary on app launch,
+   alongside creating the window rather than before it - first paint does not
+   wait on the engine
 2. **Health Monitoring**: Manager polls `/health` endpoint to verify connectivity
 3. **Graceful Shutdown**: Engine is stopped when Electron app quits
 
@@ -186,12 +188,24 @@ one app instance may drive it:
   report itself listening. It never falls back to another port: the app and CLI
   both address the engine at a fixed one, so an engine on a different port would
   be a quieter failure than no engine at all.
-- **A startup that cannot succeed fails immediately.** The readiness poll allows
-  45 seconds, but it watches the spawned child as well as the port: an engine
-  that exits first - a missing shared library, a lock it could not acquire -
-  fails the launch at once, naming the exit code or signal and the engine's last
-  stderr lines. The window is created after startup, so the ceiling would
-  otherwise be 45 seconds of an empty screen.
+- **A startup that cannot succeed fails immediately; one that is merely slow
+  does not.** The readiness poll spends a 45-second budget watching the spawned
+  child as well as the port: an engine that exits first - a missing shared
+  library, a lock it could not acquire - fails the launch at once, naming the
+  exit code or signal and the engine's last stderr lines. An engine still alive
+  when that budget runs out is not killed for it: the launch path logs
+  `EngineNotReadyError` and leaves it to the renderer's health poll, which
+  adopts it the moment it answers. Quitting there used to end launches that
+  were seconds from succeeding.
+- **The window is created alongside the engine, not after it.** First paint must
+  not wait on a process whose own startup housekeeping is allowed to run for 45
+  seconds - `db.init()` does orphan reconciliation, inbox cleanup and a
+  page-reclaim rewrite before the engine listens at all, and that whole window
+  used to be blank screen. Nothing is lost by overlapping them: the renderer
+  tolerates an absent engine by design, polling `/health` itself and rendering
+  the disconnected state until one answers. MCP still starts after the window,
+  for its own reason - it reads a config file, and a corrupt one must not cost
+  the user a window.
 
 **Development vs Production:**
 - **Development**: Engine binary at `engine/build/vayu-engine`

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -135,8 +135,9 @@ Three things worth knowing about where it sits:
   it found it.
 
 The outcome is logged at info level (`Reclaimed N KB of freed database pages`), because the cost
-is paid on the startup path - `db.init()` returns before `/health` answers, and the app gives the
-engine 45 seconds to come up. A rewrite slow enough to matter is one this line explains.
+is paid on the startup path - `db.init()` returns before `/health` answers, and the app's readiness
+poll budgets 45 seconds against it before handing the engine to the renderer's own health poll. A
+rewrite slow enough to matter is one this line explains.
 Best-effort like the sweeps before it: a failure is a warning, never a daemon that will not start.
 `auto_vacuum` was rejected as the alternative - switching an existing database's mode requires a
 full `VACUUM` anyway, and it changes page bookkeeping for every write thereafter.


### PR DESCRIPTION
## Description

First paint no longer waits on the engine.

`main.ts` awaited `startEngine()` before `createWindow()`, so no BrowserWindow existed and the renderer bundle had not begun loading until the spawned engine answered `/health`. Three costs compounded: `waitForEngine` probed immediately after `spawn()` (which necessarily misses - nothing is listening microseconds later) and then slept a flat `500ms`, so every launch paid one full quantum; the engine answers `/health` only after `db.init()` completes, which runs orphan reconciliation, spec-binding repair, inbox cleanup, run pruning and a guarded page-reclaim rewrite, all of it in front of a blank screen; and past the 45s ceiling `showErrorBox` + `app.quit()` killed a healthy engine that was about to come up.

**Root cause and approach.** The serialization was never load-bearing. The renderer does not need the engine to boot: it polls `/health` over HTTP itself and the Dock renders the disconnected state until one answers. So the window is created alongside the engine, the readiness poll ramps (50ms doubling to 500ms) so a healthy engine is caught in tens of milliseconds, and a budget spent against a *live* child raises `EngineNotReadyError`, which the launch path treats as "not yet" rather than as fatal. A child that actually died is unchanged - still fatal, still naming the exit code/signal and the stderr tail.

The ceiling is now spent as a budget of accumulated waiting rather than as a fixed attempt count, which keeps the 45s figure exactly where it was. That matters because it is not arbitrary: `engine/src/db/database.cpp` explicitly prices its page-reclaim rewrite against "the app gives the engine 45 seconds to answer `/health`".

**The alternative I rejected**, and why: ramping the poll alone would have satisfied the first acceptance criterion on its own and touched one function. It leaves both of the real costs standing - the blank screen is `db.init()`'s duration, not the poll's granularity, and the fatal-for-healthy quit is independent of either. Reordering is the fix; the ramp is worth keeping because it also removes the per-launch quantum.

**One consequence had to be fixed with it, or the reorder would have been a regression.** Moving the window ahead of the engine makes "the engine is not there yet" an ordinary launch condition rather than only a crash, and nothing in the renderer was built for that. Every query other than the health poll gives up after `shouldRetryQuery`'s two attempts, and a connection refused by a port nothing is listening on is a plain `Error`, not an `ApiError` - so collections, runs and config would settle into an error state that nothing revisits. `refetchOnReconnect` does not cover it: it fires on the browser's online/offline event, which localhost never changes. Left alone, this would have traded a blank screen for a broken one. So a health poll that succeeds after one that failed invalidates once (the same move `useEngineRestart` already makes), guarded on an actual failure so an ordinary launch does not pay a second boot's worth of requests; and `/health` is polled every 1s while erroring, 30s once connected, because the poll that ends the disconnected state is now on the startup path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check`, plus `mkdocs build --strict`.

- **App suite: 548 files / 6003 tests passing.** Baseline on the base commit `e1c578a` was 547 / 5994, all green - no pre-existing failures to report.
- Type-check, ESLint (zero warnings) and `format:check` clean; `mkdocs build --strict` builds.
- Engine untouched, so the C++ suite is not implicated: no file under `engine/` is in this diff.

New coverage (9 tests):

- `electron/sidecar.test.ts` - the ramp spends one 50ms step rather than a 500ms quantum for a fast engine; the interval doubles `[50,100,200,400]` and pins at 500 with the total inside `[45000, 45500)`; and slow-versus-dead is separated by error *type*, not by message, since the launch path branches on it. The pre-existing "waits out the ceiling for an engine that is merely slow" case was updated to the new contract rather than deleted.
- `src/queries/health.test.ts` - recovery refetches, and an ordinary launch where nothing failed does not. **Both mutation-checked**: dropping the `sawDisconnect` guard fails the second, removing the invalidation fails the first. Plus both branches of the two-speed interval.
- `electron/startup-order.test.ts` (new) - `main.ts` creates windows and starts the engine at import time, so its sequencing can only be read; this follows the existing characterization pattern in `renderer-recovery.test.ts` / `quit-shutdown.test.ts`. Asserts the window precedes the engine wait, that MCP still starts after the window (the original ordering rule, which still holds for its own reason), and that the early return sits between the `EngineNotReadyError` check and `app.quit()`.

Not verified by launching the packaged app - this environment is headless, so the startup timing itself is argued from the code and the sidecar tests rather than measured. #1162 is the issue that would measure it per platform.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1144

Docs moved in the same commit: `docs/architecture.md` (the ordering decision and its rationale - the issue's third acceptance criterion), `docs/app/architecture.md` (ramped poll, non-fatal slow engine), `docs/app/api-integration.md` (two-speed health poll, invalidate-on-recovery), and `docs/engine/db-schema.md`, which independently hardcoded the same 45s figure and its now-obsolete consequence.

### Deliberate deviation from the issue spec

The issue's preferred pathway asks for an "engine starting" renderer state. This PR reuses the existing disconnected state (`Dock.tsx`'s `EngineStatus` pill plus its `engineError` tooltip) rather than adding a new one, which meets the acceptance criterion literally - the user sees state, not nothing, and the app never quits - but leaves one signal carrying two meanings: on a launch whose engine takes over about a second, the user briefly sees an affordance written to describe a failure. Splitting that into a real third state touches the engine store, the health query, `Dock.tsx` and the design-system status tokens, which is a wider change than this fix needs and is worth reviewing on its own. Filed as #1164 with its own acceptance criteria rather than left as a "later" with no issue number behind it.