### PR TITLE
perf(runs): warm the runs list instead of polling it from the App root, and memoize the row summary

### DIFF
--- a/app/src/App.runs-poll.test.ts
+++ b/app/src/App.runs-poll.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The App root warms the runs list; it does not observe it (#1150).
+ *
+ * `useRunsQuery` carries a 5s `refetchInterval`, so *any* observer of it holds
+ * a poll open for as long as it is mounted - and the root is mounted for the
+ * app's whole visible life. Mounting it there cost a renderer fetch, three
+ * engine queries and a main-process stdout wake every 5s with History closed,
+ * nothing running and nobody reading the result.
+ *
+ * The behaviour is pinned in `queries/runs.query.test.tsx` (`usePrefetchRuns`
+ * fetches once and installs no timer). This case pins the *call site*, which
+ * that one cannot see: re-adding `useRunsQuery()` to `App.tsx` would restore
+ * the lifetime poll while every hook-level test stayed green.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const APP_SOURCE = readFileSync(fileURLToPath(new URL("./App.tsx", import.meta.url)), "utf8");
+
+describe("the App root's runs wiring", () => {
+	it("reads a non-empty App.tsx", () => {
+		// A guard that scanned an empty string would pass forever.
+		expect(APP_SOURCE.length).toBeGreaterThan(0);
+		expect(APP_SOURCE).toContain("function App()");
+	});
+
+	it("warms the runs list with the prefetch hook", () => {
+		expect(APP_SOURCE).toContain("usePrefetchRuns()");
+	});
+
+	it("never mounts the polled runs query", () => {
+		expect(APP_SOURCE).not.toMatch(/\buseRunsQuery\s*\(/);
+	});
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,7 +15,7 @@ import {
 	useConfigQuery,
 	useHealthQuery,
 	usePrefetchCollectionsAndRequests,
-	useRunsQuery,
+	usePrefetchRuns,
 } from "./queries";
 import { useElectronTheme } from "./hooks/useElectronTheme";
 import { useActiveEnvironmentRestore } from "./hooks/useActiveEnvironmentRestore";
@@ -52,7 +52,11 @@ function App() {
 
 	// Prefetch collections and all their requests (TanStack handles caching automatically)
 	usePrefetchCollectionsAndRequests();
-	useRunsQuery();
+	// Warm the runs list once, rather than observing it from here: History,
+	// Welcome and the palette poll it themselves while they are mounted, and a
+	// root observer polled it for the app's whole life with nobody reading the
+	// result (#1150).
+	usePrefetchRuns();
 
 	// Keep engine config warm - proxied call timeouts derive from its
 	// defaultTimeout setting (see services/api.ts proxiedRequestTimeoutMs)

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -53,6 +53,8 @@ export {
 // Runs (History)
 export {
 	useRunsQuery,
+	runsListInfiniteOptions,
+	usePrefetchRuns,
 	useRunSearchQuery,
 	RUN_SEARCH_LIMIT,
 	useAllRunsQuery,

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -53,7 +53,6 @@ export {
 // Runs (History)
 export {
 	useRunsQuery,
-	runsListInfiniteOptions,
 	usePrefetchRuns,
 	useRunSearchQuery,
 	RUN_SEARCH_LIMIT,

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -24,8 +24,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { InfiniteData } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import {
 	useLastDesignRunQuery,
@@ -34,6 +35,7 @@ import {
 	useStartScenarioRunMutation,
 	RECENT_DESIGN_RUN_LIMIT,
 	useRunsQuery,
+	usePrefetchRuns,
 	flattenRunPages,
 	runsPollInterval,
 	runDetailOptions,
@@ -97,6 +99,15 @@ beforeEach(() => {
 function runRow(id: string) {
 	return { id, type: "load", status: "completed", startTime: 1, endTime: 2 } as const;
 }
+
+/**
+ * The cadence an unpaged runs list polls on. Restated here rather than derived,
+ * because `runsPollInterval` also returns `false` and a derivation that
+ * collapsed to `0` would make the timer assertions below pass vacuously - the
+ * `runsPollInterval` case at the bottom of this file is what holds the source
+ * to this number.
+ */
+const UNPAGED_POLL_MS = 5000;
 
 describe("useLastDesignRunQuery", () => {
 	it("issues one filtered single-run call, not a full-list scan", async () => {
@@ -306,6 +317,82 @@ describe("useRunsQuery", () => {
 		renderHook(() => useRunsQuery(undefined, false), { wrapper: wrapper(makeClient()) });
 		await waitFor(() => expect(listRuns).toHaveBeenCalled());
 		expect(listRuns).toHaveBeenCalledWith(expect.objectContaining({ baseline: undefined }));
+	});
+});
+
+/**
+ * The App root warms this cache and must not go on polling it (#1150). The
+ * three assertions below are the whole contract: the warm entry is the one the
+ * visible surfaces read, warming installs no timer, and a surface that *is*
+ * mounted still polls on the documented cadence.
+ */
+describe("usePrefetchRuns", () => {
+	it("warms the exact entry a mounted runs surface reads, in InfiniteData shape", async () => {
+		listRuns.mockResolvedValue(page([runRow("warm")]));
+		const client = makeClient();
+
+		renderHook(() => usePrefetchRuns(), { wrapper: wrapper(client) });
+		await waitFor(() => expect(listRuns).toHaveBeenCalledTimes(1));
+		expect(listRuns).toHaveBeenCalledWith({
+			q: undefined,
+			baseline: undefined,
+			limit: 50,
+			offset: 0,
+		});
+
+		// Paged shape, not a bare page: `prefetchQuery` would store the
+		// `RunListResponse` itself here and every reader walks `.pages`.
+		const cached = client.getQueryData<InfiniteData<RunListResponse>>(
+			queryKeys.runs.list({ q: undefined, baseline: undefined })
+		);
+		expect(cached?.pages).toHaveLength(1);
+		expect(flattenRunPages(cached).map((r) => r.id)).toEqual(["warm"]);
+
+		// ...and the hook finds it already there, which is what keeps Welcome
+		// showing runs on first paint now that the root no longer observes.
+		const { result } = renderHook(() => useRunsQuery(), { wrapper: wrapper(client) });
+		expect(result.current.isLoading).toBe(false);
+		expect(flattenRunPages(result.current.data).map((r) => r.id)).toEqual(["warm"]);
+	});
+
+	it("installs no poll of its own - one request, then silence", async () => {
+		vi.useFakeTimers();
+		try {
+			listRuns.mockResolvedValue(page([runRow("warm")]));
+			renderHook(() => usePrefetchRuns(), { wrapper: wrapper(makeClient()) });
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(listRuns).toHaveBeenCalledTimes(1);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(UNPAGED_POLL_MS * 4);
+			});
+			expect(listRuns).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("leaves the cadence intact for a surface that does observe the list", async () => {
+		vi.useFakeTimers();
+		try {
+			listRuns.mockResolvedValue(page([runRow("warm")]));
+			renderHook(() => useRunsQuery(), { wrapper: wrapper(makeClient()) });
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(listRuns).toHaveBeenCalledTimes(1);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(UNPAGED_POLL_MS + 100);
+			});
+			expect(listRuns.mock.calls.length).toBeGreaterThan(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -11,6 +11,7 @@
  * TanStack Query hooks for run history operations.
  */
 
+import { useEffect } from "react";
 import {
 	useQuery,
 	useMutation,
@@ -45,11 +46,13 @@ export function runsPollInterval(loadedPages: number): number | false {
 }
 
 /**
- * Fetch run history as an infinite query over the `{data, pagination}`
- * envelope, newest first. The 5s `refetchInterval` keeps the loaded pages
- * fresh - in the default state that is just the first page, so new runs (which
- * land on page 1 under start_time DESC) appear without re-fetching older pages.
- * Older pages are fetched on demand via `fetchNextPage`.
+ * The runs list as infinite-query options, shared by the hook that observes it
+ * and the startup warm-up that only fills it.
+ *
+ * One factory rather than two copies of the key and the fetcher: the entry the
+ * warm-up writes has to be the exact entry the visible surfaces read. A key or
+ * a page shape that drifted apart would leave a cache nobody reads and every
+ * surface fetching on mount anyway - "written but never read" in cache form.
  *
  * @param q Optional server-side substring search over the stored snapshot.
  *          Type/status/sort stay client-side (see history-store `filterRuns`).
@@ -57,25 +60,66 @@ export function runsPollInterval(loadedPages: number): number | false {
  *          a pin older than the loaded pages is reachable. Left unset rather
  *          than passed as `false`, which the engine reads as "only unpinned".
  */
-export function useRunsQuery(q?: string, pinnedOnly = false) {
+export function runsListInfiniteOptions(q?: string, pinnedOnly = false) {
 	const search = q?.trim() || undefined;
 	const baseline = pinnedOnly ? true : undefined;
-	return useInfiniteQuery<RunListResponse, Error>({
+	return {
 		queryKey: queryKeys.runs.list({ q: search, baseline }),
-		queryFn: ({ pageParam = 0 }) =>
+		queryFn: ({ pageParam }: { pageParam: number }): Promise<RunListResponse> =>
 			apiService.listRuns({
 				q: search,
 				baseline,
 				limit: RUNS_PAGE_LIMIT,
-				offset: pageParam as number,
+				offset: pageParam,
 			}),
 		initialPageParam: 0,
-		getNextPageParam: (lastPage) =>
+		getNextPageParam: (lastPage: RunListResponse) =>
 			lastPage.pagination.hasMore
 				? lastPage.pagination.offset + lastPage.pagination.limit
 				: undefined,
+	};
+}
+
+/**
+ * Fetch run history as an infinite query over the `{data, pagination}`
+ * envelope, newest first. The 5s `refetchInterval` keeps the loaded pages
+ * fresh - in the default state that is just the first page, so new runs (which
+ * land on page 1 under start_time DESC) appear without re-fetching older pages.
+ * Older pages are fetched on demand via `fetchNextPage`.
+ *
+ * The interval belongs to this hook rather than to the options above because it
+ * is what an *observer* costs: a surface that renders runs pays it while it is
+ * mounted, and nothing pays it while none is (#1150).
+ */
+export function useRunsQuery(q?: string, pinnedOnly = false) {
+	return useInfiniteQuery({
+		...runsListInfiniteOptions(q, pinnedOnly),
 		refetchInterval: (query) => runsPollInterval(query.state.data?.pages.length ?? 0),
 	});
+}
+
+/**
+ * Warm the unfiltered runs list once, without becoming an observer of it.
+ *
+ * The App root used to call `useRunsQuery()` for this. That warmed the cache
+ * and then kept the 5s poll running for the app's whole visible life - History
+ * closed, nothing running, and nothing at the root reading the result - waking
+ * the renderer, the engine and (through the engine's stdout pipe) the main
+ * process every tick (#1150). A prefetch does the warming half only: the three
+ * surfaces that actually render runs - `HistoryList`, `WelcomeScreen` and the
+ * palette's entity source - observe this same key while they are mounted and
+ * drive the cadence themselves.
+ *
+ * `prefetchInfiniteQuery`, not `prefetchQuery`: those readers are infinite
+ * queries, so the entry has to be written in `InfiniteData` shape. A plain
+ * prefetch would store one bare page under the key and the first reader would
+ * walk a `pages` that is not there.
+ */
+export function usePrefetchRuns() {
+	const queryClient = useQueryClient();
+	useEffect(() => {
+		void queryClient.prefetchInfiniteQuery(runsListInfiniteOptions());
+	}, [queryClient]);
 }
 
 /**

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -52,7 +52,9 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
 
 ### `App` (`App.tsx`)
 
-Root component. Renders `<TitleBar />` over `<Shell />`. On mount it wires up app-wide concerns via hooks/queries: OS/Electron theme sync (`useElectronTheme`), engine health polling (`useHealthQuery`), and prefetching of server state (`usePrefetchCollectionsAndRequests`, `useRunsQuery`, `useScriptCompletionsQuery`).
+Root component. Renders `<TitleBar />` over `<Shell />`. On mount it wires up app-wide concerns via hooks/queries: OS/Electron theme sync (`useElectronTheme`), engine health polling (`useHealthQuery`), and prefetching of server state (`usePrefetchCollectionsAndRequests`, `usePrefetchRuns`, `useScriptCompletionsQuery`).
+
+Those three are prefetches in the literal sense - they fill a cache once and do not observe it. The root deliberately mounts no polled query but `useHealthQuery`: an observer here lives for the whole session, so mounting `useRunsQuery` for its cache-warming side effect kept a 5s runs poll running with History closed and nothing at the root reading the result (#1150).
 
 ### The two chrome rows
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1235,6 +1235,20 @@ are how the app sees what got stamped (`queries/trash.ts`).
     a user ten pages deep drove ~10 engine requests per tick. Only page 1 can
     gain rows (`start_time DESC`) anyway; a paged list refreshes on the next
     mutation or invalidation instead of on a timer.
+  - **Only a surface that renders runs mounts it.** The interval belongs to the
+    hook, so it runs for as long as *any* observer is mounted - and the App root
+    used to be one, which kept the poll alive with History closed, nothing
+    running and nothing at the root reading the result (#1150). The root now
+    calls **`usePrefetchRuns()`** instead: one `prefetchInfiniteQuery` over
+    `runsListInfiniteOptions()`, which warms the same cache entry without
+    observing it. `HistoryList`, `WelcomeScreen` and the palette's
+    `useEntityItems` observe the key while they are visible and drive the
+    cadence themselves.
+  - **`runsListInfiniteOptions(q?, pinnedOnly?)`** - the key, fetcher and page
+    params, shared by the hook and the warm-up so the entry one writes is the
+    entry the other reads. `prefetchInfiniteQuery`, not `prefetchQuery`: the
+    readers are infinite queries and the cache entry has to be in `InfiniteData`
+    shape.
   - **`flattenRunPages(data)`** - flatten the pages into a de-duped `Run[]`
     (dedupe by id guards the momentary double-row a head insertion can cause
     across two refetched pages). **`runsTotal(data)`** - the server's total from
@@ -1473,6 +1487,12 @@ key rather than a stale entry under this one.
   is keyed as `queryKeys.prefetch.allRequests()` rather than an inline key, so
   creating a collection can invalidate it - it succeeds once at startup and
   would otherwise never re-run for a collection created mid-session.
+- **...but warming a *polled* list must not be a query.** `usePrefetchRuns` is a
+  one-shot `prefetchInfiniteQuery` on mount, not an observer, because
+  `useRunsQuery` carries a `refetchInterval` and observing it from the root
+  bought the warm cache at the price of a poll that never stopped (#1150). An
+  invalidation of `runs.lists()` then marks the warm entry stale without
+  refetching it, which is the wanted behaviour: nothing is displaying it.
 
 **Writes from outside the renderer: `mcp:data-changed`.** An MCP tool call
 mutates the engine from the Electron **main** process, so no mutation runs here
@@ -2066,4 +2086,4 @@ starts the engine at import time.
 
 10. **Variable resolution priority:** Always resolve variables in priority order: environment > collection > global. Use `useVariableResolver({ collectionId })` to scope a preview to a collection; the active environment comes from the session store and is not a parameter.
 
-11. **Lazy loading and prefetch:** Use `usePrefetchCollectionsAndRequests()` on app init to warm up caches. Lazily fetch environments, globals, and run reports only when needed to reduce initial bundle size and API load.
+11. **Lazy loading and prefetch:** Use `usePrefetchCollectionsAndRequests()` and `usePrefetchRuns()` on app init to warm up caches. Lazily fetch environments, globals, and run reports only when needed to reduce initial bundle size and API load. Warm a *polled* list with a prefetch, never by mounting its hook at the root - an observer that lives for the session polls for the session (#1150).

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5896,6 +5896,17 @@ List test runs (design mode, load tests and collection runs), newest first
 `summary` rather than the full `configSnapshot`, so the polled history sidebar
 stays cheap as history grows.
 
+Each row's `summary` is derived from that run's `config_snapshot`, and the
+derivation is **cached per run id** (issue #1150): a snapshot is written once,
+when the run is created, so a repeated poll re-serves what the previous one
+built instead of re-parsing up to 500 snapshots a tick. The cache is bounded and
+holds nothing a request cannot rebuild, so it changes no answer - a run deleted
+between polls is gone from the list because the query no longer returns it, not
+because anything was invalidated. This route also logs at **debug**, not info: it
+is the one endpoint a visible client polls, and an info line here reached the
+console of every engine started at the default app verbosity, every five
+seconds.
+
 **Query parameters** (passing **any** of them opts into the paginated envelope):
 - `limit` - page size (default 50, invalid/&le;0 falls back to 50, capped at 500).
 - `offset` - rows to skip (default 0, negative floored to 0).

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5899,7 +5899,8 @@ stays cheap as history grows.
 Each row's `summary` is derived from that run's `config_snapshot`, and the
 derivation is **cached per run id** (issue #1150): a snapshot is written once,
 when the run is created, so a repeated poll re-serves what the previous one
-built instead of re-parsing up to 500 snapshots a tick. The cache is bounded and
+built instead of re-parsing one snapshot per row every tick - 50 at the default
+page size, up to 500 at the cap. The cache is bounded and
 holds nothing a request cannot rebuild, so it changes no answer - a run deleted
 between polls is gone from the list because the query no longer returns it, not
 because anything was invalidated. This route also logs at **debug**, not info: it

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -808,8 +808,14 @@ keys are the wire names the payload declared, carried through unchanged; the rep
 drift apart silently.
 
 Do not confuse this **results** summary with the `summary` key on a `GET /runs` list row - that
-one is a derived view of `config_snapshot` (url/method/mode/duration/concurrency/comment) built
-per request and never stored.
+one is a derived view of `config_snapshot` (url/method/mode/duration/concurrency/comment) and is
+never stored. It is built once per run id and held in a bounded in-memory cache
+for as long as the process lives (issue #1150), which is sound only because
+`config_snapshot` is write-once: `create_run` sets it, and every later write to a
+run row - status, end time, summary, baseline, the startup reconcile - is a
+read-modify-write that puts the same string back. **A change that edits a stored
+snapshot in place breaks that**, and would have to invalidate the cache in
+`engine/include/vayu/http/run_summary_cache.hpp`.
 
 **A scenario run's `summary`** is a different shape, written by
 `vayu::core::build_scenario_summary_payload` (`core/scenario_runner.cpp`): the

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -33,6 +33,7 @@
 // shared with the scenario runner and therefore declared where `vayu_core` can
 // see it. Included here so route TUs keep naming it through routes.hpp.
 #include "vayu/http/request_exchange.hpp"
+#include "vayu/http/run_summary_cache.hpp"
 #include "vayu/utils/logger.hpp"
 
 namespace vayu::core {
@@ -1092,6 +1093,10 @@ struct RouteContext {
     /// The streaming consumers (issue #573). Owned by Server; started by
     /// `/execute`, read by `/runs/:id/events`, stopped by `/runs/:id/stop`.
     vayu::http::SseStreamManager& sse_manager;
+    /// The `GET /runs` row summaries (issue #1150). Owned by Server; read by
+    /// `/runs` alone, which is the one endpoint a visible history surface
+    /// polls. See run_summary_cache.hpp for why a run id keys it exactly.
+    vayu::http::RunSummaryCache& run_summary_cache;
 };
 
 // Route registration functions (implemented in separate files)

--- a/engine/include/vayu/http/run_summary_cache.hpp
+++ b/engine/include/vayu/http/run_summary_cache.hpp
@@ -24,8 +24,9 @@ namespace vayu::http {
  * `GET /runs` is the polled endpoint (issue #1150): the history sidebar, the
  * welcome screen and the command palette each re-ask every 5 seconds while they
  * are on screen, and every call rebuilt the same nine-key summary for every row
- * by re-parsing that run's stored `config_snapshot` - up to 50 JSON parses a
- * tick, all producing what the previous tick already produced.
+ * by re-parsing that run's stored `config_snapshot` - one JSON parse per row, so
+ * 50 a tick at the default page size and up to 500 at the largest the route
+ * allows, all producing what the previous tick already produced.
  *
  * **Keyed by run id, and that is exact rather than merely likely.** A run's
  * `config_snapshot` is written once, by `Database::create_run`, from the two

--- a/engine/include/vayu/http/run_summary_cache.hpp
+++ b/engine/include/vayu/http/run_summary_cache.hpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL-3.0 license found in the
+ * LICENSE file in the "engine" directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+namespace vayu::http {
+
+/**
+ * @brief The compact `summary` object of a `GET /runs` row, kept between calls.
+ *
+ * `GET /runs` is the polled endpoint (issue #1150): the history sidebar, the
+ * welcome screen and the command palette each re-ask every 5 seconds while they
+ * are on screen, and every call rebuilt the same nine-key summary for every row
+ * by re-parsing that run's stored `config_snapshot` - up to 50 JSON parses a
+ * tick, all producing what the previous tick already produced.
+ *
+ * **Keyed by run id, and that is exact rather than merely likely.** A run's
+ * `config_snapshot` is written once, by `Database::create_run`, from the two
+ * call sites in `execution.cpp` that start a run. Every later write to a run
+ * row - status, end time, report summary, baseline, the startup reconcile -
+ * is a read-modify-write that puts back the snapshot string it just read.
+ * Nothing edits a snapshot in place, so a run id names one snapshot for the
+ * whole life of the row, and an entry can never go stale. Deleting or pruning
+ * a run leaves an entry no request can reach again; capacity, not
+ * invalidation, is what reclaims it, and ids are never reused.
+ *
+ * **Threading: one mutex, held only around the map** - the same discipline
+ * `CookieJar` runs on, and deliberately *not* the database mutex, which
+ * `/health`, this poll and SSE all serialize on (see `Database::with_lock`).
+ * `summary_for` returns a copy, so no reference into the storage escapes the
+ * lock and a caller cannot read an entry another thread is evicting.
+ */
+class RunSummaryCache {
+    public:
+    /// Two full pages of the largest `limit` the route allows (500), so one
+    /// page can never evict rows of the page it is serializing, and a client
+    /// that pages back and forth still finds its recent rows warm.
+    static constexpr std::size_t DEFAULT_CAPACITY = 1000;
+
+    explicit RunSummaryCache (std::size_t capacity = DEFAULT_CAPACITY)
+    : capacity_ (capacity == 0 ? 1 : capacity) {
+    }
+
+    /**
+     * @brief The summary for @p run_id, calling @p build only on a miss.
+     * @param run_id  The run whose summary is wanted.
+     * @param build   Builds the summary from scratch; invoked at most once per
+     *                run id for as long as the entry survives eviction.
+     * @return A copy of the cached summary.
+     */
+    template <typename Build>
+    nlohmann::json summary_for (const std::string& run_id, Build&& build) {
+        const std::lock_guard<std::mutex> lock (mutex_);
+
+        if (const auto found = index_.find (run_id); found != index_.end ()) {
+            // Most recently used goes to the front; the back is what evicts.
+            entries_.splice (entries_.begin (), entries_, found->second);
+            return found->second->second;
+        }
+
+        nlohmann::json summary = build ();
+        ++build_count_;
+        entries_.emplace_front (run_id, summary);
+        index_[run_id] = entries_.begin ();
+
+        while (entries_.size () > capacity_) {
+            index_.erase (entries_.back ().first);
+            entries_.pop_back ();
+        }
+        return summary;
+    }
+
+    /// How many entries are held. Never above the configured capacity.
+    std::size_t size () const {
+        const std::lock_guard<std::mutex> lock (mutex_);
+        return index_.size ();
+    }
+
+    /// How many times a summary has actually been built. The seam the tests
+    /// assert on: a poll that re-parses nothing leaves this unchanged.
+    std::size_t build_count () const {
+        const std::lock_guard<std::mutex> lock (mutex_);
+        return build_count_;
+    }
+
+    private:
+    mutable std::mutex mutex_;
+    std::size_t capacity_;
+
+    /// Front is most recently used. The map holds iterators into this list,
+    /// which `std::list` keeps valid across every insertion and every erase
+    /// but its own.
+    using Entry = std::pair<std::string, nlohmann::json>;
+    std::list<Entry> entries_;
+    std::unordered_map<std::string, std::list<Entry>::iterator> index_;
+    std::size_t build_count_ = 0;
+};
+
+} // namespace vayu::http

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -102,6 +102,11 @@ class Server {
     InboxManager inbox_manager_;
     MockServerManager mock_server_manager_;
     SseStreamManager sse_manager_;
+    /// Read only by the `/runs` handler, which runs on the httplib thread pool
+    /// - so it needs no place in the shutdown ordering above, unlike the
+    /// managers that own listeners or transfers. It holds derived data and can
+    /// be dropped at any point without losing anything (see #1150).
+    RunSummaryCache run_summary_cache_;
     httplib::Server server_;
     std::thread server_thread_;
     std::atomic<bool> is_running_{ false };

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "vayu/http/routes.hpp"
+#include "vayu/http/run_summary_cache.hpp"
 #include "vayu/http/sse_stream.hpp"
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
@@ -549,7 +550,11 @@ ReportExtras& extras) {
 // Serialize one run into a list row: identity + status + the compact summary,
 // deliberately *without* the full config_snapshot (that is what makes the list
 // cheap). Mirrors the camelCase keys vayu::json::serialize(Run) emits.
-nlohmann::json serialize_run_row (const vayu::db::Run& run) {
+//
+// The summary is passed in rather than built here, so each caller decides where
+// it comes from: the polled list takes it from the run-summary cache, and the
+// one-row baseline response - which no client polls - builds it directly.
+nlohmann::json serialize_run_row (const vayu::db::Run& run, nlohmann::json summary) {
     nlohmann::json row;
     row["id"]        = run.id;
     row["type"]      = vayu::to_string (run.type);
@@ -562,7 +567,7 @@ nlohmann::json serialize_run_row (const vayu::db::Run& run) {
     nlohmann::json (*run.environment_id) :
     nlohmann::json (nullptr);
     row["baseline"]      = run.baseline;
-    row["summary"]       = build_run_summary (run.config_snapshot);
+    row["summary"]       = std::move (summary);
     return row;
 }
 
@@ -580,6 +585,13 @@ nlohmann::json serialize_run_row (const vayu::db::Run& run) {
  * design run's row also carries `resultSummary` (statusCode + latencyMs), which
  * is what a reader would otherwise fetch a report per row to learn.
  *
+ * `summaries` spares the poll the work it would otherwise repeat: this is the
+ * endpoint a visible history surface re-asks every 5s, and each call used to
+ * re-parse every row's immutable `config_snapshot` to rebuild the summary the
+ * previous call had already built (#1150). It is a parameter rather than a
+ * detail of this function so a caller - a test included - owns the cache's
+ * lifetime and two of them never share one.
+ *
  * Extracted so the envelope shape, clamping and filtering are covered without
  * an in-process HTTP server - see runs_route_test.cpp. Exceptions propagate to
  * the route's try/catch (500).
@@ -587,7 +599,8 @@ nlohmann::json serialize_run_row (const vayu::db::Run& run) {
 std::pair<int, nlohmann::json> get_runs_response (vayu::db::Database& db,
 const vayu::db::RunFilter& filter,
 int64_t limit,
-int64_t offset) {
+int64_t offset,
+vayu::http::RunSummaryCache& summaries) {
     const int64_t total = db.count_runs (filter);
     auto runs           = db.get_runs_paginated (filter, limit, offset);
 
@@ -606,7 +619,9 @@ int64_t offset) {
 
     nlohmann::json data = nlohmann::json::array ();
     for (const auto& run : runs) {
-        auto row = serialize_run_row (run);
+        auto row = serialize_run_row (run, summaries.summary_for (run.id, [&run] {
+            return build_run_summary (run.config_snapshot);
+        }));
         if (const auto found = outcomes.find (run.id); found != outcomes.end ()) {
             row["resultSummary"]["statusCode"] = found->second.status_code;
             row["resultSummary"]["latencyMs"]  = found->second.latency_ms;
@@ -792,7 +807,7 @@ const std::string& body) {
     if (!updated) {
         return { 404, error_body (404, "Run not found") };
     }
-    return { 200, serialize_run_row (*updated) };
+    return { 200, serialize_run_row (*updated, build_run_summary (updated->config_snapshot)) };
 }
 
 /**
@@ -1330,11 +1345,18 @@ void handle_list_runs (RouteContext& ctx, const httplib::Request& req, httplib::
             filter.baseline = false;
     }
 
-    vayu::utils::log_info ("GET /runs - Listing runs (limit=" + std::to_string (limit) +
+    // Debug, not info: this is the polled endpoint, and at the production
+    // verbosity the app spawns the engine with (`--verbose 1`) an info line
+    // here was flushed to stdout every 5s, through a pipe the Electron main
+    // process reads, splits and logs - a third process woken per tick by an
+    // idle app (#1150). The file sink defaults to `debug`, so the line is not
+    // lost, only taken off the console's poll cadence.
+    vayu::utils::log_debug ("GET /runs - Listing runs (limit=" + std::to_string (limit) +
     ", offset=" + std::to_string (offset) + ")");
     try {
-        auto [status, body] = get_runs_response (ctx.db, filter, limit, offset);
-        res.status          = status;
+        auto [status, body] =
+        get_runs_response (ctx.db, filter, limit, offset, ctx.run_summary_cache);
+        res.status = status;
         res.set_content (body.dump (), "application/json");
     } catch (const std::exception& e) {
         vayu::utils::log_error ("GET /runs - Error: " + std::string (e.what ()));

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -170,9 +170,10 @@ void Server::setup_routes () {
     // Register Modular Routes
     // ==========================================
     // Note: route_ctx_ is a class member, ensuring it outlives the lambdas
-    route_ctx_ = std::make_unique<routes::RouteContext> (routes::RouteContext{ server_,
-    db_, run_manager_, verbose_, shutdown_callback_, oauth_authorize_manager_, cookie_jar_,
-    mock_issuer_manager_, inbox_manager_, mock_server_manager_, sse_manager_ });
+    route_ctx_ = std::make_unique<routes::RouteContext> (
+    routes::RouteContext{ server_, db_, run_manager_, verbose_, shutdown_callback_,
+    oauth_authorize_manager_, cookie_jar_, mock_issuer_manager_, inbox_manager_,
+    mock_server_manager_, sse_manager_, run_summary_cache_ });
 
     routes::register_health_routes (*route_ctx_);
     routes::register_config_routes (*route_ctx_);

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -27,6 +27,7 @@
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/spec_coverage.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/run_summary_cache.hpp"
 #include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/json.hpp"
 
@@ -37,7 +38,8 @@ namespace vayu::http::routes {
 std::pair<int, nlohmann::json> get_runs_response (vayu::db::Database& db,
 const vayu::db::RunFilter& filter,
 int64_t limit,
-int64_t offset);
+int64_t offset,
+vayu::http::RunSummaryCache& summaries);
 
 // Defined in runs.cpp; builds the GET /runs/:id/report `configuration`
 // object from an already-parsed config_snapshot, extracted so it is testable
@@ -112,6 +114,10 @@ class RunsRouteTest : public ::testing::Test {
     VAYU_DIAGNOSTIC_POP
 
     std::unique_ptr<vayu::db::Database> db_;
+    /// One per test, like the database beside it: the cache is keyed by run id
+    /// and these cases reuse ids across tests, so a shared one would answer a
+    /// later test from an earlier test's snapshot.
+    vayu::http::RunSummaryCache summaries_;
 };
 
 // The happy path: envelope keys, DESC ordering by start_time, and the compact
@@ -121,7 +127,8 @@ TEST_F (RunsRouteTest, EnvelopeShapeAndNewestFirst) {
     seed ({ .id = "run_b", .start_time = 300 });
     seed ({ .id = "run_c", .start_time = 200 });
 
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [status, body] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
 
     ASSERT_TRUE (body.contains ("data"));
@@ -151,14 +158,16 @@ TEST_F (RunsRouteTest, PaginationHasMoreAndOffset) {
     for (int i = 0; i < 5; ++i)
         seed ({ .id = "run_" + std::to_string (i), .start_time = i });
 
-    auto [page1_status, page1] = vayu::http::routes::get_runs_response (*db_, {}, 2, 0);
+    auto [page1_status, page1] =
+    vayu::http::routes::get_runs_response (*db_, {}, 2, 0, summaries_);
     EXPECT_EQ (page1_status, 200);
     EXPECT_EQ (page1["data"].size (), 2u);
     EXPECT_EQ (page1["pagination"]["total"], 5);
     EXPECT_EQ (page1["pagination"]["hasMore"], true);
     EXPECT_EQ (page1["pagination"]["returned"], 2);
 
-    auto [page3_status, page3] = vayu::http::routes::get_runs_response (*db_, {}, 2, 4);
+    auto [page3_status, page3] =
+    vayu::http::routes::get_runs_response (*db_, {}, 2, 4, summaries_);
     EXPECT_EQ (page3_status, 200);
     EXPECT_EQ (page3["data"].size (), 1u);
     EXPECT_EQ (page3["pagination"]["hasMore"], false);
@@ -170,7 +179,7 @@ TEST_F (RunsRouteTest, SummaryHasExactlyNineKeysAndOmitsAbsent) {
     "followRedirects":false,"maxRedirects":5,"headers":{"X":"1"}})" });
     seed ({ .id = "run_sparse", .start_time = 1, .config_snapshot = R"({"url":"https://b/"})" });
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     // Sparse row is newest (start_time 1 > 0).
     const auto& sparse = body["data"][0]["summary"];
     EXPECT_EQ (body["data"][0]["id"], "run_sparse");
@@ -216,7 +225,7 @@ TEST_F (RunsRouteTest, SummaryHttpVersionDefaultsToAutoOnNullOrAbsent) {
     .config_snapshot = R"({"url":"https://a/","httpVersion":null})" });
     seed ({ .id = "run_no_version", .start_time = 1, .config_snapshot = R"({"url":"https://b/"})" });
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     // Newest first: run_no_version (start_time 1), then run_null_version (0).
     EXPECT_EQ (body["data"][0]["id"], "run_no_version");
     EXPECT_EQ (body["data"][0]["summary"]["httpVersion"], "auto");
@@ -234,7 +243,8 @@ TEST_F (RunsRouteTest, SummaryCarriesScenarioDescriptorWithoutTheStepManifest) {
     "steps":[{"index":0,"requestId":"req_1","name":"login","method":"POST","url":"https://a/login"},
              {"index":1,"requestId":"req_2","name":"checkout","method":"GET","url":"https://a/cart"}]}})" });
 
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [status, body] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
 
@@ -259,7 +269,7 @@ TEST_F (RunsRouteTest, SummaryCarriesScenarioDescriptorWithoutTheStepManifest) {
 TEST_F (RunsRouteTest, SummaryOmitsScenarioOnANonScenarioRun) {
     seed ({ .id = "run_load", .config_snapshot = R"({"url":"https://a/","mode":"constant_rps"})" });
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     EXPECT_FALSE (body["data"][0]["summary"].contains ("scenario"));
 }
 
@@ -271,7 +281,8 @@ TEST_F (RunsRouteTest, DesignRowCarriesItsStatusCodeAndLatency) {
     seed ({ .id = "run_design", .type = vayu::RunType::Design });
     seed_result ("run_design", 503, 42.5);
 
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [status, body] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
 
@@ -294,7 +305,7 @@ TEST_F (RunsRouteTest, EachDesignRowGetsItsOwnOutcome) {
     seed_result ("run_first", 200, 10.0);
     seed_result ("run_second", 404, 20.0);
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 2u);
     EXPECT_EQ (body["data"][0]["id"], "run_second");
     EXPECT_EQ (body["data"][0]["resultSummary"]["statusCode"], 404);
@@ -313,7 +324,7 @@ TEST_F (RunsRouteTest, LoadRowCarriesNoOutcomeAndItsResultsAreNeverRead) {
     seed_result ("run_load", 500, 98.0);
     seed_result ("run_scenario", 200, 5.0);
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 2u);
     EXPECT_FALSE (body["data"][0].contains ("resultSummary"));
     EXPECT_FALSE (body["data"][1].contains ("resultSummary"));
@@ -327,7 +338,7 @@ TEST_F (RunsRouteTest, LoadRowCarriesNoOutcomeAndItsResultsAreNeverRead) {
 TEST_F (RunsRouteTest, DesignRowWithNoStoredResultOmitsTheKey) {
     seed ({ .id = "run_running", .type = vayu::RunType::Design, .status = vayu::RunStatus::Running });
 
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_FALSE (body["data"][0].contains ("resultSummary"));
 }
@@ -335,11 +346,79 @@ TEST_F (RunsRouteTest, DesignRowWithNoStoredResultOmitsTheKey) {
 TEST_F (RunsRouteTest, MalformedSnapshotYieldsEmptySummaryNot500) {
     seed ({ .id = "run_bad", .config_snapshot = "not valid json {{{" });
 
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [status, body] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_TRUE (body["data"][0]["summary"].is_object ());
     EXPECT_TRUE (body["data"][0]["summary"].empty ());
+}
+
+/*
+ * The list is polled - every visible history surface re-asks it every 5s - and
+ * each call used to re-parse every row's config_snapshot to rebuild a summary
+ * identical to the one the previous call built (#1150). A run's snapshot is
+ * written once, at create_run, so a run id names one summary for the life of
+ * the row and the second poll owes no work at all.
+ */
+TEST_F (RunsRouteTest, RepeatedPollsBuildEachSummaryOnce) {
+    seed ({ .id = "run_a", .start_time = 1 });
+    seed ({ .id = "run_b", .start_time = 2 });
+    seed ({ .id = "run_c", .start_time = 3 });
+
+    auto [first_status, first] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    EXPECT_EQ (first_status, 200);
+    EXPECT_EQ (summaries_.build_count (), 3u);
+
+    auto [second_status, second] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    EXPECT_EQ (second_status, 200);
+    // The point of the case: three rows served, nothing rebuilt.
+    EXPECT_EQ (summaries_.build_count (), 3u);
+    EXPECT_EQ (second["data"], first["data"]);
+
+    // A row that arrives later is still built - the cache answers for the runs
+    // it holds, it does not freeze the list.
+    seed ({ .id = "run_d", .start_time = 4 });
+    auto [_, third] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    EXPECT_EQ (summaries_.build_count (), 4u);
+    ASSERT_EQ (third["data"].size (), 4u);
+    EXPECT_EQ (third["data"][0]["id"], "run_d");
+}
+
+// A malformed snapshot reads as an empty summary on every call, not only the
+// first: the failure is cached like any other answer, and never becomes a 500.
+TEST_F (RunsRouteTest, MalformedSnapshotStaysEmptyAcrossPolls) {
+    seed ({ .id = "run_bad", .config_snapshot = "not valid json {{{" });
+
+    for (int poll = 0; poll < 3; ++poll) {
+        auto [status, body] =
+        vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+        EXPECT_EQ (status, 200);
+        ASSERT_EQ (body["data"].size (), 1u);
+        EXPECT_TRUE (body["data"][0]["summary"].is_object ());
+        EXPECT_TRUE (body["data"][0]["summary"].empty ());
+    }
+    EXPECT_EQ (summaries_.build_count (), 1u);
+}
+
+// The cache is bounded, so a long-lived daemon listing its way through a large
+// history cannot grow it without limit - a deleted or pruned run leaves an
+// entry no request can reach, and capacity is what reclaims it.
+TEST_F (RunsRouteTest, SummaryCacheStaysWithinCapacity) {
+    constexpr std::size_t CAPACITY = 4;
+    vayu::http::RunSummaryCache small (CAPACITY);
+
+    for (int i = 0; i < 10; ++i) {
+        seed ({ .id = "run_" + std::to_string (i), .start_time = i });
+    }
+
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, small);
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (body["data"].size (), 10u);
+    EXPECT_EQ (small.build_count (), 10u);
+    EXPECT_LE (small.size (), CAPACITY);
 }
 
 TEST_F (RunsRouteTest, FilterByType) {
@@ -347,8 +426,8 @@ TEST_F (RunsRouteTest, FilterByType) {
     seed ({ .id = "run_design", .type = vayu::RunType::Design, .start_time = 1 });
 
     vayu::db::RunFilter f;
-    f.type         = vayu::RunType::Design;
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    f.type = vayu::RunType::Design;
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_design");
     EXPECT_EQ (body["pagination"]["total"], 1);
@@ -359,8 +438,8 @@ TEST_F (RunsRouteTest, FilterByStatus) {
     seed ({ .id = "run_fail", .status = vayu::RunStatus::Failed, .start_time = 1 });
 
     vayu::db::RunFilter f;
-    f.status       = vayu::RunStatus::Failed;
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    f.status = vayu::RunStatus::Failed;
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_fail");
 }
@@ -371,8 +450,8 @@ TEST_F (RunsRouteTest, FilterByRequestId) {
     seed ({ .id = "run_3", .start_time = 2, .request_id = std::nullopt });
 
     vayu::db::RunFilter f;
-    f.request_id   = "req_A";
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    f.request_id = "req_A";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_1");
     EXPECT_EQ (body["data"][0]["requestId"], "req_A");
@@ -383,8 +462,8 @@ TEST_F (RunsRouteTest, FilterByQSubstringOverSnapshot) {
     seed ({ .id = "run_orders", .start_time = 1, .config_snapshot = R"({"url":"https://api/orders"})" });
 
     vayu::db::RunFilter f;
-    f.q            = "orders";
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    f.q = "orders";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_orders");
 }
@@ -406,7 +485,7 @@ TEST_F (RunsRouteTest, FilterByCollectionIdMatchesOnlyThatCollectionsRuns) {
 
     vayu::db::RunFilter f;
     f.collection_id = "col_A";
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_mine");
@@ -431,7 +510,7 @@ TEST_F (RunsRouteTest, NonScenarioRunsNeverMatchACollectionId) {
 
     vayu::db::RunFilter f;
     f.collection_id = "col_A";
-    auto [_, body]  = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_scenario");
 }
@@ -445,7 +524,7 @@ TEST_F (RunsRouteTest, UnknownCollectionIdIsAnEmptyPageNotAnError) {
 
     vayu::db::RunFilter f;
     f.collection_id = "col_ghost";
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     EXPECT_EQ (body["data"].size (), 0u);
     EXPECT_EQ (body["pagination"]["total"], 0);
@@ -465,7 +544,7 @@ TEST_F (RunsRouteTest, AMalformedSnapshotDoesNotBreakTheCollectionFilter) {
 
     vayu::db::RunFilter f;
     f.collection_id = "col_A";
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0, summaries_);
     EXPECT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "run_scenario");
@@ -492,7 +571,7 @@ TEST_F (RunsRouteTest, CollectionIdComposesWithTypeStatusAndLimit) {
     f.collection_id = "col_A";
     f.type          = vayu::RunType::Scenario;
     f.status        = vayu::RunStatus::Completed;
-    auto [_, body]  = vayu::http::routes::get_runs_response (*db_, f, 1, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 1, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "keep");
     EXPECT_EQ (body["pagination"]["total"], 1);
@@ -522,7 +601,7 @@ TEST_F (RunsRouteTest, CollectionIdKeepsNewestFirstSoLimitOneIsTheLastRun) {
 
     vayu::db::RunFilter f;
     f.collection_id = "col_A";
-    auto [_, body]  = vayu::http::routes::get_runs_response (*db_, f, 1, 0);
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 1, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "newest");
     // The page is one row of three, not one row of one.
@@ -569,10 +648,10 @@ TEST_F (RunsRouteTest, FiltersCombine) {
     .request_id = "req_X" });
 
     vayu::db::RunFilter f;
-    f.type         = vayu::RunType::Design;
-    f.status       = vayu::RunStatus::Completed;
-    f.request_id   = "req_X";
-    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 1, 0);
+    f.type       = vayu::RunType::Design;
+    f.status     = vayu::RunStatus::Completed;
+    f.request_id = "req_X";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 1, 0, summaries_);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "keep");
     EXPECT_EQ (body["pagination"]["total"], 1);
@@ -1341,7 +1420,8 @@ TEST_F (RunsRouteTest, ListRowsCarryTheBaselineFlag) {
     seed ({ .id = "run_a", .start_time = 100 });
     vayu::http::routes::set_run_baseline_response (*db_, "run_a", R"({"baseline":true})");
 
-    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    auto [status, body] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
     ASSERT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_TRUE (body["data"][0]["baseline"].get<bool> ());
@@ -1355,7 +1435,7 @@ TEST_F (RunsRouteTest, ListFiltersToBaselinesAndBackAgain) {
     vayu::db::RunFilter only_baselines;
     only_baselines.baseline = true;
     auto [status, body] =
-    vayu::http::routes::get_runs_response (*db_, only_baselines, 50, 0);
+    vayu::http::routes::get_runs_response (*db_, only_baselines, 50, 0, summaries_);
     ASSERT_EQ (status, 200);
     ASSERT_EQ (body["data"].size (), 1u);
     EXPECT_EQ (body["data"][0]["id"], "pinned");
@@ -1364,7 +1444,7 @@ TEST_F (RunsRouteTest, ListFiltersToBaselinesAndBackAgain) {
     vayu::db::RunFilter no_baselines;
     no_baselines.baseline = false;
     auto [plain_status, plain_body] =
-    vayu::http::routes::get_runs_response (*db_, no_baselines, 50, 0);
+    vayu::http::routes::get_runs_response (*db_, no_baselines, 50, 0, summaries_);
     ASSERT_EQ (plain_status, 200);
     ASSERT_EQ (plain_body["data"].size (), 1u);
     EXPECT_EQ (plain_body["data"][0]["id"], "plain");

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -17,12 +17,16 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstring>
+#include <filesystem>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
 #include "optional_assert.hpp"
+#include "source_scan.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/spec_coverage.hpp"
@@ -419,6 +423,47 @@ TEST_F (RunsRouteTest, SummaryCacheStaysWithinCapacity) {
     EXPECT_EQ (body["data"].size (), 10u);
     EXPECT_EQ (small.build_count (), 10u);
     EXPECT_LE (small.size (), CAPACITY);
+}
+
+/*
+ * The other half of #1150's idle cost is a log line, and no behavioural test
+ * here can see it: the listing log lives in `handle_list_runs`, which needs an
+ * HTTP server, while everything else in this file covers the extracted core.
+ * At the verbosity the app spawns the engine with (`--verbose 1`) an info line
+ * reaches stdout, and the Electron main process reads, splits and logs every
+ * line of that pipe - so an info line on the polled route wakes a third
+ * process every five seconds. What the route *says* is the only observable, so
+ * it is scanned for, with the two disciplines source_scan.hpp asks of a scan:
+ * assert it read something, and plant a positive so a blanked input cannot
+ * pass for a clean file.
+ */
+TEST (RunsRouteLogging, TheListingLineIsDebugNotInfo) {
+    const std::filesystem::path route =
+    std::filesystem::path{ VAYU_ENGINE_SOURCE_DIR } / "src" / "http" / "routes" / "runs.cpp";
+    const std::string code =
+    vayu::tests::strip_comments (vayu::tests::read_source (route));
+    ASSERT_FALSE (code.empty ()) << route.string () << " read as empty";
+
+    constexpr std::string_view MESSAGE = "\"GET /runs - Listing runs (limit=\"";
+    const auto at                      = code.find (MESSAGE);
+    ASSERT_NE (at, std::string::npos)
+    << "the listing log line is gone or reworded - re-point this guard at it";
+
+    // The call opening the statement that holds the message.
+    const auto call = code.rfind ("vayu::utils::log_", at);
+    ASSERT_NE (call, std::string::npos);
+    EXPECT_EQ (code.compare (call, std::strlen ("vayu::utils::log_debug"), "vayu::utils::log_debug"), 0)
+    << "the polled /runs listing must log at debug, not info (#1150)";
+
+    // Planted positive: the matcher does find an info spelling when there is
+    // one, so the assertion above is reading the level rather than nothing.
+    const std::string planted =
+    "vayu::utils::log_info (\"GET /runs - Listing runs (limit=\"";
+    const auto planted_at = planted.find (MESSAGE);
+    ASSERT_NE (planted_at, std::string::npos);
+    EXPECT_NE (planted.compare (planted.rfind ("vayu::utils::log_", planted_at),
+               std::strlen ("vayu::utils::log_debug"), "vayu::utils::log_debug"),
+    0);
 }
 
 TEST_F (RunsRouteTest, FilterByType) {

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -34,6 +34,7 @@
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/http/routes.hpp"
+#include "vayu/http/run_summary_cache.hpp"
 #include "vayu/http/server.hpp"
 #include "vayu/http/sse_stream.hpp"
 
@@ -727,7 +728,7 @@ class RelayTest : public ::testing::Test {
         ctx_     = std::make_unique<vayu::http::routes::RouteContext> (
         vayu::http::routes::RouteContext{ svr_, *db_, run_manager_, false,
         nullptr, authorize_manager_, cookie_jar_, mock_issuer_manager_,
-        inbox_manager_, mock_server_manager_, *manager_ });
+        inbox_manager_, mock_server_manager_, *manager_, run_summary_cache_ });
         vayu::http::routes::register_event_stream_routes (*ctx_);
         svr_.set_write_timeout (60, 0);
         port_   = svr_.bind_to_any_port ("127.0.0.1");
@@ -794,6 +795,7 @@ class RelayTest : public ::testing::Test {
     vayu::http::MockIssuerManager mock_issuer_manager_;
     vayu::http::InboxManager inbox_manager_;
     vayu::http::MockServerManager mock_server_manager_;
+    vayu::http::RunSummaryCache run_summary_cache_;
     /// Held by pointer so `TearDown` can join its workers *before* the
     /// database they write through goes away - see the note there (#646).
     std::unique_ptr<SseStreamManager> manager_;
@@ -913,7 +915,7 @@ class StreamExecuteTest : public ::testing::Test {
         ctx_     = std::make_unique<vayu::http::routes::RouteContext> (
         vayu::http::routes::RouteContext{ svr_, *db_, run_manager_, false,
         nullptr, authorize_manager_, cookie_jar_, mock_issuer_manager_,
-        inbox_manager_, mock_server_manager_, *manager_ });
+        inbox_manager_, mock_server_manager_, *manager_, run_summary_cache_ });
         vayu::http::routes::register_execution_routes (*ctx_);
         vayu::http::routes::register_event_stream_routes (*ctx_);
         svr_.set_write_timeout (60, 0);
@@ -1037,6 +1039,7 @@ class StreamExecuteTest : public ::testing::Test {
     vayu::http::MockIssuerManager mock_issuer_manager_;
     vayu::http::InboxManager inbox_manager_;
     vayu::http::MockServerManager mock_server_manager_;
+    vayu::http::RunSummaryCache run_summary_cache_;
     /// Held by pointer so `TearDown` can join its workers *before* the
     /// database they write through goes away - see the note there (#646).
     std::unique_ptr<SseStreamManager> manager_;


### PR DESCRIPTION
## Description

`App.tsx` mounted `useRunsQuery()` at the root for its cache-warming side effect. That hook carries a 5s `refetchInterval` and the root is mounted for the app's whole visible life, so the poll ran with History closed, no run active and nothing at the root reading the result - a renderer fetch and JSON parse, up to three SQLite queries plus a JSON re-parse per row in the engine, and (through the engine's stdout pipe at the production `--verbose 1` the app spawns it with) a main-process wake, every five seconds at idle.

**Root cause and approach.** The root observer was doing two jobs at once - warming the cache and holding a poll open - and only the first was wanted there. The fix separates them: `usePrefetchRuns()` is a one-shot `prefetchInfiniteQuery` on mount, and the three surfaces that actually render runs (`HistoryList`, `WelcomeScreen`, the palette's `useEntityItems`) already observe the same key while visible and keep driving the cadence. Engine-side, the two independent trims the issue names: the row summary is memoized per run id, and the per-call listing log drops from info to debug.

Two deliberate deviations from the issue text, both recorded here because a reviewer would otherwise read them as drift:

- **`prefetchInfiniteQuery`, not the `prefetchQuery` the issue suggested.** The readers are infinite queries, so a bare page written under that key leaves the first reader walking a `pages` that is not there. The shape assertion in `runs.query.test.tsx` fails if it is swapped back.
- **Memoizing rather than storing the summary beside the run.** The issue offers either. Memoizing needs no column, no migration and no backfill for existing rows, and it keeps one source of truth for the derivation; the alternative would have made every pre-migration row fall back to a parse anyway, so the cache would still have to exist.

`RunSummaryCache` is keyed by run id, and that key is exact rather than merely likely: `config_snapshot` is written once by `create_run`, and every later write to a run row (status, end time, report summary, baseline, the startup reconcile) is a read-modify-write that puts the same string back. Deleting or pruning a run leaves an entry no request can reach and ids are never reused, so capacity reclaims it and nothing has to invalidate. It holds its own mutex - deliberately not the database mutex, which `/health`, this poll and SSE all serialize on - and returns copies, so nothing escapes the lock. It is owned by `Server` and reached through `RouteContext`, like `CookieJar`; `get_runs_response` takes it as a parameter so a test owns its own and two never share one.

The wire response is unchanged byte-for-byte: the same `build_run_summary` produces the same nine keys from the same immutable input, and `PUT /runs/:id/baseline` - which nothing polls - still builds its one row directly.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Every command the issue names, run locally on this branch:

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2823 passed, 0 failed** (2822 before this branch; the new cases are in existing files).
- `cd app && pnpm test` - **6197 passed across 566 files, 0 failed**.
- `cd app && pnpm type-check` - clean (all three projects). `pnpm lint` - clean. `pnpm format:check` on the touched files - clean.
- `clang-format-19 --dry-run -Werror` on every touched engine file - clean. `clang-tidy-19` on the changed translation units - no new findings.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.

No pre-existing failures were observed on the base commit.

Four new cases, each mutation-checked (the fix reverted, the case confirmed red, the fix restored):

| Case | Pins | Reverting the fix |
|---|---|---|
| `usePrefetchRuns > warms the exact entry a mounted runs surface reads` | the warm entry is `InfiniteData`-shaped and `useRunsQuery` finds it on first render | fails with `prefetchQuery` |
| `usePrefetchRuns > installs no poll of its own` | one request, then silence across four cadences | fails if the root observes again |
| `usePrefetchRuns > leaves the cadence intact for a surface that does observe` | a mounted surface still polls at 5s | proves the harness can see a poll, so the case above is not vacuous |
| `RunsRouteTest.RepeatedPollsBuildEachSummaryOnce` | three polls, three builds; a later row still built | fails without the memo |
| `RunsRouteTest.MalformedSnapshotStaysEmptyAcrossPolls` | a bad snapshot stays an empty summary and is built once | fails without the memo |
| `RunsRouteTest.SummaryCacheStaysWithinCapacity` | the cache never exceeds its bound | fails without the memo |
| `RunsRouteLogging.TheListingLineIsDebugNotInfo` | the polled route logs at debug | fails on `log_info` |
| `App.runs-poll.test.ts` | the call site, which the hook-level tests cannot see | fails if `useRunsQuery()` returns to `App.tsx` |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs, in the commits that change what they describe: `docs/app/COMPONENTS.md` (the root's mount list was calling this "prefetching"), `docs/app/state-management.md` (the hook entry, the warm-cache-prefetch rule, the lazy-loading guidance), `docs/engine/api-reference.md` (the derivation is cached, the route logs at debug) and `docs/engine/db-schema.md`, which said the summary is built per request and now records the write-once invariant the cache rests on.

## Related Issues
Closes #1150