### PR TITLE
perf(app): bound the response cache at twice the open-tab count - #1156

### DIFF
--- a/app/src/stores/response-store.test.ts
+++ b/app/src/stores/response-store.test.ts
@@ -134,6 +134,43 @@ describe("the cap covers the tabs a session works in", () => {
 			expect(getResponse(id)?.body).toBe(`body of ${id}`);
 		}
 	});
+
+	it("re-sending the open tabs keeps them ahead of any tail, however long", () => {
+		const openTabRequests = Array.from({ length: MAX_OPEN_TABS }, (_, i) => `open_${i}`);
+		for (const id of openTabRequests) {
+			useResponseStore.getState().setResponse(id, aResponse(`body of ${id}`));
+		}
+
+		// Twice what the previous case sends, with the tabs worked in between:
+		// recency is what the cap buys, so a tab being *used* stays regardless of
+		// how much else the session sends.
+		for (let round = 0; round < 2; round++) {
+			send(RESPONSE_CACHE_MAX_ENTRIES - MAX_OPEN_TABS, `tail_${round}`);
+			for (const id of openTabRequests) {
+				useResponseStore.getState().setResponse(id, aResponse(`body of ${id}`));
+			}
+		}
+
+		const { getResponse } = useResponseStore.getState();
+		for (const id of openTabRequests) {
+			expect(getResponse(id)?.body).toBe(`body of ${id}`);
+		}
+	});
+
+	/*
+	 * The honest edge of the bound, stated as a test rather than left for
+	 * someone to discover: recency is write recency, so a tab held open without
+	 * being re-sent is not protected by being open. Tab eviction only allows
+	 * that for a dirty tab, and the entry it loses is the unabridged copy - the
+	 * request re-opens against the backend's stored run.
+	 */
+	it("does not protect a tab that stays open without being re-sent", () => {
+		useResponseStore.getState().setResponse("untouched_open_tab", aResponse());
+
+		send(RESPONSE_CACHE_MAX_ENTRIES);
+
+		expect(useResponseStore.getState().getResponse("untouched_open_tab")).toBeNull();
+	});
 });
 
 describe("the delete seams still evict by identity", () => {
@@ -148,13 +185,14 @@ describe("the delete seams still evict by identity", () => {
 
 	it("clearing an id it does not hold changes nothing", () => {
 		send(2);
-		const before = useResponseStore.getState().responses;
+		const { responses: mapBefore, lru: lruBefore } = useResponseStore.getState();
 
 		useResponseStore.getState().clearResponse("never-sent");
 
-		// Same map object: an absent id is not worth a new reference, which
-		// every subscriber would re-render for.
-		expect(useResponseStore.getState().responses).toBe(before);
+		// The same objects, not merely equal ones: an absent id is not worth a
+		// new reference, which every subscriber would re-render for.
+		expect(useResponseStore.getState().responses).toBe(mapBefore);
+		expect(useResponseStore.getState().lru).toBe(lruBefore);
 		expect(retained()).toEqual(["req_0", "req_1"]);
 	});
 

--- a/app/src/stores/response-store.test.ts
+++ b/app/src/stores/response-store.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The response map's bound (#1156).
+ *
+ * Before it, the only evictions were the two delete seams - so the map grew
+ * with every distinct request a session sent, each entry a body plus its raw
+ * copy, until the app quit. These cases lock the ceiling and the order it
+ * evicts in.
+ *
+ * Mutation check: drop the `while (lru.length > RESPONSE_CACHE_MAX_ENTRIES)`
+ * loop in `withResponse` and every case in "bounds the session" fails; drop the
+ * `.filter((id) => id !== requestId)` that moves a re-written key to the recent
+ * end and "a re-sent request is not the next victim" fails; forget the `lru`
+ * half of `clearResponse` or `clearAll` and "the recency list and the map hold
+ * the same keys" fails, because a cleared id would keep occupying a slot.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	RESPONSE_CACHE_MAX_ENTRIES,
+	useResponseStore,
+	type StoredResponse,
+} from "./response-store";
+import { MAX_OPEN_TABS } from "./tabs-store";
+
+beforeEach(() => {
+	useResponseStore.getState().clearAll();
+});
+
+/** A response with a body big enough to be worth evicting, and nothing else. */
+function aResponse(body = "x".repeat(1024)): StoredResponse {
+	return {
+		status: 200,
+		statusText: "OK",
+		headers: {},
+		body,
+		bodyType: "text",
+		size: body.length,
+		time: 12,
+	};
+}
+
+/** Sends `count` distinct requests, named `req_0` … `req_<count-1>`. */
+function send(count: number, prefix = "req") {
+	for (let i = 0; i < count; i++) {
+		useResponseStore.getState().setResponse(`${prefix}_${i}`, aResponse());
+	}
+}
+
+/** The keys the store currently holds, in the order it would evict them. */
+function retained(): string[] {
+	return [...useResponseStore.getState().lru];
+}
+
+describe("bounds the session", () => {
+	it("keeps at most RESPONSE_CACHE_MAX_ENTRIES responses however many are sent", () => {
+		send(RESPONSE_CACHE_MAX_ENTRIES * 3);
+
+		expect(useResponseStore.getState().responses.size).toBe(RESPONSE_CACHE_MAX_ENTRIES);
+	});
+
+	it("evicts least-recently-written first and keeps the newest", () => {
+		const sent = RESPONSE_CACHE_MAX_ENTRIES + 5;
+		send(sent);
+
+		const { getResponse } = useResponseStore.getState();
+		// The five oldest are gone …
+		for (let i = 0; i < 5; i++) expect(getResponse(`req_${i}`)).toBeNull();
+		// … and every one after them survived, in write order.
+		expect(retained()).toEqual(
+			Array.from({ length: RESPONSE_CACHE_MAX_ENTRIES }, (_, i) => `req_${i + 5}`)
+		);
+	});
+
+	it("never evicts the response just stored", () => {
+		send(RESPONSE_CACHE_MAX_ENTRIES);
+
+		useResponseStore.getState().setResponse("newest", aResponse("the body on screen"));
+
+		expect(useResponseStore.getState().getResponse("newest")?.body).toBe("the body on screen");
+	});
+
+	it("a re-sent request is not the next victim", () => {
+		send(RESPONSE_CACHE_MAX_ENTRIES);
+		// Re-send the oldest: it moves to the recent end, so the eviction the
+		// next send forces must take `req_1` instead.
+		useResponseStore.getState().setResponse("req_0", aResponse());
+
+		useResponseStore.getState().setResponse("one_more", aResponse());
+
+		expect(useResponseStore.getState().getResponse("req_0")).not.toBeNull();
+		expect(useResponseStore.getState().getResponse("req_1")).toBeNull();
+		expect(useResponseStore.getState().responses.size).toBe(RESPONSE_CACHE_MAX_ENTRIES);
+	});
+
+	it("a re-send replaces the entry rather than adding one", () => {
+		useResponseStore.getState().setResponse("req_0", aResponse("first"));
+		useResponseStore.getState().setResponse("req_0", aResponse("second"));
+
+		expect(useResponseStore.getState().responses.size).toBe(1);
+		expect(useResponseStore.getState().getResponse("req_0")?.body).toBe("second");
+		expect(retained()).toEqual(["req_0"]);
+	});
+});
+
+describe("the cap covers the tabs a session works in", () => {
+	/*
+	 * The store cannot read `tabs-store` - that store imports this one - so the
+	 * bound is stated as a number here and held against the tab cap by this
+	 * guard. Raise `MAX_OPEN_TABS` past twelve without raising the cache and an
+	 * open tab's response could be evicted while its tab is still on screen.
+	 */
+	it("retains at least twice MAX_OPEN_TABS", () => {
+		expect(RESPONSE_CACHE_MAX_ENTRIES).toBeGreaterThanOrEqual(2 * MAX_OPEN_TABS);
+	});
+
+	it("a full set of open tabs keeps every full-fidelity response through a tail of one-off sends", () => {
+		const openTabRequests = Array.from({ length: MAX_OPEN_TABS }, (_, i) => `open_${i}`);
+		for (const id of openTabRequests) {
+			useResponseStore.getState().setResponse(id, aResponse(`body of ${id}`));
+		}
+
+		// Everything the cap has room for beyond those tabs, sent afterwards.
+		send(RESPONSE_CACHE_MAX_ENTRIES - MAX_OPEN_TABS, "tail");
+
+		const { getResponse } = useResponseStore.getState();
+		for (const id of openTabRequests) {
+			expect(getResponse(id)?.body).toBe(`body of ${id}`);
+		}
+	});
+});
+
+describe("the delete seams still evict by identity", () => {
+	it("clearResponse drops the named request and leaves the rest", () => {
+		send(3);
+
+		useResponseStore.getState().clearResponse("req_1");
+
+		expect(useResponseStore.getState().getResponse("req_1")).toBeNull();
+		expect(retained()).toEqual(["req_0", "req_2"]);
+	});
+
+	it("clearing an id it does not hold changes nothing", () => {
+		send(2);
+		const before = useResponseStore.getState().responses;
+
+		useResponseStore.getState().clearResponse("never-sent");
+
+		// Same map object: an absent id is not worth a new reference, which
+		// every subscriber would re-render for.
+		expect(useResponseStore.getState().responses).toBe(before);
+		expect(retained()).toEqual(["req_0", "req_1"]);
+	});
+
+	it("clearAll empties both halves", () => {
+		send(4);
+
+		useResponseStore.getState().clearAll();
+
+		expect(useResponseStore.getState().responses.size).toBe(0);
+		expect(retained()).toEqual([]);
+	});
+});
+
+describe("the recency list and the map hold the same keys", () => {
+	it("through a mixed sequence of sends, re-sends, clears and overflow", () => {
+		// Deterministic pseudo-random walk: a seeded LCG, so a failure is
+		// reproducible rather than a once-a-week surprise.
+		let seed = 1337;
+		const next = (n: number) => {
+			seed = (seed * 1103515245 + 12345) % 2147483648;
+			return seed % n;
+		};
+
+		for (let step = 0; step < 500; step++) {
+			const id = `req_${next(RESPONSE_CACHE_MAX_ENTRIES * 2)}`;
+			if (next(4) === 0) {
+				useResponseStore.getState().clearResponse(id);
+			} else {
+				useResponseStore.getState().setResponse(id, aResponse("body"));
+			}
+
+			const { responses, lru } = useResponseStore.getState();
+			expect(lru.length).toBe(responses.size);
+			expect(new Set(lru).size).toBe(lru.length); // no key listed twice
+			for (const key of lru) expect(responses.has(key)).toBe(true);
+			expect(responses.size).toBeLessThanOrEqual(RESPONSE_CACHE_MAX_ENTRIES);
+		}
+	});
+});

--- a/app/src/stores/response-store.ts
+++ b/app/src/stores/response-store.ts
@@ -14,6 +14,15 @@
  *
  * Response data is stored in memory (not persisted to localStorage)
  * since responses can be large and we can reload from backend.
+ *
+ * The map is bounded by `RESPONSE_CACHE_MAX_ENTRIES` (#1156): before the cap,
+ * the only evictions were the two delete seams (`useDeleteRequestMutation` and
+ * `closeTabsForEntities`), so a session retained every distinct request it had
+ * ever sent - a body plus its raw copy each - until the app quit. The bound is
+ * write recency, not open-tab identity: this store cannot ask `tabs-store` what
+ * is open (that store imports *this* one, and the cycle is the wrong shape), so
+ * the cap is set to twice `MAX_OPEN_TABS` instead, and `response-store.test.ts`
+ * holds the two constants together.
  */
 
 import { create } from "zustand";
@@ -52,9 +61,27 @@ export interface StoredResponse {
 	executedAt?: number;
 }
 
+/**
+ * How many responses the map retains, twice `tabs-store`'s `MAX_OPEN_TABS`: the
+ * open tabs plus an equal tail, so switching back to any tab a session is
+ * actually working in still finds its full-fidelity body. Beyond the tail the
+ * response is not lost, only its unabridged copy - the request re-opens against
+ * the backend's stored run, whose body the engine truncates at
+ * `maxTraceBodyBytes`.
+ */
+export const RESPONSE_CACHE_MAX_ENTRIES = 24;
+
 interface ResponseStoreState {
 	// Map of requestId -> response
 	responses: Map<string, StoredResponse>;
+	/**
+	 * Request ids least-recently-written first. Every key of `responses`
+	 * appears here exactly once, and this list - not `executedAt` - is what
+	 * eviction reads: a response restored from a stored run carries the
+	 * execution's own timestamp, which says nothing about when this session
+	 * last touched it.
+	 */
+	lru: string[];
 
 	// Actions
 	setResponse: (requestId: string, response: StoredResponse) => void;
@@ -63,16 +90,45 @@ interface ResponseStoreState {
 	clearAll: () => void;
 }
 
+/**
+ * The one place an entry is written, so the map and the recency list can never
+ * disagree about which keys exist. Shaped after `schema-cache.ts`'s
+ * `withEntry`, the codebase's other keyed LRU.
+ */
+function withResponse(
+	state: Pick<ResponseStoreState, "responses" | "lru">,
+	requestId: string,
+	response: StoredResponse
+): Pick<ResponseStoreState, "responses" | "lru"> {
+	const responses = new Map(state.responses);
+	responses.set(requestId, {
+		...response,
+		executedAt: response.executedAt || Date.now(),
+	});
+
+	// Re-writing a request moves it back to the most-recent end rather than
+	// leaving it where it first landed - a request being re-sent is the one
+	// least likely to want evicting.
+	const lru = [...state.lru.filter((id) => id !== requestId), requestId];
+
+	// The write that pushed the map over the cap is the request on screen, so
+	// the victim is always some other request: taking from the front cannot
+	// take what was just stored.
+	while (lru.length > RESPONSE_CACHE_MAX_ENTRIES) {
+		const victim = lru.shift();
+		if (victim === undefined) break;
+		responses.delete(victim);
+	}
+
+	return { responses, lru };
+}
+
 export const useResponseStore = create<ResponseStoreState>((set, get) => ({
 	responses: new Map(),
+	lru: [],
 
 	setResponse: (requestId, response) => {
-		const newResponses = new Map(get().responses);
-		newResponses.set(requestId, {
-			...response,
-			executedAt: response.executedAt || Date.now(),
-		});
-		set({ responses: newResponses });
+		set(withResponse(get(), requestId, response));
 	},
 
 	getResponse: (requestId) => {
@@ -80,12 +136,17 @@ export const useResponseStore = create<ResponseStoreState>((set, get) => ({
 	},
 
 	clearResponse: (requestId) => {
-		const newResponses = new Map(get().responses);
+		const { responses, lru } = get();
+		if (!responses.has(requestId)) return;
+		const newResponses = new Map(responses);
 		newResponses.delete(requestId);
-		set({ responses: newResponses });
+		set({
+			responses: newResponses,
+			lru: lru.filter((id) => id !== requestId),
+		});
 	},
 
 	clearAll: () => {
-		set({ responses: new Map() });
+		set({ responses: new Map(), lru: [] });
 	},
 }));

--- a/app/src/stores/response-store.ts
+++ b/app/src/stores/response-store.ts
@@ -62,12 +62,14 @@ export interface StoredResponse {
 }
 
 /**
- * How many responses the map retains, twice `tabs-store`'s `MAX_OPEN_TABS`: the
- * open tabs plus an equal tail, so switching back to any tab a session is
- * actually working in still finds its full-fidelity body. Beyond the tail the
- * response is not lost, only its unabridged copy - the request re-opens against
- * the backend's stored run, whose body the engine truncates at
- * `maxTraceBodyBytes`.
+ * How many responses the map retains. The order is write recency, so what this
+ * number buys is headroom rather than a guarantee about open tabs: at twice
+ * `MAX_OPEN_TABS` a full set of tabs can each be re-sent, and every one of them
+ * still finds its full-fidelity body on the way back. A tab held open without
+ * being re-sent while twenty-four other requests are - a dirty tab, which tab
+ * eviction exempts - does lose its entry, and loses only the unabridged copy:
+ * the request re-opens against the backend's stored run, whose body the engine
+ * truncated at `maxTraceBodyBytes`.
  */
 export const RESPONSE_CACHE_MAX_ENTRIES = 24;
 

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -27,7 +27,12 @@ export interface Tab {
 	entityId: string | null; // requestId, collectionId, runId - null for singletons
 }
 
-const MAX_OPEN_TABS = 12;
+/**
+ * Exported because `response-store`'s cache bound is derived from it: that
+ * store retains the open tabs' responses plus an equal tail, and a guard there
+ * fails if the two numbers drift apart.
+ */
+export const MAX_OPEN_TABS = 12;
 
 /**
  * Singletons: only one tab of this type can exist at a time.
@@ -358,8 +363,10 @@ export const useTabsStore = create<TabsState>()(
 
 				// A delete that can name a request takes its response with it: the
 				// collection tree reaches here after deleting a request or a whole
-				// collection, nothing else evicts from that map, and each entry
-				// holds a body plus its raw copy. Skipped for a `type`-scoped sweep
+				// collection, and each entry holds a body plus its raw copy. The
+				// map's own LRU bound (#1156) only puts a ceiling on the session -
+				// a response nothing can reach again should go now, not in
+				// twenty-four sends' time. Skipped for a `type`-scoped sweep
 				// that is not about requests - `"run"` ids cannot key a response, so
 				// walking them would only look like it meant something. Done before
 				// the early return below, since a deleted request with no open tab

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -163,7 +163,7 @@ The app uses a dual-state management approach:
    - `session-store.ts`: Active environment id (mirrored from the engine) and the last-used collection
    - `engine-store.ts`: Engine health, connectivity status
    - `dashboard-store.ts`: Load test metrics (retained by time window, see `state-management.md`), streaming state
-   - `response-store.ts`: The last response per request id - status, headers, body, script results
+   - `response-store.ts`: The last response per request id - status, headers, body, script results. LRU-bounded at twice `MAX_OPEN_TABS`, since each entry holds a body plus its raw copy
    - `client-settings-store.ts`: Renderer preferences (editor, charts, auto-save, notifications)
    - `toast-store.ts`: The transient notification queue
    - `save-store.ts`: Auto-save orchestration and progress

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -78,8 +78,10 @@ Manages all open tabs (welcome, request, collection, dashboard, run, variables, 
   keeps a tab that could have closed, under-matching loses work. Nothing is
   flushed *during* eviction; the predicate already refused the tab
 - Response eviction: `closeTabsForEntities` clears each id's entry in
-  `response-store`. Both callers reach it after a delete, and nothing else
-  evicts from that map
+  `response-store`. Both callers reach it after a delete - the map's own LRU
+  bound would get there eventually, but a response nothing can reach again
+  should go at the delete, not twenty-four sends later. `MAX_OPEN_TABS` is
+  exported for that bound: the cache retains twice it
 - Focus recency: `tabFocusedAt` stamps `openTab` and `focusTab`, and is read by
   the command palette, which lists open tabs most-recently-used first. It cannot
   come from `openTabs`, which is insertion order - the tab you were just in sits
@@ -575,7 +577,8 @@ In-memory storage of responses per request ID, persisted across view/tab switche
 **State:**
 ```typescript
 {
-  responses: Map<string, StoredResponse>
+  responses: Map<string, StoredResponse>,
+  lru: string[]  // request ids, least-recently-written first
 }
 ```
 
@@ -586,11 +589,22 @@ In-memory storage of responses per request ID, persisted across view/tab switche
 const { setResponse, getResponse, clearResponse, clearAll } = useResponseStore();
 ```
 
-**Eviction:** `clearResponse` runs from `useDeleteRequestMutation` (the delete is
-what makes the response unreachable) and from `tabs-store`'s
+**Eviction by identity:** `clearResponse` runs from `useDeleteRequestMutation`
+(the delete is what makes the response unreachable) and from `tabs-store`'s
 `closeTabsForEntities` (the collection cascade, which knows every descendant id).
-Nothing else drops an entry, so a map with no eviction at all grew for the whole
-session - each entry holds a body plus its raw copy.
+
+**Eviction by count:** `RESPONSE_CACHE_MAX_ENTRIES` (24) bounds the map (#1156).
+Those two delete seams were once the only ones, so the map grew with every
+distinct request a session sent - each entry a body plus its raw copy - until
+the app quit. The cap is twice `tabs-store`'s `MAX_OPEN_TABS`: the open tabs
+plus an equal tail, so a tab a session is working in still re-opens on its
+full-fidelity body. Order comes from `lru`, not from `executedAt`, which a
+restored response carries from the run that produced it and which therefore
+says nothing about when this session last touched the entry; `setResponse` is
+the only writer, and it moves a re-sent request back to the recent end, so the
+entry just stored is never the one evicted. Past the tail nothing is lost, only
+unabridged: the request re-opens against the backend's stored run, whose body
+the engine truncated at `maxTraceBodyBytes`.
 
 **Non-persisted** (responses are reloadable from backend).
 
@@ -1971,7 +1985,7 @@ restore) and `save-request-name.test.ts` (the payload).
 4. Request is transformed (frontend → backend format) and sent via HTTP
 5. Response is stored in `useResponseStore()` keyed by request ID
 6. Response viewer component reads the response and displays it
-7. On **request tab switch**, the response persists in `response-store` and is displayed if the user returns
+7. On **request tab switch**, the response persists in `response-store` and is displayed if the user returns - for the 24 most recently sent requests, past which the store's LRU bound has dropped the entry and the backend's stored run answers instead
 8. If any script ran, the environment / globals / collection query families are invalidated so values the script wrote are visible in the variables editor and the resolver. The gate is `scriptsMayWriteVariables(pre, post)` (`request-builder/utils/execute-mapping.ts`), shared by the builder's send path and the History run view's resend. **Both** script kinds count: `pm.environment.set` and friends persist engine-side from a Tests-tab script exactly as from a pre-request one, and with `refetchOnWindowFocus: false` nothing else is coming to correct a stale value
 
 ### Starting a Load Test Run

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -596,15 +596,20 @@ const { setResponse, getResponse, clearResponse, clearAll } = useResponseStore()
 **Eviction by count:** `RESPONSE_CACHE_MAX_ENTRIES` (24) bounds the map (#1156).
 Those two delete seams were once the only ones, so the map grew with every
 distinct request a session sent - each entry a body plus its raw copy - until
-the app quit. The cap is twice `tabs-store`'s `MAX_OPEN_TABS`: the open tabs
-plus an equal tail, so a tab a session is working in still re-opens on its
-full-fidelity body. Order comes from `lru`, not from `executedAt`, which a
-restored response carries from the run that produced it and which therefore
-says nothing about when this session last touched the entry; `setResponse` is
-the only writer, and it moves a re-sent request back to the recent end, so the
-entry just stored is never the one evicted. Past the tail nothing is lost, only
-unabridged: the request re-opens against the backend's stored run, whose body
-the engine truncated at `maxTraceBodyBytes`.
+the app quit. What the map holds is the 24 most recently *sent* requests, not
+the open tabs: this store cannot ask `tabs-store` what is open, since that
+store imports this one. The cap is twice `MAX_OPEN_TABS` so that recency covers
+tab reach in practice - a full set of tabs can each be re-sent and every one of
+them still re-opens on its full-fidelity body. The gap is a tab held open
+without being re-sent while 24 other requests are, which tab eviction allows
+only for a dirty tab; it falls back like any older request. Order comes from
+`lru`, not from `executedAt`, which a restored response carries from the run
+that produced it and which therefore says nothing about when this session last
+touched the entry; `setResponse` is the only writer, and it moves a re-sent
+request back to the recent end, so the entry just stored is never the one
+evicted. Past the cap nothing is lost, only unabridged: the request re-opens
+against the backend's stored run, whose body the engine truncated at
+`maxTraceBodyBytes`.
 
 **Non-persisted** (responses are reloadable from backend).
 


### PR DESCRIPTION
## Description

The renderer's response map had eviction **by identity only** - `useDeleteRequestMutation` (`queries/collections.ts:662`) and `closeTabsForEntities` (`stores/tabs-store.ts:368`), both delete seams - so a session retained every distinct request it had ever sent, a body plus its raw copy each, until the app quit. Closing a tab dropped nothing; LRU-evicting one dropped nothing either.

**Root cause and approach.** The store never had a notion of eviction-by-count, and it cannot acquire one by asking which tabs are open: `tabs-store` imports *this* store, so reading back would be a cycle in the wrong direction. So the bound is stated as a number - `RESPONSE_CACHE_MAX_ENTRIES = 24`, twice `MAX_OPEN_TABS` - and a guard holds the two constants together rather than letting them drift. What the map holds is the 24 most recently **sent** requests; the 2x is headroom that makes recency cover tab reach in practice, not membership (see the deviation note at the bottom, which the tests now state rather than leaving to prose). Order comes from a `lru: string[]` rather than the existing `executedAt`: a response restored from a stored run carries the execution's own timestamp, which says nothing about when this session last touched the entry (`executedAt` also turns out to have no UI reader at all, so building eviction on it would have been the "written but never read" defect twice over). Writes funnel through one `withResponse` helper - shaped after `lib/graphql/schema-cache.ts`'s `withEntry`, the codebase's other keyed LRU - so the map and the recency list cannot disagree about which keys exist, and because it moves a re-sent request to the recent end, the entry just stored is never the victim: the request on screen is structurally safe.

**Rejected alternative: clear-on-close.** It is the smaller change and it is not lossless - the copy a reopened request falls back to is the backend's stored run, whose body the engine truncated at `maxTraceBodyBytes` - so closing and reopening a tab would silently downgrade a large response the user still had on screen a second ago. A cap keeps recently used tabs on their full-fidelity body and bounds the session anyway; past the cap the same fallback applies, but only to requests the session has moved well past.

One behavioural detail worth a reviewer's eye: `clearResponse` now returns early for an id it does not hold, instead of publishing a fresh `Map`. `RequestBuilderProvider.tsx:148` subscribes to the whole store with no selector, so the old version re-rendered every mounted provider once per id in a collection cascade that named requests it had no response for. It is a second fix in the function the LRU bookkeeping was already rewriting; say the word and I will split it out.

## Type of Change
- [ ] Bug fix
- [x] New feature *(performance work - the closest fit; user-visible behaviour is unchanged within the cap)*
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `cd app && pnpm test` - **551 files, 6,024 tests, all passing** (up from 6,011: 13 new cases in `src/stores/response-store.test.ts`, which the store did not have before).
- `cd app && pnpm type-check` - clean (renderer, electron, electron tests).
- `cd app && pnpm lint` - clean, and `prettier --check` on every touched file under `app/`.
- Engine untouched, so no engine build and no ctest run - verification scaled to what the change could break, per CLAUDE.md.
- No pre-existing failures encountered on the base commit (`59f8b14`).

New guards, each mutation-checked (reverted the fix, confirmed the exact expected subset goes red, restored):
- Disabling the eviction loop → the three "bounds the session" size/order cases fail.
- Removing the recency refresh on a re-send → "a re-sent request is not the next victim" fails.
- Forgetting the `lru` half of `clearResponse` → the delete-seam case and the invariant walk fail (a cleared id would keep occupying a slot).

The cases cover: the ceiling holds however many requests are sent; least-recently-written is evicted first; the response just stored is never evicted; a re-send refreshes recency and replaces rather than grows; a full set of `MAX_OPEN_TABS` requests survives a tail of one-off sends, and survives two full tails when re-sent in between; a tab left untouched through a full cap of other sends does lose its entry (the bound's honest edge, asserted rather than left to be discovered); `clearResponse` / `clearAll` semantics unchanged, including the no-op for an absent id keeping both references; and a 500-step seeded pseudo-random walk asserting the recency list and the map hold exactly the same keys with the size never over the cap.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Documentation (same commit)

- `docs/app/state-management.md` - the response-store section's **Eviction** paragraph, which previously *admitted* the unbounded growth, now states the bound, that it is recency rather than open-tab membership, where the order comes from, and what the fallback past the cap is; the `tabs-store` "nothing else evicts from that map" bullet and the tab-switch flow line are corrected to match.
- `docs/app/architecture.md` - the store's one-line description says it is LRU-bounded, matching how `schema-cache.ts` is described two lines below.
- The `response-store.ts` header comment and the `closeTabsForEntities` comment that asserted nothing else evicts.

## Deviation from the issue spec

The issue suggests a cap "keyed off open-tab reach". The cap is keyed off the open-tab **count**, not the open-tab identities, for the import-cycle reason above. The practical difference is a tab held open without being re-sent while 24 other requests are sent - it keeps its tab, and falls back to the backend copy on return. Tab eviction only lets a tab stay open that long if it is dirty, and 2x headroom covers the rest. Making identity the key would mean `tabs-store` pushing its reach into this store on every open and close: more machinery, in the direction the dependency already runs, for a case the headroom covers.

The second commit is review feedback applied: the first commit's comment and doc wording promised an absolute open-tab guarantee that write recency cannot give, and the boundary test sent exactly the tail the cap has room for, so it would have passed under a design that only worked at that count.

## Related Issues

Closes #1156