### PR TITLE
test(app): pin the tooltip value's break-all, and share the block scan - #1195

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -165,6 +165,14 @@ white-on-`--primary` never occurs because fills use `--primary-fill`).
   → `tooltip-hint-contrast.test.ts` (ratios per scheme, plus a scan of every
   tooltip block in `src`), `tooltip-icon-button.test.tsx` (the rendered class,
   which the scan cannot see)
+- **A tooltip's value and the hint sourcing it stack; they never share a flex
+  row.** `TooltipContent` is capped at `max-w-xs`, a `break-all` value has a
+  min-content width of about one character, and a `shrink-0` hint keeps its
+  intrinsic width - so one long source name takes the whole 320px and leaves
+  the value a vertical strip of letter fragments. Write `TooltipValue`, which
+  holds the stacked shape. → `tooltip-value-layout.test.ts` (the same block
+  scan, from `tooltip-blocks.testkit.ts`), plus rendered-class guards in
+  `VariableInput/`
 - **Adding an accent scheme:** `constants/color-schemes.ts` + `index.css`, both
   themes, nothing else. → `color-schemes.test.ts`
 - **A `Badge` that paints its own `bg-` must be `variant="chip"`.** Every other

--- a/app/src/components/shared/VariableInput/EditableVariable.test.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.test.tsx
@@ -83,6 +83,10 @@ function expectStacked(valueText: string, hintText: string) {
 	expect(value.parentElement).toBe(hint.parentElement);
 	expect(value.parentElement?.className).toContain("flex-col");
 	expect(hint.className).not.toContain("shrink-0");
+	// The other half of the contract, and the half the stack exists to make
+	// safe: a value long enough to need it still wraps mid-token rather than
+	// widening the tooltip past its cap or spilling out of it.
+	expect(value.className).toContain("break-all");
 }
 
 describe("a long value stays readable beside a long source name", () => {

--- a/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
+++ b/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
@@ -140,6 +140,11 @@ describe("a run-time token's tooltip", () => {
 		expect(note!.textContent).toContain(columns.join(", "));
 		expect(note!.className).not.toContain("shrink-0");
 		expect(note!.parentElement?.className).toContain("flex-col");
+		// And the description above it still wraps mid-token: a column name is
+		// one unbroken word, so without this it widens the tooltip instead.
+		const description = note!.previousElementSibling;
+		expect(description?.textContent).toContain("Not a declared column of");
+		expect(description?.className).toContain("break-all");
 	});
 });
 

--- a/app/src/components/ui/tooltip-blocks.testkit.ts
+++ b/app/src/components/ui/tooltip-blocks.testkit.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Every `<TooltipContent>…</TooltipContent>` written in `src`, for the guards
+ * that read them.
+ *
+ * Two rules are enumerable rather than impossible - a canvas-tuned foreground
+ * on the tooltip's fill (`tooltip-hint-contrast.test.ts`) and a value sharing a
+ * flex row with a label that will not shrink (`tooltip-value-layout.test.ts`) -
+ * and both need the same walk. The second guard began as a copy of the first's
+ * helpers, which is the shape the repo has been bitten by often enough to have
+ * a rule about it: widening the block regex to catch a spelling it misses, or
+ * changing which directories are skipped, has to reach both scans.
+ *
+ * A scan cannot see a class that arrives in a variable, which is why each rule
+ * also has a rendered-class guard. The two catch different halves and neither
+ * is sufficient.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** `app/src` - this file lives in `src/components/ui`. */
+export const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function tsxFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "dist") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...tsxFiles(full));
+		else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) out.push(full);
+	}
+	return out;
+}
+
+/** `<TooltipContent …>…</TooltipContent>`, comments stripped so prose about a
+ *  rule does not read as a violation of it. */
+const TOOLTIP_BLOCK = /<TooltipContent\b[^>]*>[\s\S]*?<\/TooltipContent>/g;
+
+export interface TooltipBlock {
+	/** Absolute path of the component the block was read from. */
+	file: string;
+	/** The block's source, comments removed. */
+	source: string;
+}
+
+/** Read once: both guards walk the same tree over the same regex. */
+export const tooltipBlocks: TooltipBlock[] = tsxFiles(SRC).flatMap((file) =>
+	[
+		...readFileSync(file, "utf8")
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.matchAll(TOOLTIP_BLOCK),
+	].map((m) => ({ file, source: m[0] }))
+);

