### PR TITLE
ci(perf): a per-platform measurement workflow on the existing runners - #1162

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -136,7 +136,7 @@ jobs:
           # an older vcpkg while resolving against the new manifest baseline,
           # which is the exact divergence the second half of this step rejects.
           files=(release.yml pr-tests.yml codeql.yml cache-warm.yml \
-                 sanitizers.yml engine-tidy-scan.yml)
+                 sanitizers.yml engine-tidy-scan.yml perf-measure.yml)
           keys=() commits=()
           for f in "${files[@]}"; do
             p=".github/workflows/$f"

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -161,9 +161,17 @@ jobs:
         working-directory: app
         run: pnpm run build
 
-      # Go ships with all three runner images, but no workflow here has used it
-      # before - so print the version, which turns a missing toolchain into a
-      # named failure rather than a confusing `go: command not found` later.
+      # Not left to the runner image: the first run of this workflow died here
+      # with `go: command not found` on macos-latest. Go is documented as
+      # preinstalled on all three images and is not actually on PATH for every
+      # one of them, and the mock server is the load phase's target - without it
+      # there is no measurement at all. `stable` rather than a pin because
+      # mock-server.go is plain net/http with no go.mod and no version floor.
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
       - name: Build the mock server
         shell: bash
         run: |

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -153,11 +153,12 @@ jobs:
         working-directory: app
         run: pnpm install --frozen-lockfile
 
-      - name: Build the app
+      # The renderer only. The startup harness loads dist/ into a window of its
+      # own and never touches the compiled main process, so electron:compile
+      # would be build time nothing here reads.
+      - name: Build the renderer
         working-directory: app
-        run: |
-          pnpm run electron:compile
-          pnpm run build
+        run: pnpm run build
 
       # Go ships with all three runner images, but no workflow here has used it
       # before - so print the version, which turns a missing toolchain into a

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -1,0 +1,210 @@
+name: Perf Measure
+
+# Per-platform performance measurement for the #1143 program (filed as #1162).
+#
+# The 2026-08-30 sweep could only measure Linux, so every per-platform magnitude
+# in that program's sub-issues is code-derived. This runs the same method on the
+# Windows and macOS runners the repo already pays for, and doubles as the
+# standing harness #1143's exit criterion needs ("startup re-measured after the
+# #1144-#1149 cluster lands, per platform").
+#
+# It measures; it does not gate. There are no thresholds and nothing here fails
+# a PR on a number - humans compare runs. Per-PR regression gating is a later
+# decision, once several weeks of baseline exist.
+#
+# Deliberately out of scope, so nobody looks for it here:
+#   - Deep power measurement for #1161's idle-timer question (powercfg /energy,
+#     ETW). Shared CI runners cannot measure it meaningfully; that half of #1161
+#     stays honestly unmeasured.
+#   - The CURLSSLOPT_NATIVE_CA handshake delta - it needs a TLS target, and the
+#     mock server has no TLS mode yet. Phase 2.
+
+on:
+  schedule:
+    # Weekly, Monday. 14:00 UTC keeps clear of the other crons competing for the
+    # runner pool: cache-warm and codeql at 06:00, sanitizers 09:00, tidy 11:00.
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+  # A measurement workflow has no business running on ordinary PRs, and this
+  # trigger does not: it is scoped to this workflow's own machinery. Without it
+  # the first evidence that any of this works arrives after merge, on a cron, as
+  # a red master - a workflow cannot be dispatched before it exists on the
+  # default branch. Same pattern, same reason, as sanitizers.yml and
+  # engine-tidy-scan.yml.
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/perf-measure.yml'
+      - 'scripts/perf/**'
+
+concurrency:
+  # Not cancel-in-progress: a cancelled measurement is a wasted half-hour of
+  # runner time that measured nothing (cache-warm.yml makes the same call).
+  group: perf-measure-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # The engine build dominates: pr-tests.yml budgets 90 for build + ctest, and
+    # this trades ctest for ~6 min of sampling. A runaway guard, not a budget.
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            preset: linux-prod
+            engine: engine/build-release/vayu-engine
+            mock: ./mock-server
+          - os: windows-latest
+            preset: windows-prod
+            engine: engine/build-release/vayu-engine.exe
+            mock: ./mock-server.exe
+          - os: macos-latest
+            preset: macos-prod
+            engine: engine/build-release/vayu-engine
+            mock: ./mock-server
+    env:
+      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
+      SCCACHE_GHA_ENABLED: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build \
+            build-essential \
+            pkg-config \
+            ca-certificates \
+            autoconf \
+            autoconf-archive \
+            automake \
+            libtool \
+            xvfb
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          command -v ninja || brew install ninja
+          for pkg in autoconf autoconf-archive automake libtool; do
+            brew list --formula "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
+
+      - name: Cache vcpkg compiled packages
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.vcpkg-archives
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('engine/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ hashFiles('engine/vcpkg.json') }}-
+            vcpkg-${{ runner.os }}-
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+          vcpkgGitCommitId: '${{ env.VCPKG_COMMIT }}'
+          vcpkgJsonGlob: 'engine/vcpkg.json'
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Configure sccache compiler launcher
+        shell: bash
+        run: |
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+
+      # The production preset, not dev. A debug engine's CPU figures are
+      # inflated - the caveat the sweep had to carry, and the reason this exists.
+      - name: Build engine (production preset)
+        uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
+          configurePreset: ${{ matrix.preset }}
+          buildPreset: ${{ matrix.preset }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the app
+        working-directory: app
+        run: |
+          pnpm run electron:compile
+          pnpm run build
+
+      # Go ships with all three runner images, but no workflow here has used it
+      # before - so print the version, which turns a missing toolchain into a
+      # named failure rather than a confusing `go: command not found` later.
+      - name: Build the mock server
+        shell: bash
+        run: |
+          go version
+          go build -o "${{ matrix.mock }}" scripts/test/mock-server.go
+
+      - name: Measure the engine
+        shell: bash
+        run: |
+          python scripts/perf/measure_engine.py \
+            --engine "${{ matrix.engine }}" \
+            --mock "${{ matrix.mock }}" \
+            --data-dir "$RUNNER_TEMP/perf-data" \
+            --log-dir perf-logs \
+            --out perf-engine.json
+
+      - name: Measure the app
+        shell: bash
+        env:
+          # xvfb on the Linux runner, which has no display; the Windows and
+          # macOS runners have a desktop session and launch the app directly.
+          LAUNCHER: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }}
+        run: $LAUNCHER node scripts/perf/measure-app.mjs --out perf-app.json
+
+      - name: Summarize
+        if: always()
+        shell: bash
+        run: |
+          python scripts/perf/summarize.py \
+            --os "${{ matrix.os }}" \
+            --engine-json perf-engine.json \
+            --app-json perf-app.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the measurements
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-measure-${{ matrix.os }}
+          path: |
+            perf-engine.json
+            perf-app.json
+            perf-logs/
+          # The child logs are why perf-logs/ is here: when a leg fails, the
+          # engine's own stdout is the only diagnostic the runner keeps.
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -8,16 +8,17 @@ name: Perf Measure
 # standing harness #1143's exit criterion needs ("startup re-measured after the
 # #1144-#1149 cluster lands, per platform").
 #
-# It measures; it does not gate. There are no thresholds and nothing here fails
-# a PR on a number - humans compare runs. Per-PR regression gating is a later
-# decision, once several weeks of baseline exist.
+# It measures; it does not gate. There are no thresholds, nothing here fails a
+# build on a number, and no ordinary pull request runs it - humans compare runs.
 #
 # Deliberately out of scope, so nobody looks for it here:
 #   - Deep power measurement for #1161's idle-timer question (powercfg /energy,
 #     ETW). Shared CI runners cannot measure it meaningfully; that half of #1161
-#     stays honestly unmeasured.
-#   - The CURLSSLOPT_NATIVE_CA handshake delta - it needs a TLS target, and the
-#     mock server has no TLS mode yet. Phase 2.
+#     stays honestly unmeasured, and #1161 says so.
+#   - The CURLSSLOPT_NATIVE_CA handshake delta - it needs a TLS target and the
+#     mock server has no TLS mode, which is where #1143 records it.
+#   - The real app's end-to-end cold start, which cannot be launched unpackaged
+#     (#1165). The startup figure here is the renderer graph alone.
 
 on:
   schedule:

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -203,9 +203,17 @@ jobs:
         shell: bash
         working-directory: app
         run: |
-          sandbox="$(dirname "$(node -p "require('electron')")")/chrome-sandbox"
+          # tail -n 1 because requiring electron can print "Downloading Electron
+          # binary..." to stdout ahead of the path, and the whole two-line
+          # capture then gets handed to chown as one filename.
+          sandbox="$(dirname "$(node -p "require('electron')" | tail -n 1)")/chrome-sandbox"
+          if [ ! -f "$sandbox" ]; then
+            echo "::warning::no chrome-sandbox at $sandbox - the startup leg will report unavailable"
+            exit 0
+          fi
           sudo chown root:root "$sandbox"
           sudo chmod 4755 "$sandbox"
+          ls -l "$sandbox"
 
       - name: Measure the app
         shell: bash

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -191,6 +191,22 @@ jobs:
             --log-dir perf-logs \
             --out perf-engine.json
 
