### PR TITLE
perf(engine): a retained run keeps its tick topic, not its event loop - #1154

### DIFF
--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -227,7 +227,12 @@ Manages the lifecycle of load test runs:
   **tick topic** (ring of wire-ready metric snapshots) per run
 - **Retained finished runs**: Completed/failed/stopped runs are moved to a separate retained
   map rather than unregistered immediately, so a late SSE client still receives the full metric
-  series. A TTL sweep evicts them after `liveRetentionMs` (default 60s).
+  series. A TTL sweep evicts them after `liveRetentionMs` (default 60s). **The tick topic is
+  what is retained, not the machinery that filled it**: the move releases the run's event loop -
+  its curl handle pools, its multi handles and the connections they cache against the target,
+  its submission queues - along with the bound data rows and the scenario plan, so a finished
+  run holds none of them for the window (issue #1154). The counters and histograms behind the
+  summary stay, because the report and a late `/live` consumer read them.
 - **Stop discards, completion drains (with a deadline)**: a stopped run throws away its queued
   backlog and cancels in-flight transfers, so a stop is not paced by the upstream; a run that
   reaches the end of its duration waits for genuine in-flight requests, but no longer than
@@ -710,8 +715,9 @@ continue-on-failure policy** beyond "an errored step ends its iteration".
 9. Client streams ticks via SSE (/runs/:runId/live), replayed
    from the oldest retained tick then tailed to the `complete` event
    ↓
-10. On completion: batch-write results to DB; run retained (TTL) so
-    late clients still get the full series
+10. On completion: batch-write results to DB; event loop, data rows
+    and plan released; run retained (TTL) so late clients still get
+    the full series
 ```
 
 The metrics thread's exit is gated on `is_running`, not on `should_stop`. A stop

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -209,6 +209,33 @@ struct RunContext {
         return event_loop ? event_loop->active_count () : 0;
     }
 
+    /// Let go of everything the run needed only while it was sending: the
+    /// event loop - with its per-worker curl handle pools, its multi handles
+    /// and the TCP/TLS connections those hold open against the target, and the
+    /// 512KB submission queues - the bound CSV rows, and the scenario plan.
+    /// What retention exists for is untouched: the tick topic, `closed`, the
+    /// summary counters and the collector behind them (issue #1154).
+    ///
+    /// Called once, by `RunManager::retain_run`, so no exit path can forget
+    /// it. By then the run's own thread has made its last read of these
+    /// members - the strategy has returned, `event_loop->stop` has drained,
+    /// and `join_aux_threads` has joined the metrics thread, the one other
+    /// reader of the loop.
+    ///
+    /// The loop is moved out under `event_loop_mtx` and destroyed after it is
+    /// dropped: `active_transfer_count` answers 0 from the swap on, and the
+    /// frees - which close sockets - never run with a lock held.
+    void release_execution_resources () {
+        std::unique_ptr<vayu::http::EventLoop> loop;
+        {
+            std::lock_guard<std::mutex> lock (event_loop_mtx);
+            loop = std::move (event_loop);
+        }
+        load_data.reset ();
+        scenario.reset ();
+        // `loop` frees here, outside the critical section above.
+    }
+
     // The run's worker thread is NOT owned here: it holds a shared_ptr to this
     // context, so a context whose last reference is dropped by its own worker
     // (a retained run swept while the worker is still unwinding) would join
@@ -845,7 +872,8 @@ class RunManager {
     // Background TTL sweeper. Without this, retained runs only get evicted when
     // /metrics/live or start_run fires - headless API users (POST /run +
     // GET /run/:id/report) never trigger either, and retained RunContexts
-    // (full tick_buffer, HdrHistogram, counters) accumulate indefinitely.
+    // (tick_buffer, HdrHistogram, counters - the execution machinery is
+    // already released by retain_run) accumulate indefinitely.
     std::thread sweeper_thread_;
     std::mutex sweeper_mtx_;
     std::condition_variable sweeper_cv_;
@@ -907,6 +935,9 @@ class RunManager {
     // On completion a run is MOVED from active_runs_ to retained_runs_ so its
     // in-memory tick topic survives for late/instant consumers. active_count()
     // and get_all_active_runs() keep their exact meaning (active only).
+    // The topic is all that survives: the move calls
+    // RunContext::release_execution_resources(), so the event loop, the bound
+    // rows and the plan are freed here rather than at the sweep (issue #1154).
     void retain_run (const std::string& run_id);
     // Active OR retained-within-window. Used only by /metrics/live.
     std::shared_ptr<RunContext> get_run_or_retained (const std::string& run_id);

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -699,13 +699,24 @@ void RunManager::unregister_run (const std::string& run_id) {
 }
 
 void RunManager::retain_run (const std::string& run_id) {
-    std::lock_guard<std::mutex> lock (mutex_);
-    auto it = active_runs_.find (run_id);
-    if (it == active_runs_.end ())
-        return;
-    it->second->completed_at_ms.store (now_ms ());
-    retained_runs_[run_id] = it->second;
-    active_runs_.erase (it);
+    std::shared_ptr<RunContext> retained;
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        auto it = active_runs_.find (run_id);
+        if (it == active_runs_.end ())
+            return;
+        it->second->completed_at_ms.store (now_ms ());
+        retained               = it->second;
+        retained_runs_[run_id] = it->second;
+        active_runs_.erase (it);
+    }
+    // Retention is for the tick topic, not for the machinery that filled it:
+    // a finished run held its curl handle pools, its cached connections to the
+    // target, its submission queues and its bound rows for the whole window
+    // (issue #1154). Freed here, after the map move and with `mutex_` dropped,
+    // because closing thousands of sockets under it would stall /health, the
+    // runs poll and a starting run for the length of the teardown.
+    retained->release_execution_resources ();
 }
 
 std::shared_ptr<RunContext> RunManager::get_run_or_retained (const std::string& run_id) {

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(vayu_tests
     run_route_test.cpp
     run_stop_test.cpp
     run_shutdown_test.cpp
+    run_retention_release_test.cpp
     run_config_validation_test.cpp
     run_row_seed_test.cpp
     transient_execute_test.cpp
@@ -341,6 +342,7 @@ set(vayu_scratch_database_suites
     RequestsRouteTest
     ResourceWriteRouteTest
     ResponseCaptureTest
+    RunRetentionReleaseTest
     RunShutdownTest
     RunStopAccountingTest
     RunsRouteTest

--- a/engine/tests/mock_server.hpp
+++ b/engine/tests/mock_server.hpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -27,7 +28,7 @@ class SlowMockServer {
         // concurrent /slow requests, and the worker drains active transfers on
         // stop(). A thread-starved mock would serialize them and make teardown
         // take tens of seconds (a harness artifact, not engine behavior).
-        svr.new_task_queue = vayu::tests::pooled_task_queue (128);
+        svr.new_task_queue = vayu::tests::counting_task_queue (128, live_connections);
 
         svr.Get ("/slow", [] (const httplib::Request&, httplib::Response& res) {
             std::this_thread::sleep_for (std::chrono::milliseconds (500));
@@ -147,11 +148,23 @@ class SlowMockServer {
         return scrapes.load ();
     }
 
+    /// Connections the server is holding open right now - one per task in
+    /// flight (see `counting_task_queue`). A client that keeps its connections
+    /// alive after its last request, as libcurl's connection cache does, is
+    /// counted until it closes them or the fixture goes away.
+    int live_connection_count () const {
+        return live_connections->load (std::memory_order_relaxed);
+    }
+
     httplib::Server svr;
     std::thread thread;
     int port = 0;
     std::atomic<bool> released{ false };
     std::atomic<int> scrapes{ 0 };
+    /// Read through `live_connection_count()`. Shared with the task queue
+    /// httplib owns, which is why it is not a plain member.
+    std::shared_ptr<std::atomic<int>> live_connections =
+    std::make_shared<std::atomic<int>> (0);
 };
 
 } // namespace vayu::tests

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -283,6 +283,43 @@ TEST (RunManagerRetention, RetainMovesOutOfActiveButKeepsLookup) {
     EXPECT_GT (found->completed_at_ms.load (), 0);
 }
 
+// Retention is for the tick topic, and since #1154 that is all it holds: the
+// event loop (curl handle pools, the connections cached against the target,
+// the submission queues), the bound rows and the plan are released as the run
+// is retained, not 60-90s later when the sweeper drops the last reference.
+TEST (RunManagerRetention, RetainReleasesTheMachineryAndKeepsTheTopic) {
+    RunManager mgr;
+    nlohmann::json cfg;
+    auto ctx = std::make_shared<RunContext> ("run_y", cfg);
+
+    vayu::http::EventLoopConfig loop_cfg;
+    loop_cfg.num_workers    = 1;
+    loop_cfg.max_concurrent = 1;
+    ctx->publish_event_loop (std::make_unique<vayu::http::EventLoop> (loop_cfg));
+    ctx->load_data = std::make_unique<LoadDataSet> ();
+    ctx->scenario  = std::make_shared<const ScenarioExecution> ();
+    ctx->append_tick ("tick-0");
+    ctx->closed.store (true);
+    mgr.register_run ("run_y", ctx);
+
+    mgr.retain_run ("run_y");
+
+    auto found = mgr.get_run_or_retained ("run_y");
+    ASSERT_NE (found, nullptr);
+    EXPECT_EQ (found->event_loop, nullptr);
+    EXPECT_EQ (found->load_data, nullptr);
+    EXPECT_EQ (found->scenario, nullptr);
+    // The one accessor a reader could still be inside answers for a released
+    // loop rather than reading through it.
+    EXPECT_EQ (found->active_transfer_count (), 0u);
+
+    // What a late consumer of /runs/:id/live reads is untouched.
+    ASSERT_EQ (found->ticks_since (0).payloads.size (), 1u);
+    EXPECT_EQ (found->ticks_since (0).payloads[0], "tick-0");
+    EXPECT_EQ (found->published_count.load (), 1u);
+    EXPECT_TRUE (found->closed.load ());
+}
+
 TEST (BuildTickPayload, WrapsStatsAsSseEventWithOffsetId) {
     nlohmann::json stats;
     stats["totalRequests"] = 42;

--- a/engine/tests/run_retention_release_test.cpp
+++ b/engine/tests/run_retention_release_test.cpp
@@ -1,0 +1,141 @@
+/**
+ * @file run_retention_release_test.cpp
+ * @brief A finished run lets go of its machinery as it is retained (#1154).
+ *
+ * Retention exists so a late consumer of `/runs/:id/live` still gets the whole
+ * tick series, and for 60-90s a finished run used to hold everything else with
+ * it: the event loop's per-worker curl handle pools, the multi handles and the
+ * TCP connections cached inside them against the tested target, the submission
+ * queues, and the run's bound rows.
+ *
+ * The mock server counts the connections it is holding open, which is what
+ * makes the release observable from outside the engine: with the release
+ * removed, the count stays up until the multi handles are freed at sweep time.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+#include "mock_server.hpp"
+#include "optional_assert.hpp"
+#include "temp_database.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+
+namespace {
+
+using vayu::tests::SlowMockServer;
+using Clock = std::chrono::steady_clock;
+
+int64_t ms_since (Clock::time_point start) {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (Clock::now () - start)
+    .count ();
+}
+
+class RunRetentionReleaseTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_run_retention_release.db";
+
+    void SetUp () override {
+        vayu::http::global_init ();
+        server = std::make_unique<SlowMockServer> ();
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+        server.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    /// A run row for @p run_id, stamped now: a terminal run triggers
+    /// prune_runs_configured, and an age-based window would sweep a 1970 row
+    /// away before the assertions could read it.
+    void create_run_row (const std::string& run_id) {
+        vayu::db::Run row;
+        row.id              = run_id;
+        row.type            = vayu::RunType::Load;
+        row.status          = vayu::RunStatus::Pending;
+        row.config_snapshot = "{}";
+        row.start_time = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                         .count ();
+        row.end_time = 0;
+        db->create_run (row);
+    }
+
+    std::unique_ptr<SlowMockServer> server;
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+// The acceptance criterion end to end: once a real run has been retained, the
+// engine is holding no connection to the target - and the tick topic retention
+// exists for still answers.
+TEST_F (RunRetentionReleaseTest, RetainedRunHoldsNoConnectionToTheTarget) {
+    const std::string run_id = "run-retention-release";
+    create_run_row (run_id);
+
+    // Short, modest and single-worker: enough requests to have the mock holding
+    // connections open, few enough that its own keep-alive request cap (100 per
+    // connection) never closes one for us.
+    nlohmann::json config = { { "mode", "constant_rps" }, { "duration", "1s" },
+        { "targetRps", 40.0 }, { "url", server->fast_url () }, { "method", "GET" },
+        { "timeout", 5000 }, { "workers", 1 }, { "concurrency", 4 } };
+
+    vayu::core::RunManager manager;
+    manager.start_run (run_id, config, *db, false);
+
+    auto context = manager.get_run (run_id);
+    ASSERT_NE (context, nullptr);
+
+    auto ramp = Clock::now ();
+    while (server->live_connection_count () == 0 && ms_since (ramp) < 5000) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
+    }
+    ASSERT_GT (server->live_connection_count (), 0)
+    << "the run never opened a connection; the test cannot prove anything";
+
+    // retain_run() is the worker's last act, so a run that has left active_runs_
+    // is fully done. The wait is far longer than the assertions below need: the
+    // worker holds references to this test's `db` and `manager`, so returning
+    // while it is still running would tear those out from under it.
+    auto finish = Clock::now ();
+    while (manager.get_run (run_id) != nullptr && ms_since (finish) < 45000) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (20));
+    }
+    ASSERT_EQ (manager.get_run (run_id), nullptr) << "the run never finished";
+
+    // The release happens just after the map move, so poll rather than read on
+    // the same instant. The budget is well inside the 60s retention window this
+    // is about, and inside httplib's own 5s keep-alive timeout, so a count that
+    // only drops later is the sweep or the mock closing up, not this fix.
+    auto closing = Clock::now ();
+    while (server->live_connection_count () > 0 && ms_since (closing) < 2000) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
+    }
+    EXPECT_EQ (server->live_connection_count (), 0)
+    << "a retained run was still holding connections open against the target";
+
+    // What retention is for still answers a late consumer.
+    auto retained = manager.get_run_or_retained (run_id);
+    ASSERT_NE (retained, nullptr);
+    EXPECT_GT (retained->published_count.load (), 0u);
+    EXPECT_FALSE (retained->ticks_since (0).payloads.empty ())
+    << "the tick topic did not survive the release";
+
+    auto stored = db->get_run (run_id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->status, vayu::RunStatus::Completed);
+}
+
+} // namespace

--- a/engine/tests/task_queue.hpp
+++ b/engine/tests/task_queue.hpp
@@ -21,8 +21,11 @@
 
 #include <httplib.h>
 
+#include <atomic>
 #include <cstddef>
 #include <functional>
+#include <memory>
+#include <utility>
 
 namespace vayu::tests {
 
@@ -37,6 +40,86 @@ inline std::function<httplib::TaskQueue*()> pooled_task_queue (std::size_t threa
         // comment above.
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         return new httplib::ThreadPool (threads);
+    };
+}
+
+namespace detail {
+
+/**
+ * @brief Holds a mock server's live-connection count up for one task.
+ *
+ * A guard rather than a pair of statements, so a handler that throws past
+ * httplib cannot leave the count high for the rest of the test.
+ */
+class ConnectionScope {
+    public:
+    explicit ConnectionScope (std::shared_ptr<std::atomic<int>> live)
+    : live_ (std::move (live)) {
+        live_->fetch_add (1, std::memory_order_relaxed);
+    }
+    ~ConnectionScope () {
+        live_->fetch_sub (1, std::memory_order_relaxed);
+    }
+    ConnectionScope (const ConnectionScope&)            = delete;
+    ConnectionScope& operator= (const ConnectionScope&) = delete;
+    ConnectionScope (ConnectionScope&&)                 = delete;
+    ConnectionScope& operator= (ConnectionScope&&)      = delete;
+
+    private:
+    std::shared_ptr<std::atomic<int>> live_;
+};
+
+/**
+ * @brief A pooled task queue that also counts the connections open right now.
+ *
+ * httplib runs a whole connection - its accept, every keep-alive request on it,
+ * and its close - as ONE queued task, so tasks in flight is exactly the number
+ * of connections the server is holding open. `httplib::ThreadPool` is `final`,
+ * so this wraps one instead of deriving from it.
+ */
+class CountingTaskQueue final : public httplib::TaskQueue {
+    public:
+    CountingTaskQueue (std::size_t threads, std::shared_ptr<std::atomic<int>> live)
+    : pool_ (threads), live_ (std::move (live)) {
+    }
+    ~CountingTaskQueue () override                          = default;
+    CountingTaskQueue (const CountingTaskQueue&)            = delete;
+    CountingTaskQueue& operator= (const CountingTaskQueue&) = delete;
+    CountingTaskQueue (CountingTaskQueue&&)                 = delete;
+    CountingTaskQueue& operator= (CountingTaskQueue&&)      = delete;
+
+    bool enqueue (std::function<void ()> fn) override {
+        return pool_.enqueue ([live = live_, task = std::move (fn)] () {
+            const ConnectionScope open (live);
+            task ();
+        });
+    }
+
+    void shutdown () override {
+        pool_.shutdown ();
+    }
+
+    private:
+    httplib::ThreadPool pool_;
+    std::shared_ptr<std::atomic<int>> live_;
+};
+
+} // namespace detail
+
+/**
+ * @brief `pooled_task_queue`, with @p live tracking the connections held open.
+ *
+ * The count is a `shared_ptr` because httplib owns the queue and shuts it down
+ * from inside `listen()`; a counter borrowed from the fixture would outlive its
+ * reader only by luck.
+ */
+inline std::function<httplib::TaskQueue*()>
+counting_task_queue (std::size_t threads, std::shared_ptr<std::atomic<int>> live) {
+    return [threads, live = std::move (live)] () -> httplib::TaskQueue* {
+        // httplib owns and deletes what this factory returns; see the file
+        // comment above.
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        return new detail::CountingTaskQueue (threads, live);
     };
 }
 


### PR DESCRIPTION
## Description

**Root cause.** `retain_run` moved the whole `RunContext` into `retained_runs_` and nothing reset the heavy members first, so for `liveRetentionMs` (60s, swept within `ttl..1.5*ttl`) a finished run still owned its `EventLoop` - each worker's curl handle pool, the multi handles and the **TCP/TLS connections cached inside them against the tested target**, a 512KB SPSC queue per worker - plus the bound CSV rows (`load_data`) and the scenario plan. The sole retained-run consumer, `stream_live_metrics` via `get_run_or_retained`, reads only the tick ring, `closed` and `published_count`; everything else was retained by accident of ownership and freed only when the sweeper dropped the last reference.

**Approach.** `RunContext::release_execution_resources()` lets go of `event_loop`, `load_data` and `scenario`, and `RunManager::retain_run` calls it - so the load path's three exits and the sequential scenario runner all get it and no future exit path can forget. It runs *after* the map move and with `mutex_` dropped: closing thousands of sockets under that lock would stall `/health`, the runs poll and a starting run for the length of the teardown. The loop is moved out under `event_loop_mtx` and destroyed once that is released, so `active_transfer_count()` answers 0 from the swap on rather than reading a pointer being freed.

**The alternative rejected.** The issue's suggested site was beside `event_loop->stop()` / `join_aux_threads()` in `execute_load_test`. Verified against the current code, that is too early: `finish_load_test` runs after the drain and its deferred script replay (`validate_scripts`, which reads `context->scenario->request.collection_id` and `context->load_data->rows`) and the schema pass (`validate_sampled_responses`) both come before `retain_run`. Releasing there would break both, and it would have to be repeated at four call sites. `retain_run` is the one point every path reaches, after every reader.

**Ordering verified, as the issue asks:** deferred script validation and the schema pass both run inside `finish_load_test`, i.e. before `retain_run` - so they are unaffected. The metrics thread, the only other reader of `event_loop`, is joined by `join_aux_threads()` before that.

**Deliberate deviation:** the collector's sample reservoirs are *not* cleared, though the issue offers it as optional. `POST /runs/:id/stop` returns once `is_running` clears, then calls `MetricsHelper::calculate_summary(*context)`, which reads `metrics_collector` on the HTTP thread with no lock while the worker is still inside `finish_load_test`. Today that pointer is never freed, so the read is safe; nulling it would turn a benign concurrent read into a use-after-free window. The reservoirs' byte budget is #1155's subject and can take that on with the synchronization it needs.

**App changes:** none, as the issue states and this PR re-verified. `/runs/:id/live` (renderer `sse-client.ts`, MCP `get_live_metrics`) reads pre-rendered tick frames; `stop`, the report, samples, and the metric/monitor time series are all DB-backed for a finished run. No response payload changes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2802 tests, 2802 passed, 0 failed** (45.2s). No pre-existing failures on this tree.

Two new tests, both mutation-checked by removing `release_execution_resources()` and rebuilding:

- `RunRetentionReleaseTest.RetainedRunHoldsNoConnectionToTheTarget` (new file) - a real run through `RunManager` against the in-process mock; once it has left `active_runs_`, the mock is holding **zero** connections, and the tick topic still answers a late consumer. With the release removed it fails with `live_connection_count() == 4`.
- `RunManagerRetention.RetainReleasesTheMachineryAndKeepsTheTopic` - the members are null and `active_transfer_count()` is 0 after retention, while the ticks, `published_count` and `closed` survive. With the release removed it fails on the first member.

The connection half is observable because `SlowMockServer` now counts the connections it holds open: httplib runs a whole connection (accept, every keep-alive request, close) as one queued task, so tasks in flight is exactly the open-connection count. That lives in `tests/task_queue.hpp` beside `pooled_task_queue`, not as a copy inside the new test.

`clang-format-19` clean on every touched file; `clang-tidy-19` clean on all six (three sources, three headers).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/architecture.md`'s "Retained finished runs" bullet and the run-flow step 10 now say what retention actually holds, and the two `run_manager.hpp` comments that described the retained cost (`retained_runs_`'s sweeper note and the "Live topic retention" block) match the code again.

## Related Issues
Closes #1154


---
_Generated by [Claude Code](https://claude.ai/code/session_01SyPRXcQHzMZMwV36MAWKEo)_