### PR TITLE
perf(app): the dashboard charts stop paying twice, the scatter buckets, and the live dot pulses - #1152

### DIFF
--- a/app/src/modules/dashboard/README.md
+++ b/app/src/modules/dashboard/README.md
@@ -20,7 +20,7 @@ import LoadTestDashboard from "@/modules/dashboard";
 
 ## Code-quality gates
 
-Five rules this module holds to. Each names the file that owns it - that file is
+Seven rules this module holds to. Each names the file that owns it - that file is
 the authority, so a change belongs there rather than in the component that
 consumes it.
 
@@ -43,6 +43,22 @@ consumes it.
   one memoized `DashboardDerived` bundle (shape in `types.ts`) and passes it to
   `HeroRow` and `ModeStatsRow`, which stay pure presentational components that
   read what they need.
+- **A chart card's render gate asks a predicate, not a series.**
+  `utils/metricsTransforms.ts` owns both halves: the transform a chart plots,
+  and the `spansMultipleBuckets` / `hasPercentileSignal` predicates a card reads
+  to decide whether it is worth rendering. `MetricsView` used to build the
+  latency, percentile and status series purely to read `.length`, while the
+  chart inside that card built the identical series again from the identical
+  array - and the store hands down a new array on every batch, so neither memo
+  held and the three heaviest transforms were paid twice per flush (#1152). A
+  gate that needs a count builds nothing.
+- **Every chart buckets before it draws.**
+  `components/charts/uplot/buildData.ts` owns the reduction: `bucketColumns` and
+  `rebucket` for the time-series charts, `buildConcurrencyScatter` for the
+  ramp-up scatter, all at the user's `chartBucketSeconds`. This is the step that
+  makes `constants/live-window.ts`'s retention cap a memory bound rather than a
+  rendering one, and the scatter - one dot per tick, up to the 50,000-tick cap -
+  was the one chart that argument did not cover (#1152).
 - **The per-mode stat-card table lives with its router.**
   `components/stats/ModeStatsRow.tsx` decides which four cards each mode shows,
   and its file comment tabulates them. Add a mode there, next to the branch that

--- a/app/src/modules/dashboard/components/MetricsView.transforms.test.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.transforms.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Each series transform runs once per flush, not once per layer (#1152).
+ *
+ * MetricsView used to build the latency, percentile and status series in its
+ * own memos purely to read `.length` for a card's render gate, while the chart
+ * inside that card built the identical series again from the identical array -
+ * so the three heaviest transforms were paid twice on every store commit, ~2Hz
+ * for the life of a run. The gates now ask a predicate; the chart that plots a
+ * series is the only place it is built. Spying on the module is the only way to
+ * see that, since both copies produced the same numbers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { DisplayMetrics, MetricsViewProps } from "../types";
+import type { LoadTestMetrics } from "@/types";
+
+const spies = vi.hoisted(() => ({
+	buildLatencyChartData: vi.fn(),
+	buildPercentileChartData: vi.fn(),
+	buildStatusOverTime: vi.fn(),
+}));
+
+vi.mock("../utils/metricsTransforms", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../utils/metricsTransforms")>();
+	return {
+		...actual,
+		buildLatencyChartData: (...args: Parameters<typeof actual.buildLatencyChartData>) => {
+			spies.buildLatencyChartData(...args);
+			return actual.buildLatencyChartData(...args);
+		},
+		buildPercentileChartData: (...args: Parameters<typeof actual.buildPercentileChartData>) => {
+			spies.buildPercentileChartData(...args);
+			return actual.buildPercentileChartData(...args);
+		},
+		buildStatusOverTime: (...args: Parameters<typeof actual.buildStatusOverTime>) => {
+			spies.buildStatusOverTime(...args);
+			return actual.buildStatusOverTime(...args);
+		},
+	};
+});
+
+const MetricsView = (await import("./MetricsView")).default;
+
+/** Ticks that make all three cards render: two 0.5s buckets, p99 and statuses. */
+function history(n: number): LoadTestMetrics[] {
+	return Array.from({ length: n }, (_, i) => ({
+		timestamp: i * 1000,
+		elapsed_seconds: i,
+		requests_completed: i * 100,
+		requests_failed: i * 2,
+		current_rps: 100 + i * 10,
+		current_concurrency: 10 + i * 5,
+		latency_p50_ms: 20 + i,
+		latency_p95_ms: 40 + i * 3,
+		latency_p99_ms: 80 + i * 8,
+		avg_latency_ms: 25 + i,
+		avg_queue_wait_ms: i * 0.5,
+		bytes_sent: i * 1000,
+		bytes_received: i * 5000,
+		status_codes: { "200": i * 90, "500": i * 3 },
+	}));
+}
+
+const metrics: DisplayMetrics = {
+	requests_completed: 500,
+	requests_failed: 4,
+	current_rps: 120,
+	latency_p50_ms: 22,
+	latency_p95_ms: 48,
+	latency_p99_ms: 96,
+	avg_latency_ms: 27,
+	bytes_sent: 5000,
+	bytes_received: 25000,
+} as DisplayMetrics;
+
+function props(ticks: LoadTestMetrics[]): MetricsViewProps {
+	return {
+		metrics,
+		historicalMetrics: ticks,
+		isCompleted: false,
+		finalReport: null,
+		// Not ramp_up: that mode swaps the percentile card for the scatter, and
+		// the percentile transform is one of the three under test here.
+		mode: "constant_concurrency",
+		concurrency: 10,
+	};
+}
+
+function renderView(ticks: LoadTestMetrics[]) {
+	return render(
+		<TooltipProvider>
+			<MetricsView {...props(ticks)} />
+		</TooltipProvider>
+	);
+}
+
+describe("MetricsView series transforms", () => {
+	beforeEach(() => {
+		spies.buildLatencyChartData.mockClear();
+		spies.buildPercentileChartData.mockClear();
+		spies.buildStatusOverTime.mockClear();
+	});
+
+	it("builds each series exactly once per flush", () => {
+		const { rerender } = renderView(history(6));
+
+		// Once each: inside the chart that plots it. A gate that rebuilt the
+		// series to read its length would make each of these 2.
+		expect(spies.buildLatencyChartData).toHaveBeenCalledTimes(1);
+		expect(spies.buildPercentileChartData).toHaveBeenCalledTimes(1);
+		expect(spies.buildStatusOverTime).toHaveBeenCalledTimes(1);
+
+		// A flush: the store hands down a new array on every batch.
+		rerender(
+			<TooltipProvider>
+				<MetricsView {...props(history(7))} />
+			</TooltipProvider>
+		);
+
+		expect(spies.buildLatencyChartData).toHaveBeenCalledTimes(2);
+		expect(spies.buildPercentileChartData).toHaveBeenCalledTimes(2);
+		expect(spies.buildStatusOverTime).toHaveBeenCalledTimes(2);
+	});
+
+	it("renders the three cards whose gates those transforms used to build", () => {
+		// The counts above would also hold if a card had silently stopped
+		// rendering - then the transform would run zero times, not twice.
+		const { getByText } = renderView(history(6));
+		expect(getByText("Latency over time")).toBeTruthy();
+		expect(getByText("Response time percentiles over time")).toBeTruthy();
+		expect(getByText("Status codes over time")).toBeTruthy();
+	});
+
+	it("builds nothing while a run has one bucket of ticks", () => {
+		// Both layers agreed on this before; the gates keep it true, so an early
+		// flush costs no transform at all.
+		renderView([]);
+		expect(spies.buildLatencyChartData).not.toHaveBeenCalled();
+		expect(spies.buildPercentileChartData).not.toHaveBeenCalled();
+		expect(spies.buildStatusOverTime).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -33,11 +33,11 @@ import { STATUS_CLASS_SERIES, STATUS_CLASS_CSS_VAR } from "@/constants/http-stat
 import { useMode } from "../hooks/useMode";
 import {
 	isRateLimitedRun,
-	buildLatencyChartData,
 	buildRampOverlay,
-	buildPercentileChartData,
-	buildStatusOverTime,
+	hasPercentileSignal,
+	hasStatusCodes,
 	latestThroughputMbps,
+	spansMultipleBuckets,
 } from "../utils/metricsTransforms";
 import { createAnomalyDetector } from "../utils/detectAnomalies";
 import { HeroRow } from "./hero/HeroRow";
@@ -79,13 +79,18 @@ function MetricsView({
 	// uPlot (Canvas) renders the whole buffer cheaply, so it's gone.
 	const chartWindow = historicalMetrics;
 
-	const latencyChartData = useMemo(() => buildLatencyChartData(chartWindow), [chartWindow]);
-
-	const percentileChartData = useMemo(() => buildPercentileChartData(chartWindow), [chartWindow]);
-	const hasPercentileData = percentileChartData.some((d) => d.p99 > 0);
-
-	const statusChartData = useMemo(() => buildStatusOverTime(chartWindow), [chartWindow]);
-	const hasStatusData = statusChartData.length > 1;
+	// Which chart cards are worth rendering. Each chart builds its own series
+	// from `chartWindow` (it also needs the user's bucket width, which only it
+	// reads), so these gates ask the cheap question - is there more than one
+	// 0.5s bucket to plot - rather than building the series a second time here
+	// and throwing it away (#1152). Latency and percentiles share the count
+	// gate: both transforms bucket every tick, so they yield the same length.
+	const hasMultiplePoints = useMemo(() => spansMultipleBuckets(chartWindow), [chartWindow]);
+	const hasPercentileData = useMemo(() => hasPercentileSignal(chartWindow), [chartWindow]);
+	const hasStatusData = useMemo(
+		() => spansMultipleBuckets(chartWindow, hasStatusCodes),
+		[chartWindow]
+	);
 	const liveMbps = useMemo(() => latestThroughputMbps(chartWindow), [chartWindow]);
 
 	const rampOverlay = useMemo(
@@ -298,7 +303,7 @@ function MetricsView({
 			)}
 
 			{/* Row 2.5 - Latency over time (perceived vs wire, queue-wait gap) */}
-			{latencyChartData.length > 1 && (
+			{hasMultiplePoints && (
 				<div className="bg-card border border-border rounded-md p-3.5">
 					<div className="flex items-baseline justify-between mb-3">
 						<h3 className="text-xs font-semibold text-foreground">
@@ -372,7 +377,7 @@ function MetricsView({
 							/>
 						</div>
 					)
-				: percentileChartData.length > 1 &&
+				: hasMultiplePoints &&
 					hasPercentileData && (
 						<div className="bg-card border border-border rounded-md p-3.5">
 							<div className="flex items-baseline justify-between mb-3">

--- a/app/src/modules/dashboard/components/charts/uplot/ScatterAndDistribution.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/ScatterAndDistribution.tsx
@@ -17,13 +17,14 @@ import type { LoadTestMetrics, RunReport } from "@/types";
 import { type Breakpoint } from "../../../utils/computeBreakpoint";
 import { useClientSettingsStore } from "@/stores";
 import { UPlotChart, type UPlotSeriesSpec, type Marker } from "./UPlotChart";
-import { pickConcurrency } from "./buildData";
+import { buildConcurrencyScatter } from "./buildData";
 import { axisMs, fmtMs } from "./formatters";
 
 /**
- * Response time vs concurrency - a scatter of per-tick (concurrency, p99). The
- * flat-left headroom, the elbow (breakpoint) and the steep-right saturation read
- * against the origin. Amber marker at the SLO-crossing concurrency.
+ * Response time vs concurrency - a scatter of (concurrency, p99), one point per
+ * chart bucket. The flat-left headroom, the elbow (breakpoint) and the
+ * steep-right saturation read against the origin. Amber marker at the
+ * SLO-crossing concurrency.
  */
 export function ResponseTimeVsConcurrencyChart({
 	history,
@@ -38,22 +39,18 @@ export function ResponseTimeVsConcurrencyChart({
 	 *  dot for that tick, and hovering a dot moves the time charts' cursor. */
 	syncKey?: string;
 }) {
+	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
 	const { data, focusTimes } = useMemo(() => {
-		// uPlot needs x ascending; concurrency rises over a ramp, but sort to be safe.
-		// Keep each point's timestamp aligned to the sorted order so the focus
-		// channel can map a dot ↔ a moment in time.
-		const pts = history
-			.map((m) => ({
-				c: pickConcurrency(m),
-				p99: m.latency_p99_ms ?? 0,
-				t: m.elapsed_seconds,
-			}))
-			.sort((a, b) => a.c - b.c);
+		// Bucketed to the same width as every other chart here, so a dot is a
+		// bucket rather than a tick and the redraw cost stops following the
+		// retention window. `times` keeps each point's moment for the focus
+		// channel, which maps a dot ↔ the time charts' cursor.
+		const { concurrency, p99, times } = buildConcurrencyScatter(history, bucketSeconds);
 		return {
-			data: [pts.map((p) => p.c), pts.map((p) => p.p99)] as uPlot.AlignedData,
-			focusTimes: pts.map((p) => p.t),
+			data: [concurrency, p99] as uPlot.AlignedData,
+			focusTimes: times,
 		};
-	}, [history]);
+	}, [history, bucketSeconds]);
 
 	const series: UPlotSeriesSpec[] = [
 		// `categorical`, not `primary`: `--primary` tracks the user's accent theme,

--- a/app/src/modules/dashboard/components/charts/uplot/UPlotChart.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/UPlotChart.tsx
@@ -404,6 +404,7 @@ export function UPlotChart({
 			{liveDot && (
 				<span
 					aria-hidden
+					className="animate-[vayu-pulse_1.6s_ease-in-out_infinite]"
 					style={{
 						position: "absolute",
 						right: 6,
@@ -413,7 +414,6 @@ export function UPlotChart({
 						borderRadius: "50%",
 						background: "hsl(var(--primary))",
 						boxShadow: "0 0 0 3px hsl(var(--primary) / 0.25)",
-						animation: "vayuPulse 1.6s ease-in-out infinite",
 					}}
 				/>
 			)}

--- a/app/src/modules/dashboard/components/charts/uplot/buildData.test.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/buildData.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, it, expect } from "vitest";
 import type { LoadTestMetrics } from "@/types";
-import { bucketColumns, rebucket, pickThroughput, pickErrorRate } from "./buildData";
+import {
+	bucketColumns,
+	buildConcurrencyScatter,
+	rebucket,
+	pickThroughput,
+	pickErrorRate,
+} from "./buildData";
 
 function tick(partial: Partial<LoadTestMetrics>): LoadTestMetrics {
 	return {
@@ -83,5 +89,71 @@ describe("rebucket", () => {
 		const { times: outT, cols } = rebucket(times, [[1, 2, 3]]);
 		expect(outT).toEqual([0, 0.5, 1]);
 		expect(cols[0]).toEqual([1, 2, 3]);
+	});
+});
+
+describe("buildConcurrencyScatter", () => {
+	it("plots one point per bucket, not one per tick", () => {
+		// A minute of the engine's 10Hz tick: 600 ticks over 0..59.9s, which
+		// round-to-nearest collapses into the 121 half-second buckets 0..60.
+		const history = Array.from({ length: 600 }, (_, i) =>
+			tick({
+				elapsed_seconds: i / 10,
+				current_concurrency: 10 + i,
+				latency_p99_ms: 50 + i,
+			})
+		);
+		const { concurrency, p99, times } = buildConcurrencyScatter(history);
+		expect(concurrency).toHaveLength(121);
+		expect(p99).toHaveLength(121);
+		expect(times).toHaveLength(121);
+		// The point of the change: cost follows the bucket count, so a window
+		// five times longer at the same tick rate is five times the dots, not
+		// 3,000 of them for every flush of a 5-minute window.
+		expect(concurrency.length).toBeLessThan(history.length / 4);
+	});
+
+	it("keeps the last sample in a bucket, so a ramp step's settled value survives", () => {
+		const history = [
+			tick({ elapsed_seconds: 0.1, current_concurrency: 10, latency_p99_ms: 90 }),
+			// Same bucket as above (0.0), and the one that wins.
+			tick({ elapsed_seconds: 0.2, current_concurrency: 12, latency_p99_ms: 95 }),
+			tick({ elapsed_seconds: 0.6, current_concurrency: 20, latency_p99_ms: 140 }),
+		];
+		const { concurrency, p99, times } = buildConcurrencyScatter(history);
+		expect(concurrency).toEqual([12, 20]);
+		expect(p99).toEqual([95, 140]);
+		expect(times).toEqual([0, 0.5]);
+	});
+
+	it("sorts by concurrency and carries each point's bucket time with it", () => {
+		// Concurrency falling over time - uPlot needs x ascending, and a dot's
+		// timestamp has to follow it into the sorted order or the focus channel
+		// highlights the wrong moment.
+		const history = [
+			tick({ elapsed_seconds: 0, current_concurrency: 30, latency_p99_ms: 300 }),
+			tick({ elapsed_seconds: 1, current_concurrency: 20, latency_p99_ms: 200 }),
+			tick({ elapsed_seconds: 2, current_concurrency: 10, latency_p99_ms: 100 }),
+		];
+		const { concurrency, p99, times } = buildConcurrencyScatter(history);
+		expect(concurrency).toEqual([10, 20, 30]);
+		expect(p99).toEqual([100, 200, 300]);
+		expect(times).toEqual([2, 1, 0]);
+	});
+
+	it("honours a wider bucket setting, and treats a missing p99 as zero", () => {
+		const history = [
+			tick({ elapsed_seconds: 0, current_concurrency: 5 }),
+			tick({ elapsed_seconds: 0.9, current_concurrency: 8, latency_p99_ms: 40 }),
+			tick({ elapsed_seconds: 2.0, current_concurrency: 9, latency_p99_ms: 60 }),
+		];
+		// 2s buckets: round(0/2)*2 = 0, round(0.9/2)*2 = 0, round(2/2)*2 = 2.
+		const { concurrency, p99 } = buildConcurrencyScatter(history, 2);
+		expect(concurrency).toEqual([8, 9]);
+		expect(p99).toEqual([40, 60]);
+	});
+
+	it("returns empty columns for an empty history", () => {
+		expect(buildConcurrencyScatter([])).toEqual({ concurrency: [], p99: [], times: [] });
 	});
 });

--- a/app/src/modules/dashboard/components/charts/uplot/buildData.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/buildData.ts
@@ -72,5 +72,41 @@ export function rebucket(
 export const pickThroughput = (m: LoadTestMetrics): number => m.throughput ?? m.current_rps ?? 0;
 export const pickSendRate = (m: LoadTestMetrics): number => m.send_rate ?? 0;
 export const pickConcurrency = (m: LoadTestMetrics): number => m.current_concurrency ?? 0;
+export const pickLatencyP99 = (m: LoadTestMetrics): number => m.latency_p99_ms ?? 0;
 export const pickErrorRate = (m: LoadTestMetrics): number =>
 	m.requests_completed > 0 ? ((m.requests_failed || 0) / m.requests_completed) * 100 : 0;
+
+/**
+ * (concurrency, p99) points for the response-time-vs-concurrency scatter,
+ * bucketed to the shared chart width before they are sorted.
+ *
+ * The scatter used to map and sort every retained tick and hand uPlot one dot
+ * per tick, while every other chart here collapses ticks into buckets first -
+ * so a 5-minute window at the engine's 10Hz tick was ~3,000 dots redrawn on
+ * every flush, and a full-run window up to the store's 50,000-tick cap. Its
+ * per-flush cost is now the bucket count, like everything else on this canvas.
+ *
+ * Last sample in a bucket wins (that is {@link bucketColumns}), which keeps the
+ * elbow: the point a ramp step settles at is the one that survives, where an
+ * average over the bucket would round the knee off. `times` carries each
+ * point's bucket timestamp in the plotted order, so the focus channel still
+ * maps a dot to a moment - and now to the same instant the time charts key on.
+ */
+export function buildConcurrencyScatter(
+	history: LoadTestMetrics[],
+	bucketSeconds: number = DEFAULT_CHART_BUCKET_SECONDS
+): { concurrency: number[]; p99: number[]; times: number[] } {
+	const { times, cols } = bucketColumns(
+		history,
+		[pickConcurrency, pickLatencyP99],
+		bucketSeconds
+	);
+	// uPlot needs x ascending; concurrency rises over a ramp, but sort to be
+	// safe. Sorting an index permutation keeps each bucket's (x, y, t) together.
+	const order = times.map((_, i) => i).sort((a, b) => cols[0][a] - cols[0][b]);
+	return {
+		concurrency: order.map((i) => cols[0][i]),
+		p99: order.map((i) => cols[1][i]),
+		times: order.map((i) => times[i]),
+	};
+}

--- a/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The live-dot overlay (UPlotChart.tsx) pulses via a CSS animation. A CSS
+ * keyframe name is case-sensitive, so a class that names a keyframe nothing
+ * defines renders a static dot - the animation silently no-ops. This test
+ * guards both ends: the class the rendered dot actually carries, and that the
+ * keyframe it names is a real `@keyframes` definition somewhere in the app's
+ * CSS. See #1152.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { LoadTestMetrics } from "@/types";
+import { RequestRateChart } from "./index";
+
+function series(n: number): LoadTestMetrics[] {
+	return Array.from({ length: n }, (_, i) => ({
+		timestamp: i * 1000,
+		elapsed_seconds: i,
+		requests_completed: i * 100,
+		requests_failed: i * 2,
+		current_rps: 100 + i * 10,
+		current_concurrency: i * 20,
+		latency_p50_ms: 20 + i,
+		latency_p95_ms: 40 + i * 3,
+		latency_p99_ms: 80 + i * 8,
+		avg_latency_ms: 25 + i,
+		bytes_sent: i * 1000,
+		bytes_received: i * 5000,
+		send_rate: 110 + i * 10,
+		throughput: 100 + i * 9,
+		avg_queue_wait_ms: i * 0.5,
+		status_codes: { "200": i * 90, "404": i * 5, "500": i * 3 },
+	}));
+}
+
+describe("live-dot animation resolves to a real keyframe", () => {
+	it("names a keyframe that is actually defined", () => {
+		// Rendered half: mount a live chart and find the dot.
+		const { container, unmount } = render(
+			<RequestRateChart history={series(3)} isCompleted={false} />
+		);
+		const dot = container.querySelector("span[aria-hidden]");
+		expect(dot).not.toBeNull();
+
+		const className = dot!.className;
+		expect(className.length).toBeGreaterThan(0);
+
+		const match = className.match(/animate-\[([a-zA-Z0-9-]+)_/);
+		expect(match).not.toBeNull();
+		const animationName = match![1];
+
+		unmount();
+
+		// Definition half: read the app's actual CSS/config from disk and
+		// confirm the name the dot uses is one of the defined keyframes.
+		const cssPath = path.resolve(__dirname, "../../../../../index.css");
+		const configPath = path.resolve(__dirname, "../../../../../../tailwind.config.js");
+		const css = readFileSync(cssPath, "utf-8");
+		const config = readFileSync(configPath, "utf-8");
+		expect(css.length).toBeGreaterThan(0);
+		expect(config.length).toBeGreaterThan(0);
+
+		const definedKeyframes = [...css.matchAll(/@keyframes\s+([a-zA-Z0-9-]+)/g)].map(
+			(m) => m[1]
+		);
+		expect(definedKeyframes.length).toBeGreaterThan(0);
+
+		expect(definedKeyframes).toContain(animationName);
+	});
+});

--- a/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
@@ -63,14 +63,11 @@ describe("live-dot animation resolves to a real keyframe", () => {
 
 		unmount();
 
-		// Definition half: read the app's actual CSS/config from disk and
-		// confirm the name the dot uses is one of the defined keyframes.
-		const cssPath = path.resolve(__dirname, "../../../../../index.css");
-		const configPath = path.resolve(__dirname, "../../../../../../tailwind.config.js");
-		const css = readFileSync(cssPath, "utf-8");
-		const config = readFileSync(configPath, "utf-8");
+		// Definition half: read the app's actual CSS from disk - the import a
+		// test sees is stubbed to "", which is how a guard like this passed for
+		// weeks while reading nothing.
+		const css = readFileSync(path.resolve(__dirname, "../../../../../index.css"), "utf-8");
 		expect(css.length).toBeGreaterThan(0);
-		expect(config.length).toBeGreaterThan(0);
 
 		const definedKeyframes = [...css.matchAll(/@keyframes\s+([a-zA-Z0-9-]+)/g)].map(
 			(m) => m[1]
@@ -78,5 +75,21 @@ describe("live-dot animation resolves to a real keyframe", () => {
 		expect(definedKeyframes.length).toBeGreaterThan(0);
 
 		expect(definedKeyframes).toContain(animationName);
+	});
+
+	it("keeps the shipped keyframe and the Tailwind config's copy in step", () => {
+		// `vayu-pulse` is defined twice - in index.css, which ships, and in
+		// tailwind.config.js, which backs the utility class. Reading one and
+		// asserting nothing about the other is how the two drift apart.
+		const css = readFileSync(path.resolve(__dirname, "../../../../../index.css"), "utf-8");
+		const config = readFileSync(
+			path.resolve(__dirname, "../../../../../../tailwind.config.js"),
+			"utf-8"
+		);
+		expect(css.length).toBeGreaterThan(0);
+		expect(config.length).toBeGreaterThan(0);
+
+		expect(css).toContain("@keyframes vayu-pulse");
+		expect(config).toContain('"vayu-pulse"');
 	});
 });

--- a/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/live-dot.test.tsx
@@ -89,7 +89,10 @@ describe("live-dot animation resolves to a real keyframe", () => {
 		expect(css.length).toBeGreaterThan(0);
 		expect(config.length).toBeGreaterThan(0);
 
-		expect(css).toContain("@keyframes vayu-pulse");
-		expect(config).toContain('"vayu-pulse"');
+		// Anchored, not a substring: `toContain("@keyframes vayu-pulse")` is
+		// satisfied by `@keyframes vayu-pulse-DELETED`, which is the rename this
+		// case exists to catch.
+		expect(css).toMatch(/@keyframes\s+vayu-pulse\s*\{/);
+		expect(config).toMatch(/["']vayu-pulse["']\s*:/);
 	});
 });

--- a/app/src/modules/dashboard/utils/metricsTransforms.test.ts
+++ b/app/src/modules/dashboard/utils/metricsTransforms.test.ts
@@ -6,7 +6,10 @@ import {
 	buildRampOverlay,
 	buildPercentileChartData,
 	buildStatusOverTime,
+	hasPercentileSignal,
+	hasStatusCodes,
 	latestThroughputMbps,
+	spansMultipleBuckets,
 } from "./metricsTransforms";
 
 function tick(partial: Partial<LoadTestMetrics>): LoadTestMetrics {
@@ -206,3 +209,111 @@ describe("latestThroughputMbps", () => {
 		expect(latestThroughputMbps([tick({ bytes_received: 5 })])).toBe(0);
 	});
 });
+
+/*
+ * The chart cards' render gates. Each one used to build the whole series and
+ * read its length, so these prove the cheap predicate answers exactly what the
+ * discarded series answered - anything less and a card appears or disappears at
+ * a different moment than before.
+ */
+describe("spansMultipleBuckets", () => {
+	it("agrees with the built series' length over randomized histories", () => {
+		const rng = seeded(20260901);
+		let sawTrue = 0;
+		let sawFalse = 0;
+		for (let run = 0; run < 200; run++) {
+			const history = randomHistory(rng);
+			const spans = spansMultipleBuckets(history);
+			expect(spans).toBe(buildLatencyChartData(history).length > 1);
+			expect(spans).toBe(buildPercentileChartData(history).length > 1);
+			expect(spansMultipleBuckets(history, hasStatusCodes)).toBe(
+				buildStatusOverTime(history).length > 1
+			);
+			if (spans) sawTrue++;
+			else sawFalse++;
+		}
+		// The agreement above is worthless if every case landed on one side.
+		expect(sawTrue).toBeGreaterThan(20);
+		expect(sawFalse).toBeGreaterThan(20);
+	});
+
+	it("is false for ticks that share one 0.5s bucket, true once one leaves it", () => {
+		const sameBucket = [tick({ elapsed_seconds: 1.0 }), tick({ elapsed_seconds: 1.1 })];
+		expect(spansMultipleBuckets(sameBucket)).toBe(false);
+		expect(buildLatencyChartData(sameBucket)).toHaveLength(1);
+
+		const twoBuckets = [...sameBucket, tick({ elapsed_seconds: 1.4 })];
+		expect(spansMultipleBuckets(twoBuckets)).toBe(true);
+		expect(buildLatencyChartData(twoBuckets)).toHaveLength(2);
+	});
+
+	it("is false for an empty or single-tick history", () => {
+		expect(spansMultipleBuckets([])).toBe(false);
+		expect(spansMultipleBuckets([tick({ elapsed_seconds: 3 })])).toBe(false);
+	});
+
+	it("counts only the ticks `include` accepts", () => {
+		const history = [
+			tick({ elapsed_seconds: 1, status_codes: { "200": 5 } }),
+			tick({ elapsed_seconds: 2 }),
+			tick({ elapsed_seconds: 3 }),
+		];
+		// Three buckets, but only one tick carries the status map the stacked
+		// chart reads - the same tick `buildStatusOverTime` keeps.
+		expect(spansMultipleBuckets(history)).toBe(true);
+		expect(spansMultipleBuckets(history, hasStatusCodes)).toBe(false);
+		expect(buildStatusOverTime(history)).toHaveLength(1);
+	});
+});
+
+describe("hasPercentileSignal", () => {
+	it("is true when any tick reports a p99 above zero", () => {
+		expect(hasPercentileSignal([tick({ elapsed_seconds: 1, latency_p99_ms: 12 })])).toBe(true);
+		expect(hasPercentileSignal([tick({ elapsed_seconds: 1, latency_p99_ms: 0 })])).toBe(false);
+		expect(hasPercentileSignal([])).toBe(false);
+	});
+
+	it("agrees with the built series wherever a bucket's last tick carries the signal", () => {
+		const rng = seeded(4242);
+		let sawTrue = 0;
+		for (let run = 0; run < 200; run++) {
+			const history = randomHistory(rng);
+			const built = buildPercentileChartData(history).some((p) => p.p99 > 0);
+			if (built) {
+				// Documented direction: the predicate reads every tick, so it is
+				// true wherever the built series is, and may be true when a
+				// bucket's final tick alone reported nothing.
+				expect(hasPercentileSignal(history)).toBe(true);
+				sawTrue++;
+			}
+		}
+		expect(sawTrue).toBeGreaterThan(20);
+	});
+});
+
+/** Deterministic 0..1 generator - a fixed seed keeps a failure reproducible. */
+function seeded(seed: number): () => number {
+	let s = seed >>> 0;
+	return () => {
+		s = (s * 1664525 + 1013904223) >>> 0;
+		return s / 0x100000000;
+	};
+}
+
+/**
+ * A history with the shapes the gates actually meet: empty, one tick, several
+ * ticks inside one 0.5s bucket, ticks spanning buckets, ticks with and without
+ * a status map, and p99 zero on some ticks (a tick with no completions).
+ */
+function randomHistory(rng: () => number): LoadTestMetrics[] {
+	const n = Math.floor(rng() * 12);
+	let elapsed = rng() * 2;
+	return Array.from({ length: n }, () => {
+		elapsed += rng() * 0.4; // often the same bucket, sometimes the next
+		return tick({
+			elapsed_seconds: Math.round(elapsed * 100) / 100,
+			latency_p99_ms: rng() < 0.4 ? 0 : Math.round(rng() * 200),
+			status_codes: rng() < 0.5 ? undefined : { "200": Math.floor(rng() * 100) },
+		});
+	});
+}

--- a/app/src/modules/dashboard/utils/metricsTransforms.ts
+++ b/app/src/modules/dashboard/utils/metricsTransforms.ts
@@ -13,6 +13,16 @@
 
 import type { LoadTestMetrics } from "@/types";
 
+/**
+ * The bucket every series transform here rounds a tick's elapsed time to before
+ * plotting. Shared so the "is there anything to plot" predicates below bucket
+ * exactly as the transforms do - a second copy of `* 2) / 2` is how the two
+ * would drift apart.
+ */
+function halfSecondBucket(elapsedSeconds: number): number {
+	return Math.round(elapsedSeconds * 2) / 2;
+}
+
 /** A run is "rate limited" (can drop requests) only in constant_rps with a target. */
 export function isRateLimitedRun(mode: string | undefined, targetRps: number | undefined): boolean {
 	return mode === "constant_rps" && (targetRps ?? 0) > 0;
@@ -60,7 +70,7 @@ export function buildStatusOverTime(history: LoadTestMetrics[]): StatusPoint[] {
 	const byBucket = new Map<number, ClassSums & { time: number }>();
 	for (const m of history) {
 		if (!m.status_codes) continue;
-		const t = Math.round(m.elapsed_seconds * 2) / 2;
+		const t = halfSecondBucket(m.elapsed_seconds);
 		byBucket.set(t, { time: t, ...classifyCumulative(m.status_codes) });
 	}
 	const cum = Array.from(byBucket.values()).sort((a, b) => a.time - b.time);
@@ -106,7 +116,7 @@ export interface LatencyPoint {
 export function buildLatencyChartData(history: LoadTestMetrics[]): LatencyPoint[] {
 	const byBucket = new Map<number, LatencyPoint>();
 	for (const m of history) {
-		const t = Math.round(m.elapsed_seconds * 2) / 2;
+		const t = halfSecondBucket(m.elapsed_seconds);
 		const latency = m.avg_latency_ms ?? 0;
 		const queue = m.avg_queue_wait_ms ?? 0;
 		// Clamp wire >= 0 so wire <= latency always holds; this keeps the
@@ -154,7 +164,7 @@ export interface PercentilePoint {
 export function buildPercentileChartData(history: LoadTestMetrics[]): PercentilePoint[] {
 	const byBucket = new Map<number, PercentilePoint>();
 	for (const m of history) {
-		const t = Math.round(m.elapsed_seconds * 2) / 2;
+		const t = halfSecondBucket(m.elapsed_seconds);
 		byBucket.set(t, {
 			time: t,
 			p50: m.latency_p50_ms ?? 0,
@@ -182,7 +192,7 @@ export function buildRampOverlay(
 	const byBucket = new Map<number, RampPoint>();
 	let peak = 0;
 	for (const m of history) {
-		const t = Math.round(m.elapsed_seconds * 2) / 2;
+		const t = halfSecondBucket(m.elapsed_seconds);
 		const achieved = m.current_concurrency ?? 0;
 		if (achieved > peak) peak = achieved;
 		const configured =
@@ -207,4 +217,50 @@ export function buildRampOverlay(
 		peakAchieved: peak,
 		target,
 	};
+}
+
+/** A tick carrying the cumulative status map `buildStatusOverTime` reads. */
+export const hasStatusCodes = (m: LoadTestMetrics): boolean => Boolean(m.status_codes);
+
+/**
+ * True when `history` covers more than one 0.5s bucket - i.e. when the series
+ * transforms above would return more than one point.
+ *
+ * The dashboard renders a chart card only when its series has something to
+ * draw, and that question is a count, not a series: building the whole series
+ * to read `.length` meant the transform ran twice per flush, once in the card's
+ * gate and once inside the chart that actually plots it. This answers it
+ * directly, allocating nothing and stopping at the first tick that lands in a
+ * second bucket - two ticks, in the normal case.
+ *
+ * `include` narrows which ticks count, for a transform that skips some:
+ * `buildStatusOverTime` ignores ticks with no `status_codes` map.
+ */
+export function spansMultipleBuckets(
+	history: LoadTestMetrics[],
+	include?: (m: LoadTestMetrics) => boolean
+): boolean {
+	let first: number | null = null;
+	for (const m of history) {
+		if (include && !include(m)) continue;
+		const t = halfSecondBucket(m.elapsed_seconds);
+		if (first === null) first = t;
+		else if (t !== first) return true;
+	}
+	return false;
+}
+
+/**
+ * True when any tick reports a p99 above zero - the "is there latency to show"
+ * half of the percentile card's gate, read off the ticks rather than off a
+ * built series.
+ *
+ * Deliberately not bucket-aware. `buildPercentileChartData` keeps the last tick
+ * in each bucket, so a bucket whose final tick reported no completions reads 0
+ * there while an earlier tick in it did not. This predicate can therefore only
+ * be *more* permissive, and only while every such bucket is in that state - the
+ * chart's own two-point guard still decides whether anything is drawn.
+ */
+export function hasPercentileSignal(history: LoadTestMetrics[]): boolean {
+	return history.some((m) => (m.latency_p99_ms ?? 0) > 0);
 }


### PR DESCRIPTION
## Description

Three findings in one chart surface, one work item (#1152). All three are the same shape: work done that nothing reads.

**Root cause.** `MetricsView` built the latency, percentile and status series in its own `useMemo`s purely to read `.length` for a card's render gate, then handed the same raw history to the chart inside that card, which built the identical series again from the identical array. The store replaces `historicalMetrics` on every batch, so neither memo ever held: the three heaviest transforms were paid twice per flush, ~2Hz for the life of a run. Separately, the ramp-up scatter mapped every retained tick into an object, sorted the lot and handed uPlot one dot per tick, while every other chart in that directory collapses ticks into `chartBucketSeconds` buckets first - and `live-window.ts` leans on exactly that when it argues the 50,000-tick retention cap is a memory bound rather than a rendering one. And the live-dot overlay named a keyframe, `vayuPulse`, that does not exist anywhere (the app defines `vayu-pulse`; CSS keyframe names are case-sensitive), so an unknown animation name was silently ignored and the dot rendered static on every live chart while the comment above it described a pulse.

**Approach.** A gate's question is a count, not a series, so `spansMultipleBuckets` answers it off the ticks - allocating nothing, stopping at the first tick that lands in a second bucket - and `hasPercentileSignal` answers the percentile card's second half. The chart that plots a series is now the only place it is built. The scatter bucket-reduces through the shared `bucketColumns` before sorting, so its per-flush cost is the bucket count, and it sorts an index permutation so each point's bucket time follows it into plotted order. The dot carries `animate-[vayu-pulse_1.6s_ease-in-out_infinite]`, the same arbitrary-value form the four existing `vayu-spin` sites use.

**The alternative I rejected: computing each series once in `MetricsView` and passing it down as a prop** - the first option the issue lists. It splits one pipeline across two layers for no gain: each chart re-buckets its series at the user's `chartBucketSeconds`, a setting only the chart reads, so the parent cannot finish the work it would be starting. It also changes a prop signature shared by nine render sites across the live dashboard *and* the history views, when the cheap gate needs no signature change at all. Deleting the parent's copies was smaller and strictly less coupled.

**One deliberate behavioural difference, disclosed rather than hidden.** `hasPercentileSignal` is not bucket-aware. `buildPercentileChartData` keeps a bucket's last tick, so a bucket whose final tick reported no completions reads p99 = 0 there while an earlier tick in it did not. The predicate reads every tick, so it can only be *more* permissive, and only for a flush in which that holds of every bucket; the chart's own two-point guard still decides whether anything is drawn. The comment says so and the test asserts only the direction that is actually guaranteed.

**`focusTimes` changed meaning**, from raw tick timestamps to bucket timestamps. This is a wash at worst and an improvement in practice: `UPlotChart`'s focus channel does nearest-timestamp matching against the time charts' bucketed x-values, so a scatter dot and a time-chart cursor now sit on the same grid instead of near it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally at the head of this branch:

- **App suite:** `pnpm test` - **563 files, 6164 tests, all passed**. On the base commit `cbfc38b` the same suite is 561 files / 6148 tests, so this adds 2 files and 16 tests and regresses none. `pnpm type-check`, `pnpm lint` (zero warnings) and `npx prettier --check` on every touched file are clean.
- **The 16 new tests:** 6 in `metricsTransforms.test.ts` (200-run randomized-history equivalence between each predicate and the series length it replaces, asserting both answers actually occurred so the agreement is not two empty sets, plus the same-bucket, empty, and `include`-filter cases); 5 in `buildData.test.ts` (bucket-count bound, last-sample-wins, the sort carrying timestamps with it, a non-default bucket width, empty history); 3 in the new `MetricsView.transforms.test.tsx` (the spy proof: one build per transform per flush, the three cards still rendering, and nothing built at all while a run has one bucket); 2 in the new `live-dot.test.tsx` (the class the rendered dot carries names a keyframe `index.css` actually defines, and the CSS and Tailwind copies of that keyframe stay in step).
- **Mutation-checked, not just green.** An unbucketed predicate fails the equivalence test; restoring a series-building gate in `MetricsView` fails the spy test; per-tick scatter points fail three of the five `buildConcurrencyScatter` cases; renaming the keyframe on either side fails the live-dot guard. Each was run forwards - mutate, see it red, restore, see it green.
- **A late fix to my own guard:** the keyframe test first used `toContain("@keyframes vayu-pulse")`, which is satisfied by `@keyframes vayu-pulse-DELETED` - it passed under exactly the mutation it existed to catch. Both sides are matched anchored now (`8d92c71`).
- The new `live-dot.test.tsx` was run 10 times in a row on a clean tree: 10/10 green. One transient failure seen during review was a concurrent mutation check that had the keyframe renamed in `index.css` at that moment, not the test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**Docs, in the same commit.** `app/src/modules/dashboard/README.md` gains the two rules this change establishes, beside the five gates already there: a card's render gate asks a predicate rather than building the series it gates, and every chart on the canvas buckets before it draws. No page under `docs/` needed an edit: `COMPONENTS.md` describes the chart tree, not these mechanics, and `live-window.ts`'s bucketing claim was made *true* by this change rather than stale by it - the scatter was the one chart it did not cover.

**Correction to a commit message.** `1fb4f41` says moving the dot off an inline style "brings the dot under the app-wide reduced-motion collapse". That is wrong, and I am not rewriting pushed history to hide it: the collapse in `index.css` uses `!important` on `animation-duration` and `animation-iteration-count`, which already overrode a non-important inline style. The justification for the class stands on its own - it is the app's existing idiom rather than a second hand-rolled copy of an animation the design system owns.

**Deferred, with an issue behind it:** `PerformanceTab.tsx:48-49` runs the same build-then-gate pattern on the history path. It is out of scope here - #1152 is about per-flush cost, and that call site runs once per loaded run over a series that arrives complete, the same distinction #1151 drew - but it is one import away from breaking the README rule this PR adds, so it is #1190 rather than a comment saying "later".

## Related Issues
Closes #1152