--- a/app/src/components/ui/tooltip-hint-contrast.test.ts
+++ b/app/src/components/ui/tooltip-hint-contrast.test.ts
@@ -28,12 +28,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { SRC, tooltipBlocks } from "./tooltip-blocks.testkit";
 
 const uiDir = dirname(fileURLToPath(import.meta.url));
-const SRC = join(uiDir, "..", "..");
 const css = readFileSync(join(SRC, "index.css"), "utf8");
 const tooltip = readFileSync(join(uiDir, "tooltip.tsx"), "utf8");
 
@@ -134,31 +134,16 @@ describe("a tooltip hint on the tooltip's own fill", () => {
  * rendered-class guard in `tooltip-icon-button.test.tsx` exists alongside it.
  * The two catch different halves and neither is sufficient.
  */
-function tsxFiles(dir: string): string[] {
-	const out: string[] = [];
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		if (entry.name === "node_modules" || entry.name === "dist") continue;
-		const full = join(dir, entry.name);
-		if (entry.isDirectory()) out.push(...tsxFiles(full));
-		else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) out.push(full);
-	}
-	return out;
-}
-
-/** `<TooltipContent …>…</TooltipContent>`, comments stripped so prose about the
- *  rule does not read as a violation of it. */
-const TOOLTIP_BLOCK = /<TooltipContent\b[^>]*>[\s\S]*?<\/TooltipContent>/g;
-
 /** The foregrounds tuned for the canvas: muted, plain, and the `-text` tier. */
 const CANVAS_FOREGROUND = /\btext-(?:muted-foreground|foreground|[a-z]+-text)\b/;
 
