### PR TITLE
fix(ci): publish the Windows installer's .blockmap so an update is a ranged download

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -176,9 +176,12 @@ Things about it that the code cannot tell you:
   `VAYU_SUDO` lets `install_e2e.sh` substitute a stub, which is the only way CI
   can see the privileged path at all - the runners have passwordless sudo and no
   terminal, which is where three bugs in a row hid.
-- **Every release artifact publishes a `.sha256`** (checksum steps in
+- **Every release installer publishes a `.sha256`** (checksum steps in
   `release.yml`), so the installer's verification is real on all three platforms
-  rather than dead code outside macOS.
+  rather than dead code outside macOS. The `latest*.yml` feeds and the Windows
+  `.exe.blockmap` are excluded: they are electron-updater's own metadata, and
+  what it assembles from them is verified against the sha512 the feed carries,
+  not against a sidecar nothing would fetch.
 - **Errors go through `die()`, never `step || exit 1` at a call site.** Bash
   disables `errexit` for the whole body of a function invoked in an `||`
   context, so an unchecked command inside it falls through - that is how a failed
@@ -195,6 +198,36 @@ Things about it that the code cannot tell you:
   `Vayu-<v>-x86_64.AppImage`) while `Vayu-x64.exe` and `Vayu-amd64.deb` do not,
   so `/releases/latest/download/<name>` **404s for macOS and Linux**. Link the
   installer or `/releases/latest`; never invent an unversioned asset URL.
+
+## Windows updates are differential, and the `.exe.blockmap` is what makes them so
+
+`resolveUpdateStrategy` gives Windows `silent`, so an update there is
+electron-updater's own download rather than a trip to the releases page.
+`NsisUpdater` asks for `<installer>.blockmap` twice - once for the release it is
+installing, once for the release being upgraded from, the second URL derived by
+substituting the old version into the new one's path - compares the two block
+lists and range-requests only the blocks that differ. Both files have to exist
+as release assets, which is why the Windows collect step in `release.yml` fails
+when electron-builder produced no blockmap: through v0.24.0 none were ever
+uploaded, so every Windows update pulled the whole 127MB installer and the only
+trace was one error-level `Cannot download differentially, fallback to full
+download` in the updater log.
+
+Three things to know before reading a release for evidence:
+
+- **The first release carrying a blockmap still updates in full.** The release
+  it is upgrading from has none, so that fetch 404s and the fallback runs. The
+  saving starts one release later.
+- **`latest.yml` does not gain a `blockMapSize`, and does not need one.** That
+  field is written only when the blockmap is appended to the artifact itself,
+  which is the AppImage's arrangement - `blockMapSize` in `latest-linux.yml`,
+  the map read back from the AppImage's own tail, no asset to upload. NSIS
+  writes a sibling file instead and the updater finds it by name, so an absent
+  `blockMapSize` on the exe is correct rather than a symptom.
+- **macOS ships no blockmap on purpose.** Its strategy is `notify`, since an
+  ad-hoc signature gives Squirrel.Mac nothing to verify, so the app never
+  downloads an update there and a `.zip.blockmap` would be an asset with no
+  reader.
 
 ## Windows also publishes to winget, automatically
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,23 @@ jobs:
             exit 1
           }
           $exeFiles | ForEach-Object { Copy-Item $_.FullName -Destination artifacts/ }
