### PR TITLE
perf(app): a clipped spike window no longer re-walks its recovery tail - #1151

### DIFF
--- a/app/src/modules/dashboard/utils/detectAnomalies.test.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.test.ts
@@ -25,6 +25,7 @@ import {
 	ERROR_BURST_RATE,
 	THROUGHPUT_DROP_FACTOR,
 } from "./detectAnomalies";
+import { detectAnomaliesFromScratch } from "./detectAnomalies.testkit";
 
 function tick(elapsed: number, partial: Partial<LoadTestMetrics> = {}): LoadTestMetrics {
 	return {
@@ -338,7 +339,10 @@ function replay(
 		if (buffer.length > cap) buffer = buffer.slice(-cap);
 
 		const found = detector.detect(buffer);
-		expect(found).toEqual(detectAnomalies(buffer));
+		expect(found).toEqual(detectAnomaliesFromScratch(buffer));
+		// The one-shot has to answer the oracle too - it is what the history view
+		// calls, and it is now a wrapper over the same rules.
+		expect(detectAnomalies(buffer)).toEqual(found);
 		for (const a of found) kinds.add(a.kind);
 		commits++;
 	}
@@ -417,7 +421,7 @@ describe("createAnomalyDetector - the same answer as a from-scratch pass", () =>
 
 		expect(detector.detect(run.slice(0, 30))).toHaveLength(1);
 		const trimmed = run.slice(10, 30);
-		expect(detectAnomalies(trimmed)).toEqual([]);
+		expect(detectAnomaliesFromScratch(trimmed)).toEqual([]);
 		expect(detector.detect(trimmed)).toEqual([]);
 	});
 
@@ -428,7 +432,7 @@ describe("createAnomalyDetector - the same answer as a from-scratch pass", () =>
 		detector.detect(healthyRun(40));
 
 		const second = healthyRun(40, (i) => (i === 25 || i === 26 ? { latency_p99_ms: 500 } : {}));
-		expect(detector.detect(second)).toEqual(detectAnomalies(second));
+		expect(detector.detect(second)).toEqual(detectAnomaliesFromScratch(second));
 	});
 
 	it("answers the same buffer twice with the same result", () => {
@@ -458,7 +462,7 @@ describe("createAnomalyDetector - what a commit costs", () => {
 		const incremental = measure(() => detector.detect(run.slice(0, 910)));
 		expect(incremental.sorts).toBeLessThanOrEqual(3 * 10 + 1);
 
-		const scratch = measure(() => detectAnomalies(run.slice(0, 910)));
+		const scratch = measure(() => detectAnomaliesFromScratch(run.slice(0, 910)));
 		expect(scratch.sorts).toBeGreaterThan(3 * (910 - BASELINE_TICKS));
 		expect(incremental.result).toEqual(scratch.result);
 	});
@@ -500,7 +504,7 @@ describe("createAnomalyDetector - what a commit costs", () => {
 		});
 
 		const trimmed = run.slice(50);
-		expect(detector.detect(trimmed)).toEqual(detectAnomalies(trimmed));
+		expect(detector.detect(trimmed)).toEqual(detectAnomaliesFromScratch(trimmed));
 		expect(detector.detect(trimmed)[0]).toMatchObject({
 			kind: "first_5xx",
 			startSeconds: 60,
@@ -522,7 +526,7 @@ describe("createAnomalyDetector - the edges of recognising the next buffer", () 
 		const spliced = run.slice(20);
 		spliced[0] = { ...run[20], requests_failed: run[21].requests_failed };
 
-		expect(detector.detect(spliced)).toEqual(detectAnomalies(spliced));
+		expect(detector.detect(spliced)).toEqual(detectAnomaliesFromScratch(spliced));
 		expect(detector.detect(spliced).filter((a) => a.kind === "error_burst")[0]).toMatchObject({
 			startSeconds: 22,
 		});
@@ -543,7 +547,7 @@ describe("createAnomalyDetector - the edges of recognising the next buffer", () 
 				.slice(21)
 				.map((m, i) => ({ ...m, latency_p99_ms: i === 20 || i === 21 ? 900 : 100 })),
 		];
-		expect(detector.detect(relabelled)).toEqual(detectAnomalies(relabelled));
+		expect(detector.detect(relabelled)).toEqual(detectAnomaliesFromScratch(relabelled));
 		expect(detector.detect(relabelled).filter((a) => a.kind === "latency_spike")).toHaveLength(
 			1
 		);
@@ -583,10 +587,90 @@ describe("createAnomalyDetector - the edges of recognising the next buffer", () 
 				expect({ seed, next, found: detector.detect(buffer) }).toEqual({
 					seed,
 					next,
-					found: detectAnomalies(buffer),
+					found: detectAnomaliesFromScratch(buffer),
 				});
 			}
 		}
+	});
+
+	it("does not re-walk an open recovery tail each time a trim clips the window", () => {
+		/*
+		 * The two costly things meeting: a window still open at the buffer's end,
+		 * and a trim clipping its start a tick at a time as it ages out. The clip
+		 * moves the baseline the window is frozen against, so the walk cannot just
+		 * be kept - but it can be re-justified, because the walk recorded the
+		 * lowest p99 it accepted and a threshold still under that takes no tick
+		 * back out. Without that, every one of these commits re-read the whole
+		 * tail: measured at ~2,000 reads each across six consecutive commits.
+		 */
+		const source = Array.from({ length: 2040 }, (_, i) =>
+			tick(i, {
+				latency_p99_ms: i < 20 ? 100 : i < 30 ? 600 : 250,
+				current_rps: 500,
+				current_concurrency: 50,
+				requests_completed: i * 500,
+			})
+		);
+		let p99Reads = 0;
+		const run = source.map((m) => ({
+			...m,
+			get latency_p99_ms() {
+				p99Reads++;
+				return m.latency_p99_ms;
+			},
+		}));
+
+		const detector = createAnomalyDetector();
+		const open = detector.detect(run).filter((a) => a.kind === "latency_spike");
+		// The window is open at the buffer's end, so there is a tail to re-walk.
+		expect(open).toHaveLength(1);
+		expect(open[0].endSeconds).toBe(2039);
+
+		let worst = 0;
+		for (let dropped = 1; dropped <= 12; dropped++) {
+			const buffer = run.slice(dropped);
+			p99Reads = 0;
+			const found = detector.detect(buffer);
+			worst = Math.max(worst, p99Reads);
+			expect(found).toEqual(detectAnomaliesFromScratch(buffer));
+		}
+		// Bounded by the hot span the clip is eating through, not by the tail.
+		expect(worst).toBeLessThan(50);
+	});
+
+	it("re-walks the tail when a clip does move the baseline the window is frozen against", () => {
+		/*
+		 * The other half of the clip: an escalating spike - each tick several times
+		 * the last, the shape of a system going over rather than wobbling - stays
+		 * hot long enough that its own ticks reach the trailing median. Once they
+		 * do, clipping the start moves the frozen baseline, the recovery threshold
+		 * moves with it, and a tail walked against the old one is no longer the
+		 * window. Keeping it would report a degradation running to the end of the
+		 * buffer that ended twenty seconds ago.
+		 */
+		const run = Array.from({ length: 80 }, (_, i) =>
+			tick(i, {
+				latency_p99_ms: i < 20 ? 100 : i < 35 ? 100 * 4 ** (i - 19) : 300,
+				current_rps: 500,
+				current_concurrency: 50,
+				requests_completed: i * 500,
+			})
+		);
+		const detector = createAnomalyDetector();
+
+		const before = detector.detect(run).filter((a) => a.kind === "latency_spike");
+		expect(before).toHaveLength(1);
+		// Against the pre-spike baseline of 100 the 300ms plateau clears the 1.5x
+		// recovery threshold, so the window runs to the end of the buffer.
+		expect(before[0]).toMatchObject({ startSeconds: 20, endSeconds: 79 });
+
+		// Clip far enough in that the spike's own ticks are the trailing median.
+		const trimmed = run.slice(13);
+		const after = detector.detect(trimmed);
+		expect(after).toEqual(detectAnomaliesFromScratch(trimmed));
+		// The baseline moved off 100, so the plateau no longer clears the threshold
+		// and the window ends with the spike instead of running on.
+		expect(after.filter((a) => a.kind === "latency_spike")[0].endSeconds).toBeLessThan(79);
 	});
 
 	it("walks an open recovery tail once, not once per commit", () => {

--- a/app/src/modules/dashboard/utils/detectAnomalies.testkit.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.testkit.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The anomaly detector as it stood before #1151 made it incremental: one pass
+ * over the whole series, no state, nothing cached. Test-only.
+ *
+ * This is the oracle. `detectAnomalies` is now a thin wrapper over
+ * `createAnomalyDetector`, so comparing the two proves only that a detector
+ * carries no state between buffers - not that either still answers what the
+ * detector answered before the rewrite, which is what #1151's second acceptance
+ * criterion actually asks. Only an independent implementation can say that, and
+ * this is that implementation, taken verbatim from `db346d3`.
+ *
+ * It is a deliberate copy and it is meant to stay one. A rule change has to be
+ * made here as well, on purpose, with the equivalence tests failing in between -
+ * that failure is the point. Do not import it from anything that ships.
+ */
+
+import type { LoadTestMetrics } from "@/types";
+import {
+	type Anomaly,
+	BASELINE_TICKS,
+	LATENCY_SPIKE_FACTOR,
+	LATENCY_RECOVERY_FACTOR,
+	ERROR_BURST_RATE,
+	THROUGHPUT_DROP_FACTOR,
+	MIN_CONSECUTIVE_TICKS,
+	MAX_ANOMALIES,
+} from "./detectAnomalies";
+
+function median(values: number[]): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = sorted.length >> 1;
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Median of the {@link BASELINE_TICKS} ticks *before* each index - `null` until
+ * that much history exists, which is what makes the opening seconds of a run
+ * (where every value is its own outlier) produce nothing.
+ */
+function trailingMedians(values: number[]): Array<number | null> {
+	return values.map((_, i) =>
+		i < BASELINE_TICKS ? null : median(values.slice(i - BASELINE_TICKS, i))
+	);
+}
+
+/**
+ * Maximal runs of consecutive ticks satisfying `isHot`, at least
+ * {@link MIN_CONSECUTIVE_TICKS} long, as inclusive `[start, end]` index pairs.
+ * Runs are disjoint and ordered by construction, so no merge pass is needed
+ * downstream.
+ */
+function findRuns(length: number, isHot: (i: number) => boolean): Array<[number, number]> {
+	const runs: Array<[number, number]> = [];
+	let i = 0;
+	while (i < length) {
+		if (!isHot(i)) {
+			i++;
+			continue;
+		}
+		const start = i;
+		while (i < length && isHot(i)) i++;
+		if (i - start >= MIN_CONSECUTIVE_TICKS) runs.push([start, i - 1]);
+	}
+	return runs;
+}
+
+/** Seconds, at the precision a reader can act on: "3s", "0.4s". */
+function formatSeconds(seconds: number): string {
+	return seconds >= 10 ? `${Math.round(seconds)}s` : `${Number(seconds.toFixed(1))}s`;
+}
+
+function span(history: LoadTestMetrics[], start: number, end: number): string {
+	return formatSeconds(history[end].elapsed_seconds - history[start].elapsed_seconds);
+}
+
+function detectLatencySpikes(history: LoadTestMetrics[]): Anomaly[] {
+	const p99 = history.map((m) => m.latency_p99_ms ?? 0);
+	const baselines = trailingMedians(p99);
+	const isHot = (i: number) => {
+		const base = baselines[i];
+		return base != null && base > 0 && p99[i] > base * LATENCY_SPIKE_FACTOR;
+	};
+
+	const out: Anomaly[] = [];
+	let consumedThrough = -1;
+	for (const [start, hotEnd] of findRuns(history.length, isHot)) {
+		// A window that the previous one already swallowed during its recovery
+		// extension is the same degradation, not a second one.
+		if (start <= consumedThrough) continue;
+		/*
+		 * The baseline is frozen at the opening tick. Recomputing it as the window
+		 * extends would fold the spike's own ticks into the trailing median, so a
+		 * long degradation would raise its own bar and report itself as recovered
+		 * while it was still happening.
+		 */
+		const base = baselines[start] as number;
+		let end = hotEnd;
+		while (end + 1 < history.length && p99[end + 1] > base * LATENCY_RECOVERY_FACTOR) end++;
+		consumedThrough = end;
+
+		let peak = 0;
+		for (let i = start; i <= end; i++) peak = Math.max(peak, p99[i]);
+		const magnitude = peak / base;
+		out.push({
+			kind: "latency_spike",
+			startSeconds: history[start].elapsed_seconds,
+			endSeconds: history[end].elapsed_seconds,
+			magnitude,
+			label: `p99 ${magnitude.toFixed(1)}x baseline for ${span(history, start, end)}`,
+		});
+	}
+	return out;
+}
+
+function detectErrorBursts(history: LoadTestMetrics[]): Anomaly[] {
+	/*
+	 * `requests_failed` and `requests_completed` are cumulative counters, so the
+	 * rate that matters is the per-tick delta. Reading them undiffed would report
+	 * a run that failed early and recovered as failing for the rest of its life.
+	 */
+	const rate = history.map((m, i) => {
+		if (i === 0) return 0;
+		const failed = Math.max(
+			0,
+			(m.requests_failed ?? 0) - (history[i - 1].requests_failed ?? 0)
+		);
+		const completed = Math.max(0, m.requests_completed - history[i - 1].requests_completed);
+		return completed > 0 ? failed / completed : 0;
+	});
+
+	return findRuns(history.length, (i) => rate[i] > ERROR_BURST_RATE).map(([start, end]) => {
+		let peak = 0;
+		for (let i = start; i <= end; i++) peak = Math.max(peak, rate[i]);
+		return {
+			kind: "error_burst" as const,
+			startSeconds: history[start].elapsed_seconds,
+			endSeconds: history[end].elapsed_seconds,
+			magnitude: peak / ERROR_BURST_RATE,
+			label: `errors ${(peak * 100).toFixed(1)}% of requests for ${span(history, start, end)}`,
+		};
+	});
+}
+
+function detectThroughputDrops(history: LoadTestMetrics[]): Anomaly[] {
+	const rps = history.map((m) => m.current_rps ?? 0);
+	const concurrency = history.map((m) => m.current_concurrency ?? 0);
+	const rpsBaselines = trailingMedians(rps);
+	const concurrencyBaselines = trailingMedians(concurrency);
+
+	const isHot = (i: number) => {
+		const base = rpsBaselines[i];
+		if (base == null || base <= 0) return false;
+		// Concurrency held: a ramp winding down, or a stopped run, produces less
+		// throughput because it was asked to. That is not a degradation.
+		const heldConcurrency = concurrency[i] >= (concurrencyBaselines[i] ?? 0);
+		return heldConcurrency && rps[i] < base * THROUGHPUT_DROP_FACTOR;
+	};
+
+	return findRuns(history.length, isHot).map(([start, end]) => {
+		const base = rpsBaselines[start] as number;
+		let trough = Infinity;
+		for (let i = start; i <= end; i++) trough = Math.min(trough, rps[i]);
+		const share = trough / base;
+		return {
+			kind: "throughput_drop" as const,
+			startSeconds: history[start].elapsed_seconds,
+			endSeconds: history[end].elapsed_seconds,
+			// trough can be 0 (throughput stopped entirely) - report that as the
+			// worst possible multiple rather than as Infinity.
+			magnitude: share > 0 ? 1 / share : Number.MAX_SAFE_INTEGER,
+			label: `throughput ${Math.round(share * 100)}% of baseline for ${span(history, start, end)}`,
+		};
+	});
+}
+
+function detectFirst5xx(history: LoadTestMetrics[]): Anomaly[] {
+	for (const m of history) {
+		// The map is cumulative, so the tick a 5xx key first appears on with a
+		// non-zero count IS the onset - no diffing needed to find the first one.
+		const code = Object.entries(m.status_codes ?? {}).find(
+			([status, count]) => count > 0 && Number(status) >= 500 && Number(status) < 600
+		);
+		if (!code) continue;
+		return [
+			{
+				kind: "first_5xx",
+				startSeconds: m.elapsed_seconds,
+				endSeconds: m.elapsed_seconds,
+				magnitude: 1,
+				label: `first ${code[0]} response`,
+			},
+		];
+	}
+	return [];
+}
+
+/**
+ * Every anomaly in a run's per-tick series, in time order.
+ *
+ * Returns `[]` for a clean run - and for a run too short to have a baseline,
+ * which is the same answer for the same reason: nothing here is established
+ * enough to be abnormal.
+ */
+export function detectAnomaliesFromScratch(history: LoadTestMetrics[]): Anomaly[] {
+	if (history.length < 2) return [];
+
+	const found = [
+		...detectLatencySpikes(history),
+		...detectErrorBursts(history),
+		...detectThroughputDrops(history),
+		...detectFirst5xx(history),
+	];
+
+	const byTime = (a: Anomaly, b: Anomaly) => a.startSeconds - b.startSeconds;
+	if (found.length <= MAX_ANOMALIES) return found.sort(byTime);
+
+	// Over the cap the list is triaged, not truncated: the worst survive, and the
+	// last one says how many did not - a silently shortened list reads as a
+	// complete one.
+	const kept = [...found].sort((a, b) => b.magnitude - a.magnitude).slice(0, MAX_ANOMALIES);
+	kept.sort(byTime);
+	const dropped = found.length - kept.length;
+	const last = kept[kept.length - 1];
+	kept[kept.length - 1] = { ...last, label: `${last.label} (+${dropped} more)` };
+	return kept;
+}

--- a/app/src/modules/dashboard/utils/detectAnomalies.ts
+++ b/app/src/modules/dashboard/utils/detectAnomalies.ts
@@ -317,12 +317,14 @@ interface SpikeRun extends Run {
 	 * while it was still happening.
 	 */
 	base: number;
+	/** Highest p99 over the hot ticks `[startAbs, endAbs]`. */
+	hotPeak: number;
 	/** Last tick of the window including its recovery tail. */
 	tailAbs: number;
 	/** True once a tick has ended the tail, which it then cannot re-open. */
 	tailClosed: boolean;
-	/** Peak p99 over `[startAbs, tailAbs]`. */
-	peak: number;
+	/** Highest p99 over the tail ticks `(endAbs, tailAbs]`. */
+	tailPeak: number;
 	window: Anomaly | null;
 }
 
@@ -331,17 +333,41 @@ function createSpikeDetector(): RuleDetector {
 	const runs: SpikeRun[] = [];
 	let clipped = false;
 
-	/** Reset everything a clipped start invalidates: the frozen baseline, the tail, the peak. */
+	/**
+	 * Re-derive what a clipped start invalidates. The clip took hot ticks off the
+	 * front, one of which may have been the peak, and moved the baseline the whole
+	 * window is measured against - so the frozen base, the peak and the reach of
+	 * the recovery tail are all in question.
+	 *
+	 * Re-walking the tail is the expensive part, and it is avoidable whenever the
+	 * clip left the baseline where it was - which is the usual case, and the one
+	 * that matters, since a window aging out of the buffer is clipped on every
+	 * commit for as many commits as its hot span is long.
+	 */
 	function reseat(run: SpikeRun, history: LoadTestMetrics[], firstAbs: number): void {
 		// The clipped start is the oldest tick this rule can speak for, so it
 		// arrived with a full lead-in and its baseline is there.
-		run.base = baselines.at(run.startAbs) ?? 0;
-		run.tailAbs = run.endAbs;
-		run.tailClosed = false;
-		run.peak = 0;
+		const base = baselines.at(run.startAbs) ?? 0;
+
+		// The hot span is the spike itself, so this is short whatever the tail did.
+		run.hotPeak = 0;
 		for (let abs = run.startAbs; abs <= run.endAbs; abs++) {
-			run.peak = Math.max(run.peak, readP99(history[abs - firstAbs]));
+			run.hotPeak = Math.max(run.hotPeak, readP99(history[abs - firstAbs]));
 		}
+
+		if (base !== run.base) {
+			// The threshold the walk measured itself against has moved, so the walk
+			// has to happen again. Salvaging it would mean re-justifying every tick
+			// it accepted *and* the tick that ended it against the new threshold -
+			// more subtlety than the saving is worth, because a clip usually does not
+			// move the baseline at all: it advances the start by one tick through a
+			// window whose lead-in is mostly unchanged.
+			run.tailAbs = run.endAbs;
+			run.tailClosed = false;
+			run.tailPeak = 0;
+		}
+
+		run.base = base;
 		run.window = null;
 	}
 
@@ -357,7 +383,7 @@ function createSpikeDetector(): RuleDetector {
 				break;
 			}
 			end++;
-			run.peak = Math.max(run.peak, next);
+			run.tailPeak = Math.max(run.tailPeak, next);
 		}
 		if (end !== run.tailAbs) {
 			run.tailAbs = end;
@@ -382,13 +408,17 @@ function createSpikeDetector(): RuleDetector {
 				startAbs: abs,
 				endAbs: abs,
 				base,
+				hotPeak: p99,
 				tailAbs: abs,
 				tailClosed: false,
-				peak: p99,
+				tailPeak: 0,
 				window: null,
 			}));
-			if (abs > run.tailAbs) run.tailAbs = abs;
-			run.peak = Math.max(run.peak, p99);
+			// A hot tick can only ever extend a run whose tail is empty: the walk
+			// only covers ticks the rule already found cold, and a tick's hotness
+			// never comes back. So the tail ends where the hot span does.
+			run.tailAbs = run.endAbs;
+			run.hotPeak = Math.max(run.hotPeak, p99);
 			run.window = null;
 		},
 
@@ -406,7 +436,7 @@ function createSpikeDetector(): RuleDetector {
 				advanceTail(run, history, firstAbs);
 				consumedThrough = run.tailAbs;
 				if (!run.window) {
-					const magnitude = run.peak / run.base;
+					const magnitude = Math.max(run.hotPeak, run.tailPeak) / run.base;
 					run.window = {
 						kind: "latency_spike",
 						startSeconds: elapsedAt(history, firstAbs, run.startAbs),


### PR DESCRIPTION
## Description

Follow-up to #1178 (merged), from an adversarial review of it. Two things that review turned up, both real.

**1. An open recovery tail was re-walked on every clipped commit.** A latency window still open at the buffer's end - a degradation that spiked and then stalled above the recovery factor rather than recovering - re-read its entire tail once per commit while the window aged out of the retention window. `reseat` threw the walk away unconditionally whenever a trim clipped the window's start, so `advanceTail` walked from the hot span's end back up to the buffer's end again, for as many consecutive commits as the spike's hot span is long.

Reproduced before fixing, on a 10-tick spike followed by a 2,000-tick stalled recovery, counting `latency_p99_ms` reads per commit while dropping one tick from the front each time:

```
drop= 1..5   reads = 0
drop= 6      reads = 2019     <- clip begins
drop= 7      reads = 2018
drop= 8      reads = 2017
drop= 9      reads = 2016
drop=10      reads = 2015
drop=11      reads = 2014
drop=12      reads = 1        <- window falls below MIN_CONSECUTIVE_TICKS
drop=13..    reads = 0
```

Six commits at ~2,019 reads where every other commit costs 0 - the O(retained history) shape #1178 set out to remove, left behind in the one case where a window outlives its own lead-in. The same measurement after the fix: `7, 6, 5, 4, 3, 2`.

The clip invalidates three things and they are not equally expensive, which is what the old code missed by treating them as one:

- **The peak** is now split - `hotPeak` over the hot ticks, `tailPeak` over the tail. A clip only ever removes ticks from the *hot* span, so only `hotPeak` needs recomputing, and the hot span is the spike itself and therefore short.
- **The walk** is kept whenever the clip left the frozen baseline where it was, which is the usual case: a clip advances the start one tick through a lead-in that is mostly unchanged, and a median of fifteen does not move for that.
- **When the baseline does move**, the walk is redone, because the recovery threshold moved with it.

I first wrote the middle case as two branches - one for a threshold that fell, one for a threshold that rose past the lowest tick the walk had accepted. Both survived mutation testing, which was the tell: a clip only ever adds *hot* ticks to the baseline window, so the median it takes can never fall, and the "threshold fell" branch was unreachable. It is gone, and the remaining condition is a single `base !== run.base` that is correct whether or not that argument holds.

**2. The equivalence oracle was not an oracle.** #1178's tests compared `detector.detect(buffer)` against `detectAnomalies(buffer)` - but `detectAnomalies` is now a thin wrapper over `createAnomalyDetector`, so those assertions proved only that a detector carries no state between buffers. Real, and worth keeping, but not what the issue's second acceptance criterion asks, which is that the output is *unchanged*. Nothing in that PR compared the new code against the old.

`app/src/modules/dashboard/utils/detectAnomalies.testkit.ts` now carries the pre-#1151 implementation verbatim (taken from `db346d3`) as `detectAnomaliesFromScratch`, and every equivalence assertion runs against it - including the randomized replays, which now also assert the one-shot `detectAnomalies` agrees, since that is what the history view calls. It is a deliberate copy and is meant to stay one: a future rule change has to be made in both places, with the equivalence tests failing in between, and that failure is the point. `.testkit.ts` follows the existing `routed-inputs.testkit.ts` convention; nothing that ships imports it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

A performance bug in code merged an hour ago. No behaviour change - the reported anomalies are identical, now checked against the pre-rewrite implementation rather than against a sibling of the code under test.

## Testing

Local, all green on `152d563`:

- `pnpm test` - **556 files, 6076 tests passed** (the detector's file goes 25 → 28).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - all clean.

No engine build or `ctest`: the diff touches no C++ and no engine input, so nothing there could change colour.

Three new cases:

- **`does not re-walk an open recovery tail each time a trim clips the window`** - the measurement above, asserting the worst commit stays under 50 reads. It is the test #1178 was missing: its open-tail case grew the buffer without ever trimming the front, so it never combined the two costly things.
- **`re-walks the tail when a clip does move the baseline`** - an escalating spike (each tick several times the last, the shape of a system going over rather than wobbling) stays hot long enough that its own ticks reach the trailing median, so clipping genuinely moves the frozen baseline and the window has to stop running to the end of the buffer.
- The oracle swap above, which strengthens every pre-existing equivalence assertion rather than adding one.

Mutation-checked, each failing at least one test: keeping the tail when the baseline moved (1), always re-walking (1, the cost test), dropping the hot-peak recompute (2, both replays). The nine mutations from #1178 were re-run against the new oracle and all still fail.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

No doc change: this corrects the cost of an internal transform, and the `README.md` section #1178 added still describes it accurately.

## Related Issues

Follow-up to #1178, which closed #1151. Opened as a new PR because #1178 is already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrWfwFDVtRBBcM2wLYSTEQ)_