### PR TITLE
perf(app): probe the lock PID cheaply before spawning tasklist - #1148

### DIFF
--- a/app/electron/engine-liveness.test.ts
+++ b/app/electron/engine-liveness.test.ts
@@ -58,19 +58,25 @@ function stubPlatform(platform: NodeJS.Platform) {
 }
 
 /**
- * A fake OS process table: which PIDs are alive, and which of those we may
- * signal. `process.kill` is the probe under test on the aliveness half, so it
- * is stubbed rather than pointed at a real process - a real live PID we are
- * allowed to signal is exactly what a test cannot conjure portably.
+ * A fake OS process table: which PIDs are alive, and what the signal-0 probe
+ * is told about the ones it may not touch. `process.kill` is the probe under
+ * test on the aliveness half, so it is stubbed rather than pointed at a real
+ * process - a real live PID we are allowed to signal is exactly what a test
+ * cannot conjure portably.
+ *
+ * `refused` carries the error code the probe comes back with for a process it
+ * cannot open: Unix reports `EPERM`, and Windows an `OpenProcess` denial that
+ * libuv translates as `EACCES`. Both mean "could not tell", never "gone".
  */
-function stubProcessTable(table: { alive?: number[]; aliveButForeign?: number[] } = {}) {
+function stubProcessTable(table: { alive?: number[]; refused?: [number, string][] } = {}) {
 	const alive = new Set(table.alive ?? []);
-	const foreign = new Set(table.aliveButForeign ?? []);
+	const refused = new Map(table.refused ?? []);
 
 	return vi.spyOn(process, "kill").mockImplementation((pid: number) => {
 		if (alive.has(pid)) return true;
-		const err: NodeJS.ErrnoException = new Error(foreign.has(pid) ? "EPERM" : "ESRCH");
-		err.code = foreign.has(pid) ? "EPERM" : "ESRCH";
+		const code = refused.get(pid) ?? "ESRCH";
+		const err: NodeJS.ErrnoException = new Error(code);
+		err.code = code;
 		throw err;
 	});
 }
@@ -178,10 +184,24 @@ describe("engine aliveness probe - the name half", () => {
 
 	it("verifies a process it is not allowed to signal rather than assuming either way", () => {
 		stubPlatform("linux");
-		stubProcessTable({ aliveButForeign: [LIVE_PID] });
+		stubProcessTable({ refused: [[LIVE_PID, "EPERM"]] });
 		stubProcessName("vayu-engine\n");
 
 		// EPERM says something holds the PID; only the name says whose it is.
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(true);
+		expect(execSync).toHaveBeenCalledOnce();
+	});
+
+	it("does not read a Windows access denial as a dead engine", () => {
+		stubPlatform("win32");
+		// libuv sends an OpenProcess denial back through the generic Win32 error
+		// translation, so it arrives as EACCES and not the EPERM the Unix branch
+		// sees. Only ESRCH is proof of death - anything else pays the subprocess,
+		// which is what the old tasklist-only path did unconditionally.
+		stubProcessTable({ refused: [[LIVE_PID, "EACCES"]] });
+		stubProcessName(ENGINE_ROW);
+
+		// Reading this as "dead" would delete a live engine's lock file.
 		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(true);
 		expect(execSync).toHaveBeenCalledOnce();
 	});

--- a/app/electron/engine-liveness.test.ts
+++ b/app/electron/engine-liveness.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A dead PID must not cost a subprocess.
+ *
+ * The engine writes `vayu.lock` and releases it only on a clean shutdown - it
+ * never unlinks the file - so the *ordinary* state at launch is a lock file
+ * naming a process that is long gone. Windows answered that question by
+ * spawning cmd.exe and tasklist, 52.5ms median measured on a CI runner, on the
+ * Electron main-process event loop, every single boot; Unix had had the cheap
+ * `process.kill(pid, 0)` early-out since the beginning (#1148).
+ *
+ * `sidecar.test.ts` drives the lifecycle through a fake `SidecarSystem` and
+ * deliberately mocks nothing else, so the probe underneath that seam is exactly
+ * the part it cannot see. These cases go the other way: the real
+ * `defaultSidecarSystem` against a stubbed `process.kill` and a stubbed
+ * `execSync`, so "no subprocess was spawned" is an assertion rather than a
+ * hope. Both platform branches are driven by stubbing `process.platform` - a
+ * test that reads the host's would only ever exercise the runner it landed on.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execSync } from "child_process";
+
+vi.mock("child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("child_process")>();
+	return { ...actual, execSync: vi.fn() };
+});
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: () => "",
+		getAppPath: () => "",
+		getVersion: () => "0.0.0-test",
+	},
+}));
+
+import { defaultSidecarSystem } from "./sidecar";
+
+const LIVE_PID = 4242;
+const DEAD_PID = 4243;
+
+/** The tasklist row a real engine produces, and one from something else. */
+const ENGINE_ROW = '"vayu-engine.exe","4242","Console","1","12,345 K"\n';
+const STRANGER_ROW = '"notepad.exe","4242","Console","1","12,345 K"\n';
+/** What tasklist prints when its PID filter matches nothing. */
+const NO_SUCH_TASK = "INFO: No tasks are running which match the specified criteria.\n";
+
+const realPlatform = process.platform;
+
+function stubPlatform(platform: NodeJS.Platform) {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+/**
+ * A fake OS process table: which PIDs are alive, and which of those we may
+ * signal. `process.kill` is the probe under test on the aliveness half, so it
+ * is stubbed rather than pointed at a real process - a real live PID we are
+ * allowed to signal is exactly what a test cannot conjure portably.
+ */
+function stubProcessTable(table: { alive?: number[]; aliveButForeign?: number[] } = {}) {
+	const alive = new Set(table.alive ?? []);
+	const foreign = new Set(table.aliveButForeign ?? []);
+
+	return vi.spyOn(process, "kill").mockImplementation((pid: number) => {
+		if (alive.has(pid)) return true;
+		const err: NodeJS.ErrnoException = new Error(foreign.has(pid) ? "EPERM" : "ESRCH");
+		err.code = foreign.has(pid) ? "EPERM" : "ESRCH";
+		throw err;
+	});
+}
+
+/** What the name-verification subprocess would print, if it is reached at all. */
+function stubProcessName(output: string) {
+	vi.mocked(execSync).mockReturnValue(output);
+}
+
+beforeEach(() => {
+	vi.mocked(execSync).mockReset();
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	stubPlatform(realPlatform);
+});
+
+describe("engine aliveness probe - the cheap half", () => {
+	it("spawns nothing for a dead PID on Windows", () => {
+		stubPlatform("win32");
+		const kill = stubProcessTable({ alive: [LIVE_PID] });
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(DEAD_PID)).toBe(false);
+
+		// The whole point: the dominant boot case - a stale lock file - is
+		// answered by a signal-0 probe, and tasklist is never reached.
+		expect(kill).toHaveBeenCalledWith(DEAD_PID, 0);
+		expect(execSync).not.toHaveBeenCalled();
+	});
+
+	it("spawns nothing for a dead PID off Windows", () => {
+		stubPlatform("linux");
+		const kill = stubProcessTable({ alive: [LIVE_PID] });
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(DEAD_PID)).toBe(false);
+
+		expect(kill).toHaveBeenCalledWith(DEAD_PID, 0);
+		expect(execSync).not.toHaveBeenCalled();
+	});
+
+	it("refuses a PID that is not one, before signalling anything", () => {
+		stubPlatform("linux");
+		const kill = stubProcessTable({ alive: [LIVE_PID] });
+
+		// A garbled or truncated lock file is the source here, and on Unix a
+		// zero or negative target is a *process group* - this app's own.
+		for (const notAPid of [0, -1, -LIVE_PID, Number.NaN, 1.5]) {
+			expect(defaultSidecarSystem.isEngineProcessAlive(notAPid)).toBe(false);
+			expect(defaultSidecarSystem.killEngineProcess(notAPid)).toBe(false);
+		}
+
+		expect(kill).not.toHaveBeenCalled();
+		expect(execSync).not.toHaveBeenCalled();
+	});
+});
+
+describe("engine aliveness probe - the name half", () => {
+	it("still name-verifies a live PID on Windows, so a recycled one is not ours", () => {
+		stubPlatform("win32");
+		stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName(STRANGER_ROW);
+
+		// PID reuse is the reason the subprocess exists: alive is not enough.
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(false);
+		expect(execSync).toHaveBeenCalledOnce();
+		expect(vi.mocked(execSync).mock.calls[0][0]).toContain(`PID eq ${LIVE_PID}`);
+	});
+
+	it("recognises the engine on Windows", () => {
+		stubPlatform("win32");
+		stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName(ENGINE_ROW);
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(true);
+	});
+
+	it("hides the console window the name check would otherwise flash", () => {
+		stubPlatform("win32");
+		stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName(ENGINE_ROW);
+
+		defaultSidecarSystem.isEngineProcessAlive(LIVE_PID);
+
+		expect(vi.mocked(execSync).mock.calls[0][1]).toMatchObject({ windowsHide: true });
+	});
+
+	it("reads a PID filter that matched nothing as not-the-engine", () => {
+		stubPlatform("win32");
+		stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName(NO_SUCH_TASK);
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(false);
+	});
+
+	it("name-verifies a live PID off Windows", () => {
+		stubPlatform("darwin");
+		stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName("vayu-engine\n");
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(true);
+		expect(vi.mocked(execSync).mock.calls[0][0]).toContain(`ps -p ${LIVE_PID}`);
+	});
+
+	it("verifies a process it is not allowed to signal rather than assuming either way", () => {
+		stubPlatform("linux");
+		stubProcessTable({ aliveButForeign: [LIVE_PID] });
+		stubProcessName("vayu-engine\n");
+
+		// EPERM says something holds the PID; only the name says whose it is.
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(true);
+		expect(execSync).toHaveBeenCalledOnce();
+	});
+
+	it("treats a name it could not read as not-the-engine", () => {
+		stubPlatform("linux");
+		stubProcessTable({ alive: [LIVE_PID] });
+		vi.mocked(execSync).mockImplementation(() => {
+			throw new Error("ps: command not found");
+		});
+
+		expect(defaultSidecarSystem.isEngineProcessAlive(LIVE_PID)).toBe(false);
+	});
+});
+
+describe("engine kill path", () => {
+	it("does not reach for taskkill on a PID nothing holds", () => {
+		stubPlatform("win32");
+		stubProcessTable({ alive: [LIVE_PID] });
+
+		expect(defaultSidecarSystem.killEngineProcess(DEAD_PID)).toBe(false);
+		expect(execSync).not.toHaveBeenCalled();
+	});
+
+	it("kills a name-verified engine and nothing else", () => {
+		stubPlatform("linux");
+		const kill = stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName("vayu-engine\n");
+
+		expect(defaultSidecarSystem.killEngineProcess(LIVE_PID)).toBe(true);
+		expect(kill).toHaveBeenCalledWith(LIVE_PID, "SIGKILL");
+	});
+
+	it("leaves a stranger on a recycled PID alone", () => {
+		stubPlatform("linux");
+		const kill = stubProcessTable({ alive: [LIVE_PID] });
+		stubProcessName("postgres\n");
+
+		expect(defaultSidecarSystem.killEngineProcess(LIVE_PID)).toBe(false);
+		expect(kill).not.toHaveBeenCalledWith(LIVE_PID, "SIGKILL");
+	});
+});

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -107,64 +107,83 @@ async function requestEngineShutdown(port: number): Promise<boolean> {
 }
 
 /**
- * Check if a process is still running by PID and verify it's vayu-engine
- * Cross-platform implementation with process name verification
+ * A number we are willing to hand to `process.kill`.
  *
- * This prevents PID reuse issues where a different process might have
- * reused the same PID that was previously held by vayu-engine.
+ * The PID comes out of a lock file on disk, so it is whatever that file says.
+ * Zero and negatives are not PIDs: `process.kill` reads them as *process
+ * group* targets on Unix, so a truncated or garbled lock file would aim the
+ * probe - and, through `killVayuEngineProcess`, a SIGKILL - at this app's own
+ * process group.
  */
