### PR TITLE
feat(engine): bound the script-validation reservoir in bytes, not only in count - #1155

### DIFF
--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1202,7 +1202,13 @@ under its own notice. Both are about *rendering* cost, not about what arrived.
 `report.sampling` carries what each of the run's bounded stores thinned away -
 `successTracesDropped` / `slowTracesDropped` for the trace records behind
 `report.results`, and `responseSamplesDropped` for the buffer post-run test
-scripts are graded on. The renderer treats a non-zero count as "this list is a
+scripts are graded on. That buffer is bounded twice, and one counter reports
+both: by count (`max_response_samples`), which displaces an incumbent and so
+keeps the graded set uniform over the run, and by bytes
+(`max_response_sample_bytes`), which stops admitting once the retained bodies
+fill it. The renderer cannot tell which applied, which is why the note's
+uniformity sentence is not always true - issue #1192.
+The renderer treats a non-zero count as "this list is a
 *sample* of a larger set": `SampleRetentionNote` (shared) renders under the
 dashboard's Sampled Requests, the history Samples tab and the Test Validation
 card, and the sample-count badges say **shown** rather than *captured*, since

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6517,7 +6517,9 @@ stores a *cut* body, because a deferred check reading one reports a failure the
 target never produced. They differ in one way worth knowing: the count cap
 displaces an incumbent, so the tested set stays a uniform sample of the run,
 while an exhausted byte budget stops admitting - a run that spends it is graded