+          # The installer's .blockmap is what makes a Windows update a ranged
+          # download instead of the whole 127MB installer: NsisUpdater derives
+          # <installer>.blockmap for this release and for the one being upgraded
+          # from, and transfers only the blocks that differ. Left behind in
+          # app/release/, both fetches 404, the differential path throws, and
+          # every update falls back to the full download with nothing but a log
+          # line to say so - which is how it went unnoticed for 24 releases. So
+          # a missing blockmap fails the release rather than being skipped
+          # quietly. Windows is the only platform that needs the file uploaded:
+          # the AppImage carries its blockmap appended to its own tail, and
+          # macOS notifies rather than downloading.
+          $blockMaps = Get-ChildItem app/release/*.exe.blockmap -ErrorAction SilentlyContinue
+          if ($blockMaps.Count -eq 0) {
+            Write-Error "No .exe.blockmap produced - every Windows update would fall back to the full installer."
+            exit 1
+          }
+          $blockMaps | ForEach-Object { Copy-Item $_.FullName -Destination artifacts/ }
           # electron-updater feed metadata for the NSIS auto-updater.
           Copy-Item app/release/latest.yml -Destination artifacts/ -ErrorAction SilentlyContinue
           Get-ChildItem artifacts
@@ -388,8 +405,10 @@ jobs:
       # generated for every artifact rather than the one that happened to have
       # it, and a missing one is a release-blocking error rather than a silent
       # skip: a checksum that is sometimes absent is a checksum nobody can rely
-      # on. The .yml feeds are excluded - electron-updater carries its own
-      # hashes inside them.
+      # on. The .yml feeds and the .blockmap are excluded - both are
+      # electron-updater's own metadata, and what it assembles from them is
+      # verified against the sha512 the feed carries, never against a sidecar
+      # nothing would fetch.
       - name: Checksum artifacts (Unix)
         if: runner.os != 'Windows'
         shell: bash
@@ -397,7 +416,7 @@ jobs:
           shopt -s nullglob
           count=0
           for f in artifacts/*; do
-            case "$f" in *.yml|*.sha256) continue ;; esac
+            case "$f" in *.yml|*.sha256|*.blockmap) continue ;; esac
             shasum -a 256 "$f" | awk '{print $1}' > "$f.sha256"
             count=$((count + 1))
           done
@@ -412,7 +431,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $files = Get-ChildItem artifacts -File | Where-Object { $_.Extension -notin '.yml', '.sha256' }
+          $files = Get-ChildItem artifacts -File | Where-Object { $_.Extension -notin '.yml', '.sha256', '.blockmap' }
           if ($files.Count -eq 0) {
             Write-Error "No artifacts to checksum - the collect step should have failed first."
             exit 1


### PR DESCRIPTION
## Description

**Root cause.** electron-builder writes `Vayu-x64.exe.blockmap` beside the installer in `app/release/`, but the Windows "Collect artifacts" step (`release.yml:350-363`) copies only `*.exe` and `latest.yml` into `artifacts/`, and the upload step's `artifacts/*` glob can only publish what that step put there. `NsisUpdater` asks for the installer's URL with `.blockmap` appended, twice - for the release it is installing and, by substituting the old version into the same path, for the release being upgraded from - so both fetches 404, the differential path throws, and every Windows update since the first release has silently pulled the whole 127MB installer with one error-level `Cannot download differentially, fallback to full download` as the only trace. Verified live against v0.24.0: `Vayu-x64.exe.blockmap` 404s and `latest.yml` names only url/sha512/size.

**Approach.** Copy `*.exe.blockmap` in that step, and fail the step when NSIS produced an installer without one - a silent skip is exactly how this went unnoticed through 24 releases, and `NsisTarget.isBuildDifferentialAware` is true for this config (`win.target: ["nsis"]`, no `differentialPackage`, non-portable, non-web), so an absent blockmap means someone changed the packaging deliberately. `.blockmap` is excluded from the `.sha256` sidecars for the same reason the `latest*.yml` feeds already are: it is electron-updater's own metadata, and what the updater assembles from it is verified against the sha512 the feed carries, never against a sidecar nothing fetches.

**The alternative I rejected: shipping the AppImage and mac blockmaps too**, which is what the issue's first acceptance criterion asks for literally.

- **AppImage.** `AppImageUpdater` uses `FileWithEmbeddedBlockMapDifferentialDownloader`, which range-requests the new map from the AppImage's own tail using the `blockMapSize` already in `latest-linux.yml` and reads the old map from the installed file - it never calls `provider.getBlockMapFiles`, so no sibling asset is ever requested. Stronger still: electron-builder's AppImage path calls only `appendBlockmap()` (`targets/appimage/appImageUtil.js:39,72`), never `createBlockmap()`, so **no `.AppImage.blockmap` file is ever written to `app/release/`** - adding `*.blockmap` to the Linux collect step, as the issue's fix pathway proposes, would have copied nothing.
- **macOS.** Here a sidecar *is* produced (`macPackager.js:117` builds the zip target with `isWriteUpdateInfo: true`, so `ArchiveTarget.js:64-66` takes the `createBlockmap` branch), but the app resolves to the `notify` strategy on `darwin` (`updater-strategy.ts:38-39`), which leaves `autoUpdater.autoDownload` false (`updater.ts:283`) with no manual-download IPC handler, so `MacUpdater` never downloads and its differential path is unreachable. Uploading the versioned `universal.zip.blockmap` would publish an asset with no reader.

Publishing either would be the "written but never read" defect CLAUDE.md names as this repo's most repeated one, so Windows gets the asset and the other two platforms get the reason recorded in `SKILL.md` instead.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

No suite covers a release workflow, and per the repo's verification-scaling rule a workflow-and-Markdown change needs no engine or app suite - nothing in either could change colour. What was verified instead:

- `.github/workflows/release.yml` parses (`yaml.safe_load`, both jobs intact).
- `cache-warm.yml`'s `guard` job compares only the vcpkg cache key / `VCPKG_COMMIT` and the pnpm `cache-dependency-path` across workflows; this diff touches neither.
- Consumer trace over every reader of a release's assets: `install.sh` builds one exact filename per platform and never lists `assets[]`; `winget-releaser`'s `installers-regex: 'Vayu-x64\.exe$'` is anchored and `winget-publish.yml`'s check is `grep -qx 'Vayu-x64.exe'`; `install_test.sh` / `install_e2e.sh` assert named files, never a set or a count; electron-updater drives off the YAML feed, not the asset list. Extra assets break nothing.
- Blockmap mechanics read out of the pinned dependencies rather than assumed: `NsisTarget.js:308` -> `createBlockmap` writes the installer path with `.blockmap` appended, which under the top-level `artifactName` (`electron-builder.json:29`) is exactly the `Vayu-x64.exe.blockmap` that `Provider.getBlockMapFiles` derives; `blockmap.js:144` shows `blockMapSize` is emitted only in append mode.
- PowerShell: `Get-ChildItem app/release/*.exe` does not match `*.exe.blockmap`, so the two copies are disjoint; `$blockMaps.Count` on no match is 0 under `pwsh`, the same idiom the pre-existing `$exeFiles.Count` check has used for 24 releases.
- Premise re-verified live: all three `.blockmap` URLs 404 on v0.24.0, `latest-linux.yml` carries `blockMapSize: 176417` for the AppImage, `latest.yml` carries none for the exe.

Release-time verification, per the issue: the next release should carry `Vayu-x64.exe.blockmap`, and the Windows updater log should show a differential download instead of the fallback error.

**Two deliberate deviations from the acceptance criteria, both evidence-backed:**

1. *"`latest.yml` carries `blockMapSize`"* - it will not, and does not need to. `blockMapSize` is written only when the map is appended to the artifact itself (`app-builder-lib/out/targets/blockmap/blockmap.js:144`, the append branch); the separate-file branch deliberately omits it. `NsisUpdater` finds the sibling by name, and only `differentialDownloadWebPackage` (nsis-web, unused here) reads the field. The AC as written is unachievable for an NSIS target and describes the AppImage's arrangement.
2. *"the next release carries `.blockmap` assets for exe **and AppImage**"* - only the exe does, for the no-reader reasons above. The AppImage half is not merely unnecessary, it is impossible: electron-builder writes no such file.

One honest limit on the second AC: differential needs a blockmap on *both* releases, so the first release after this lands still falls back (the release it upgrades from has none) and the saving starts one release later. Recorded in the docs so nobody reads that first fallback as a failed fix.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - no suite can exercise a release workflow; the verification is the next release
- [x] I have updated documentation

Docs, in the same commit: no page under `docs/` describes the updater or enumerates release assets (grepped for `electron-updater`/`auto-update`/`differential` across `docs/`, `README.md`, `llms.txt` - no hits), so the change lands in `.claude/skills/releasing/SKILL.md`, which owns release conventions per CLAUDE.md: a new section on the Windows differential path and the blockmap it needs, plus a correction to the "every release artifact publishes a `.sha256`" bullet, which is now about installers.

## Related Issues
Closes #1160