-function isVayuEngineRunning(pid: number): boolean {
+function isPlausiblePid(pid: number): boolean {
+	return Number.isInteger(pid) && pid > 0;
+}
+
+/**
+ * Does *anything* hold this PID?
+ *
+ * Signal 0 delivers nothing - it is an existence-and-permission probe, and
+ * libuv implements it on Windows too (`OpenProcess` plus an exit-code check, so
+ * a process that has terminated while someone still holds a handle to it
+ * reports `ESRCH` rather than "alive"). That makes it the cheap first half of
+ * the question on every platform, which matters because the dominant case at
+ * startup is a leftover lock file naming a PID that is long gone: the engine
+ * only releases its lock on a clean shutdown and never unlinks the file, so
+ * every ordinary boot asks about a dead PID. Windows used to answer that by
+ * spawning cmd.exe + tasklist - 52.5 ms median, measured, on the main-process
+ * event loop, every launch.
+ *
+ * `EPERM` is alive-but-not-ours: something is running under that PID, and the
+ * name check is what decides whether it is our engine.
+ */
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/**
+ * Does the OS agree that this live PID is a vayu-engine?
+ *
+ * The subprocess half, and the only half that costs anything - reached only
+ * once something is known to be alive under the PID. Failure to read the name
+ * is not evidence of an engine, so it answers no.
+ */
+function isEngineProcessName(pid: number): boolean {
 	try {
 		if (process.platform === "win32") {
-			// On Windows, use tasklist to check if process exists and verify name
-			try {
-				const output = execSync(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, {
-					encoding: "utf-8",
-				});
-
-				// Check if output contains vayu-engine.exe
-				// Format: "vayu-engine.exe","12345","Console","1","12,345 K"
-				if (!output || output.includes("INFO: No tasks are running")) {
-					return false;
-				}
-
-				// Verify the process name is vayu-engine.exe
-				return output.toLowerCase().includes("vayu-engine.exe");
-			} catch {
-				return false;
-			}
-		} else {
-			// On Unix (macOS, Linux), first check if process exists with signal 0
-			try {
-				process.kill(pid, 0);
-			} catch (err) {
-				// ESRCH means process doesn't exist
-				if ((err as NodeJS.ErrnoException).code === "ESRCH") {
-					return false;
-				}
-				// EPERM means process exists but we don't have permission
-				// Continue to verify process name
-				if ((err as NodeJS.ErrnoException).code !== "EPERM") {
-					return false;
-				}
-			}
-
-			// Process exists, now verify it's vayu-engine
-			try {
-				const output = execSync(`ps -p ${pid} -o comm=`, {
-					encoding: "utf-8",
-				}).trim();
-
-				// Process name should contain "vayu-engine"
-				return output.includes("vayu-engine");
-			} catch {
-				// If ps fails, assume process doesn't exist or is inaccessible
-				return false;
-			}
+			// Format: "vayu-engine.exe","12345","Console","1","12,345 K" - and
+			// "INFO: No tasks are running..." when the PID filter matches nothing,
+			// which fails the same name test.
+			const output = execSync(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, {
+				encoding: "utf-8",
+				windowsHide: true,
+			});
+			return output.toLowerCase().includes("vayu-engine.exe");
 		}
+
+		return execSync(`ps -p ${pid} -o comm=`, { encoding: "utf-8" }).includes("vayu-engine");
 	} catch {
 		return false;
 	}
+}
+
+/**
+ * Check if a process is still running by PID and verify it's vayu-engine
+ *
+ * Cheap first, subprocess second: a PID nothing holds is answered by the signal-0
+ * probe alone, and only a live PID is worth paying a `tasklist` / `ps` for. The
+ * name check is not optional politeness - it prevents PID reuse issues where a
+ * different process might have reused the same PID that was previously held by
+ * vayu-engine.
+ */
+function isVayuEngineRunning(pid: number): boolean {
+	if (!isPlausiblePid(pid)) return false;
+	if (!isPidAlive(pid)) return false;
+	return isEngineProcessName(pid);
 }
 
 /**
@@ -182,7 +201,7 @@ function killVayuEngineProcess(pid: number): boolean {
 
 	try {
 		if (process.platform === "win32") {
-			execSync(`taskkill /PID ${pid} /F /T`, { stdio: "ignore" });
+			execSync(`taskkill /PID ${pid} /F /T`, { stdio: "ignore", windowsHide: true });
 		} else {
 			process.kill(pid, "SIGKILL");
 		}

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -120,7 +120,7 @@ function isPlausiblePid(pid: number): boolean {
 }
 
 /**
- * Does *anything* hold this PID?
+ * Can we rule out this PID without spawning anything?
  *
  * Signal 0 delivers nothing - it is an existence-and-permission probe, and
  * libuv implements it on Windows too (`OpenProcess` plus an exit-code check, so
@@ -133,15 +133,21 @@ function isPlausiblePid(pid: number): boolean {
  * spawning cmd.exe + tasklist - 52.5 ms median, measured, on the main-process
  * event loop, every launch.
  *
- * `EPERM` is alive-but-not-ours: something is running under that PID, and the
- * name check is what decides whether it is our engine.
+ * Only `ESRCH` is proof, and the asymmetry is deliberate. Every other failure
+ * means we could not tell - `EPERM` for a process we may not signal, and on
+ * Windows an `OpenProcess` denial that libuv reports as `EACCES` rather than
+ * `EPERM`, since it comes back through the generic Win32 error translation.
+ * Reading "could not tell" as "gone" would let a *running* engine be declared
+ * stale, its lock deleted underneath it; so an unclear answer costs a
+ * subprocess and lets the name check decide, which is what the old
+ * tasklist-only Windows path did in every case.
  */
-function isPidAlive(pid: number): boolean {
+function isPidCertainlyDead(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
-		return true;
+		return false;
 	} catch (err) {
-		return (err as NodeJS.ErrnoException).code === "EPERM";
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
 	}
 }
 
@@ -182,7 +188,7 @@ function isEngineProcessName(pid: number): boolean {
  */
 function isVayuEngineRunning(pid: number): boolean {
 	if (!isPlausiblePid(pid)) return false;
-	if (!isPidAlive(pid)) return false;
+	if (isPidCertainlyDead(pid)) return false;
 	return isEngineProcessName(pid);
 }
 

--- a/docs/lock-file-handling.md
+++ b/docs/lock-file-handling.md
@@ -60,7 +60,9 @@ The Electron sidecar (`app/electron/sidecar.ts`) automatically handles stale loc
 
 1. **Checks lock file** before starting the engine
 2. **Reads PID** from lock file
-3. **Verifies process** is still running
+3. **Verifies process** is still running - cheap first, subprocess second: a
+   signal-0 probe answers a PID nothing holds, and only a live PID is worth a
+   `tasklist` / `ps` call to verify the name
 4. **Removes stale lock** if process is dead
 5. **Logs warnings** for debugging
 
@@ -100,7 +102,7 @@ rm ~/Library/Application\ Support/vayu/vayu.lock
 
 ### Electron Sidecar
 - Function: `checkLockFile()` - checks lock file and verifies PID
-- Function: `isVayuEngineRunning()` - cross-platform process check with process name verification
+- Function: `isVayuEngineRunning()` - cross-platform process check with process name verification. `process.kill(pid, 0)` first on every platform (no subprocess, and the stale-lock case ends there), then `tasklist` / `ps` to verify the name against PID reuse
 - Automatic cleanup in `start()` method
 - File: `app/electron/sidecar.ts`
 


### PR DESCRIPTION
## Description

**Root cause.** The engine takes `vayu.lock` and releases it only on a clean shutdown - it never unlinks the file - so the *ordinary* state at launch is a lock file naming a process that is long gone. `isVayuEngineRunning` answered that question in two different shapes: Unix short-circuited on `process.kill(pid, 0)` / `ESRCH` and spawned nothing, while Windows had no early-out at all and always ran `cmd.exe` + `tasklist`. Measured by the #1162 harness at **52.5 ms median** (59.5 ms on a second run), synchronously, on the Electron main-process event loop, on every Windows boot.

**Approach.** Collapse the two shapes into one: `process.kill(pid, 0)` first on every platform - libuv implements signal 0 on Windows via `OpenProcess` plus an exit-code check, so a process that terminated while someone still holds a handle reports `ESRCH` rather than "alive" - then `tasklist` / `ps` only for a PID the probe could not rule out. That deletes the duplicated per-platform structure rather than adding a Windows-shaped copy of the Unix branch, and PID-reuse safety is untouched: a live foreign process on a recycled PID is still name-verified.

**The probe can only rule death out, never in**, and that asymmetry is the load-bearing detail. Only `ESRCH` is proof; every other failure means "could not tell" and pays for the name check. Windows had never called `process.kill` before this change, so its error mapping never mattered - and libuv sends an `OpenProcess` denial back through the generic Win32 error translation, which surfaces as `EACCES`, not the `EPERM` the Unix branch sees. A probe that read anything-but-`EPERM` as death would have declared a live engine we cannot open stale and deleted its lock file underneath it. That was caught in review of the first commit and fixed in the second; it is the one way this change could have been worse than the `tasklist` call it replaces.

**The alternative I rejected:** widening `SidecarSystem.isEngineProcessAlive` to async (`execFile`), which the issue lists as optional. It buys nothing on the boot path the issue is about - that path now spawns nothing at all - and it costs a change to the one shared `fakeSystem()` factory behind all 15 `sidecar.test.ts` cases plus `checkLockFile`'s signature and its caller. It also has a quiet failure mode: `waitForAdoptedExit` consumes the result in a ternary whose other arm is already awaited, so a missed `await` would make `alive` an always-truthy Promise and turn the exit wait into a silent 5-second spin. The remaining sync execs are on the adopted-engine quit path only, and even there the poll now spawns nothing once the process is gone. Recorded here rather than deferred silently; say the word and it can be a follow-up issue.

**Two boundary fixes alongside**, both in the same function family:
- The PID comes from a file on disk and was handed straight to `process.kill`. Zero and negatives are *process group* targets on Unix, so a truncated or garbled lock file could have aimed a probe - and, through `killVayuEngineProcess`, a `SIGKILL` - at this app's own process group. It is now checked for plausibility first. This closes a gap the refactor itself opens: before this change Windows never reached `process.kill` at all.
- Both Windows execs pass `windowsHide: true` (the issue asks for it on `tasklist`; `taskkill` in the same file had the same missing flag).

Anchors were re-verified at `5fab794` before writing: the issue body's own "pre-window critical path" clause is stale post-#1163 (corrected on the issue), and this PR is written against the corrected framing - the block delays window *show*, not window *creation*.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **551 files, 6025 tests, all passing** (14 of them new).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - all clean.
- **Mutation-checked twice**: restoring the Windows always-spawn behaviour fails 2 of the new cases; restoring the `EPERM`-only reading of the probe fails the `EACCES` case. The tests assert the absence of a subprocess and the refusal to conclude death, which is what would silently regress.
- Engine untouched, so no engine build or ctest run - no test there could change colour.
- No pre-existing failures observed on the base commit.

New file `app/electron/engine-liveness.test.ts` rather than an addition to `sidecar.test.ts` - a **deliberate deviation** from the issue's Tests note, with a reason: `sidecar.test.ts` drives the lifecycle through a fake `SidecarSystem` and deliberately mocks nothing else ("the lock file, the data directory and the binary lookup are real - those are the parts a mock would have 'passed' against"), so the probe *underneath* that seam is exactly what it cannot see, and a file-wide `child_process` mock would fight that design. The new file drives the real `defaultSidecarSystem` against a stubbed `process.kill` and `execSync`, so "no subprocess was spawned" is an assertion rather than a hope. Both platform branches are exercised by stubbing `process.platform` per the repo's platform-test rule, using the same `stubPlatform` shape `sidecar.test.ts` uses.

Four of the fourteen cases prove the fix itself (the Windows dead-PID early-out, the implausible-PID guard, `windowsHide`, the `EACCES` reading); the rest are regression guards on the name-verification behaviour AC2 says must not change, and would pass against the old code by design.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/lock-file-handling.md` updated in the same commit (the doc of record for lock behaviour, per the root `CLAUDE.md` doc map): the startup-cleanup step and the `isVayuEngineRunning()` implementation note now say cheap-first, subprocess-second. `docs/architecture.md:176-178` was checked and is *not* stale - it describes the shutdown-time name-verified kill, a different path.

## Acceptance criteria

- [x] A normal Windows boot performs zero synchronous subprocess spawns for the lock check (dead-PID case), proven by test - `"spawns nothing for a dead PID on Windows"` asserts the `execSync` spy uncalled.
- [x] PID-reuse safety unchanged: a live foreign process with the recycled PID is still name-checked - `"still name-verifies a live PID on Windows, so a recycled one is not ours"`, plus the `EPERM` and `EACCES` cases and the kill-path equivalent.

## Related Issues
Closes #1148