-const blocks = tsxFiles(SRC).flatMap((file) =>
-	[
-		...readFileSync(file, "utf8")
-			.replace(/\/\*[\s\S]*?\*\//g, "")
-			.matchAll(TOOLTIP_BLOCK),
-	].map((m) => ({ file, source: m[0] }))
-);
+/**
+ * The walk itself is `tooltip-blocks.testkit.ts`, shared with the layout guard
+ * (issue #1195). It was written here first and copied there, which is the shape
+ * this repo has a rule about: widening the block regex, or changing which
+ * directories it skips, has to reach both scans.
+ */
+const blocks = tooltipBlocks;
 
 describe("every tooltip in the app, not only the three this fix touched", () => {
 	it("found the tooltips to scan", () => {

--- a/app/src/components/ui/tooltip-value-layout.test.ts
+++ b/app/src/components/ui/tooltip-value-layout.test.ts
@@ -21,53 +21,29 @@
  * hand-written tooltip can reach for the same row exactly as they did. So the
  * rule is made **enumerable rather than impossible**, the way the border and
  * tooltip-contrast rules are - the mistake is one shape and every tooltip block
- * in `src` is read. `TooltipValue` is the cure: it stacks the pair, so a call
- * site that uses it cannot express the defect.
+ * in `src` is read.
  *
- * This scan sees only literal class strings. The rendered-class assertions in
+ * `TooltipValue` is the cure: it stacks the pair, so a call site that uses it
+ * cannot express the defect. That the primitive itself keeps its half of the
+ * bargain - the stack, and the `break-all` that makes a long value wrap at all
+ * - is pinned where a class can be read off a rendered element, in
  * `VariableInput/EditableVariable.test.tsx` and
- * `VariableInput/runtime-token-interaction.test.tsx` cover the other half.
+ * `VariableInput/runtime-token-interaction.test.tsx`. This scan sees only
+ * literal class strings; the two halves are not interchangeable.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-
-function tsxFiles(dir: string): string[] {
-	const out: string[] = [];
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		if (entry.name === "node_modules" || entry.name === "dist") continue;
-		const full = join(dir, entry.name);
-		if (entry.isDirectory()) out.push(...tsxFiles(full));
-		else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) out.push(full);
-	}
-	return out;
-}
-
-/** `<TooltipContent …>…</TooltipContent>`, comments stripped so prose about the
- *  rule does not read as a violation of it. */
-const TOOLTIP_BLOCK = /<TooltipContent\b[^>]*>[\s\S]*?<\/TooltipContent>/g;
-
-const blocks = tsxFiles(SRC).flatMap((file) =>
-	[
-		...readFileSync(file, "utf8")
-			.replace(/\/\*[\s\S]*?\*\//g, "")
-			.matchAll(TOOLTIP_BLOCK),
-	].map((m) => ({ file, source: m[0] }))
-);
+import { tooltipBlocks } from "./tooltip-blocks.testkit";
 
 describe("every tooltip that prints a value", () => {
 	it("found the tooltips to scan", () => {
-		// A regex that stopped matching would make the case below vacuous - this
+		// A walk that stopped matching would make the case below vacuous - this
 		// repo has had a guard pass for weeks while reading an empty string.
-		expect(blocks.length).toBeGreaterThan(12);
+		expect(tooltipBlocks.length).toBeGreaterThan(12);
 	});
 
 	it("puts no unshrinkable label beside a value that wraps on any character", () => {
-		const offenders = blocks
+		const offenders = tooltipBlocks
 			.filter((b) => b.source.includes("break-all") && b.source.includes("shrink-0"))
 			.map((b) => b.file);
 		expect(offenders).toEqual([]);


### PR DESCRIPTION
## Description

Follow-up to #1200, which merged while this commit was being validated - so it lands as its own PR rather than on that branch. Two findings from the review pass on #1200's diff, both verified against the code before acting on them.

**1. The layout guards pinned the stack and forgot the wrap.** `TooltipValue` is `cn("break-all", className)` on the value span, but nothing asserted that. Deleting `break-all` from the primitive left the entire new test set green: `expectStacked` read only the parent's `flex-col` and the hint's missing `shrink-0`, the `RuntimeToken` case read only the note element, and the source scan flags a block only when `break-all` and `shrink-0` appear *together* - so a block with neither is invisible to it. That makes the mutation check the issue asked for half a check. The stack is what keeps a long value at full tooltip width; `break-all` is what makes it wrap there instead of pushing the tooltip past its cap. Both components now read the class off the rendered element.

**2. The new scan was a copy of `tooltip-hint-contrast.test.ts`'s walk**, down to the `tsxFiles` recursion and the `TOOLTIP_BLOCK` regex - the shape the repo has a rule about, since widening that regex to catch a spelling it misses, or changing which directories it skips, has to reach both guards. The walk moves to `components/ui/tooltip-blocks.testkit.ts` (the `kebab-case.testkit.ts` convention from `docs/app/file-name-conventions.md`) and both scans import it. Behaviour is unchanged: same files, same regex, same 17 blocks.

Also corrects the record from #1200's body: that PR said the scan reads 107 blocks. It reads **17** - 107 was a count of `rg` output lines, not of matched blocks. The guard's `> 12` floor is still a real non-empty assertion, not a vacuous one.

Rejected finding, recorded with the reason: a reviewer noted `TooltipValue` types its props inline rather than exporting a named `TooltipValueProps` interface, unlike `TooltipIconButtonProps`. Left as is - `Eyebrow` in the same directory takes an inline `{ children; className? }` and exports no props type either, so the precedent is mixed and this is not a rule.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **568 files, 6213 tests passed** (360s), run before this commit was split out; the affected files were re-run on this base: `VariableInput/` + both tooltip scans, **10 files, 111 tests passed**.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests)
- `cd app && pnpm lint` - clean, zero warnings
- `pnpm prettier --check` on the touched files, `app/CLAUDE.md` included (verified it was prettier-clean before the edit too) - clean

**Mutation check, the point of the change:** deleting `break-all` from `TooltipValue` now fails 3 cases across `EditableVariable.test.tsx` and `runtime-token-interaction.test.tsx`. Before this commit the same deletion failed nothing. Restoring the one-row layout still fails 3 cases, as before.

No engine change, so no engine build or ctest run - nothing here could take a C++ test from green to red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `app/CLAUDE.md` gains the rule as a bullet in its "UI rules (enforced by tests)" list, beside the tooltip-contrast rule it sits next to - that list is where a UI rule with a test behind it is written down, and #1200 documented the rule in `docs/design-system.md` but not there.

## Related Issues

Follow-up to #1195 (closed by #1200); no new issue is deferred by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5i6ruv3Ybid5DM2bdWsp1)_