### PR TITLE
feat(app): command palette launcher capabilities - Recents, Quick actions, chord chips and a hints footer - #1176

### DIFF
--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -59,11 +59,13 @@ const CommandDialog = ({
 			{/* No corner close button: it would land on top of the search field,
 			    and Escape or a click outside is how a palette is dismissed.
 
-			    No `DialogBody` either (issue #773): a palette is its input plus
-			    `CommandList`, which caps and scrolls itself, so the band that
-			    would claim the leftover height already exists one level in. The
-			    panel's cap still applies, and `overflow-hidden` keeps the list's
-			    own scroll the only one. */}
+			    No `DialogBody` either (issue #773): a palette is its input,
+			    `CommandList` and a footer of hints, and the list caps and
+			    scrolls itself - so the band that would claim the leftover
+			    height already exists one level in, and the two around it are
+			    `shrink-0` rather than growing. The panel's cap still applies,
+			    and `overflow-hidden` keeps the list's own scroll the only
+			    one. */}
 			<DialogContent showClose={false} className={cn("overflow-hidden p-0", className)}>
 				<DialogTitle className="sr-only">{title}</DialogTitle>
 				<DialogDescription className="sr-only">{description}</DialogDescription>

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -107,6 +107,32 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
 	);
 }
 
+/**
+ * The band under the list, for keyboard hints.
+ *
+ * Outside `CommandList` on purpose, and that is the whole rule: the list is the
+ * one thing that scrolls here (issue #773), so hints placed inside it would
+ * scroll away with the results they describe - the same reason `DialogFooter`
+ * sits outside `DialogBody` in every other dialog. `shrink-0` keeps it a band
+ * rather than the first thing a full panel squashes.
+ *
+ * `border-t` rather than `border-rule`: nothing in this tree declares a
+ * surface, and `border-rule` under none falls back to the invisible default.
+ * The input's divider one band up is the same token for the same reason.
+ */
+function CommandFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="command-footer"
+			className={cn(
+				"flex shrink-0 items-center gap-3 border-t px-3 py-2 text-[10px] text-muted-foreground",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
 function CommandEmpty(props: React.ComponentProps<typeof CommandPrimitive.Empty>) {
 	return (
 		<CommandPrimitive.Empty
@@ -164,6 +190,7 @@ export {
 	CommandDialog,
 	CommandInput,
 	CommandList,
+	CommandFooter,
 	CommandEmpty,
 	CommandGroup,
 	CommandItem,

--- a/app/src/components/ui/dialog-height-band.test.tsx
+++ b/app/src/components/ui/dialog-height-band.test.tsx
@@ -136,8 +136,8 @@ describe("the dialogs that can grow", () => {
 		// Bands of its own (header, tab strip, body, footer), each with a
 		// divider, and the scroll already on the one that needs it.
 		["modules/collections/ImportModal.tsx", "manages its own bands"],
-		// A palette is its input plus `CommandList`, which caps and scrolls
-		// itself one level in.
+		// A palette is its input, `CommandList` and a footer of hints. The list
+		// caps and scrolls itself one level in; the bands around it do not grow.
 		["components/ui/command.tsx", "cmdk owns the list scroll"],
 		// Header and footer only - there is no middle to scroll.
 		["components/ui/delete-confirm-dialog.tsx", "no body"],

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -106,6 +106,7 @@ export {
 	CommandDialog,
 	CommandInput,
 	CommandList,
+	CommandFooter,
 	CommandEmpty,
 	CommandGroup,
 	CommandItem,

--- a/app/src/lib/commands/registry.ts
+++ b/app/src/lib/commands/registry.ts
@@ -27,6 +27,7 @@
 // `Zap` is the load-test mark throughout the app - the dashboard tab, a finished
 // load run in the strip (`tab-descriptors.ts`). The palette uses the same bolt.
 import { Download, Play, Plus, Settings, SunMoon, X, Zap } from "lucide-react";
+import { CLOSE_TAB_CHORD, LOAD_TEST_CHORD, SETTINGS_CHORD } from "@/constants/shortcuts";
 import { useImportModalStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
@@ -93,6 +94,9 @@ const ACTION_COMMANDS: readonly Command[] = [
 		keywords: ["load", "benchmark", "stress", "performance", "rps", "throughput", "start"],
 		group: "action",
 		icon: Zap,
+		// The builder's window handler matches this chord and calls the very
+		// `startLoadTest` below - the one the mounted builder contributes.
+		shortcut: LOAD_TEST_CHORD,
 		/*
 		 * The one surface no host can mount for itself. Starting a load test needs
 		 * the request builder's live draft, so the mounted builder contributes the
@@ -109,6 +113,8 @@ const ACTION_COMMANDS: readonly Command[] = [
 		keywords: ["dismiss", "shut"],
 		group: "action",
 		icon: X,
+		// The Shell's handler closes the same active tab on this chord.
+		shortcut: CLOSE_TAB_CHORD,
 		available: (ctx) => ctx.activeTab !== null,
 		perform: (ctx) => {
 			if (ctx.activeTab) useTabsStore.getState().closeTab(ctx.activeTab.id);
@@ -129,6 +135,8 @@ const ACTION_COMMANDS: readonly Command[] = [
 		keywords: ["preferences", "options", "config"],
 		group: "action",
 		icon: Settings,
+		// The Shell's handler opens the same tab on ⌘, - see `openSettingsTab`.
+		shortcut: SETTINGS_CHORD,
 		perform: openSettingsTab,
 	},
 ];

--- a/app/src/lib/commands/types.ts
+++ b/app/src/lib/commands/types.ts
@@ -21,6 +21,7 @@
  */
 
 import type { LucideIcon } from "lucide-react";
+import type { Chord } from "@/lib/platform";
 import type { Tab } from "@/stores";
 import type { Collection } from "@/types";
 
@@ -98,6 +99,16 @@ export interface Command {
 	icon: LucideIcon;
 	/** Where the row says this action already lives, when that is not obvious. */
 	subtitle?: string;
+	/**
+	 * The chord that already runs this action, for a surface that advertises it.
+	 *
+	 * The `Chord` object from `constants/shortcuts.ts` and never a second
+	 * spelling of it (#938): a row printing "⌘W" that the handler does not
+	 * listen for is exactly the drift that file exists to end. Present only
+	 * where a chord genuinely runs *this* command - most commands have none, and
+	 * inventing one for them would put a key on screen that does nothing.
+	 */
+	shortcut?: Chord;
 	/**
 	 * Whether this command can run at all right now. Omitted means always -
 	 * spelled that way rather than `() => true` so the roster reads as "these

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -34,7 +34,10 @@ import { CommandPalette } from "./CommandPalette";
 import { useImportModalStore, useLayoutStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import { useLiveCommandSurfaceStore } from "@/lib/commands";
-import { isMac } from "@/lib/platform";
+import { CLOSE_TAB_CHORD } from "@/constants/shortcuts";
+import { chordKeys, isMac } from "@/lib/platform";
+import { formatRelativeTime } from "@/utils";
+import { RECENT_LIMIT } from "./ranking";
 
 /**
  * The primary modifier as this platform sends it.
@@ -145,6 +148,19 @@ function typeQuery(text: string) {
 /** Enter on the highlighted row - cmdk handles the key on its root. */
 function pressEnter() {
 	fireEvent.keyDown(input(), { key: "Enter" });
+}
+
+/** The rows under one heading, in visible order. */
+function rowsUnder(heading: string): string[] {
+	const group = screen.getByText(heading).closest("[cmdk-group]")!;
+	return [...group.querySelectorAll("[cmdk-item]")].map(
+		(el) => el.querySelector("span.flex-1")?.textContent ?? ""
+	);
+}
+
+/** Every group heading on screen, in visible order. */
+function headings(): string[] {
+	return [...document.querySelectorAll("[cmdk-group-heading]")].map((el) => el.textContent ?? "");
 }
 
 /** Every result row on screen, in visible order. Escape rows are not results. */
@@ -325,11 +341,10 @@ describe("the empty query", () => {
 		renderPalette();
 		open();
 
-		const tabsGroup = screen.getByText("Tabs").closest("[cmdk-group]")!;
-		const labels = [...tabsGroup.querySelectorAll("[cmdk-item]")].map(
-			(el) => el.querySelector("span.flex-1")?.textContent
-		);
-		expect(labels).toEqual(["Inbox", "Variables", "Settings"]);
+		// Recency is what Recents is ordered by, and a dated row is lifted into
+		// it - so this is where the attention order shows, rather than inside
+		// Tabs as it did before the section existed.
+		expect(rowsUnder("Recents")).toEqual(["Inbox", "Variables", "Settings"]);
 	});
 
 	it("puts the most recently sent request first", async () => {
@@ -344,12 +359,10 @@ describe("the empty query", () => {
 		renderPalette();
 		open();
 
-		const group = screen.getByText("Requests").closest("[cmdk-group]")!;
-		const labels = [...group.querySelectorAll("[cmdk-item]")].map(
-			(el) => el.querySelector("span.flex-1")?.textContent
-		);
-		// Tree order is Charge card, Refund, Issue token; Refund ran last.
-		expect(labels[0]).toBe("Refund");
+		// Tree order is Charge card, Refund, Issue token; Refund ran last, and
+		// Issue token has never run, so it is not recent at all.
+		expect(rowsUnder("Recents")).toEqual(["Refund", "Charge card"]);
+		expect(rowsUnder("Requests")).toEqual(["Issue token"]);
 	});
 
 	it("keeps the groups in a fixed order", async () => {
@@ -362,17 +375,174 @@ describe("the empty query", () => {
 		open();
 
 		expect(screen.getByText("Tabs")).toBeInTheDocument();
-		const headings = [...document.querySelectorAll("[cmdk-group-heading]")].map(
-			(el) => el.textContent
-		);
-		expect(headings).toEqual([
+		// Nothing here is dated - no focus time, no runs - so Recents is absent
+		// and the verbs lead. "Commands" does not appear: on an empty query its
+		// rows are Quick actions.
+		expect(headings()).toEqual([
+			"Quick actions",
 			"Tabs",
 			"Requests",
 			"Collections",
 			"Views",
-			"Commands",
 			"Settings",
 		]);
+	});
+});
+
+/**
+ * The launcher affordances (#1176): the two sections the empty query leads
+ * with, the chord chips, and the hints under the list.
+ *
+ * The thing each of these is guarding is the same one the top result guards -
+ * a section above the fixed order holds rows *lifted* out of the sections
+ * below, never copied into it. Two rows carrying the same cmdk `value` both
+ * read as selected, and both would be counted.
+ */
+describe("the launcher sections", () => {
+	/** Three tabs and two sent requests: five dated rows, one short of the cap. */
+	function withRecentActivity() {
+		useTabsStore.setState({
+			openTabs: [
+				{ id: "t1", type: "settings", entityId: null },
+				{ id: "t2", type: "inbox", entityId: null },
+				{ id: "t3", type: "variables", entityId: null },
+			],
+			activeTabId: "t1",
+			tabFocusedAt: { t1: 9000, t2: 8000, t3: 7000 },
+		});
+		runPages = [
+			{
+				data: [
+					{ id: "run2", requestId: "r2", startTime: 5000 },
+					{ id: "run1", requestId: "r1", startTime: 1000 },
+				],
+			},
+		];
+	}
+
+	it("leads with Recents, then the verbs, above the fixed order", () => {
+		withRecentActivity();
+		renderPalette();
+		open();
+
+		expect(headings().slice(0, 2)).toEqual(["Recents", "Quick actions"]);
+	});
+
+	it("lifts a recent row out of its own section rather than copying it", () => {
+		withRecentActivity();
+		renderPalette();
+		open();
+
+		const rows = visibleRows();
+		// A lifted row appears exactly once in the whole list. Only the request
+		// names are asserted this way: a tab reads as its view does ("Inbox" is
+		// both an open tab and the drawer view), so a count would be testing
+		// that coincidence rather than the lift.
+		for (const label of ["Refund", "Charge card"]) {
+			expect(rows.filter((row) => row === label)).toHaveLength(1);
+		}
+		// The section a row was lifted from no longer lists it - and with every
+		// tab dated, Tabs has nothing left to render at all.
+		expect(screen.queryByText("Tabs")).not.toBeInTheDocument();
+		expect(rowsUnder("Requests")).toEqual(["Issue token"]);
+	});
+
+	it("counts a lifted row once in the announcement", () => {
+		withRecentActivity();
+		renderPalette();
+		open();
+
+		const announced = screen.getByText(/^\d+ results$/).textContent ?? "";
+		expect(announced).toBe(`${visibleRows().length} results`);
+	});
+
+	it("caps Recents, keeping the newest", () => {
+		useTabsStore.setState({
+			openTabs: Array.from({ length: RECENT_LIMIT + 2 }, (_, i) => ({
+				id: `t${i}`,
+				type: "settings" as const,
+				entityId: null,
+			})),
+			activeTabId: "t0",
+			// t0 is the oldest, so the two oldest fall off the end of the cap.
+			tabFocusedAt: Object.fromEntries(
+				Array.from({ length: RECENT_LIMIT + 2 }, (_, i) => [`t${i}`, 1000 + i])
+			),
+		});
+		renderPalette();
+		open();
+
+		expect(rowsUnder("Recents")).toHaveLength(RECENT_LIMIT);
+		// The two that did not fit are still reachable, in the section they
+		// were lifted from - a cap must not make a row unreachable.
+		expect(rowsUnder("Tabs")).toHaveLength(2);
+	});
+
+	it("says how long ago a recent row was touched", () => {
+		const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+		runPages = [{ data: [{ id: "run2", requestId: "r2", startTime: fiveMinutesAgo }] }];
+		renderPalette();
+		open();
+
+		const row = screen.getByText("Refund").closest("[cmdk-item]")!;
+		expect(row.textContent).toContain(formatRelativeTime(fiveMinutesAgo));
+	});
+
+	it("offers the verbs on an empty query and ranks them as Commands on a typed one", () => {
+		renderPalette();
+		open();
+
+		expect(rowsUnder("Quick actions")).toContain("Import collection");
+		expect(screen.queryByText("Commands")).not.toBeInTheDocument();
+
+		typeQuery("import");
+		expect(screen.queryByText("Quick actions")).not.toBeInTheDocument();
+		expect(screen.queryByText("Recents")).not.toBeInTheDocument();
+		expect(visibleRows()).toContain("Import collection");
+	});
+
+	/*
+	 * Nothing here asserts a platform, for the reason `KeyboardShortcutsPanel`'s
+	 * tests give: `chordKeys` answers differently on macOS and elsewhere, and the
+	 * rule being held is that the row reads the chord the handler matches rather
+	 * than spelling one of its own. So the caps are compared to what `chordKeys`
+	 * returns for that same chord, which fails on a hardcoded string, on
+	 * `formatChord`'s single joined cap, and on the wrong chord.
+	 */
+	it("prints a row's chord as key-caps, one Kbd per key", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "inbox", entityId: null }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+
+		const row = screen.getByText('Close "Inbox"').closest("[cmdk-item]")!;
+		const caps = [...row.querySelectorAll("kbd")].map((el) => el.textContent);
+		expect(caps).toEqual(chordKeys(CLOSE_TAB_CHORD));
+	});
+
+	it("prints no caps on a row no chord runs", () => {
+		renderPalette();
+		open();
+
+		// The registry binds no chord to importing - and a made-up one on screen
+		// is worse than none, since nothing would answer it.
+		const row = screen.getByText("Import collection").closest("[cmdk-item]")!;
+		expect(row.querySelectorAll("kbd")).toHaveLength(0);
+	});
+
+	it("puts the keyboard hints outside the band that scrolls", () => {
+		renderPalette();
+		open();
+
+		const footer = document.querySelector('[data-slot="command-footer"]')!;
+		expect(footer).toBeInTheDocument();
+		expect(footer.textContent).toContain("navigate");
+		// Inside `CommandList` the hints would scroll away with the results
+		// they describe - which is the whole reason the band exists (#773).
+		expect(footer.closest('[data-slot="command-list"]')).toBeNull();
 	});
 });
 

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -34,10 +34,9 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { CommandDialog, CommandInput } from "@/components/ui";
+import { CommandDialog, CommandFooter, CommandInput, Kbd } from "@/components/ui";
 import { useLayoutStore } from "@/stores";
 import { PALETTE_CHORD, matchesChord } from "@/constants/shortcuts";
-import { formatChord } from "@/lib/platform";
 import { useCommandContext } from "@/hooks/useCommandContext";
 import RunCollectionDialog from "@/modules/collections/RunCollectionDialog";
 import { CollectionPicker } from "@/modules/welcome/components/CollectionPicker";
@@ -143,10 +142,14 @@ export function CommandPalette() {
 				   since a section it could not re-order outranked any score. */
 				shouldFilter={false}
 			>
+				{/* No chord in the placeholder: the palette is already open by the
+				    time anyone reads it, so the one thing it would teach has
+				    just been used. The title bar's search bar advertises ⌘K
+				    where it is still worth knowing. */}
 				<CommandInput
 					value={query}
 					onValueChange={setQuery}
-					placeholder={`Search tabs, requests, settings, runs… (${formatChord(PALETTE_CHORD)})`}
+					placeholder="Search tabs, requests, commands, settings…"
 				/>
 				{/*
 				 * Mounted only while open, so a shut palette holds no query observers
@@ -156,6 +159,25 @@ export function CommandPalette() {
 				{paletteOpen && (
 					<PaletteResults query={query} onPick={pick} commandContext={commandContext} />
 				)}
+				{/* Below the list rather than inside it: `CommandList` is the band
+				    that scrolls, and hints that scroll away are hints nobody
+				    reads. Every key here is one the open palette answers - the
+				    arrows and Enter are cmdk's, Escape is the dialog's. */}
+				<CommandFooter>
+					<span className="flex items-center gap-1">
+						<Kbd size="sm">↑</Kbd>
+						<Kbd size="sm">↓</Kbd>
+						<span>navigate</span>
+					</span>
+					<span className="flex items-center gap-1">
+						<Kbd size="sm">↵</Kbd>
+						<span>open</span>
+					</span>
+					<span className="flex items-center gap-1">
+						<Kbd size="sm">esc</Kbd>
+						<span>close</span>
+					</span>
+				</CommandFooter>
 			</CommandDialog>
 			{/* Outside the palette on purpose: a command closes the palette as it
 			    runs, so a dialog rendered inside it would be unmounted by the very

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -21,7 +21,9 @@
  * What this file does *not* do is match. `ranking.ts` decides what renders and
  * in what order, once, and the palette tells cmdk not to score anything a
  * second time (`shouldFilter={false}` in `CommandPalette`). So the order below
- * is the order on screen: a promoted top result, then the fixed sections.
+ * is the order on screen: the lead sections the ranking lifted rows into - a
+ * promoted top result when something is typed, Recents and the verbs when
+ * nothing is - and then the fixed sections.
  */
 
 import { useMemo } from "react";
@@ -31,11 +33,13 @@ import {
 	CommandItem,
 	CommandList,
 	CommandSeparator,
+	Kbd,
 } from "@/components/ui";
-import { getMethodColor } from "@/utils";
+import { formatRelativeTime, getMethodColor } from "@/utils";
+import { chordKeys } from "@/lib/platform";
 import type { CommandContext } from "@/lib/commands";
 import { PALETTE_GROUP_LABELS, type PaletteItem } from "./types";
-import { rankPalette, TOP_RESULT_LABEL } from "./ranking";
+import { QUICK_ACTIONS_LABEL, RECENTS_LABEL, rankPalette, TOP_RESULT_LABEL } from "./ranking";
 import { useTabItems } from "./sources/useTabItems";
 import { useEntityItems } from "./sources/useEntityItems";
 import { useViewItems } from "./sources/useViewItems";
@@ -84,6 +88,19 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	 */
 	const { total } = ranked;
 
+	/*
+	 * The sections above the fixed order, in the order they render. Each holds
+	 * rows lifted out of the sections below rather than copied into it - two
+	 * rows carrying the same `value` would both read as selected - so at most
+	 * one of these is ever populated at a time: the top result answers a typed
+	 * query, Recents and the verbs answer an empty one.
+	 */
+	const lead: LeadSection[] = [
+		{ key: "top", heading: TOP_RESULT_LABEL, items: ranked.top },
+		{ key: "recents", heading: RECENTS_LABEL, items: ranked.recents, withRecency: true },
+		{ key: "quick-actions", heading: QUICK_ACTIONS_LABEL, items: ranked.quickActions },
+	].filter((section) => section.items.length > 0);
+
 	return (
 		<>
 			<span aria-live="polite" className="sr-only">
@@ -91,19 +108,24 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 			</span>
 			<CommandList>
 				<CommandEmpty>No matches.</CommandEmpty>
-				{/* The best match across every section, lifted out of its own
-				    section rather than copied into this one: two rows carrying
-				    the same `value` would both read as selected. */}
-				{ranked.top.length > 0 && (
-					<CommandGroup heading={TOP_RESULT_LABEL}>
-						{ranked.top.map((item) => (
-							<PaletteRow key={item.id} item={item} onPick={onPick} />
-						))}
-					</CommandGroup>
-				)}
+				{lead.map((section, index) => (
+					<div key={section.key}>
+						{index > 0 && <CommandSeparator />}
+						<CommandGroup heading={section.heading}>
+							{section.items.map((item) => (
+								<PaletteRow
+									key={item.id}
+									item={item}
+									onPick={onPick}
+									showRecency={section.withRecency}
+								/>
+							))}
+						</CommandGroup>
+					</div>
+				))}
 				{ranked.groups.map((group, index) => (
 					<div key={group.kind}>
-						{(index > 0 || ranked.top.length > 0) && <CommandSeparator />}
+						{(index > 0 || lead.length > 0) && <CommandSeparator />}
 						<CommandGroup heading={PALETTE_GROUP_LABELS[group.kind]}>
 							{group.items.map((item) => (
 								<PaletteRow key={item.id} item={item} onPick={onPick} />
@@ -126,8 +148,30 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	);
 }
 
-function PaletteRow({ item, onPick }: { item: PaletteItem; onPick: (item: PaletteItem) => void }) {
+/** One of the sections that render above the fixed group order. */
+interface LeadSection {
+	key: string;
+	heading: string;
+	items: PaletteItem[];
+	/** Print each row's age. Only Recents, where the age is the reason it is there. */
+	withRecency?: boolean;
+}
+
+function PaletteRow({
+	item,
+	onPick,
+	showRecency = false,
+}: {
+	item: PaletteItem;
+	onPick: (item: PaletteItem) => void;
+	showRecency?: boolean;
+}) {
 	const Icon = item.icon;
+	// Only where the section asked for it *and* the row knows one: a row with no
+	// recency in Recents cannot happen (that is what put it there), and the
+	// check is what keeps it from printing an epoch date if it ever did.
+	const recency =
+		showRecency && item.recencyAt !== undefined && formatRelativeTime(item.recencyAt);
 	return (
 		<CommandItem
 			// cmdk no longer matches on these - `ranking.ts` does, against the
@@ -153,6 +197,24 @@ function PaletteRow({ item, onPick }: { item: PaletteItem; onPick: (item: Palett
 			{item.subtitle && (
 				<span className="ml-auto shrink-0 truncate pl-3 text-xs text-muted-foreground">
 					{item.subtitle}
+				</span>
+			)}
+			{/* One cap per key, the `Kbd` docstring's own chord form, drawn from
+			    the chord the handler matches rather than a second spelling of
+			    it (#938). A row without a bound chord prints nothing: an empty
+			    slot is honest, a made-up key is not. */}
+			{item.shortcut && (
+				<span className="ml-auto flex shrink-0 items-center gap-1 pl-3">
+					{chordKeys(item.shortcut).map((cap) => (
+						<Kbd key={cap} size="sm">
+							{cap}
+						</Kbd>
+					))}
+				</span>
+			)}
+			{recency && (
+				<span className="ml-auto shrink-0 pl-3 text-xs text-muted-foreground">
+					{recency}
 				</span>
 			)}
 		</CommandItem>

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -199,7 +199,12 @@ function PaletteRow({
 					{item.subtitle}
 				</span>
 			)}
-			{/* One cap per key, the `Kbd` docstring's own chord form, drawn from
+			{/* The two trailing slots below are mutually exclusive by
+			    construction, which is why neither guards against the other: a
+			    chord belongs to a command, and no command source stamps a
+			    recency.
+
+			    One cap per key, the `Kbd` docstring's own chord form, drawn from
 			    the chord the handler matches rather than a second spelling of
 			    it (#938). A row without a bound chord prints nothing: an empty
 			    slot is honest, a made-up key is not. */}

--- a/app/src/modules/palette/ranking.test.ts
+++ b/app/src/modules/palette/ranking.test.ts
@@ -16,18 +16,20 @@
 
 import { describe, it, expect } from "vitest";
 
-import { rankPalette, scoreItem, MATCH_FLOOR } from "./ranking";
+import { rankPalette, scoreItem, MATCH_FLOOR, RECENT_LIMIT } from "./ranking";
 import type { PaletteItem, PaletteKind } from "./types";
 
 function item(overrides: Partial<PaletteItem> & { id: string; kind: PaletteKind }): PaletteItem {
 	return { title: overrides.id, perform: () => {}, ...overrides };
 }
 
-/** Every row that renders, in visible order, top result first. */
+/** Every row that renders, in visible order: the lead sections, then the rest. */
 function rendered(items: PaletteItem[], query: string): string[] {
 	const ranked = rankPalette(items, query);
 	return [
 		...ranked.top.map((i) => i.id),
+		...ranked.recents.map((i) => i.id),
+		...ranked.quickActions.map((i) => i.id),
 		...ranked.groups.flatMap((g) => [...g.items, ...g.escapes].map((i) => i.id)),
 	];
 }
@@ -207,5 +209,80 @@ describe("the announced total", () => {
 		const ranked = rankPalette(items, "theme");
 		expect(ranked.total).toBe(rendered(items, "theme").length);
 		expect(ranked.total).toBe(1);
+	});
+
+	it("counts a lifted row once, not once per section it could be in", () => {
+		const items = [
+			item({ id: "tab", kind: "tab", recencyAt: 2000 }),
+			item({ id: "verb", kind: "command" }),
+			item({ id: "undated", kind: "request" }),
+		];
+		const ranked = rankPalette(items, "");
+		expect(ranked.total).toBe(3);
+		expect(rendered(items, "")).toEqual(["tab", "verb", "undated"]);
+	});
+});
+
+/**
+ * The two sections the empty query leads with.
+ *
+ * Both hold rows lifted out of the sections below rather than copied into them:
+ * a copy would render the same cmdk `value` twice, and both copies would read
+ * as selected - the hazard that made the top result a lift in the first place.
+ */
+describe("the empty query's lead sections", () => {
+	it("lifts the dated rows into Recents, newest first", () => {
+		const items = [
+			item({ id: "older", kind: "tab", recencyAt: 1000 }),
+			item({ id: "newest", kind: "request", recencyAt: 3000 }),
+			item({ id: "undated", kind: "request" }),
+		];
+		const ranked = rankPalette(items, "");
+		expect(ranked.recents.map((i) => i.id)).toEqual(["newest", "older"]);
+		// And the sections they came from do not list them a second time.
+		expect(ranked.groups.flatMap((g) => g.items.map((i) => i.id))).toEqual(["undated"]);
+	});
+
+	it("keeps the newest when there are more dated rows than the cap", () => {
+		const items = Array.from({ length: RECENT_LIMIT + 1 }, (_, i) =>
+			item({ id: `t${i}`, kind: "tab", recencyAt: 1000 + i })
+		);
+		const ranked = rankPalette(items, "");
+		expect(ranked.recents).toHaveLength(RECENT_LIMIT);
+		expect(ranked.recents[0]?.id).toBe(`t${RECENT_LIMIT}`);
+		// The one over the cap is still reachable in the section it came from.
+		expect(ranked.groups.flatMap((g) => g.items.map((i) => i.id))).toEqual(["t0"]);
+	});
+
+	it("never lifts an escape row, which is not a result", () => {
+		// An escape row with a recency has no business leading the list: it is
+		// the way out of a section, and it belongs under the one it escapes.
+		const items = [item({ id: "esc", kind: "run", recencyAt: 9000, escape: true })];
+		const ranked = rankPalette(items, "");
+		expect(ranked.recents).toEqual([]);
+		expect(ranked.groups[0]?.escapes.map((i) => i.id)).toEqual(["esc"]);
+	});
+
+	it("lifts the commands into Quick actions, in registry order", () => {
+		const items = [
+			item({ id: "first", kind: "command" }),
+			item({ id: "second", kind: "command" }),
+			item({ id: "panel", kind: "settings" }),
+		];
+		const ranked = rankPalette(items, "");
+		expect(ranked.quickActions.map((i) => i.id)).toEqual(["first", "second"]);
+		expect(ranked.groups.map((g) => g.kind)).toEqual(["settings"]);
+	});
+
+	it("has neither section once something is typed", () => {
+		const items = [
+			item({ id: "verb", kind: "command", title: "Import collection" }),
+			item({ id: "tab", kind: "tab", title: "Import collection", recencyAt: 3000 }),
+		];
+		const ranked = rankPalette(items, "import");
+		expect(ranked.recents).toEqual([]);
+		expect(ranked.quickActions).toEqual([]);
+		// Typed, a command ranks as the Commands section it has always been.
+		expect(ranked.groups.map((g) => g.kind)).toContain("command");
 	});
 });

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -47,6 +47,22 @@ export const MATCH_FLOOR = 0.1;
 /** The heading over the promoted best match. */
 export const TOP_RESULT_LABEL = "Top result";
 
+/** The heading over the rows the user touched most recently. */
+export const RECENTS_LABEL = "Recents";
+
+/** The heading over the verbs the palette offers on an empty query. */
+export const QUICK_ACTIONS_LABEL = "Quick actions";
+
+/**
+ * How many rows Recents holds.
+ *
+ * The list shows about six rows without scrolling, and the section's whole job
+ * is to answer "what was I just doing" before the user reaches for the wheel.
+ * A seventh row is one nobody sees and one more thing between the query and the
+ * sections below.
+ */
+export const RECENT_LIMIT = 6;
+
 /**
  * What a row is matched against: what it reads as, plus its extra terms.
  *
@@ -101,7 +117,17 @@ export interface RankedGroup {
 export interface RankedPalette {
 	/** The promoted best match, or empty - never more than one row. */
 	top: PaletteItem[];
-	/** The familiar fixed order, minus whatever was promoted. */
+	/**
+	 * The most recent rows across every kind, newest first. Empty query only:
+	 * once something is typed, what matches has to beat what is merely recent.
+	 */
+	recents: PaletteItem[];
+	/**
+	 * The verbs the palette offers, at the head of the empty query. Empty query
+	 * only - typed, they rank as the `command` section they have always been.
+	 */
+	quickActions: PaletteItem[];
+	/** The familiar fixed order, minus whatever was promoted or lifted. */
 	groups: RankedGroup[];
 	/**
 	 * How many result rows render. Escape rows are navigation, not results, and
@@ -119,12 +145,30 @@ export interface RankedPalette {
  * promote because nothing has been asked for yet. Once something is typed the
  * score decides - a result that matches better has to win over one that is
  * merely more recent, or typing stops feeling like searching.
+ *
+ * The empty query answers that question with two sections of its own, above the
+ * fixed order: Recents, and the verbs. Both are *lifted* out of the sections
+ * their rows belong to rather than copied into the new ones - the same rule the
+ * top result follows, and for the same reason: two rows carrying the same cmdk
+ * `value` would both read as selected.
  */
 export function rankPalette(items: PaletteItem[], query: string): RankedPalette {
 	const needle = query.trim();
 	if (needle === "") {
-		const groups = groupsOf(items, (ofKind) => rankForEmptyQuery(ofKind));
-		return { top: [], groups, total: countItems(groups) };
+		const quickActions = items.filter((item) => item.kind === "command" && !item.escape);
+		const recents = recentsOf(items);
+		const lifted = new Set([...quickActions, ...recents].map((item) => item.id));
+		const groups = groupsOf(
+			items.filter((item) => !lifted.has(item.id)),
+			(ofKind) => rankForEmptyQuery(ofKind)
+		);
+		return {
+			top: [],
+			recents,
+			quickActions,
+			groups,
+			total: countItems(groups) + recents.length + quickActions.length,
+		};
 	}
 
 	const scores = new Map<string, number>();
@@ -155,9 +199,35 @@ export function rankPalette(items: PaletteItem[], query: string): RankedPalette 
 
 	return {
 		top: promoted ? [promoted] : [],
+		recents: [],
+		quickActions: [],
 		groups,
 		total: countItems(groups) + (promoted ? 1 : 0),
 	};
+}
+
+/**
+ * The rows the user touched most recently, newest first, across every kind.
+ *
+ * Built from `recencyAt` alone, which every source that knows one already
+ * stamps - so this needs no store of its own and cannot disagree with the
+ * within-section order that reads the same field. A row that knows no time is
+ * not recent, it is merely undated, and belongs in its own section.
+ *
+ * In practice that is open tabs and requests that have been sent: the deep
+ * sources contribute nothing to an empty query at all, so a past run reaches
+ * Recents only once something is typed - and then it is a search result rather
+ * than a recent, which is the distinction the empty query is drawing.
+ *
+ * How far back it reaches follows the data. Tab focus times are session-scoped
+ * by `tabs-store`'s documented design, so after a restart Recents is the
+ * requests the run history remembers, and fills with tabs again as they are
+ * used. Persisting focus time to lengthen this list would rank a restored strip
+ * by yesterday's attention, which is the thing that rationale refuses.
+ */
+function recentsOf(items: PaletteItem[]): PaletteItem[] {
+	const dated = items.filter((item) => item.recencyAt !== undefined && !item.escape);
+	return rankForEmptyQuery(dated).slice(0, RECENT_LIMIT);
 }
 
 /**

--- a/app/src/modules/palette/sources/commandItems.ts
+++ b/app/src/modules/palette/sources/commandItems.ts
@@ -29,6 +29,7 @@ export function commandItems(ctx: CommandContext): PaletteItem[] {
 		...(command.subtitle ? { subtitle: command.subtitle } : {}),
 		keywords: [...command.keywords],
 		icon: command.icon,
+		...(command.shortcut ? { shortcut: command.shortcut } : {}),
 		perform: () => command.perform(ctx),
 	}));
 }

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { LucideIcon } from "lucide-react";
+import type { Chord } from "@/lib/platform";
 
 /**
  * Which group a result renders under. The order here is the order on screen:
@@ -94,6 +95,12 @@ export interface PaletteItem {
 	icon?: LucideIcon;
 	/** HTTP method, drawn as the same colour rail the tab strip uses. */
 	method?: string;
+	/**
+	 * The chord that already runs this row, drawn as key caps on its trailing
+	 * edge. Carried from the command registry, which holds the one definition
+	 * the handler also reads (#938) - never matched against, only printed.
+	 */
+	shortcut?: Chord;
 	/**
 	 * When this last mattered to the user, in epoch ms; `undefined` when
 	 * nothing knows. Orders the empty query - see `rankForEmptyQuery`.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -835,8 +835,31 @@ setting, because sections render in a fixed order that cmdk's cross-group re-sor
 
 On the empty query, `rankForEmptyQuery` puts the most recent first - focus time for tabs
 (`tabFocusedAt` in `tabs-store`, session-scoped), last-run time for requests (from the run history
-already in cache) - and nothing is promoted, because nothing has been asked for. Once something is
-typed, four rules apply:
+already in cache) - and nothing is promoted, because nothing has been asked for. Two sections lead
+it (#1176), and both are built here rather than by a source of their own:
+
+- **`Recents`** - the dated rows across every kind, newest first, capped at `RECENT_LIMIT` (6,
+  about what the list shows without scrolling). It reads the same `recencyAt` the within-section
+  order reads, so nothing re-derives a recency and the two cannot disagree. In practice that is
+  open tabs and requests that have been sent: the deep sources contribute nothing to an empty
+  query at all, so a past run reaches the list only once something is typed - where it is a
+  search result rather than a recent, which is the distinction being drawn. How far back it
+  reaches follows the data. Tab focus times are session-scoped by `tabs-store`'s documented
+  design, so after a restart Recents is the requests the run history remembers, and fills with
+  tabs again as they are used; persisting focus time to lengthen the list would rank a restored
+  strip by yesterday's attention, which is the thing that rationale refuses.
+- **`Quick actions`** - the `command` rows. The verbs are what an empty palette is *for*, and they
+  sat fifth of eight sections, under a fold that shows about six rows. Typed, they rank as the
+  `Commands` section they have always been, so the heading follows the query rather than the
+  section moving around.
+
+Both **lift** their rows out of the sections below rather than copying them into the new ones -
+the same rule the top result follows, and for the same reason: two rows carrying one cmdk `value`
+would both read as selected, and both would be counted. A row past the Recents cap is still
+reachable in the section it was not lifted from. Neither section is a `PaletteKind`: no source
+produces one, so a kind for it would be a shape nothing returns.
+
+Once something is typed, four rules apply:
 
 - **The best match is promoted to a `Top result` section**, lifted out of its own section rather
   than copied into the new one: two rows carrying the same `value` would both read as selected.
@@ -884,6 +907,25 @@ Four rules govern the deep sources, and each exists because of a way the naive v
   with a whole description sentence for settings, and with the query itself for runs, which scored
   every run as an exact match and outranked everything else.
 
+Three things the rows and the frame say (#1176):
+
+- **A row's trailing edge tells you what already runs it.** A command bound to a chord prints that
+  chord's key-caps - one `Kbd` per key, through `chordKeys`, from the `Chord` in
+  `constants/shortcuts.ts` that the handler itself matches (#938) and never a second spelling of
+  one. The registry carries it as `Command.shortcut`, and three commands have one; every other row
+  prints nothing, because a plausible key that answers to nothing is worse than no key at all. A
+  `Recents` row prints its age there instead, that being the reason it is in the section.
+- **The keyboard hints sit outside the band that scrolls.** `CommandFooter`
+  (`components/ui/command.tsx`) is a sibling of `CommandList`, not a row in it: the list is the
+  one scroller here, so hints placed inside it would scroll away with the results they describe -
+  the same reason `DialogFooter` sits outside `DialogBody` in every other dialog (#773). It draws
+  `border-t` rather than `border-rule`, because nothing in this tree declares a surface and
+  `border-rule` under none falls back to the invisible default. All three keys it names are real:
+  the arrows and Enter are cmdk's, Escape is the dialog's.
+- **The placeholder does not advertise the chord that opened the palette.** By the time anyone
+  reads it the dialog is open, so the one thing the suffix could teach has just been used. The
+  title bar's search bar carries ⌘K, where it is still worth knowing.
+
 Two invariants are tested rather than commented. **A variable's value is never indexed**, secret
 or not (`secret` is a masking hint, so trusting it would leak every token nobody flagged) - held
 in `sources/useVariableItems.test.ts` against the source's output, because the ranking would hide
@@ -901,9 +943,12 @@ a command, never a second definition of one. Before this, "open settings" existe
 the native-menu bridge, the Dock, the settings sidebar and a keydown case, and nothing kept them
 in step or could enumerate them.
 
-- **`types.ts`** - `Command` (`id`, `title`, `keywords`, `group`, `icon`, `available?`,
-  `perform`) and `CommandContext`. A `title` may be a function of the context, which is how a
-  contextual command names its target: `Run "payments"`, not `Run collection`.
+- **`types.ts`** - `Command` (`id`, `title`, `keywords`, `group`, `icon`, `shortcut?`,
+  `available?`, `perform`) and `CommandContext`. A `title` may be a function of the context, which
+  is how a contextual command names its target: `Run "payments"`, not `Run collection`. A
+  `shortcut` is the `Chord` from `constants/shortcuts.ts` that already runs this command - the
+  object the handler matches, so a surface printing it cannot advertise a key nothing answers
+  (#938) - and is present only where such a chord genuinely exists.
 - **`registry.ts`** - the roster. Actions (new request, import, run collection, load test, close
   tab, toggle theme, open settings) plus one command per settings section, **generated** from
   `app-panels.ts` and `engine-categories.ts` so a section added there appears here without an
@@ -1571,7 +1616,9 @@ close button, positioned against the panel, does not scroll away with the
 content. `ImportModal` and `CommandDialog` opt out because each already has a
 self-scrolling band of its own, and `DeleteConfirmDialog` has no middle at all;
 every other call site takes the band, which `dialog-height-band.test.tsx`
-enforces. The rules and the measurements are in
+enforces. `command` keeps the shape without the primitive: `CommandFooter` is a
+`shrink-0` sibling of `CommandList`, so the palette's hints sit outside the one
+thing that scrolls. The rules and the measurements are in
 [design-system.md](../design-system.md).
 
 The `cva` definitions for `badge`, `button` and `toast` live in sibling

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1571,6 +1571,12 @@ is already a self-scrolling list (`CommandDialog`) opts out at the call site wit
 the reason written there; `dialog-height-band.test.tsx` holds that list closed,
 so a new dialog cannot skip the band silently.
 
+Opting out of the band does not opt out of the shape. The command palette's
+keyboard hints are a `CommandFooter` - `shrink-0`, a sibling of `CommandList`
+and never a row inside it - because the rule is about what scrolls, not about
+which primitive names it: hints that scroll away with the results they describe
+are hints nobody reads.
+
 ---
 
 ## Layout Structure


### PR DESCRIPTION
## Description

The empty query is meant to answer "what was I just doing", and the palette answered it by spreading the answer across four sections: the tab you were last in under Tabs, the request you last sent under Requests, and the seven things the palette can actually *do* fifth of eight, below a fold that shows about six rows. No row said which chord already ran it, and nothing on screen said which keys navigate.

**Approach.** Keep `ranking.ts` as the one authority #1175 left in charge, and give its empty-query branch two more *lifts* - the mechanism the Top result already uses. `Recents` holds the dated rows across kinds, newest first; `Quick actions` holds the verbs. Both are lifted out of the sections their rows belong to rather than copied into the new ones, because two rows carrying the same cmdk `value` would both read as selected and both be announced. Rows gained a trailing edge: a `Kbd` chord chip where the registry declares one (a new `shortcut?: Chord` on `Command`, sourced from `constants/shortcuts.ts` and read at every hop), and a relative age in Recents. A `CommandFooter` primitive renders outside `CommandList`, the one band that scrolls (#773).

**The alternative rejected.** The issue proposes a `sources/useRecentItems.ts` building its own cross-kind MRU. That would re-derive `lastSentByRequest` a third time and emit rows whose `value` duplicates the ones already in Tabs and Requests - reviving exactly the duplicate-selection hazard #1175 solved by lifting. Every source already stamps `recencyAt`, so the ranking has the data without a new source and cannot disagree with the within-section order that reads the same field.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test`, `pnpm type-check`, `pnpm lint`, `pnpm format:check` - all green locally, and CI is green on the current head across ubuntu, macOS and both Windows shards.

Whole-suite count measured on the base commit `76309e5` and on this branch: **560 files / 6122 tests → 560 files / 6137 tests, +15**. The second commit is comments only and adds none.

Mutation-checked: reverting the lift (grouping the un-lifted items) reds 14 tests, including every one that pins the new sections.

New coverage - `ranking.test.ts`: Recents lifts and orders newest-first, the cap keeps the newest and leaves the overflow reachable in its own section, an escape row is never lifted, Quick actions lift in registry order, neither section exists once something is typed, and a lifted row is counted once in the announced total. `CommandPalette.test.tsx`: the lead order, one-appearance-per-row through the DOM, the cap, the relative age, the empty-vs-typed split, the chip's caps compared to `chordKeys` of the same chord, no caps on a row no chord runs, and the footer outside `[data-slot="command-list"]`.

Three existing empty-query tests were updated deliberately rather than deleted - the recency ordering they pin still holds, in the section that now expresses it, and the fixed-order array gains `Quick actions` and loses `Commands` (on an empty query those rows *are* Quick actions).

Nothing asserts a platform: chord caps are compared to what `chordKeys` returns for the same chord, the pattern `KeyboardShortcutsPanel.test.tsx` established for the same rule.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Deliberate deviations from the issue spec

- **No `recent` / `quickAction` entries in `PALETTE_GROUPS`.** No source produces such a row, so a `PaletteKind` for one would be a lie about the type and `PALETTE_GROUP_LABELS` would carry entries no `item.kind` ever equals. They are rendered sections, like `Top result`, which is likewise not a kind.
- **Recents draws on tabs and sent requests, not runs.** The deep sources contribute nothing to an empty query by documented design - "a server-backed group must not fetch for a palette nobody typed into" - so a past run reaches the list only once something is typed, where it is a search result rather than a recent.
- **`CommandList`'s `max-h` is unchanged.** The footer adds a band below a 300px list inside a panel capped at `85vh`; there is no height to reclaim. Raising the visible row count is #1177's ask.

## The session-vs-persisted recents decision

Session-scoped recents accepted, and the rationale it would have contradicted left standing. Recents rides on `recencyAt`, whose tab half is `tabFocusedAt` - deliberately absent from `tabs-store`'s `partialize`, because tabs *are* restored across launches and a persisted copy would rank a restored strip by yesterday's attention. The request half comes from run history, which is server-side, so after a restart Recents is what the runs remember and fills with tabs again as they are used. Recorded in `docs/app/COMPONENTS.md` alongside the section itself.

## Related Issues

Closes #1176