+      # Electron ships its SUID sandbox helper without the ownership it needs,
+      # and npm cannot set it - so on the Linux runner every launch aborts with
+      # "The SUID sandbox helper binary was found, but is not configured
+      # correctly", which cost this workflow its Linux startup figure on the
+      # first green run. This is the remedy that error itself prescribes, and
+      # it keeps the sandbox: --no-sandbox would also work and would be turning
+      # off a security boundary to make a measurement convenient.
+      - name: Configure Electron's sandbox helper (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        working-directory: app
+        run: |
+          sandbox="$(dirname "$(node -p "require('electron')")")/chrome-sandbox"
+          sudo chown root:root "$sandbox"
+          sudo chmod 4755 "$sandbox"
+
       - name: Measure the app
         shell: bash
         env:

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -40,10 +40,13 @@ on:
       - 'scripts/perf/**'
 
 concurrency:
-  # Not cancel-in-progress: a cancelled measurement is a wasted half-hour of
-  # runner time that measured nothing (cache-warm.yml makes the same call).
   group: perf-measure-${{ github.ref }}
-  cancel-in-progress: false
+  # A cron or dispatch run is data and is never thrown away half-taken
+  # (cache-warm.yml makes the same call). A pull_request run is only proving
+  # this machinery still works, and only the newest commit's answer counts -
+  # left uncancelled, every push during a fix cycle stacks another three-OS
+  # engine build alongside the ones already running.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -250,6 +250,27 @@ guard-proved values are no-ops without it.
   missing module in `resolve.test.ts` passed CI while breaking
   `python build.py --dev`
 
+## Measuring what a build costs
+
+`.github/workflows/perf-measure.yml` records the built renderer's entry-chunk
+size, its total `dist/` size, and how long a window takes to become showable
+with that bundle in it - per platform, weekly and on demand. It is a
+measurement, not a gate: nothing there fails a build on a number.
+
+`scripts/perf/measure-app.mjs` is what produces those figures and runs locally
+the same way, against an existing `pnpm run build`:
+
+```bash
+node scripts/perf/measure-app.mjs --out perf-app.json   # from the repo root
+```
+
+The startup figure comes from `scripts/perf/startup-harness.cjs`, a small
+Electron main script that loads `app/dist/index.html` into one window - not the
+Vayu app, which cannot start unpackaged (it resolves its engine under
+`process.resourcesPath`). So the number covers the renderer's module graph and
+its render-blocking fetches, and not the main process's own startup work. That
+file's header states the boundary in full; read it before quoting the number.
+
 ## Vite Configuration
 
 Key settings in `vite.config.ts`:

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -512,6 +512,32 @@ For load testing this class of target on this machine:
 | `dbSynchronous` | 0 (Off) | Already optimal by default |
 | measurement method | standalone engine | Worth ~9% versus running through the app |
 
