### PR TITLE
refactor(app): one throttled batch flush, shared by both streaming services

### DIFF
--- a/app/src/services/load-test-service.monitor-flush.test.ts
+++ b/app/src/services/load-test-service.monitor-flush.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Monitor scrapes ride the metrics flush - the part of `LoadTestService` that
+ * the shared batcher (issue #1206) deliberately does not know about.
+ *
+ * The batcher owns one buffer and commits nothing for an empty one, so the
+ * pairing of ticks and scrapes had to stay here. That makes the seam worth its
+ * own cases: before the extraction a single `flushMetrics` guard covered "one
+ * of the two lists has something", and the case where only the scrape list does
+ * was covered by nothing.
+ *
+ * A sibling file rather than cases inside `load-test-service.test.ts`, whose
+ * store mock declares no `addMonitorSamples` - #1206 asks that suite to pass
+ * unchanged, as the proof that no behaviour moved.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { LoadTestMetrics, MonitorSample } from "@/types";
+
+const mockAddMetricsBatch = vi.fn();
+const mockAddMonitorSamples = vi.fn();
+vi.mock("@/stores", () => ({
+	useDashboardStore: {
+		getState: () => ({
+			currentRunId: null,
+			setStreaming: vi.fn(),
+			setError: vi.fn(),
+			setFinalReport: vi.fn(),
+			addMetricsBatch: mockAddMetricsBatch,
+			addMonitorSamples: mockAddMonitorSamples,
+		}),
+	},
+	// The module default (500ms) applies, so a window is a window.
+	useClientSettingsStore: { getState: () => ({ liveRefreshMs: 0 }) },
+}));
+vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn(), disconnect: vi.fn() } }));
+vi.mock("./api", () => ({
+	apiService: { getRunReport: vi.fn().mockResolvedValue({ summary: {}, latency: {} }) },
+}));
+
+import { loadTestService } from "./load-test-service";
+import { sseClient } from "./sse-client";
+import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
+
+type MetricsHandler = (m: LoadTestMetrics) => void;
+type MonitorHandler = (s: MonitorSample) => void;
+
+/** The handlers the service handed the SSE client for the active run. */
+function streamHandlers(): { tick: MetricsHandler; scrape: MonitorHandler } {
+	const calls = vi.mocked(sseClient.connect).mock.calls;
+	const call = calls[calls.length - 1];
+	if (!call) throw new Error("startMonitoring did not connect");
+	return { tick: call[1] as MetricsHandler, scrape: call[5] as MonitorHandler };
+}
+
+/** `handleClose` is private; the SSE client is what calls it in production. */
+function closeStream(): Promise<void> {
+	return (loadTestService as unknown as { handleClose: () => Promise<void> }).handleClose();
+}
+
+/**
+ * Reset the singleton's stream state between cases, so each one starts on the
+ * leading edge the way a fresh run does.
+ */
+function resetService(): void {
+	const internals = loadTestService as unknown as {
+		activeRunId: string | null;
+		pendingMonitor: MonitorSample[];
+		metricsBatcher: { discard: () => void };
+	};
+	internals.activeRunId = null;
+	internals.pendingMonitor = [];
+	internals.metricsBatcher.discard();
+}
+
+const tickAt = (timestamp: number) => ({ timestamp }) as unknown as LoadTestMetrics;
+const scrapeAt = (timestamp: number) => ({ timestamp }) as unknown as MonitorSample;
+
+describe("LoadTestService - scrapes riding the metrics flush", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		resetService();
+	});
+	afterEach(() => {
+		resetService();
+		vi.useRealTimers();
+	});
+
+	it("commits a scrape and the tick it arrived beside in the same flush", () => {
+		loadTestService.startMonitoring("run_1");
+		const { tick, scrape } = streamHandlers();
+
+		scrape(scrapeAt(1));
+		tick(tickAt(1)); // leading edge
+
+		expect(mockAddMetricsBatch).toHaveBeenCalledTimes(1);
+		expect(mockAddMonitorSamples).toHaveBeenCalledTimes(1);
+		expect(mockAddMonitorSamples).toHaveBeenLastCalledWith([scrapeAt(1)]);
+	});
+
+	it("carries a scrape that arrived inside the window on the trailing commit", () => {
+		loadTestService.startMonitoring("run_2");
+		const { tick, scrape } = streamHandlers();
+
+		tick(tickAt(1)); // leading edge
+		mockAddMonitorSamples.mockClear();
+		scrape(scrapeAt(2));
+		tick(tickAt(2));
+
+		// A scrape has no timer of its own - it waits for the next tick's flush.
+		expect(mockAddMonitorSamples).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(METRICS_UI_THROTTLE_MS);
+		expect(mockAddMonitorSamples).toHaveBeenLastCalledWith([scrapeAt(2)]);
+	});
+
+	it("commits a scrape the run ended before any tick could carry", async () => {
+		loadTestService.startMonitoring("run_3");
+		const { scrape } = streamHandlers();
+
+		// The whole point: no tick is buffered, so the batcher commits nothing,
+		// and the scrape is left holding the only unflushed state there is.
+		scrape(scrapeAt(3));
+		await closeStream();
+
+		// The mutation check: drop the `pendingMonitor` drain from `flushPending`
+		// and this scrape is silently lost at the end of every run that ends
+		// between ticks.
+		expect(mockAddMonitorSamples).toHaveBeenCalledTimes(1);
+		expect(mockAddMonitorSamples).toHaveBeenLastCalledWith([scrapeAt(3)]);
+		// Beside an empty tick batch, which is what this did before the batcher.
+		expect(mockAddMetricsBatch).toHaveBeenLastCalledWith([]);
+	});
+
+	it("drops what a stopped run left buffered rather than committing it late", () => {
+		loadTestService.startMonitoring("run_4");
+		const { tick, scrape } = streamHandlers();
+
+		tick(tickAt(1)); // leading edge
+		tick(tickAt(2)); // buffered behind the window
+		scrape(scrapeAt(1));
+		mockAddMetricsBatch.mockClear();
+		mockAddMonitorSamples.mockClear();
+
+		loadTestService.stopMonitoring();
+		vi.advanceTimersByTime(METRICS_UI_THROTTLE_MS * 2);
+
+		// Both buffers dropped, and the trailing timer with them.
+		expect(mockAddMetricsBatch).not.toHaveBeenCalled();
+		expect(mockAddMonitorSamples).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -18,23 +18,26 @@ import { apiService } from "./api";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { QUERY_CACHE } from "@/config/cache";
-import { useDashboardStore, useClientSettingsStore } from "@/stores";
+import { useDashboardStore } from "@/stores";
 import type { LoadTestMetrics, MonitorSample } from "@/types";
 // Engine emits at 10 Hz (100ms cadence - see engine/src/http/routes/metrics.cpp).
-// We throttle UI commits to keep render cost bounded, but BUFFER every tick the
-// engine sends so historicalMetrics keeps the full 10 Hz signal.
-import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
+// The batcher throttles UI commits to keep render cost bounded, but every tick
+// the engine sends is BUFFERED, so historicalMetrics keeps the full 10 Hz signal.
+import { createThrottledBatcher } from "./throttled-batcher";
 
 class LoadTestService {
 	private activeRunId: string | null = null;
 	private isConnected: boolean = false;
-	private lastMetricsPushTime = 0;
-	private pendingBuffer: LoadTestMetrics[] = [];
+	/** Ticks, buffered and committed on the live-refresh cadence. */
+	private metricsBatcher = createThrottledBatcher<LoadTestMetrics>((batch) =>
+		this.commitBatch(batch)
+	);
 	// Scrapes ride the same throttle as the ticks: they arrive on the same
 	// stream and are drawn on the same chart row, so committing them separately
 	// would render the overlay a frame out of step with the series under it.
+	// They stay this service's own buffer - the batcher carries one list, and
+	// which lists ride a flush together is a caller's decision.
 	private pendingMonitor: MonitorSample[] = [];
-	private throttleTimer: ReturnType<typeof setTimeout> | null = null;
 
 	/**
 	 * Start monitoring a load test run
@@ -86,13 +89,8 @@ class LoadTestService {
 			return;
 		}
 
-		if (this.throttleTimer) {
-			clearTimeout(this.throttleTimer);
-			this.throttleTimer = null;
-		}
-		this.pendingBuffer = [];
+		this.metricsBatcher.discard();
 		this.pendingMonitor = [];
-		this.lastMetricsPushTime = 0;
 		this.activeRunId = null;
 		this.isConnected = false;
 		sseClient.disconnect();
@@ -118,20 +116,7 @@ class LoadTestService {
 	// --- Private handlers ---
 
 	private handleMetrics(metrics: LoadTestMetrics): void {
-		this.pendingBuffer.push(metrics);
-		const now = Date.now();
-		const elapsed = now - this.lastMetricsPushTime;
-		// User-configurable live refresh rate (falls back to the module default).
-		const throttleMs =
-			useClientSettingsStore.getState().liveRefreshMs || METRICS_UI_THROTTLE_MS;
-		if (elapsed >= throttleMs || this.lastMetricsPushTime === 0) {
-			this.flushMetrics();
-		} else if (!this.throttleTimer) {
-			this.throttleTimer = setTimeout(() => {
-				this.throttleTimer = null;
-				this.flushMetrics();
-			}, throttleMs - elapsed);
-		}
+		this.metricsBatcher.push(metrics);
 	}
 
 	private handleMonitorSample(sample: MonitorSample): void {
@@ -142,16 +127,26 @@ class LoadTestService {
 		// whatever the last tick left behind.
 	}
 
-	private flushMetrics(): void {
-		if (this.pendingBuffer.length === 0 && this.pendingMonitor.length === 0) return;
-		this.lastMetricsPushTime = Date.now();
-		const batch = this.pendingBuffer;
+	/** Commit a batch of ticks together with whatever scrapes arrived beside it. */
+	private commitBatch(batch: LoadTestMetrics[]): void {
 		const monitor = this.pendingMonitor;
-		this.pendingBuffer = [];
 		this.pendingMonitor = [];
 		const store = useDashboardStore.getState();
 		store.addMetricsBatch(batch);
 		store.addMonitorSamples(monitor);
+	}
+
+	/**
+	 * Commit everything buffered, on either list.
+	 *
+	 * A scrape can outlive the last tick it would have ridden - the run ends
+	 * between ticks - and the batcher commits nothing for an empty buffer, so
+	 * that case commits the scrapes beside an empty tick batch, which is what
+	 * this did before the batcher was extracted.
+	 */
+	private flushPending(): void {
+		this.metricsBatcher.flush();
+		if (this.pendingMonitor.length > 0) this.commitBatch([]);
 	}
 
 	private handleError(error: Error): void {
@@ -162,11 +157,7 @@ class LoadTestService {
 
 	private async handleClose(): Promise<void> {
 		const runId = this.activeRunId;
-		if (this.throttleTimer) {
-			clearTimeout(this.throttleTimer);
-			this.throttleTimer = null;
-		}
-		this.flushMetrics();
+		this.flushPending();
 		this.isConnected = false;
 		const store = useDashboardStore.getState();
 		store.setStreaming(false);

--- a/app/src/services/scenario-run-service.ts
+++ b/app/src/services/scenario-run-service.ts
@@ -21,7 +21,8 @@
  * the engine's scenario loop is sequential with no pacing, so a local or fast
  * target returns hundreds of steps per second - well above the 10 Hz the load
  * path already considered worth throttling - and each one committed a store
- * write that copied the whole step list and re-rendered the run tab.
+ * write that copied the whole step list and re-rendered the run tab. The
+ * mechanism itself lives in `throttled-batcher.ts`, which both services use.
  */
 
 import { sseClient } from "./sse-client";
@@ -29,15 +30,14 @@ import { apiService } from "./api";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { useScenarioRunStore } from "@/stores/scenario-run-store";
-import { useClientSettingsStore } from "@/stores";
-import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
+import { createThrottledBatcher } from "./throttled-batcher";
 import type { ScenarioStepEvent } from "@/types";
 
 class ScenarioRunService {
 	private activeRunId: string | null = null;
-	private pendingSteps: ScenarioStepEvent[] = [];
-	private lastStepPushTime = 0;
-	private throttleTimer: ReturnType<typeof setTimeout> | null = null;
+	private stepBatcher = createThrottledBatcher<ScenarioStepEvent>((batch) =>
+		useScenarioRunStore.getState().addSteps(batch)
+	);
 
 	/** Attach to a scenario run's stream and push its steps into the store. */
 	startMonitoring(runId: string): void {
@@ -67,45 +67,17 @@ class ScenarioRunService {
 	/**
 	 * Buffer a step, and commit the buffer no more often than the cadence.
 	 *
-	 * The leading edge commits immediately - the first step of a run is the one
-	 * a reader is waiting on, and holding it back would make a fast run look
-	 * slow to start - and a trailing timer commits whatever arrives inside the
-	 * window. Identical to `LoadTestService.handleMetrics`, on the same setting,
-	 * because the two are the same problem: a stream the renderer cannot commit
-	 * per event.
+	 * The batcher holds the mechanism - `LoadTestService` puts the same one on
+	 * its ticks, because the two are the same problem: a stream the renderer
+	 * cannot commit per event.
 	 */
 	private handleStep(step: ScenarioStepEvent): void {
-		this.pendingSteps.push(step);
-		const elapsed = Date.now() - this.lastStepPushTime;
-		const throttleMs =
-			useClientSettingsStore.getState().liveRefreshMs || METRICS_UI_THROTTLE_MS;
-		if (elapsed >= throttleMs || this.lastStepPushTime === 0) {
-			this.flushSteps();
-		} else if (!this.throttleTimer) {
-			this.throttleTimer = setTimeout(() => {
-				this.throttleTimer = null;
-				this.flushSteps();
-			}, throttleMs - elapsed);
-		}
-	}
-
-	/** Commit the buffered steps as one batch. */
-	private flushSteps(): void {
-		if (this.pendingSteps.length === 0) return;
-		this.lastStepPushTime = Date.now();
-		const batch = this.pendingSteps;
-		this.pendingSteps = [];
-		useScenarioRunStore.getState().addSteps(batch);
+		this.stepBatcher.push(step);
 	}
 
 	/** Drop the buffer and its pending commit, for steps nothing will show. */
 	private discardPending(): void {
-		if (this.throttleTimer) {
-			clearTimeout(this.throttleTimer);
-			this.throttleTimer = null;
-		}
-		this.pendingSteps = [];
-		this.lastStepPushTime = 0;
+		this.stepBatcher.discard();
 	}
 
 	/*
@@ -124,7 +96,7 @@ class ScenarioRunService {
 		// notice explaining why no more will be. A buffered batch stranded here
 		// would be the run's last steps, silently missing from a list the reader
 		// is now being told is incomplete.
-		this.flushSteps();
+		this.stepBatcher.flush();
 		useScenarioRunStore.getState().setError(error.message);
 	}
 
@@ -140,7 +112,7 @@ class ScenarioRunService {
 		// stored rows supersede them a moment later, but only if the report
 		// fetch below succeeds - and a run that ended without one is exactly the
 		// case where the live rows are all the reader will ever have.
-		this.flushSteps();
+		this.stepBatcher.flush();
 		this.discardPending();
 		useScenarioRunStore.getState().setStreaming(false);
 		if (!runId) return;

--- a/app/src/services/throttled-batcher.test.ts
+++ b/app/src/services/throttled-batcher.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The batcher's own contract, which both streaming services now depend on
+ * (issue #1206). `load-test-service.test.ts` and `scenario-run-service.test.ts`
+ * keep their behavioural cases - what a batch commits to is theirs - so what is
+ * pinned here is only what the helper owns: the leading edge, the trailing
+ * timer, the cadence it reads, and the two ways a buffer ends.
+ *
+ * The mutation checks are named per case: each says which line of
+ * `throttled-batcher.ts` reverting would redden it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const FLUSH_MS = 500;
+let liveRefreshMs = FLUSH_MS;
+
+vi.mock("@/stores", () => ({
+	useClientSettingsStore: { getState: () => ({ liveRefreshMs }) },
+}));
+
+import { createThrottledBatcher } from "./throttled-batcher";
+import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
+
+describe("createThrottledBatcher", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		liveRefreshMs = FLUSH_MS;
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("commits the first item at once, so a fast stream does not look slow to start", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(1);
+
+		// The mutation check: drop `|| lastCommitTime === 0` from the leading-edge
+		// condition and the run's first item waits out a whole window instead.
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenLastCalledWith([1]);
+	});
+
+	it("carries everything inside one window on a single trailing commit", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge
+		commit.mockClear();
+		for (let i = 1; i <= 8; i++) batcher.push(i);
+
+		// Nothing yet: the window that opened on the leading edge is still open.
+		expect(commit).not.toHaveBeenCalled();
+
+		// The mutation check: remove the trailing `setTimeout` and these eight
+		// never arrive - the assertion below reddens on an empty mock.
+		vi.advanceTimersByTime(FLUSH_MS);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenLastCalledWith([1, 2, 3, 4, 5, 6, 7, 8]);
+	});
+
+	it("schedules one timer for a window, not one per item", () => {
+		const commit = vi.fn();
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge, no timer
+		setTimeoutSpy.mockClear();
+		for (let i = 1; i <= 5; i++) batcher.push(i);
+
+		// The mutation check: drop the `timer === null` guard and each item
+		// inside the window arms its own timer.
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+		setTimeoutSpy.mockRestore();
+	});
+
+	it("re-opens the leading edge once a window has passed with nothing buffered", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(1); // leading edge
+		vi.advanceTimersByTime(FLUSH_MS);
+		batcher.push(2);
+
+		// Two commits, both immediate: the second push is a window later, so it
+		// takes the leading edge rather than waiting for a timer.
+		expect(commit).toHaveBeenCalledTimes(2);
+		expect(commit).toHaveBeenLastCalledWith([2]);
+	});
+
+	it("flush commits what is buffered, and is a no-op when nothing is", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge
+		batcher.push(1);
+		batcher.push(2);
+		commit.mockClear();
+
+		batcher.flush();
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenLastCalledWith([1, 2]);
+
+		// Nothing left, so a second flush commits nothing - the property
+		// `LoadTestService` leans on to tell an empty buffer from a full one.
+		batcher.flush();
+		expect(commit).toHaveBeenCalledTimes(1);
+
+		// The mutation check for `clearTimer` inside `flush`: a stale timer left
+		// armed here commits nothing (the buffer it would drain is empty), so
+		// only the pending count shows it. Left uncleared per window on a long
+		// run, that is the leak.
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(FLUSH_MS * 2);
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it("discard drops the buffer, its pending commit, and re-arms the leading edge", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge
+		batcher.push(1);
+		batcher.push(2);
+		commit.mockClear();
+
+		batcher.discard();
+
+		// The mutation check for `clearTimer` inside `discard`. An armed timer
+		// left behind commits nothing - it would drain a buffer this just
+		// emptied - so the commit assertions below cannot see it, and only the
+		// pending count can: a run replaced mid-flight leaks one timer per
+		// window it had open.
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(FLUSH_MS * 2);
+
+		expect(commit).not.toHaveBeenCalled();
+
+		// The next item belongs to a list nothing has seen, so it leads again
+		// rather than inheriting the discarded window's timestamp.
+		batcher.push(3);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenLastCalledWith([3]);
+	});
+
+	it("reads the live-refresh setting per push, so a change takes effect on the next item", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge at the 500ms cadence
+		liveRefreshMs = 100;
+		batcher.push(1);
+		commit.mockClear();
+
+		// The new cadence, not the one in force when the window opened.
+		vi.advanceTimersByTime(100);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(commit).toHaveBeenLastCalledWith([1]);
+	});
+
+	it("falls back to the module default when the setting is unset", () => {
+		const commit = vi.fn();
+		liveRefreshMs = 0;
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.push(0); // leading edge
+		batcher.push(1);
+		commit.mockClear();
+
+		vi.advanceTimersByTime(METRICS_UI_THROTTLE_MS - 1);
+		expect(commit).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(commit).toHaveBeenCalledTimes(1);
+	});
+
+	it("never hands the commit an empty batch", () => {
+		const commit = vi.fn();
+		const batcher = createThrottledBatcher<number>(commit);
+
+		batcher.flush();
+		batcher.discard();
+		vi.advanceTimersByTime(FLUSH_MS * 2);
+
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it("hands each commit its own array, not a buffer it keeps writing into", () => {
+		const batches: number[][] = [];
+		const batcher = createThrottledBatcher<number>((batch) => batches.push(batch));
+
+		batcher.push(0); // leading edge
+		batcher.push(1);
+		vi.advanceTimersByTime(FLUSH_MS);
+		batcher.push(2);
+		vi.advanceTimersByTime(FLUSH_MS);
+
+		// A batcher that reused one array would leave every recorded batch
+		// pointing at the same, latest contents.
+		expect(batches).toEqual([[0], [1], [2]]);
+	});
+});

--- a/app/src/services/throttled-batcher.ts
+++ b/app/src/services/throttled-batcher.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A leading-edge-plus-trailing-timer batcher for a live SSE stream.
+ *
+ * `LoadTestService` and `ScenarioRunService` both read a stream the renderer
+ * cannot commit per event, and both answered it the same way: buffer, commit
+ * the first item at once - the first tick or step of a run is the one a reader
+ * is waiting on, and holding it back makes a fast run look slow to start - and
+ * let a trailing timer carry whatever arrives inside the window. Since #1153
+ * that was two field-for-field copies of one mechanism, which is the shape a
+ * timing fix or a teardown leak lands in one of and not the other.
+ *
+ * It owns the buffer, the timer and the cadence, and nothing else. What a batch
+ * commits to, when a stream is torn down, and whatever else rides the same
+ * flush stay with the caller, whose lifecycles genuinely differ: one has a
+ * `stopMonitoring` and a second buffer riding this flush, the other drains on
+ * error as well as on close.
+ */
+
+import { useClientSettingsStore } from "@/stores";
+import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
+
+export interface ThrottledBatcher<T> {
+	/** Buffer an item, committing now or on the trailing timer. */
+	push(item: T): void;
+	/** Commit whatever is buffered; a no-op when nothing is. */
+	flush(): void;
+	/** Drop the buffer and its pending commit, for items nothing will show. */
+	discard(): void;
+}
+
+/**
+ * @param commit Receives each batch. Never called with an empty array, and
+ * never called re-entrantly from `push` for an item it is not carrying.
+ */
+export function createThrottledBatcher<T>(commit: (batch: T[]) => void): ThrottledBatcher<T> {
+	let pending: T[] = [];
+	let lastCommitTime = 0;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	const clearTimer = (): void => {
+		if (timer !== null) {
+			clearTimeout(timer);
+			timer = null;
+		}
+	};
+
+	const flush = (): void => {
+		if (pending.length === 0) return;
+		clearTimer();
+		lastCommitTime = Date.now();
+		const batch = pending;
+		pending = [];
+		commit(batch);
+	};
+
+	return {
+		push(item: T): void {
+			pending.push(item);
+			// Read per push, not once: a live change to the setting takes effect
+			// on the next event rather than on the next run.
+			const throttleMs =
+				useClientSettingsStore.getState().liveRefreshMs || METRICS_UI_THROTTLE_MS;
+			const elapsed = Date.now() - lastCommitTime;
+			if (elapsed >= throttleMs || lastCommitTime === 0) {
+				flush();
+			} else if (timer === null) {
+				timer = setTimeout(() => {
+					timer = null;
+					flush();
+				}, throttleMs - elapsed);
+			}
+		},
+		flush,
+		discard(): void {
+			clearTimer();
+			pending = [];
+			// Back to the leading edge: the next item belongs to a list nothing
+			// has seen yet, so it commits at once the way a run's first does.
+			lastCommitTime = 0;
+		},
+	};
+}

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -778,7 +778,7 @@ It holds **one** run. A scenario is sequential and the app starts one at a time,
 }
 ```
 
-**A batch per flush, not a commit per event** (issue #1153). `ScenarioRunService` buffers arriving `step` events and commits what it collected on the user's `liveRefreshMs` cadence, the same throttle `LoadTestService` puts on its ticks. The premise for having none - that a scenario's step rate is bounded by request latency - does not hold: the engine's scenario loop is sequential with no pacing, so a local target returns hundreds of steps per second, and each one used to cost a full copy of the step list, a store notify and a re-render of the run tab. The buffer is committed on the leading edge of a window and again on a trailing timer, and drained when the stream closes or fails; a run replaced mid-flight discards whatever it left buffered, since those rows belong to a list the store has already cleared.
+**A batch per flush, not a commit per event** (issue #1153). `ScenarioRunService` buffers arriving `step` events and commits what it collected on the user's `liveRefreshMs` cadence, the same throttle `LoadTestService` puts on its ticks. The premise for having none - that a scenario's step rate is bounded by request latency - does not hold: the engine's scenario loop is sequential with no pacing, so a local target returns hundreds of steps per second, and each one used to cost a full copy of the step list, a store notify and a re-render of the run tab. The buffer is committed on the leading edge of a window and again on a trailing timer, and drained when the stream closes or fails; a run replaced mid-flight discards whatever it left buffered, since those rows belong to a list the store has already cleared. That mechanism - buffer, leading edge, trailing timer, and the `liveRefreshMs` read behind it - is one implementation, `services/throttled-batcher.ts` (issue #1206); when to flush and when to discard stay each service's own, because the two lifecycles genuinely differ.
 
 Steps are folded in by `foldStepEvents` (`modules/history/main/scenario-steps.ts`), which keys on `(iteration, stepIndex)` rather than arrival order: the engine's SSE ring replays from `Last-Event-ID`, so a reconnect re-delivers events already rendered and an append-only list would double every row it re-saw. A whole batch costs one array copy, and the fold returns the state it was given when every event in the batch was an idempotent replay, so a reconnect's replay does not re-render the list.
 
@@ -1641,7 +1641,11 @@ loadTestService.stopMonitoring();
   charts rather than starting blank.
 - Every tick is buffered; commits into `useDashboardStore().addMetricsBatch()`
   are throttled to `METRICS_UI_THROTTLE_MS` so `historicalMetrics` keeps the
-  full 10 Hz signal while renders stay bounded.
+  full 10 Hz signal while renders stay bounded. The buffer, the leading edge and
+  the trailing timer are `services/throttled-batcher.ts`, shared with
+  `ScenarioRunService` (issue #1206) - a monitor scrape has no timer of its own
+  and rides the next tick's flush, which is why that second buffer stays in the
+  service rather than moving into the batcher.
 - The engine sends an explicit `complete` event, so a `CLOSED` readyState is a
   genuine failure. **There is no custom reconnect**: `EventSource` cannot set
   `Last-Event-ID` on a fresh connection, so a manual reconnect would replay the


### PR DESCRIPTION
## Description

`ScenarioRunService` gained a leading-edge-plus-trailing-timer flush in #1153 that was a field-for-field copy of the one `LoadTestService` has had since the dashboard work - same buffer and timer fields, same `elapsed >= throttleMs || last === 0` condition, same trailing `setTimeout`, same `liveRefreshMs || METRICS_UI_THROTTLE_MS` fallback, same drain-on-close and clear-on-teardown. The new code's own comment conceded it ("Identical to `LoadTestService.handleMetrics`, on the same setting"). Two copies is where a timing fix or a teardown leak lands in one and not the other, and nothing fails.

**Root cause and approach.** The duplication is mechanism, not policy: what the two services genuinely disagree about is *lifecycle*, not *how to batch*. So `app/src/services/throttled-batcher.ts` takes the buffer, the timer and the cadence read, exposing `push` / `flush` / `discard`, and each service keeps its own decisions - `LoadTestService` its `stopMonitoring` and its second buffer, `ScenarioRunService` its drain on error as well as on close. The helper carries no flag that exists only to tell the two callers apart, per the issue's own bar.

**The alternative I rejected:** teaching the helper about the monitor-scrape buffer, so it could own both of `LoadTestService`'s lists. That is exactly the "generic scheduling abstraction with options for the differences" the issue rules out - the scrape buffer's whole contract (no timer of its own, rides the next tick's flush) is a `LoadTestService` decision about two lists drawn on one chart row, and nothing in `ScenarioRunService` has a counterpart. It stays in the service.

One consequence worth naming, since it is the only place behaviour could have moved: the batcher commits nothing for an empty buffer, but the old `flushMetrics` guard fired when *either* list had something. A run that ends between ticks with a scrape buffered therefore needs `flushPending` to commit the scrapes beside an empty tick batch - which is precisely what the old code did. That seam had no coverage before this PR.

**Placement note (deliberate deviation from no spec, stated for review):** the helper lives in `services/` beside `sse-client.ts` and its two callers rather than in `lib/`. It is not a general-purpose utility - it reads the live-refresh setting, which is meaningful only for a live stream - and `lib/` is not a lower layer here in any case (several `lib/` modules already import stores and services). Happy to move it if you would rather it sat in `lib/`.

## Type of Change
- [x] Bug fix *(latent: a fix applied to one copy and not the other)*
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **572 files, 6249 tests, all passing**, of which **14 are new** (10 for the batcher, 4 for the scrapes riding the flush). `pnpm type-check`, `pnpm lint` and `pnpm format:check` on the touched files all clean. No engine side, so no engine build or ctest run - nothing under `engine/` is touched. No pre-existing failures encountered.

- `throttled-batcher.test.ts` - 10 cases: leading edge, one trailing commit per window, one timer per window, the leading edge re-opening after an idle window, `flush` draining and no-opping, `discard` dropping buffer + timer + re-arming the edge, the cadence read per push, the `METRICS_UI_THROTTLE_MS` fallback, never handing `commit` an empty batch, and each batch getting its own array.
- `load-test-service.monitor-flush.test.ts` - 4 cases for the seam above: a scrape committed with the tick it arrived beside, a scrape carried on the trailing commit, **a scrape the run ended before any tick could carry**, and both buffers dropped by `stopMonitoring`.
- A sibling file rather than cases added to `load-test-service.test.ts`, whose store mock declares no `addMonitorSamples` - the issue asks that suite to pass **unchanged**, as the proof no behaviour moved. Both existing service suites are untouched and green.

**Mutation-checked**, each reverted in turn against the suites:

| Reverted | Reddens |
|---|---|
| `\|\| lastCommitTime === 0` (leading edge) | 6 cases, incl. the scenario suite's batching case |
| the trailing `setTimeout` | 6 cases |
| the `timer === null` guard | "schedules one timer for a window" |
| `clearTimer()` in `flush` | "flush commits what is buffered…" |
| `clearTimer()` in `discard` | "discard drops the buffer…" |
| the `pendingMonitor` drain in `flushPending` | "commits a scrape the run ended before any tick could carry" |

The two `clearTimer` reverts are worth a note: a stale timer commits *nothing* (it would drain a buffer just emptied), so it is invisible through commit assertions - my first draft of those two cases passed under mutation and claimed a failure mode it did not test. They now assert `vi.getTimerCount()`, which is what actually shows the leak, and the comments say so.

### One internal divergence, deliberately left

Old `flushMetrics` bumped `lastMetricsPushTime` whenever *either* list had something, so the monitor-only case bumped it too; the batcher's `flush()` short-circuits on an empty buffer and leaves `lastCommitTime` at the last real tick flush. That case is reachable only from `handleClose`, and neither the old code nor the new one resets the timestamp on a natural close - so a stale value already carried into the next run in both versions, and all that changes is *which* stale value. Reproducing a difference needs a new run started within one `throttleMs` (100ms-1s) of a close whose last event was a lone scrape.

Left alone on purpose. Matching it exactly means giving the helper a timestamp-poke that exists for one caller's edge case, and the tidier-looking alternative - discarding the batcher on close, as `ScenarioRunService` does - would genuinely *change* behaviour, which the "no behaviour moved" criterion forbids. Flagging it rather than burying it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/state-management.md` carried two separate descriptions of this cadence (one per service, lines ~781 and ~1642). Both now name the single implementation, and the load-test entry records why the scrape buffer did not move into it.

## Related Issues
Closes #1206

Unblocks #1158, whose stated fix ("adopt the LoadTestService throttle pattern") would otherwise have made this a third copy.