### PR TITLE
perf(app): self-host the six faces the app can render - #1149

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -89,12 +89,12 @@
 				}
 			})();
 		</script>
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Fira+Code:wght@400;500&family=IBM+Plex+Mono:wght@400;500&family=Space+Mono:wght@400;700&display=swap"
-			rel="stylesheet"
-		/>
+		<!--
+			No font <link> here on purpose. The six faces are bundled and declared
+			in src/fonts.css: a stylesheet in this head is render-blocking, and the
+			window is shown on ready-to-show, so a fetch here is a fetch the window
+			waits for. See src/fonts.css.
+		-->
 	</head>
 	<body>
 		<div id="root"></div>

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,12 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@fontsource/fira-code": "^5.3.0",
+		"@fontsource/ibm-plex-mono": "^5.3.0",
+		"@fontsource/inter": "^5.3.0",
+		"@fontsource/jetbrains-mono": "^5.3.0",
+		"@fontsource/space-grotesk": "^5.3.0",
+		"@fontsource/space-mono": "^5.3.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@monaco-editor/react": "^4.7.0",
 		"@radix-ui/react-collapsible": "^1.1.13",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -8,6 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/fira-code':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/space-grotesk':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/space-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -620,6 +638,24 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/fira-code@5.3.0':
+    resolution: {integrity: sha512-EJL968RJRkakubAj/coU8pSUaeTE5UNoRjtzAr6kGiSZ3jWuN8/AKWHwym/PFUaQL1q7IL/H+EXs4358YhrTBQ==}
+
+  '@fontsource/ibm-plex-mono@5.3.0':
+    resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
+
+  '@fontsource/inter@5.3.0':
+    resolution: {integrity: sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==}
+
+  '@fontsource/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==}
+
+  '@fontsource/space-grotesk@5.3.0':
+    resolution: {integrity: sha512-ksnGizDPXIDuvqcTYTSrmZ+evx9sDlS8rp7+42BQ7wU+spt3twEoXfbJz672C+5CLg6VeUQwRy5RXshWb67LcQ==}
+
+  '@fontsource/space-mono@5.3.0':
+    resolution: {integrity: sha512-FrpBMOVWn3PRdRHlrZWC55X3kZG/2BTH7SM5ZyS/bky3iKya2BturI5lk+t0RoDQL2JyHzURsVq/EisCsxpI5A==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -4928,6 +4964,18 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/fira-code@5.3.0': {}
+
+  '@fontsource/ibm-plex-mono@5.3.0': {}
+
+  '@fontsource/inter@5.3.0': {}
+
+  '@fontsource/jetbrains-mono@5.3.0': {}
+
+  '@fontsource/space-grotesk@5.3.0': {}
+
+  '@fontsource/space-mono@5.3.0': {}
 
   '@hapi/address@5.1.1':
     dependencies:

--- a/app/src/constants/appearance.bundled-faces.test.ts
+++ b/app/src/constants/appearance.bundled-faces.test.ts
@@ -78,7 +78,9 @@ describe("the bundled faces", () => {
 	it("are declared before any rule, as CSS requires of an @import", () => {
 		// An `@import` after a rule is dropped, which would leave every
 		// declaration in fonts.css unread while the file itself still scans fine.
-		const beforeOurImport = indexCss.slice(0, indexCss.indexOf('@import "./fonts.css";'));
+		const at = indexCss.indexOf('@import "./fonts.css";');
+		expect(at).toBeGreaterThanOrEqual(0);
+		const beforeOurImport = indexCss.slice(0, at);
 		expect(beforeOurImport.replace(/@import [^;]+;|\/\*[\s\S]*?\*\/|\s+/g, "")).toBe("");
 	});
 
@@ -92,5 +94,32 @@ describe("the bundled faces", () => {
 
 	it("are files, not fetches - fonts.css pulls nothing from the network", () => {
 		expect(fontsCss).not.toMatch(/url\(\s*["']?https?:/);
+	});
+
+	it("each declare the range they cover, so only the needed file is read", () => {
+		/*
+		 * The trap this exists for. `@fontsource` also ships per-subset entry
+		 * points (`latin-400.css`, `latin-ext-400.css`), and those declare their
+		 * `@font-face` with no `unicode-range` at all - so nothing tells the
+		 * browser which file holds which characters, and every subset face for a
+		 * rendered weight is read whether a character needs it or not. Measured on
+		 * the built app, painting the shell read four Space Grotesk files that way
+		 * where the weight files read two, which with every subset bundled is
+		 * seven times the font bytes on the first-paint path. Typography still
+		 * looks right (the browser falls back within the family per character), so
+		 * nothing else would catch it. Read from `node_modules` because the
+		 * declarations are the dependency's, not ours, and that is where the
+		 * mistake would land.
+		 */
+		const imports = [...fontsCss.matchAll(/@import "(@fontsource\/[^"]+)";/g)].map((m) => m[1]);
+		expect(imports.length).toBeGreaterThan(0);
+
+		const rangeless = imports.filter((specifier) => {
+			const css = read(`../../node_modules/${specifier}`);
+			const faces = css.match(/@font-face/g)?.length ?? 0;
+			const ranges = css.match(/unicode-range:/g)?.length ?? 0;
+			return faces === 0 || faces !== ranges;
+		});
+		expect(rangeless).toEqual([]);
 	});
 });

--- a/app/src/constants/appearance.bundled-faces.test.ts
+++ b/app/src/constants/appearance.bundled-faces.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A face the picker offers must be a face the app carries, and vice versa.
+ *
+ * The six families used to arrive from `fonts.googleapis.com` through a link in
+ * the head of `index.html` - render-blocking, and the window is only shown on
+ * first paint, so the window waited on the network to appear (#1149). They are
+ * bundled in `src/fonts.css` now, which moves the failure mode: a family added
+ * to a stack here is no longer fetched on demand, it simply does not exist, and
+ * the option falls silently through to its system fallback. Nothing about the
+ * picker looks wrong when that happens - it is the repo's "written but never
+ * read" defect with the layers swapped.
+ *
+ * So both directions are asserted: every face an option promises is imported,
+ * and every import is a face some option promises (a bundled family nothing can
+ * select is installer weight for no one). The two remaining checks hold the
+ * wiring: `index.css` must actually pull `fonts.css` in, and the head of
+ * `index.html` must stay free of the fetch this all replaced.
+ *
+ * Read from disk rather than imported: vitest stubs a CSS import to `""`, and a
+ * guard that scans an empty string passes while proving nothing (repo
+ * CLAUDE.md). Hence the non-empty assertions first.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import { MONO_FONTS, UI_FONTS } from "./appearance";
+
+const read = (relative: string): string => readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const fontsCss = read("../fonts.css");
+const indexCss = read("../index.css");
+const indexHtml = read("../../index.html");
+
+/**
+ * The face an option promises - the head of its stack, when that head is a
+ * named family. `system-ui, ...` and `ui-monospace, ...` lead with a generic
+ * the OS provides, and everything after a stack's head is a fallback that has
+ * to exist on the machine already, so neither is ours to bundle.
+ */
+const promisedFace = (stack: string): string | undefined => /^\s*"([^"]+)"/.exec(stack)?.[1];
+
+/** `"IBM Plex Mono"` -> `ibm-plex-mono`, the `@fontsource` package for it. */
+const fontsourcePackage = (family: string): string => family.toLowerCase().replace(/\s+/g, "-");
+
+const promised = [...new Set([...UI_FONTS, ...MONO_FONTS].map((f) => promisedFace(f.stack)))]
+	.filter((face): face is string => face !== undefined)
+	.map(fontsourcePackage)
+	.sort();
+
+const imported = [
+	...new Set([...fontsCss.matchAll(/@import "@fontsource\/([^/"]+)\//g)].map((m) => m[1])),
+].sort();
+
+describe("the bundled faces", () => {
+	it("scanned non-empty sources", () => {
+		// Without this every scan below is vacuous.
+		expect(fontsCss.length).toBeGreaterThan(0);
+		expect(indexCss.length).toBeGreaterThan(0);
+		expect(indexHtml.length).toBeGreaterThan(0);
+		expect(promised.length).toBeGreaterThan(0);
+	});
+
+	it("are exactly the faces the pickers offer", () => {
+		expect(imported).toEqual(promised);
+	});
+
+	it("reach the renderer - index.css imports them", () => {
+		expect(indexCss).toContain('@import "./fonts.css";');
+	});
+
+	it("are declared before any rule, as CSS requires of an @import", () => {
+		// An `@import` after a rule is dropped, which would leave every
+		// declaration in fonts.css unread while the file itself still scans fine.
+		const beforeOurImport = indexCss.slice(0, indexCss.indexOf('@import "./fonts.css";'));
+		expect(beforeOurImport.replace(/@import [^;]+;|\/\*[\s\S]*?\*\/|\s+/g, "")).toBe("");
+	});
+
+	it("are the only source of a face - nothing in the head fetches one", () => {
+		expect(indexHtml).not.toContain("fonts.googleapis.com");
+		expect(indexHtml).not.toContain("fonts.gstatic.com");
+		// Broader than the two hosts: any external stylesheet in this head is a
+		// round trip the window waits on, whoever serves it.
+		expect(indexHtml).not.toMatch(/<link[^>]+href="https?:/);
+	});
+
+	it("are files, not fetches - fonts.css pulls nothing from the network", () => {
+		expect(fontsCss).not.toMatch(/url\(\s*["']?https?:/);
+	});
+});

--- a/app/src/constants/appearance.ts
+++ b/app/src/constants/appearance.ts
@@ -12,9 +12,10 @@
  * persisted to localStorage and applied to the document. This file is the
  * single source of truth: types, the settings controls, and the runtime guards
  * all derive from the arrays (font, radius) and the scale range below. Font
- * stacks reference faces already loaded by index.html (Space Grotesk, Inter and
- * the four mono faces) or system fonts, so switching never triggers a network
- * fetch.
+ * stacks reference faces bundled by src/fonts.css (Space Grotesk, Inter and the
+ * four mono faces) or system fonts, so switching never triggers a network
+ * fetch - and since #1149 that is true offline too, the faces being files in
+ * the app rather than a Google Fonts stylesheet.
  */
 
 export interface FontOption {
@@ -71,8 +72,9 @@ export type UiFontChoice = UiFont | "custom";
 /**
  * Monospace (code) font - applied by overriding the `--font-mono` custom
  * property (Tailwind's `font-mono` utilities read it) and passed to the Monaco
- * editor's `fontFamily`. Stacks reference faces already loaded by index.html
- * (JetBrains Mono) or system fonts, so switching never triggers a fetch.
+ * editor's `fontFamily`. Stacks reference faces bundled by src/fonts.css
+ * (JetBrains Mono, Fira Code, IBM Plex Mono, Space Mono) or system fonts, so
+ * switching never triggers a fetch.
  */
 export const MONO_FONTS = [
 	{

--- a/app/src/fonts-woff2-only.test.ts
+++ b/app/src/fonts-woff2-only.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The `.woff` files must not reach `dist/`.
+ *
+ * `@fontsource` gives every `@font-face` a woff2 and then a `.woff` for
+ * browsers that predate it. Chromium takes the first and never asks for the
+ * second, but Vite emits every `url()` a stylesheet names, so without
+ * `woff2Only` the build ships 90 files - 1.18MB - that nothing can reach
+ * (#1149).
+ *
+ * This runs a real Vite build over one `@import`, because the mistake this
+ * guards is not in the regex. An earlier version of the plugin did the same
+ * substitution in a `transform`, which matched only because
+ * `@tailwindcss/vite` had already flattened the `@import` tree in the app's own
+ * config: on any pipeline without it - a fixture like this one, or a future
+ * Vite whose CSS plugin inlines differently - the hook saw `@import
+ * "./fonts.css";` and nothing else, stripped nothing, and every test stayed
+ * green while the 1.18MB came back. So the assertion is on emitted files, and
+ * the fixture deliberately does not load the rest of the app's plugins.
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll } from "vitest";
+import { build } from "vite";
+
+import { woff2Only } from "../vite-plugins/woff2-only";
+
+const appRoot = path.resolve(__dirname, "..");
+
+/** One family is enough: every `@fontsource` face is written the same way. */
+const FIXTURE_IMPORT = '@import "@fontsource/inter/400.css";\n';
+
+interface BuildResult {
+	files: string[];
+	css: string;
+}
+
+const buildFixture = async (plugins: ReturnType<typeof woff2Only>[]): Promise<BuildResult> => {
+	const root = mkdtempSync(path.join(tmpdir(), "vayu-woff2-"));
+	const entry = path.join(root, "entry.css");
+	writeFileSync(entry, FIXTURE_IMPORT);
+	const outDir = path.join(root, "out");
+
+	await build({
+		root,
+		logLevel: "silent",
+		// The fixture lives outside the app, so point the bare specifier at the
+		// app's own installed packages rather than copying font files around.
+		resolve: { alias: { "@fontsource": path.join(appRoot, "node_modules/@fontsource") } },
+		plugins,
+		build: { outDir, rollupOptions: { input: entry } },
+	});
+
+	const assets = path.join(outDir, "assets");
+	const files = readdirSync(assets);
+	const cssFile = files.find((f) => f.endsWith(".css"));
+	expect(cssFile).toBeDefined();
+	return { files, css: readFileSync(path.join(assets, cssFile as string), "utf8") };
+};
+
+describe("the built font assets", () => {
+	let withPlugin: BuildResult;
+	let withoutPlugin: BuildResult;
+
+	beforeAll(async () => {
+		withPlugin = await buildFixture([woff2Only()]);
+		withoutPlugin = await buildFixture([]);
+	}, 60_000);
+
+	it("carry the woff2 of every face", () => {
+		// Guards the assertions below against a fixture that emitted nothing.
+		expect(withPlugin.files.filter((f) => f.endsWith(".woff2")).length).toBeGreaterThan(0);
+		expect(withPlugin.files.filter((f) => f.endsWith(".woff2"))).toEqual(
+			withoutPlugin.files.filter((f) => f.endsWith(".woff2"))
+		);
+	});
+
+	it("carry no legacy .woff, which the plugin is the only reason for", () => {
+		expect(withPlugin.files.filter((f) => f.endsWith(".woff"))).toEqual([]);
+		// The same build without it, so the guard fails loudly rather than
+		// passing on a fixture that never had a `.woff` to begin with.
+		expect(withoutPlugin.files.filter((f) => f.endsWith(".woff")).length).toBeGreaterThan(0);
+	});
+
+	it("leave no stylesheet pointing at a file that is gone", () => {
+		expect(withPlugin.css).not.toMatch(/url\([^)]+\.woff\)/);
+		const referenced = [...withPlugin.css.matchAll(/url\(([^)]+\.woff2)\)/g)].map((m) =>
+			m[1].slice(m[1].lastIndexOf("/") + 1)
+		);
+		expect(referenced.length).toBeGreaterThan(0);
+		for (const file of referenced) expect(withPlugin.files).toContain(file);
+	});
+});

--- a/app/src/fonts.css
+++ b/app/src/fonts.css
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/*
+ * The faces the app can render, bundled rather than fetched.
+ *
+ * These six families used to arrive through one `fonts.googleapis.com`
+ * stylesheet in the head of `index.html`. A stylesheet in the head is
+ * render-blocking, and the window is only shown on `ready-to-show` - first
+ * paint, with no fallback timer (`electron/main.ts`) - so the window's
+ * appearance waited on that round trip: a revalidation on any launch after a
+ * day away, and ~12.8s of blank window on a network that black-holes the
+ * request rather than refusing it. Bundling the faces removes the renderer's
+ * only startup network dependency and makes typography identical offline.
+ *
+ * Each `@import` is one `@font-face` from the `@fontsource` package, so the
+ * `unicode-range`, `font-display: swap` and the woff2 itself stay the
+ * package's business and a version bump carries its own corrections. The
+ * families keep their real names ("Inter", not "Inter Variable"), which is why
+ * every stack in `index.css`, `tailwind.config.js`, `constants/appearance.ts`
+ * and the uPlot themes reads exactly as it did.
+ *
+ * Two axes are deliberately narrow, and both mirror what the old css2 URL
+ * asked for rather than what the packages offer:
+ *
+ * - Weights: the set each family was fetched at. `font-mono font-bold` has
+ *   always been browser-synthesised for JetBrains Mono, Fira Code and IBM Plex
+ *   Mono - none of them was ever loaded at 700 - and it still is. Adding the
+ *   real face would change how ~15 rendered call sites look, which is not this
+ *   change's business.
+ * - Subsets: latin and latin-ext. Google served the other subsets (cyrillic,
+ *   greek, vietnamese) on demand behind a `unicode-range`; bundled, they would
+ *   be installer weight every user pays for, so text outside these two subsets
+ *   falls back to the system stack that follows each family.
+ *
+ * A face added here needs a reader: it is selectable only if
+ * `constants/appearance.ts` names it in a stack.
+ * `constants/appearance.bundled-faces.test.ts` holds the two files together and
+ * fails in both directions - a family the app can select but nothing bundles,
+ * and a family bundled that nothing can select.
+ */
+
+/* Space Grotesk - the UI default (`--font-sans`). */
+@import "@fontsource/space-grotesk/latin-400.css";
+@import "@fontsource/space-grotesk/latin-500.css";
+@import "@fontsource/space-grotesk/latin-600.css";
+@import "@fontsource/space-grotesk/latin-700.css";
+@import "@fontsource/space-grotesk/latin-ext-400.css";
+@import "@fontsource/space-grotesk/latin-ext-500.css";
+@import "@fontsource/space-grotesk/latin-ext-600.css";
+@import "@fontsource/space-grotesk/latin-ext-700.css";
+
+/* Inter - the alternate UI face. */
+@import "@fontsource/inter/latin-400.css";
+@import "@fontsource/inter/latin-500.css";
+@import "@fontsource/inter/latin-600.css";
+@import "@fontsource/inter/latin-700.css";
+@import "@fontsource/inter/latin-ext-400.css";
+@import "@fontsource/inter/latin-ext-500.css";
+@import "@fontsource/inter/latin-ext-600.css";
+@import "@fontsource/inter/latin-ext-700.css";
+
+/* JetBrains Mono - the code default (`--font-mono`), and a UI option. */
+@import "@fontsource/jetbrains-mono/latin-400.css";
+@import "@fontsource/jetbrains-mono/latin-500.css";
+@import "@fontsource/jetbrains-mono/latin-600.css";
+@import "@fontsource/jetbrains-mono/latin-400-italic.css";
+@import "@fontsource/jetbrains-mono/latin-ext-400.css";
+@import "@fontsource/jetbrains-mono/latin-ext-500.css";
+@import "@fontsource/jetbrains-mono/latin-ext-600.css";
+@import "@fontsource/jetbrains-mono/latin-ext-400-italic.css";
+
+/* Fira Code - a code option. */
+@import "@fontsource/fira-code/latin-400.css";
+@import "@fontsource/fira-code/latin-500.css";
+@import "@fontsource/fira-code/latin-ext-400.css";
+@import "@fontsource/fira-code/latin-ext-500.css";
+
+/* IBM Plex Mono - a code option. */
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-ext-400.css";
+@import "@fontsource/ibm-plex-mono/latin-ext-500.css";
+
+/* Space Mono - a code option, and the one mono face with a real bold. */
+@import "@fontsource/space-mono/latin-400.css";
+@import "@fontsource/space-mono/latin-700.css";
+@import "@fontsource/space-mono/latin-ext-400.css";
+@import "@fontsource/space-mono/latin-ext-700.css";

--- a/app/src/fonts.css
+++ b/app/src/fonts.css
@@ -17,77 +17,66 @@
  * request rather than refusing it. Bundling the faces removes the renderer's
  * only startup network dependency and makes typography identical offline.
  *
- * Each `@import` is one `@font-face` from the `@fontsource` package, so the
- * `unicode-range`, `font-display: swap` and the woff2 itself stay the
+ * Each `@import` is the `@fontsource` package's own stylesheet for one weight,
+ * so the `unicode-range`, `font-display: swap` and the woff2 files stay the
  * package's business and a version bump carries its own corrections. The
  * families keep their real names ("Inter", not "Inter Variable"), which is why
  * every stack in `index.css`, `tailwind.config.js`, `constants/appearance.ts`
  * and the uPlot themes reads exactly as it did.
  *
- * Two axes are deliberately narrow, and both mirror what the old css2 URL
- * asked for rather than what the packages offer:
+ * Import the `<weight>.css` files, never the `<subset>-<weight>.css` ones. The
+ * per-subset entry points declare their `@font-face` with no `unicode-range` at
+ * all, so nothing tells the browser which file holds which characters and every
+ * subset face for a rendered weight is read, whether or not a character needs
+ * it. Measured on the built app: with per-subset imports, painting the shell
+ * read four Space Grotesk files where the weight files read two - and with
+ * every subset bundled that multiplies by seven, on the first-paint path this
+ * whole change exists to shorten. What it does *not* do is break typography -
+ * Chromium falls back within the family per character, so the text looks right
+ * and only the profiler knows - which is what makes it easy to ship by
+ * accident. `constants/appearance.bundled-faces.test.ts` fails on a range-less
+ * import.
  *
- * - Weights: the set each family was fetched at. `font-mono font-bold` has
- *   always been browser-synthesised for JetBrains Mono, Fira Code and IBM Plex
- *   Mono - none of them was ever loaded at 700 - and it still is. Adding the
- *   real face would change how ~15 rendered call sites look, which is not this
- *   change's business.
- * - Subsets: latin and latin-ext. Google served the other subsets (cyrillic,
- *   greek, vietnamese) on demand behind a `unicode-range`; bundled, they would
- *   be installer weight every user pays for, so text outside these two subsets
- *   falls back to the system stack that follows each family.
+ * The weights are the ones the old css2 URL asked for, so nothing about how the
+ * app renders changes: `font-mono font-bold` has always been
+ * browser-synthesised for JetBrains Mono, Fira Code and IBM Plex Mono - none of
+ * them was ever loaded at 700 - and it still is. Every subset each package
+ * ships is bundled, which is what Google served on demand; behind their
+ * `unicode-range` a file is still only read when a character needs it, so the
+ * subsets beyond latin cost installer bytes, not startup work.
  *
  * A face added here needs a reader: it is selectable only if
- * `constants/appearance.ts` names it in a stack.
- * `constants/appearance.bundled-faces.test.ts` holds the two files together and
- * fails in both directions - a family the app can select but nothing bundles,
- * and a family bundled that nothing can select.
+ * `constants/appearance.ts` names it in a stack. The same test holds the two
+ * files together in both directions - a family the app can select but nothing
+ * bundles, and a family bundled that nothing can select.
  */
 
 /* Space Grotesk - the UI default (`--font-sans`). */
-@import "@fontsource/space-grotesk/latin-400.css";
-@import "@fontsource/space-grotesk/latin-500.css";
-@import "@fontsource/space-grotesk/latin-600.css";
-@import "@fontsource/space-grotesk/latin-700.css";
-@import "@fontsource/space-grotesk/latin-ext-400.css";
-@import "@fontsource/space-grotesk/latin-ext-500.css";
-@import "@fontsource/space-grotesk/latin-ext-600.css";
-@import "@fontsource/space-grotesk/latin-ext-700.css";
+@import "@fontsource/space-grotesk/400.css";
+@import "@fontsource/space-grotesk/500.css";
+@import "@fontsource/space-grotesk/600.css";
+@import "@fontsource/space-grotesk/700.css";
 
 /* Inter - the alternate UI face. */
-@import "@fontsource/inter/latin-400.css";
-@import "@fontsource/inter/latin-500.css";
-@import "@fontsource/inter/latin-600.css";
-@import "@fontsource/inter/latin-700.css";
-@import "@fontsource/inter/latin-ext-400.css";
-@import "@fontsource/inter/latin-ext-500.css";
-@import "@fontsource/inter/latin-ext-600.css";
-@import "@fontsource/inter/latin-ext-700.css";
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/500.css";
+@import "@fontsource/inter/600.css";
+@import "@fontsource/inter/700.css";
 
 /* JetBrains Mono - the code default (`--font-mono`), and a UI option. */
-@import "@fontsource/jetbrains-mono/latin-400.css";
-@import "@fontsource/jetbrains-mono/latin-500.css";
-@import "@fontsource/jetbrains-mono/latin-600.css";
-@import "@fontsource/jetbrains-mono/latin-400-italic.css";
-@import "@fontsource/jetbrains-mono/latin-ext-400.css";
-@import "@fontsource/jetbrains-mono/latin-ext-500.css";
-@import "@fontsource/jetbrains-mono/latin-ext-600.css";
-@import "@fontsource/jetbrains-mono/latin-ext-400-italic.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+@import "@fontsource/jetbrains-mono/600.css";
+@import "@fontsource/jetbrains-mono/400-italic.css";
 
 /* Fira Code - a code option. */
-@import "@fontsource/fira-code/latin-400.css";
-@import "@fontsource/fira-code/latin-500.css";
-@import "@fontsource/fira-code/latin-ext-400.css";
-@import "@fontsource/fira-code/latin-ext-500.css";
+@import "@fontsource/fira-code/400.css";
+@import "@fontsource/fira-code/500.css";
 
 /* IBM Plex Mono - a code option. */
-@import "@fontsource/ibm-plex-mono/latin-400.css";
-@import "@fontsource/ibm-plex-mono/latin-500.css";
-@import "@fontsource/ibm-plex-mono/latin-ext-400.css";
-@import "@fontsource/ibm-plex-mono/latin-ext-500.css";
+@import "@fontsource/ibm-plex-mono/400.css";
+@import "@fontsource/ibm-plex-mono/500.css";
 
 /* Space Mono - a code option, and the one mono face with a real bold. */
-@import "@fontsource/space-mono/latin-400.css";
-@import "@fontsource/space-mono/latin-700.css";
-@import "@fontsource/space-mono/latin-ext-400.css";
-@import "@fontsource/space-mono/latin-ext-700.css";
+@import "@fontsource/space-mono/400.css";
+@import "@fontsource/space-mono/700.css";

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+/* The bundled faces behind every stack below - see fonts.css for what and why. */
+@import "./fonts.css";
 @config "../tailwind.config.js";
 
 /* Tailwind 4 theme configuration for custom colors */

--- a/app/vite-plugins/woff2-only.ts
+++ b/app/vite-plugins/woff2-only.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import type { Plugin } from "vite";
+
+/**
+ * A `.woff` listed after a woff2 in the same `src:`, and the file it names.
+ * `@fontsource` writes every face that way for browsers older than woff2.
+ */
+const LEGACY_WOFF_SOURCE = /,\s*url\(([^)]+\.woff)\)\s*format\(["']woff["']\)/g;
+
+const basename = (url: string): string => url.slice(url.lastIndexOf("/") + 1);
+
+/**
+ * Ship woff2 only.
+ *
+ * The `@fontsource` stylesheets give each `@font-face` two sources - the woff2,
+ * then a `.woff` for browsers that predate it. The renderer is Chromium, which
+ * takes the first and never asks for the second, but Vite emits every `url()` a
+ * stylesheet names: importing the packages as they ship put 90 unreachable
+ * files, 1.18MB, into `dist/assets`, measured by building with this plugin off.
+ *
+ * It works on the assembled bundle rather than in a `transform`, and that is
+ * the whole design. A `transform` sees `index.css` before Vite's CSS plugin
+ * inlines the `@import` tree - the font faces are not in the text yet - so a
+ * `pre` transform only matches at all because `@tailwindcss/vite` happens to
+ * flatten the imports first, and a `post` one is too late, the urls having
+ * already become `__VITE_ASSET__` placeholders. Both make correctness a
+ * property of plugin order. By `generateBundle` the CSS is final text with real
+ * filenames, whoever produced it.
+ *
+ * Deleting a source rather than hand-writing our own `@font-face` blocks is
+ * also deliberate: those blocks would copy each face's `unicode-range` into
+ * this repo and stop receiving the package's corrections.
+ */
+export const woff2Only = (): Plugin => ({
+	name: "vayu:woff2-only",
+	generateBundle(_options, bundle) {
+		const unreferenced = new Set<string>();
+
+		for (const asset of Object.values(bundle)) {
+			if (asset.type !== "asset" || !asset.fileName.endsWith(".css")) continue;
+			const css =
+				typeof asset.source === "string"
+					? asset.source
+					: Buffer.from(asset.source).toString();
+			const stripped = css.replace(LEGACY_WOFF_SOURCE, (_match, url: string) => {
+				unreferenced.add(basename(url));
+				return "";
+			});
+			if (stripped !== css) asset.source = stripped;
+		}
+
+		if (unreferenced.size === 0) return;
+
+		// Only drop a file nothing points at any more: a stylesheet this plugin
+		// did not touch is free to name the same face, and deleting out from
+		// under it would be a 404 rather than a saving.
+		const stillReferenced = new Set<string>();
+		for (const asset of Object.values(bundle)) {
+			if (asset.type !== "asset" || !asset.fileName.endsWith(".css")) continue;
+			const css =
+				typeof asset.source === "string"
+					? asset.source
+					: Buffer.from(asset.source).toString();
+			for (const name of unreferenced) if (css.includes(name)) stillReferenced.add(name);
+		}
+
+		for (const [key, asset] of Object.entries(bundle)) {
+			if (asset.type !== "asset") continue;
+			const name = basename(asset.fileName);
+			if (unreferenced.has(name) && !stillReferenced.has(name)) delete bundle[key];
+		}
+	},
+});

--- a/app/vite-plugins/woff2-only.ts
+++ b/app/vite-plugins/woff2-only.ts
@@ -8,8 +8,12 @@
 import type { Plugin } from "vite";
 
 /**
- * A `.woff` listed after a woff2 in the same `src:`, and the file it names.
- * `@fontsource` writes every face that way for browsers older than woff2.
+ * A `.woff` listed *after* another source in the same `src:`, and the file it
+ * names. Every `@fontsource` face is written that way - woff2 first, the legacy
+ * file behind it - and the leading comma is what says the browser had a better
+ * option before reaching this one. A stylesheet that ever lists the `.woff`
+ * first is left alone rather than left broken: nothing would then be stripped,
+ * and the build grows by the files, which `fonts-woff2-only.test.ts` reads.
  */
 const LEGACY_WOFF_SOURCE = /,\s*url\(([^)]+\.woff)\)\s*format\(["']woff["']\)/g;
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -20,7 +20,8 @@ const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, "./package.j
  * Each of their `@font-face` rules lists woff2 first and a `.woff` after it for
  * browsers that predate woff2. Chromium takes the woff2 and never asks for the
  * sibling - but Vite emits every `url()` a stylesheet names, so importing the
- * packages as they ship put 36 unreachable files (769KB) in `dist/assets`.
+ * packages as they ship put 90 unreachable files (1.18MB) in `dist/assets`,
+ * measured by building with this plugin off.
  *
  * Stripping the second source here rather than hand-writing our own
  * `@font-face` blocks is deliberate: those blocks would copy each face's

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -14,6 +14,34 @@ import { readFileSync } from "fs";
 // Read version from package.json
 const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf-8"));
 
+/**
+ * Drop the legacy `.woff` source from the `@fontsource` stylesheets.
+ *
+ * Each of their `@font-face` rules lists woff2 first and a `.woff` after it for
+ * browsers that predate woff2. Chromium takes the woff2 and never asks for the
+ * sibling - but Vite emits every `url()` a stylesheet names, so importing the
+ * packages as they ship put 36 unreachable files (769KB) in `dist/assets`.
+ *
+ * Stripping the second source here rather than hand-writing our own
+ * `@font-face` blocks is deliberate: those blocks would copy each face's
+ * `unicode-range` into this repo and stop receiving the package's corrections.
+ * The rule is matched on the `url()` itself, not on the module id, because the
+ * `@import`s are already inlined into `index.css` by the time any plugin sees
+ * it.
+ */
+const woff2Only = {
+	name: "vayu:woff2-only",
+	enforce: "pre" as const,
+	transform(code: string, id: string) {
+		if (!id.split("?")[0].endsWith(".css")) return null;
+		const stripped = code.replace(
+			/,\s*url\(([^)]*@fontsource[^)]*)\.woff\)\s*format\(["']woff["']\)/g,
+			""
+		);
+		return stripped === code ? null : stripped;
+	},
+};
+
 export default defineConfig({
 	// Tailwind v4 runs as a Vite plugin, not a PostCSS plugin. As a PostCSS
 	// plugin it injected generated declarations with no `source.input.file`,
@@ -21,7 +49,7 @@ export default defineConfig({
 	// `from` option to `postcss.parse`" on every dev CSS transform. As a Vite
 	// plugin its output is re-parsed with a real `from`, so no fromless nodes.
 	// Autoprefixer stays in postcss.config.cjs, so vendor prefixing is unchanged.
-	plugins: [react(), tailwindcss()],
+	plugins: [react(), tailwindcss(), woff2Only],
 	define: {
 		__VAYU_VERSION__: JSON.stringify(packageJson.version),
 	},

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,40 +8,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { woff2Only } from "./vite-plugins/woff2-only";
 import path from "path";
 import { readFileSync } from "fs";
 
 // Read version from package.json
 const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf-8"));
-
-/**
- * Drop the legacy `.woff` source from the `@fontsource` stylesheets.
- *
- * Each of their `@font-face` rules lists woff2 first and a `.woff` after it for
- * browsers that predate woff2. Chromium takes the woff2 and never asks for the
- * sibling - but Vite emits every `url()` a stylesheet names, so importing the
- * packages as they ship put 90 unreachable files (1.18MB) in `dist/assets`,
- * measured by building with this plugin off.
- *
- * Stripping the second source here rather than hand-writing our own
- * `@font-face` blocks is deliberate: those blocks would copy each face's
- * `unicode-range` into this repo and stop receiving the package's corrections.
- * The rule is matched on the `url()` itself, not on the module id, because the
- * `@import`s are already inlined into `index.css` by the time any plugin sees
- * it.
- */
-const woff2Only = {
-	name: "vayu:woff2-only",
-	enforce: "pre" as const,
-	transform(code: string, id: string) {
-		if (!id.split("?")[0].endsWith(".css")) return null;
-		const stripped = code.replace(
-			/,\s*url\(([^)]*@fontsource[^)]*)\.woff\)\s*format\(["']woff["']\)/g,
-			""
-		);
-		return stripped === code ? null : stripped;
-	},
-};
 
 export default defineConfig({
 	// Tailwind v4 runs as a Vite plugin, not a PostCSS plugin. As a PostCSS
@@ -50,7 +22,10 @@ export default defineConfig({
 	// `from` option to `postcss.parse`" on every dev CSS transform. As a Vite
 	// plugin its output is re-parsed with a real `from`, so no fromless nodes.
 	// Autoprefixer stays in postcss.config.cjs, so vendor prefixing is unchanged.
-	plugins: [react(), tailwindcss(), woff2Only],
+	// `woff2Only` drops the legacy `.woff` sibling `@fontsource` names next to
+	// every woff2 - 90 files, 1.18MB, that Chromium never asks for. See the
+	// plugin for why it works on the bundle rather than in a transform.
+	plugins: [react(), tailwindcss(), woff2Only()],
 	define: {
 		__VAYU_VERSION__: JSON.stringify(packageJson.version),
 	},

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -279,6 +279,9 @@ Key settings in `vite.config.ts`:
 - **Port**: 5173 (dev server)
 - **Aliases**: Path shortcuts (`@/components`, `@/stores`, etc.)
 - **Code Splitting**: React vendor and charts in separate chunks
+- **`vayu:woff2-only`**: strips the legacy `.woff` source from the
+  `@fontsource` stylesheets, which Chromium never asks for but Vite would
+  otherwise emit alongside every woff2 (36 unreachable files, 769KB)
 
 ## Dependencies
 
@@ -292,6 +295,8 @@ Key settings in `vite.config.ts`:
 - **Tailwind CSS**: Styling
 - **Monaco Editor**: Code editing
 - **uPlot**: Charts
+- **@fontsource** (Space Grotesk, Inter, JetBrains Mono, Fira Code, IBM Plex
+  Mono, Space Mono): bundled font faces, imported from `src/fonts.css`
 
 ### Development Dependencies
 

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -281,7 +281,7 @@ Key settings in `vite.config.ts`:
 - **Code Splitting**: React vendor and charts in separate chunks
 - **`vayu:woff2-only`**: strips the legacy `.woff` source from the
   `@fontsource` stylesheets, which Chromium never asks for but Vite would
-  otherwise emit alongside every woff2 (36 unreachable files, 769KB)
+  otherwise emit alongside every woff2 (90 unreachable files, 1.18MB)
 
 ## Dependencies
 

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -279,9 +279,12 @@ Key settings in `vite.config.ts`:
 - **Port**: 5173 (dev server)
 - **Aliases**: Path shortcuts (`@/components`, `@/stores`, etc.)
 - **Code Splitting**: React vendor and charts in separate chunks
-- **`vayu:woff2-only`**: strips the legacy `.woff` source from the
-  `@fontsource` stylesheets, which Chromium never asks for but Vite would
-  otherwise emit alongside every woff2 (90 unreachable files, 1.18MB)
+- **`vayu:woff2-only`** (`vite-plugins/woff2-only.ts`): strips the legacy
+  `.woff` source from the `@fontsource` stylesheets, which Chromium never asks
+  for but Vite would otherwise emit alongside every woff2 (90 unreachable
+  files, 1.18MB). It edits the assembled bundle rather than a `transform`, so
+  it does not depend on which plugin inlines the `@import` tree;
+  `src/fonts-woff2-only.test.ts` builds a fixture with and without it
 
 ## Dependencies
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -831,18 +831,36 @@ only desaturated option.
 
 | Role | Family | Import |
 |------|--------|--------|
-| UI / body | Space Grotesk | Google Fonts |
-| Code / mono | JetBrains Mono | Google Fonts |
+| UI / body default | Space Grotesk | Bundled (`@fontsource`) |
+| UI / body alternate | Inter | Bundled (`@fontsource`) |
+| Code / mono default | JetBrains Mono | Bundled (`@fontsource`) |
+| Code / mono option | Fira Code | Bundled (`@fontsource`) |
+| Code / mono option | IBM Plex Mono | Bundled (`@fontsource`) |
+| Code / mono option | Space Mono | Bundled (`@fontsource`) |
 
-```html
-<!-- app/index.html -->
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
+```css
+/* app/src/index.css */
+@import "./fonts.css";
 ```
+
+`app/src/fonts.css` holds the `@fontsource` `@import` lines for all six
+families - the weights bundled, the subsets, and why.
 
 ```css
 body { font-family: var(--font-sans); } /* default: "Space Grotesk", system-ui, sans-serif */
 /* mono via font-mono Tailwind class, or .font-code utility */
 ```
+
+The faces are bundled rather than fetched because a stylesheet in
+`index.html`'s head is render-blocking and the window is only shown on first
+paint, so the fetch delayed the window appearing at all - measured at ~12.8s
+on a network that black-holes the request. Nothing about how the app renders
+changed with the move: the weights bundled are exactly the ones the old css2
+URL asked for, so `font-mono font-bold` stays browser-synthesised for JetBrains
+Mono, Fira Code and IBM Plex Mono, same as before. Every subset each family
+ships is bundled too, which is what Google served on demand; behind their
+`unicode-range` a file is still only read when a character needs it, so the
+subsets beyond latin cost installer bytes and no startup work.
 
 **User-selectable UI font + scale.** Settings → Appearance → Interface lets the
 user pick the sans/body face (Space Grotesk / Inter / System / JetBrains Mono)
@@ -2177,7 +2195,8 @@ opt-out.
 |------|---------|
 | `app/src/index.css` | All CSS custom properties, keyframes, utility classes |
 | `app/tailwind.config.js` | Color mapping, font families, keyframes, animation aliases |
-| `app/index.html` | Google Fonts preconnect + link tags |
+| `app/index.html` | Pre-paint appearance script; no font `<link>` (see `fonts.css`) |
+| `app/src/fonts.css` | Bundled `@fontsource` imports for all six font families |
 | `app/src/components/layout/Shell.tsx` | Root layout - resizable sidebar + drag handle + main |
 | `app/src/components/layout/Sidebar.tsx` | ActivityBar + SidebarPanel |
 | `app/src/hooks/useResizable.ts` | Drag-to-resize hook (delta-based, horizontal/vertical) |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -829,14 +829,14 @@ only desaturated option.
 
 ### Fonts
 
-| Role | Family | Import |
-|------|--------|--------|
-| UI / body default | Space Grotesk | Bundled (`@fontsource`) |
-| UI / body alternate | Inter | Bundled (`@fontsource`) |
-| Code / mono default | JetBrains Mono | Bundled (`@fontsource`) |
-| Code / mono option | Fira Code | Bundled (`@fontsource`) |
-| Code / mono option | IBM Plex Mono | Bundled (`@fontsource`) |
-| Code / mono option | Space Mono | Bundled (`@fontsource`) |
+| Role | Family | Weights bundled | Source |
+|------|--------|-----------------|--------|
+| UI / body default | Space Grotesk | 400, 500, 600, 700 | `@fontsource`, in the app |
+| UI / body alternate | Inter | 400, 500, 600, 700 | `@fontsource`, in the app |
+| Code / mono default | JetBrains Mono | 400, 500, 600, 400 italic | `@fontsource`, in the app |
+| Code / mono option | Fira Code | 400, 500 | `@fontsource`, in the app |
+| Code / mono option | IBM Plex Mono | 400, 500 | `@fontsource`, in the app |
+| Code / mono option | Space Mono | 400, 700 | `@fontsource`, in the app |
 
 ```css
 /* app/src/index.css */


### PR DESCRIPTION
## Description

The renderer's only startup network dependency was one render-blocking `fonts.googleapis.com` stylesheet in the head of `app/index.html`, covering six families of which four are merely selectable options. The window is shown on `ready-to-show` with no fallback timer (`electron/main.ts:277, 289-291`), so the window's *appearance* waited on that round trip - a revalidation on any launch after a day away, and the ~12.8s blank window #1171's measurements found on a network that black-holes the request.

**Approach.** `app/src/fonts.css` declares the same faces from the `@fontsource` packages, at the weights and styles the old css2 URL asked for, and `index.css` imports it; the two preconnects and the stylesheet link are gone. The static packages keep the real family names, so every stack in `index.css`, `tailwind.config.js`, `constants/appearance.ts`, the pre-paint script and the uPlot themes is untouched, and a user's custom-font entry still resolves the same way.

**Rejected alternative:** `@fontsource-variable/*`. One file per subset covers the whole weight axis, so it is roughly 300KB smaller - but those packages name the families "Inter Variable", "Space Grotesk Variable" and so on. Every stack in the five places above would have to carry a second name for the same face, the custom-font path would silently miss it, and the design-system doc would document a name no user recognises. Not worth the bytes.

Also rejected: hand-writing `@font-face` blocks against the packages' woff2 files. That copies each face's `unicode-range` into this repo, which is the "hand-rolled copy of a primitive does not receive the primitive's fixes" defect the repo CLAUDE.md names.

### Two things the diff carries that the issue did not name

1. **`vayu:woff2-only`** (`app/vite-plugins/woff2-only.ts`). The `@fontsource` stylesheets list a legacy `.woff` after each woff2. Chromium never asks for it, but Vite emits every `url()` a stylesheet names - so importing the packages as they ship put **90 unreachable files, 1.18MB**, into `dist/assets` (measured by building with the plugin off). That is weight this PR would have introduced, next door to #1147's complaint about unreachable Monaco workers, so it is cleaned up here rather than deferred.

2. **The `<weight>.css` entry points, not the `<subset>-<weight>.css` ones.** Caught by reading the built CSS, then measured in Chromium: the per-subset files declare their `@font-face` with **no `unicode-range` at all**, so nothing tells the browser which file holds which characters and every subset face for a rendered weight is read whether a character needs it or not. Painting the shell that way read **four** Space Grotesk files where the weight files read **two**; with every subset bundled that is seven times the font bytes on the first-paint path this PR exists to shorten. It does not break typography - the browser falls back within the family per character, so the text looks right and only the profiler knows, which is exactly what makes it easy to ship by accident. `appearance.bundled-faces.test.ts` now fails on a range-less import.

### Two corrections made during review, recorded because the history shows them

- The first commit's message calls that second point a rendering failure. That was my reading of the spec before I measured it; the amended message and the code comments state the measured behaviour.
- The plugin began as a `pre` `transform`, and a review of Vite's own pipeline argued it could never fire - a `transform` sees `index.css` before the CSS plugin inlines the `@import` tree, and after it the urls are already `__VITE_ASSET__` placeholders. The build disagreed (90 `.woff` without it, 0 with it) and **both were true**: it matched only because `@tailwindcss/vite` had already flattened the imports by the time a `pre` hook ran. Correctness by plugin order is not correctness, so it now works in `generateBundle`, on final text with real filenames, and deletes a font file only when nothing still points at it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **558 files, 6086 tests, all passing** (baseline on `2efcd48`: 556 files, 6076 tests, so +2 files and +10 tests, no pre-existing failures). Also green: `pnpm type-check`, `pnpm lint`, `pnpm format:check`. No engine build or `ctest`: the diff is `app/` plus two docs, so no C++ test could change colour. `mkdocs build --strict` was **not** run - mkdocs is not installed in this container and the docs edits add no links or headings; the Docs site workflow is green on the branch.

**The built output, read back** (`pnpm run build`):

| Check | Result |
|---|---|
| `grep -r "fonts.googleapis\|fonts.gstatic" dist/` | empty |
| `@font-face` rules in the entry CSS | 94, each with a `unicode-range` |
| woff2 emitted / referenced / orphaned | 85 / 85 / 0 (971KB) |
| legacy `.woff` emitted | 0 (90 and 1.18MB without the plugin) |

**The built app, in Chromium under `file://` with the engine down** - the closest thing available here to the issue's "devtools network panel clean on launch":

- 94 faces declared from the bundled stylesheet, and the shell paints in Space Grotesk: 90px against 96.3px for the same string in the monospace fallback.
- Rendering read exactly **two** font files (`space-grotesk-latin-400`, `-600`) out of the 85 bundled - the `unicode-range` keeps the rest on disk.
- The only requests leaving the renderer are to `127.0.0.1:9876`, the app's own engine sidecar. Nothing external, offline or not. (Monaco already uses the bundled copy rather than jsDelivr, so nothing else reaches out either.)

Every new rule is mutation-checked - the fix reverted, the test confirmed red, the fix restored:

| Reverted | Test that reds |
|---|---|
| a Google Fonts `<link>` back in the head | "are the only source of a face - nothing in the head fetches one" |
| `index.css` stops importing `fonts.css` | "reach the renderer - index.css imports them" |
| the import moved below a rule | "are declared before any rule, as CSS requires of an @import" |
| one family unbundled | "are exactly the faces the pickers offer" |
| one import swapped to `latin-400.css` | "each declare the range they cover, so only the needed file is read" |
| the plugin dropped from the fixture build | "carry no legacy .woff, which the plugin is the only reason for" |

That last guard builds a one-line fixture twice, with the plugin and without, and asserts on emitted files - deliberately without the app's other plugins, since the transform version passed every unit-level check while depending on Tailwind to have run first. Two builds, ~550ms.

### Deliberate deviations, recorded

- **AC1 as written is unreachable and stays that way.** The renderer still calls the local engine on `127.0.0.1:9876` at boot. That is the sidecar the app is built on, not the network; what this PR removes is every request that leaves the machine.
- **The optional mono families are bundled, not lazy-loaded on selection** - the issue's own recommendation ("bundled-all is simpler and offline-correct"). Behind their `unicode-range` they are installer bytes, never startup work.
- **Weights are unchanged from what the css2 URL fetched**, so `font-mono font-bold` stays browser-synthesised for JetBrains Mono, Fira Code and IBM Plex Mono exactly as before. Adding the real 700 face would change how ~15 rendered call sites look, which is not this change's business.
- **`docs/index.md`'s offline FAQ is untouched.** "Vayu contacts no external server during normal use" was contradicted by the font fetch and is simply true now; adding a fonts clause to it would be padding.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1149

Unblocks the startup half of #1143 alongside #1147; #1165 is sequenced after both.