+## Per-platform measurement in CI
+
+The numbers above are throughput on one machine. What the engine *costs* while
+it runs - resident memory, threads and CPU at idle, under load, and in the
+minute after a run finishes - is measured per platform by
+[`.github/workflows/perf-measure.yml`](https://github.com/athrvk/vayu/blob/master/.github/workflows/perf-measure.yml),
+weekly and on demand, on the same Windows, macOS and Linux runners the test
+matrix uses. It is the source for those figures, and the standing harness the
+app-performance program (#1143) re-runs to compare before and after.
+
+It builds the engine on the `-prod` preset, so its CPU figures carry no
+debug-build caveat, spawns it with the same `--verbose 1` the app's sidecar
+uses, then samples through a 60 s idle phase, one 8-VU 30 s
+`constant_concurrency` run against the same `scripts/test/mock-server.go` used
+here, and 60 s of post-run retention. Each run writes a JSON artifact per OS and
+a table to the run summary. It measures rather than gates: there are no
+thresholds, and nothing in it fails a build on a number. The sampling itself
+lives in `scripts/perf/measure_engine.py` and runs the same way locally:
+
+```bash
+go build -o mock-server scripts/test/mock-server.go
+python scripts/perf/measure_engine.py \
+    --engine engine/build-release/vayu-engine \
+    --mock ./mock-server --out perf-engine.json
+```
+
 ## Reproduce it
 
 ```bash

--- a/scripts/perf/measure-app.mjs
+++ b/scripts/perf/measure-app.mjs
@@ -4,9 +4,9 @@
  * tasklist-spawn cost of the built Electron app.
  *
  * Written for `.github/workflows/perf-measure.yml` (issue #1162), which runs
- * this after `pnpm run electron:compile && pnpm run build` in `app/`. Output
- * is JSON matching the exact shape `scripts/perf/summarize.py`'s `app_rows()`
- * reads - that function is the contract, this script is what fills it.
+ * this after `pnpm run build` in `app/`. Output is JSON matching the exact
+ * shape `scripts/perf/summarize.py`'s `app_rows()` reads - that function is
+ * the contract, this script is what fills it.
  *
  * Three independent measurements, none of which needs the other two to run:
  *
@@ -24,7 +24,7 @@
  *
  * Deliberately does not:
  *   - Measure a packaged installer, or the real app's end-to-end cold start.
- *     Both need electron-builder in this workflow; filed separately.
+ *     Both need electron-builder in this workflow - #1165.
  *   - Retry a failed launch. A flaky Electron launch on a shared runner is
  *     recorded as `"method": "unavailable"` with the actual reason in `note`,
  *     not smoothed over by trying again.

--- a/scripts/perf/measure-app.mjs
+++ b/scripts/perf/measure-app.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+/**
+ * Measure the renderer bundle, cold-start time and (Windows only) the
+ * tasklist-spawn cost of the built Electron app.
+ *
+ * Written for `.github/workflows/perf-measure.yml` (issue #1162), which runs
+ * this after `pnpm run electron:compile && pnpm run build` in `app/`. Output
+ * is JSON matching the exact shape `scripts/perf/summarize.py`'s `app_rows()`
+ * reads - that function is the contract, this script is what fills it.
+ *
+ * Three independent measurements, none of which needs the other two to run:
+ *
+ *   - bundle: reads `app/dist/index.html` for the entry module chunk Vite
+ *     wrote (Rolldown hashes the name, so it can only be discovered by
+ *     parsing the HTML, never hardcoded) and totals `app/dist`.
+ *   - startup: runs `startup-harness.cjs` under Electron 3 times empty and 3
+ *     times holding the built renderer, and reports both medians plus the
+ *     delta between them - the renderer module graph's cost. Read that file's
+ *     header for why this is a harness rather than the real app, and for what
+ *     the number therefore does not include.
+ *   - tasklistSpawn: on Windows only, times the synchronous `tasklist` spawn
+ *     `app/electron/sidecar.ts` pays on every boot to verify an adopted
+ *     engine's PID - issue #1148's missing number.
+ *
+ * Deliberately does not:
+ *   - Measure a packaged installer, or the real app's end-to-end cold start.
+ *     Both need electron-builder in this workflow; filed separately.
+ *   - Retry a failed launch. A flaky Electron launch on a shared runner is
+ *     recorded as `"method": "unavailable"` with the actual reason in `note`,
+ *     not smoothed over by trying again.
+ *   - Add `--no-sandbox` or any other flag to make a failing launch pass. A
+ *     launch failure is a real finding about that environment, not something
+ *     to work around.
+ *
+ * Stdlib only, no dependencies - same reasoning as `measure_engine.py`.
+ *
+ * Usage:
+ *   node scripts/perf/measure-app.mjs --out perf-app.json
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { spawn, execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// Must match startup-harness.cjs's HARNESS_MARKER. Both files are in this
+// directory and change together; a rename that missed one would time out every
+// launch and be reported as an unavailable startup leg rather than a silent
+// zero.
+const HARNESS_MARKER = "[perf] harness";
+const HARNESS_SCRIPT = "scripts/perf/startup-harness.cjs";
+
+const STARTUP_LAUNCH_COUNT = 3;
+const LAUNCH_TIMEOUT_MS = 90_000;
+// Same grace the sidecar itself gives the engine before SIGKILL
+// (ENGINE_GRACEFUL_EXIT_TIMEOUT_MS in app/electron/constants.ts).
+const TERMINATE_GRACE_MS = 5_000;
+const STDERR_TAIL_LINES = 20;
+const TASKLIST_ITERATIONS = 20;
+
+function fail(message) {
+	console.error(`[perf] ${message}`);
+	process.exit(2);
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function median(values) {
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+// --------------------------------------------------------------------------
+// (a) bundle
+// --------------------------------------------------------------------------
+
+/** Find the entry `<script type="module" src="...">` in index.html's markup. */
+function findEntryModuleSrc(html) {
+	const scriptTagRe = /<script\b([^>]*)>/gi;
+	let match;
+	while ((match = scriptTagRe.exec(html)) !== null) {
+		const attrs = match[1];
+		if (!/\btype\s*=\s*["']module["']/i.test(attrs)) continue;
+		const srcMatch = /\bsrc\s*=\s*["']([^"']+)["']/i.exec(attrs);
+		if (srcMatch) return srcMatch[1];
+	}
+	return null;
+}
+
+/** `index.html`'s script src, resolved against `app/dist` (base is "./"). */
+function resolveDistAsset(distDir, src) {
+	const withoutQuery = src.split(/[?#]/)[0];
+	const relative = withoutQuery.replace(/^\.?\//, "");
+	return path.join(distDir, relative);
+}
+
+/** Total bytes and file count of everything under `dir`, recursively. */
+function walkDir(dir) {
+	let totalBytes = 0;
+	let fileCount = 0;
+	const stack = [dir];
+	while (stack.length > 0) {
+		const current = stack.pop();
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const full = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(full);
+			} else if (entry.isFile()) {
+				fileCount += 1;
+				totalBytes += statSync(full).size;
+			}
+		}
+	}
+	return { totalBytes, fileCount };
+}
+
+function measureBundle(repoRoot) {
+	const distDir = path.join(repoRoot, "app", "dist");
+	const indexPath = path.join(distDir, "index.html");
+
+	if (!existsSync(indexPath)) {
+		fail(
+			`${indexPath} not found - build the renderer first (\`pnpm run build\` in app/) ` +
+				`before measuring the bundle.`
+		);
+	}
+
+	const html = readFileSync(indexPath, "utf8");
+	const entrySrc = findEntryModuleSrc(html);
+	if (!entrySrc) {
+		fail(`no <script type="module" src="..."> entry chunk found in ${indexPath}`);
+	}
+
+	const entryPath = resolveDistAsset(distDir, entrySrc);
+	if (!existsSync(entryPath)) {
+		fail(`entry chunk named by ${indexPath} does not exist on disk: ${entryPath}`);
+	}
+
+	const entryChunkBytes = statSync(entryPath).size;
+	const { totalBytes, fileCount } = walkDir(distDir);
+
+	return {
+		entryChunkName: path.basename(entryPath),
+		entryChunkBytes,
+		totalDistBytes: totalBytes,
+		fileCount,
+	};
+}
+
+// --------------------------------------------------------------------------
+// (b) startup
+// --------------------------------------------------------------------------
+
+/**
+ * The local Electron executable.
+ *
+ * Resolved through the `electron` package, whose main export is the absolute
+ * path to the binary, rather than through `app/node_modules/.bin/electron`.
+ * The `.bin` shim on Windows is `electron.cmd`, and since Node's fix for
+ * CVE-2024-27980 `child_process.spawn` refuses to run a `.cmd` without
+ * `shell: true` - so the shim path would have failed on the one runner whose
+ * numbers this workflow exists to get. The package export is a real
+ * executable (`electron.exe` there), which spawn takes directly.
+ */
+function resolveElectronBinary(repoRoot) {
+	const requireFromApp = createRequire(path.join(repoRoot, "app", "package.json"));
+	try {
+		return requireFromApp("electron");
+	} catch {
+		return null;
+	}
+}
+
+/** Ask nicely, then insist - and wait for the exit either way. */
+async function terminateAndWait(child, exited) {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	child.kill("SIGTERM");
+	const settledInTime = await Promise.race([
+		exited.then(() => true),
+		sleep(TERMINATE_GRACE_MS).then(() => false),
+	]);
+	if (!settledInTime && child.exitCode === null && child.signalCode === null) {
+		child.kill("SIGKILL");
+	}
+	await exited;
+}
+
+/**
+ * Launch the built app once, watch stdout for the startup marker, and tear
+ * the process down before returning either way.
+ *
+ * Resolves to `{ ok: true, readyToShowMs }` or `{ ok: false, reason }` -
+ * never rejects and never throws, so a bad launch is data, not an exception.
+ */
+async function launchOnce(electronBin, repoRoot, harnessArgs) {
+	const child = spawn(electronBin, [HARNESS_SCRIPT, ...harnessArgs], {
+		cwd: repoRoot,
+		env: process.env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	const stderrTail = [];
+	child.stderr.setEncoding("utf8");
+	child.stderr.on("data", (chunk) => {
+		for (const line of chunk.split("\n")) {
+			if (!line.trim()) continue;
+			stderrTail.push(line);
+			if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
+		}
+	});
+
+	const exited = new Promise((resolve) => {
+		child.on("exit", (code, signal) => resolve({ code, signal }));
+	});
+	let spawnError = null;
+	child.on("error", (err) => {
+		spawnError = err.message;
+	});
+
+	const markerFound = new Promise((resolve) => {
+		let buffered = "";
+		child.stdout.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			buffered += chunk;
+			let newlineAt;
+			while ((newlineAt = buffered.indexOf("\n")) !== -1) {
+				const line = buffered.slice(0, newlineAt);
+				buffered = buffered.slice(newlineAt + 1);
+				const markerAt = line.indexOf(HARNESS_MARKER);
+				if (markerAt === -1) continue;
+				try {
+					const payload = JSON.parse(line.slice(markerAt + HARNESS_MARKER.length).trim());
+					if (typeof payload.readyToShowMs === "number") {
+						resolve({ ok: true, readyToShowMs: payload.readyToShowMs });
+						return;
+					}
+				} catch {
+					// Malformed marker line - keep reading rather than failing on it;
+					// the timeout or exit below is the real backstop.
+				}
+			}
+		});
+	});
+
+	const exitedAsFailure = exited.then(({ code, signal }) => ({
+		ok: false,
+		reason: spawnError
+			? `failed to spawn: ${spawnError}`
+			: `exited (code ${code}, signal ${signal}) before logging the startup marker`,
+	}));
+	const timedOut = sleep(LAUNCH_TIMEOUT_MS).then(() => ({
+		ok: false,
+		reason: `timed out after ${LAUNCH_TIMEOUT_MS}ms waiting for the startup marker`,
+	}));
+
+	let result = await Promise.race([markerFound, exitedAsFailure, timedOut]);
+	if (!result.ok && stderrTail.length > 0) {
+		result = { ...result, reason: `${result.reason} - stderr tail: ${stderrTail.join(" | ")}` };
+	}
+
+	await terminateAndWait(child, exited);
+	return result;
+}
+
+/** Run the harness `STARTUP_LAUNCH_COUNT` times in one mode. */
+async function timeHarness(electronBin, repoRoot, harnessArgs, label) {
+	const launches = [];
+	for (let i = 0; i < STARTUP_LAUNCH_COUNT; i++) {
+		const result = await launchOnce(electronBin, repoRoot, harnessArgs);
+		if (!result.ok) {
+			return { ok: false, reason: `${label} launch ${i + 1}/${STARTUP_LAUNCH_COUNT}: ${result.reason}` };
+		}
+		launches.push(result.readyToShowMs);
+	}
+	return { ok: true, launches, medianMs: median(launches) };
+}
+
+/**
+ * Time an empty window, then the same window holding the built renderer.
+ *
+ * The delta is what the renderer's module graph costs, which is the sweep's
+ * method and the number #1146/#1147 move. The absolute renderer figure is not a
+ * user's cold-start time - it excludes everything the real main process does
+ * before a window exists - so it is reported alongside the baseline rather than
+ * on its own, and `method` says which measurement this is.
+ */
+async function measureStartup(repoRoot) {
+	const unavailable = (note) => ({
+		method: "unavailable",
+		launches: [],
+		medianMs: null,
+		blankMedianMs: null,
+		rendererGraphMs: null,
+		note,
+	});
+
+	const electronBin = resolveElectronBinary(repoRoot);
+	if (!electronBin || !existsSync(electronBin)) {
+		return unavailable(
+			`electron binary not resolvable from app/ (${electronBin ?? "package not found"}) - was \`pnpm install\` run there?`
+		);
+	}
+
+	const entry = path.join(repoRoot, "app", "dist", "index.html");
+	const blank = await timeHarness(electronBin, repoRoot, ["--mode", "blank"], "blank");
+	if (!blank.ok) return unavailable(blank.reason);
+
+	const renderer = await timeHarness(
+		electronBin,
+		repoRoot,
+		["--mode", "renderer", "--entry", entry],
+		"renderer"
+	);
+	if (!renderer.ok) return unavailable(renderer.reason);
+
+	return {
+		method: "renderer-graph-delta",
+		launches: renderer.launches,
+		medianMs: renderer.medianMs,
+		blankMedianMs: blank.medianMs,
+		rendererGraphMs: renderer.medianMs - blank.medianMs,
+		note: null,
+	};
+}
+
+// --------------------------------------------------------------------------
+// (c) tasklistSpawn - Windows only
+// --------------------------------------------------------------------------
+
+/**
+ * Time the exact `tasklist` spawn `app/electron/sidecar.ts` (lines ~120-122)
+ * makes to verify an adopted engine's PID. Mirrored command and options, this
+ * process's own pid standing in for the engine's - the number that matters is
+ * what a synchronous `execSync` spawn costs on this machine, not which PID it
+ * asks about.
+ */
+function measureTasklistSpawn() {
+	if (process.platform !== "win32") return null;
+
+	const timings = [];
+	for (let i = 0; i < TASKLIST_ITERATIONS; i++) {
+		const started = performance.now();
+		execSync(`tasklist /FI "PID eq ${process.pid}" /FO CSV /NH`, {
+			encoding: "utf-8",
+		});
+		timings.push(performance.now() - started);
+	}
+
+	return {
+		iterations: TASKLIST_ITERATIONS,
+		medianMs: median(timings),
+		meanMs: timings.reduce((sum, t) => sum + t, 0) / timings.length,
+	};
+}
+
+// --------------------------------------------------------------------------
+// CLI
+// --------------------------------------------------------------------------
+
+function parseArgs(argv) {
+	let out = null;
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--out") out = argv[++i];
+	}
+	if (!out) {
+		console.error("[perf] usage: node scripts/perf/measure-app.mjs --out <path>");
+		process.exit(2);
+	}
+	return { out };
+}
+
+async function main() {
+	const { out } = parseArgs(process.argv.slice(2));
+	// cwd is the repo root - see the workflow step that invokes this script.
+	const repoRoot = process.cwd();
+
+	const bundle = measureBundle(repoRoot);
+	const startup = await measureStartup(repoRoot);
+	const tasklistSpawn = measureTasklistSpawn();
+
+	const result = {
+		schema: 1,
+		os: process.platform,
+		bundle,
+		startup,
+		tasklistSpawn,
+	};
+
+	writeFileSync(out, JSON.stringify(result, null, 2) + "\n", "utf8");
+	console.log(`[perf] wrote ${out}`);
+}
+
+main().catch((err) => {
+	console.error(`[perf] measurement failed: ${err instanceof Error ? err.stack : err}`);
+	process.exit(1);
+});