-on the part of the run whose bodies fit.
+on the part of the run whose bodies fit. The counter cannot say which bound
+applied, so the app's retention note states the uniform case for both; issue
+#1192 is that gap.
 
 Three of its keys are about captured responses rather than retention:
 `responseBodiesCaptured` is how many exchanges the run stored (see

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -638,6 +638,7 @@ governs what a run measures rather than what it keeps:
 | `maxDesignResponseBodyBytes` | `33554432` | 1024–1073741824 | Largest response body a **design-mode** send - `POST /execute`, and each step of a collection run - reads into memory. A bigger response is read up to this point and answered with `bodyCapped: true` (see `POST /execute`) rather than failing, because someone is watching for it. Separate from `maxResponseBodyBytes` above, which is the load path's and refuses instead. |
 | `maxSampleBodyBytes` | `32768`  | 0–104857600  | Largest response body kept for a single captured **load-run** sample. Bigger bodies are stored truncated and marked. Deliberately far below `maxTraceBodyBytes`: a design run stores one exchange the user asked for, a load run stores tens nobody asked for individually. `0` keeps headers and metadata and no body. |
 | `maxSampleBytes`    | `2097152` | 0–1073741824 | Total captured body bytes one load run may store. Once spent, samples keep their headers and metadata and only their bodies are dropped; the report counts them as `sampling.sampleBodiesDropped`. |
+| `maxResponseSampleBytes` | `268435456` | 0–1073741824 | Total response-body bytes one load run may hold for its post-run test scripts and schema checks. Two orders of magnitude above `maxSampleBytes` because these bodies are kept **whole** - a truncated one would fail a check the target passed - so past the budget whole samples are dropped instead, counted as `sampling.responseSamplesDropped`. `0` retains no sample that has a body. |
 | `phaseHistograms`   | `true`    | boolean      | Record DNS/connect/TLS/first-byte/download times for **every** load-test completion into five HdrHistograms, so the report can carry `timingBreakdown.phases` percentiles instead of averages over the retained trace sample. Costs five atomic histogram writes per completion; see [benchmarks](benchmarks.md). |
 | `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results, **including captured response bodies**) are pruned at startup and after each run finishes. `0` = unlimited. Captured data is stored verbatim, so this doubles as its expiry. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
@@ -5318,6 +5319,7 @@ default, and whose message names the offending field and why the bound exists:
 | `success_sample_rate` | `1`-`100000` | It is a sampling *period* (keep 1 in N), used as `counter % rate`. A `0` was a division by zero that killed the daemon mid-run. |
 | `response_sample_rate` | `1`-`100000` | Same modulo, same crash. |
 | `max_response_samples` | `0`-`1000000` | Each retained sample holds a full response body, and the vector is reserved up front; a negative value casts to ~1.8e19. |
+| `max_response_sample_bytes` | `0`-`1073741824` | The whole-run budget for those bodies, held in memory for the run *and* its retention window. The count cap above bounds the store only for a target whose bodies are small - at 1 MiB each, 1000 samples is ~1 GB. `0` retains no sample that has a body. Defaults to the `maxResponseSampleBytes` setting. |
 | `max_success_results` | `0`-`1000000` | Each retained record holds a serialised timing breakdown, and the store is reserved up front. `0` means unlimited. |
 | `max_slow_results` | `0`-`1000000` | Same store, same reserve, separate budget. `0` means unlimited. |
 | `slow_threshold_ms` | `0`-`86400000` ms | `0` disables outlier capture; a negative threshold would mark **every** completion an outlier and fill the slow store with the whole run. |
@@ -5365,7 +5367,7 @@ independent budgets:
 |--------|-----------|------------|
 | Sampled timing traces | 1 in `success_sample_rate` completions, only while `save_timing_breakdown` is on | `max_success_results` |
 | Slow-request traces | any completion at or past `slow_threshold_ms`, **regardless** of `save_timing_breakdown` | `max_slow_results` |
-| Response samples (post-run test scripts) | 1 in `response_sample_rate` completions | `max_response_samples` |
+| Response samples (post-run test scripts) | 1 in `response_sample_rate` completions | `max_response_samples`, **and** `max_response_sample_bytes` |
 | Per-status exemplars (captured responses) | the first three completions of each distinct status code **that no other budget already stored** | `max_exemplar_results` |
 
 None of these budgets bound the report's `timingBreakdown.phases`: the per-phase
@@ -6505,6 +6507,17 @@ describes.
 count means they are a **uniform sample of the whole run** (reservoir retention)
 rather than a truncated prefix of it. The section is absent on a run recorded
 before it was reported, which is not the same claim as "nothing was dropped".
+
+`responseSamplesDropped` counts responses the post-run test scripts and schema
+checks never saw, for either of the two bounds on that store: the count cap
+(`max_response_samples`), and the byte budget (`max_response_sample_bytes`) that
+drops a whole sample once the run's retained bodies would exceed it. Both mean
+the same thing to a reader - this response was not validated - and neither ever
+stores a *cut* body, because a deferred check reading one reports a failure the
+target never produced. They differ in one way worth knowing: the count cap
+displaces an incumbent, so the tested set stays a uniform sample of the run,
+while an exhausted byte budget stops admitting - a run that spends it is graded
+on the part of the run whose bodies fit.
 
 Three of its keys are about captured responses rather than retention:
 `responseBodiesCaptured` is how many exchanges the run stored (see

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -998,7 +998,11 @@ row exists - and the executor is the only thing that differs.
   samples the last step of a long plan. The run's `max_response_samples` budget
   is split evenly across the steps that carry a script (not across every step),
   floored at one apiece; a step with no script is never sampled and never
-  counted as a thinned sample. A `pre_script` runs nowhere: it would have to run
+  counted as a thinned sample. The byte budget beside it
+  (`max_response_sample_bytes`) is deliberately *not* split: those bodies are
+  resident in one process, so a forty-step plan must not multiply the ceiling by
+  forty, and a step that drops a sample over it is counted like any other thinned
+  one. A `pre_script` runs nowhere: it would have to run
   before a send this mode never pauses for. `pm.execution` still throws in a
   load run for the reason the flow-control section gives, and there is
   deliberately no inline-script path on the load hot path.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -2269,6 +2269,19 @@ The **language** is current; what is missing is the **host environment**:
   response displaces a uniformly chosen incumbent, so a target that starts
   failing halfway through is graded on those failures rather than on the healthy
   window before them
+- A second bound applies to the same store: `max_response_sample_bytes`
+  (`maxResponseSampleBytes`, 256 MiB by default) is the whole-run budget for the
+  retained bodies, because each is kept **whole** and a target answering 1 MiB
+  responses would otherwise put ~1 GB in that store. Past it a sample is dropped
+  entire rather than truncated - a script reading a cut body would fail a
+  response the target got right - and the drop is counted the same way, in
+  `sampling.responseSamplesDropped`
+- **A run that spends that budget is graded on the part of it that fit**, not on
+  a uniform sample: the count cap displaces incumbents and stays uniform, while
+  an exhausted byte budget simply stops admitting. Only a target whose retained
+  bodies average more than ~256 KiB reaches it at the defaults; raise
+  `maxResponseSampleBytes`, or lower `max_response_samples` so fewer, later
+  responses share the budget, if that matters for the run you are grading
 - `samplesTested` in the report (`TestsSampled`) is the **size of that sample**,
   not the run's request count, and `sampling.responseSamplesDropped` beside it
   says how many responses the bound thinned away

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -165,6 +165,10 @@ constexpr int64_t MAX_SAMPLE_BODY_BYTES = 104857600; // 100MB
 /// Upper bound on `max_sample_bytes` (the whole-run capture budget). Every
 /// byte under it is held in memory until the run flushes.
 constexpr int64_t MAX_SAMPLE_BYTES = 1073741824; // 1GB
+/// Upper bound on `max_response_sample_bytes` (the whole-run budget for the
+/// script-validation reservoir). Every byte under it is held in memory for the
+/// run *and* its retention window, so the ceiling is the capture budget's.
+constexpr int64_t MAX_RESPONSE_SAMPLE_BYTES = 1073741824; // 1GB
 /// Upper bound on `max_exemplar_results`. Each retained exemplar holds a
 /// captured exchange, bounded in turn by the two budgets above.
 constexpr int64_t MAX_EXEMPLAR_RESULTS = 100000;
@@ -468,6 +472,17 @@ constexpr size_t DEFAULT_MAX_SAMPLE_BODY_BYTES = 32768;
 /// MetricsCollector::sample_bodies_dropped so the UI can say the set is
 /// incomplete rather than showing a silently biased subset.
 constexpr size_t DEFAULT_MAX_SAMPLE_BYTES = size_t{ 2 } * 1024 * 1024;
+/// Whole-run budget for the script-validation reservoir's bodies (config key
+/// `maxResponseSampleBytes`). Two orders of magnitude above the capture budget
+/// beside it because the two stores answer different questions: a captured
+/// exchange is an exhibit a person reads, truncated to 32 KiB, while a retained
+/// sample is the *input* to a deferred script or schema check and is kept whole
+/// - truncating it would make that check report a failure the target never
+/// produced. So the budget drops whole samples instead, and this is where it
+/// starts: against a target answering 1 MiB bodies the count cap alone
+/// (`max_response_samples`, 1000) allowed ~1 GB resident, held through the
+/// retention window after the run (issue #1155).
+constexpr size_t DEFAULT_MAX_RESPONSE_SAMPLE_BYTES = size_t{ 256 } * 1024 * 1024;
 /// How many exemplars of each distinct status code a run guarantees to retain.
 /// Small on purpose: exemplars answer "what does a 503 from this target look
 /// like", which the first few answer as well as the first few hundred.

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -201,6 +201,16 @@ struct MetricsCollectorConfig {
     /// Maximum response samples to store for script validation
     size_t max_response_samples = constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLES;
 
+    /// Whole-run byte budget for those samples' bodies, shared by the run-level
+    /// reservoir and every per-step one. A sample whose body would exceed what
+    /// is left is dropped **whole** and counted by response_samples_dropped();
+    /// nothing here is ever truncated, because a deferred script or schema
+    /// check reading a cut body reports a failure the target never produced.
+    /// The figure is what is currently *held*, so a displaced sample gives its
+    /// bytes back - see MetricsCollector::response_sample_bytes.
+    size_t max_response_sample_bytes =
+    constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLE_BYTES;
+
     /// Sample rate for response storage (1 = all, 100 = 1%, etc.)
     size_t response_sample_rate = constants::metrics_collector::DEFAULT_RESPONSE_SAMPLE_RATE;
 
@@ -427,6 +437,22 @@ class MetricsCollector {
     SampleIdentity identity);
 
     /**
+     * @brief Let go of every retained response sample and its bytes.
+     *
+     * Called once the run is retained: the deferred passes that read these
+     * stores have already run (they are what the samples exist for), and the
+     * retention window keeps the tick topic and the summary counters, not the
+     * bodies behind them (issue #1154's deferred half). Without this a run
+     * against a 1 MiB endpoint held its whole sample budget resident for
+     * `liveRetentionMs` after it stopped sending.
+     *
+     * Takes each store's lock rather than assuming the run has drained: a
+     * stopped run's last completions can still be landing when the retention
+     * hand-off happens.
+     */
+    void release_response_samples ();
+
+    /**
      * @brief Record a failed request
      * Thread-safe. The error counters and the status-code distribution always
      * see every error; the individual record is stored only while the store is
@@ -461,9 +487,26 @@ class MetricsCollector {
         return slow_dropped_.load (std::memory_order_relaxed);
     }
 
-    /** @brief Response samples dropped or displaced by the reservoir. */
+    /**
+     * @brief Response samples dropped or displaced by the reservoir.
+     *
+     * Two budgets end a sample here and both count the same way, because both
+     * mean the same thing to a reader: this response was not validated. The
+     * count cap (`max_response_samples`) refuses or displaces a candidate; the
+     * byte budget (`max_response_sample_bytes`) drops one whose body no longer
+     * fits. Neither ever stores a truncated body - see the config field.
+     */
     [[nodiscard]] size_t response_samples_dropped () const {
         return response_dropped_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Body bytes the retained response samples currently hold.
+     * The figure `max_response_sample_bytes` is spent against, across the
+     * run-level reservoir and every per-step one.
+     */
+    [[nodiscard]] size_t response_sample_bytes () const {
+        return response_sample_bytes_.load (std::memory_order_relaxed);
     }
 
     /**
@@ -928,6 +971,13 @@ class MetricsCollector {
     std::atomic<size_t> response_sample_counter_{ 0 };
     std::atomic<size_t> response_seen_{ 0 };
     std::atomic<size_t> response_dropped_{ 0 };
+    /// Body bytes the retained samples hold, run-level store and every step
+    /// store together - one budget for one run's memory. Kept exact rather
+    /// than monotonic: a displaced sample gives its bytes back, because
+    /// otherwise a long run's charge grows with the *candidates* the reservoir
+    /// accepted (~k ln(n/k) of them) while what is held stays at k, and the
+    /// budget would eventually freeze a reservoir that is nowhere near it.
+    std::atomic<size_t> response_sample_bytes_{ 0 };
 
     /**
      * @brief One reservoir per plan step, for a scenario load run's deferred
@@ -979,6 +1029,19 @@ class MetricsCollector {
      * being reported.
      */
     [[nodiscard]] CapturedExchange capture_exchange (const Response& response);
+
+    /**
+     * @brief Charge @p bytes to the run's response-sample budget.
+     *
+     * Answers false when the budget cannot cover them, having charged nothing;
+     * the caller then drops the whole sample. Called after the reservoir slot
+     * is claimed and *before* the body is copied, so a refusal costs neither
+     * the copy nor the store's mutex.
+     */
+    [[nodiscard]] bool claim_response_sample_bytes (size_t bytes);
+
+    /** @brief Give @p bytes back - a displaced incumbent, or a refused insert. */
+    void release_response_sample_bytes (size_t bytes);
 
     // Helper for atomic double addition
     void atomic_add_double (std::atomic<double>& target, double value);

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -446,9 +446,11 @@ class MetricsCollector {
      * against a 1 MiB endpoint held its whole sample budget resident for
      * `liveRetentionMs` after it stopped sending.
      *
-     * Takes each store's lock rather than assuming the run has drained: a
-     * stopped run's last completions can still be landing when the retention
-     * hand-off happens.
+     * Each store gives back exactly the bytes it held, under its own lock,
+     * rather than the budget being zeroed - that is what keeps the figure from
+     * going below zero, which for a size_t is a budget of 1.8e19. The locking
+     * is defensive rather than load-bearing: `retain_run` is a worker's last
+     * act, after the run has drained, so no completion is still landing.
      */
     void release_response_samples ();
 
@@ -504,6 +506,13 @@ class MetricsCollector {
      * @brief Body bytes the retained response samples currently hold.
      * The figure `max_response_sample_bytes` is spent against, across the
      * run-level reservoir and every per-step one.
+     *
+     * The run report carries the *drop count*, not this - what a reader needs
+     * to know is which responses went unvalidated, and a resident-byte figure
+     * for a store that no longer exists by the time the report is read would
+     * be one more number to explain. So this is the tests' seam, exactly as
+     * `captured_body_bytes()` beside it is: deliberately test-only, not a
+     * field that lost its reader.
      */
     [[nodiscard]] size_t response_sample_bytes () const {
         return response_sample_bytes_.load (std::memory_order_relaxed);

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -155,6 +155,12 @@ size_t max_ticks = constants::server::DEFAULT_MAX_LIVE_TICKS) {
 struct EngineDefaults {
     size_t max_sample_body_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES;
     size_t max_sample_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES;
+    /// Config key `maxResponseSampleBytes`. The whole-run budget for the
+    /// script-validation reservoir's bodies, which are kept untruncated - so
+    /// this is the setting that decides how much of a large-bodied target's
+    /// traffic a run can validate.
+    size_t max_response_sample_bytes =
+    constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLE_BYTES;
     /// Config key `phaseHistograms`. Whether the run feeds the five per-phase
     /// histograms behind the report's `timingBreakdown.phases`.
     bool phase_histograms = constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS;
@@ -212,9 +218,12 @@ struct RunContext {
     /// Let go of everything the run needed only while it was sending: the
     /// event loop - with its per-worker curl handle pools, its multi handles
     /// and the TCP/TLS connections those hold open against the target, and the
-    /// 512KB submission queues - the bound CSV rows, and the scenario plan.
+    /// 512KB submission queues - the bound CSV rows, the scenario plan, and the
+    /// response bodies the deferred passes have already read (issue #1155).
     /// What retention exists for is untouched: the tick topic, `closed`, the
-    /// summary counters and the collector behind them (issue #1154).
+    /// summary counters and the collector behind them (issue #1154) - including
+    /// `response_samples_dropped`, so the report still says what was thinned
+    /// after the samples themselves are gone.
     ///
     /// Called once, by `RunManager::retain_run`, so no exit path can forget
     /// it. By then the run's own thread has made its last read of these
@@ -233,6 +242,14 @@ struct RunContext {
         }
         load_data.reset ();
         scenario.reset ();
+        // The sample reservoirs, but not the collector: the two deferred passes
+        // that read them have run by now - both finish before the summary is
+        // written, and the paths that reach retention without them are the ones
+        // that failed before a response existed to sample - while the counters
+        // beside them are read for the whole retention window.
+        if (metrics_collector) {
+            metrics_collector->release_response_samples ();
+        }
         // `loop` frees here, outside the critical section above.
     }
 

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -41,6 +41,20 @@ uint64_t next_random () {
 }
 
 /**
+ * @brief What applying a reservoir slot did with the candidate.
+ *
+ * Three outcomes rather than "did it cost a record": every caller counts a drop
+ * for the two that are not `Appended`, but a caller holding a byte budget also
+ * has to know *whose* bytes to give back - the incumbent's on `Displaced`, the
+ * candidate's own on `Refused`.
+ */
+enum class SlotOutcome : std::uint8_t {
+    Appended,  ///< stored in a store that had room
+    Displaced, ///< stored over an incumbent, which the caller now holds
+    Refused    ///< not stored; the store was full with no slot to take
+};
+
+/**
  * Apply a reservoir slot to a bounded store. Requires the store's mutex.
  *
  * The slot is claimed outside the lock (that is what keeps the copy off the
@@ -49,26 +63,53 @@ uint64_t next_random () {
  * slot's own append flag. Anything that lands on an occupied index displaces
  * the incumbent, which the caller counts as a drop.
  *
- * @return true if the insert cost a record - an incumbent displaced, or this
- *         candidate dropped because the store was full with no slot to take.
+ * @param value taken by reference and **swapped** on `Displaced`, so the caller
+ *        is handed the record that left the store rather than having it
+ *        destroyed here - which is the only place its size can still be read.
+ *        Moved from on `Appended`, untouched on `Refused`.
  */
 template <typename T>
-bool insert_at_slot (std::vector<T>& store, size_t capacity, const ReservoirSlot& slot, T&& value) {
-    // `std::forward`, not `std::move`: `T&&` beside a `std::vector<T>&` is a
-    // forwarding reference, and spelling the transfer as an unconditional move
-    // is what would silently gut an lvalue the day the parameter stops being
-    // deduced from the store's element type.
+SlotOutcome
+insert_at_slot (std::vector<T>& store, size_t capacity, const ReservoirSlot& slot, T& value) {
     if (store.size () < capacity) {
-        store.push_back (std::forward<T> (value));
-        return false;
+        store.push_back (std::move (value));
+        return SlotOutcome::Appended;
     }
     if (slot.index < store.size ()) {
-        store[slot.index] = std::forward<T> (value);
-        return true;
+        std::swap (store[slot.index], value);
+        return SlotOutcome::Displaced;
     }
     // Capacity is full and the slot points past the end: nothing to replace
     // without growing past the bound, so the candidate is dropped.
-    return true;
+    return SlotOutcome::Refused;
+}
+
+/**
+ * Body bytes a settled insert gives back to the run's sample budget.
+ *
+ * The candidate was charged before it was copied, so what is released depends
+ * on which record actually left the retained set: the incumbent `insert_at_slot`
+ * swapped out on `Displaced`, and the candidate's own bytes on `Refused`. One
+ * function because getting that backwards leaks budget in one direction and
+ * double-refunds it in the other, and neither shows up as a wrong number until
+ * a long run stops sampling.
+ */
+/// Body bytes a store of retained samples holds. Requires the store's mutex.
+size_t held_body_bytes (const std::vector<ResponseSample>& samples) {
+    size_t total = 0;
+    for (const auto& sample : samples) {
+        total += sample.body.size ();
+    }
+    return total;
+}
+
+size_t reclaimed_bytes (SlotOutcome outcome, size_t candidate_bytes, const ResponseSample& leftover) {
+    switch (outcome) {
+    case SlotOutcome::Displaced: return leftover.body.size ();
+    case SlotOutcome::Refused: return candidate_bytes;
+    case SlotOutcome::Appended: return 0;
+    }
+    return 0;
 }
 } // namespace
 
@@ -399,12 +440,12 @@ const Timing* phases) {
         record.capture = capture_exchange (*capture);
     }
 
-    bool displaced = false;
+    SlotOutcome outcome = SlotOutcome::Refused;
     {
         std::lock_guard<std::mutex> lock (success_mutex_);
-        displaced = insert_at_slot (store, capacity, slot, std::move (record));
+        outcome = insert_at_slot (store, capacity, slot, record);
     }
-    if (displaced) {
+    if (outcome != SlotOutcome::Appended) {
         dropped.fetch_add (1, std::memory_order_relaxed);
     }
 }
@@ -441,18 +482,29 @@ SampleIdentity identity) {
         return;
     }
 
+    // The run's byte budget, charged before the body-sized copy for the same
+    // reason the slot is claimed before it. A body that no longer fits drops
+    // the *whole* sample: truncating it here would hand the deferred script or
+    // schema pass a cut body and have it report a failure the target never
+    // produced (issue #1155).
+    const size_t bytes = response.body.size ();
+    if (!claim_response_sample_bytes (bytes)) {
+        response_dropped_.fetch_add (1, std::memory_order_relaxed);
+        return;
+    }
+
     ResponseSample sample (response, now_ms ());
     sample.iteration      = identity.iteration;
     sample.vu             = identity.vu;
     sample.data_row_index = identity.data_row_index;
 
-    bool displaced = false;
+    SlotOutcome outcome = SlotOutcome::Refused;
     {
         std::lock_guard<std::mutex> lock (response_samples_mutex_);
-        displaced =
-        insert_at_slot (response_samples_, capacity, slot, std::move (sample));
+        outcome = insert_at_slot (response_samples_, capacity, slot, sample);
     }
-    if (displaced) {
+    if (outcome != SlotOutcome::Appended) {
+        release_response_sample_bytes (reclaimed_bytes (outcome, bytes, sample));
         response_dropped_.fetch_add (1, std::memory_order_relaxed);
     }
 }
@@ -515,19 +567,69 @@ SampleIdentity identity) {
         return;
     }
 
+    // One budget for the whole run, not one per step: a plan's steps share the
+    // process the samples are resident in, so a hot step's bodies have to be
+    // spendable against the same ceiling the run-level store spends against.
+    const size_t bytes = response.body.size ();
+    if (!claim_response_sample_bytes (bytes)) {
+        response_dropped_.fetch_add (1, std::memory_order_relaxed);
+        return;
+    }
+
     ResponseSample sample (response, now_ms ());
     sample.iteration      = identity.iteration;
     sample.vu             = identity.vu;
     sample.data_row_index = identity.data_row_index;
 
-    bool displaced = false;
+    SlotOutcome outcome = SlotOutcome::Refused;
     {
         std::lock_guard<std::mutex> lock (store.mutex);
-        displaced =
-        insert_at_slot (store.samples, store.capacity, slot, std::move (sample));
+        outcome = insert_at_slot (store.samples, store.capacity, slot, sample);
     }
-    if (displaced) {
+    if (outcome != SlotOutcome::Appended) {
+        release_response_sample_bytes (reclaimed_bytes (outcome, bytes, sample));
         response_dropped_.fetch_add (1, std::memory_order_relaxed);
+    }
+}
+
+bool MetricsCollector::claim_response_sample_bytes (size_t bytes) {
+    // fetch_add-then-refund rather than a CAS loop, exactly as the capture
+    // budget does it (see capture_exchange): the overshoot is bounded by one
+    // body per concurrent writer, and a run that briefly reads its own budget
+    // as fuller than it is drops one more sample, which the counter discloses.
+    const size_t before =
+    response_sample_bytes_.fetch_add (bytes, std::memory_order_relaxed);
+    if (before + bytes > config_.max_response_sample_bytes) {
+        response_sample_bytes_.fetch_sub (bytes, std::memory_order_relaxed);
+        return false;
+    }
+    return true;
+}
+
+void MetricsCollector::release_response_sample_bytes (size_t bytes) {
+    if (bytes == 0) {
+        return;
+    }
+    response_sample_bytes_.fetch_sub (bytes, std::memory_order_relaxed);
+}
+
+void MetricsCollector::release_response_samples () {
+    // Each store gives back exactly what it held, rather than the budget being
+    // zeroed: a store zeroed here and a completion still unwinding its own
+    // refund would take the counter below zero, and a size_t below zero is a
+    // budget of 1.8e19 - the bound off, silently, in the one window where
+    // nothing else would notice.
+    {
+        std::lock_guard<std::mutex> lock (response_samples_mutex_);
+        release_response_sample_bytes (held_body_bytes (response_samples_));
+        response_samples_.clear ();
+        response_samples_.shrink_to_fit ();
+    }
+    for (auto& store : step_samples_) {
+        std::lock_guard<std::mutex> lock (store->mutex);
+        release_response_sample_bytes (held_body_bytes (store->samples));
+        store->samples.clear ();
+        store->samples.shrink_to_fit ();
     }
 }
 

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -84,6 +84,15 @@ insert_at_slot (std::vector<T>& store, size_t capacity, const ReservoirSlot& slo
     return SlotOutcome::Refused;
 }
 
+/// Body bytes a store of retained samples holds. Requires the store's mutex.
+size_t held_body_bytes (const std::vector<ResponseSample>& samples) {
+    size_t total = 0;
+    for (const auto& sample : samples) {
+        total += sample.body.size ();
+    }
+    return total;
+}
+
 /**
  * Body bytes a settled insert gives back to the run's sample budget.
  *
@@ -94,15 +103,6 @@ insert_at_slot (std::vector<T>& store, size_t capacity, const ReservoirSlot& slo
  * double-refunds it in the other, and neither shows up as a wrong number until
  * a long run stops sampling.
  */
-/// Body bytes a store of retained samples holds. Requires the store's mutex.
-size_t held_body_bytes (const std::vector<ResponseSample>& samples) {
-    size_t total = 0;
-    for (const auto& sample : samples) {
-        total += sample.body.size ();
-    }
-    return total;
-}
-
 size_t reclaimed_bytes (SlotOutcome outcome, size_t candidate_bytes, const ResponseSample& leftover) {
     switch (outcome) {
     case SlotOutcome::Displaced: return leftover.body.size ();

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -635,9 +635,15 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
     static_cast<int64_t> (constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS)));
     capture_response_bodies = mc_config.capture_response_bodies;
 
-    // Configure response sampling for script validation
+    // Configure response sampling for script validation. Bounded twice: in
+    // count here, and in bytes by the budget below - a retained sample holds a
+    // whole response body, so the count alone bounds the store's memory only
+    // for a target whose bodies are small (issue #1155).
     mc_config.max_response_samples =
     static_cast<size_t> (config.value ("max_response_samples", 1000));
+    mc_config.max_response_sample_bytes =
+    static_cast<size_t> (config.value ("max_response_sample_bytes",
+    static_cast<int64_t> (engine_defaults.max_response_sample_bytes)));
     mc_config.response_sample_rate =
     static_cast<size_t> (config.value ("response_sample_rate", 100));
 
@@ -945,6 +951,9 @@ const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn) {
         engine_defaults.max_sample_bytes =
         static_cast<size_t> (db.get_config_int ("maxSampleBytes",
         static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES)));
+        engine_defaults.max_response_sample_bytes =
+        static_cast<size_t> (db.get_config_int ("maxResponseSampleBytes",
+        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLE_BYTES)));
         // The same two settings the design path's stream reads, so a user who
         // tightened them once has tightened them for both (issue #576).
         engine_defaults.stream_max_duration_ms =

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -4016,6 +4016,19 @@ void Database::seed_default_config () {
     "1073741824", // 1GB
     std::nullopt, now }));
 
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxResponseSampleBytes",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLE_BYTES),
+    "integer", "Load-Run Validation Sample Budget",
+    "How much response-body data one load run may hold for its post-run test "
+    "scripts and schema checks. These bodies are kept whole - a truncated one "
+    "would fail a check the target passed - so past the budget whole samples "
+    "are dropped instead, and the report counts them. Lower it for a target "
+    "with large responses; raise it to validate more of them.",
+    "data_retention", std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_RESPONSE_SAMPLE_BYTES),
+    "0",          // 0 retains no sample that has a body
+    "1073741824", // 1GB
+    std::nullopt, now }));
+
     upsert_config (ConfigEntry{ "maxScenarioStoredSteps",
     std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS),
     "integer", "Max Stored Scenario Steps",

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -918,6 +918,9 @@ const vayu::core::MonitorLimits& monitor_limits) {
     { "response_sample_rate", 1, 100000, "It is a sampling period (keep 1 in N), and 0 is a division by zero." },
     { "max_response_samples", 0, limits::MAX_RESPONSE_SAMPLES,
     "Each retained sample holds a full response body." },
+    { "max_response_sample_bytes", 0, limits::MAX_RESPONSE_SAMPLE_BYTES,
+    "It is the whole-run budget for those bodies, held in memory for the "
+    "run and its retention window; 0 retains no sample that has a body." },
     { "max_success_results", 0, limits::MAX_RETAINED_RESULTS,
     "Each retained record holds a serialised timing breakdown, and the "
     "store is reserved up front." },

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -1000,6 +1000,141 @@ TEST (MetricsCollectorRetention, ResponseSamplesStayBoundedUnderConcurrentWriter
 }
 
 // ============================================================================
+// Response-sample byte budget (issue #1155)
+// ============================================================================
+
+namespace {
+
+/// A reservoir sized in both dimensions, which is the whole subject here: the
+/// count cap alone bounds the store's memory only for a target whose bodies
+/// are small.
+MetricsCollectorConfig reservoir_config (size_t capacity, size_t budget_bytes) {
+    MetricsCollectorConfig config;
+    config.expected_requests         = 1000;
+    config.response_sample_rate      = 1;
+    config.max_response_samples      = capacity;
+    config.max_response_sample_bytes = budget_bytes;
+    return config;
+}
+
+vayu::Response response_with_body (size_t body_bytes) {
+    vayu::Response response;
+    response.status_code     = 200;
+    response.body            = std::string (body_bytes, 'x');
+    response.timing.total_ms = 1.0;
+    return response;
+}
+
+} // namespace
+
+// The finding itself: the store was bounded in count only, so a target
+// answering 1MB bodies put ~1GB in this one vector at the defaults. Past the
+// budget a whole sample is dropped - never a truncated one, because a deferred
+// script or schema check reading a cut body reports a failure the target never
+// produced. Remove the gate in claim_response_sample_bytes and this reddens:
+// all ten are retained.
+TEST (MetricsCollectorSampleBudget, ASpentBudgetDropsWholeSamplesAndCountsThem) {
+    MetricsCollector collector ("run_sample_budget", reservoir_config (1000, 250));
+
+    for (int i = 0; i < 10; ++i) {
+        collector.record_response_sample (response_with_body (100));
+    }
+
+    EXPECT_EQ (collector.response_samples ().size (), 2u); // 250 / 100, floored
+    EXPECT_EQ (collector.response_samples_dropped (), 8u);
+    EXPECT_EQ (collector.response_sample_bytes (), 200u);
+    for (const auto& sample : collector.response_samples ()) {
+        EXPECT_EQ (sample.body.size (), 100u)
+        << "a retained sample was truncated, which is what would make a "
+           "deferred script or schema check fail a response the target passed";
+    }
+}
+
+// The budget is what is *held*, not what has been offered: a displaced sample
+// gives its bytes back. Without the refund the charge grows with every
+// candidate the reservoir accepts (~k ln(n/k) of them) while the store still
+// holds k, and the budget eventually freezes a reservoir nowhere near it -
+// which reads as "validation stopped covering the run" and as nothing else.
+// Drop the release in the displaced arm and this reddens: the held figure
+// climbs to the budget and stays there.
+TEST (MetricsCollectorSampleBudget, DisplacedSamplesGiveTheirBytesBack) {
+    MetricsCollector collector ("run_sample_refund", reservoir_config (4, 800));
+
+    for (int i = 0; i < 200; ++i) {
+        collector.record_response_sample (response_with_body (100));
+    }
+
+    ASSERT_EQ (collector.response_samples ().size (), 4u);
+    EXPECT_EQ (collector.response_sample_bytes (), 400u)
+    << "the budget is charged for samples the store no longer holds";
+    // Every candidate is either retained or counted; nothing vanishes.
+    EXPECT_EQ (
+    collector.response_samples ().size () + collector.response_samples_dropped (), 200u);
+}
+
+// Feature-off in the only sense this budget has one: a run whose bodies are
+// ordinary never reaches it, so the retained set is exactly what the count cap
+// alone would have kept.
+TEST (MetricsCollectorSampleBudget, OrdinaryBodiesAreUnaffectedAtTheDefault) {
+    MetricsCollectorConfig config;
+    config.expected_requests    = 1000;
+    config.response_sample_rate = 1;
+    config.max_response_samples = 100;
+    MetricsCollector collector ("run_sample_default", config);
+
+    for (int i = 0; i < 100; ++i) {
+        collector.record_response_sample (response_with_body (4096));
+    }
+
+    EXPECT_EQ (collector.response_samples ().size (), 100u);
+    EXPECT_EQ (collector.response_samples_dropped (), 0u);
+    EXPECT_EQ (collector.response_sample_bytes (), 100u * 4096u);
+}
+
+// One run, one budget: a plan's per-step reservoirs are resident in the same
+// process, so a hot step's bodies spend against the same ceiling. Give each
+// step its own and a forty-step plan multiplies the ceiling by forty.
+TEST (MetricsCollectorSampleBudget, StepReservoirsShareTheRunsBudget) {
+    MetricsCollector collector ("run_step_budget", reservoir_config (10, 250));
+    collector.configure_step_samples ({ true, true });
+
+    for (int i = 0; i < 5; ++i) {
+        collector.record_step_response_sample (response_with_body (100), 0, {});
+        collector.record_step_response_sample (response_with_body (100), 1, {});
+    }
+
+    const size_t retained = collector.step_response_samples (0).size () +
+    collector.step_response_samples (1).size ();
+    EXPECT_EQ (retained, 2u) << "each step was given a budget of its own";
+    EXPECT_EQ (collector.response_sample_bytes (), 200u);
+    EXPECT_EQ (collector.response_samples_dropped (), 8u);
+}
+
+// #1154's deferred half: the retention window keeps the tick topic and the
+// summary counters, not the bodies the deferred passes have already read. A
+// run against a large-bodied target used to hold its whole sample budget
+// resident for `liveRetentionMs` after it stopped sending.
+TEST (MetricsCollectorSampleBudget, ReleasingSamplesFreesTheirBytesAndKeepsTheCounters) {
+    MetricsCollector collector ("run_sample_release", reservoir_config (2, 1000));
+    collector.configure_step_samples ({ true });
+
+    for (int i = 0; i < 5; ++i) {
+        collector.record_response_sample (response_with_body (100));
+        collector.record_step_response_sample (response_with_body (100), 0, {});
+    }
+    const size_t dropped_before = collector.response_samples_dropped ();
+    ASSERT_GT (collector.response_sample_bytes (), 0u);
+
+    collector.release_response_samples ();
+
+    EXPECT_TRUE (collector.response_samples ().empty ());
+    EXPECT_TRUE (collector.step_response_samples (0).empty ());
+    EXPECT_EQ (collector.response_sample_bytes (), 0u);
+    EXPECT_EQ (collector.response_samples_dropped (), dropped_before)
+    << "the report still has to say what the run thinned away";
+}
+
+// ============================================================================
 // Per-Phase Histograms (issue #476)
 // ============================================================================
 

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -455,6 +455,23 @@ TEST (RunConfigValidation, ZeroRetentionLimitIsAcceptedAsUnlimited) {
     EXPECT_FALSE (validate_run_config (config).has_value ());
 }
 
+// The reservoir's other dimension (issue #1155). Read as a size_t like its
+// neighbours, so a negative is ~1.8e19 - a budget that removes the bound it
+// exists to provide rather than widening it.
+TEST (RunConfigValidation, SampleBudgetBoundsAreInclusive) {
+    auto config                         = valid_config ();
+    config["max_response_sample_bytes"] = 0;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["max_response_sample_bytes"] =
+    vayu::core::constants::run_config::MAX_RESPONSE_SAMPLE_BYTES;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["max_response_sample_bytes"] =
+    vayu::core::constants::run_config::MAX_RESPONSE_SAMPLE_BYTES + 1;
+    expect_rejected (config, "max_response_sample_bytes");
+    config["max_response_sample_bytes"] = -1;
+    expect_rejected (config, "max_response_sample_bytes");
+}
+
 TEST (RunConfigValidation, NegativeSlowThresholdIsRejected) {
     // A negative threshold would make every completion an outlier, filling the
     // slow store with the whole run.


### PR DESCRIPTION
## Description

The script-validation response reservoir was bounded in **count** only
(`max_response_samples`, default 1000), while every retained `ResponseSample`
copies `Response::body` verbatim. Against a target answering ~1 MiB bodies the
defaults allowed ~1 GB resident in that one vector during the run - and, since
#1154 releases the event loop but keeps the collector, held for the whole
`liveRetentionMs` window after it. The full-body copy itself is deliberate and
documented (`run_manager.cpp`, `constants.hpp`): a truncated body makes deferred
script replay and #682 schema validation report failures the target never
produced. What was missing is the aggregate budget.

**Root cause / approach.** Add a whole-run byte budget beside the count cap,
mirroring `max_sample_bytes`'s shape end to end (constant, engine setting,
per-run override, validated ceiling): a sample whose body would exceed what is
left is dropped **whole** and tallied into the existing
`response_samples_dropped` counter, which already surfaces in the summary's
`sampling` section. Nothing is ever truncated. The budget is charged after the
reservoir slot is claimed and before the body-sized copy, so a refusal costs
neither the copy nor the store's mutex - the same claim-before-copy shape
`capture_exchange` uses. Default 256 MiB, ceiling 1 GiB, shared by the run-level
store and every per-step one (those bodies are resident in one process, so
splitting the budget per step would multiply the ceiling by the plan's length).

**The alternative rejected:** truncating each stored body to a per-sample cap,
the way `CapturedExchange` does. It bounds the same memory and is a smaller
diff, but it is the one thing the design forbids - a deferred script or schema
check reading a cut body fails a response the target got right, which is worse
than not checking that response at all. Dropping whole samples keeps every
verdict truthful and discloses what was thinned.

Two details worth a reviewer's eye:

- **The budget is what is *held*, not what has been offered.** A displaced
  sample gives its bytes back (`insert_at_slot` now swaps rather than
  overwrites, so the incumbent's size can still be read). Without that, a long
  run's charge grows with the candidates the reservoir *accepts* - about
  `k*ln(n/k)` of them - while the store still holds `k`, and the budget would
  eventually freeze a reservoir nowhere near it.
- **A run that spends the budget is graded on the part of it that fit**, not on
  a uniform sample: the count cap displaces incumbents and stays uniform, an
  exhausted byte budget stops admitting. Only a target whose retained bodies
  average more than ~256 KiB reaches it at the defaults. Documented in
  `scripting.md` and `api-reference.md` rather than left to be inferred; the
  renderer's "drawn uniformly" copy is filed as a follow-up issue (linked
  below).

Also lands #1154's deferred half, which #1143 assigns here: the sample stores
are released when the run is retained
(`RunContext::release_execution_resources`), after both deferred passes have
read them, so a large-bodied run no longer holds its whole sample budget
resident through the retention window. The counters - including
`response_samples_dropped` - are untouched, so the report still says what was
thinned after the bodies are gone.

**App changes: none, verified.** The app never sends any reservoir field (no
match for `max_response_samples` or `max_sample_bytes` in `app/src`), the new
`data_retention` setting appears in Settings automatically - engine settings are
rendered generically from `GET /config` by category, with no per-key allowlist -
and `sampling.responseSamplesDropped` is already typed (`domain.ts`) and
displayed (`SampleRetentionNote.tsx`), so a byte-budget drop surfaces with no
renderer change.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`
- **2819 / 2819 passed, 0 failed** (2813 before this branch; 6 new). No
pre-existing failure reproduced on the base commit.

New cases, each mutation-checked (the mutation that reddens it is named in the
test's own comment):

- `MetricsCollectorSampleBudget.ASpentBudgetDropsWholeSamplesAndCountsThem` -
  budget 250 B against 100 B bodies retains 2, drops 8, and every retained body
  is whole.
- `MetricsCollectorSampleBudget.DisplacedSamplesGiveTheirBytesBack` - 200
  candidates through a 4-slot reservoir leave exactly 4 x 100 B charged.
- `MetricsCollectorSampleBudget.OrdinaryBodiesAreUnaffectedAtTheDefault` - a
  4 KiB-body run at the default budget drops nothing.
- `MetricsCollectorSampleBudget.StepReservoirsShareTheRunsBudget` - two steps,
  one budget.
- `MetricsCollectorSampleBudget.ReleasingSamplesFreesTheirBytesAndKeepsTheCounters`
  - the retention release empties both store kinds and keeps the drop count.
- `RunConfigValidation.SampleBudgetBoundsAreInclusive` - 0 and the ceiling are
  accepted, ceiling + 1 and -1 are refused naming the field.

`scripts/pre-commit` (clang-format 19 and clang-tidy over every touched engine
source) exits 0.

Throughput guard: the added work on the sampled path is one relaxed `fetch_add`
and one compare per candidate the reservoir already accepted, and nothing at all
for a run with no test script or contract - the sampling gate in
`load_strategy.cpp` is unchanged. No hot-path allocation was added.

App suite untouched and not run: no file under `app/` is modified.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1155

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZyFVrQk8tYmhDWdomGyHH)_