### PR TITLE
perf(app): the anomaly detector derives what arrived, not the whole buffer - #1151

### DIFF
--- a/app/src/modules/dashboard/README.md
+++ b/app/src/modules/dashboard/README.md
@@ -62,8 +62,8 @@ arrives:
 - **`detectAnomalies(history)`** is the one-shot, pure over the whole series.
   `LoadTestDetail` uses it: a stored run's series arrives once, complete.
 - **`createAnomalyDetector()`** holds its derivation across calls, for a caller
-  handing over the same growing buffer again and again. `MetricsView` uses it,
-  in a ref. The live buffer's array identity changes on every store commit
+  handing over the same growing buffer again and again. `MetricsView` holds one
+  for the run's life. The live buffer's array identity changes on every commit
   (twice a second by default), so a from-scratch pass re-derived a trailing
   median per tick per series over the whole retained window - ~9,000
   fifteen-element sorts twice a second at the default 5-minute window, up to

--- a/app/src/modules/dashboard/README.md
+++ b/app/src/modules/dashboard/README.md
@@ -47,3 +47,33 @@ consumes it.
   `components/stats/ModeStatsRow.tsx` decides which four cards each mode shows,
   and its file comment tabulates them. Add a mode there, next to the branch that
   renders it.
+
+## Anomaly detection (`utils/detectAnomalies.ts`)
+
+The run's degradation windows - latency spikes, error bursts, throughput drops
+and the first 5xx - scanned out of the same per-tick series the charts plot,
+with fixed factors over a trailing median and nothing tunable. Two readings of
+one detection: the charts shade the windows, and the history Overview's
+`RunEvents` card states them in words. Both are absent for a clean run.
+
+It has two entry points, and which one a view wants depends on how its series
+arrives:
+
+- **`detectAnomalies(history)`** is the one-shot, pure over the whole series.
+  `LoadTestDetail` uses it: a stored run's series arrives once, complete.
+- **`createAnomalyDetector()`** holds its derivation across calls, for a caller
+  handing over the same growing buffer again and again. `MetricsView` uses it,
+  in a ref. The live buffer's array identity changes on every store commit
+  (twice a second by default), so a from-scratch pass re-derived a trailing
+  median per tick per series over the whole retained window - ~9,000
+  fifteen-element sorts twice a second at the default 5-minute window, up to
+  ~150,000 during a full-run soak, on the renderer's main thread (#1151).
+
+The two answer identically for the same buffer, and the rule that keeps them
+that way is in the file's header comment: what a tick and its predecessors
+decide is cached once under an index no trim renumbers, and what a tick's
+_position in the buffer_ decides is re-applied when the buffer is trimmed. A new
+rule that reads a tick's position without honouring the second half will pass
+its own unit test and disagree with the one-shot the first time the window
+fills; `detectAnomalies.test.ts` replays randomized append/trim sequences
+against a from-scratch pass to catch exactly that.

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -107,7 +107,9 @@ function MetricsView({
 	 * window (#1151). Handed the same buffer again it takes only what arrived.
 	 * It answers exactly what the one-shot `detectAnomalies` would, including for
 	 * a buffer that is not a continuation (a second run, a remount), which it
-	 * starts over on - so nothing here depends on the ref surviving.
+	 * starts over on - so nothing here depends on the instance surviving. Held in
+	 * `useState` rather than a ref because the state initialiser is the one hook
+	 * that runs exactly once without reading anything during render.
 	 */
 	const [detector] = useState(createAnomalyDetector);
 	const anomalies = useMemo(() => detector.detect(chartWindow), [detector, chartWindow]);

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -21,7 +21,7 @@
  * derives - it does not render metric chrome inline.
  */
 
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 import { Activity } from "lucide-react";
 import { formatNumber } from "@/utils";
 import { useDashboardStore } from "@/stores";
@@ -39,7 +39,7 @@ import {
 	buildStatusOverTime,
 	latestThroughputMbps,
 } from "../utils/metricsTransforms";
-import { detectAnomalies } from "../utils/detectAnomalies";
+import { createAnomalyDetector } from "../utils/detectAnomalies";
 import { HeroRow } from "./hero/HeroRow";
 import { ModeStatsRow } from "./stats/ModeStatsRow";
 import {
@@ -99,8 +99,18 @@ function MetricsView({
 	 * tick and not on the whole history array, so folding a history-wide scan into
 	 * it would rebuild it at 10 Hz and defeat the React.memo on HeroRow /
 	 * ModeStatsRow. The charts are the consumers, and they take it directly.
+	 *
+	 * The detector is held across commits rather than re-run from scratch on each
+	 * one. `chartWindow`'s identity changes every time the store appends a batch,
+	 * so a pure derivation re-derived the whole retained buffer twice a second -
+	 * a trailing-median sort per tick per series, ~9,000 of them at the default
+	 * window (#1151). Handed the same buffer again it takes only what arrived.
+	 * It answers exactly what the one-shot `detectAnomalies` would, including for
+	 * a buffer that is not a continuation (a second run, a remount), which it
+	 * starts over on - so nothing here depends on the ref surviving.
 	 */
-	const anomalies = useMemo(() => detectAnomalies(chartWindow), [chartWindow]);
+	const [detector] = useState(createAnomalyDetector);
+	const anomalies = useMemo(() => detector.detect(chartWindow), [detector, chartWindow]);
 
 	// Read the monotonic aggregates from the store - they are folded into running
 	// values on each tick in addMetricsBatch, so this is O(1) per render instead

--- a/app/src/modules/dashboard/utils/detectAnomalies.test.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from "vitest";
 import type { LoadTestMetrics } from "@/types";
 import {
 	detectAnomalies,
+	createAnomalyDetector,
 	BASELINE_TICKS,
 	LATENCY_SPIKE_FACTOR,
 	MIN_CONSECUTIVE_TICKS,
@@ -235,5 +236,361 @@ describe("detectAnomalies - the cap", () => {
 		// Still in time order after the triage, so the list reads as a timeline.
 		const times = found.map((a) => a.startSeconds);
 		expect([...times].sort((a, b) => a - b)).toEqual(times);
+	});
+});
+
+/*
+ * The incremental detector (#1151). Two things have to hold and neither is
+ * visible from the rule tests above: that it answers exactly what a from-scratch
+ * pass answers for the same buffer, and that it gets there without re-deriving
+ * the buffer it already derived. The first is proved by equivalence over a
+ * randomized append/trim sequence, the second by counting the work - a
+ * trailing-median sort and a status-map scan - that the caching exists to avoid.
+ */
+
+/** Seeded so a failure names one reproducible sequence rather than "sometimes". */
+function mulberry32(seed: number): () => number {
+	let a = seed;
+	return () => {
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/**
+ * A run that trips every rule repeatedly, so equivalence is checked on findings
+ * rather than on two empty lists agreeing.
+ *
+ * Degradations arrive as episodes of several ticks, not as independent per-tick
+ * rolls: every rule here needs {@link MIN_CONSECUTIVE_TICKS} in a row, so a
+ * coin flip per tick produces a series that is technically random and
+ * practically clean.
+ */
+function noisyRun(ticks: number, rand: () => number): LoadTestMetrics[] {
+	const out: LoadTestMetrics[] = [];
+	const kinds = ["spike", "burst", "drop"] as const;
+	let completed = 0;
+	let failed = 0;
+	let serverErrors = 0;
+	let episode: (typeof kinds)[number] | null = null;
+	let remaining = 0;
+
+	for (let i = 0; i < ticks; i++) {
+		if (remaining === 0) {
+			episode = rand() < 0.25 ? kinds[Math.floor(rand() * kinds.length)] : null;
+			remaining = 2 + Math.floor(rand() * 5);
+		}
+		remaining--;
+
+		const rps = episode === "drop" ? 150 : 480 + Math.round(rand() * 40);
+		completed += rps;
+		if (episode === "burst") failed += Math.round(rps * 0.05);
+		if (i > 60 && rand() < 0.01) serverErrors += 3;
+
+		out.push(
+			tick(i, {
+				latency_p99_ms:
+					episode === "spike"
+						? 400 + Math.round(rand() * 300)
+						: 100 + Math.round(rand() * 10),
+				current_rps: rps,
+				current_concurrency: 50,
+				requests_completed: completed,
+				requests_failed: failed,
+				status_codes:
+					serverErrors > 0
+						? { "200": completed - serverErrors, "503": serverErrors }
+						: { "200": completed },
+			})
+		);
+	}
+	return out;
+}
+
+/**
+ * Replay a run through the store's own buffer discipline - append a batch, drop
+ * the front past the time window, then past the hard cap - checking after every
+ * commit that the detector and a from-scratch pass say the same thing.
+ */
+function replay(
+	source: LoadTestMetrics[],
+	rand: () => number,
+	windowSeconds: number,
+	cap: number
+): { commits: number; kinds: Set<string> } {
+	const detector = createAnomalyDetector();
+	let buffer: LoadTestMetrics[] = [];
+	let next = 0;
+	let commits = 0;
+	const kinds = new Set<string>();
+
+	while (next < source.length) {
+		const batch = 1 + Math.floor(rand() * 6);
+		buffer = [...buffer, ...source.slice(next, next + batch)];
+		next += batch;
+
+		const cutoff = buffer[buffer.length - 1].elapsed_seconds - windowSeconds;
+		let start = 0;
+		while (start < buffer.length && buffer[start].elapsed_seconds < cutoff) start++;
+		if (start > 0) buffer = buffer.slice(start);
+		if (buffer.length > cap) buffer = buffer.slice(-cap);
+
+		const found = detector.detect(buffer);
+		expect(found).toEqual(detectAnomalies(buffer));
+		for (const a of found) kinds.add(a.kind);
+		commits++;
+	}
+	return { commits, kinds };
+}
+
+/**
+ * The sorts and status-map scans one call costs. Both are what the from-scratch
+ * pass spent per tick of retained history and what the detector is supposed to
+ * spend per tick of *new* history, so counting them is the mutation check:
+ * revert the caching and the incremental numbers rise to the from-scratch ones.
+ */
+function measure<T>(fn: () => T): { result: T; sorts: number; statusScans: number } {
+	type SortFn = typeof Array.prototype.sort;
+	const realSort = Array.prototype.sort;
+	const realEntries = Object.entries;
+	let sorts = 0;
+	let statusScans = 0;
+
+	Array.prototype.sort = function (this: unknown[], ...args: unknown[]) {
+		sorts++;
+		return Reflect.apply(realSort, this, args) as unknown[];
+	} as unknown as SortFn;
+	Object.entries = ((value: object) => {
+		statusScans++;
+		return realEntries(value);
+	}) as typeof Object.entries;
+
+	try {
+		const result = fn();
+		return { result, sorts, statusScans };
+	} finally {
+		Array.prototype.sort = realSort;
+		Object.entries = realEntries;
+	}
+}
+
+describe("createAnomalyDetector - the same answer as a from-scratch pass", () => {
+	it("agrees over a randomized append/trim sequence on a tight window", () => {
+		// A cap smaller than the run means every commit trims, so the clip path -
+		// windows going quiet as the history they rested on rolls out - is the
+		// common case here rather than an edge one.
+		const rand = mulberry32(20260831);
+		const { commits, kinds } = replay(noisyRun(900, rand), rand, 30, 40);
+		expect(commits).toBeGreaterThan(100);
+		// An agreement on nothing is not an agreement: the sequence has to have
+		// actually produced findings of every kind for the equivalence to mean
+		// anything.
+		expect([...kinds].sort()).toEqual([
+			"error_burst",
+			"first_5xx",
+			"latency_spike",
+			"throughput_drop",
+		]);
+	});
+
+	it("agrees over a randomized append/trim sequence on a window wide enough to hold whole windows", () => {
+		const rand = mulberry32(31082026);
+		const { commits, kinds } = replay(noisyRun(900, rand), rand, 200, 5000);
+		expect(commits).toBeGreaterThan(100);
+		expect([...kinds].sort()).toEqual([
+			"error_burst",
+			"first_5xx",
+			"latency_spike",
+			"throughput_drop",
+		]);
+	});
+
+	it("falls silent for a window whose lead-in has rolled out, exactly as a rescan does", () => {
+		// The spike at ticks 20-21 rests on a baseline taken from ticks 5-19. Trim
+		// past those and the rule can no longer speak for it, so both the detector
+		// and a rescan of the shortened buffer report nothing - a detector that
+		// remembered its own finding would keep reporting it.
+		const run = healthyRun(40, (i) => (i === 20 || i === 21 ? { latency_p99_ms: 480 } : {}));
+		const detector = createAnomalyDetector();
+
+		expect(detector.detect(run.slice(0, 30))).toHaveLength(1);
+		const trimmed = run.slice(10, 30);
+		expect(detectAnomalies(trimmed)).toEqual([]);
+		expect(detector.detect(trimmed)).toEqual([]);
+	});
+
+	it("starts over on a buffer that is not a continuation of the last one", () => {
+		// A second run, a replay, a remount: the ticks are different objects, so
+		// there is no alignment to find and the answer has to come from scratch.
+		const detector = createAnomalyDetector();
+		detector.detect(healthyRun(40));
+
+		const second = healthyRun(40, (i) => (i === 25 || i === 26 ? { latency_p99_ms: 500 } : {}));
+		expect(detector.detect(second)).toEqual(detectAnomalies(second));
+	});
+
+	it("answers the same buffer twice with the same result", () => {
+		// React renders twice under StrictMode, so `detect` is called twice with
+		// one array; the second call must be served from the memo and not
+		// re-ingest ticks the detector has already taken.
+		const run = healthyRun(40, (i) => (i === 20 || i === 21 ? { latency_p99_ms: 480 } : {}));
+		const detector = createAnomalyDetector();
+
+		const first = detector.detect(run);
+		const { result, sorts } = measure(() => detector.detect(run));
+		expect(result).toBe(first);
+		expect(sorts).toBe(0);
+	});
+});
+
+describe("createAnomalyDetector - what a commit costs", () => {
+	it("pays for the ticks that arrived, not for the ones it is still holding", () => {
+		const run = healthyRun(1000);
+		const detector = createAnomalyDetector();
+		detector.detect(run.slice(0, 900));
+
+		// Three trailing-median series (p99, rps, concurrency) over 10 new ticks,
+		// plus the report's own ordering sort. The from-scratch pass below pays
+		// the same three sorts for every tick it is holding - which is the whole
+		// of #1151, and what reverting the per-tick cache would restore here.
+		const incremental = measure(() => detector.detect(run.slice(0, 910)));
+		expect(incremental.sorts).toBeLessThanOrEqual(3 * 10 + 1);
+
+		const scratch = measure(() => detectAnomalies(run.slice(0, 910)));
+		expect(scratch.sorts).toBeGreaterThan(3 * (910 - BASELINE_TICKS));
+		expect(incremental.result).toEqual(scratch.result);
+	});
+
+	it("reads each tick's status map once, and none at all once the first 5xx is known", () => {
+		const clean = healthyRun(1000);
+		const detector = createAnomalyDetector();
+		detector.detect(clean.slice(0, 900));
+
+		// Ten new status maps, not nine hundred.
+		expect(measure(() => detector.detect(clean.slice(0, 910))).statusScans).toBe(10);
+
+		// Once the onset is found the rest of the run's maps are never opened.
+		const dirty = healthyRun(1000, (i) => (i >= 100 ? { status_codes: { "503": 4 } } : {}));
+		const known = createAnomalyDetector();
+		known.detect(dirty.slice(0, 900));
+		expect(measure(() => known.detect(dirty.slice(0, 910))).statusScans).toBe(0);
+	});
+
+	it("resumes the search when the tick the first 5xx landed on rolls out", () => {
+		// Two separate onsets. Trim past the first and the answer becomes the
+		// second - and the scan resumes at the new front rather than restarting,
+		// so it re-reads nothing it had already cleared.
+		const run = healthyRun(
+			80,
+			(i): Partial<LoadTestMetrics> =>
+				i >= 20 && i < 40
+					? { status_codes: { "503": 4 } }
+					: i >= 60
+						? { status_codes: { "500": 9 } }
+						: {}
+		);
+		const detector = createAnomalyDetector();
+
+		expect(detector.detect(run.slice(0, 70))[0]).toMatchObject({
+			kind: "first_5xx",
+			startSeconds: 20,
+			label: "first 503 response",
+		});
+
+		const trimmed = run.slice(50);
+		expect(detector.detect(trimmed)).toEqual(detectAnomalies(trimmed));
+		expect(detector.detect(trimmed)[0]).toMatchObject({
+			kind: "first_5xx",
+			startSeconds: 60,
+			label: "first 500 response",
+		});
+	});
+});
+
+describe("createAnomalyDetector - the edges of recognising the next buffer", () => {
+	it("refuses a buffer whose head is a different tick at the same elapsed time", () => {
+		// Aligning on elapsed time alone would accept this: the times line up and
+		// the tail is shared, so only object identity says the head is not the tick
+		// the detector already took. Ingesting it as if it were rolls the burst's
+		// onset a tick early - a wrong answer, silently.
+		const run = healthyRun(60, (i) => ({ requests_failed: i * 30 }));
+		const detector = createAnomalyDetector();
+		detector.detect(run);
+
+		const spliced = run.slice(20);
+		spliced[0] = { ...run[20], requests_failed: run[21].requests_failed };
+
+		expect(detector.detect(spliced)).toEqual(detectAnomalies(spliced));
+		expect(detector.detect(spliced).filter((a) => a.kind === "error_burst")[0]).toMatchObject({
+			startSeconds: 22,
+		});
+	});
+
+	it("refuses a buffer that shares only its first tick with the last one", () => {
+		// The offset is confirmed at both ends because confirming it in full would
+		// be the O(n) pass the detector exists to avoid. Sharing a head is not
+		// enough: everything behind it can still be a different run's ticks, whose
+		// values would then never be ingested at all.
+		const run = healthyRun(60);
+		const detector = createAnomalyDetector();
+		detector.detect(run);
+
+		const relabelled = [
+			run[20],
+			...run
+				.slice(21)
+				.map((m, i) => ({ ...m, latency_p99_ms: i === 20 || i === 21 ? 900 : 100 })),
+		];
+		expect(detector.detect(relabelled)).toEqual(detectAnomalies(relabelled));
+		expect(detector.detect(relabelled).filter((a) => a.kind === "latency_spike")).toHaveLength(
+			1
+		);
+	});
+
+	it("walks an open recovery tail once, not once per commit", () => {
+		/*
+		 * A degradation that opens and then stalls above the recovery factor keeps
+		 * its window open for the rest of the run, so the tail is the one thing in
+		 * the detector that grows without bound while a commit is being served.
+		 * It has to be resumed from where the last commit left it; restarting it at
+		 * the run's end would re-read the whole tail twice a second, which is the
+		 * shape of the cost #1151 is about.
+		 */
+		// Flat at 100ms, 6x for two ticks at t=100, then stalled at 2.5x forever:
+		// the window opens and never closes, and the risen baseline behind it keeps
+		// any second window from opening.
+		const source = Array.from({ length: 800 }, (_, i) =>
+			tick(i, {
+				latency_p99_ms: i < 100 ? 100 : i < 102 ? 600 : 250,
+				current_rps: 500,
+				current_concurrency: 50,
+				requests_completed: i * 500,
+			})
+		);
+		let p99Reads = 0;
+		const run = source.map((m) => ({
+			...m,
+			get latency_p99_ms() {
+				p99Reads++;
+				return m.latency_p99_ms;
+			},
+		}));
+
+		const detector = createAnomalyDetector();
+		const held = run.slice(0, 700);
+		const open = detector.detect(held).filter((a) => a.kind === "latency_spike");
+		// The window really is still open at the buffer's end - otherwise there is
+		// no tail for the assertion below to be about.
+		expect(open).toHaveLength(1);
+		expect(open[0].endSeconds).toBe(699);
+
+		p99Reads = 0;
+		detector.detect(run.slice(0, 710));
+		// Ten new ticks: a trailing median reads BASELINE_TICKS values each, the
+		// rule reads one more, and the tail advances by ten. Restarting the tail
+		// at the run's end instead would add ~600 reads on top.
+		expect(p99Reads).toBeLessThan(10 * (BASELINE_TICKS + 2) + 50);
 	});
 });

--- a/app/src/modules/dashboard/utils/detectAnomalies.test.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.test.ts
@@ -549,6 +549,46 @@ describe("createAnomalyDetector - the edges of recognising the next buffer", () 
 		);
 	});
 
+	it("agrees through resets, near-total trims and repeated elapsed times", () => {
+		/*
+		 * The replays above drive the store's ordinary discipline. This one drives
+		 * what the store does at a run's edges - clearing the buffer between runs,
+		 * trimming it down to a single tick, handing over ticks whose elapsed times
+		 * repeat because two scrapes landed in the same second - which is where
+		 * recognising the next buffer either holds or quietly reports the wrong
+		 * run's windows. Sixty seeds, because these paths are reached by
+		 * coincidence rather than by design.
+		 */
+		for (let seed = 1; seed <= 60; seed++) {
+			const rand = mulberry32(seed);
+			const source = noisyRun(300, rand).map((m, i, all) =>
+				// Two scrapes in the same second: the search that finds the buffer's
+				// new head can no longer assume elapsed times are distinct.
+				i > 0 && rand() < 0.15 ? { ...m, elapsed_seconds: all[i - 1].elapsed_seconds } : m
+			);
+
+			const detector = createAnomalyDetector();
+			let buffer: LoadTestMetrics[] = [];
+			let next = 0;
+			while (next < source.length) {
+				buffer = [...buffer, ...source.slice(next, next + 1 + Math.floor(rand() * 8))];
+				next += 1 + Math.floor(rand() * 8);
+
+				const roll = rand();
+				if (roll < 0.15) buffer = [];
+				else if (roll < 0.3) buffer = buffer.slice(-1);
+				else if (roll < 0.5) buffer = buffer.slice(Math.floor(rand() * 5));
+				else if (roll < 0.6) buffer = buffer.slice(-Math.max(1, Math.floor(rand() * 25)));
+
+				expect({ seed, next, found: detector.detect(buffer) }).toEqual({
+					seed,
+					next,
+					found: detectAnomalies(buffer),
+				});
+			}
+		}
+	});
+
 	it("walks an open recovery tail once, not once per commit", () => {
 		/*
 		 * A degradation that opens and then stalls above the recovery factor keeps

--- a/app/src/modules/dashboard/utils/detectAnomalies.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.ts
@@ -263,6 +263,27 @@ function clipRunsFront(runs: Run[], minStartAbs: number): boolean {
 }
 
 /**
+ * The windows a rule reports, one per run long enough to count, built once and
+ * kept on the run until its bounds move.
+ *
+ * The spike rule does not use this: its windows extend past their own hot run
+ * and swallow the ones behind them, which is a fold over the runs rather than a
+ * map across them. Burst and drop are maps, and were the same eight lines twice.
+ */
+function collectWindows<R extends Run & { window: Anomaly | null }>(
+	runs: R[],
+	build: (run: R) => Anomaly
+): Anomaly[] {
+	const out: Anomaly[] = [];
+	for (const run of runs) {
+		if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
+		if (!run.window) run.window = build(run);
+		out.push(run.window);
+	}
+	return out;
+}
+
+/**
  * One rule's incremental state. `trim` and `push` are the ingest half - called
  * once per commit and once per arriving tick - and `windows` is the read half,
  * which materialises what the rule currently says about the buffer it is given.
@@ -471,21 +492,13 @@ function createBurstDetector(): RuleDetector {
 			if (clipped && runs.length > 0) reseat(runs[0]);
 			clipped = false;
 
-			const out: Anomaly[] = [];
-			for (const run of runs) {
-				if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
-				if (!run.window) {
-					run.window = {
-						kind: "error_burst",
-						startSeconds: elapsedAt(history, firstAbs, run.startAbs),
-						endSeconds: elapsedAt(history, firstAbs, run.endAbs),
-						magnitude: run.peak / ERROR_BURST_RATE,
-						label: `errors ${(run.peak * 100).toFixed(1)}% of requests for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
-					};
-				}
-				out.push(run.window);
-			}
-			return out;
+			return collectWindows(runs, (run) => ({
+				kind: "error_burst",
+				startSeconds: elapsedAt(history, firstAbs, run.startAbs),
+				endSeconds: elapsedAt(history, firstAbs, run.endAbs),
+				magnitude: run.peak / ERROR_BURST_RATE,
+				label: `errors ${(run.peak * 100).toFixed(1)}% of requests for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
+			}));
 		},
 	};
 }
@@ -554,24 +567,18 @@ function createDropDetector(): RuleDetector {
 			if (clipped && runs.length > 0) reseat(runs[0], history, firstAbs);
 			clipped = false;
 
-			const out: Anomaly[] = [];
-			for (const run of runs) {
-				if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
-				if (!run.window) {
-					const share = run.trough / run.base;
-					run.window = {
-						kind: "throughput_drop",
-						startSeconds: elapsedAt(history, firstAbs, run.startAbs),
-						endSeconds: elapsedAt(history, firstAbs, run.endAbs),
-						// trough can be 0 (throughput stopped entirely) - report that as
-						// the worst possible multiple rather than as Infinity.
-						magnitude: share > 0 ? 1 / share : Number.MAX_SAFE_INTEGER,
-						label: `throughput ${Math.round(share * 100)}% of baseline for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
-					};
-				}
-				out.push(run.window);
-			}
-			return out;
+			return collectWindows(runs, (run) => {
+				const share = run.trough / run.base;
+				return {
+					kind: "throughput_drop",
+					startSeconds: elapsedAt(history, firstAbs, run.startAbs),
+					endSeconds: elapsedAt(history, firstAbs, run.endAbs),
+					// trough can be 0 (throughput stopped entirely) - report that as the
+					// worst possible multiple rather than as Infinity.
+					magnitude: share > 0 ? 1 / share : Number.MAX_SAFE_INTEGER,
+					label: `throughput ${Math.round(share * 100)}% of baseline for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
+				};
+			});
 		},
 	};
 }

--- a/app/src/modules/dashboard/utils/detectAnomalies.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.ts
@@ -25,6 +25,42 @@
  * Pure over `LoadTestMetrics[]`, like {@link computeBreakpoint} beside it: the
  * live dashboard and the history view both derive from their own series and pass
  * the result down, so no card re-derives from raw metrics.
+ *
+ * ## One-shot, or incremental over a live buffer
+ *
+ * {@link detectAnomalies} is the one-shot: a whole series in, its windows out,
+ * no state. That is what the history view wants, and it is the definition every
+ * rule here is written against.
+ *
+ * The live dashboard cannot afford it. Its buffer is handed over again on every
+ * store commit - twice a second by default, and the array reference changes each
+ * time - so a from-scratch pass re-derived a trailing median *per tick, per
+ * series* over the whole retained window: ~9,000 fifteen-element sorts twice a
+ * second at the default 5-minute window, up to ~150,000 during a full-run soak,
+ * on the renderer's main thread (#1151). So the live path holds a
+ * {@link createAnomalyDetector} instead, which recognises the next buffer as the
+ * last one with ticks appended and the oldest dropped, and derives only what
+ * actually arrived.
+ *
+ * The two agree exactly, and the split that makes that true is worth stating,
+ * because every future rule has to honour it:
+ *
+ * - What a tick's own value and its **predecessors** decide - a trailing median,
+ *   a failure-rate delta, whether the rule is satisfied - is computed once, when
+ *   the tick arrives, and cached under an absolute tick index that no later trim
+ *   renumbers. None of it can change afterwards.
+ * - What a tick's **position in the buffer** decides is the part a trim moves:
+ *   there is no baseline for the first {@link BASELINE_TICKS} ticks and no delta
+ *   for the first tick, so a window resting on history that has since rolled out
+ *   has to go quiet, exactly as a from-scratch pass over the shortened buffer
+ *   does. A position only ever *falls*, so that is a one-way door - hotness is
+ *   monotone, and re-applying the rule is {@link clipRunsFront} moving the
+ *   leading window's start to the oldest tick the rule can still speak for. A
+ *   trim clips a window and can never split one.
+ *
+ * Which is why the front clip is load-bearing rather than defensive: it is the
+ * only thing that re-applies a positional rule after ingest, and reverting it
+ * makes the equivalence tests fail on the first trim.
  */
 
 import type { LoadTestMetrics } from "@/types";
@@ -81,191 +117,568 @@ export const MIN_CONSECUTIVE_TICKS = 2;
 /** Most anomalies reported; beyond this the list stops being readable. */
 export const MAX_ANOMALIES = 20;
 
-function median(values: number[]): number {
-	if (values.length === 0) return 0;
-	const sorted = [...values].sort((a, b) => a - b);
-	const mid = sorted.length >> 1;
-	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-}
-
-/**
- * Median of the {@link BASELINE_TICKS} ticks *before* each index - `null` until
- * that much history exists, which is what makes the opening seconds of a run
- * (where every value is its own outlier) produce nothing.
- */
-function trailingMedians(values: number[]): Array<number | null> {
-	return values.map((_, i) =>
-		i < BASELINE_TICKS ? null : median(values.slice(i - BASELINE_TICKS, i))
-	);
-}
-
-/**
- * Maximal runs of consecutive ticks satisfying `isHot`, at least
- * {@link MIN_CONSECUTIVE_TICKS} long, as inclusive `[start, end]` index pairs.
- * Runs are disjoint and ordered by construction, so no merge pass is needed
- * downstream.
- */
-function findRuns(length: number, isHot: (i: number) => boolean): Array<[number, number]> {
-	const runs: Array<[number, number]> = [];
-	let i = 0;
-	while (i < length) {
-		if (!isHot(i)) {
-			i++;
-			continue;
-		}
-		const start = i;
-		while (i < length && isHot(i)) i++;
-		if (i - start >= MIN_CONSECUTIVE_TICKS) runs.push([start, i - 1]);
-	}
-	return runs;
-}
-
 /** Seconds, at the precision a reader can act on: "3s", "0.4s". */
 function formatSeconds(seconds: number): string {
 	return seconds >= 10 ? `${Math.round(seconds)}s` : `${Number(seconds.toFixed(1))}s`;
 }
 
-function span(history: LoadTestMetrics[], start: number, end: number): string {
-	return formatSeconds(history[end].elapsed_seconds - history[start].elapsed_seconds);
-}
+/* -------------------------------------------------------------------------- */
+/* Per-tick storage                                                            */
+/* -------------------------------------------------------------------------- */
 
-function detectLatencySpikes(history: LoadTestMetrics[]): Anomaly[] {
-	const p99 = history.map((m) => m.latency_p99_ms ?? 0);
-	const baselines = trailingMedians(p99);
-	const isHot = (i: number) => {
-		const base = baselines[i];
-		return base != null && base > 0 && p99[i] > base * LATENCY_SPIKE_FACTOR;
-	};
+/**
+ * Values derived once per tick and addressed by *absolute* tick index - the
+ * count of ticks the detector has ever seen, which no trim renumbers. Dropping
+ * the oldest is then a pointer move; the backing array is compacted only once
+ * the dead prefix outweighs the live one, so it tracks what is retained rather
+ * than the length of the whole run.
+ */
+class TickCache<T> {
+	private values: T[] = [];
+	private head = 0;
+	private baseAbs = 0;
 
-	const out: Anomaly[] = [];
-	let consumedThrough = -1;
-	for (const [start, hotEnd] of findRuns(history.length, isHot)) {
-		// A window that the previous one already swallowed during its recovery
-		// extension is the same degradation, not a second one.
-		if (start <= consumedThrough) continue;
-		/*
-		 * The baseline is frozen at the opening tick. Recomputing it as the window
-		 * extends would fold the spike's own ticks into the trailing median, so a
-		 * long degradation would raise its own bar and report itself as recovered
-		 * while it was still happening.
-		 */
-		const base = baselines[start] as number;
-		let end = hotEnd;
-		while (end + 1 < history.length && p99[end + 1] > base * LATENCY_RECOVERY_FACTOR) end++;
-		consumedThrough = end;
-
-		let peak = 0;
-		for (let i = start; i <= end; i++) peak = Math.max(peak, p99[i]);
-		const magnitude = peak / base;
-		out.push({
-			kind: "latency_spike",
-			startSeconds: history[start].elapsed_seconds,
-			endSeconds: history[end].elapsed_seconds,
-			magnitude,
-			label: `p99 ${magnitude.toFixed(1)}x baseline for ${span(history, start, end)}`,
-		});
+	push(value: T): void {
+		this.values.push(value);
 	}
-	return out;
+
+	at(abs: number): T {
+		return this.values[this.head + (abs - this.baseAbs)];
+	}
+
+	dropBefore(abs: number): void {
+		const drop = abs - this.baseAbs;
+		if (drop <= 0) return;
+		this.head += drop;
+		this.baseAbs = abs;
+		if (this.head * 2 > this.values.length) {
+			this.values = this.values.slice(this.head);
+			this.head = 0;
+		}
+	}
 }
 
-function detectErrorBursts(history: LoadTestMetrics[]): Anomaly[] {
+/** One number read off a tick, with the same `?? 0` the from-scratch pass used. */
+type Reader = (m: LoadTestMetrics) => number;
+
+const readP99: Reader = (m) => m.latency_p99_ms ?? 0;
+const readRps: Reader = (m) => m.current_rps ?? 0;
+const readConcurrency: Reader = (m) => m.current_concurrency ?? 0;
+
+/**
+ * Trailing-median baselines for one series: the median of the
+ * {@link BASELINE_TICKS} ticks *before* each tick, computed when that tick
+ * arrives and never revisited - the values behind it cannot change.
+ *
+ * `null` for a tick that arrived without that much history in front of it, which
+ * is what makes the opening seconds of a run (where every value is its own
+ * outlier) produce nothing. A tick that *loses* its lead-in to a later trim is
+ * not handled here - it keeps a baseline no rule may use any more, and
+ * {@link clipRunsFront} is what stops any of them using it.
+ */
+function createBaselines(read: Reader) {
+	const cache = new TickCache<number | null>();
+	const scratch = new Array<number>(BASELINE_TICKS);
+
+	return {
+		dropBefore(abs: number): void {
+			cache.dropBefore(abs);
+		},
+
+		push(history: LoadTestMetrics[], pos: number): void {
+			if (pos < BASELINE_TICKS) {
+				cache.push(null);
+				return;
+			}
+			for (let k = 0; k < BASELINE_TICKS; k++) {
+				scratch[k] = read(history[pos - BASELINE_TICKS + k]);
+			}
+			scratch.sort((a, b) => a - b);
+			const mid = BASELINE_TICKS >> 1;
+			cache.push(
+				BASELINE_TICKS % 2 === 0 ? (scratch[mid - 1] + scratch[mid]) / 2 : scratch[mid]
+			);
+		},
+
+		at(abs: number): number | null {
+			return cache.at(abs);
+		},
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* Runs of consecutive hot ticks                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A maximal run of consecutive ticks satisfying one rule, in absolute indices
+ * and inclusive of both ends. Runs shorter than {@link MIN_CONSECUTIVE_TICKS}
+ * are kept but never reported: they are still the run a later contiguous tick
+ * extends, and dropping them would report that pair a tick late.
+ */
+interface Run {
+	startAbs: number;
+	endAbs: number;
+}
+
+function runLength(run: Run): number {
+	return run.endAbs - run.startAbs + 1;
+}
+
+/**
+ * Extend the trailing run to `abs`, or open a new one. Returns the run that
+ * changed, so the caller can refresh whatever it caches on it.
+ */
+function extendOrOpen<R extends Run>(runs: R[], abs: number, open: () => R): R {
+	const last = runs[runs.length - 1];
+	if (last && last.endAbs === abs - 1) {
+		last.endAbs = abs;
+		return last;
+	}
+	const run = open();
+	runs.push(run);
+	return run;
+}
+
+/**
+ * Drop runs the buffer no longer holds, and clip the first survivor to
+ * `minStartAbs` - the oldest tick the rule can still speak for. Hotness only
+ * ever falls away at the front, so this clips a run and can never split one.
+ * Returns whether the leading run moved, which is what invalidates the caller's
+ * cached window for it.
+ */
+function clipRunsFront(runs: Run[], minStartAbs: number): boolean {
+	let expired = 0;
+	while (expired < runs.length && runs[expired].endAbs < minStartAbs) expired++;
+	if (expired > 0) runs.splice(0, expired);
+
+	const first = runs[0];
+	if (first && first.startAbs < minStartAbs) {
+		first.startAbs = minStartAbs;
+		return true;
+	}
+	// An expired run leaves the survivor behind it untouched, so nothing the
+	// caller cached about it went stale.
+	return false;
+}
+
+/**
+ * One rule's incremental state. `trim` and `push` are the ingest half - called
+ * once per commit and once per arriving tick - and `windows` is the read half,
+ * which materialises what the rule currently says about the buffer it is given.
+ *
+ * A rule with nothing to derive per tick omits `push` and does its reading in
+ * `windows`, from a cursor it carries itself.
+ */
+interface RuleDetector {
+	trim(firstAbs: number): void;
+	push?(history: LoadTestMetrics[], firstAbs: number, pos: number): void;
+	windows(history: LoadTestMetrics[], firstAbs: number): Anomaly[];
+}
+
+function elapsedAt(history: LoadTestMetrics[], firstAbs: number, abs: number): number {
+	return history[abs - firstAbs].elapsed_seconds;
+}
+
+function spanOf(history: LoadTestMetrics[], firstAbs: number, from: number, to: number): string {
+	return formatSeconds(elapsedAt(history, firstAbs, to) - elapsedAt(history, firstAbs, from));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Latency spikes                                                              */
+/* -------------------------------------------------------------------------- */
+
+interface SpikeRun extends Run {
+	/**
+	 * The baseline frozen at the opening tick. Recomputing it as the window
+	 * extends would fold the spike's own ticks into the trailing median, so a
+	 * long degradation would raise its own bar and report itself as recovered
+	 * while it was still happening.
+	 */
+	base: number;
+	/** Last tick of the window including its recovery tail. */
+	tailAbs: number;
+	/** True once a tick has ended the tail, which it then cannot re-open. */
+	tailClosed: boolean;
+	/** Peak p99 over `[startAbs, tailAbs]`. */
+	peak: number;
+	window: Anomaly | null;
+}
+
+function createSpikeDetector(): RuleDetector {
+	const baselines = createBaselines(readP99);
+	const runs: SpikeRun[] = [];
+	let clipped = false;
+
+	/** Reset everything a clipped start invalidates: the frozen baseline, the tail, the peak. */
+	function reseat(run: SpikeRun, history: LoadTestMetrics[], firstAbs: number): void {
+		// The clipped start is the oldest tick this rule can speak for, so it
+		// arrived with a full lead-in and its baseline is there.
+		run.base = baselines.at(run.startAbs) ?? 0;
+		run.tailAbs = run.endAbs;
+		run.tailClosed = false;
+		run.peak = 0;
+		for (let abs = run.startAbs; abs <= run.endAbs; abs++) {
+			run.peak = Math.max(run.peak, readP99(history[abs - firstAbs]));
+		}
+		run.window = null;
+	}
+
+	/** Walk the recovery tail forward from where the last commit left it. */
+	function advanceTail(run: SpikeRun, history: LoadTestMetrics[], firstAbs: number): void {
+		if (run.tailClosed) return;
+		const lastAbs = firstAbs + history.length - 1;
+		let end = run.tailAbs;
+		while (end < lastAbs) {
+			const next = readP99(history[end + 1 - firstAbs]);
+			if (next <= run.base * LATENCY_RECOVERY_FACTOR) {
+				run.tailClosed = true;
+				break;
+			}
+			end++;
+			run.peak = Math.max(run.peak, next);
+		}
+		if (end !== run.tailAbs) {
+			run.tailAbs = end;
+			run.window = null;
+		}
+	}
+
+	return {
+		trim(firstAbs) {
+			baselines.dropBefore(firstAbs);
+			clipped = clipRunsFront(runs, firstAbs + BASELINE_TICKS) || clipped;
+		},
+
+		push(history, firstAbs, pos) {
+			baselines.push(history, pos);
+			const abs = firstAbs + pos;
+			const base = baselines.at(abs);
+			const p99 = readP99(history[pos]);
+			if (base == null || base <= 0 || p99 <= base * LATENCY_SPIKE_FACTOR) return;
+
+			const run = extendOrOpen<SpikeRun>(runs, abs, () => ({
+				startAbs: abs,
+				endAbs: abs,
+				base,
+				tailAbs: abs,
+				tailClosed: false,
+				peak: p99,
+				window: null,
+			}));
+			if (abs > run.tailAbs) run.tailAbs = abs;
+			run.peak = Math.max(run.peak, p99);
+			run.window = null;
+		},
+
+		windows(history, firstAbs) {
+			if (clipped && runs.length > 0) reseat(runs[0], history, firstAbs);
+			clipped = false;
+
+			const out: Anomaly[] = [];
+			let consumedThrough = -Infinity;
+			for (const run of runs) {
+				if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
+				// A window the previous one already swallowed during its recovery
+				// extension is the same degradation, not a second one.
+				if (run.startAbs <= consumedThrough) continue;
+				advanceTail(run, history, firstAbs);
+				consumedThrough = run.tailAbs;
+				if (!run.window) {
+					const magnitude = run.peak / run.base;
+					run.window = {
+						kind: "latency_spike",
+						startSeconds: elapsedAt(history, firstAbs, run.startAbs),
+						endSeconds: elapsedAt(history, firstAbs, run.tailAbs),
+						magnitude,
+						label: `p99 ${magnitude.toFixed(1)}x baseline for ${spanOf(history, firstAbs, run.startAbs, run.tailAbs)}`,
+					};
+				}
+				out.push(run.window);
+			}
+			return out;
+		},
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* Error bursts                                                                */
+/* -------------------------------------------------------------------------- */
+
+interface BurstRun extends Run {
+	/** Peak per-tick failure rate over the run. */
+	peak: number;
+	window: Anomaly | null;
+}
+
+function createBurstDetector(): RuleDetector {
 	/*
 	 * `requests_failed` and `requests_completed` are cumulative counters, so the
 	 * rate that matters is the per-tick delta. Reading them undiffed would report
 	 * a run that failed early and recovered as failing for the rest of its life.
+	 * The delta is a property of a tick and the one before it, so it is cached;
+	 * that the *first* tick in the buffer has no predecessor is a property of the
+	 * buffer, so it is applied on read.
 	 */
-	const rate = history.map((m, i) => {
-		if (i === 0) return 0;
-		const failed = Math.max(
-			0,
-			(m.requests_failed ?? 0) - (history[i - 1].requests_failed ?? 0)
-		);
-		const completed = Math.max(0, m.requests_completed - history[i - 1].requests_completed);
-		return completed > 0 ? failed / completed : 0;
-	});
+	const rates = new TickCache<number>();
+	const runs: BurstRun[] = [];
+	let clipped = false;
 
-	return findRuns(history.length, (i) => rate[i] > ERROR_BURST_RATE).map(([start, end]) => {
-		let peak = 0;
-		for (let i = start; i <= end; i++) peak = Math.max(peak, rate[i]);
-		return {
-			kind: "error_burst" as const,
-			startSeconds: history[start].elapsed_seconds,
-			endSeconds: history[end].elapsed_seconds,
-			magnitude: peak / ERROR_BURST_RATE,
-			label: `errors ${(peak * 100).toFixed(1)}% of requests for ${span(history, start, end)}`,
-		};
-	});
-}
+	const rateAt = (abs: number) => rates.at(abs);
 
-function detectThroughputDrops(history: LoadTestMetrics[]): Anomaly[] {
-	const rps = history.map((m) => m.current_rps ?? 0);
-	const concurrency = history.map((m) => m.current_concurrency ?? 0);
-	const rpsBaselines = trailingMedians(rps);
-	const concurrencyBaselines = trailingMedians(concurrency);
-
-	const isHot = (i: number) => {
-		const base = rpsBaselines[i];
-		if (base == null || base <= 0) return false;
-		// Concurrency held: a ramp winding down, or a stopped run, produces less
-		// throughput because it was asked to. That is not a degradation.
-		const heldConcurrency = concurrency[i] >= (concurrencyBaselines[i] ?? 0);
-		return heldConcurrency && rps[i] < base * THROUGHPUT_DROP_FACTOR;
-	};
-
-	return findRuns(history.length, isHot).map(([start, end]) => {
-		const base = rpsBaselines[start] as number;
-		let trough = Infinity;
-		for (let i = start; i <= end; i++) trough = Math.min(trough, rps[i]);
-		const share = trough / base;
-		return {
-			kind: "throughput_drop" as const,
-			startSeconds: history[start].elapsed_seconds,
-			endSeconds: history[end].elapsed_seconds,
-			// trough can be 0 (throughput stopped entirely) - report that as the
-			// worst possible multiple rather than as Infinity.
-			magnitude: share > 0 ? 1 / share : Number.MAX_SAFE_INTEGER,
-			label: `throughput ${Math.round(share * 100)}% of baseline for ${span(history, start, end)}`,
-		};
-	});
-}
-
-function detectFirst5xx(history: LoadTestMetrics[]): Anomaly[] {
-	for (const m of history) {
-		// The map is cumulative, so the tick a 5xx key first appears on with a
-		// non-zero count IS the onset - no diffing needed to find the first one.
-		const code = Object.entries(m.status_codes ?? {}).find(
-			([status, count]) => count > 0 && Number(status) >= 500 && Number(status) < 600
-		);
-		if (!code) continue;
-		return [
-			{
-				kind: "first_5xx",
-				startSeconds: m.elapsed_seconds,
-				endSeconds: m.elapsed_seconds,
-				magnitude: 1,
-				label: `first ${code[0]} response`,
-			},
-		];
+	function reseat(run: BurstRun): void {
+		run.peak = 0;
+		for (let abs = run.startAbs; abs <= run.endAbs; abs++) {
+			run.peak = Math.max(run.peak, rateAt(abs));
+		}
+		run.window = null;
 	}
-	return [];
+
+	return {
+		trim(firstAbs) {
+			rates.dropBefore(firstAbs);
+			// The first tick of the buffer has no predecessor to diff against, so
+			// it is the one position this rule cannot speak for.
+			clipped = clipRunsFront(runs, firstAbs + 1) || clipped;
+		},
+
+		push(history, firstAbs, pos) {
+			if (pos === 0) {
+				rates.push(0);
+			} else {
+				const m = history[pos];
+				const prev = history[pos - 1];
+				const failed = Math.max(0, (m.requests_failed ?? 0) - (prev.requests_failed ?? 0));
+				const completed = Math.max(0, m.requests_completed - prev.requests_completed);
+				rates.push(completed > 0 ? failed / completed : 0);
+			}
+
+			const abs = firstAbs + pos;
+			const rate = rateAt(abs);
+			if (rate <= ERROR_BURST_RATE) return;
+
+			const run = extendOrOpen<BurstRun>(runs, abs, () => ({
+				startAbs: abs,
+				endAbs: abs,
+				peak: rate,
+				window: null,
+			}));
+			run.peak = Math.max(run.peak, rate);
+			run.window = null;
+		},
+
+		windows(history, firstAbs) {
+			if (clipped && runs.length > 0) reseat(runs[0]);
+			clipped = false;
+
+			const out: Anomaly[] = [];
+			for (const run of runs) {
+				if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
+				if (!run.window) {
+					run.window = {
+						kind: "error_burst",
+						startSeconds: elapsedAt(history, firstAbs, run.startAbs),
+						endSeconds: elapsedAt(history, firstAbs, run.endAbs),
+						magnitude: run.peak / ERROR_BURST_RATE,
+						label: `errors ${(run.peak * 100).toFixed(1)}% of requests for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
+					};
+				}
+				out.push(run.window);
+			}
+			return out;
+		},
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* Throughput drops                                                            */
+/* -------------------------------------------------------------------------- */
+
+interface DropRun extends Run {
+	/** The rps baseline at the opening tick, which the share is measured against. */
+	base: number;
+	/** Lowest rps over the run. */
+	trough: number;
+	window: Anomaly | null;
+}
+
+function createDropDetector(): RuleDetector {
+	const rpsBaselines = createBaselines(readRps);
+	const concurrencyBaselines = createBaselines(readConcurrency);
+	const runs: DropRun[] = [];
+	let clipped = false;
+
+	function reseat(run: DropRun, history: LoadTestMetrics[], firstAbs: number): void {
+		// See the spike detector: a clipped start always has its baseline.
+		run.base = rpsBaselines.at(run.startAbs) ?? 0;
+		run.trough = Infinity;
+		for (let abs = run.startAbs; abs <= run.endAbs; abs++) {
+			run.trough = Math.min(run.trough, readRps(history[abs - firstAbs]));
+		}
+		run.window = null;
+	}
+
+	return {
+		trim(firstAbs) {
+			rpsBaselines.dropBefore(firstAbs);
+			concurrencyBaselines.dropBefore(firstAbs);
+			clipped = clipRunsFront(runs, firstAbs + BASELINE_TICKS) || clipped;
+		},
+
+		push(history, firstAbs, pos) {
+			rpsBaselines.push(history, pos);
+			concurrencyBaselines.push(history, pos);
+
+			const abs = firstAbs + pos;
+			const base = rpsBaselines.at(abs);
+			if (base == null || base <= 0) return;
+			const rps = readRps(history[pos]);
+			// Concurrency held: a ramp winding down, or a stopped run, produces less
+			// throughput because it was asked to. That is not a degradation.
+			const heldConcurrency =
+				readConcurrency(history[pos]) >= (concurrencyBaselines.at(abs) ?? 0);
+			if (!heldConcurrency || rps >= base * THROUGHPUT_DROP_FACTOR) return;
+
+			const run = extendOrOpen<DropRun>(runs, abs, () => ({
+				startAbs: abs,
+				endAbs: abs,
+				base,
+				trough: rps,
+				window: null,
+			}));
+			run.trough = Math.min(run.trough, rps);
+			run.window = null;
+		},
+
+		windows(history, firstAbs) {
+			if (clipped && runs.length > 0) reseat(runs[0], history, firstAbs);
+			clipped = false;
+
+			const out: Anomaly[] = [];
+			for (const run of runs) {
+				if (runLength(run) < MIN_CONSECUTIVE_TICKS) continue;
+				if (!run.window) {
+					const share = run.trough / run.base;
+					run.window = {
+						kind: "throughput_drop",
+						startSeconds: elapsedAt(history, firstAbs, run.startAbs),
+						endSeconds: elapsedAt(history, firstAbs, run.endAbs),
+						// trough can be 0 (throughput stopped entirely) - report that as
+						// the worst possible multiple rather than as Infinity.
+						magnitude: share > 0 ? 1 / share : Number.MAX_SAFE_INTEGER,
+						label: `throughput ${Math.round(share * 100)}% of baseline for ${spanOf(history, firstAbs, run.startAbs, run.endAbs)}`,
+					};
+				}
+				out.push(run.window);
+			}
+			return out;
+		},
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* First 5xx                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function first5xxCode(m: LoadTestMetrics): string | null {
+	// The map is cumulative, so the tick a 5xx key first appears on with a
+	// non-zero count IS the onset - no diffing needed to find the first one.
+	const code = Object.entries(m.status_codes ?? {}).find(
+		([status, count]) => count > 0 && Number(status) >= 500 && Number(status) < 600
+	);
+	return code ? code[0] : null;
+}
+
+function createFirst5xxDetector(): RuleDetector {
+	/** Absolute index the status maps have been scanned up to, exclusive. */
+	let scannedTo = 0;
+	let foundAbs: number | null = null;
+	let foundCode = "";
+	let window: Anomaly | null = null;
+
+	return {
+		trim(firstAbs) {
+			if (foundAbs != null && foundAbs < firstAbs) {
+				// The onset rolled out of the buffer. Every tick before it was
+				// scanned and clean, and those went first - so the search for the
+				// next onset resumes at the new front having re-read nothing.
+				foundAbs = null;
+				window = null;
+				scannedTo = firstAbs;
+			}
+			if (scannedTo < firstAbs) scannedTo = firstAbs;
+		},
+
+		windows(history, firstAbs) {
+			const lastAbs = firstAbs + history.length - 1;
+			// Only ever forward, and only while nothing has been found: once the
+			// onset is known the rest of the run's status maps are never read.
+			for (let abs = scannedTo; foundAbs == null && abs <= lastAbs; abs++) {
+				scannedTo = abs + 1;
+				const code = first5xxCode(history[abs - firstAbs]);
+				if (code == null) continue;
+				foundAbs = abs;
+				foundCode = code;
+				window = null;
+			}
+
+			if (foundAbs == null) return [];
+			if (!window) {
+				const seconds = elapsedAt(history, firstAbs, foundAbs);
+				window = {
+					kind: "first_5xx",
+					startSeconds: seconds,
+					endSeconds: seconds,
+					magnitude: 1,
+					label: `first ${foundCode} response`,
+				};
+			}
+			return [window];
+		},
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* The detector                                                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * How the buffer just handed over relates to the last one: how many ticks fell
+ * off the front, or `null` when it is not the same buffer at all (a new run, a
+ * replay, a remount) and the detector has to start over.
+ *
+ * The store only ever drops from the front of a time-ordered buffer, so the new
+ * head sits at the first tick with its elapsed time - found by search, then
+ * confirmed by object identity at both ends. Anything that does not confirm is
+ * refused rather than guessed at: a wrong alignment would silently report a
+ * different run's windows.
+ */
+function droppedFromFront(prev: LoadTestMetrics[], next: LoadTestMetrics[]): number | null {
+	if (prev.length === 0 || next.length === 0) return null;
+
+	const head = next[0].elapsed_seconds;
+	let lo = 0;
+	let hi = prev.length - 1;
+	while (lo <= hi) {
+		const mid = (lo + hi) >> 1;
+		if (prev[mid].elapsed_seconds < head) lo = mid + 1;
+		else hi = mid - 1;
+	}
+	if (prev[lo] !== next[0]) return null;
+
+	const overlap = prev.length - lo;
+	if (next.length < overlap) return null;
+	if (next[overlap - 1] !== prev[prev.length - 1]) return null;
+	return lo;
 }
 
 /**
- * Every anomaly in a run's per-tick series, in time order.
- *
- * Returns `[]` for a clean run - and for a run too short to have a baseline,
- * which is the same answer for the same reason: nothing here is established
- * enough to be abnormal.
+ * Every anomaly in the buffer, in time order - the shared tail of both entry
+ * points, so the one-shot and the incremental detector cannot report differently
+ * ranked or differently ordered lists.
  */
-export function detectAnomalies(history: LoadTestMetrics[]): Anomaly[] {
-	if (history.length < 2) return [];
-
-	const found = [
-		...detectLatencySpikes(history),
-		...detectErrorBursts(history),
-		...detectThroughputDrops(history),
-		...detectFirst5xx(history),
-	];
+function assemble(rules: RuleDetector[], history: LoadTestMetrics[], firstAbs: number): Anomaly[] {
+	const found = rules.flatMap((rule) => rule.windows(history, firstAbs));
 
 	const byTime = (a: Anomaly, b: Anomaly) => a.startSeconds - b.startSeconds;
 	if (found.length <= MAX_ANOMALIES) return found.sort(byTime);
@@ -279,4 +692,83 @@ export function detectAnomalies(history: LoadTestMetrics[]): Anomaly[] {
 	const last = kept[kept.length - 1];
 	kept[kept.length - 1] = { ...last, label: `${last.label} (+${dropped} more)` };
 	return kept;
+}
+
+/**
+ * The rules, in the order they report. That order fixes the report's order for
+ * anomalies sharing a start second, since the sort in {@link assemble} is stable.
+ */
+function makeRules(): RuleDetector[] {
+	return [
+		createSpikeDetector(),
+		createBurstDetector(),
+		createDropDetector(),
+		createFirst5xxDetector(),
+	];
+}
+
+/**
+ * A detector that carries its derivation across calls, for a caller handing over
+ * the same growing buffer again and again.
+ *
+ * `detect` answers exactly what {@link detectAnomalies} would answer for the
+ * buffer it is given - including for a buffer that is not a continuation of the
+ * last one, which it starts over on. It is safe to call twice with the same
+ * array (React renders it twice under StrictMode): the second call is served
+ * from the memo, not re-ingested.
+ */
+export interface AnomalyDetector {
+	detect(history: LoadTestMetrics[]): Anomaly[];
+}
+
+export function createAnomalyDetector(): AnomalyDetector {
+	let rules = makeRules();
+	let seen: LoadTestMetrics[] = [];
+	let reported: Anomaly[] = [];
+	let firstAbs = 0;
+
+	function ingest(history: LoadTestMetrics[], dropped: number, from: number): void {
+		firstAbs += dropped;
+		for (const rule of rules) rule.trim(firstAbs);
+		for (let pos = from; pos < history.length; pos++) {
+			for (const rule of rules) rule.push?.(history, firstAbs, pos);
+		}
+	}
+
+	return {
+		detect(history) {
+			if (history === seen) return reported;
+
+			const dropped = droppedFromFront(seen, history);
+			if (dropped == null) {
+				rules = makeRules();
+				firstAbs = 0;
+				ingest(history, 0, 0);
+			} else {
+				ingest(history, dropped, seen.length - dropped);
+			}
+
+			seen = history;
+			// A series too short to say anything about is the same answer as a clean
+			// run, for the same reason: nothing here is established enough to be
+			// abnormal. Applied after ingest so the state stays in step with the
+			// buffer either way.
+			reported = history.length < 2 ? [] : assemble(rules, history, firstAbs);
+			return reported;
+		},
+	};
+}
+
+/**
+ * Every anomaly in a run's per-tick series, in time order.
+ *
+ * Returns `[]` for a clean run - and for a run too short to have a baseline,
+ * which is the same answer for the same reason: nothing here is established
+ * enough to be abnormal.
+ *
+ * This is the one-shot form, for a series that arrives whole. A caller handing
+ * the same buffer over on a timer wants {@link createAnomalyDetector}.
+ */
+export function detectAnomalies(history: LoadTestMetrics[]): Anomaly[] {
+	return createAnomalyDetector().detect(history);
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -399,7 +399,7 @@ The dashboard is **mode-adaptive**: a `useMode()` discriminator maps the run con
 
 **`utils/`** - `metricsTransforms.ts` (SSE history → chart series), `reportToDerived.ts` (stored `RunReport` → the same `DashboardDerived` shape, so history reuses the live components), `computeBreakpoint.ts`, `detectAnomalies.ts`, `computeEta.ts`, `chartGeometry.ts`. `types.ts` holds the shared dashboard types (`DashboardDerived`, etc.).
 
-`detectAnomalies.ts` is the run's degradation windows - latency spikes, error bursts, throughput drops and the first 5xx - scanned out of the same per-tick series the charts plot, with fixed factors over a trailing median and nothing tunable. It is derived once per view (`MetricsView` live, `LoadTestDetail` for a stored run) and passed down, so no card or chart re-derives it. Two readings of one detection: the charts shade the windows, and the history Overview's `RunEvents` card states them in words. Both are absent for a clean run.
+`detectAnomalies.ts` names the run's degradation windows. It is derived once per view - `MetricsView` for the live buffer, `LoadTestDetail` for a stored run - and passed down, so no card or chart re-derives it. The rules, the two entry points (a pure one-shot for a series that arrives whole, an incremental detector for a buffer handed over on a timer) and the invariant that keeps them in agreement are in `app/src/modules/dashboard/README.md`.
 
 ## History (`modules/history/`)
 


### PR DESCRIPTION
## Description

`MetricsView.tsx:103` memoized `detectAnomalies(chartWindow)` on the store's `historicalMetrics`, and `dashboard-store.ts:180` builds a new array reference on every `addMetricsBatch` - so the memo never held across commits and the detector re-derived the entire retained buffer twice a second (250ms at the fastest setting). Per pass that was a 15-element slice-plus-spread comparator sort *per index, per series* over three series - ~9,000 sorts and ~18,000 short-lived arrays at the default 5-minute window, up to ~150,000 sorts during a full-run soak - plus `detectFirst5xx` running `Object.entries` per tick over the whole history for the life of a healthy run. All of it on the renderer's main thread. Every anchor in the issue was re-verified against master `db346d3`; all seven were confirmed, with only cosmetic line drift.

**The plan.** `detectAnomalies` stays exactly what it was: the pure one-shot over a whole series, which is what `LoadTestDetail` wants and what every rule is defined against. Alongside it, `createAnomalyDetector()` holds its derivation across calls, and the live view keeps one. The split that makes the two agree is the whole design: what a tick **and its predecessors** decide - a trailing median, a failure-rate delta, whether a rule is satisfied - is computed once when the tick arrives and cached under an *absolute* tick index that no trim renumbers, so it can never need revisiting; what a tick's **position in the buffer** decides - no baseline for the first `BASELINE_TICKS`, no delta for the first tick - is re-applied when the buffer is trimmed, by clipping the leading window's start to the oldest tick the rule can still speak for. A position only ever falls, so hotness is monotone: a trim clips a window and can never split one, and a window whose lead-in has rolled out goes quiet exactly as a from-scratch pass over the shortened buffer does. The next buffer is recognised as the last one with ticks appended and the oldest dropped, the offset found by searching elapsed time and then confirmed by object identity at *both* ends; anything that does not confirm is refused and re-derived from scratch rather than guessed at, since a wrong alignment would silently report another run's windows.

**The alternative I rejected.** The obvious one is the store's own latched-aggregate pattern - fold anomalies into `addMetricsBatch` beside `peakConcurrency` and `breakpoint`, whose rationale comment (`dashboard-store.ts:84-90`) is precisely this "O(1) per tick rather than a full scan" stance. It does not fit: those two are *latched* on purpose ("peak only grows, breakpoint sticks on first crossing, so they survive old ticks rolling out of the retention window"), and anomalies are the opposite - a window must stop being reported when the history it rested on is trimmed away. A latched store field would have changed what the dashboard reports, failing the issue's second acceptance criterion. It also could not serve `LoadTestDetail`, which detects over a fetched series that never touches the store. So the derivation stays in the view; only its *state* is now carried between commits.

A second, smaller alternative the issue offers - run detection at 1Hz on a stable snapshot - was rejected because it leaves per-commit cost scaling with total retained history, which is what acceptance criterion 1 rules out.

**Note on the residual cost.** Per-commit work is now O(dropped + appended + number of open anomaly windows). The last term is why this is not flatly O(new ticks): assembling the report walks the run list, and a run's list is proportional to the anomalies in the buffer, not to its length. On a healthy run that list is empty and the commit costs only the arriving ticks. The recovery tail - the one piece of state that grows unboundedly while a degradation stalls - is resumed rather than rescanned, and there is a test for that specifically.

**Adjacent, not touched:** `LATENCY_RECOVERY_FACTOR` is exported but read only inside this module, and `Anomaly.magnitude` is consumed only by the over-cap ranking - no renderer reads it (the label carries the number as text). Both are small instances of the repo's "written but never read" pattern and both are out of this issue's scope; flagged here rather than folded into the diff.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

Closest to a performance change; ticked "new feature" for the added entry point. No behaviour change: the reported anomalies are identical.

## Testing

Local, all green:

- `pnpm test` - **556 files, 6073 tests passed**. The detector's own file goes from 14 to 25 tests.
- `pnpm type-check` - clean across all three projects (renderer, electron, electron-tests).
- `pnpm lint` - clean, zero warnings.
- `pnpm format:check` - clean.

No engine build or `ctest` run: the diff touches no C++ and no engine input, so nothing there could go from green to red (root `CLAUDE.md`, "scale the verification to what the change could actually break"). No pre-existing failures were observed on the base commit.

The 11 new cases are:

- **Equivalence** - two randomized append/trim replays (seeded, so a failure names one reproducible sequence) driving the store's real buffer discipline: append a batch, front-trim past the time window, then past the hard cap, and compare against a from-scratch pass after *every* commit. One replay uses a cap smaller than the run so every commit trims; the other a window wide enough to hold whole anomaly windows. Both assert the sequence actually produced all four anomaly kinds - an agreement between two empty lists is not an agreement, and the first draft of this test silently was one until that assertion was added.
- **Trim semantics** - a window whose lead-in has rolled out falls silent, matching a rescan of the shortened buffer.
- **Buffer recognition** - starting over on a buffer that is not a continuation; refusing one whose head is a different tick at the same elapsed time; refusing one that shares only its first tick; and returning the identical result (and spending zero sorts) when handed the same array twice, which is what React does under StrictMode.
- **Cost** - counting the comparator sorts, `Object.entries` scans and `latency_p99_ms` reads a single commit spends, against a from-scratch pass over the same buffer for contrast.

Each was mutation-checked by breaking the implementation and confirming a failure: disabling the front clip (3 tests fail), dropping the clip's cache invalidation (2), restarting rather than resuming the recovery tail (1), removing the head alignment check (1), removing the tail alignment check (1).

Two mutations *survived* the first draft, and rather than adding tests for them I removed what they proved was redundant: the position rules were being applied in three places at once - a placeholder at push, a check on read, and the front clip - and only the clip was observable. The read-time checks are gone and the front clip is now the single mechanism, documented as load-bearing.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs, same commit: the detector's mechanics moved out of `docs/app/COMPONENTS.md` (as the issue asked - it did describe them) into `app/src/modules/dashboard/README.md`, which now carries the rules, the two entry points and the invariant a future rule has to honour. `COMPONENTS.md` keeps a one-line pointer.

## Related Issues

Closes #1151

Unblocks #1152 (the per-flush chart efficiency issue), which the wave map in #1143 sequences after this one in the dashboard pair.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrWfwFDVtRBBcM2wLYSTEQ)_