### PR TITLE
perf(app): load the MCP stack on demand, not at process start - #1145

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -36,21 +36,32 @@ import { createSaveFlusher } from "./save-flush.js";
 import { createRendererRecovery } from "./renderer-recovery.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
 import { stampInstalledVersion } from "./appimage-stamp.js";
+/*
+ * MCP is imported by weight, not through its barrel.
+ *
+ * `mcp/index.js` re-exports `toolCatalog` from the 7,300-line tool registry and
+ * constructs its facade over `http.js`, so importing *anything* runtime from it
+ * evaluates the MCP SDK, zod and all 67 tool schemas - ~250-300ms of serial
+ * main-process evaluation, before `app.whenReady` and therefore ahead of the
+ * window, on every launch including the ones where MCP is switched off.
+ *
+ * `config`, `store` and `connect` reach none of that (`electron-store` and
+ * `node:child_process` are their heaviest dependencies), so the startup gate and
+ * the Settings IPC read them directly and for free. The two symbols that do pull
+ * the SDK - the service and the tool catalog - are loaded on demand by
+ * `loadMcp()` below.
+ */
+import { resolveSafetyConfig, sanitizeSafetyInput, type McpSafetyConfig } from "./mcp/config.js";
 import {
-	VayuMcpService,
-	resolveSafetyConfig,
-	sanitizeSafetyInput,
 	loadPersistedSafety,
 	savePersistedSafety,
 	effectiveSafety,
 	loadMcpEnabled,
 	saveMcpEnabled,
-	connectClient,
-	toolCatalog,
-	type McpConnectClient,
-	type McpDataChangedEvent,
-	type McpSafetyConfig,
-} from "./mcp/index.js";
+} from "./mcp/store.js";
+import { connectClient, type McpConnectClient } from "./mcp/connect.js";
+import type { McpDataChangedEvent } from "./mcp/tools.js";
+import type { VayuMcpService } from "./mcp/index.js";
 import {
 	DOCS_URL,
 	SCRIPTING_DOCS_URL,
@@ -556,14 +567,34 @@ async function startEngine() {
 	}
 }
 
