### PR TITLE
feat(app): the palette shows eleven rows, rules its dividers, and answers a dead query - #1177

### DIFF
--- a/app/src/components/ui/command.chrome.test.tsx
+++ b/app/src/components/ui/command.chrome.test.tsx
@@ -116,12 +116,26 @@ describe("the command list's surface and its dividers", () => {
 });
 
 describe("the command list's density", () => {
-	it("draws rows at py-2, the launcher metric, not the shadcn py-3", () => {
-		const cls = tokens(renderPalette());
-		// The padding reaches the rows through a descendant selector here, so
-		// this is where it can be read - the item itself carries neither value.
-		expect(cls).toContain("[&_[cmdk-item]]:py-2");
-		expect(cls).not.toContain("[&_[cmdk-item]]:py-3");
+	it("leaves a row at the primitive's 32px rather than padding it to 44px", () => {
+		const root = renderPalette();
+		const row = root.querySelector("[cmdk-item]");
+		expect(row, "a row should render").toBeTruthy();
+		// 14px of text in `py-1.5` is the 32px single-line row this app draws
+		// everywhere else, and the launcher metric besides.
+		expect(tokens(row!)).toContain("py-1.5");
+		// The dialog used to override that to `py-3` from up here, where no
+		// scan of the row itself would ever see it.
+		for (const forced of ["[&_[cmdk-item]]:py-3", "[&_[cmdk-item]]:py-2"]) {
+			expect(tokens(root)).not.toContain(forced);
+		}
+	});
+
+	it("lets a row size its own icon, which the old override silently won over", () => {
+		const root = renderPalette();
+		// `[&_[cmdk-item]_svg]:h-5` is a class, an attribute and a type against
+		// the row's single class, so it won - and every row drew a 20px icon
+		// beside the 14px rail written to match it.
+		expect(tokens(root)).not.toContain("[&_[cmdk-item]_svg]:h-5");
 	});
 });
 

--- a/app/src/components/ui/command.chrome.test.tsx
+++ b/app/src/components/ui/command.chrome.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The command list's chrome: the surface it declares, the dividers that read on
+ * it, its row density, and who draws a section label (#1177).
+ *
+ * The surface half is the `--rule` contract these guards exist for, as in
+ * `ImportModal.surface-rule.test.tsx`: what is pinned is the *declaration*, not
+ * the `border-rule` classes, because a `border-rule` under no declared surface
+ * silently falls back to the `:root` default - which on a card is invisible in
+ * dark, and is exactly the state this tree was in. jsdom cannot resolve the
+ * colour; that was measured in the browser.
+ *
+ * The density half is a rendered class read, not a source scan, per the rule in
+ * `app/CLAUDE.md`: the row padding arrives through a descendant selector on the
+ * dialog's `Command` root, which no scan of the item would ever see. At 44px
+ * rows a 300px list showed about six of them, so a section past the second was
+ * below the fold with nothing on screen saying so.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import {
+	CommandDialog,
+	CommandFooter,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandSeparator,
+} from "./command";
+
+/** Exact class tokens, safe for SVG nodes whose className is not a string. */
+function tokens(el: Element): string[] {
+	return (el.getAttribute("class") ?? "").split(/\s+/).filter(Boolean);
+}
+
+function renderPalette() {
+	render(
+		<CommandDialog open title="Command palette" description="Search everything.">
+			<CommandInput placeholder="Search…" />
+			<CommandList>
+				<CommandGroup heading="Tabs">
+					<CommandItem value="inbox">Inbox</CommandItem>
+				</CommandGroup>
+				<CommandSeparator />
+				<CommandGroup heading="Settings">
+					<CommandItem value="theme">Theme Mode</CommandItem>
+				</CommandGroup>
+			</CommandList>
+			<CommandFooter>
+				<span>navigate</span>
+			</CommandFooter>
+		</CommandDialog>
+	);
+	const root = document.querySelector('[data-slot="command"]');
+	expect(root, "the command root should render").toBeTruthy();
+	return root as HTMLElement;
+}
+
+/** Every element in the tree, root included - what each scan below reads. */
+function everything(root: HTMLElement): Element[] {
+	return [root, ...Array.from(root.querySelectorAll("*"))];
+}
+
+describe("the command list's surface and its dividers", () => {
+	it("pairs bg-card with surface-card on the root - both halves load-bearing", () => {
+		const cls = tokens(renderPalette());
+		// surface-card declares the --rule every divider below here inherits.
+		expect(cls).toContain("surface-card");
+		// bg-card is what tailwind-merge can strip a background utility with;
+		// the surface class lives in @layer components and would lose to one.
+		expect(cls).toContain("bg-card");
+		// The token it replaced. --popover and --card are the same three numbers
+		// in both themes, so this is a rename - but only one of them declares.
+		expect(cls).not.toContain("bg-popover");
+	});
+
+	it("draws no divider with a token the surface cannot resolve", () => {
+		const root = renderPalette();
+		const scanned = everything(root);
+		// The scan has to be reading a real tree, or it passes forever: input
+		// wrapper, list, two groups, two rows, separator, footer and more.
+		expect(scanned.length).toBeGreaterThan(8);
+		const offenders = scanned
+			.filter((el) => {
+				const cls = tokens(el);
+				return cls.includes("bg-border") || cls.includes("border-border");
+			})
+			.map((el) => el.getAttribute("class") ?? "");
+		expect(offenders).toEqual([]);
+	});
+
+	it("rules the three dividers the palette actually draws", () => {
+		const root = renderPalette();
+		const dividers = [
+			root.querySelector("[cmdk-input-wrapper]"),
+			root.querySelector('[data-slot="command-separator"]'),
+			document.querySelector('[data-slot="command-footer"]'),
+		];
+		for (const divider of dividers) {
+			expect(divider, "every band this asserts should be on screen").toBeTruthy();
+			expect(tokens(divider!)).toContain("border-rule");
+		}
+	});
+});
+
+describe("the command list's density", () => {
+	it("draws rows at py-2, the launcher metric, not the shadcn py-3", () => {
+		const cls = tokens(renderPalette());
+		// The padding reaches the rows through a descendant selector here, so
+		// this is where it can be read - the item itself carries neither value.
+		expect(cls).toContain("[&_[cmdk-item]]:py-2");
+		expect(cls).not.toContain("[&_[cmdk-item]]:py-3");
+	});
+});
+
+describe("a section label", () => {
+	it("is the app's Eyebrow, not a third spelling of its class string", () => {
+		renderPalette();
+		const headings = [...document.querySelectorAll("[cmdk-group-heading]")];
+		expect(headings).toHaveLength(2);
+		for (const heading of headings) {
+			expect(heading.querySelector('p[data-slot="eyebrow"]')).toBeTruthy();
+			// The wrapper cmdk labels the group by keeps its text, so every
+			// heading query - and every `aria-labelledby` - still resolves.
+			expect(heading.textContent).toMatch(/^(Tabs|Settings)$/);
+		}
+		expect(screen.getByText("Settings").closest("[cmdk-group]")).toBeTruthy();
+	});
+
+	it("leaves a caller's own node alone, rather than nesting it in a <p>", () => {
+		render(
+			<CommandDialog open title="Palette" description="Search.">
+				<CommandList>
+					<CommandGroup heading={<div data-testid="own-heading">Runs</div>}>
+						<CommandItem value="r1">A run</CommandItem>
+					</CommandGroup>
+				</CommandList>
+			</CommandDialog>
+		);
+		const own = screen.getByTestId("own-heading");
+		expect(own.closest('[data-slot="eyebrow"]')).toBeNull();
+	});
+});

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -92,14 +92,28 @@ const CommandDialog = ({
 				<DialogDescription className="sr-only">{description}</DialogDescription>
 				<Command
 					shouldFilter={shouldFilter}
-					/* `py-2` rows (~36px), not `py-3` (~44px): a launcher is read by
-					   scanning, and at 44px a 300px list showed about six rows,
-					   so anything past the second section was below the fold with
-					   nothing on screen saying it existed (#1177). The list's own
-					   cap is the other half of that, and belongs to whoever
-					   renders the list. Group headings carry no typography here -
-					   `CommandGroup` draws them with `Eyebrow`. */
-					className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+					/*
+					 * No row overrides here at all any more (#1177). This
+					 * string used to force `px-2 py-3` and 20px icons onto every
+					 * row, which made a 32px row a 44px one - about six of them
+					 * in a 300px list, so anything past the second section was
+					 * below the fold with nothing on screen saying it existed.
+					 * `CommandItem`'s own `px-2 py-1.5` is the 32px single-line
+					 * row this app draws everywhere else, which is also the
+					 * launcher metric, so the fix is to stop overriding it.
+					 *
+					 * The icon sizes went the same way and were never doing what
+					 * they said: `[&_[cmdk-item]_svg]:h-5` outranks the `h-3.5`
+					 * a row writes on its own icon - one class, one attribute
+					 * and a type against one class - so every palette row drew a
+					 * 20px icon beside the 14px rail meant to match it.
+					 *
+					 * The list's cap is the other half of the density and
+					 * belongs to whoever renders the list. Group headings carry
+					 * no typography here either - `CommandGroup` draws them with
+					 * `Eyebrow`.
+					 */
+					className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12"
 				>
 					{children}
 				</Command>

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -14,13 +14,34 @@ import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { Eyebrow } from "@/components/ui/eyebrow";
+
+/**
+ * The surface every command list sits on, and the reason it is `card` rather
+ * than `popover`.
+ *
+ * A divider inside this tree - the input's, the footer's, the separator between
+ * two sections - has to say `border-rule` to read on both themes, and
+ * `border-rule` resolves through the nearest declared surface. `--popover` had
+ * no surface class to declare, and adding a `surface-popover` that duplicated
+ * `surface-card` would be a second definition with nothing behind it:
+ * `--popover` and `--card` are the same three numbers in both themes, as are
+ * their foregrounds. So this root declares the surface it already painted, and
+ * every divider below it inherits the rule that reads on it.
+ *
+ * The pair `bg-card surface-card` rather than `surface-card` alone, per the
+ * rule in `app/CLAUDE.md`: this element already carried a background utility,
+ * and a surface class alone loses that cascade.
+ */
+const COMMAND_SURFACE = "bg-card surface-card text-card-foreground";
 
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
 	return (
 		<CommandPrimitive
 			data-slot="command"
 			className={cn(
-				"flex h-full w-full flex-col overflow-hidden rounded-lg bg-popover text-popover-foreground",
+				"flex h-full w-full flex-col overflow-hidden rounded-lg",
+				COMMAND_SURFACE,
 				className
 			)}
 			{...props}
@@ -71,7 +92,14 @@ const CommandDialog = ({
 				<DialogDescription className="sr-only">{description}</DialogDescription>
 				<Command
 					shouldFilter={shouldFilter}
-					className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+					/* `py-2` rows (~36px), not `py-3` (~44px): a launcher is read by
+					   scanning, and at 44px a 300px list showed about six rows,
+					   so anything past the second section was below the fold with
+					   nothing on screen saying it existed (#1177). The list's own
+					   cap is the other half of that, and belongs to whoever
+					   renders the list. Group headings carry no typography here -
+					   `CommandGroup` draws them with `Eyebrow`. */
+					className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
 				>
 					{children}
 				</Command>
@@ -85,7 +113,7 @@ function CommandInput({
 	...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
 	return (
-		<div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+		<div className="flex items-center border-b border-rule px-3" cmdk-input-wrapper="">
 			<Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
 			<CommandPrimitive.Input
 				data-slot="command-input"
@@ -118,16 +146,17 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
  * sits outside `DialogBody` in every other dialog. `shrink-0` keeps it a band
  * rather than the first thing a full panel squashes.
  *
- * `border-t` rather than `border-rule`: nothing in this tree declares a
- * surface, and `border-rule` under none falls back to the invisible default.
- * The input's divider one band up is the same token for the same reason.
+ * `border-rule`, which the `Command` root's `surface-card` resolves - the same
+ * token the input's divider one band up and the separators between sections
+ * now use. It read `border-t` alone while nothing in this tree declared a
+ * surface, since `border-rule` under none falls back to the invisible default.
  */
 function CommandFooter({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="command-footer"
 			className={cn(
-				"flex shrink-0 items-center gap-3 border-t px-3 py-2 text-[10px] text-muted-foreground",
+				"flex shrink-0 items-center gap-3 border-t border-rule px-3 py-2 text-[10px] text-muted-foreground",
 				className
 			)}
 			{...props}
@@ -147,13 +176,27 @@ function CommandEmpty(props: React.ComponentProps<typeof CommandPrimitive.Empty>
 
 function CommandGroup({
 	className,
+	heading,
 	...props
 }: React.ComponentProps<typeof CommandPrimitive.Group>) {
 	return (
 		<CommandPrimitive.Group
 			data-slot="command-group"
+			/*
+			 * A section label is an `Eyebrow` here as it is everywhere else in
+			 * the app, rather than a third spelling of the same eleven pixels -
+			 * the primitive exists because that string was hand-typed in about a
+			 * dozen components and two of them had already drifted.
+			 *
+			 * Wrapped only when the heading is text: a caller passing its own
+			 * node owns its typography, and a block element inside `Eyebrow`'s
+			 * `<p>` would be invalid markup. cmdk still renders the wrapper it
+			 * labels the group by, so the element every test and every
+			 * `aria-labelledby` reaches for is unchanged.
+			 */
+			heading={typeof heading === "string" ? <Eyebrow>{heading}</Eyebrow> : heading}
 			className={cn(
-				"overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+				"overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5",
 				className
 			)}
 			{...props}
@@ -168,7 +211,11 @@ function CommandSeparator({
 	return (
 		<CommandPrimitive.Separator
 			data-slot="command-separator"
-			className={cn("-mx-1 h-px bg-border", className)}
+			// `border-t border-rule`, not a 1px `bg-border` slab: the same one
+			// pixel, in the colour the `Command` root's surface declares. On a
+			// card `--border` is the card's own background in dark, so the old
+			// version drew a divider that was simply absent there.
+			className={cn("-mx-1 border-t border-rule", className)}
 			{...props}
 		/>
 	);

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -246,11 +246,22 @@ describe("searching", () => {
 		expect(screen.getByText("Payments / Auth")).toBeInTheDocument();
 	});
 
-	it("says so when nothing matches", async () => {
+	/*
+	 * Saying so is half of it. A launcher that matched nothing offers what it
+	 * can still do (#1177) - drop the verbs from the no-match branch of
+	 * `ranking.ts` and the palette is a dead end again, which is what the second
+	 * half of this asserts.
+	 */
+	it("says nothing matched, and offers the verbs instead of a dead end", async () => {
 		renderPalette();
 		open();
 		typeQuery("zzzzz");
-		expect(screen.getByText("No matches.")).toBeInTheDocument();
+
+		expect(screen.getByText(/No matches for “zzzzz”/)).toBeInTheDocument();
+		expect(rowsUnder("Quick actions")).toContain("Import collection");
+		// Suggestions are not results: the announcement still says the query
+		// narrowed everything away.
+		expect(screen.getByText(/searchable results$/).textContent).toBe("0 searchable results");
 	});
 
 	/*
@@ -543,6 +554,26 @@ describe("the launcher sections", () => {
 		// Inside `CommandList` the hints would scroll away with the results
 		// they describe - which is the whole reason the band exists (#773).
 		expect(footer.closest('[data-slot="command-list"]')).toBeNull();
+	});
+});
+
+/**
+ * How much of the list is on screen (#1177). The primitive's 300px showed about
+ * six rows at the old density, so the Settings section a query named sat below
+ * the fold with nothing saying it was there - the search fix put the right row
+ * first, and this is what makes the rest of the answer visible.
+ */
+describe("the list's height", () => {
+	it("caps the list at about eleven rows, and at 60vh before that", () => {
+		renderPalette();
+		open();
+
+		const list = document.querySelector('[data-slot="command-list"]')!;
+		const cls = (list.getAttribute("class") ?? "").split(/\s+/);
+		expect(cls).toContain("max-h-[min(400px,60vh)]");
+		// tailwind-merge has to have dropped the primitive's own cap, or both
+		// declarations ship and the smaller one wins on source order.
+		expect(cls).not.toContain("max-h-[300px]");
 	});
 });
 

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -98,9 +98,15 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	/*
 	 * Nothing the query could match. The ranking answers that by handing back
 	 * the verbs (#1177), so the line below introduces them rather than ending
-	 * the palette on "No matches." - and it is a line rather than cmdk's
-	 * `CommandEmpty`, which renders only when the list has no rows at all and
-	 * the verbs are rows.
+	 * the palette on "No matches."
+	 *
+	 * It is a line of its own rather than either primitive for the job, and
+	 * both were considered: cmdk's `CommandEmpty` renders only when the list
+	 * has no rows at all, and the verbs under this are rows; `EmptyState`'s
+	 * `inline` variant is a centred `p-8` block that owns the space it sits in,
+	 * and overriding it to a tight left-aligned lead-in would leave nothing of
+	 * it but `text-sm text-muted-foreground`. This is not an empty state - the
+	 * list below it is full.
 	 */
 	const nothingMatched = query.trim() !== "" && total === 0;
 

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -23,18 +23,12 @@
  * second time (`shouldFilter={false}` in `CommandPalette`). So the order below
  * is the order on screen: the lead sections the ranking lifted rows into - a
  * promoted top result when something is typed, Recents and the verbs when
- * nothing is - and then the fixed sections.
+ * nothing is, the verbs again when what was typed matched nothing - and then
+ * the fixed sections.
  */
 
 import { useMemo } from "react";
-import {
-	CommandEmpty,
-	CommandGroup,
-	CommandItem,
-	CommandList,
-	CommandSeparator,
-	Kbd,
-} from "@/components/ui";
+import { CommandGroup, CommandItem, CommandList, CommandSeparator, Kbd } from "@/components/ui";
 import { formatRelativeTime, getMethodColor } from "@/utils";
 import { chordKeys } from "@/lib/platform";
 import type { CommandContext } from "@/lib/commands";
@@ -101,13 +95,30 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 		{ key: "quick-actions", heading: QUICK_ACTIONS_LABEL, items: ranked.quickActions },
 	].filter((section) => section.items.length > 0);
 
+	/*
+	 * Nothing the query could match. The ranking answers that by handing back
+	 * the verbs (#1177), so the line below introduces them rather than ending
+	 * the palette on "No matches." - and it is a line rather than cmdk's
+	 * `CommandEmpty`, which renders only when the list has no rows at all and
+	 * the verbs are rows.
+	 */
+	const nothingMatched = query.trim() !== "" && total === 0;
+
 	return (
 		<>
 			<span aria-live="polite" className="sr-only">
 				{query ? `${total} searchable results` : `${total} results`}
 			</span>
-			<CommandList>
-				<CommandEmpty>No matches.</CommandEmpty>
+			{/* The list caps itself at 400px, and at 60vh before that: about
+			    eleven rows where the primitive's 300px showed six, and never
+			    more than the dialog panel's own 85vh has room for once the
+			    input and the hints are counted (#1177). */}
+			<CommandList className="max-h-[min(400px,60vh)]">
+				{nothingMatched && (
+					<p className="px-3 pb-1 pt-3 text-sm text-muted-foreground">
+						No matches for “{query.trim()}”. Try one of these:
+					</p>
+				)}
 				{lead.map((section, index) => (
 					<div key={section.key}>
 						{index > 0 && <CommandSeparator />}

--- a/app/src/modules/palette/ranking.test.ts
+++ b/app/src/modules/palette/ranking.test.ts
@@ -286,3 +286,51 @@ describe("the empty query's lead sections", () => {
 		expect(ranked.groups.map((g) => g.kind)).toContain("command");
 	});
 });
+
+/**
+ * What a query that matched nothing gets (#1177): the verbs, as an offer rather
+ * than a result. The palette used to end on one line of type, which is the one
+ * state a launcher has nothing to say in and the one where the user most needs
+ * it to.
+ */
+describe("a query that matched nothing", () => {
+	it("offers the verbs, without counting them as results", () => {
+		const items = [
+			item({ id: "verb", kind: "command", title: "Import collection" }),
+			item({ id: "request", kind: "request", title: "Charge card" }),
+		];
+		const ranked = rankPalette(items, "zzzzz");
+
+		expect(ranked.quickActions.map((i) => i.id)).toEqual(["verb"]);
+		// Suggestions, not results: the count answers "did what I typed narrow
+		// anything", and the honest answer here is that it narrowed everything.
+		expect(ranked.total).toBe(0);
+		expect(ranked.top).toEqual([]);
+	});
+
+	it("keeps the escape rows that survived, and offers the verbs beside them", () => {
+		const items = [
+			item({ id: "verb", kind: "command", title: "Import collection" }),
+			item({ id: "esc", kind: "run", title: "Search runs for zzzzz", escape: true }),
+		];
+		const ranked = rankPalette(items, "zzzzz");
+
+		expect(ranked.groups.flatMap((g) => g.escapes.map((i) => i.id))).toEqual(["esc"]);
+		expect(ranked.quickActions.map((i) => i.id)).toEqual(["verb"]);
+		// An escape row is navigation, so the count stays at nothing-matched.
+		expect(ranked.total).toBe(0);
+	});
+
+	it("says nothing extra when the query did match something", () => {
+		const items = [
+			item({ id: "verb", kind: "command", title: "Import collection" }),
+			item({ id: "request", kind: "request", title: "Charge card" }),
+		];
+		const ranked = rankPalette(items, "charge");
+
+		// One hit is a hit: offering the verbs on top of it would push the
+		// answer down the list the palette just found.
+		expect(ranked.quickActions).toEqual([]);
+		expect(ranked.total).toBe(1);
+	});
+});

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -50,7 +50,10 @@ export const TOP_RESULT_LABEL = "Top result";
 /** The heading over the rows the user touched most recently. */
 export const RECENTS_LABEL = "Recents";
 
-/** The heading over the verbs the palette offers on an empty query. */
+/**
+ * The heading over the verbs the palette offers: on an empty query, and again
+ * when a typed query matched nothing.
+ */
 export const QUICK_ACTIONS_LABEL = "Quick actions";
 
 /**

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -56,10 +56,11 @@ export const QUICK_ACTIONS_LABEL = "Quick actions";
 /**
  * How many rows Recents holds.
  *
- * The list shows about six rows without scrolling, and the section's whole job
- * is to answer "what was I just doing" before the user reaches for the wheel.
- * A seventh row is one nobody sees and one more thing between the query and the
- * sections below.
+ * The section's whole job is to answer "what was I just doing" before the user
+ * reaches for the wheel, and six is a glance. It stays six now that the list is
+ * taller (#1177): the extra height went to the sections *under* Recents, which
+ * were the ones nobody could see, and a longer list of recents would take it
+ * straight back.
  */
 export const RECENT_LIMIT = 6;
 
@@ -123,8 +124,9 @@ export interface RankedPalette {
 	 */
 	recents: PaletteItem[];
 	/**
-	 * The verbs the palette offers, at the head of the empty query. Empty query
-	 * only - typed, they rank as the `command` section they have always been.
+	 * The verbs the palette offers: at the head of the empty query, and again
+	 * when a typed query matched nothing at all. In between - a query with
+	 * results - they rank as the `command` section they have always been.
 	 */
 	quickActions: PaletteItem[];
 	/** The familiar fixed order, minus whatever was promoted or lifted. */
@@ -155,7 +157,7 @@ export interface RankedPalette {
 export function rankPalette(items: PaletteItem[], query: string): RankedPalette {
 	const needle = query.trim();
 	if (needle === "") {
-		const quickActions = items.filter((item) => item.kind === "command" && !item.escape);
+		const quickActions = verbsOf(items);
 		const recents = recentsOf(items);
 		const lifted = new Set([...quickActions, ...recents].map((item) => item.id));
 		const groups = groupsOf(
@@ -196,14 +198,33 @@ export function rankPalette(items: PaletteItem[], query: string): RankedPalette 
 	const byScore = (ofKind: PaletteItem[]) =>
 		[...ofKind].sort((a, b) => (scores.get(b.id) ?? 0) - (scores.get(a.id) ?? 0));
 	const groups = groupsOf(rest, byScore);
+	const total = countItems(groups) + (promoted ? 1 : 0);
+
+	/*
+	 * Nothing matched, so the palette offers what it can still do rather than
+	 * one dead-end line (#1177). The verbs come back as *suggestions*, not
+	 * results: `total` stays 0, which is what the announcement counts and what
+	 * tells the list to say that nothing matched. Whatever survives in `groups`
+	 * at this point is escape rows - a row that is navigation rather than a
+	 * result is why the count can be zero with rows on screen - and no verb can
+	 * be among them, since none of them cleared the floor.
+	 */
+	if (total === 0) {
+		return { top: [], recents: [], quickActions: verbsOf(items), groups, total };
+	}
 
 	return {
 		top: promoted ? [promoted] : [],
 		recents: [],
 		quickActions: [],
 		groups,
-		total: countItems(groups) + (promoted ? 1 : 0),
+		total,
 	};
+}
+
+/** The commands the palette offers as verbs - every command row that is not an escape. */
+function verbsOf(items: PaletteItem[]): PaletteItem[] {
+	return items.filter((item) => item.kind === "command" && !item.escape);
 }
 
 /**

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -851,9 +851,10 @@ it (#1176), and both are built here rather than by a source of their own:
   tabs again as they are used; persisting focus time to lengthen the list would rank a restored
   strip by yesterday's attention, which is the thing that rationale refuses.
 - **`Quick actions`** - the `command` rows. The verbs are what an empty palette is *for*, and they
-  sat fifth of eight sections, under a fold that shows about six rows. Typed, they rank as the
-  `Commands` section they have always been, so the heading follows the query rather than the
-  section moving around.
+  sat fifth of eight sections, under a fold that showed about six rows before #1177 raised it.
+  Typed, they rank as the `Commands` section they have always been, so the heading follows the
+  query rather than the section moving around - except on a query that matched nothing, where they
+  come back as the offer (#1177, below).
 
 Both **lift** their rows out of the sections below rather than copying them into the new ones -
 the same rule the top result follows, and for the same reason: two rows carrying one cmdk `value`
@@ -928,15 +929,20 @@ Three things the rows and the frame say (#1176):
 
 Three about the frame itself (#1177):
 
-- **Density is a launcher's, not a menu's.** `CommandDialog` draws rows at `py-2` (~36px) and
-  `PaletteResults` caps its `CommandList` at `min(400px, 60vh)`, so about eleven rows are on
-  screen where the primitive's 44px rows in a 300px list showed six. Six rows plus a heading is
-  two sections, which is why the Settings group a query named could sit below the fold with
-  nothing on screen saying it existed - the search fix (#1175) put the right row first, and this
-  is what makes the rest of the answer visible. The `60vh` half is what keeps the panel inside
-  its own `max-h-[85vh]` on a short window once the input and the hints are counted; the
-  autocompletes that share these primitives keep the 300px default, their popups being anchored
-  under an input rather than centred.
+- **Density is a launcher's, not a menu's.** `CommandDialog` no longer overrides row padding or
+  icon size at all, so a row is `CommandItem`'s own `px-2 py-1.5` - the 30px single-line row this
+  app draws everywhere else - and `PaletteResults` caps its `CommandList` at `min(400px, 60vh)`.
+  Measured in Chromium: **eleven rows and two headings on screen at a 768px or taller window,
+  nine at 600px**, where the old `py-3` rows in a 300px list showed about six. Six rows plus a
+  heading is two sections, which is why the Settings group a query named could sit below the fold
+  with nothing on screen saying it existed - the search fix (#1175) put the right row first, and
+  this is what makes the rest of the answer visible. The `60vh` half keeps the whole panel inside
+  its own `max-h-[85vh]` on a short window once the input and the hints are counted (435px of a
+  600px viewport, measured); the autocompletes that share these primitives keep the 300px
+  default, their popups being anchored under an input rather than centred. The icon override went
+  because it never did what it read as: `[&_[cmdk-item]_svg]:h-5` outranks the `h-3.5` a row
+  writes on its own icon, so every palette row drew a 20px icon beside the 14px method rail
+  written to match it.
 - **The chrome sits on a declared surface, so its dividers can be `border-rule`.** `Command`
   declares `bg-card surface-card` - `--popover` and `--card` are the same three numbers in both
   themes, and only one of them has a surface class to declare, so this is a rename rather than a

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -838,8 +838,10 @@ On the empty query, `rankForEmptyQuery` puts the most recent first - focus time 
 already in cache) - and nothing is promoted, because nothing has been asked for. Two sections lead
 it (#1176), and both are built here rather than by a source of their own:
 
-- **`Recents`** - the dated rows across every kind, newest first, capped at `RECENT_LIMIT` (6,
-  about what the list shows without scrolling). It reads the same `recencyAt` the within-section
+- **`Recents`** - the dated rows across every kind, newest first, capped at `RECENT_LIMIT` (6, a
+  glance at what you were just doing). The cap stayed at six when the list grew taller (#1177):
+  the extra height went to the sections *under* Recents, which were the ones nobody could see, and
+  a longer list of recents would take it straight back. It reads the same `recencyAt` the within-section
   order reads, so nothing re-derives a recency and the two cannot disagree. In practice that is
   open tabs and requests that have been sent: the deep sources contribute nothing to an empty
   query at all, so a past run reaches the list only once something is typed - where it is a
@@ -918,13 +920,38 @@ Three things the rows and the frame say (#1176):
 - **The keyboard hints sit outside the band that scrolls.** `CommandFooter`
   (`components/ui/command.tsx`) is a sibling of `CommandList`, not a row in it: the list is the
   one scroller here, so hints placed inside it would scroll away with the results they describe -
-  the same reason `DialogFooter` sits outside `DialogBody` in every other dialog (#773). It draws
-  `border-t` rather than `border-rule`, because nothing in this tree declares a surface and
-  `border-rule` under none falls back to the invisible default. All three keys it names are real:
-  the arrows and Enter are cmdk's, Escape is the dialog's.
+  the same reason `DialogFooter` sits outside `DialogBody` in every other dialog (#773). All three
+  keys it names are real: the arrows and Enter are cmdk's, Escape is the dialog's.
 - **The placeholder does not advertise the chord that opened the palette.** By the time anyone
   reads it the dialog is open, so the one thing the suffix could teach has just been used. The
   title bar's search bar carries ⌘K, where it is still worth knowing.
+
+Three about the frame itself (#1177):
+
+- **Density is a launcher's, not a menu's.** `CommandDialog` draws rows at `py-2` (~36px) and
+  `PaletteResults` caps its `CommandList` at `min(400px, 60vh)`, so about eleven rows are on
+  screen where the primitive's 44px rows in a 300px list showed six. Six rows plus a heading is
+  two sections, which is why the Settings group a query named could sit below the fold with
+  nothing on screen saying it existed - the search fix (#1175) put the right row first, and this
+  is what makes the rest of the answer visible. The `60vh` half is what keeps the panel inside
+  its own `max-h-[85vh]` on a short window once the input and the hints are counted; the
+  autocompletes that share these primitives keep the 300px default, their popups being anchored
+  under an input rather than centred.
+- **The chrome sits on a declared surface, so its dividers can be `border-rule`.** `Command`
+  declares `bg-card surface-card` - `--popover` and `--card` are the same three numbers in both
+  themes, and only one of them has a surface class to declare, so this is a rename rather than a
+  repaint. With it declared, the input's divider, the separators between sections and the footer's
+  `border-t` all resolve through the surface instead of the canvas token that is the card's own
+  background in dark. Section headings are the `Eyebrow` primitive, wrapped inside the element
+  cmdk labels the group by, rather than a third hand-typed copy of its eleven pixels.
+  `command.chrome.test.tsx` pins the declaration, the absence of the canvas tokens, and the
+  density - `border-rule` classes on their own prove nothing.
+- **A query that matched nothing gets an offer, not a dead end.** `ranking.ts` hands the verbs
+  back as `quickActions` when a typed query keeps no result, and the list says
+  `No matches for “…”. Try one of these:` above them. They are suggestions, not results: the
+  announced total stays at zero, which is what "did what I typed narrow anything" asks. cmdk's
+  own `CommandEmpty` is unused here for the same reason - it renders only when the list has no
+  rows at all, and the verbs are rows.
 
 Two invariants are tested rather than commented. **A variable's value is never indexed**, secret
 or not (`secret` is a masking hint, so trusting it would leak every token nobody flagged) - held

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -388,9 +388,19 @@ their own. Resolved colour is a computed-style question and is checked in the
 browser.
 
 Definitions live in `app/src/index.css` under "Surfaces, and the rule colour that
-reads on each". Adopted by the response-viewer family and the import dialog
-(`ImportModal.surface-rule.test.tsx` guards the latter's declarations); the rest
-of the app still uses explicit tokens and can migrate as it is touched.
+reads on each". Adopted by the response-viewer family, the import dialog
+(`ImportModal.surface-rule.test.tsx` guards the latter's declarations) and the
+command list, whose `Command` root declares `bg-card surface-card` so the
+input's divider, the section separators and the footer can all say `border-rule`
+(`command.chrome.test.tsx`); the rest of the app still uses explicit tokens and
+can migrate as it is touched.
+
+A surface a component only *looks* like it has is the case the command list
+answers: it painted `bg-popover`, which no surface class declares. `--popover`
+and `--card` hold the same three numbers in both themes, and their foregrounds
+do too, so it declares the card rather than gaining a `surface-popover` that
+would be a second definition with nothing behind it. Check the values before
+copying that move - two tokens that merely look alike are two surfaces.
 
 One trap the import dialog documents: `surface-card` **cannot simply replace**
 a background utility that a primitive already sets. The surface classes live in
@@ -1575,7 +1585,12 @@ Opting out of the band does not opt out of the shape. The command palette's
 keyboard hints are a `CommandFooter` - `shrink-0`, a sibling of `CommandList`
 and never a row inside it - because the rule is about what scrolls, not about
 which primitive names it: hints that scroll away with the results they describe
-are hints nobody reads.
+are hints nobody reads. Nor does opting out excuse the cap: the list that
+scrolls in place of a band owns one of its own, and the palette's is
+`min(400px, 60vh)` (#1177) rather than a bare pixel value, so the input, the
+list and the hints together stay inside the panel's `85vh` on a short window
+instead of being clipped by the `overflow-hidden` that keeps the list's scroll
+the only one.
 
 ---
 
@@ -1694,6 +1709,13 @@ Never use hardcoded background colors like `bg-gray-50`, `bg-blue-50`, `bg-zinc-
   Section Title
 </p>
 ```
+
+That string has one home: the `Eyebrow` primitive
+(`app/src/components/ui/eyebrow.tsx`), which is what a section label should
+render - it was extracted because the class was hand-typed in about a dozen
+components and two of them had already drifted, and `eyebrow.test.ts` fails on a
+second copy of the literal. The command palette's group headings are an
+`Eyebrow` inside the element cmdk labels the group by.
 
 ### Status Badges / Pills
 


### PR DESCRIPTION
## Description

The last sub of #1174, after #1175 (search relevance) and #1176 (launcher capabilities).

**The plan.** The palette's chrome was scaled for a menu rather than a launcher: `CommandDialog` forced `py-3` rows and 20px icons into a 300px `CommandList`, so about six rows were on screen - six rows plus a heading is two sections, which is how a Settings hit that #1175 had just promoted could still sit below the fold with nothing saying the section existed. Its three dividers used canvas-tuned tokens (`border-b`, `bg-border`, #1176's `border-t`) because nothing in the tree declared a surface, and `--border` is the card's own background in dark, so those rules were simply absent there; the group headings were a hand-styled `text-xs` where `Eyebrow` is the primitive. The fix declares the surface the root already painted (`bg-card surface-card` - `--popover` and `--card` hold the same three numbers in both themes, and their foregrounds too, so this is a rename, not a repaint), which lets all three dividers say `border-rule`; drops the dialog's row overrides so a row is the primitive's own 30px; caps the list at `min(400px, 60vh)`; renders headings with `Eyebrow`; and replaces the "No matches." dead end with the verbs, handed back by `ranking.ts` under a line naming what was searched for.

**The alternative rejected:** adding a `surface-popover` class to `index.css` so `bg-popover` could stay. It would have duplicated `surface-card` exactly, in both themes - a second definition with nothing behind it, which is the drift the surface classes exist to end. The values are documented next to the change so the next component that looks similar checks rather than copies.

Deliberate scope calls, recorded in the code and the docs rather than left implicit:

- **The row override went entirely, rather than dropping `py-3` to `py-2`.** Nothing needed the dialog to restate a row's shape: `CommandItem`'s own `px-2 py-1.5` is the single-line row this app draws everywhere else and the launcher metric the issue asks for. The icon override went with it, and that one never did what it read as - `[&_[cmdk-item]_svg]:h-5` outranks the `h-3.5` a row writes on its own icon (a class, an attribute and a type against one class), so every palette row drew a 20px icon beside the 14px method rail written to match it. That is in the density path rather than adjacent to it, so it is fixed here rather than filed.
- **`RECENT_LIMIT` stays at 6.** The extra height went to the sections *under* Recents, which were the ones nobody could see; lengthening Recents would take it straight back. It is a ranking constant, not chrome.
- **The raised cap is on the palette's own `CommandList`, not on the primitive.** `suggestion-list.tsx` and `variable-autocomplete.tsx` share these primitives but are popups anchored under an input, where a 400px dropdown near a viewport edge is a regression rather than a fix. They are unaffected by the density change too: `py-3` only ever reached rows inside `CommandDialog`, and both render a bare `Command` at the primitive's `py-1.5`.
- **The "no matches" line is neither `CommandEmpty` nor `EmptyState`,** and the code says why: cmdk's `CommandEmpty` renders only when the list has no rows at all, and the verbs under this line are rows; `EmptyState`'s `inline` variant is a centred `p-8` block that owns its space, and overriding it into a tight left-aligned lead-in would leave nothing of it but `text-sm text-muted-foreground`. This is not an empty state - the list below it is full.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All local, at `abc2bd2`:

- `cd app && pnpm test` - **560 files / 6137 tests green on the base commit** before any edit, and **561 / 6148 green after**. No pre-existing failures to report.
- `pnpm type-check` (renderer, electron, electron-tests), `pnpm lint`, and `pnpm prettier --check` on the touched app files - all clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean. Both pages were already in the nav; no heading renamed.
- **Measured in Chromium** against the built stylesheet, since jsdom has no layout and the AC is a layout claim: rows **30.0px**, headings **28.5px**, and **eleven rows plus two headings visible at a 768px or taller window, nine at 600px** - where the whole panel comes to 435px of a 600px viewport, well inside its own `max-h-[85vh]`. Both shapes measure the same: the empty query (Recents, then the verbs) and a typed one (Top result, then Settings). The `min(400px, 60vh)` cap is what keeps the panel inside 85vh at every window height above ~310px; `max-height:min(400px,60vh)` is present in the built CSS, and tailwind-merge drops the primitive's `max-h-[300px]` rather than shipping both.

New guards, each written so reverting the fix reds it:

- `app/src/components/ui/command.chrome.test.tsx` (6 cases) - the `bg-card surface-card` pair on the root and the absence of `bg-popover`; a scan asserting it read a real tree and found no `bg-border`/`border-border` anywhere in the chrome; `border-rule` on all three dividers; the row at the primitive's `py-1.5` with neither override present on the root, read off the rendered elements since a descendant selector is invisible to a scan of the item; the `Eyebrow` heading inside cmdk's own `[cmdk-group-heading]`, and that a caller's own heading node is *not* nested inside a `<p>`.
- `CommandPalette.test.tsx` - the raised cap (and that tailwind-merge dropped the 300px); the rewritten no-match case asserts the line, the offered verbs, and that the announcement still says `0 searchable results`.
- `ranking.test.ts` (3 cases) - the verbs come back on a query that matched nothing, escape rows survive beside them, and a query with one hit gets no verbs on top of its answer.

Not run: the engine build and `ctest`. Nothing outside `app/` and `docs/` is touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs moved with the code: `docs/app/COMPONENTS.md` (the density and the measured numbers, the surface and its dividers, the new empty state, the now-false line saying the footer draws `border-t` "because nothing in this tree declares a surface", and two sentences that still said the fold shows six rows) and `docs/design-system.md` (the `border-rule` adoption list, a note on a surface a component only *looks* like it has, the `Eyebrow` primitive pointer under the class string that section still quotes, and the list's own cap under the dialog-height opt-out).

One deliberate deviation from the issue's Tests section: it names `surface-rule.test.tsx` as the guard, but that file is scoped to the response-viewer family, so the palette gets its own in the shape of `ImportModal.surface-rule.test.tsx` - named `command.chrome.test.tsx` because it also pins the density and the heading primitive, which are not surface rules.

## Related Issues
Closes #1177

Acceptance criteria, line by line:

- [x] At least ~10 rows visible at default size; the Settings group reachable without scrolling for a typed query that matches it - eleven rows measured, and the typed shape puts Settings directly under the promoted Top result.
- [x] No un-surfaced border in the palette chrome; the guard passes with the declarations pinned rather than exempted.
- [x] Empty state offers an action, not just "No matches."