### PR TITLE
fix(app): stack a token tooltip's value above its source - #1195

### DIFF
--- a/app/src/components/shared/VariableInput/EditableVariable.test.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.test.tsx
@@ -66,6 +66,43 @@ function renderToken(props: Partial<React.ComponentProps<typeof EditableVariable
 	);
 }
 
+/**
+ * Issue #1195. jsdom has no layout, so the assertion is the class contract that
+ * decides the layout rather than a measurement: the value and its hint are
+ * stacked (`flex-col`), and the hint no longer refuses to shrink beside a
+ * `break-all` value. Under the one-row shape those two classes were the reason
+ * a long source name took the whole 320px cap and left the value a vertical
+ * strip of letter fragments - so restoring that shape reds this.
+ *
+ * Radix renders the content twice while open; the first match is the visible
+ * copy and the hidden one carries the same markup.
+ */
+function expectStacked(valueText: string, hintText: string) {
+	const value = screen.getAllByText(valueText)[0];
+	const hint = screen.getAllByText(hintText)[0];
+	expect(value.parentElement).toBe(hint.parentElement);
+	expect(value.parentElement?.className).toContain("flex-col");
+	expect(hint.className).not.toContain("shrink-0");
+}
+
+describe("a long value stays readable beside a long source name", () => {
+	// The reported pair: an unbroken domain, and an environment named in prose.
+	const LONG_VALUE = "acme-eu-storefront-staging.myshopify.com";
+	const LONG_SOURCE = "Staging - EU storefront integration";
+
+	it("stacks the value above its source rather than sharing one row", () => {
+		renderToken({ value: LONG_VALUE, sourceName: LONG_SOURCE });
+		expectStacked(LONG_VALUE, LONG_SOURCE);
+	});
+
+	it("still prints both, in full", () => {
+		// The layout must not have bought its width by clipping either one.
+		renderToken({ value: LONG_VALUE, sourceName: LONG_SOURCE });
+		expect(screen.getAllByText(LONG_VALUE).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(LONG_SOURCE).length).toBeGreaterThan(0);
+	});
+});
+
 describe("the hover preview", () => {
 	it("shows the resolved value without opening anything", () => {
 		renderToken();
@@ -180,6 +217,13 @@ describe("a bound row's column answers the token", () => {
 		renderToken();
 		expect(screen.getAllByText("mrc_8813").length).toBeGreaterThan(0);
 		expect(screen.queryByText("Bound row")).not.toBeInTheDocument();
+	});
+
+	it("stacks the cell above its Bound row hint too", () => {
+		// The bound-row branch is the second copy of the layout below, and it was
+		// the second copy of the defect.
+		renderToken({ name: "email", value: "staging@acme.io", variables: withRow });
+		expectStacked("alice@acme.io", "Bound row");
 	});
 
 	it("never lets a row's cell reveal a secret variable's value", () => {

--- a/app/src/components/shared/VariableInput/EditableVariable.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.tsx
@@ -23,8 +23,8 @@ import {
 	VariablePopover,
 	Tooltip,
 	TooltipContent,
-	TooltipHint,
 	TooltipTrigger,
+	TooltipValue,
 } from "@/components/ui";
 import type { VariableScope } from "@/components/ui";
 import { cn } from "@/lib/utils";
@@ -158,38 +158,27 @@ export default function EditableVariable({
 							 * cell is never a secret: it came from the picked file, not
 							 * from a stored variable someone marked.
 							 */
-							<span className="flex items-baseline gap-2">
-								<span className="break-all font-mono">
-									{boundRowValue || "empty"}
-								</span>
-								<TooltipHint className="shrink-0">Bound row</TooltipHint>
-							</span>
+							<TooltipValue className="font-mono" hint="Bound row">
+								{boundRowValue || "empty"}
+							</TooltipValue>
 						) : !resolved ? (
 							<span className="italic opacity-90">not defined</span>
 						) : (
-							<span className="flex items-baseline gap-2">
-								{/*
-								 * A secret says it *is* a secret rather than drawing a
-								 * row of dots. Dots on hover are the worst of both:
-								 * they occupy the space of an answer, tell you nothing
-								 * you did not already know from the token, and invite a
-								 * second look to check you did not misread them. The
-								 * word plus the source is the useful part - whether it
-								 * is set at all belongs in the popover, where revealing
-								 * is a deliberate act.
-								 */}
-								<span
-									className={cn(
-										"break-all",
-										secret ? "italic opacity-90" : "font-mono"
-									)}
-								>
-									{secret ? "secret" : value || "empty"}
-								</span>
-								{sourceName && (
-									<TooltipHint className="shrink-0">{sourceName}</TooltipHint>
-								)}
-							</span>
+							/*
+							 * A secret says it *is* a secret rather than drawing a row
+							 * of dots. Dots on hover are the worst of both: they occupy
+							 * the space of an answer, tell you nothing you did not
+							 * already know from the token, and invite a second look to
+							 * check you did not misread them. The word plus the source
+							 * is the useful part - whether it is set at all belongs in
+							 * the popover, where revealing is a deliberate act.
+							 */
+							<TooltipValue
+								className={secret ? "italic opacity-90" : "font-mono"}
+								hint={sourceName}
+							>
+								{secret ? "secret" : value || "empty"}
+							</TooltipValue>
 						)}
 					</TooltipContent>
 				</Tooltip>

--- a/app/src/components/shared/VariableInput/RuntimeToken.tsx
+++ b/app/src/components/shared/VariableInput/RuntimeToken.tsx
@@ -32,7 +32,7 @@
  * tooltip that says where the value will come from.
  */
 
-import { Tooltip, TooltipContent, TooltipHint, TooltipTrigger } from "@/components/ui";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { DataTokenTone } from "@/lib/data-contract";
 import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
@@ -72,10 +72,12 @@ export default function RuntimeToken({
 				</span>
 			</TooltipTrigger>
 			<TooltipContent side="bottom" className="max-w-xs">
-				<span className="flex items-baseline gap-2">
-					<span className="break-all">{description}</span>
-					<TooltipHint className="shrink-0">{note}</TooltipHint>
-				</span>
+				{/*
+				 * The same stacked shape as `EditableVariable`, and for a sharper
+				 * reason: this note carries the declared column list, so it is the
+				 * user's own data and unbounded in length (issue #1195).
+				 */}
+				<TooltipValue hint={note}>{description}</TooltipValue>
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
+++ b/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
@@ -120,6 +120,27 @@ describe("a run-time token's tooltip", () => {
 
 		expect(await screen.findByRole("tooltip")).toHaveTextContent("declared: email");
 	});
+
+	it("stacks the description above a declared list of any length", async () => {
+		/*
+		 * Issue #1195, and this tooltip is the sharper case: the note is the
+		 * user's own column list, so it is unbounded, and beside a `break-all`
+		 * description a note that refused to shrink took the whole 320px cap.
+		 * jsdom cannot measure, so the class contract that decides the layout is
+		 * what is pinned - restore the one-row shape and this reds.
+		 */
+		const columns = ["customer_email_address", "shipping_postal_code", "order_reference"];
+		const { container } = renderInput("https://x/{{data.emial}}", columns);
+
+		hover(runtimeToken(container));
+
+		const tooltip = await screen.findByRole("tooltip");
+		const note = tooltip.querySelector(`[class*="text-primary-foreground/"]`);
+		expect(note).toBeTruthy();
+		expect(note!.textContent).toContain(columns.join(", "));
+		expect(note!.className).not.toContain("shrink-0");
+		expect(note!.parentElement?.className).toContain("flex-col");
+	});
 });
 
 describe("clicking a run-time token", () => {

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -80,7 +80,14 @@ export type { ToastVariantName } from "./toast";
 
 export { ToggleGroup, ToggleGroupItem } from "./toggle-group";
 export type { ToggleGroupProps } from "./toggle-group";
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipHint, TooltipProvider } from "./tooltip";
+export {
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+	TooltipHint,
+	TooltipValue,
+	TooltipProvider,
+} from "./tooltip";
 export { TooltipIconButton } from "./tooltip-icon-button";
 export type { TooltipIconButtonProps } from "./tooltip-icon-button";
 export { InfoChip } from "./info-chip";

--- a/app/src/components/ui/tooltip-value-layout.test.ts
+++ b/app/src/components/ui/tooltip-value-layout.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A tooltip's value never shares a flex row with a label that refuses to shrink
+ * (issue #1195).
+ *
+ * `TooltipContent` is capped at `max-w-xs`. A value carrying `break-all` has a
+ * min-content width of about one character, so it is the only item flexbox can
+ * take width from; a `shrink-0` sibling keeps its own intrinsic width whatever
+ * it holds. Put the two in one row and a long source name - an environment with
+ * a descriptive title, a declared column list - takes the whole 320px and
+ * leaves the value a vertical strip of five-letter fragments. The value is the
+ * thing the tooltip exists to show.
+ *
+ * Fixing the two components that had this shape does not fix the app: the next
+ * hand-written tooltip can reach for the same row exactly as they did. So the
+ * rule is made **enumerable rather than impossible**, the way the border and
+ * tooltip-contrast rules are - the mistake is one shape and every tooltip block
+ * in `src` is read. `TooltipValue` is the cure: it stacks the pair, so a call
+ * site that uses it cannot express the defect.
+ *
+ * This scan sees only literal class strings. The rendered-class assertions in
+ * `VariableInput/EditableVariable.test.tsx` and
+ * `VariableInput/runtime-token-interaction.test.tsx` cover the other half.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function tsxFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "dist") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...tsxFiles(full));
+		else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) out.push(full);
+	}
+	return out;
+}
+
+/** `<TooltipContent …>…</TooltipContent>`, comments stripped so prose about the
+ *  rule does not read as a violation of it. */
+const TOOLTIP_BLOCK = /<TooltipContent\b[^>]*>[\s\S]*?<\/TooltipContent>/g;
+
+const blocks = tsxFiles(SRC).flatMap((file) =>
+	[
+		...readFileSync(file, "utf8")
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.matchAll(TOOLTIP_BLOCK),
+	].map((m) => ({ file, source: m[0] }))
+);
+
+describe("every tooltip that prints a value", () => {
+	it("found the tooltips to scan", () => {
+		// A regex that stopped matching would make the case below vacuous - this
+		// repo has had a guard pass for weeks while reading an empty string.
+		expect(blocks.length).toBeGreaterThan(12);
+	});
+
+	it("puts no unshrinkable label beside a value that wraps on any character", () => {
+		const offenders = blocks
+			.filter((b) => b.source.includes("break-all") && b.source.includes("shrink-0"))
+			.map((b) => b.file);
+		expect(offenders).toEqual([]);
+	});
+});

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -54,4 +54,40 @@ function TooltipHint({ className, ...props }: React.ComponentProps<"span">) {
 	return <span className={cn("text-primary-foreground/80", className)} {...props} />;
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipHint, TooltipProvider };
+/**
+ * A tooltip's value line, with the hint that says where the value came from.
+ *
+ * **The two never share a flex row** (issue #1195). `TooltipContent` is capped
+ * at `max-w-xs`, a value wraps on `break-all` - a min-content width of about
+ * one character - and a hint has to keep its intrinsic width to stay readable,
+ * so a row of the two hands its whole width to the hint and leaves the value a
+ * vertical strip of letter fragments. That is not a rare shape: it needs only a
+ * long environment name beside an unbroken value, and it hid the URL-ish values
+ * these tooltips exist to show. Stacking them gives the value the full width
+ * whichever of the two is long, and costs a hint that is short today nothing
+ * but a line.
+ *
+ * The single-line alternative - `min-w-0 flex-1` on the value plus a truncated
+ * hint - was rejected: a clipped source name loses the answer to "which
+ * environment", which is half of what the reader hovered for.
+ */
+function TooltipValue({
+	hint,
+	className,
+	children,
+}: {
+	/** Where the value came from - an environment, a bound row, a contract. */
+	hint?: React.ReactNode;
+	/** Classes for the value itself: its typeface, or the muted italic states. */
+	className?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<span className="flex flex-col gap-0.5">
+			<span className={cn("break-all", className)}>{children}</span>
+			{hint ? <TooltipHint>{hint}</TooltipHint> : null}
+		</span>
+	);
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipHint, TooltipValue, TooltipProvider };

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -814,6 +814,20 @@ out-read the label it is secondary to - white on `sunset` is the ceiling at
 3.6:1 - so the bar is 2.5:1 on every scheme, checked in
 `tooltip-hint-contrast.test.ts`.
 
+**A value and the hint that sources it stack; they never share a flex row.**
+`TooltipContent` is capped at `max-w-xs`, a value that wraps on `break-all` has
+a min-content width of about one character, and a hint has to keep its
+intrinsic width to stay readable - so a row of the two hands its whole width to
+the hint and leaves the value a vertical strip of letter fragments. It takes
+only a long environment name beside an unbroken value (issue #1195), or a note
+carrying the user's own data, such as a declared column list. `TooltipValue`
+holds the stacked shape and takes the hint as a prop, so a call site using it
+cannot express the row; the one-line alternative - `min-w-0 flex-1` on the
+value plus a truncated hint - was rejected, because a clipped source name loses
+the answer to "which environment". A short label beside a short one
+(`TooltipIconButton`'s shortcut hint) has neither ingredient and stays a row.
+→ `tooltip-value-layout.test.ts` reads every tooltip block for the shape.
+
 | Scheme | Light (`--primary` = `--primary-fill`) | Dark `--primary` | Dark `--primary-fill` |
 |--------|-----------|----------|----------|
 | `sunset` | `24 90% 46%` | `24 95% 58%` | `24 90% 46%` |


### PR DESCRIPTION
## Description

**Root cause.** A `{{token}}` tooltip laid its value and the label sourcing it out as one flex row - the label `shrink-0`, the value `break-all`. `TooltipContent` is capped at `max-w-xs` (320px), a `break-all` value has a min-content width of about one character and is therefore the only item flexbox can take width from, and a `shrink-0` sibling keeps its full intrinsic width however long it is. So a long environment name beside an unbroken value (the reported `*.myshopify.com` domain) takes the whole row and collapses the value into a vertical strip of five-letter fragments - the value being the one thing the tooltip exists to show. **Approach:** stop putting an unshrinkable label and an infinitely-shrinkable value in one row; stack them, in one primitive (`TooltipValue`, beside `TooltipHint` in `ui/tooltip.tsx`) that takes the hint as a prop, so the value gets full width whichever of the two is long and a call site using it cannot express the row. **Rejected alternative:** the one-line shape kept alive with `min-w-0 flex-1` on the value plus a bounded, truncated hint - it preserves the current look, but a clipped source name loses the answer to "which environment", which is half of what the reader hovered for; the issue reaches the same conclusion.

**Deviation from the issue spec, deliberate.** The issue asks to "check `RuntimeToken.tsx:76` - its tooltip is a single `break-all` span with no competing sibling - verify it needs nothing". Verified at `b30dc8a`, and it needs the fix: `RuntimeToken` renders the same `flex items-baseline` row with a `shrink-0` `TooltipHint` beside a `break-all` description, and it is the *sharpest* of the three cases, because its note is `declared: ${columnList(contract.columns)}` (`lib/data-contract.ts:169-170`) - the user's own column list, unbounded in length, against a description that is also user-named (`Not a declared column of <collectionName>`). It moves to the same primitive. `variable-popover.tsx:499` is left alone as instructed (block layout, already correct), and `TooltipIconButton`'s hint row is left alone too: a short label beside a short shortcut has neither ingredient of the defect, and touching it would be scope creep.

Three call sites shared this shape and two of them were found by hand, which is why the fix is a primitive plus an enumerable guard rather than three local edits - the same argument the repo's border and tooltip-contrast rules make.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

jsdom has no layout, so the layout is pinned as the class contract that decides it, at two levels:

- `EditableVariable.test.tsx` - 3 new cases: the resolved branch stacks a long value above a long source name, both still render in full, and the bound-row branch stacks too.
- `runtime-token-interaction.test.tsx` - 1 new case: a real hover on a `{{data.*}}` token whose contract declares three long columns, asserting the note is not `shrink-0` and its parent is `flex-col`.
- `ui/tooltip-value-layout.test.ts` (new) - a source scan of every `<TooltipContent>` block in `src` for the shape (`break-all` alongside `shrink-0`), with the non-empty assertion the repo requires of a scan (`blocks.length > 12`; it reads 107 blocks).

**Mutation check:** restoring the one-row layout inside `TooltipValue` (`flex items-baseline gap-2` + `shrink-0` on the hint) fails 3 tests across both component test files. The scan is deliberately unaffected by that mutation - it guards call sites hand-rolling the row, which is the half the rendered assertions cannot enumerate.

Commands run, all green on this branch:

- `cd app && pnpm test` - **568 files, 6213 tests passed** (383s)
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests)
- `cd app && pnpm lint` - clean, zero warnings
- `pnpm prettier --check` on the touched `app/` files - clean

No pre-existing failures observed. The engine is untouched, so no engine build or ctest run: nothing in this diff could take a C++ test from green to red. `mkdocs build --strict` was not run - mkdocs is not installed in this environment - but the docs change is prose only, adding no link, heading or nav entry.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/design-system.md` gains a paragraph next to the existing `TooltipHint` rule stating that a value and the hint sourcing it stack and never share a flex row, why, the rejected alternative, and which guard reads it. `docs/app/COMPONENTS.md` was checked and needs nothing: its `VariableInput` section describes the tooltip's *wording* and the `Bound row` origin, never the one-line layout. No new file under `components/ui/`, so its primitive list is unchanged. No test here reads a file outside `app/`, so `routed-inputs.testkit.ts` needs no entry.

## Related Issues
Closes #1195

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5i6ruv3Ybid5DM2bdWsp1)_