+/**
+ * The MCP barrel - the SDK, the tool registry - loaded at most once, on demand.
+ *
+ * The promise is cached rather than the module, so concurrent callers (a launch
+ * starting the server while Settings asks for the catalog) share one evaluation.
+ * A rejection is cached with it: the module is a file inside the asar, so a
+ * failure to load it is a broken install rather than something a retry fixes,
+ * and every caller here already reports or swallows one.
+ */
+type McpModule = typeof import("./mcp/index.js");
+let mcpModule: Promise<McpModule> | null = null;
+
+function loadMcp(): Promise<McpModule> {
+	mcpModule ??= import("./mcp/index.js");
+	return mcpModule;
+}
+
 async function startMcp() {
 	try {
 		// Inside the try, not ahead of it: this is the first thing in the whole app
 		// to touch the persisted MCP config, so it is where a store failure lands.
+		// It also gates the import below, so a disabled launch never evaluates the
+		// SDK or the tool registry at all.
 		if (!loadMcpEnabled()) {
 			console.log("[Main] MCP server disabled by preference; not starting.");
 			return;
 		}
+		const { VayuMcpService } = await loadMcp();
 		mcpService = new VayuMcpService({
 			engineBaseUrl: `http://${ENGINE_HOST}:${ENGINE_PORT}`,
 			host: MCP_HOST,
@@ -710,31 +741,37 @@ function setupIpcHandlers() {
 	});
 
 	// The tool catalog (name/description/category) for the Settings tool list.
-	ipcMain.handle("mcp:getTools", () => toolCatalog());
+	// Async because the registry is loaded on demand - opening Settings is the
+	// place to pay for it, not launching the app.
+	ipcMain.handle("mcp:getTools", async () => (await loadMcp()).toolCatalog());
 
 	// Apply and persist a safety-config change from Settings. The renderer input
 	// is sanitized here (never trusted), applied live to the running server, and
 	// written to disk so it survives a restart. Returns the resolved config.
-	ipcMain.handle("mcp:updateSafety", (_event, partial: unknown): McpSafetyConfig => {
-		const clean = sanitizeSafetyInput((partial ?? {}) as Partial<McpSafetyConfig>);
-		// Drop unknown tool names so a stale/hand-edited disabled list can't
-		// accumulate junk (the sanitizer can't see the registry).
-		if (clean.disabledTools) {
-			const known = new Set(toolCatalog().map((t) => t.name));
-			clean.disabledTools = clean.disabledTools.filter((name) => known.has(name));
-		}
-		if (mcpService) {
-			mcpService.updateSafety(clean);
-			const resolved = mcpService.getSafety();
+	ipcMain.handle(
+		"mcp:updateSafety",
+		async (_event, partial: unknown): Promise<McpSafetyConfig> => {
+			const clean = sanitizeSafetyInput((partial ?? {}) as Partial<McpSafetyConfig>);
+			// Drop unknown tool names so a stale/hand-edited disabled list can't
+			// accumulate junk (the sanitizer can't see the registry). The registry is
+			// loaded only on this branch: a caps- or allowlist-only change never needs it.
+			if (clean.disabledTools) {
+				const known = new Set((await loadMcp()).toolCatalog().map((t) => t.name));
+				clean.disabledTools = clean.disabledTools.filter((name) => known.has(name));
+			}
+			if (mcpService) {
+				mcpService.updateSafety(clean);
+				const resolved = mcpService.getSafety();
+				savePersistedSafety(resolved);
+				return resolved;
+			}
+			// MCP server never came up (e.g. port in use) - still persist so the
+			// change takes effect on the next launch.
+			const resolved = resolveSafetyConfig({ ...loadPersistedSafety(), ...clean });
 			savePersistedSafety(resolved);
 			return resolved;
 		}
-		// MCP server never came up (e.g. port in use) - still persist so the
-		// change takes effect on the next launch.
-		const resolved = resolveSafetyConfig({ ...loadPersistedSafety(), ...clean });
-		savePersistedSafety(resolved);
-		return resolved;
-	});
+	);
 
 	// Theme management
 	ipcMain.handle("theme:get", () => {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -573,15 +573,16 @@ async function startEngine() {
  * The promise is cached rather than the module, so concurrent callers (a launch
  * starting the server while Settings asks for the catalog) share one evaluation.
  * A rejection is cached with it: the module is a file inside the asar, so a
- * failure to load it is a broken install rather than something a retry fixes,
- * and every caller here already reports or swallows one.
+ * failure to load it is a broken install rather than something a retry fixes.
+ * `startMcp` logs one and continues without MCP; the two IPC handlers let it
+ * reject, which reaches Settings as the failed call it is.
  */
 type McpModule = typeof import("./mcp/index.js");
-let mcpModule: Promise<McpModule> | null = null;
+let mcpModulePromise: Promise<McpModule> | null = null;
 
 function loadMcp(): Promise<McpModule> {
-	mcpModule ??= import("./mcp/index.js");
-	return mcpModule;
+	mcpModulePromise ??= import("./mcp/index.js");
+	return mcpModulePromise;
 }
 
 async function startMcp() {

--- a/app/electron/mcp/lazy-load.test.ts
+++ b/app/electron/mcp/lazy-load.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The barrel `main.ts` loads on demand still answers with what it takes from it.
+ *
+ * `main.ts` no longer imports `mcp/index.js` statically (#1145): `startMcp()`
+ * destructures `VayuMcpService` from it, and the `mcp:getTools` and
+ * `mcp:updateSafety` handlers call its `toolCatalog()`, all through one cached
+ * `await import("./mcp/index.js")`. Nothing type-checks that seam - a dynamic
+ * import resolves at runtime, and `main.ts` cannot be imported to exercise it -
+ * so a symbol dropped from the barrel's export surface, or a barrel that fails
+ * to load at all, would type-check, ship, and fail in a user's Settings panel.
+ *
+ * These drive the same specifier the same way and assert the answer. The
+ * catalog is asserted non-empty rather than merely defined, so a registry that
+ * evaluated to nothing fails here instead of rendering an empty tool list.
+ *
+ * `electron` is faked for the reason store.test.ts fakes it: the barrel
+ * re-exports the store, which builds an `electron-store` over `app.getPath`.
+ */
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const fake = vi.hoisted(() => ({ userData: "" }));
+
+vi.mock("electron", () => {
+	const api = {
+		app: {
+			getPath: () => fake.userData,
+			getVersion: () => "0.0.0-test",
+		},
+		ipcMain: { on: () => {} },
+		shell: { openPath: async () => "" },
+	};
+	// electron-store reaches for the default export.
+	return { ...api, default: api };
+});
+
+fake.userData = mkdtempSync(join(tmpdir(), "vayu-mcp-lazy-"));
+
+afterAll(() => {
+	rmSync(fake.userData, { recursive: true, force: true });
+});
+
+describe("the on-demand MCP barrel", () => {
+	it("resolves through the specifier main.ts uses", async () => {
+		const mcp = await import("./index.js");
+		expect(mcp).toBeDefined();
+	});
+
+	it("serves the service startMcp constructs", async () => {
+		const { VayuMcpService } = await import("./index.js");
+		expect(typeof VayuMcpService).toBe("function");
+	});
+
+	it("serves a populated catalog to the tool-list handlers", async () => {
+		const { toolCatalog } = await import("./index.js");
+		const tools = toolCatalog();
+
+		expect(tools.length).toBeGreaterThan(0);
+		for (const tool of tools) {
+			expect(tool.name).toBeTruthy();
+			expect(tool.description).toBeTruthy();
+			expect(tool.category).toBeTruthy();
+		}
+	});
+
+	/*
+	 * `mcp:updateSafety` filters a persisted disabled list against this, so a
+	 * catalog of unnamed tools would silently empty the user's selection rather
+	 * than fail. Names are what that branch matches on.
+	 */
+	it("names every tool uniquely, which is what updateSafety filters on", async () => {
+		const { toolCatalog } = await import("./index.js");
+		const names = toolCatalog().map((tool) => tool.name);
+
+		expect(new Set(names).size).toBe(names.length);
+	});
+});

--- a/app/electron/startup-import-graph.test.ts
+++ b/app/electron/startup-import-graph.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the main process evaluates before it does anything.
+ *
+ * The main process is unbundled: `electron:compile` is plain `tsc`, so
+ * `dist-electron/` is one emitted file per source module and Node's ESM loader
+ * walks the static import graph from `main.ts` file by file, evaluating every
+ * module in it, before `app.whenReady` ever fires. Nothing else gates that -
+ * a preference read inside a function cannot stop work the loader already did
+ * on the way to calling it. So the graph below *is* the startup cost, and the
+ * only way to not pay for a subsystem is to not be in it.
+ *
+ * The MCP stack is the case that made this a test (#1145): the barrel pulled
+ * the MCP SDK, zod and a 7,300-line tool registry with 67 schemas built at
+ * module scope, ~250-300ms of serial evaluation ahead of the window, on every
+ * launch - including launches with MCP switched off, because `main.ts` reached
+ * through that barrel for the very preference that decides whether to start it.
+ *
+ * Scanned rather than executed for the usual reason: `main.ts` creates windows
+ * and starts the engine at import time, so it cannot be imported. The counts in
+ * the first case exist so a broken walk or a regex that stopped matching fails
+ * loudly instead of passing over an empty graph.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const electronDir = path.dirname(fileURLToPath(import.meta.url));
+const entry = path.join(electronDir, "main.ts");
+
+/**
+ * Specifiers whose module the ESM loader actually evaluates.
+ *
+ * `import type` / `export type` are erased by tsc, and so is a brace list whose
+ * every member carries an inline `type` modifier - none of those reach the
+ * loader, so none of them cost anything at startup.
+ */
+function eagerSpecifiers(source: string): string[] {
+	const withClause =
+		/(?:^|\n)\s*(?:import|export)\s+(type\s+)?([\s\S]*?)\s+from\s*["']([^"']+)["']/g;
+	const sideEffectOnly = /(?:^|\n)\s*import\s*["']([^"']+)["']/g;
+
+	const specifiers = [...source.matchAll(withClause)]
+		.filter(([, typeKeyword, clause]) => !typeKeyword && !isAllTypeOnly(clause))
+		.map(([, , , specifier]) => specifier);
+
+	return [...specifiers, ...[...source.matchAll(sideEffectOnly)].map((m) => m[1])];
+}
+
+/** `{ type A, type B }` - erased. A default or namespace clause never is. */
+function isAllTypeOnly(clause: string): boolean {
+	const braced = clause.match(/^\{([\s\S]*)\}$/);
+	if (!braced) return false;
+	const names = braced[1]
+		.split(",")
+		.map((name) => name.trim())
+		.filter(Boolean);
+	return names.length > 0 && names.every((name) => /^type\s/.test(name));
+}
+
+/** A relative specifier back to the `.ts` it was emitted from, or null for a package. */
+function resolveSource(fromFile: string, specifier: string): string | null {
+	if (!specifier.startsWith(".")) return null;
+	const source = path.resolve(path.dirname(fromFile), specifier).replace(/\.js$/, ".ts");
+	return existsSync(source) ? source : null;
+}
+
+/** Every module the loader evaluates on the way to running `main.ts`. */
+function eagerGraph(entryFile: string): { files: Set<string>; packages: Set<string> } {
+	const files = new Set<string>();
+	const packages = new Set<string>();
+	const queue = [entryFile];
+
+	while (queue.length > 0) {
+		const file = queue.pop() as string;
+		if (files.has(file)) continue;
+		files.add(file);
+
+		for (const specifier of eagerSpecifiers(readFileSync(file, "utf8"))) {
+			const source = resolveSource(file, specifier);
+			if (source) queue.push(source);
+			else if (!specifier.startsWith(".")) packages.add(specifier);
+		}
+	}
+	return { files, packages };
+}
+
+describe("main process startup import graph", () => {
+	const { files, packages } = eagerGraph(entry);
+	const relative = new Set([...files].map((f) => path.relative(electronDir, f)));
+
+	it("walks a real graph", () => {
+		expect(relative.size).toBeGreaterThan(15);
+		expect(packages.size).toBeGreaterThan(3);
+		// A module main.ts genuinely does need at launch - if this is missing the
+		// walk resolved nothing and every exclusion below is vacuous.
+		expect(relative).toContain("sidecar.ts");
+	});
+
+	it("does not evaluate the MCP SDK or the tool registry", () => {
+		const sdk = [...packages].filter((p) => p.startsWith("@modelcontextprotocol/sdk"));
+		expect(sdk).toEqual([]);
+
+		const mcpModules = [...relative].filter((f) => f.startsWith(`mcp${path.sep}`));
+		expect(mcpModules.sort()).toEqual(
+			[
+				path.join("mcp", "config.ts"),
+				path.join("mcp", "connect.ts"),
+				path.join("mcp", "store.ts"),
+			].sort()
+		);
+	});
+
+	/*
+	 * The exclusion above is only worth anything if the cheap half is still
+	 * reached - a lazy load that also stopped reading the preference would pass
+	 * it while breaking the feature.
+	 */
+	it("still evaluates the modules the startup gate and Settings IPC need", () => {
+		expect(relative).toContain(path.join("mcp", "store.ts"));
+		expect(relative).toContain(path.join("mcp", "config.ts"));
+		expect(relative).toContain(path.join("mcp", "connect.ts"));
+	});
+
+	it("reads the enabled preference before loading the MCP barrel", () => {
+		const main = readFileSync(entry, "utf8");
+		const start = main.indexOf("async function startMcp()");
+		const end = main.indexOf("async function stopMcp()", start);
+		expect(start).toBeGreaterThan(-1);
+		expect(end).toBeGreaterThan(start);
+		const body = main.slice(start, end);
+
+		const gate = body.indexOf("loadMcpEnabled()");
+		const load = body.indexOf("await loadMcp()");
+		expect(gate).toBeGreaterThan(-1);
+		expect(load).toBeGreaterThan(-1);
+		expect(gate).toBeLessThan(load);
+	});
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,17 @@ one app instance may drive it:
   the disconnected state until one answers. MCP still starts after the window,
   for its own reason - it reads a config file, and a corrupt one must not cost
   the user a window.
+- **MCP is *loaded* after the window too, not merely started there.** Placing the
+  start call late does nothing about the import: the main process is unbundled,
+  so Node's ESM loader walks `main.ts`'s static import graph and evaluates every
+  module in it before `app.whenReady` fires at all. Reaching through the
+  `mcp/index.js` barrel for anything therefore evaluated the MCP SDK, zod and a
+  7,300-line tool registry - ~250-300 ms ahead of the window on every launch,
+  including the ones where MCP is switched off, since the barrel also carried the
+  preference that decides. `main.ts` now imports the three self-contained modules
+  it needs at startup (`mcp/config`, `mcp/store`, `mcp/connect`) and pulls the
+  barrel through a cached dynamic `import()` inside `startMcp()`, behind the
+  enabled check. `startup-import-graph.test.ts` holds the graph to that.
 
 **Development vs Production:**
 - **Development**: Engine binary at `engine/build/vayu-engine`

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -1379,12 +1379,25 @@ Everything lives under `app/electron/mcp/` and is managed by `main.ts` alongside
 | `cli.ts`           | Standalone stdio server (env-configured).                                   |
 | `connect.ts`       | One-click connect: resolves and runs the `claude` / `code` CLIs.            |
 | `store.ts`         | Persist safety config + enabled preference (`electron-store`).              |
-| `index.ts`         | `VayuMcpService` facade consumed by `main.ts`.                              |
+| `index.ts`         | `VayuMcpService` facade consumed by `main.ts`, loaded on demand.            |
 
 ### Lifecycle & IPC
 
 `main.ts` starts the server in `app.whenReady()` (skipped if disabled), stops it
-on quit, and exposes IPC the Settings panel uses:
+on quit, and exposes IPC the Settings panel uses.
+
+**`main.ts` imports this directory by weight.** `config.ts`, `store.ts` and
+`connect.ts` are self-contained (`electron-store` and `node:child_process` are
+their heaviest dependencies), so they are ordinary static imports. Everything
+reachable from `index.ts` - the SDK, zod, `tools.ts` and its 67 schemas built at
+module scope - is loaded by a cached dynamic `import()` instead, inside
+`startMcp()` after the enabled check and inside the two IPC handlers that need
+the tool catalog. The main process is unbundled, so a static import here is
+evaluated before `app.whenReady` and cost every launch ~250-300 ms ahead of the
+window, MCP switched off or not (#1145). A disabled launch now evaluates none of
+it; opening the Settings tool list is what pays for the registry.
+
+The IPC surface:
 
 | IPC handler         | Purpose                                                     |
 | ------------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
## Description

**Root cause.** The main process is unbundled - `electron:compile` is plain `tsc`, so `dist-electron/` is one emitted file per module and Node's ESM loader walks `main.ts`'s static import graph, evaluating every module in it, *before* `app.whenReady` fires. `main.ts:39-53` reached through the `mcp/index.js` barrel for ten runtime symbols; that barrel re-exports `toolCatalog` from the 7,318-line `tools.ts` (67 tools, every zod schema built at module scope) and builds its facade over `http.ts` → the SDK `StreamableHTTPServerTransport` → `server.ts` → the SDK `McpServer`. So the whole SDK + zod + registry graph was evaluated serially ahead of the window on **every** launch - including launches with MCP switched off, because `loadMcpEnabled()` itself came through that same barrel. Starting the server last (`main.ts:1013`) never addressed this: the import lands first.

**Approach.** Import the directory *by weight* rather than moving the whole barrel behind one dynamic import. `config.ts` (zero imports), `store.ts` (`electron-store` + config) and `connect.ts` (`node:child_process`) reach neither the SDK nor `tools.ts`, so their eight symbols are imported statically and direct - the startup gate and the Settings safety/connect IPC keep working for free. The two symbols that genuinely pull the SDK, `VayuMcpService` and `toolCatalog`, come from a cached `await import("./mcp/index.js")` inside `startMcp()` **after** the enabled check, and inside the two IPC handlers that need the catalog. `mcp:updateSafety` loads it only on the branch that filters `disabledTools`; a caps- or allowlist-only change never touches the registry.

**Alternative rejected.** Wrapping the entire barrel import in one dynamic import inside `startMcp()` defeats itself: the barrel *is* the heavy thing, so pulling `loadMcpEnabled` through it would evaluate the SDK and `tools.ts` on the first call anyway - the gate would have to pay the load it exists to avoid. Also rejected: extracting `toolCatalog` into a light module. It maps over `TOOLS` (`tools.ts:3563`), so extraction means restructuring a 7,318-line registry to save a load on a user-initiated Settings call that can honestly pay for it.

Measured: the deferred graph costs **~197 ms** (median of 3, warm cache, node 22, unpackaged). Same order as the filed 250-300 ms, which summed zod, the SDK graphs and `tools.ts` eval separately; cold and packaged launches are higher.

The emitted output confirms the shape - `dist-electron/main.js` has static `./mcp/config.js`, `./mcp/store.js`, `./mcp/connect.js`, and the barrel appears only as `mcpModulePromise ?? (mcpModulePromise = import("./mcp/index.js"))`. The type-only imports of `VayuMcpService` and `McpDataChangedEvent` are erased entirely.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

(Closest fit: a performance change. Behaviour changes only in *when* modules load.)

## Testing

- `cd app && pnpm test` - **549 files, 6007 tests, all passing** on the first commit; the electron project (33 files, 971 tests) re-run green after the second. The same suite is green on the base commit `f978fd5`, so there are no pre-existing failures to report.
- `cd app && pnpm type-check` - clean across all three projects (renderer, electron, electron-tests).
- `cd app && pnpm lint` and `pnpm format:check` - clean. Only files this PR touches were formatted, all prettier-clean beforehand.
- `cd app && pnpm electron:compile` - clean, and the emitted `main.js` was inspected to confirm the import shape above.

**`app/electron/startup-import-graph.test.ts`** (4 cases) - acceptance criterion 1, stated directly. It walks the *eager* import graph from `main.ts`, ignoring `import type` and all-inline-`type` brace lists (which tsc erases), and asserts no `@modelcontextprotocol/sdk` package and no `mcp/` module beyond `config`/`connect`/`store` appears in it. The graph is what the loader evaluates, so exclusion from it *is* "not evaluated at launch". Mutation-checked: re-adding `import { toolCatalog } from "./mcp/index.js"` fails it with both SDK subpaths named. Per the repo's rule about scans that silently read nothing, the first case asserts >15 modules, >3 packages and `sidecar.ts`; a third asserts the three light modules are *still* eager, so a lazy load that also broke the startup gate cannot pass by deleting the feature.

**`app/electron/mcp/lazy-load.test.ts`** (4 cases) - the issue's "assert `startMcp` still serves the catalog after the dynamic import". The static guard proves what is no longer loaded; this proves the deferred path still answers. It drives the same specifier the same way and asserts both symbols the lazy call sites take, with the catalog non-empty and its names unique (that uniqueness is what `mcp:updateSafety` filters a persisted disabled list on). Mutation-checked: dropping `toolCatalog` from the barrel's re-export fails two cases with `toolCatalog is not a function` - a break that type-checks and ships otherwise, since a dynamic import is resolved at runtime.

Acceptance criterion 2 is otherwise covered by the existing net, all green: `startup-order.test.ts` and `store.test.ts`'s `main.ts startup ordering` block pin the call-site ordering and the `try {` → `loadMcpEnabled()` sequence, `protocol.integration.test.ts` drives a real SDK client against a real `McpHttpServer` over loopback, and `McpSettingsPanel.test.tsx` covers the renderer side of every `mcp:*` channel. All six `mcp:*` channels keep their names and payload shapes; two became `async`, which is a non-event across `ipcRenderer.invoke` (it already returned a promise, and both call sites already awaited).

Not run: the engine suite and `build.py`. No C++ or engine behaviour is touched.

**Deviation from the issue spec, disclosed:** the issue suggested a require-hook or `--cpu-prof` proof for criterion 1. A static graph walk is stronger for a guard - deterministic, no timing flake, and it fails on the *cause* rather than a threshold - and it fits the established `main.ts`-cannot-be-imported scanning pattern the other startup tests use. The measured number is reported here rather than asserted in a test, since a wall-clock assertion is the machine-load flake `app/CLAUDE.md` warns against.

**Reviewer findings considered and not acted on**, recorded so they are not re-found: (1) `startup-import-graph.test.ts`'s specifier regex is not comment-aware, so an import inside a block comment would count as eager - no file in the current graph has one, and the failure mode is a false *fail*, never a masked eager SDK load, so comment-stripping would add complexity for no soundness gain. (2) `import { type as Y }` - a value literally named `type`, renamed - would misclassify as type-only; no such import exists anywhere under `app/electron/`. (3) This test's specifier extraction overlaps `esm-import-extensions.test.ts`'s: the two genuinely diverge (relative-only + dynamic imports vs. all specifiers + type-only filtering) and no shared primitive existed to reuse, so factoring one out would be a refactor this issue does not own.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit as the code: `docs/architecture.md` (the startup section said MCP starts after the window "for its own reason" - it now also records that MCP is *loaded* there, and why placing the start call late did nothing on its own) and `docs/engine/mcp.md` (the Lifecycle section states the import-by-weight rule; the `index.ts` row notes it is loaded on demand). `docs/app/architecture.md` was checked and deliberately left alone - its main-process section lists responsibilities only and mentions neither MCP nor module loading, so the issue's condition for updating it does not apply.

## Related Issues

Closes #1145