--- a/scripts/perf/measure_engine.py
+++ b/scripts/perf/measure_engine.py
@@ -161,7 +161,7 @@ def _parse_ps_cpu_time(value: str) -> float:
     return days * 86400.0 + seconds
 
 
-def _sample_darwin(pid: int) -> tuple[int, int, float]:
+def _sample_darwin(pid: int) -> tuple[int, Optional[int], float]:
     """`ps` for RSS and CPU time, `ps -M` for the thread count macOS ps has no
     column for (there is no `nlwp` outside Linux)."""
     proc = subprocess.run(
@@ -173,7 +173,7 @@ def _sample_darwin(pid: int) -> tuple[int, int, float]:
     line = proc.stdout.strip()
     if proc.returncode != 0 or not line:
         raise MeasurementError(f"engine pid {pid} is gone (ps rc={proc.returncode})")
-    rss_kb, _, cpu_time = line.split(None, 1)
+    rss_kb, cpu_time = line.split(None, 1)
 
     return int(rss_kb) * 1024, _darwin_thread_count(pid), _parse_ps_cpu_time(cpu_time.strip())
 
@@ -234,7 +234,7 @@ def _sample_windows(pid: int) -> tuple[int, int, float]:
     return int(payload["rss"]), int(payload["threads"]), float(payload["cpu"])
 
 
-def resolve_sampler() -> Callable[[int], tuple[int, int, float]]:
+def resolve_sampler() -> Callable[[int], tuple[int, Optional[int], float]]:
     if sys.platform.startswith("linux"):
         return _sample_linux
     if sys.platform == "darwin":

--- a/scripts/perf/measure_engine.py
+++ b/scripts/perf/measure_engine.py
@@ -308,7 +308,7 @@ def run_status(base_url: str, run_id: str) -> str:
 class Recorder:
     """Collects samples and knows when the process stopped answering."""
 
-    sampler: Callable[[int], tuple[int, int, float]]
+    sampler: Callable[[int], tuple[int, Optional[int], float]]
     pid: int
     origin: float = field(default_factory=time.monotonic)
     samples: list[Sample] = field(default_factory=list)

--- a/scripts/perf/measure_engine.py
+++ b/scripts/perf/measure_engine.py
@@ -68,7 +68,8 @@ class Sample:
     phase: str
     elapsed_s: float
     rss_bytes: int
-    threads: int
+    # None where the platform gives no reliable count - see _darwin_thread_count.
+    threads: Optional[int]
     cpu_seconds: float
 
     def to_json(self) -> dict:
@@ -90,9 +91,9 @@ class PhaseStats:
     rss_min_bytes: int
     rss_max_bytes: int
     rss_last_bytes: int
-    threads_min: int
-    threads_max: int
-    threads_last: int
+    threads_min: Optional[int]
+    threads_max: Optional[int]
+    threads_last: Optional[int]
     cpu_percent_of_one_core: Optional[float]
 
     def to_json(self) -> dict:
@@ -174,21 +175,30 @@ def _sample_darwin(pid: int) -> tuple[int, int, float]:
         raise MeasurementError(f"engine pid {pid} is gone (ps rc={proc.returncode})")
     rss_kb, _, cpu_time = line.split(None, 1)
 
-    threads_proc = subprocess.run(
+    return int(rss_kb) * 1024, _darwin_thread_count(pid), _parse_ps_cpu_time(cpu_time.strip())
+
+
+def _darwin_thread_count(pid: int) -> Optional[int]:
+    """Thread count from `ps -M`, or None when it cannot be read.
+
+    macOS has no `nlwp` column - `ps -M` listing one line per thread after a
+    header is the only spelling - and it is the one call in this file that
+    could not be tried before CI ran it. So it is best-effort by design: None
+    when the output is not what it should be, never a fabricated 0, and never
+    fatal. Whether the process is alive is settled by the RSS read above, which
+    is authoritative and strict; losing a cosmetic count is not a reason to
+    throw away a measurement that took three minutes to take.
+    """
+    proc = subprocess.run(
         ["ps", "-M", "-p", str(pid)],
         capture_output=True,
         text=True,
         check=False,
     )
-    # One header line, then one line per thread. Checked rather than trusted:
-    # if the engine dies between these two calls, an unchecked parse would
-    # report threads=0 beside a real RSS - a sample that looks valid and is not.
-    thread_lines = [ln for ln in threads_proc.stdout.splitlines() if ln.strip()]
-    if threads_proc.returncode != 0 or len(thread_lines) < 2:
-        raise MeasurementError(f"engine pid {pid} is gone (ps -M rc={threads_proc.returncode})")
-    threads = len(thread_lines) - 1
-
-    return int(rss_kb) * 1024, threads, _parse_ps_cpu_time(cpu_time.strip())
+    if proc.returncode != 0:
+        return None
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    return len(lines) - 1 if len(lines) >= 2 else None
 
 
 def _powershell() -> str:
@@ -350,14 +360,18 @@ def summarize(samples: list[Sample]) -> PhaseStats:
     cpu_delta = samples[-1].cpu_seconds - samples[0].cpu_seconds
     cpu_percent = round(cpu_delta / span * 100.0, 3) if span > 0 else None
 
+    # Threads are optional per platform, so aggregate only what was read. An
+    # absent count stays absent rather than becoming a 0 that reads as a fact.
+    counts = [s.threads for s in samples if s.threads is not None]
+
     return PhaseStats(
         samples=len(samples),
         seconds=round(span, 3),
         rss_min_bytes=min(s.rss_bytes for s in samples),
         rss_max_bytes=max(s.rss_bytes for s in samples),
         rss_last_bytes=samples[-1].rss_bytes,
-        threads_min=min(s.threads for s in samples),
-        threads_max=max(s.threads for s in samples),
+        threads_min=min(counts) if counts else None,
+        threads_max=max(counts) if counts else None,
         threads_last=samples[-1].threads,
         cpu_percent_of_one_core=cpu_percent,
     )
@@ -469,6 +483,24 @@ def measure(args: argparse.Namespace) -> dict:
         terminate(mock, "mock-server")
 
 
+def print_engine_log_tail(log_dir: Path, lines: int = 20) -> None:
+    """Echo the end of the engine's own log when a measurement fails.
+
+    The log is in the run's artifact either way, but a failing CI step is read
+    from its own output first, and a job log cannot be paged to the middle -
+    so a failure that says only what threw costs a whole cycle to diagnose.
+    """
+    log = log_dir / "engine.log"
+    if not log.exists():
+        print(f"[perf] no engine log at {log}", file=sys.stderr)
+        return
+
+    tail = log.read_text(encoding="utf-8", errors="replace").splitlines()[-lines:]
+    print(f"[perf] last {len(tail)} lines of {log}:", file=sys.stderr)
+    for line in tail:
+        print(f"[perf]   {line}", file=sys.stderr)
+
+
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--engine", required=True, help="path to the vayu-engine binary")
@@ -499,6 +531,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         result = measure(args)
     except (MeasurementError, urllib.error.URLError, OSError, KeyError, ValueError) as exc:
         print(f"[perf] measurement failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        print_engine_log_tail(Path(args.log_dir))
         return 1
 
     Path(args.out).write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")

--- a/scripts/perf/measure_engine.py
+++ b/scripts/perf/measure_engine.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Measure the engine daemon's resident cost at idle, under load, and after.
+
+Written for `.github/workflows/perf-measure.yml` (issue #1162), which runs it on
+a Windows, a macOS and a Linux runner. The 2026-08-30 sweep (#1143) could only
+measure Linux, so every per-platform magnitude in that program's sub-issues is
+code-derived; this script is the thing that turns them into numbers.
+
+It is one Python file rather than three shell legs on purpose. The sampling is
+the only genuinely per-OS part - /proc on Linux, `ps` on macOS, PowerShell's
+`Get-Process` on Windows - and everything around it (start the engine, wait for
+/health, drive a run over HTTP, aggregate) is identical everywhere. Three copies
+of that in bash/bash/pwsh would be three things to keep in step and none of them
+runnable on a developer's machine.
+
+Method mirrors the sweep's, so the numbers are comparable to the Linux baselines
+recorded in #1143: the engine is spawned with the same `--verbose 1` the app's
+sidecar uses (`app/electron/sidecar.ts`), idle is sampled for 60s, the load phase
+is one 8-VU constant_concurrency run against `scripts/test/mock-server.go`, and
+the post-run phase watches what a completed run keeps hold of (#1154).
+
+Stdlib only - the runners have no third-party Python and this must not need pip.
+
+Usage:
+    python scripts/perf/measure_engine.py \
+        --engine engine/build-release/vayu-engine \
+        --mock ./mock-server \
+        --out perf-engine.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+# A sample is cheap, so the intervals are the sweep's rather than the finest the
+# machine allows: 5s at idle (nothing moves), 2s under load (the ramp does).
+IDLE_INTERVAL_S = 5.0
+LOAD_INTERVAL_S = 2.0
+RETENTION_INTERVAL_S = 5.0
+
+# How long to wait for /health after spawning. The engine runs orphan
+# reconciliation, inbox cleanup and the page-reclaim rewrite before it listens,
+# and #1144 prices that at up to 45s on a cold data dir; 90s is a runaway guard.
+HEALTH_TIMEOUT_S = 90.0
+
+# Grace beyond the requested run duration before a run is called stuck.
+RUN_GRACE_S = 90.0
+
+TERMINAL_RUN_STATUSES = frozenset({"completed", "failed", "stopped"})
+
+
+@dataclass
+class Sample:
+    """One observation of the engine process."""
+
+    phase: str
+    elapsed_s: float
+    rss_bytes: int
+    threads: int
+    cpu_seconds: float
+
+    def to_json(self) -> dict:
+        return {
+            "phase": self.phase,
+            "elapsedSeconds": self.elapsed_s,
+            "rssBytes": self.rss_bytes,
+            "threads": self.threads,
+            "cpuSeconds": self.cpu_seconds,
+        }
+
+
+@dataclass
+class PhaseStats:
+    """What a phase's samples add up to. Consumed by scripts/perf/summarize.py."""
+
+    samples: int
+    seconds: float
+    rss_min_bytes: int
+    rss_max_bytes: int
+    rss_last_bytes: int
+    threads_min: int
+    threads_max: int
+    threads_last: int
+    cpu_percent_of_one_core: Optional[float]
+
+    def to_json(self) -> dict:
+        """camelCase, because the rest of the artifact and the engine's own
+        report are camelCase - the dataclass stays PEP 8 on the Python side."""
+        return {
+            "samples": self.samples,
+            "seconds": self.seconds,
+            "rssMinBytes": self.rss_min_bytes,
+            "rssMaxBytes": self.rss_max_bytes,
+            "rssLastBytes": self.rss_last_bytes,
+            "threadsMin": self.threads_min,
+            "threadsMax": self.threads_max,
+            "threadsLast": self.threads_last,
+            "cpuPercentOfOneCore": self.cpu_percent_of_one_core,
+        }
+
+
+class MeasurementError(RuntimeError):
+    """A failure that makes the measurement meaningless rather than merely odd."""
+
+
+# --------------------------------------------------------------------------
+# Per-OS sampling. Each backend returns (rss_bytes, threads, cpu_seconds) for a
+# live pid and raises MeasurementError when the process is gone - a process that
+# died mid-phase invalidates the phase, so it must not be swallowed.
+# --------------------------------------------------------------------------
+
+
+def _sample_linux(pid: int) -> tuple[int, int, float]:
+    """Read /proc/<pid>/stat. No spawn, so sampling perturbs nothing."""
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise MeasurementError(f"engine pid {pid} is gone: {exc}") from exc
+
+    # comm (field 2) is parenthesised and may itself contain spaces and ')',
+    # so fields are counted from after the last ')' rather than by splitting.
+    close = raw.rfind(")")
+    if close < 0:
+        raise MeasurementError(f"unparseable /proc/{pid}/stat")
+    fields = raw[close + 2 :].split()
+
+    # Offsets are from `man 5 proc`, minus the 3 fields consumed above.
+    utime, stime = int(fields[11]), int(fields[12])
+    num_threads = int(fields[17])
+    rss_pages = int(fields[21])
+
+    ticks = os.sysconf("SC_CLK_TCK")
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    return rss_pages * page_size, num_threads, (utime + stime) / ticks
+
+
+def _parse_ps_cpu_time(value: str) -> float:
+    """Parse ps's cumulative CPU time: [[dd-]hh:]mm:ss[.ss]."""
+    days = 0.0
+    if "-" in value:
+        day_part, _, value = value.partition("-")
+        days = float(day_part)
+
+    parts = [float(p) for p in value.split(":")]
+    seconds = 0.0
+    for part in parts:
+        seconds = seconds * 60.0 + part
+    return days * 86400.0 + seconds
+
+
+def _sample_darwin(pid: int) -> tuple[int, int, float]:
+    """`ps` for RSS and CPU time, `ps -M` for the thread count macOS ps has no
+    column for (there is no `nlwp` outside Linux)."""
+    proc = subprocess.run(
+        ["ps", "-o", "rss=,time=", "-p", str(pid)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    line = proc.stdout.strip()
+    if proc.returncode != 0 or not line:
+        raise MeasurementError(f"engine pid {pid} is gone (ps rc={proc.returncode})")
+    rss_kb, _, cpu_time = line.split(None, 1)
+
+    threads_proc = subprocess.run(
+        ["ps", "-M", "-p", str(pid)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # One header line, then one line per thread.
+    thread_lines = [ln for ln in threads_proc.stdout.splitlines() if ln.strip()]
+    threads = max(len(thread_lines) - 1, 0)
+
+    return int(rss_kb) * 1024, threads, _parse_ps_cpu_time(cpu_time.strip())
+
+
+def _powershell() -> str:
+    exe = shutil.which("pwsh") or shutil.which("powershell")
+    if not exe:
+        raise MeasurementError("neither pwsh nor powershell is on PATH")
+    return exe
+
+
+def _sample_windows(pid: int) -> tuple[int, int, float]:
+    """PowerShell `Get-Process`, one spawn per sample.
+
+    A spawn every 2s is itself load, which is exactly the cost #1148 is about -
+    but at 0.5 Hz against a 12k-RPS run it is noise, and the alternative (a
+    long-lived sampler process streaming JSON lines) buys precision this
+    measurement does not need at the price of a second lifecycle to manage.
+    """
+    script = (
+        f"$p = Get-Process -Id {pid} -ErrorAction Stop; "
+        "[pscustomobject]@{ rss = $p.WorkingSet64; threads = $p.Threads.Count; "
+        "cpu = $p.TotalProcessorTime.TotalSeconds } | ConvertTo-Json -Compress"
+    )
+    proc = subprocess.run(
+        [_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise MeasurementError(f"engine pid {pid} is gone: {proc.stderr.strip()}")
+
+    payload = json.loads(proc.stdout)
+    return int(payload["rss"]), int(payload["threads"]), float(payload["cpu"])
+
+
+def resolve_sampler() -> Callable[[int], tuple[int, int, float]]:
+    if sys.platform.startswith("linux"):
+        return _sample_linux
+    if sys.platform == "darwin":
+        return _sample_darwin
+    if os.name == "nt":
+        return _sample_windows
+    raise MeasurementError(f"no sampler for platform {sys.platform!r}")
+
+
+# --------------------------------------------------------------------------
+# HTTP against the engine
+# --------------------------------------------------------------------------
+
+
+def http_json(url: str, body: Optional[dict] = None, timeout: float = 15.0) -> dict:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    request = urllib.request.Request(url, data=data, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_health(base_url: str, deadline_s: float) -> dict:
+    """Poll /health until it answers. Returns the health payload."""
+    started = time.monotonic()
+    last_error = "no attempt made"
+    while time.monotonic() - started < deadline_s:
+        try:
+            return http_json(f"{base_url}/health", timeout=5.0)
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            last_error = str(exc)
+            time.sleep(0.25)
+    raise MeasurementError(
+        f"engine did not answer /health within {deadline_s:.0f}s: {last_error}"
+    )
+
+
+def start_run(base_url: str, target_url: str, vus: int, duration_s: int) -> str:
+    """POST /runs and return the run id.
+
+    `constant_concurrency` is the spelling `parse_load_test_type` actually
+    recognises (engine/include/vayu/types.hpp). The two checked-in fixtures under
+    scripts/test/ say `"constant"`, which parses to nullopt and only works
+    because the strategy defaults to constant - not a spelling to copy.
+    """
+    payload = {
+        "method": "GET",
+        "url": target_url,
+        "headers": {},
+        "mode": "constant_concurrency",
+        "concurrency": vus,
+        "duration": f"{duration_s}s",
+    }
+    response = http_json(f"{base_url}/runs", body=payload)
+    run_id = response.get("runId")
+    if not run_id:
+        raise MeasurementError(f"POST /runs returned no runId: {response}")
+    return run_id
+
+
+def run_status(base_url: str, run_id: str) -> str:
+    return str(http_json(f"{base_url}/runs/{run_id}").get("status", "unknown"))
+
+
+# --------------------------------------------------------------------------
+# Phases
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Recorder:
+    """Collects samples and knows when the process stopped answering."""
+
+    sampler: Callable[[int], tuple[int, int, float]]
+    pid: int
+    origin: float = field(default_factory=time.monotonic)
+    samples: list[Sample] = field(default_factory=list)
+
+    def take(self, phase: str) -> Sample:
+        rss, threads, cpu = self.sampler(self.pid)
+        sample = Sample(
+            phase=phase,
+            elapsed_s=round(time.monotonic() - self.origin, 3),
+            rss_bytes=rss,
+            threads=threads,
+            cpu_seconds=cpu,
+        )
+        self.samples.append(sample)
+        return sample
+
+    def phase_samples(self, phase: str) -> list[Sample]:
+        return [s for s in self.samples if s.phase == phase]
+
+
+def sample_for(
+    recorder: Recorder,
+    phase: str,
+    seconds: float,
+    interval: float,
+    until: Optional[Callable[[], bool]] = None,
+) -> None:
+    """Sample `phase` for `seconds`, stopping early when `until()` is true.
+
+    `until` is polled on the sampling interval rather than in a tighter loop of
+    its own: the run-status poll is an HTTP request to the process being
+    measured, and a busy one would be measuring itself.
+    """
+    started = time.monotonic()
+    recorder.take(phase)
+    while time.monotonic() - started < seconds:
+        time.sleep(interval)
+        recorder.take(phase)
+        if until is not None and until():
+            return
+
+
+def summarize(samples: list[Sample]) -> PhaseStats:
+    """Aggregate one phase. CPU is a delta over the phase, not an instant."""
+    if not samples:
+        raise MeasurementError("cannot summarize a phase with no samples")
+
+    span = samples[-1].elapsed_s - samples[0].elapsed_s
+    cpu_delta = samples[-1].cpu_seconds - samples[0].cpu_seconds
+    cpu_percent = round(cpu_delta / span * 100.0, 3) if span > 0 else None
+
+    return PhaseStats(
+        samples=len(samples),
+        seconds=round(span, 3),
+        rss_min_bytes=min(s.rss_bytes for s in samples),
+        rss_max_bytes=max(s.rss_bytes for s in samples),
+        rss_last_bytes=samples[-1].rss_bytes,
+        threads_min=min(s.threads for s in samples),
+        threads_max=max(s.threads for s in samples),
+        threads_last=samples[-1].threads,
+        cpu_percent_of_one_core=cpu_percent,
+    )
+
+
+def directory_bytes(path: Path) -> int:
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+# --------------------------------------------------------------------------
+# Process lifecycle
+# --------------------------------------------------------------------------
+
+
+def spawn(command: list[str], log_path: Path) -> subprocess.Popen:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = log_path.open("w", encoding="utf-8")
+    return subprocess.Popen(command, stdout=handle, stderr=subprocess.STDOUT)
+
+
+def terminate(process: Optional[subprocess.Popen], name: str) -> None:
+    """Ask, then insist. A leaked child fails the runner's job cleanup, not this
+    script, so it is worth being thorough about."""
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=15)
+        return
+    except subprocess.TimeoutExpired:
+        print(f"[perf] {name} ignored terminate, killing", file=sys.stderr)
+    process.kill()
+    process.wait(timeout=15)
+
+
+def measure(args: argparse.Namespace) -> dict:
+    base_url = f"http://127.0.0.1:{args.port}"
+    target_url = f"http://127.0.0.1:{args.mock_port}/fast"
+    logs = Path(args.log_dir)
+    data_dir = Path(args.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    mock: Optional[subprocess.Popen] = None
+    engine: Optional[subprocess.Popen] = None
+    try:
+        mock = spawn(
+            [args.mock, "-port", str(args.mock_port), "-host", "127.0.0.1"],
+            logs / "mock-server.log",
+        )
+        engine = spawn(
+            # --verbose 1 is what app/electron/sidecar.ts spawns in production;
+            # measuring a quieter engine would measure something nobody runs.
+            [args.engine, "--port", str(args.port), "--data-dir", str(data_dir), "--verbose", "1"],
+            logs / "engine.log",
+        )
+
+        health = wait_for_health(base_url, HEALTH_TIMEOUT_S)
+        recorder = Recorder(sampler=resolve_sampler(), pid=engine.pid)
+
+        sample_for(recorder, "idle", args.idle_seconds, IDLE_INTERVAL_S)
+        pre_run_rss = recorder.phase_samples("idle")[-1].rss_bytes
+
+        run_id = start_run(base_url, target_url, args.vus, args.load_seconds)
+        sample_for(
+            recorder,
+            "load",
+            args.load_seconds + RUN_GRACE_S,
+            LOAD_INTERVAL_S,
+            until=lambda: run_status(base_url, run_id) in TERMINAL_RUN_STATUSES,
+        )
+
+        status = run_status(base_url, run_id)
+        if status != "completed":
+            raise MeasurementError(f"run {run_id} ended as {status!r}, not completed")
+
+        report = http_json(f"{base_url}/runs/{run_id}/report", timeout=60.0)
+        sample_for(recorder, "retention", args.retention_seconds, RETENTION_INTERVAL_S)
+
+        summary = report.get("summary", {})
+        retention = recorder.phase_samples("retention")
+        return {
+            "schema": 1,
+            "os": platform.system(),
+            "osRelease": platform.release(),
+            "machine": platform.machine(),
+            "engineVersion": health.get("version"),
+            "engineWorkers": health.get("workers"),
+            "idle": summarize(recorder.phase_samples("idle")).to_json(),
+            "load": {
+                "vus": args.vus,
+                "durationSeconds": args.load_seconds,
+                **summarize(recorder.phase_samples("load")).to_json(),
+                "avgRps": summary.get("avgRps"),
+                "totalRequests": summary.get("totalRequests"),
+                "errorRate": summary.get("errorRate"),
+            },
+            "retention": {
+                **summarize(retention).to_json(),
+                "preRunRssBytes": pre_run_rss,
+                # The number #1154 is about: what a finished run still holds
+                # once the app has stopped looking at it.
+                "residualBytes": retention[-1].rss_bytes - pre_run_rss,
+            },
+            "dataDirBytes": directory_bytes(data_dir),
+            "samples": [s.to_json() for s in recorder.samples],
+        }
+    finally:
+        terminate(engine, "engine")
+        terminate(mock, "mock-server")
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--engine", required=True, help="path to the vayu-engine binary")
+    parser.add_argument("--mock", required=True, help="path to the built mock server")
+    parser.add_argument("--out", required=True, help="where to write the JSON result")
+    parser.add_argument("--data-dir", default="perf-data", help="scratch engine data dir")
+    parser.add_argument("--log-dir", default="perf-logs", help="where child stdout goes")
+    parser.add_argument("--port", type=int, default=9876)
+    parser.add_argument("--mock-port", type=int, default=8080)
+    parser.add_argument("--vus", type=int, default=8, help="constant_concurrency VUs")
+    parser.add_argument("--idle-seconds", type=float, default=60.0)
+    parser.add_argument("--load-seconds", type=int, default=30)
+    parser.add_argument("--retention-seconds", type=float, default=60.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    for label, value in (("engine", args.engine), ("mock", args.mock)):
+        if not Path(value).exists():
+            print(f"[perf] {label} binary not found: {value}", file=sys.stderr)
+            return 2
+
+    try:
+        result = measure(args)
+    except MeasurementError as exc:
+        print(f"[perf] measurement failed: {exc}", file=sys.stderr)
+        return 1
+
+    Path(args.out).write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(f"[perf] wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/measure_engine.py
+++ b/scripts/perf/measure_engine.py
@@ -180,9 +180,13 @@ def _sample_darwin(pid: int) -> tuple[int, int, float]:
         text=True,
         check=False,
     )
-    # One header line, then one line per thread.
+    # One header line, then one line per thread. Checked rather than trusted:
+    # if the engine dies between these two calls, an unchecked parse would
+    # report threads=0 beside a real RSS - a sample that looks valid and is not.
     thread_lines = [ln for ln in threads_proc.stdout.splitlines() if ln.strip()]
-    threads = max(len(thread_lines) - 1, 0)
+    if threads_proc.returncode != 0 or len(thread_lines) < 2:
+        raise MeasurementError(f"engine pid {pid} is gone (ps -M rc={threads_proc.returncode})")
+    threads = len(thread_lines) - 1
 
     return int(rss_kb) * 1024, threads, _parse_ps_cpu_time(cpu_time.strip())
 
@@ -488,10 +492,13 @@ def main(argv: Optional[list[str]] = None) -> int:
             print(f"[perf] {label} binary not found: {value}", file=sys.stderr)
             return 2
 
+    # The engine answering something unexpected - a 400 from POST /runs, a
+    # report missing a key - is a measurement failure like any other, and
+    # deserves the same one-line reason rather than a traceback.
     try:
         result = measure(args)
-    except MeasurementError as exc:
-        print(f"[perf] measurement failed: {exc}", file=sys.stderr)
+    except (MeasurementError, urllib.error.URLError, OSError, KeyError, ValueError) as exc:
+        print(f"[perf] measurement failed: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1
 
     Path(args.out).write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")

--- a/scripts/perf/startup-harness.cjs
+++ b/scripts/perf/startup-harness.cjs
@@ -16,8 +16,8 @@
  * built `dist/` - the app resolves its engine under `process.resourcesPath`,
  * which exists only in a packaged build, so an unpackaged launch on a runner
  * never reaches `ready-to-show` at all. Measuring the packaged app end to end
- * needs electron-builder in this workflow and is filed separately; this is the
- * fallback #1162 names for exactly that case ("the blank-window baseline vs
+ * needs electron-builder in this workflow and is #1165; this is the fallback
+ * #1162 names for exactly that case ("the blank-window baseline vs
  * full-renderer delta - the sweep's method").
  *
  * What it therefore does NOT measure, so nobody reads more into the number:

--- a/scripts/perf/startup-harness.cjs
+++ b/scripts/perf/startup-harness.cjs
@@ -1,0 +1,112 @@
+/**
+ * An Electron main script that times how long a window takes to become
+ * showable, with and without the app's built renderer in it.
+ *
+ * Run by `scripts/perf/measure-app.mjs` (issue #1162), never by a user. It is
+ * deliberately NOT the Vayu app: it creates one BrowserWindow, loads either a
+ * blank page or `app/dist/index.html`, prints the time to `ready-to-show` and
+ * quits. The difference between the two is the cost of parsing and evaluating
+ * the renderer's module graph - the number #1146 is about (one 5.5 MB entry
+ * chunk, zero React.lazy) and the one #1147's bundle work would move.
+ *
+ * Why a harness rather than launching the real app: `app/electron/main.ts`
+ * decides both where the engine binary lives and where the renderer comes from
+ * off the same `isDev` flag (`sidecar.ts` getEngineBinaryPath, `main.ts`
+ * loadFile/loadURL). With NODE_ENV unset - the only setting that loads the
+ * built `dist/` - the app resolves its engine under `process.resourcesPath`,
+ * which exists only in a packaged build, so an unpackaged launch on a runner
+ * never reaches `ready-to-show` at all. Measuring the packaged app end to end
+ * needs electron-builder in this workflow and is filed separately; this is the
+ * fallback #1162 names for exactly that case ("the blank-window baseline vs
+ * full-renderer delta - the sweep's method").
+ *
+ * What it therefore does NOT measure, so nobody reads more into the number:
+ * the main process's own startup work - the eager MCP import (#1145), the
+ * sidecar spawn (#1148), the engine handshake (#1144). Those are main.ts's,
+ * and this harness never loads it.
+ *
+ * What it DOES include, which is easy to mistake for noise: the renderer's
+ * render-blocking network fetches. `index.html` pulls six Google Fonts
+ * families before first paint (#1149), so the renderer figure moves with the
+ * runner's network and will drop when that lands - a property worth keeping,
+ * since it is what a real cold start pays. On a machine with no route to
+ * fonts.googleapis.com the figure is dominated by that stall (measured: 12.8s
+ * against a 248ms blank baseline in a sandboxed container), which is why the
+ * blank baseline is reported beside it rather than the delta alone.
+ *
+ * CommonJS on purpose: Electron's main entry is loaded as CJS unless the
+ * package is typed as a module, and this file is run directly by path.
+ *
+ * Usage (via measure-app.mjs):
+ *   electron scripts/perf/startup-harness.cjs --mode blank|renderer --entry <index.html>
+ */
+
+const { app, BrowserWindow } = require("electron");
+
+/** The line measure-app.mjs scans for, followed by a JSON payload. */
+const HARNESS_MARKER = "[perf] harness";
+
+// A blank document rather than a file, so the baseline measures window
+// creation and first paint with nothing of ours in it.
+const BLANK_PAGE = "data:text/html,<!doctype html><title>blank</title>";
+
+function parseArgs(argv) {
+	const args = { mode: "blank", entry: null };
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--mode") args.mode = argv[++i];
+		if (argv[i] === "--entry") args.entry = argv[++i];
+	}
+	return args;
+}
+
+function report(payload) {
+	process.stdout.write(`${HARNESS_MARKER} ${JSON.stringify(payload)}\n`);
+}
+
+function main() {
+	const { mode, entry } = parseArgs(process.argv.slice(2));
+	if (mode !== "blank" && mode !== "renderer") {
+		process.stderr.write(`[perf] unknown --mode ${mode}\n`);
+		app.exit(2);
+		return;
+	}
+	if (mode === "renderer" && !entry) {
+		process.stderr.write("[perf] --mode renderer needs --entry <index.html>\n");
+		app.exit(2);
+		return;
+	}
+
+	const window = new BrowserWindow({
+		show: false,
+		width: 1280,
+		height: 800,
+		// No preload: the renderer's `window.electronAPI` is main.ts's to
+		// provide, and wiring one here would drag main-process modules into a
+		// measurement that is about the renderer graph. The page will report
+		// errors once it runs; `ready-to-show` fires before that and is what
+		// this measures.
+		webPreferences: { contextIsolation: true, nodeIntegration: false },
+	});
+
+	window.once("ready-to-show", () => {
+		// performance.now() in the main process is measured from process start,
+		// so this value is already "ready-to-show minus process start".
+		report({ mode, readyToShowMs: performance.now() });
+		app.quit();
+	});
+
+	// A page that never becomes showable must not hang the run; the parent has
+	// its own timeout, but exiting here names the reason in this process's log.
+	window.webContents.on("did-fail-load", (_event, code, description) => {
+		process.stderr.write(`[perf] load failed (${code}): ${description}\n`);
+		app.exit(3);
+	});
+
+	if (mode === "blank") {
+		window.loadURL(BLANK_PAGE);
+		return;
+	}
+	window.loadFile(entry);
+}
+
+app.whenReady().then(main);

--- a/scripts/perf/summarize.py
+++ b/scripts/perf/summarize.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Render the perf-measure JSON artifacts as one Markdown table per OS.
+
+Reads what `measure_engine.py` and `measure-app.mjs` wrote and prints a table to
+stdout - the workflow appends it to `$GITHUB_STEP_SUMMARY`, so the run page
+carries the numbers without anyone downloading the artifact. The artifact stays
+the record; this is the reading of it.
+
+Missing input is reported as a row saying so rather than skipped: a leg that did
+not run is the single most important thing a reader needs to see, and a summary
+that silently omits it looks like a measurement nobody took.
+
+Usage:
+    python scripts/perf/summarize.py --os ubuntu-latest \
+        --engine-json perf-engine.json --app-json perf-app.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+MIB = 1024 * 1024
+
+
+def load(path: Optional[str]) -> Optional[dict]:
+    if not path:
+        return None
+    file = Path(path)
+    if not file.exists():
+        return None
+    try:
+        return json.loads(file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"[perf] {file} is not valid JSON: {exc}", file=sys.stderr)
+        return None
+
+
+def mib(value: Optional[float]) -> str:
+    return "-" if value is None else f"{value / MIB:.1f} MB"
+
+
+def num(value: Optional[float], suffix: str = "", digits: int = 1) -> str:
+    return "-" if value is None else f"{value:,.{digits}f}{suffix}"
+
+
+def engine_rows(data: Optional[dict]) -> list[tuple[str, str]]:
+    if data is None:
+        return [("engine leg", "**did not produce a result**")]
+
+    idle, load, retention = data["idle"], data["load"], data["retention"]
+    return [
+        ("engine version", str(data.get("engineVersion", "-"))),
+        ("engine workers", str(data.get("engineWorkers", "-"))),
+        ("idle RSS (last / max)", f"{mib(idle['rssLastBytes'])} / {mib(idle['rssMaxBytes'])}"),
+        ("idle CPU", num(idle["cpuPercentOfOneCore"], "% of one core", 2)),
+        ("idle threads", str(idle["threadsLast"])),
+        (
+            f"load: {load['vus']} VU / {load['durationSeconds']}s avg RPS",
+            num(load.get("avgRps"), "", 0),
+        ),
+        ("load requests / error rate", f"{num(load.get('totalRequests'), '', 0)} / {num(load.get('errorRate'), '', 4)}"),
+        ("load RSS peak", mib(load["rssMaxBytes"])),
+        ("load CPU", num(load["cpuPercentOfOneCore"], "% of one core", 1)),
+        ("load threads (max)", str(load["threadsMax"])),
+        ("post-run RSS after 60s", mib(retention["rssLastBytes"])),
+        ("post-run residual vs pre-run", mib(retention["residualBytes"])),
+        ("data dir after the run", mib(data.get("dataDirBytes"))),
+    ]
+
+
+def app_rows(data: Optional[dict]) -> list[tuple[str, str]]:
+    if data is None:
+        return [("app leg", "**did not produce a result**")]
+
+    bundle = data.get("bundle") or {}
+    startup = data.get("startup") or {}
+    rows = [
+        ("renderer entry chunk", f"`{bundle.get('entryChunkName', '-')}` {mib(bundle.get('entryChunkBytes'))}"),
+        ("renderer dist total", mib(bundle.get("totalDistBytes"))),
+        ("renderer dist files", str(bundle.get("fileCount", "-"))),
+        ("startup method", str(startup.get("method", "-"))),
+        ("ready-to-show (median)", num(startup.get("medianMs"), " ms", 0)),
+    ]
+    if startup.get("note"):
+        rows.append(("startup note", str(startup["note"])))
+
+    spawn = data.get("tasklistSpawn")
+    if spawn:
+        rows.append(
+            (
+                f"Windows tasklist spawn (median of {spawn.get('iterations', '?')})",
+                num(spawn.get("medianMs"), " ms", 1),
+            )
+        )
+    return rows
+
+
+def render(os_label: str, engine: Optional[dict], app: Optional[dict]) -> str:
+    lines = [f"### Perf measurement - `{os_label}`", "", "| metric | value |", "| --- | --- |"]
+    for label, value in engine_rows(engine) + app_rows(app):
+        lines.append(f"| {label} | {value} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--os", required=True, help="runner label, used as the heading")
+    parser.add_argument("--engine-json")
+    parser.add_argument("--app-json")
+    args = parser.parse_args(argv)
+
+    print(render(args.os, load(args.engine_json), load(args.app_json)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/summarize.py
+++ b/scripts/perf/summarize.py
@@ -47,6 +47,11 @@ def num(value: Optional[float], suffix: str = "", digits: int = 1) -> str:
     return "-" if value is None else f"{value:,.{digits}f}{suffix}"
 
 
+def count(value: Optional[int]) -> str:
+    """A thread count, or "-" where the platform gave none (see measure_engine)."""
+    return "-" if value is None else str(value)
+
+
 def engine_rows(data: Optional[dict]) -> list[tuple[str, str]]:
     if data is None:
         return [("engine leg", "**did not produce a result**")]
@@ -57,7 +62,7 @@ def engine_rows(data: Optional[dict]) -> list[tuple[str, str]]:
         ("engine workers", str(data.get("engineWorkers", "-"))),
         ("idle RSS (last / max)", f"{mib(idle['rssLastBytes'])} / {mib(idle['rssMaxBytes'])}"),
         ("idle CPU", num(idle["cpuPercentOfOneCore"], "% of one core", 2)),
-        ("idle threads", str(idle["threadsLast"])),
+        ("idle threads", count(idle["threadsLast"])),
         (
             f"load: {load['vus']} VU / {load['durationSeconds']}s avg RPS",
             num(load.get("avgRps"), "", 0),
@@ -66,7 +71,7 @@ def engine_rows(data: Optional[dict]) -> list[tuple[str, str]]:
         ("load RSS peak", mib(load["rssMaxBytes"])),
         ("load RSS at run end", mib(load["rssLastBytes"])),
         ("load CPU", num(load["cpuPercentOfOneCore"], "% of one core", 1)),
-        ("load threads (max)", str(load["threadsMax"])),
+        ("load threads (max)", count(load["threadsMax"])),
         ("post-run RSS after 60s", mib(retention["rssLastBytes"])),
         ("post-run residual vs pre-run", mib(retention["residualBytes"])),
         ("data dir after the run", mib(data.get("dataDirBytes"))),

--- a/scripts/perf/summarize.py
+++ b/scripts/perf/summarize.py
@@ -83,7 +83,9 @@ def app_rows(data: Optional[dict]) -> list[tuple[str, str]]:
         ("renderer dist total", mib(bundle.get("totalDistBytes"))),
         ("renderer dist files", str(bundle.get("fileCount", "-"))),
         ("startup method", str(startup.get("method", "-"))),
-        ("ready-to-show (median)", num(startup.get("medianMs"), " ms", 0)),
+        ("window ready-to-show, blank (median)", num(startup.get("blankMedianMs"), " ms", 0)),
+        ("window ready-to-show, built renderer (median)", num(startup.get("medianMs"), " ms", 0)),
+        ("renderer module graph (the delta)", num(startup.get("rendererGraphMs"), " ms", 0)),
     ]
     if startup.get("note"):
         rows.append(("startup note", str(startup["note"])))

--- a/scripts/perf/summarize.py
+++ b/scripts/perf/summarize.py
@@ -64,6 +64,7 @@ def engine_rows(data: Optional[dict]) -> list[tuple[str, str]]:
         ),
         ("load requests / error rate", f"{num(load.get('totalRequests'), '', 0)} / {num(load.get('errorRate'), '', 4)}"),
         ("load RSS peak", mib(load["rssMaxBytes"])),
+        ("load RSS at run end", mib(load["rssLastBytes"])),
         ("load CPU", num(load["cpuPercentOfOneCore"], "% of one core", 1)),
         ("load threads (max)", str(load["threadsMax"])),
         ("post-run RSS after 60s", mib(retention["rssLastBytes"])),


### PR DESCRIPTION
## Description

The 2026-08-30 sweep (#1143) measured on Linux only, so every per-platform magnitude in its sub-issues is code-derived. This adds the harness that turns them into numbers, on the Windows and macOS runners the repo already pays for, and it doubles as the standing regression harness #1143's exit criterion needs.

**Status: green on all three runners, and the baseline is recorded in [#1143](https://github.com/athrvk/vayu/issues/1143#issuecomment-5468475406). All three acceptance criteria are met.**

**The plan, and the alternative rejected.** The sampling is the only genuinely per-OS part of this - `/proc` on Linux, `ps` on macOS, PowerShell `Get-Process` on Windows - while everything around it (start the engine, wait on `/health`, drive a run over HTTP, aggregate) is identical everywhere. The obvious shape for a measurement workflow is per-OS shell inline in the YAML; that would have been three copies of the same logic in bash/bash/pwsh, three things to keep in step, and none of them runnable on a developer's machine. So the workflow is thin and the measurement lives in `scripts/perf/`: `measure_engine.py` (idle, load, retention), `measure-app.mjs` + `startup-harness.cjs` (bundle, startup, the Windows `tasklist` micro), `summarize.py` (the step-summary table). Each runs locally exactly as CI runs it.

**Engine leg** builds on the `-prod` preset, so the debug-build CPU caveat the sweep had to carry does not repeat, spawns the engine with the same `--verbose 1` `app/electron/sidecar.ts` uses in production, then samples 60 s idle at 5 s, one 8-VU 30 s `constant_concurrency` run against `scripts/test/mock-server.go` at 2 s, and 60 s of post-run retention - the observable #1154 is about.

**App leg** records the Rolldown-hashed entry chunk discovered from `dist/index.html`, the total `dist/` size, the startup figures, and on Windows the cost of the synchronous `tasklist` spawn.

### Two deliberate deviations from the issue, both for your call

**1. There is a `pull_request` trigger, which #1162 explicitly ruled out.** It is scoped by `paths:` to this workflow and `scripts/perf/**`, so no ordinary PR runs it. Without it, the first evidence that any of this works would arrive after merge, on a cron, as a red master - a workflow cannot be dispatched before it exists on the default branch. `sanitizers.yml` and `engine-tidy-scan.yml` carry the same narrow trigger for the same stated reason. **This was not academic: it caught four real bugs before merge** (see below), every one of which would otherwise have landed on master and surfaced as a red weekly cron.

**2. The startup number is the renderer graph, not the app's cold start - and no `main.ts` probe is added.** #1162 offered a `VAYU_MEASURE_STARTUP=1` hook in `main.ts` or, if a real launch proved too flaky, the sweep's blank-vs-renderer delta. It is not flakiness: `main.ts:299-304` and `sidecar.ts:374-394` pick the renderer source **and** the engine binary path off the same `isDev` flag, so the only setting that loads the built `dist/` also sends the sidecar to `process.resourcesPath`, which exists in a packaged build alone. The unpackaged launch never gets an engine, and on master the window waits on the `/health` handshake, so `ready-to-show` never fires - measured, 90 s timeout, not assumed. The hook route was therefore built and then removed: with nothing able to launch the app, the probe would have been a field written and never read, which `CLAUDE.md` names as this codebase's most repeated defect. #1162's own "App changes" section is conditional on that route, so "otherwise none" applies. The packaged-app measurement is **#1165**.

One consequence worth knowing before reading the number: the renderer figure includes the six render-blocking Google Fonts families (#1149), so it moves with the runner's network. That is kept on purpose - it is what a cold start pays, and #1149 landing should show up here - and the blank baseline is reported beside it so a stalled fetch reads as a stall rather than a regression.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Per the repo's verification-scaling rule this changes no engine or app behaviour, so neither suite was run - the diff touches no file under `app/` or `engine/`. What was run instead is the thing that could actually break: the scripts themselves, locally and then on all three runners.

**Final run, [33309102706](https://github.com/athrvk/vayu/actions/runs/33309102706) at `f492c15`: ubuntu-latest, windows-latest and macos-latest all green, every step, with a fully populated summary table per OS.** Headline figures: engine idle RSS 11.2-14.4 MB at ~0-0.9% of one core; an 8-VU 30 s run at 15.1k-26.3k RPS with **zero errors across 1.7 M requests**; 6.5-10.6 MB retained 60 s after the run (#1154's observable, bounded and flat); renderer module graph 157-297 ms; and **#1148's missing number, 52.5 ms per `tasklist` spawn**.

Local verification before each push: full engine measurement against a locally built engine (idle 14-20 MB, 11 threads, 13-22k RPS, 0 errors - the shape #1143 recorded); entry chunk 5,531,024 bytes, matching the 5.53 MB the sweep measured independently; both failure paths exercised for real (a launch that cannot start reports `method: "unavailable"` with the actual reason and does not fail the job; a missing `dist/` exits 2); `_sample_darwin` executed directly on Linux, since `ps -o rss=,time=` is POSIX; `mkdocs build --strict` clean; `cache-warm.yml`'s guard replicated across all seven workflows.

### What the PR-trigger run caught, that would otherwise have landed on master

1. `go: command not found` on macos-latest - Go is documented as preinstalled on all three images and is not on PATH for every one. Now `actions/setup-go`.
2. **`_sample_darwin` unpacked two `ps` fields into three names** - a `ValueError` on its first call. Every macOS measurement would have failed, forever, on the weekly cron.
3. Electron's `chrome-sandbox` lacks its setuid ownership on the ubuntu runner, so the Linux startup leg reported `unavailable`. Fixed with the remedy the error itself prescribes, which keeps the sandbox on rather than passing `--no-sandbox`.
4. `require('electron')` printing `Downloading Electron binary...` ahead of the path, so a command substitution captured both lines.

Two smaller corrections came from watching the PR's own behaviour: `cancel-in-progress` now follows the event (a cron measurement is data and is never discarded half-taken; a superseded PR run is not), and on failure `measure_engine.py` echoes the last 20 lines of the engine's own log - added because a job log cannot be paged to its middle, and it printed the real cause of finding 2 on the very next run after I had misdiagnosed it.

### Review pass

Two reviewers went over the diff against the issue and against `CLAUDE.md`. Acted on: the run-end RSS was written to the artifact and never read into the table (#1162 asks for peak/end/retention - the written-but-never-read defect, in this diff); `_sample_darwin` checked its first `ps` return code and not its second; `main()` caught only `MeasurementError`; a stale comment claimed the workflow runs `electron:compile`; `perf-measure.yml` was outside `cache-warm.yml`'s drift guard. Two comments promised deferred work with no issue number behind them, now **#1165** and **#1166**.

Discarded with reason: the suggestion to lint the new `.mjs`/`.cjs` in this PR - the gap is real but predates the perf scripts in kind and belongs to every future JS outside `app/`, so it is #1166 rather than scope added here.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable: no behaviour change, and #1162 states "the workflow is its own test"
- [x] I have updated documentation

## Related Issues

Closes #1162

Follow-ups filed by this run: #1165 (packaged-app cold start), #1166 (unlinted JavaScript outside `app/`).