### PR TITLE
fix(app): make the method badge a fixed-width column

### DIFF
--- a/app/src/components/shared/MethodBadge.test.tsx
+++ b/app/src/components/shared/MethodBadge.test.tsx
@@ -80,6 +80,22 @@ describe("MethodBadge - methods longer than the column", () => {
 		expect(label.className).toContain("min-w-0");
 	});
 
+	it("starts truncating at exactly the width the chip was given", () => {
+		// The width lives in a Tailwind class, which has to be a literal, and the
+		// truncation threshold lives in a constant - two spellings of the same
+		// number, so pin them to each other. Read the character count back out of
+		// what was rendered rather than restating it here, or this test is just a
+		// third copy.
+		const chars = Number(
+			/(\d+)ch/.exec(renderBadge(<MethodBadge method="GET" />).className)?.[1]
+		);
+		expect(chars).toBeGreaterThan(0);
+		const fits = "M".repeat(chars);
+		const overflows = "M".repeat(chars + 1);
+		expect(renderBadge(<MethodBadge method={fits} />).title).toBe("");
+		expect(renderBadge(<MethodBadge method={overflows} />).title).toBe(overflows);
+	});
+
 	it("exposes the full method as a title only when it is truncated", () => {
 		// An unconditional title would fight the app's own tooltips on the same
 		// rows, so the absent case is as much of the contract as the present one.

--- a/app/src/components/shared/MethodBadge.test.tsx
+++ b/app/src/components/shared/MethodBadge.test.tsx
@@ -42,13 +42,14 @@ describe("MethodBadge - badge variant is a fixed-width column", () => {
 		expect(badge.className).toContain(WIDTH_CLASS);
 	});
 
-	it("renders GET and DELETE with an identical box", () => {
-		// Method colour is an inline style, so the class list is the whole box:
-		// identical classes including the fixed width means identical width.
-		const get = renderBadge(<MethodBadge method="GET" />);
-		const del = renderBadge(<MethodBadge method="DELETE" />);
-		expect(get.className).toBe(del.className);
-		expect(get.className).toContain(WIDTH_CLASS);
+	it("gives every method the same box, however many letters it has", () => {
+		// Method colour is an inline style, so the class list is the whole box.
+		// Asserting the two class lists are *equal* would pass without the fix -
+		// the badge's classes never depended on the method - so what each one has
+		// to carry is the fixed width itself.
+		for (const method of ["GET", "POST", "DELETE", "OPTIONS", "PROPPATCH"]) {
+			expect(renderBadge(<MethodBadge method={method} />).className).toContain(WIDTH_CLASS);
+		}
 	});
 
 	it("uses the same width class at both sizes", () => {

--- a/app/src/components/shared/MethodBadge.test.tsx
+++ b/app/src/components/shared/MethodBadge.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The badge variant is a fixed-width column: sibling rows put the badge first
+ * and the request name after it, so a chip that grew with its letters started
+ * `GET` names at one x and `DELETE` names at another.
+ *
+ * jsdom does no layout - `offsetWidth` is 0 for everything - so "the two chips
+ * are the same width" cannot be measured here. These tests pin the *class
+ * contract* that produces it instead, and render the component rather than
+ * scanning the source, because the class arrives through `cn()` (a source scan
+ * would keep passing after the class was removed from the branch).
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { MethodBadge } from "./MethodBadge";
+
+/** The chip element itself - the outer span `MethodBadge` renders. */
+function renderBadge(ui: React.ReactElement): HTMLElement {
+	const { container } = render(ui);
+	return container.firstElementChild as HTMLElement;
+}
+
+/**
+ * The width class the badge variant must carry: seven characters of content
+ * (OPTIONS, CONNECT) plus the chip's own `px-1.5` and 1px border.
+ */
+const WIDTH_CLASS = "w-[calc(7ch+0.75rem+2px)]";
+
+describe("MethodBadge - badge variant is a fixed-width column", () => {
+	it("carries the fixed width, so the label after it starts at a fixed x", () => {
+		const badge = renderBadge(<MethodBadge method="GET" />);
+		expect(badge.className).toContain(WIDTH_CLASS);
+	});
+
+	it("renders GET and DELETE with an identical box", () => {
+		// Method colour is an inline style, so the class list is the whole box:
+		// identical classes including the fixed width means identical width.
+		const get = renderBadge(<MethodBadge method="GET" />);
+		const del = renderBadge(<MethodBadge method="DELETE" />);
+		expect(get.className).toBe(del.className);
+		expect(get.className).toContain(WIDTH_CLASS);
+	});
+
+	it("uses the same width class at both sizes", () => {
+		// The width is in `ch`, so it tracks the chip's own font size rather than
+		// needing a second value per size.
+		const sm = renderBadge(<MethodBadge method="GET" size="sm" />);
+		const md = renderBadge(<MethodBadge method="GET" size="md" />);
+		expect(sm.className).toContain(WIDTH_CLASS);
+		expect(md.className).toContain(WIDTH_CLASS);
+	});
+
+	it("centres the label on both axes", () => {
+		const badge = renderBadge(<MethodBadge method="GET" />);
+		expect(badge.className).toContain("inline-flex");
+		expect(badge.className).toContain("items-center");
+		expect(badge.className).toContain("justify-center");
+	});
+});
+
+describe("MethodBadge - methods longer than the column", () => {
+	it("truncates a long custom method instead of widening the chip", () => {
+		const badge = renderBadge(<MethodBadge method="PROPPATCH" />);
+		expect(badge.className).toContain(WIDTH_CLASS);
+		const label = badge.firstElementChild as HTMLElement;
+		expect(label.textContent).toBe("PROPPATCH");
+		expect(label.className).toContain("truncate");
+		// Without `min-w-0` a flex item refuses to shrink below its content, so the
+		// chip would widen and `truncate` would never fire.
+		expect(label.className).toContain("min-w-0");
+	});
+
+	it("exposes the full method as a title only when it is truncated", () => {
+		// An unconditional title would fight the app's own tooltips on the same
+		// rows, so the absent case is as much of the contract as the present one.
+		expect(renderBadge(<MethodBadge method="PROPPATCH" />).title).toBe("PROPPATCH");
+		expect(renderBadge(<MethodBadge method="OPTIONS" />).title).toBe("");
+		expect(renderBadge(<MethodBadge method="GET" />).title).toBe("");
+	});
+});
+
+describe("MethodBadge - the text variant is unchanged", () => {
+	it("takes no fixed width, so it stays inline in running text", () => {
+		const badge = renderBadge(<MethodBadge method="GET" variant="text" />);
+		expect(badge.className).not.toContain(WIDTH_CLASS);
+		expect(badge.className).not.toContain("inline-flex");
+		expect(badge.textContent).toBe("GET");
+	});
+
+	it("still lets a caller set its own width", () => {
+		// The import preview aligns its own column this way; the badge variant no
+		// longer needs the hack, this one still does.
+		const badge = renderBadge(<MethodBadge method="GET" variant="text" className="w-10" />);
+		expect(badge.className).toContain("w-10");
+	});
+});
+
+describe("MethodBadge - existing behaviour", () => {
+	it("upper-cases the method and keeps the muted dimming", () => {
+		const badge = renderBadge(<MethodBadge method="post" muted />);
+		expect(badge.textContent).toBe("POST");
+		expect(badge.className).toContain("opacity-60");
+	});
+});

--- a/app/src/components/shared/MethodBadge.tsx
+++ b/app/src/components/shared/MethodBadge.tsx
@@ -16,15 +16,47 @@
  *
  * Method colour is one of the app's strongest visual signals; it should mean the
  * same thing everywhere it appears.
+ *
+ * The `badge` variant is a fixed-width column, not a chip that grows with its
+ * letters. Sibling rows put the badge first and the name after it, so an
+ * intrinsic-width chip started `GET` names at one x, `POST` names at another and
+ * `DELETE`/`OPTIONS` further still - a ragged left edge down every list. Three
+ * decisions hold that column together:
+ *
+ * 1. **Width** is `BADGE_METHOD_CHARS` characters plus the chip's own padding
+ *    and border, expressed in `ch` so it tracks the mono font the chip already
+ *    uses and one class covers both sizes. Seven characters is the longest
+ *    standard method (`OPTIONS`, `CONNECT`), so no standard method truncates.
+ * 2. **The label is centred** inside the chip. Short methods in a wide chip read
+ *    better centred than left-aligned against the border, and it is the shape
+ *    every other client uses.
+ * 3. **Longer methods truncate** rather than widening the chip. `method` is not
+ *    bounded at runtime - a pasted `curl -X PROPPATCH` reaches this component
+ *    through a type assertion in the curl parser, and a stored run's method is
+ *    a plain `string` - so one exotic verb must not re-break the alignment of
+ *    every row around it. The full method stays available as the `title`.
+ *
+ * The width is not an opt-in prop: this component's own history (it "previously
+ * rendered seven different ways") is the argument for the primitive enforcing
+ * the rule. The `text` variant keeps its intrinsic width - it sits inline in
+ * running text (tabs), where a fixed column would punch holes, and a caller
+ * that wants a column there sets its own width.
  */
 
 import { getMethodColor } from "@/utils";
 import { cn } from "@/lib/utils";
 
+/**
+ * Longest standard HTTP method - `OPTIONS` and `CONNECT`. Kept in step with the
+ * `7ch` in the width class below, which Tailwind has to see as a literal.
+ */
+const BADGE_METHOD_CHARS = 7;
+
 interface MethodBadgeProps {
 	method: string;
 	/**
 	 * `badge` - tinted chip, for list rows and headers where it anchors a line.
+	 *   Fixed-width, so sibling labels align; see the note above.
 	 * `text` - colour only, for dense places (tabs) where chrome would crowd.
 	 */
 	variant?: "badge" | "text";
@@ -43,18 +75,27 @@ export function MethodBadge({
 	className,
 }: MethodBadgeProps) {
 	const c = getMethodColor(method);
+	const label = method.toUpperCase();
+	const isBadge = variant === "badge";
+	const isTruncated = isBadge && label.length > BADGE_METHOD_CHARS;
 
 	return (
 		<span
 			className={cn(
 				"font-mono font-semibold uppercase shrink-0 transition-opacity",
 				size === "sm" ? "text-[10px]" : "text-[11px]",
-				variant === "badge" && "rounded-md border px-1.5 py-0.5",
+				isBadge &&
+					// `7ch` of content plus this chip's own `px-1.5` and 1px border, so
+					// the box is exactly wide enough for OPTIONS at either size and the
+					// name after it starts at the same x for every method. `inline-flex`
+					// makes the width apply outside a flex row too, and centres the
+					// label on both axes.
+					"inline-flex items-center justify-center rounded-md border px-1.5 py-0.5 w-[calc(7ch+0.75rem+2px)]",
 				muted && "opacity-60",
 				className
 			)}
 			style={
-				variant === "badge"
+				isBadge
 					? {
 							color: `hsl(${c})`,
 							background: `hsl(${c} / 0.1)`,
@@ -62,8 +103,11 @@ export function MethodBadge({
 						}
 					: { color: `hsl(${c})` }
 			}
+			// Only when the chip cannot show the whole method: a native tooltip on
+			// every badge would fight the app's own tooltips on the same rows.
+			title={isTruncated ? label : undefined}
 		>
-			{method.toUpperCase()}
+			{isBadge ? <span className="min-w-0 truncate">{label}</span> : label}
 		</span>
 	);
 }

--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -294,7 +294,7 @@ export default function RunItem({
 				{/* Request Info */}
 				{requestUrl && (
 					<div className="flex items-start gap-2 mb-1.5 min-w-0 flex-wrap">
-						{method && <MethodBadge method={method} className="h-5 items-center" />}
+						{method && <MethodBadge method={method} className="h-5" />}
 						<p
 							className="text-xs text-foreground font-medium break-words flex-1 min-w-0 leading-5"
 							title={requestUrl}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -664,6 +664,23 @@ colour.
 <MethodBadge method={m} variant="text" muted={!isActive} />    // secondary context
 ```
 
+**The `badge` variant is a fixed-width column, not a chip that grows with its
+letters.** Every list that shows one puts the badge first and the name after it,
+so an intrinsic-width chip started `GET` names at one x, `POST` names at another
+and `DELETE`/`OPTIONS` further still - a ragged left edge down the collections
+tree, the history sidebar and the welcome recents at once. The chip is `7ch`
+wide plus its own padding and border (`ch`, so one class serves both sizes and
+tracks the mono font it already uses), seven being the longest standard method -
+`OPTIONS` and `CONNECT`. The label is centred, and a longer method (the engine
+and a pasted `curl -X` both pass arbitrary strings) truncates inside the chip
+with the full method on the element's `title`, rather than widening it and
+re-breaking every row around it.
+
+The width is not an opt-in prop - the primitive enforces it, which is the whole
+reason this component exists. The `text` variant keeps its intrinsic width: it
+sits inline in running text, where a fixed column would punch holes, and a
+caller that wants a column there (the import preview) still sets its own.
+
 
 Method colors are design tokens, not hardcoded hex values. **They are
 mode-adaptive** - hue and saturation are identical in both themes, so a method
@@ -711,21 +728,15 @@ background: `hsl(${c} / 0.1)`
 borderColor: `hsl(${c} / 0.3)`
 ```
 
-**Method badge pattern** (inline `<span>`, not a `<Badge>` component - used in RunItem, DashboardHeader):
-
-```tsx
-const c = `var(--method-${method.toLowerCase()})`;
-<span
-  className="text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded"
-  style={{
-    color:      `hsl(${c})`,
-    background: `hsl(${c} / 0.1)`,
-    border:     `1px solid hsl(${c} / 0.3)`,
-  }}
->
-  {method}
-</span>
-```
+**Do not hand-roll that span for a method.** This section used to carry the
+badge's markup as a pattern to copy, naming `RunItem` and `DashboardHeader` as
+its users; both have rendered `MethodBadge` for some time, and the copy here had
+already drifted (`font-bold` against the primitive's `font-semibold`, `rounded`
+against `rounded-md`, and no fixed width at all - so a copy of it would have
+reintroduced the ragged left edge the primitive now prevents). A hand-rolled
+copy of a primitive does not receive the primitive's fixes. Render
+`MethodBadge`; the three `hsl()` forms above are how it, the tab strip and the
+method selector each build a colour from `getMethodColor`.
 
 **MethodSelector** used to carry its own `METHOD_COLORS` map of those utility
 classes - a second source of truth for the same seven colours, and the kind that

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -681,7 +681,6 @@ reason this component exists. The `text` variant keeps its intrinsic width: it
 sits inline in running text, where a fixed column would punch holes, and a
 caller that wants a column there (the import preview) still sets its own.
 
-
 Method colors are design tokens, not hardcoded hex values. **They are
 mode-adaptive** - hue and saturation are identical in both themes, so a method
 always reads as "its" colour; only lightness shifts.


### PR DESCRIPTION
## Description

Sibling request rows did not align: `MethodBadge`'s `badge` variant rendered at intrinsic width (`px-1.5` around the text, no width constraint), so a name after `GET` started at a different x than one after `POST`, and `DELETE`/`OPTIONS` pushed further still - a ragged left edge down every list.

**Root cause and approach.** The badge-then-label shape repeats in the collections tree (`RequestItem.tsx:188`), the history sidebar (`RunItem.tsx:297`), the welcome recents (`RecentRuns.tsx:83`) and both dashboard headers, so the fix is in the primitive, not in one call site. The `badge` variant is now a fixed-width chip - `7ch` of content plus its own `px-1.5` and 1px border, `inline-flex items-center justify-center` so the width applies outside a flex row too and the label centres on both axes. Seven characters is the longest standard method (`OPTIONS`, `CONNECT`), and `ch` tracks the mono font the chip already uses, so one class serves both the 10px and 11px sizes rather than needing a px value per size. `method` is not bounded at runtime - a pasted `curl -X PROPPATCH` reaches the component through a type assertion in `parseCurl.ts:579`, and a stored run's method is a plain `string` - so a longer method truncates inside the chip and carries the full string as the element's `title`, instead of widening the chip and re-breaking every row around it. **The alternative I rejected** was an opt-in `fixed` prop: this component's own docstring history ("it previously rendered seven different ways") is the argument for the primitive enforcing the rule, and no consumer was found that wants intrinsic width from the badge variant.

**Deviation from the issue spec, with reason.** The issue lists `ImportModal.tsx` and `CollectionDetail/` among the badge-variant consumers to sweep. Verified against `72bef0d`: `CollectionDetail/` does not render `MethodBadge` at all, and `ImportModal.tsx:1394` uses `variant="text"` with its own `className="w-10"` - which does work, because a flex item is blockified whatever its `display`. The `text` variant is out of scope per the issue, so that call site is left exactly as it is; a test pins that a caller can still set its own width there.

One consumer changed: `RunItem.tsx:297` passed `className="h-5 items-center"`, and `items-center` was inert on a non-flex span. The primitive now supplies it, so the call site drops the dead class. Its `h-5` is a height choice for that wrapping row, not a width hack, and stays.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **567 files, 6206 tests, all passing** on the first commit; the new file and the two follow-up commits take it to 6207. New file `app/src/components/shared/MethodBadge.test.tsx`, 10 cases: the fixed-width class is present; every method from `GET` to `PROPPATCH` carries it (so the box does not depend on the method's length); one width class covers both sizes; the label is centred on both axes; a long method truncates with `min-w-0 truncate` rather than widening; truncation starts at exactly the character count the width class was given; the `title` is present only when truncated; the `text` variant takes no fixed width and still honours a caller's own; upper-casing and `muted` are unchanged.
- **Mutation check:** removing the width class from the badge branch reds 6 of the 10 cases. The tests render the component and read `element.className` rather than scanning the source, since the class arrives through `cn()` - a source scan would keep passing after the class was deleted.
- `cd app && pnpm type-check` - clean (renderer, electron, electron tests).
- `cd app && pnpm lint` - clean, zero warnings. `prettier --check` clean on the three app files touched.
- `pnpm exec vite build` - confirms Tailwind emits the arbitrary value as `width: calc(7ch + .75rem + 2px)`; a class that silently fails to generate is the one failure mode jsdom cannot see.
- `drawer-row-hit-area.test.tsx` and the history/welcome suites stay green.
- No engine change, so no engine build or ctest run. No pre-existing failures observed.

Two review findings were fixed in follow-up commits: the character count existed twice (the `BADGE_METHOD_CHARS` constant and the literal `7ch` Tailwind needs at build time), so a test now reads the count back out of the rendered class and pins the truncation threshold to it; and `expect(get.className).toBe(del.className)` was an assertion that could not fail, since the badge's classes never depended on the method - it now asserts the fixed width across five methods instead.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/design-system.md` (same commit) records the width, centring and truncation decisions under "HTTP Method Color Tokens", and retires the hand-rolled "method badge pattern" span it used to offer for copying: it named `RunItem` and `DashboardHeader` as its users when both render the primitive, and had already drifted from it (`font-bold` vs `font-semibold`, `rounded` vs `rounded-md`, and no width at all - so a copy of it would have reintroduced the ragged edge). Never formatted with prettier, per the repo rule.

One pre-existing drift found and deliberately left out of this diff, since a fixed-width fix has no business changing a font weight: the type-scale table's "Micro / badge" row still specifies `font-bold` while the component ships `font-semibold`. Filed as #1199.

## Related Issues
Closes #1194