### PR TITLE
fix(app): one ranking authority for the command palette - #1175

### DIFF
--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -38,6 +38,12 @@ interface CommandDialogProps extends DialogProps {
 	/** One line saying what typing here does, also `sr-only`. */
 	description: string;
 	className?: string;
+	/**
+	 * Forwarded to the inner `Command`, so a caller that ranks its own results
+	 * can stop cmdk scoring them a second time - the same escape hatch
+	 * `SuggestionList` and `VariableAutocomplete` take on a bare `Command`.
+	 */
+	shouldFilter?: boolean;
 }
 
 const CommandDialog = ({
@@ -45,6 +51,7 @@ const CommandDialog = ({
 	title,
 	description,
 	className,
+	shouldFilter,
 	...props
 }: CommandDialogProps) => {
 	return (
@@ -60,7 +67,10 @@ const CommandDialog = ({
 			<DialogContent showClose={false} className={cn("overflow-hidden p-0", className)}>
 				<DialogTitle className="sr-only">{title}</DialogTitle>
 				<DialogDescription className="sr-only">{description}</DialogDescription>
-				<Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+				<Command
+					shouldFilter={shouldFilter}
+					className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+				>
 					{children}
 				</Command>
 			</DialogContent>

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -147,6 +147,13 @@ function pressEnter() {
 	fireEvent.keyDown(input(), { key: "Enter" });
 }
 
+/** Every result row on screen, in visible order. Escape rows are not results. */
+function visibleRows(): string[] {
+	return [...document.querySelectorAll("[cmdk-item]")]
+		.filter((el) => el.closest("[cmdk-group]")?.querySelector("[cmdk-group-heading]"))
+		.map((el) => el.querySelector("span.flex-1")?.textContent ?? "");
+}
+
 beforeEach(() => {
 	// cmdk scrolls the highlighted row into view; jsdom has no such method.
 	Element.prototype.scrollIntoView = vi.fn();
@@ -228,6 +235,58 @@ describe("searching", () => {
 		open();
 		typeQuery("zzzzz");
 		expect(screen.getByText("No matches.")).toBeInTheDocument();
+	});
+
+	/*
+	 * The reported symptom (#1175), end to end. "theme" scores Theme Mode at
+	 * 0.99 and the request rows at 0.01-0.10, and the user saw the requests:
+	 * the sections rendered in a fixed order no score could cross. Put the
+	 * wrapper back in charge - drop the promotion in `ranking.ts` - and the
+	 * first row is a request again.
+	 */
+	it("puts the setting a query names first, above better-placed sections", async () => {
+		renderPalette();
+		open();
+
+		typeQuery("theme");
+
+		expect(visibleRows()[0]).toBe("Theme Mode");
+		const headings = [...document.querySelectorAll("[cmdk-group-heading]")].map(
+			(el) => el.textContent
+		);
+		expect(headings[0]).toBe("Top result");
+	});
+
+	/*
+	 * The floor. Every request here matches "theme" only as scattered
+	 * subsequence noise through a URL, which is how they outranked the setting
+	 * in the first place - so none of them may render at all.
+	 */
+	it("does not render a row that matched only as subsequence noise", async () => {
+		renderPalette();
+		open();
+
+		typeQuery("theme");
+
+		expect(screen.queryByText("Charge card")).not.toBeInTheDocument();
+		expect(screen.queryByText("Refund")).not.toBeInTheDocument();
+		expect(screen.queryByText("Issue token")).not.toBeInTheDocument();
+	});
+
+	/*
+	 * The announced count is the rendered count. It used to be summed from the
+	 * pre-filter groups, so a typed query announced every row the sources had
+	 * produced - the comment above it said as much and the line below did the
+	 * opposite.
+	 */
+	it("announces the number of rows it actually rendered", async () => {
+		renderPalette();
+		open();
+
+		typeQuery("theme");
+
+		const announced = screen.getByText(/searchable results$/).textContent ?? "";
+		expect(announced).toBe(`${visibleRows().length} searchable results`);
 	});
 
 	it("switches to an open tab rather than opening a second one", async () => {

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -136,6 +136,12 @@ export function CommandPalette() {
 				title="Command palette"
 				description="Search open tabs, requests, collections, views, commands, settings, variables and past runs."
 				className="max-w-xl"
+				/* Matching belongs to `ranking.ts`, which needs to decide the top
+				   result, the relevance floor and the announced count from one
+				   pass. cmdk scoring the rendered rows again would be a second
+				   authority over the same question - and the one that used to win,
+				   since a section it could not re-order outranked any score. */
+				shouldFilter={false}
 			>
 				<CommandInput
 					value={query}

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -14,11 +14,14 @@
  * query observers on any of it.
  *
  * Two shapes of source meet here. The shallow ones return everything they know
- * and let cmdk filter it; the deep ones (settings, variables, runs) search
- * corpora too large to render - so they take the query, rank and cap it
+ * and let the ranking narrow it; the deep ones (settings, variables, runs)
+ * search corpora too large to render - so they take the query, rank and cap it
  * themselves, and offer an escape row into the surface that browses the rest.
- * An escape row renders in a group of its own below the results, which is what
- * keeps cmdk's score sort from lifting it above them - see `PaletteItem.escape`.
+ *
+ * What this file does *not* do is match. `ranking.ts` decides what renders and
+ * in what order, once, and the palette tells cmdk not to score anything a
+ * second time (`shouldFilter={false}` in `CommandPalette`). So the order below
+ * is the order on screen: a promoted top result, then the fixed sections.
  */
 
 import { useMemo } from "react";
@@ -31,7 +34,8 @@ import {
 } from "@/components/ui";
 import { getMethodColor } from "@/utils";
 import type { CommandContext } from "@/lib/commands";
-import { PALETTE_GROUPS, PALETTE_GROUP_LABELS, rankForEmptyQuery, type PaletteItem } from "./types";
+import { PALETTE_GROUP_LABELS, type PaletteItem } from "./types";
+import { rankPalette, TOP_RESULT_LABEL } from "./ranking";
 import { useTabItems } from "./sources/useTabItems";
 import { useEntityItems } from "./sources/useEntityItems";
 import { useViewItems } from "./sources/useViewItems";
@@ -62,34 +66,23 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	const variables = useVariableItems(query);
 	const runs = useRunItems(query);
 
-	const grouped = useMemo(() => {
-		const all = [
-			...tabs,
-			...entities,
-			...views,
-			...commands,
-			...settings,
-			...variables,
-			...runs,
-		];
-		return PALETTE_GROUPS.map((kind) => {
-			const ofKind = all.filter((item) => item.kind === kind);
-			return {
-				kind,
-				items: rankForEmptyQuery(ofKind.filter((item) => !item.escape)),
-				escapes: ofKind.filter((item) => item.escape),
-			};
-		}).filter((group) => group.items.length > 0 || group.escapes.length > 0);
-	}, [tabs, entities, views, commands, settings, variables, runs]);
+	const ranked = useMemo(
+		() =>
+			rankPalette(
+				[...tabs, ...entities, ...views, ...commands, ...settings, ...variables, ...runs],
+				query
+			),
+		[tabs, entities, views, commands, settings, variables, runs, query]
+	);
 
 	/*
-	 * cmdk hides a group whose items all filter out, so the count has to come
-	 * from the rendered list rather than from `grouped`. `aria-live="polite"`
-	 * on an sr-only line is the announcement: a listbox that silently swaps its
+	 * The count is exact because the ranking decided it: every row it kept is a
+	 * row this renders, so nothing can hide one afterwards. `aria-live="polite"`
+	 * on an sr-only line is the announcement - a listbox that silently swaps its
 	 * contents as you type tells a screen-reader user nothing about whether the
 	 * query narrowed anything.
 	 */
-	const total = grouped.reduce((n, group) => n + group.items.length, 0);
+	const { total } = ranked;
 
 	return (
 		<>
@@ -98,18 +91,27 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 			</span>
 			<CommandList>
 				<CommandEmpty>No matches.</CommandEmpty>
-				{grouped.map((group, index) => (
+				{/* The best match across every section, lifted out of its own
+				    section rather than copied into this one: two rows carrying
+				    the same `value` would both read as selected. */}
+				{ranked.top.length > 0 && (
+					<CommandGroup heading={TOP_RESULT_LABEL}>
+						{ranked.top.map((item) => (
+							<PaletteRow key={item.id} item={item} onPick={onPick} />
+						))}
+					</CommandGroup>
+				)}
+				{ranked.groups.map((group, index) => (
 					<div key={group.kind}>
-						{index > 0 && <CommandSeparator />}
+						{(index > 0 || ranked.top.length > 0) && <CommandSeparator />}
 						<CommandGroup heading={PALETTE_GROUP_LABELS[group.kind]}>
 							{group.items.map((item) => (
 								<PaletteRow key={item.id} item={item} onPick={onPick} />
 							))}
 						</CommandGroup>
-						{/* Its own group, not the last row of the one above: cmdk
-						    sorts a group's items by score, and an escape row has
-						    to carry the query verbatim to survive the filter -
-						    which would score it above every result it escapes. */}
+						{/* Its own group, not the last row of the one above: an
+						    escape row leaves the palette, and reads as an aside
+						    to the section rather than the least of its results. */}
 						{group.escapes.length > 0 && (
 							<CommandGroup>
 								{group.escapes.map((item) => (
@@ -128,10 +130,10 @@ function PaletteRow({ item, onPick }: { item: PaletteItem; onPick: (item: Palett
 	const Icon = item.icon;
 	return (
 		<CommandItem
-			// cmdk matches against `value` plus `keywords`, so the value is what
-			// the row *reads* as and the keywords are what else should find it.
-			// The id is deliberately not in either: it is a uuid, and a query of
-			// "b7" would then match rows at random.
+			// cmdk no longer matches on these - `ranking.ts` does, against the
+			// same two fields - but `value` is still how cmdk tells one row from
+			// another for selection and keyboard navigation, so it stays what
+			// the row *reads* as.
 			value={[item.title, item.subtitle].filter(Boolean).join(" ")}
 			keywords={item.keywords}
 			onSelect={() => onPick(item)}

--- a/app/src/modules/palette/deep-sources.test.tsx
+++ b/app/src/modules/palette/deep-sources.test.tsx
@@ -156,6 +156,28 @@ function rowsUnder(heading: string): string[] {
 	);
 }
 
+/**
+ * Every result row on screen, in visible order.
+ *
+ * The unit a group used to be: since the best match is promoted into its own
+ * "Top result" section, a row that matched well is deliberately no longer under
+ * the heading its kind would put it under.
+ */
+function resultRows(): string[] {
+	return (
+		[...document.querySelectorAll("[cmdk-item]")]
+			// An escape row is not a result. Its group is the one with no heading,
+			// which is what renders it as an aside to the section above it.
+			.filter((el) => el.closest("[cmdk-group]")?.querySelector("[cmdk-group-heading]"))
+			.map((el) => el.querySelector("span.flex-1")?.textContent ?? "")
+	);
+}
+
+/** One row's whole element, to read what it prints beside its title. */
+function rowByTitle(title: string): Element {
+	return screen.getByText(title).closest("[cmdk-item]")!;
+}
+
 /** Pick one row by its visible title - `pressEnter` takes whatever cmdk highlighted. */
 function pickRow(title: string) {
 	fireEvent.click(screen.getByText(title));
@@ -239,7 +261,9 @@ describe("settings entries", () => {
 		// "Theme Mode" lives in Appearance; "dark mode" is in its keywords only.
 		typeQuery("dark mode");
 
-		expect(rowsUnder("Settings")).toContain("Theme Mode");
+		// Across the list, not under "Settings": matching this well is exactly
+		// what gets a row promoted out of its own section.
+		expect(resultRows()).toContain("Theme Mode");
 	});
 
 	it("does not list a panel twice - the registry already offers every section", () => {
@@ -250,7 +274,7 @@ describe("settings entries", () => {
 
 		// One row for the Appearance section (the registry's command), and no
 		// second one from the index's `panel` entries.
-		const appearanceRows = rowsUnder("Settings").filter((row) => row === "Appearance");
+		const appearanceRows = resultRows().filter((row) => row === "Appearance");
 		expect(appearanceRows).toHaveLength(1);
 	});
 
@@ -267,10 +291,13 @@ describe("settings entries", () => {
 
 		typeQuery("zzTimeoutSetting");
 
-		const rows = rowsUnder("Settings");
-		expect(rows).toHaveLength(DEEP_GROUP_LIMIT);
-		// The escape row lives in its own group, below the results, so cmdk's
-		// score sort cannot lift it above them.
+		// The cap is on what the source contributes, so it is counted across the
+		// list: the best of the seven is promoted into "Top result" and the
+		// other six stay under "Settings".
+		expect(resultRows()).toHaveLength(DEEP_GROUP_LIMIT);
+		expect(rowsUnder("Settings")).toHaveLength(DEEP_GROUP_LIMIT - 1);
+		// The escape row is not a result: it is never promoted, never counted,
+		// and sits in its own group below the section it is a way out of.
 		const escape = screen.getByText(/^Search settings for/);
 		expect(escape).toBeInTheDocument();
 
@@ -323,9 +350,8 @@ describe("variables", () => {
 
 		typeQuery("retryBudget");
 
-		const group = groupByHeading("Variables")!;
-		expect(group.textContent).toContain("retryBudget");
-		expect(group.textContent).toContain("Globals");
+		const row = rowByTitle("retryBudget");
+		expect(row.textContent).toContain("Globals");
 	});
 
 	it("finds an environment by its own name", () => {
@@ -349,8 +375,8 @@ describe("variables", () => {
 
 		expect(screen.getByText("apiToken")).toBeInTheDocument();
 		expect(document.body.textContent).not.toContain("s3cr3t-bearer-value");
-		// The searchable half of this invariant cannot be asserted here - cmdk
-		// filters the rendered list again, so an indexed value would be
+		// The searchable half of this invariant cannot be asserted here - the
+		// palette ranks the rendered list, so an indexed value would be
 		// invisible on screen and still be in the items. `useVariableItems.test.ts`
 		// holds that half, against what the source returns.
 	});
@@ -375,7 +401,7 @@ describe("runs", () => {
 		open();
 
 		typeQuery("checkout");
-		expect(rowsUnder("Runs")).toEqual(["https://api.example/checkout"]);
+		expect(resultRows()).toEqual(["https://api.example/checkout"]);
 
 		pickRow("https://api.example/checkout");
 		expect(useTabsStore.getState().openTabs[0]).toMatchObject({

--- a/app/src/modules/palette/ranking.test.ts
+++ b/app/src/modules/palette/ranking.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The rules the palette ranks by, against the function that holds them.
+ *
+ * `CommandPalette.test.tsx` pins the reported symptom through the DOM, which is
+ * where a wiring bug shows up. These cover the rules themselves - the floor's
+ * two edges, what a deep source's word is worth, where an escape row may and may
+ * not go - which a rendered list can only assert one example of at a time.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { rankPalette, scoreItem, MATCH_FLOOR } from "./ranking";
+import type { PaletteItem, PaletteKind } from "./types";
+
+function item(overrides: Partial<PaletteItem> & { id: string; kind: PaletteKind }): PaletteItem {
+	return { title: overrides.id, perform: () => {}, ...overrides };
+}
+
+/** Every row that renders, in visible order, top result first. */
+function rendered(items: PaletteItem[], query: string): string[] {
+	const ranked = rankPalette(items, query);
+	return [
+		...ranked.top.map((i) => i.id),
+		...ranked.groups.flatMap((g) => [...g.items, ...g.escapes].map((i) => i.id)),
+	];
+}
+
+describe("the relevance floor", () => {
+	it("keeps a match that begins mid-word", () => {
+		// "oken" finds "Issue token" by one SCORE_CHARACTER_JUMP. This is the
+		// edge the floor is set just under; raise it past 0.17 and this reds.
+		const request = item({ id: "r1", kind: "request", title: "Issue token" });
+		expect(scoreItem(request, "oken")).toBeGreaterThanOrEqual(MATCH_FLOOR);
+		expect(rendered([request], "oken")).toEqual(["r1"]);
+	});
+
+	it("drops a row the query only reaches by scattered jumps", () => {
+		// The reported noise: a t, an h, an e, an m and an e, in five places.
+		const request = item({
+			id: "r1",
+			kind: "request",
+			title: "Load test the current request",
+		});
+		expect(scoreItem(request, "theme")).toBeLessThan(MATCH_FLOOR);
+		expect(rendered([request], "theme")).toEqual([]);
+	});
+
+	it("does not apply to the empty query, which is not a search", () => {
+		const request = item({ id: "r1", kind: "request", title: "Charge card" });
+		expect(rendered([request], "")).toEqual(["r1"]);
+	});
+});
+
+describe("substring keywords", () => {
+	const request = item({
+		id: "r1",
+		kind: "request",
+		title: "Issue token",
+		// The measured worst case: fuzzily this path scores 0.51 for "theme",
+		// which is well clear of any floor that would not also drop real matches.
+		substringKeywords: ["/the/most/expensive/endpoint"],
+	});
+
+	it("finds a request by a piece of its URL", () => {
+		expect(rendered([request], "/most/expensive")).toEqual(["r1"]);
+	});
+
+	it("is not a subsequence matcher, which is the whole point", () => {
+		// Every letter of "theme" is in that path, in order. Put the URL back in
+		// the fuzzy corpus and this row outranks the setting the user wanted.
+		expect(scoreItem(request, "theme")).toBe(0);
+		expect(rendered([request], "theme")).toEqual([]);
+	});
+
+	it("loses to a row whose name actually says what was typed", () => {
+		const setting = item({ id: "s1", kind: "settings", title: "Refunds", preMatched: true });
+		expect(rankPalette([request, setting], "refunds").top.map((i) => i.id)).toEqual(["s1"]);
+	});
+});
+
+describe("a deep source's word", () => {
+	// The engine matched this run on snapshot text no row prints, so nothing
+	// on the row itself matches the query.
+	const run = item({ id: "run1", kind: "run", title: "Nothing alike", preMatched: true });
+
+	it("keeps a row whose own text does not match", () => {
+		expect(rendered([run], "checkout")).toEqual(["run1"]);
+	});
+
+	it("does not make it the top result - there is nothing on screen to justify one", () => {
+		expect(rankPalette([run], "checkout").top).toEqual([]);
+	});
+
+	it("is a property of the row, not of its kind", () => {
+		// The command registry contributes `settings` rows too, one per panel,
+		// and those are ordinary shallow rows that must clear the floor.
+		const panel = item({ id: "panel", kind: "settings", title: "Load testing" });
+		expect(rendered([panel], "checkout")).toEqual([]);
+	});
+});
+
+describe("the top result", () => {
+	const setting = item({ id: "theme", kind: "settings", title: "Theme Mode", preMatched: true });
+	// Matches "theme" too (0.891 against the setting's 0.990), so it renders -
+	// it just is not the best match.
+	const request = item({ id: "r1", kind: "request", title: "Refresh theme endpoint" });
+
+	it("is lifted out of its own section rather than copied into a new one", () => {
+		const ranked = rankPalette([request, setting], "theme");
+		expect(ranked.top.map((i) => i.id)).toEqual(["theme"]);
+		// Two rows carrying the same `value` would both read as selected.
+		expect(ranked.groups.flatMap((g) => g.items.map((i) => i.id))).toEqual(["r1"]);
+	});
+
+	it("breaks a tie by the order the sections appear in", () => {
+		const tab = item({ id: "t1", kind: "tab", title: "Inbox" });
+		const view = item({ id: "v1", kind: "view", title: "Inbox" });
+		expect(rankPalette([view, tab], "inbox").top.map((i) => i.id)).toEqual(["t1"]);
+	});
+
+	it("is absent from the empty query, which has asked for nothing", () => {
+		expect(rankPalette([request], "").top).toEqual([]);
+	});
+});
+
+describe("escape rows", () => {
+	const escape = item({
+		id: "more",
+		kind: "settings",
+		title: "Search settings for…",
+		escape: true,
+	});
+	const setting = item({ id: "s1", kind: "settings", title: "Theme Mode", preMatched: true });
+
+	it("render below the results of the section they escape", () => {
+		expect(rendered([escape, setting], "theme")).toEqual(["s1", "more"]);
+	});
+
+	it("are never promoted, however well they match", () => {
+		// The case that makes the guard load-bearing: the deep source matched
+		// this row on text the row does not print, so it scores nothing, while
+		// the escape row echoes the query by construction and scores near 1.
+		// Without the guard the way *out* of the results becomes the top result.
+		const hidden = item({ id: "s1", kind: "settings", title: "Cache Size", preMatched: true });
+		const echo = item({
+			id: "more",
+			kind: "settings",
+			title: "Search settings for “theme”…",
+			escape: true,
+		});
+		expect(rankPalette([echo, hidden], "theme").top).toEqual([]);
+		expect(rendered([echo, hidden], "theme")).toEqual(["s1", "more"]);
+	});
+
+	it("are not counted - the announcement answers whether the query narrowed anything", () => {
+		expect(rankPalette([escape, setting], "theme").total).toBe(1);
+	});
+});
+
+describe("the announced total", () => {
+	it("counts every row that renders and nothing that does not", () => {
+		const items = [
+			item({ id: "hit", kind: "settings", title: "Theme Mode", preMatched: true }),
+			item({ id: "noise", kind: "request", title: "Load test the current request" }),
+		];
+		const ranked = rankPalette(items, "theme");
+		expect(ranked.total).toBe(rendered(items, "theme").length);
+		expect(ranked.total).toBe(1);
+	});
+});

--- a/app/src/modules/palette/ranking.test.ts
+++ b/app/src/modules/palette/ranking.test.ts
@@ -79,6 +79,15 @@ describe("substring keywords", () => {
 		expect(rendered([request], "theme")).toEqual([]);
 	});
 
+	it("wants the separators too - the cost of not being a subsequence matcher", () => {
+		// A URL is all separators, so a scorer reads a query scattered across
+		// its segments as a series of *word* jumps and scores it highly - which
+		// is the soup. There is no threshold that keeps "mostexpensive" and
+		// drops "theme", so a skipped separator is a miss. Recorded, not fixed.
+		expect(rendered([request], "most/expensive")).toEqual(["r1"]);
+		expect(rendered([request], "mostexpensive")).toEqual([]);
+	});
+
 	it("loses to a row whose name actually says what was typed", () => {
 		const setting = item({ id: "s1", kind: "settings", title: "Refunds", preMatched: true });
 		expect(rankPalette([request, setting], "refunds").top.map((i) => i.id)).toEqual(["s1"]);
@@ -96,6 +105,31 @@ describe("a deep source's word", () => {
 
 	it("does not make it the top result - there is nothing on screen to justify one", () => {
 		expect(rankPalette([run], "checkout").top).toEqual([]);
+	});
+
+	it("orders its rows by what they print, keeping the source's order among equals", () => {
+		// Four runs the engine matched. Two print the query, two matched on
+		// snapshot text no row prints. Inside the section the visible ones lead,
+		// and the pair that prints nothing keeps the order the engine sent -
+		// newest first - because the sort is stable. All four still render: a
+		// deep source's word is what got them in, and only their order is ours.
+		const run = (id: string, title: string) =>
+			item({ id, kind: "run", title, preMatched: true });
+		const items = [
+			run("hidden-newer", "Nothing alike"),
+			run("hidden-older", "Nothing alike"),
+			run("weak", "Old checkout attempt"),
+			run("best", "checkout"),
+		];
+
+		const ranked = rankPalette(items, "checkout");
+		// The strongest is promoted out of the section entirely.
+		expect(ranked.top.map((i) => i.id)).toEqual(["best"]);
+		expect(ranked.groups.find((g) => g.kind === "run")?.items.map((i) => i.id)).toEqual([
+			"weak",
+			"hidden-newer",
+			"hidden-older",
+		]);
 	});
 
 	it("is a property of the row, not of its kind", () => {

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The palette's one ranking authority.
+ *
+ * Everything the list shows, in the order it shows it, is decided here and
+ * nowhere else. That is the point of the file: the palette used to run two
+ * matchers over the same rows - each deep source pre-selected with a ranking of
+ * its own, then cmdk re-scored every rendered row behind their backs - and
+ * neither was in charge. A 0.99 Settings hit sat below 0.01 request noise
+ * because the sections rendered in a fixed order that no score could cross.
+ *
+ * The scorer itself is unchanged and deliberately not ours: `defaultFilter` is
+ * the `commandScore` cmdk filters with, and it already ranks correctly. What
+ * changed is that it now runs once, here, where the result can also decide the
+ * top result, the floor and the announced count - so the palette declares
+ * `shouldFilter={false}` and cmdk scores nothing a second time. It is the same
+ * arrangement `suggestion-list.tsx` and `variable-autocomplete.tsx` already use,
+ * for the same reason: the caller knows something about matching that cmdk's
+ * default cannot.
+ */
+
+import { defaultFilter } from "cmdk";
+import { PALETTE_GROUPS, rankForEmptyQuery, type PaletteItem, type PaletteKind } from "./types";
+
+/**
+ * The score a row must reach to be a match at all.
+ *
+ * `commandScore` pays 0.17 for a `SCORE_CHARACTER_JUMP` - a run of characters
+ * that begins in the middle of a word, which is what "oken" finding "Issue
+ * token" is. A floor just under that keeps every such match and drops anything
+ * that needed two or more scattered jumps to reach the query, which is the
+ * shape of every noise row in the report: "theme" matched requests at
+ * 0.0008-0.0975 by finding a t, an h, an e, an m and an e in different places.
+ *
+ * The threshold is expressed against the scorer's own constant rather than
+ * tuned by eye: raise it past 0.17 and genuine mid-word matches start
+ * disappearing, which is a worse bug than the one it fixes.
+ */
+export const MATCH_FLOOR = 0.1;
+
+/** The heading over the promoted best match. */
+export const TOP_RESULT_LABEL = "Top result";
+
+/**
+ * What a row is matched against: what it reads as, plus its extra terms.
+ *
+ * The id is deliberately absent - it is a uuid, and a query of "b7" would
+ * otherwise match rows at random.
+ */
+function matchText(item: PaletteItem): string {
+	return [item.title, item.subtitle].filter(Boolean).join(" ");
+}
+
+/**
+ * How well a row matches, from 0 (not at all) to 1.
+ *
+ * Two corpora, because they want different matchers. `keywords` are short terms
+ * a person types on purpose, so they go through the fuzzy scorer with the title.
+ * `substringKeywords` are text the fuzzy scorer is simply wrong about - a URL is
+ * the case it exists for - so they are matched literally and scored as the
+ * mid-word match they are.
+ */
+export function scoreItem(item: PaletteItem, query: string): number {
+	const fuzzy = defaultFilter(matchText(item), query, item.keywords);
+	if (fuzzy >= MATCH_FLOOR) return fuzzy;
+	return substringScore(item, query);
+}
+
+/**
+ * A literal hit in `substringKeywords`, scored as a mid-word match.
+ *
+ * Scored rather than merely allowed through so a row found only by its URL
+ * cannot outrank one whose name actually says what the user typed.
+ */
+function substringScore(item: PaletteItem, query: string): number {
+	if (!item.substringKeywords?.length) return 0;
+	const needle = query.toLowerCase();
+	const hit = item.substringKeywords.some((term) => term.toLowerCase().includes(needle));
+	return hit ? SUBSTRING_SCORE : 0;
+}
+
+/**
+ * Just above the floor: a URL hit is a real match and must survive, but it is
+ * the weakest kind of one - the text it matched is not even on the row.
+ */
+const SUBSTRING_SCORE = 0.15;
+
+/** One rendered section: a heading, its rows, and any escape row below them. */
+export interface RankedGroup {
+	kind: PaletteKind;
+	items: PaletteItem[];
+	escapes: PaletteItem[];
+}
+
+export interface RankedPalette {
+	/** The promoted best match, or empty - never more than one row. */
+	top: PaletteItem[];
+	/** The familiar fixed order, minus whatever was promoted. */
+	groups: RankedGroup[];
+	/**
+	 * How many result rows render. Escape rows are navigation, not results, and
+	 * are not counted - the announcement answers "did what I typed narrow
+	 * anything", and an escape row is present either way.
+	 */
+	total: number;
+}
+
+/**
+ * Everything the palette renders, ranked.
+ *
+ * The empty query is a different question from a typed one and gets a different
+ * answer: "what was I just doing", ordered by recency, with no top result to
+ * promote because nothing has been asked for yet. Once something is typed the
+ * score decides - a result that matches better has to win over one that is
+ * merely more recent, or typing stops feeling like searching.
+ */
+export function rankPalette(items: PaletteItem[], query: string): RankedPalette {
+	const needle = query.trim();
+	if (needle === "") {
+		const groups = groupsOf(items, (ofKind) => rankForEmptyQuery(ofKind));
+		return { top: [], groups, total: countItems(groups) };
+	}
+
+	const scores = new Map<string, number>();
+	const kept = items.filter((item) => {
+		const score = scoreItem(item, needle);
+		scores.set(item.id, score);
+		// A deep source took the query and matched it itself, against a corpus
+		// this scorer cannot see - the engine matched a run on stored snapshot
+		// text that no row prints. Its rows are matches by the time they arrive;
+		// the score only decides where among them they sit. An escape row is not
+		// a result at all, so no floor applies to it either.
+		return item.escape || item.preMatched === true || score >= MATCH_FLOOR;
+	});
+
+	const promoted = bestMatch(kept, scores);
+	const rest = promoted ? kept.filter((item) => item.id !== promoted.id) : kept;
+	const byScore = (ofKind: PaletteItem[]) =>
+		[...ofKind].sort((a, b) => (scores.get(b.id) ?? 0) - (scores.get(a.id) ?? 0));
+	const groups = groupsOf(rest, byScore);
+
+	return {
+		top: promoted ? [promoted] : [],
+		groups,
+		total: countItems(groups) + (promoted ? 1 : 0),
+	};
+}
+
+/** Where each kind sits on screen, for breaking a tie the way the eye would. */
+const GROUP_ORDER = new Map<PaletteKind, number>(
+	PALETTE_GROUPS.map((kind, index) => [kind, index])
+);
+
+/**
+ * The row to promote: the best-scoring result, or none.
+ *
+ * A row that only cleared the floor because its source vouched for it has
+ * nothing on screen matching what was typed, so it is not a "top result" -
+ * hence the floor here as well as in the filter above. Ties go to the earlier
+ * section, so the promotion follows the order on screen rather than the order
+ * the sources happened to be concatenated in.
+ */
+function bestMatch(items: PaletteItem[], scores: Map<string, number>): PaletteItem | undefined {
+	let best: PaletteItem | undefined;
+	for (const item of items) {
+		if (item.escape) continue;
+		const score = scores.get(item.id) ?? 0;
+		if (score < MATCH_FLOOR) continue;
+		if (best && !outranks(item, score, best, scores)) continue;
+		best = item;
+	}
+	return best;
+}
+
+function outranks(
+	item: PaletteItem,
+	score: number,
+	best: PaletteItem,
+	scores: Map<string, number>
+): boolean {
+	const bestScore = scores.get(best.id) ?? 0;
+	if (score !== bestScore) return score > bestScore;
+	return (GROUP_ORDER.get(item.kind) ?? 0) < (GROUP_ORDER.get(best.kind) ?? 0);
+}
+
+/** The fixed section order, with each section's rows ordered by `order`. */
+function groupsOf(
+	items: PaletteItem[],
+	order: (ofKind: PaletteItem[]) => PaletteItem[]
+): RankedGroup[] {
+	return PALETTE_GROUPS.map((kind) => {
+		const ofKind = items.filter((item) => item.kind === kind);
+		return {
+			kind,
+			items: order(ofKind.filter((item) => !item.escape)),
+			escapes: ofKind.filter((item) => item.escape),
+		};
+	}).filter((group) => group.items.length > 0 || group.escapes.length > 0);
+}
+
+function countItems(groups: RankedGroup[]): number {
+	return groups.reduce((n, group) => n + group.items.length, 0);
+}

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -128,16 +128,12 @@ export function rankPalette(items: PaletteItem[], query: string): RankedPalette 
 	}
 
 	const scores = new Map<string, number>();
-	const kept = items.filter((item) => {
+	const kept: PaletteItem[] = [];
+	for (const item of items) {
 		const score = scoreItem(item, needle);
 		scores.set(item.id, score);
-		// A deep source took the query and matched it itself, against a corpus
-		// this scorer cannot see - the engine matched a run on stored snapshot
-		// text that no row prints. Its rows are matches by the time they arrive;
-		// the score only decides where among them they sit. An escape row is not
-		// a result at all, so no floor applies to it either.
-		return item.escape || item.preMatched === true || score >= MATCH_FLOOR;
-	});
+		if (survives(item, score)) kept.push(item);
+	}
 
 	const promoted = bestMatch(kept, scores);
 	const rest = promoted ? kept.filter((item) => item.id !== promoted.id) : kept;
@@ -150,6 +146,19 @@ export function rankPalette(items: PaletteItem[], query: string): RankedPalette 
 		groups,
 		total: countItems(groups) + (promoted ? 1 : 0),
 	};
+}
+
+/**
+ * Whether a row renders at all.
+ *
+ * A deep source took the query and matched it itself, against a corpus this
+ * scorer cannot see - the engine matched a run on stored snapshot text that no
+ * row prints. Its rows are matches by the time they arrive; the score only
+ * decides where among them they sit. An escape row is not a result at all, so
+ * no floor applies to it either.
+ */
+function survives(item: PaletteItem, score: number): boolean {
+	return item.escape === true || item.preMatched === true || score >= MATCH_FLOOR;
 }
 
 /** Where each kind sits on screen, for breaking a tie the way the eye would. */

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -137,6 +137,18 @@ export function rankPalette(items: PaletteItem[], query: string): RankedPalette 
 
 	const promoted = bestMatch(kept, scores);
 	const rest = promoted ? kept.filter((item) => item.id !== promoted.id) : kept;
+	/*
+	 * Within a section, score decides and the source's own order is the stable
+	 * tiebreak - `Array.prototype.sort` is specified as stable, so rows that
+	 * score alike keep the order their source produced (recency for runs,
+	 * `searchSettings`' rank for settings, scope order for variables).
+	 *
+	 * A `preMatched` row is sorted on what it *prints*, which can be nothing:
+	 * a run the engine matched on snapshot text sinks below one whose URL says
+	 * what was typed, and among equals stays newest-first. That is a change for
+	 * runs alone, and a deliberate one - their old order came of stuffing the
+	 * query into every row's keywords, which scored them all alike.
+	 */
 	const byScore = (ofKind: PaletteItem[]) =>
 		[...ofKind].sort((a, b) => (scores.get(b.id) ?? 0) - (scores.get(a.id) ?? 0));
 	const groups = groupsOf(rest, byScore);

--- a/app/src/modules/palette/sources/useEntityItems.ts
+++ b/app/src/modules/palette/sources/useEntityItems.ts
@@ -97,7 +97,14 @@ export function useEntityItems(): PaletteItem[] {
 				// The URL finds a request whose name says nothing about it - and
 				// it is a keyword rather than the subtitle because the collection
 				// is what the eye needs to tell two "Get user"s apart.
-				keywords: [request.method, request.url],
+				//
+				// It is matched literally rather than fuzzily: a path is character
+				// soup to a subsequence scorer, and this one line was the palette's
+				// noise generator - almost any five-letter query found its letters
+				// scattered through some URL, and that request then outranked the
+				// setting the user was actually looking for.
+				keywords: [request.method],
+				substringKeywords: [request.url],
 				method: request.method,
 				...(lastSent.has(request.id) ? { recencyAt: lastSent.get(request.id) } : {}),
 				perform: () => openTab({ type: "request", entityId: request.id }),

--- a/app/src/modules/palette/sources/useRunItems.ts
+++ b/app/src/modules/palette/sources/useRunItems.ts
@@ -22,11 +22,12 @@
  *   and a toast fired by idle input is the palette shouting at someone who did
  *   not ask it anything. The query does not retry either - a typist should not
  *   wait out a retry budget for a group that is about to disappear.
- * - **cmdk cannot re-judge these rows.** The engine matched against the whole
- *   stored snapshot, which includes text no row prints, so the rendered list's
- *   own filter would drop rows that legitimately matched. Each row carries the
- *   query in its keywords, which is how it says "the match is real, you just
- *   cannot see it from here".
+ * - **Nothing re-judges these rows.** The engine matched against the whole
+ *   stored snapshot, which includes text no row prints, so a second opinion
+ *   formed from the row alone would drop matches that are real. Each row says
+ *   so with `preMatched`, and `ranking.ts` takes it at its word. The query
+ *   itself used to be stuffed into the keywords to the same end, which worked
+ *   by making every run score as an exact match - and outrank everything else.
  */
 
 /* global setTimeout, clearTimeout */
@@ -94,12 +95,17 @@ export function useRunItems(query: string): PaletteItem[] {
 		const items: PaletteItem[] = data.data.map((run) => ({
 			id: `run:${run.id}`,
 			kind: "run" as const,
+			// The engine matched this run, against stored snapshot text no row
+			// prints - see `PaletteItem.preMatched`.
+			preMatched: true,
 			title: runTitle(run, collectionsById),
 			subtitle: `${RUN_KIND_LABEL[run.type]} · ${run.status} · ${formatRelativeTime(run.startTime)}`,
-			// The engine already decided this row matches; cmdk filters the
-			// rendered list again and cannot see the snapshot text that matched,
-			// so the query itself is what keeps the row alive.
-			keywords: [search, run.summary?.method ?? "", run.type, run.status],
+			// The query itself used to be first in this list, so cmdk's second
+			// filter could not drop a row the engine had matched on snapshot
+			// text no row prints. That is `ranking.ts`'s job now, and carrying
+			// the query was never free: a row whose keywords contain the query
+			// verbatim scores near 1, so every run outranked every real match.
+			keywords: [run.summary?.method ?? "", run.type, run.status],
 			icon: run.type === "load" ? Zap : run.summary?.scenario ? FolderTree : Clock,
 			...(run.summary?.method ? { method: run.summary.method } : {}),
 			recencyAt: run.startTime,
@@ -115,7 +121,6 @@ export function useRunItems(query: string): PaletteItem[] {
 				subtitle: `${data.pagination.total} runs`,
 				icon: Search,
 				escape: true,
-				keywords: [search],
 				perform: () => {
 					const history = useHistoryStore.getState();
 					// Reset first: type, status and pin filters are applied over

--- a/app/src/modules/palette/sources/useSettingsItems.ts
+++ b/app/src/modules/palette/sources/useSettingsItems.ts
@@ -58,6 +58,9 @@ export function useSettingsItems(query: string): PaletteItem[] {
 		const items: PaletteItem[] = shown.map((entry) => ({
 			id: `setting:${entry.kind}:${entry.id}`,
 			kind: "settings" as const,
+			// `searchSettings` matched this against the whole index entry,
+			// description included - see `PaletteItem.preMatched`.
+			preMatched: true,
 			title: entry.label,
 			// The engine key is part of what the row says, because that is what
 			// docs, logs and MCP calls name the setting; an app setting has no
@@ -66,10 +69,13 @@ export function useSettingsItems(query: string): PaletteItem[] {
 				entry.kind === "engine"
 					? `${entry.categoryLabel} · ${entry.id}`
 					: entry.categoryLabel,
-			// Everything `searchSettings` matched on, so cmdk - which filters the
-			// rendered list a second time - cannot hide a row this source has
-			// already decided matches. Its own `value` covers label and subtitle.
-			keywords: [entry.id, ...entry.keywords, entry.description],
+			// The terms someone types to reach this row: the engine key every
+			// doc and log line names it by, and its aliases. The description
+			// used to be here too - a whole sentence of prose, carried only so
+			// cmdk's second filter could not hide a row this source had already
+			// matched. Nothing filters these rows twice now (`ranking.ts`), so
+			// the defensive half is gone and what remains is search terms.
+			keywords: [entry.id, ...entry.keywords],
 			perform: () => reveal(entry),
 		}));
 
@@ -84,7 +90,6 @@ export function useSettingsItems(query: string): PaletteItem[] {
 				subtitle: `${matches.length} matches`,
 				icon: Search,
 				escape: true,
-				keywords: [needle],
 				perform: () => {
 					// The sidebar's box reads this, so the drawer opens already
 					// filtered - the palette finds, the destination browses.

--- a/app/src/modules/palette/sources/useVariableItems.ts
+++ b/app/src/modules/palette/sources/useVariableItems.ts
@@ -121,6 +121,8 @@ export function useVariableItems(query: string): PaletteItem[] {
 						item: {
 							id: `variable-scope:${scope.key}`,
 							kind: "variable",
+							// Matched by `matchRank` above - see `PaletteItem.preMatched`.
+							preMatched: true,
 							title: scope.label,
 							subtitle: "Environment",
 							keywords: ["environment", "env", "scope"],
@@ -141,6 +143,8 @@ export function useVariableItems(query: string): PaletteItem[] {
 					item: {
 						id: `variable:${scope.key}:${variableKey}`,
 						kind: "variable",
+						// Matched by `matchRank` above - see `PaletteItem.preMatched`.
+						preMatched: true,
 						title: variableKey,
 						subtitle: scope.label,
 						keywords: ["variable", `{{${variableKey}}}`],

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -82,6 +82,13 @@ export interface PaletteItem {
 	 * `/the/most/expensive/endpoint` by finding five letters in five places.
 	 * Nobody fuzzy-searches a URL - they type a piece of one - so it is matched
 	 * the way it is used.
+	 *
+	 * The piece has to be contiguous, and that is the cost: `v1/charges` finds
+	 * the row, `v1charges` no longer does. No floor could have bought that back
+	 * - a URL is all separators, so the scorer reads a query scattered across
+	 * its segments as a series of *word* jumps, which is what scored the soup
+	 * 0.51 in the first place. A query that skips a separator is
+	 * indistinguishable from one that matches nothing.
 	 */
 	substringKeywords?: string[];
 	icon?: LucideIcon;

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -66,8 +66,24 @@ export interface PaletteItem {
 	title: string;
 	/** Where it lives - a collection path, a tab's kind. Also matched. */
 	subtitle?: string;
-	/** Extra terms that should find this row but do not belong on screen. */
+	/**
+	 * Extra terms that should find this row but do not belong on screen.
+	 *
+	 * Short terms a person types on purpose - a method, a scope, an alias. They
+	 * are matched fuzzily along with the title, so anything long or punctuated
+	 * belongs in `substringKeywords` instead.
+	 */
 	keywords?: string[];
+	/**
+	 * Terms matched as a literal substring rather than fuzzily.
+	 *
+	 * A URL is the case this exists for. `commandScore` is a subsequence
+	 * matcher, and any path is character soup to it: "theme" scores 0.51 against
+	 * `/the/most/expensive/endpoint` by finding five letters in five places.
+	 * Nobody fuzzy-searches a URL - they type a piece of one - so it is matched
+	 * the way it is used.
+	 */
+	substringKeywords?: string[];
 	icon?: LucideIcon;
 	/** HTTP method, drawn as the same colour rail the tab strip uses. */
 	method?: string;
@@ -77,16 +93,28 @@ export interface PaletteItem {
 	 */
 	recencyAt?: number;
 	/**
+	 * Set by a deep source: this row was matched against text the palette's own
+	 * scorer cannot see, so no relevance floor applies to it.
+	 *
+	 * The settings index reaches a description no row prints, and the engine
+	 * matches a run on stored snapshot text. Without this the source's work
+	 * would be thrown away by a second opinion formed from less evidence.
+	 *
+	 * It is a property of the row and not of its `kind` on purpose: the command
+	 * registry contributes `settings` rows too - one per panel - and those are
+	 * ordinary shallow rows that must clear the floor like any other.
+	 */
+	preMatched?: boolean;
+	/**
 	 * A "search the rest of these over there" row rather than a result: it
 	 * leaves the palette for the surface that browses this corpus properly,
 	 * carrying the query with it.
 	 *
 	 * Rendered in a group of its own, below its results, and that placement is
-	 * the reason for the flag. cmdk re-sorts a group's items by match score, and
-	 * an escape row has to carry the query in its keywords to survive that same
-	 * filter - which would score it *above* every result it is an escape from.
-	 * A separate group has its own item container, so nothing sorts across the
-	 * boundary.
+	 * the reason for the flag. It is not a result: `ranking.ts` neither scores
+	 * it, nor lets it be promoted to the top, nor counts it in the announced
+	 * total - it is the way out of the list, and it sits at the bottom of the
+	 * section it is a way out of.
 	 */
 	escape?: boolean;
 	/** What Enter (or a click) does. The palette closes itself afterwards. */
@@ -96,9 +124,9 @@ export interface PaletteItem {
 /**
  * Order for the empty query: most recent first, then the source's own order.
  *
- * Only for the empty query. Once there is something typed, cmdk's match score
- * decides - a result that matches better has to win over one that is merely
- * more recent, or typing stops feeling like searching.
+ * Only for the empty query. Once there is something typed the match score
+ * decides (`ranking.ts`) - a result that matches better has to win over one
+ * that is merely more recent, or typing stops feeling like searching.
  *
  * Stable: `Array.prototype.sort` is specified as stable, so items with no
  * recency at all keep the order their source produced (strip order for tabs,

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -842,15 +842,23 @@ typed, four rules apply:
   than copied into the new one: two rows carrying the same `value` would both read as selected.
   Ties go to the earlier section. Below it, groups render in the same fixed order as ever (Tabs,
   Requests, Collections, Views, Commands, Settings, Variables, Runs) so the list does not reshuffle
-  as you type; within a section, rows are ordered by score. Settings is its own group rather than
-  more Commands: twelve sections would bury the handful of things the palette can actually *do*.
+  as you type; within a section, rows are ordered by score, with the source's own order as the
+  stable tiebreak. A deep row is sorted on what it *prints*, which can be nothing - a run the
+  engine matched on snapshot text sinks below one whose URL says what was typed, and among equals
+  stays newest-first. That is a change for Runs alone, and a deliberate one: their old order came
+  of stuffing the query into every row's keywords, which scored them all alike. Settings is its own
+  group rather than more Commands: twelve sections would bury the handful of things the palette can
+  actually *do*.
 - **A row must clear `MATCH_FLOOR` (0.1) to render.** cmdk keeps every score above zero, so a
   0.0008 match used to render exactly like a 0.99 one. The floor sits just under `commandScore`'s
   `SCORE_CHARACTER_JUMP` (0.17), which is what a match beginning mid-word scores - so "oken" still
   finds "Issue token", and a query reached only by two or more scattered jumps does not.
 - **`substringKeywords` are matched literally, not fuzzily.** A URL is the case this exists for:
   to a subsequence scorer any path is character soup, and "theme" scores 0.51 against
-  `/the/most/expensive/endpoint`. A request's URL is the one field that uses this.
+  `/the/most/expensive/endpoint`. A request's URL is the one field that uses this. The piece typed
+  has to be contiguous, and that is the cost - `v1/charges` finds the row, `v1charges` does not. No
+  floor could buy that back: a URL is all separators, so a query scattered across its segments
+  reads as a series of *word* jumps, which is what scores the soup so highly to begin with.
 - **The announced count is the rendered count.** The `aria-live` line reports what the ranking
   kept, which nothing downstream can hide.
 

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -787,7 +787,7 @@ run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
   (`useLayoutStore.paletteOpen` / `setPaletteOpen`, deliberately not persisted), and the host
   for the dialogs its commands open (see `useCommandSurfaces.ts` below).
 - **`sources/`** - one hook per family, each returning `PaletteItem[]`. Two shapes of source:
-  the **shallow** ones return everything they know and let cmdk filter it - `useTabItems` (open
+  the **shallow** ones return everything they know and let the ranking narrow it - `useTabItems` (open
   tabs), `useEntityItems` (requests + collections), `useViewItems` (drawer views and singleton
   tabs) - while the **deep** ones take the query, because their corpus is too large to render:
   `useSettingsItems` (every app setting and engine entry, through the shared settings index),
@@ -801,9 +801,11 @@ run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
   also merges the surfaces a *mounted feature* contributes (the request builder's live draft,
   for "Load test …") - see [Command Registry](#command-registry-libcommands).
 - **`types.ts`** - the `PaletteItem` shape, the fixed group order, and `rankForEmptyQuery`.
-- **`PaletteResults.tsx`** - grouping and rendering. **Mounted only while the palette is open**,
-  the same cost rule the context bar applies to a collapsed section: a shut palette holds no
-  query observers on collections, requests or run history.
+- **`ranking.ts`** - what renders and in what order, decided once. See Ranking below.
+- **`PaletteResults.tsx`** - grouping and rendering, and nothing else: it asks `ranking.ts` what
+  to draw. **Mounted only while the palette is open**, the same cost rule the context bar applies
+  to a collapsed section: a shut palette holds no query observers on collections, requests or run
+  history.
 
 Three things about it are load-bearing:
 
@@ -822,12 +824,35 @@ Three things about it are load-bearing:
 - **Tab rows are named by `components/layout/tab-descriptors.ts`**, the same hook `TabStrip`
   uses. A tab must not read "GET /v1/orders" in the strip and "Request" in the palette.
 
-Ranking: cmdk's own match score once anything is typed; on the empty query, `rankForEmptyQuery`
-puts the most recent first - focus time for tabs (`tabFocusedAt` in `tabs-store`, session-scoped),
-last-run time for requests (from the run history already in cache). Groups render in a fixed
-order (Tabs, Requests, Collections, Views, Commands, Settings, Variables, Runs) so the list does
-not reshuffle as you type. Settings is its own group rather than more Commands: twelve sections
-would bury the handful of things the palette can actually *do*.
+Ranking lives in `ranking.ts` and happens **once**. The palette declares `shouldFilter={false}`,
+so cmdk scores nothing a second time; the scorer is still cmdk's own (`defaultFilter`, the
+`commandScore` it would have filtered with), applied by the palette where the result can also
+decide the top result, the floor and the announced count. Before #1175 both matched: each deep
+source pre-selected with a ranking of its own and cmdk re-scored every rendered row, and neither
+was in charge - searching "theme" surfaced 0.01-scored requests over the 0.99-scored Theme Mode
+setting, because sections render in a fixed order that cmdk's cross-group re-sort cannot cross
+(each is wrapped in a `div` its `appendChild` cannot reach past).
+
+On the empty query, `rankForEmptyQuery` puts the most recent first - focus time for tabs
+(`tabFocusedAt` in `tabs-store`, session-scoped), last-run time for requests (from the run history
+already in cache) - and nothing is promoted, because nothing has been asked for. Once something is
+typed, four rules apply:
+
+- **The best match is promoted to a `Top result` section**, lifted out of its own section rather
+  than copied into the new one: two rows carrying the same `value` would both read as selected.
+  Ties go to the earlier section. Below it, groups render in the same fixed order as ever (Tabs,
+  Requests, Collections, Views, Commands, Settings, Variables, Runs) so the list does not reshuffle
+  as you type; within a section, rows are ordered by score. Settings is its own group rather than
+  more Commands: twelve sections would bury the handful of things the palette can actually *do*.
+- **A row must clear `MATCH_FLOOR` (0.1) to render.** cmdk keeps every score above zero, so a
+  0.0008 match used to render exactly like a 0.99 one. The floor sits just under `commandScore`'s
+  `SCORE_CHARACTER_JUMP` (0.17), which is what a match beginning mid-word scores - so "oken" still
+  finds "Issue token", and a query reached only by two or more scattered jumps does not.
+- **`substringKeywords` are matched literally, not fuzzily.** A URL is the case this exists for:
+  to a subsequence scorer any path is character soup, and "theme" scores 0.51 against
+  `/the/most/expensive/endpoint`. A request's URL is the one field that uses this.
+- **The announced count is the rendered count.** The `aria-live` line reports what the ranking
+  kept, which nothing downstream can hide.
 
 Four rules govern the deep sources, and each exists because of a way the naive version fails:
 
@@ -840,18 +865,21 @@ Four rules govern the deep sources, and each exists because of a way the naive v
   other filters the escape resets so a stale one cannot hide what was just promised). The row
   appears only when there *is* more. Variables has none: no surface browses variables across
   scopes, so it would have nowhere to go.
-- **An escape row renders in a group of its own**, below the results. cmdk re-sorts a group's
-  items by score, and an escape row has to carry the query verbatim to survive that filter -
-  which would score it above every result it is an escape from. A separate group has its own
-  item container, so nothing sorts across the boundary.
-- **A deep row carries what matched in its `keywords`**, because cmdk filters the rendered list
-  a second time and would otherwise drop rows the source already matched - decisively so for
-  runs, where the engine matched against stored snapshot text that no row prints.
+- **An escape row renders in a group of its own**, below the results. It is not a result: it is
+  never scored, never promoted to the top, and never counted. It echoes the query by construction,
+  which is exactly what would otherwise score it above every result it is an escape from.
+- **A deep row says `preMatched`**, and the ranking takes it at its word rather than forming a
+  second opinion from less evidence - decisively so for runs, where the engine matched against
+  stored snapshot text that no row prints. It is a property of the row and not of its `kind`: the
+  command registry contributes `settings` rows too, one per panel, and those are ordinary shallow
+  rows that must clear the floor. Before #1175 the same end was reached by stuffing the keywords -
+  with a whole description sentence for settings, and with the query itself for runs, which scored
+  every run as an exact match and outranked everything else.
 
 Two invariants are tested rather than commented. **A variable's value is never indexed**, secret
 or not (`secret` is a masking hint, so trusting it would leak every token nobody flagged) - held
-in `sources/useVariableItems.test.ts` against the source's output, because cmdk's second filter
-would hide an indexed value from any DOM assertion. And **an engine that is down hides the Runs
+in `sources/useVariableItems.test.ts` against the source's output, because the ranking would hide
+an indexed value from any DOM assertion. And **an engine that is down hides the Runs
 group silently**: typing is idle input, and idle input must never raise a toast.
 
 **Entry points:** the chord, and the `Search` tile on the welcome Launcher. The title bar's


### PR DESCRIPTION
## Description

The scorer was never the problem. cmdk's `commandScore` already ranked `Theme Mode` at **0.9899** and the request rows at **0.0008-0.0975** for "theme". The palette ran **two matchers** over the same rows and neither was in charge: each deep source pre-selected with a ranking of its own, then cmdk re-scored every rendered row behind their backs. cmdk's cross-group re-sort - the one thing that could have lifted a 0.99 Settings hit above 0.09 Requests noise - was structurally inert, because every section renders inside its own per-group wrapper `div` that `parentElement.appendChild` cannot cross.

**Approach.** Ranking moves into `palette/ranking.ts` and happens once. The palette declares `shouldFilter={false}` - the arrangement `SuggestionList` and `VariableAutocomplete` already use for the same reason - so cmdk scores nothing a second time, and the same `defaultFilter` it would have used decides everything: a promoted **Top result** section, a relevance floor, the order within each section, and the announced count.

**Rejected alternative:** passing a `filter` prop to cmdk with the floor inside it (the issue's step 2). It leaves cmdk deciding visibility while `PaletteResults` decides promotion - the same two-authority split in a new place - runs the scorer twice per row per keystroke, cannot substring-match a URL (the `filter` signature only sees value + keywords), and leaves the keyword stuffing in place, because cmdk would still be free to hide a row its source had matched. AC3 is unreachable that way.

Notable details:

- **Request URLs leave the fuzzy corpus** for `substringKeywords`, matched literally. A path is character soup to a subsequence scorer - "theme" scores **0.51** against `/the/most/expensive/endpoint` - so no floor could have covered for this line.
- **The floor is 0.1**, just under `commandScore`'s `SCORE_CHARACTER_JUMP` (0.17). Measured: a genuine mid-word match ("oken" finding "Issue token") scores 0.168 and survives; the reported noise scored 0.0008-0.0975 and does not. Raising it past 0.17 starts dropping real matches.
- **Deep sources say `preMatched`** instead of stuffing keywords to survive a second filter. `useSettingsItems` no longer carries a whole description sentence; `useRunItems` no longer carries the query itself, which had been scoring every run as an exact match. It is a property of the row and not of its `kind` on purpose: the command registry contributes `settings` rows too (one per panel), and those are ordinary shallow rows that must clear the floor. Keying this off `kind` was a real bug caught mid-implementation - it exempted 15 registry rows from the floor.
- **The announced count is exact by construction** - the ranking kept those rows, so nothing can hide one afterwards.

### Deliberate deviations, recorded

Two behaviour changes that follow from the fix rather than from the spec. Both are now documented in code and in `COMPONENTS.md`, and pinned by tests:

1. **A `substringKeywords` hit wants its separators.** `v1/charges` finds the row; `v1charges` no longer does. No floor could buy that back - a URL is all separators, so a query scattered across its segments reads as a series of *word* jumps, which is exactly what scores the soup 0.51. The fix for this would be the bug.
2. **Runs sort by what they print, then recency.** A run the engine matched on stored snapshot text sinks below one whose URL says what was typed, and among equals stays newest-first. The engine returns `start_time DESC` (`engine/src/db/database.cpp:2454`), so recency is what the stable tiebreak preserves - there is no relevance ordering to lose. Their old order came of stuffing the query into every row's keywords, which scored them all alike and made cmdk's in-group sort a no-op. Settings never had that: the issue's own diagnosis records cmdk discarding `searchSettings`' order.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **557 files, 6097 tests, all passing** (baseline on `2efcd48`: 556 files, 6076 tests - so +1 file, +21 tests, no pre-existing failures). Also green: `pnpm type-check`, `pnpm lint`, `pnpm format:check`, and `mkdocs build --strict` for the docs page.

No engine build or `ctest` run: the diff is `app/` and one doc, so no C++ test could change colour.

Every new rule is mutation-checked - the fix reverted, the test confirmed red, the fix restored:

| Reverted | Test that reds |
|---|---|
| the top-result promotion | "puts the setting a query names first, above better-placed sections" |
| `MATCH_FLOOR` → 0 | "does not render a row that matched only as subsequence noise" |
| the exact count | "announces the number of rows it actually rendered" |
| the substring path | "finds a request by a piece of its URL" |
| URL back in the fuzzy corpus | "is not a subsequence matcher, which is the whole point" |
| the `preMatched` exemption | "keeps a row whose own text does not match" |
| the escape-row guard | "are never promoted, however well they match" |
| the in-section score sort | "orders its rows by what they print, keeping the source's order among equals" |

That last one is worth flagging: it passed against a reverted fix on the first attempt, because the best match was still sitting in the section and dropping the sort left the order unchanged. It only pins anything with a row promoted out first.

`deep-sources.test.tsx` was updated deliberately, not deleted. A group is no longer the right unit for "did this row render", because a row that matched well is now promoted out of its own section - so those assertions count across the visible list instead, which is a truer statement of what each was checking ("exactly one Appearance row anywhere" was the intent). The empty-query recency and fixed-heading-order tests are untouched and green.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1175

First of the #1174 trio; #1176 and #1177 build on the reshaped `PaletteResults`.