### PR TITLE
fix(collections): open the row menu from the keyboard

### DIFF
--- a/app/src/components/shared/RowActionsMenu.test.tsx
+++ b/app/src/components/shared/RowActionsMenu.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The row menu's keyboard path (#1212).
+ *
+ * Radix's dropdown trigger opens on `pointerdown` and on its own `keydown`, and
+ * `HTMLElement.click()` is neither - which is exactly what the collection
+ * tree's Shift+F10 / Menu / Shift+Enter keys dispatch at `[data-tree-menu]`.
+ * Every menu-only row action was therefore mouse-only, and nothing caught it:
+ * the component had no test at all, and the tree's tests all open the menu with
+ * `pointerDown` because they already knew click did nothing.
+ *
+ * These cases pin both halves - the click path on, the mouse path unchanged -
+ * plus the `tabIndex` prop the roving-tabindex tree needs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Copy, Trash2 } from "lucide-react";
+import { RowActionsMenu } from "./RowActionsMenu";
+
+const duplicate = vi.fn();
+const remove = vi.fn();
+
+const actions = [
+	{ label: "Duplicate", icon: Copy, onSelect: duplicate },
+	{ label: "Delete", icon: Trash2, onSelect: remove, destructive: true },
+];
+
+const LABEL = "More actions for Get users";
+const trigger = () => screen.getByRole("button", { name: LABEL });
+
+function renderMenu(tabIndex?: number) {
+	return render(<RowActionsMenu label={LABEL} actions={actions} tabIndex={tabIndex} />);
+}
+
+/**
+ * What a mouse does: Radix opens on the pointerdown, and the click the browser
+ * fires after it - `detail` 1, because a pointer is behind it - arrives at an
+ * already-open menu.
+ */
+function mousePress(el: HTMLElement) {
+	fireEvent.pointerDown(el, { button: 0, ctrlKey: false, pointerType: "mouse" });
+	fireEvent.click(el, { detail: 1 });
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("opening the menu", () => {
+	it("opens on a click with no pointer behind it, which is what a key dispatches", async () => {
+		renderMenu();
+
+		// Exactly what `useRovingTreeFocus` does for Shift+F10 / Menu /
+		// Shift+Enter: a native click, so `detail` is 0.
+		trigger().click();
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Duplicate" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Delete" })).toBeInTheDocument();
+	});
+
+	it("runs the action the keyboard-opened menu selects", async () => {
+		renderMenu();
+		trigger().click();
+
+		fireEvent.click(await screen.findByRole("menuitem", { name: "Duplicate" }));
+
+		await waitFor(() => expect(duplicate).toHaveBeenCalledTimes(1));
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("opens once for a mouse press, whose click must not undo its own pointerdown", async () => {
+		renderMenu();
+
+		mousePress(trigger());
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		// One menu, still open: a handler that toggled on every click - rather
+		// than opening only on the pointer-less one - would close it here.
+		expect(screen.getAllByRole("menu")).toHaveLength(1);
+	});
+
+	it("renders nothing when the row has no actions", () => {
+		const { container } = render(<RowActionsMenu label={LABEL} actions={[]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+
+describe("the trigger's tab stop", () => {
+	it("is a tab stop by default, so an ordinary row's menu is reachable", () => {
+		renderMenu();
+		expect(trigger()).toHaveAttribute("tabindex", "0");
+	});
+
+	it("takes -1 from a roving-tabindex tree, where the row holds the stop", () => {
+		renderMenu(-1);
+		expect(trigger()).toHaveAttribute("tabindex", "-1");
+	});
+});
+
+describe("where focus lands when the menu closes", () => {
+	it("returns to the row when the trigger is inside a treeitem", async () => {
+		render(
+			<div role="tree">
+				<div role="treeitem" tabIndex={0} data-testid="row">
+					<RowActionsMenu label={LABEL} actions={actions} tabIndex={-1} />
+				</div>
+			</div>
+		);
+		const row = screen.getByTestId("row");
+		trigger().click();
+		const menu = await screen.findByRole("menu");
+
+		fireEvent.keyDown(menu, { key: "Escape" });
+
+		// Radix hands focus back to the trigger, which is not a tab stop here -
+		// so Escape would strand the tree's one stop on an unreachable control.
+		await waitFor(() => expect(document.activeElement).toBe(row));
+	});
+
+	it("leaves Radix's own focus return alone outside a tree", async () => {
+		renderMenu();
+		const button = trigger();
+		button.click();
+		const menu = await screen.findByRole("menu");
+
+		fireEvent.keyDown(menu, { key: "Escape" });
+
+		await waitFor(() => expect(document.activeElement).toBe(button));
+	});
+});

--- a/app/src/components/shared/RowActionsMenu.test.tsx
+++ b/app/src/components/shared/RowActionsMenu.test.tsx
@@ -90,6 +90,21 @@ describe("opening the menu", () => {
 		expect(screen.getAllByRole("menu")).toHaveLength(1);
 	});
 
+	it("closes again on the next mouse press, one toggle per click", async () => {
+		renderMenu();
+		// Held across the open: a modal menu marks everything outside it
+		// aria-hidden, so a role query cannot find the trigger while it is up.
+		const button = trigger();
+		mousePress(button);
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+
+		mousePress(button);
+
+		// Holding the open state here rather than leaving it to Radix must not
+		// cost the trigger its toggle.
+		await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+	});
+
 	it("renders nothing when the row has no actions", () => {
 		const { container } = render(<RowActionsMenu label={LABEL} actions={[]} />);
 		expect(container).toBeEmptyDOMElement();

--- a/app/src/components/shared/RowActionsMenu.tsx
+++ b/app/src/components/shared/RowActionsMenu.tsx
@@ -15,11 +15,16 @@
  * Built on the DropdownMenu primitive rather than a hand-rolled popover so it
  * gets focus management, Escape-to-close and arrow-key navigation for free.
  *
- * The trigger carries `data-tree-menu`, so inside the collection tree the
- * Shift+F10 / Menu key path opens it (every control in a tree row is
- * tabIndex=-1 - see useRovingTreeFocus).
+ * **The open state is held here so a keyboard-dispatched click can open it**
+ * (#1212). Radix's trigger listens on `pointerdown` and on its own `keydown`,
+ * and neither hears `HTMLElement.click()` - which is exactly what the
+ * collection tree's Shift+F10 / Menu / Shift+Enter keys dispatch at
+ * `[data-tree-menu]` (`useRovingTreeFocus`). Every menu-only row action was
+ * mouse-only for as long as that went unnoticed. The `detail === 0` test below
+ * is what separates that click from a real one; see the handler.
  */
 
+import { useRef, useState } from "react";
 import { MoreVertical, type LucideIcon } from "lucide-react";
 import {
 	Button,
@@ -46,29 +51,64 @@ interface RowActionsMenuProps {
 	actions: RowAction[];
 	/** Extra classes for the trigger (sizing lives with the calling row). */
 	className?: string;
+	/**
+	 * Tab stop of the trigger. `0` by default, so an ordinary row's menu is
+	 * reachable by Tab like any other control. A roving-tabindex tree passes
+	 * `-1`: there the whole tree is one tab stop and the row's keys are the
+	 * path in.
+	 */
+	tabIndex?: number;
 }
 
-export function RowActionsMenu({ label, actions, className }: RowActionsMenuProps) {
+export function RowActionsMenu({ label, actions, className, tabIndex = 0 }: RowActionsMenuProps) {
+	const [open, setOpen] = useState(false);
+	const trigger = useRef<HTMLButtonElement>(null);
+
 	if (actions.length === 0) return null;
 
 	const firstDestructive = actions.findIndex((a) => a.destructive);
 
 	return (
-		<DropdownMenu>
+		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger asChild>
 				<Button
+					ref={trigger}
 					variant="rowAction"
 					size="icon"
-					tabIndex={-1}
+					tabIndex={tabIndex}
 					data-tree-menu
 					aria-label={label}
 					className={cn("h-6 w-6 shrink-0", className)}
-					onClick={(e) => e.stopPropagation()}
+					onClick={(e) => {
+						e.stopPropagation();
+						// A click with no pointer behind it - `.click()` from the
+						// tree's key handler, or an assistive-tech activation -
+						// reports `detail === 0`. A mouse click reports 1, and Radix
+						// has already toggled on its pointerdown by the time it
+						// arrives, so opening again here would close it on the way
+						// down. Keyboard focus on the trigger itself is Radix's
+						// keydown path, which preventDefaults and so never reaches
+						// this handler at all.
+						if (e.detail === 0) setOpen(true);
+					}}
 				>
 					<MoreVertical className="h-3 w-3" />
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" className="min-w-40">
+			<DropdownMenuContent
+				align="end"
+				className="min-w-40"
+				onCloseAutoFocus={(e) => {
+					// Radix hands focus back to the trigger. In a roving-tabindex
+					// tree that control is deliberately not a tab stop, so the row
+					// it belongs to is where focus has to land - otherwise Escape
+					// leaves the tree's one stop on something Tab cannot return to.
+					const row = trigger.current?.closest<HTMLElement>('[role="treeitem"]');
+					if (!row) return;
+					e.preventDefault();
+					row.focus();
+				}}
+			>
 				{actions.map((action, i) => (
 					<div key={action.label}>
 						{action.destructive && i === firstDestructive && i > 0 && (

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -312,6 +312,9 @@ export default function CollectionItem({
 				{!isRenaming && (
 					<RowActionsMenu
 						label={`More actions for ${collection.name}`}
+						// The tree is one tab stop: the row holds it, and Shift+F10 /
+						// Menu / Shift+Enter are the way in from here.
+						tabIndex={-1}
 						className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
 						// "Move to..." is appended rather than built in
 						// `getCollectionActions`: it belongs to the drag slice, which

--- a/app/src/modules/collections/CollectionTree.row-menu.test.tsx
+++ b/app/src/modules/collections/CollectionTree.row-menu.test.tsx
@@ -96,31 +96,49 @@ describe("the three keys that open a row's menu", () => {
 		expect(screen.getByRole("menuitem", { name: /Export as OpenAPI/ })).toBeInTheDocument();
 	});
 
-	it("opens it on the Menu key", async () => {
-		renderTree();
+	// Every key against both row types. A folder row missing what a request row
+	// has is how the Delete key went dead here for months, so neither row type
+	// gets to stand in for the other.
+	const KEYS: [string, string, { shiftKey?: boolean }][] = [
+		["Shift+F10", "F10", { shiftKey: true }],
+		["the Menu key", "ContextMenu", {}],
+		["Shift+Enter", "Enter", { shiftKey: true }],
+	];
+	const ROWS: [string, () => HTMLElement][] = [
+		["a collection row", collectionRow],
+		["a request row", requestRow],
+	];
 
-		pressOnRow(collectionRow(), "ContextMenu");
+	for (const [rowName, row] of ROWS) {
+		for (const [keyName, key, init] of KEYS) {
+			it(`opens ${rowName}'s menu on ${keyName}`, async () => {
+				renderTree();
 
-		expect(await screen.findByRole("menu")).toBeInTheDocument();
-	});
+				pressOnRow(row(), key, init);
 
-	it("opens it on Shift+Enter, the Mac-reachable path, without opening the row", async () => {
-		renderTree();
+				expect(await screen.findByRole("menu")).toBeInTheDocument();
+				expect(screen.getAllByRole("menuitem").length).toBeGreaterThan(0);
+			});
+		}
+	}
 
-		pressOnRow(collectionRow(), "Enter", { shiftKey: true });
-
-		expect(await screen.findByRole("menu")).toBeInTheDocument();
-		// Shift+Enter is the menu, not a second way to activate the row.
-		expect(useTabsStore.getState().openTabs).toHaveLength(0);
-	});
-
-	it("opens a request row's menu too", async () => {
+	it("offers a request row the actions that have no chord", async () => {
 		renderTree();
 
 		pressOnRow(requestRow(), "F10", { shiftKey: true });
 
-		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		await screen.findByRole("menu");
 		expect(screen.getByRole("menuitem", { name: /Duplicate/ })).toBeInTheDocument();
+	});
+
+	it("leaves the row shut when Shift+Enter opens the menu", async () => {
+		renderTree();
+
+		pressOnRow(collectionRow(), "Enter", { shiftKey: true });
+
+		await screen.findByRole("menu");
+		// Shift+Enter is the menu, not a second way to activate the row.
+		expect(useTabsStore.getState().openTabs).toHaveLength(0);
 	});
 });
 
@@ -148,6 +166,40 @@ describe("moving around the menu once it is open", () => {
 		// Not the trigger: it is `tabIndex={-1}` inside the tree's single tab
 		// stop, so focus resting there is focus the user cannot Tab back to.
 		await waitFor(() => expect(document.activeElement).toBe(row));
+	});
+
+	// Both row types, deliberately: a folder row missing a control the request
+	// row had is how the Delete key went dead here for months.
+	it("hands focus back to a request row too", async () => {
+		renderTree();
+		const row = requestRow();
+		pressOnRow(row, "F10", { shiftKey: true });
+		const menu = await screen.findByRole("menu");
+
+		fireEvent.keyDown(menu, { key: "Escape" });
+
+		await waitFor(() => expect(document.activeElement).toBe(row));
+	});
+});
+
+describe("an action that opens a dialog", () => {
+	/*
+	 * Returning focus to the row is a claim on focus the menu did not use to
+	 * make, and most row actions open a dialog. Radix runs the close's focus
+	 * restoration on a later tick than the dialog's own mount focus, so the row
+	 * would be claiming focus a dialog has already taken - and nothing in the
+	 * tree's tests asserted where focus lands, so this went unmeasured.
+	 */
+	it("leaves focus in the dialog, not on the row behind it", async () => {
+		renderTree();
+		const row = collectionRow();
+		pressOnRow(row, "F10", { shiftKey: true });
+		fireEvent.click(await screen.findByRole("menuitem", { name: /Delete/ }));
+
+		const dialog = await screen.findByRole("dialog");
+
+		await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+		expect(document.activeElement).not.toBe(row);
 	});
 });
 

--- a/app/src/modules/collections/CollectionTree.row-menu.test.tsx
+++ b/app/src/modules/collections/CollectionTree.row-menu.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The row menu, opened the way a keyboard opens it (#1212).
+ *
+ * `useRovingTreeFocus` answers Shift+F10, the Menu key and Shift+Enter by
+ * calling `.click()` on the row's `[data-tree-menu]` control. Radix's dropdown
+ * trigger listens on `pointerdown` and on its own `keydown` and hears neither -
+ * so Duplicate, Move to, Run, Add and Export were mouse-only on every row while
+ * the tree advertised a keyboard path for them.
+ *
+ * The hook's own test could not see it: it renders a stub row whose
+ * `data-tree-menu` control is a plain button, so `.click()` there does what
+ * `.click()` on a plain button always does. These cases press the same keys on
+ * the real tree, against the real menu.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore } from "@/stores";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+
+const collections = [{ id: "acme", name: "Acme", order: 0 }];
+const requests = new Map([
+	["acme", [{ id: "r-ping", collectionId: "acme", name: "Ping", method: "GET", order: 0 }]],
+]);
+
+vi.mock("@/queries", () => ({
+	useReorderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+	useCollectionsQuery: () => ({
+		data: collections,
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: requests }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useRestoreTrashMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	return render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+const collectionRow = () => document.querySelector<HTMLElement>('[data-collection-id="acme"]')!;
+const requestRow = () => document.querySelector<HTMLElement>('[data-request-id="r-ping"]')!;
+
+/** Focus a row and press one of the three keys the hook routes to the menu. */
+function pressOnRow(row: HTMLElement, key: string, init: { shiftKey?: boolean } = {}) {
+	row.focus();
+	fireEvent.keyDown(row, { key, ...init });
+}
+
+beforeEach(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["acme"]) });
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("the three keys that open a row's menu", () => {
+	it("opens a collection row's menu on Shift+F10", async () => {
+		renderTree();
+
+		pressOnRow(collectionRow(), "F10", { shiftKey: true });
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		// The menu-only actions the issue names: none of them has a chord, so
+		// this menu is the whole keyboard path to them.
+		expect(screen.getByRole("menuitem", { name: /Run collection/ })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: /Add Request/ })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: /Export as OpenAPI/ })).toBeInTheDocument();
+	});
+
+	it("opens it on the Menu key", async () => {
+		renderTree();
+
+		pressOnRow(collectionRow(), "ContextMenu");
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+	});
+
+	it("opens it on Shift+Enter, the Mac-reachable path, without opening the row", async () => {
+		renderTree();
+
+		pressOnRow(collectionRow(), "Enter", { shiftKey: true });
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		// Shift+Enter is the menu, not a second way to activate the row.
+		expect(useTabsStore.getState().openTabs).toHaveLength(0);
+	});
+
+	it("opens a request row's menu too", async () => {
+		renderTree();
+
+		pressOnRow(requestRow(), "F10", { shiftKey: true });
+
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: /Duplicate/ })).toBeInTheDocument();
+	});
+});
+
+describe("moving around the menu once it is open", () => {
+	it("puts the first action under the arrow keys", async () => {
+		renderTree();
+		pressOnRow(collectionRow(), "F10", { shiftKey: true });
+		const menu = await screen.findByRole("menu");
+
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+
+		await waitFor(() =>
+			expect(document.activeElement).toBe(screen.getAllByRole("menuitem")[0])
+		);
+	});
+
+	it("hands focus back to the row on Escape", async () => {
+		renderTree();
+		const row = collectionRow();
+		pressOnRow(row, "F10", { shiftKey: true });
+		const menu = await screen.findByRole("menu");
+
+		fireEvent.keyDown(menu, { key: "Escape" });
+
+		// Not the trigger: it is `tabIndex={-1}` inside the tree's single tab
+		// stop, so focus resting there is focus the user cannot Tab back to.
+		await waitFor(() => expect(document.activeElement).toBe(row));
+	});
+});
+
+describe("the tree stays one tab stop", () => {
+	it("keeps every row control off the tab order, the ⋯ trigger included", () => {
+		renderTree();
+
+		const menus = document.querySelectorAll<HTMLElement>("[data-tree-menu]");
+		expect(menus.length).toBeGreaterThan(0);
+		for (const menu of menus) expect(menu).toHaveAttribute("tabindex", "-1");
+	});
+});

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -242,6 +242,9 @@ export default function RequestItem({
 			{!isRenaming && !isDeleting && (
 				<RowActionsMenu
 					label={`More actions for request ${request.name}`}
+					// The tree is one tab stop: the row holds it, and Shift+F10 /
+					// Menu / Shift+Enter are the way in from here.
+					tabIndex={-1}
 					className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
 					actions={[
 						{

--- a/app/src/modules/collections/useRovingTreeFocus.test.tsx
+++ b/app/src/modules/collections/useRovingTreeFocus.test.tsx
@@ -2,8 +2,10 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { useRef } from "react";
+import { Copy } from "lucide-react";
+import { RowActionsMenu } from "@/components/shared/RowActionsMenu";
 import { useRovingTreeFocus } from "./useRovingTreeFocus";
 import { TIMING } from "@/config/timing";
 
@@ -38,9 +40,14 @@ function Tree({ expanded }: { expanded: boolean }) {
 						<button tabIndex={-1} data-tree-activate onClick={activate}>
 							demo
 						</button>
-						<button tabIndex={-1} data-tree-menu onClick={menu}>
-							menu
-						</button>
+						{/* The real menu, not a stand-in. A plain button answered the
+						    `.click()` this hook dispatches, so a stub here certified
+						    a path the Radix-backed component did not have (#1212). */}
+						<RowActionsMenu
+							label="Row menu"
+							tabIndex={-1}
+							actions={[{ label: "Menu action", icon: Copy, onSelect: menu }]}
+						/>
 						<button tabIndex={-1} data-tree-rename onClick={rename}>
 							rename
 						</button>
@@ -222,7 +229,7 @@ describe("useRovingTreeFocus", () => {
 
 	// C makes every row control tabIndex=-1, so these keys are the replacement
 	// path - without them delete and row actions become mouse-only.
-	it("reaches row actions with Delete and Shift+F10 / ContextMenu", () => {
+	it("reaches row actions with Delete and Shift+F10 / ContextMenu", async () => {
 		render(<Tree expanded />);
 		byName("req-1").focus();
 		key("Delete");
@@ -230,9 +237,15 @@ describe("useRovingTreeFocus", () => {
 
 		byName("demo").focus();
 		key("F10", { shiftKey: true });
-		expect(menu).toHaveBeenCalledTimes(1);
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
+
+		// Close it and press the other key: the menu takes focus while open, so
+		// the row is not listening until it has it back.
+		fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+		await waitFor(() => expect(document.activeElement).toBe(byName("demo")));
+
 		key("ContextMenu");
-		expect(menu).toHaveBeenCalledTimes(2);
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
 	});
 
 	/*
@@ -255,14 +268,18 @@ describe("useRovingTreeFocus", () => {
 		expect(del).toHaveBeenCalledTimes(2);
 	});
 
-	it("opens the row menu on Shift+Enter, the Mac-reachable path", () => {
+	it("opens the row menu on Shift+Enter, the Mac-reachable path", async () => {
 		render(<Tree expanded />);
 		byName("demo").focus();
 
 		key("Enter", { shiftKey: true });
-		expect(menu).toHaveBeenCalledTimes(1);
+		expect(await screen.findByRole("menu")).toBeInTheDocument();
 		// Shift+Enter is the menu, not a second way to open the row.
 		expect(activate).not.toHaveBeenCalled();
+
+		// End to end: the action the menu offers actually runs from here.
+		fireEvent.click(screen.getByRole("menuitem", { name: "Menu action" }));
+		await waitFor(() => expect(menu).toHaveBeenCalledTimes(1));
 	});
 
 	it("still activates on plain Enter and on Space", () => {

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1230,7 +1230,10 @@ absent - and here the answer is no.
 **Prefer `RowActionsMenu`** (`components/shared`) over adding another inline icon
 button. It renders the `⋯` trigger plus a `DropdownMenu`, so rows expose actions
 consistently and get focus management, Escape-to-close and arrow-key navigation
-for free. Used by request rows and environment rows.
+for free. Used by request rows and environment rows. It opens on a pointer and
+on a click reporting `detail === 0` - the keyboard's kind - and takes a
+`tabIndex` prop, `0` unless the row sits in a roving-tabindex tree. See Tree
+Navigation for why.
 
 ---
 
@@ -1414,6 +1417,25 @@ workspace with 2 collections and 4 requests cost 17 presses to tab past.
   Both row types must render every hidden control: a folder row without
   `data-tree-delete` swallowed Delete silently for months, because the hook
   `preventDefault`s the key whether or not it finds something to click.
+
+**Those keys reach a control by clicking it, so the control has to answer a
+click.** The hook calls `.click()` on the row's `[data-tree-menu]`, and Radix's
+dropdown trigger opens on `pointerdown` and on its own `keydown` - neither of
+which a programmatic click dispatches. Every menu-only action (Duplicate, Move
+to, Run, Add, Export) was therefore mouse-only, on a path the tree advertised
+(#1212). `RowActionsMenu` now holds its own open state and opens on a click
+reporting `detail === 0`, which is what a click with no pointer behind it
+reports - the mouse path stays Radix's, since its own `pointerdown` has already
+opened the menu by the time a real click arrives. The hidden `<button>` controls
+answer a click by being plain buttons; anything richer added to a row has to
+declare how it answers one.
+
+**`RowActionsMenu` takes its `tabIndex` from the row.** It is `0` by default -
+outside a tree the `⋯` menu is an ordinary tab stop - and these rows pass `-1`,
+because the tree is one tab stop and the keys above are the way in. Closing the
+menu hands focus back to the *row*, not to the trigger Radix would return it to:
+a `tabIndex={-1}` control holding the tree's focus is a stop the user cannot Tab
+back to.
 
 Rows declare behaviour through data attributes rather than props
 (`data-tree-activate`, `data-tree-toggle`, `data-tree-menu`, `data-tree-rename`,


### PR DESCRIPTION
## Description

The collection tree advertises three keys into a row's `⋯` menu - Shift+F10, the Menu key and Shift+Enter - and all three were dead.

**Root cause.** `useRovingTreeFocus` answers those keys by calling `.click()` on the row's `[data-tree-menu]` control (`useRovingTreeFocus.ts:165,226,240,245`). Radix's `DropdownMenuTrigger` composes exactly two handlers, `onPointerDown` and `onKeyDown` (`@radix-ui/react-dropdown-menu@2.1.17`, `dist/index.mjs:74,80`), and `HTMLElement.click()` dispatches neither - so Duplicate, Move to, Run collection, Add request, Add folder and Export were mouse-only on every collection, folder and request row. F2, Delete and Alt+Arrow kept working because their targets are plain hidden `<button>`s, which is why this went unnoticed.

**Approach.** `RowActionsMenu` becomes a controlled `DropdownMenu` and opens on a click reporting `detail === 0` - the value a click with no pointer behind it carries. The change is deliberately additive: Radix's `pointerdown` has already opened the menu by the time a real click (`detail` 1) arrives, and keyboard focus on the trigger itself is Radix's own `keydown` path, which `preventDefault`s and so never produces a click at all. `tabIndex` becomes a prop, `0` by default, with the two tree rows passing `-1`. Closing returns focus to the row rather than to the trigger Radix would return it to, since that trigger is not a tab stop inside the tree.

**Rejected alternative** (named in the issue, and confirmed workable): dispatching a synthetic `KeyboardEvent("keydown", { key: "Enter" })` at the trigger from the hook. It works today and couples the hook to Radix's trigger internals, so the fix stays in the component and the hook stays ignorant of Radix.

**Knock-on, worth a reviewer's eye:** `VariablesCategoryTree.tsx:408` is the third consumer and is *not* in a roving-tabindex tree, so it takes the new `0` default. Its `⋯` menu had no keyboard path at all before this (hardcoded `tabIndex={-1}`, no Shift+F10 handler) and is now Tab-reachable. #1217 builds on this prop.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- Full suite: **574 files, 6285 tests passed**. That includes the seven `fireEvent.pointerDown` menu-open helpers across five tree tests (`CollectionTree.delete`, `.undo-toast`, `.run`, `.duplicate-order`, `.dnd`), which the mouse path had to keep passing unchanged.
- New `app/src/components/shared/RowActionsMenu.test.tsx` (9 cases): the component had **no test at all**. Covers the pointer-less click opening it, the action running from a keyboard-opened menu, a mouse press opening exactly once, **a second mouse press closing it** (one toggle per click), the `tabIndex` default and override, focus returning to the row inside a treeitem, and Radix's own focus return preserved outside one.
- New `app/src/modules/collections/CollectionTree.row-menu.test.tsx` (14 cases): presses each of the three keys on the **real** tree, as a loop over **both** row types (collection and request); asserts the menu and its chord-less actions, arrow keys landing on the first item, Escape returning focus to the row for both row types, and every `[data-tree-menu]` staying `tabindex="-1"`.
- `useRovingTreeFocus.test.tsx` now renders the real `RowActionsMenu` in its stub row instead of a plain `<button>`. That stub is precisely why the hook's test certified a path the real component lacked; it now fails when the fix is reverted (2 of its 29 cases).
- **Mutation check, run rather than assumed:** removing `if (e.detail === 0) setOpen(true)` fails 10 of the component and tree cases plus 2 of the hook's. The fix was reverted, the suite re-run, and restored.

### One finding I pinned rather than coded around

An adversarial review flagged that returning focus to the row is a claim on focus this menu never used to make, and that most row actions open a dialog: Radix runs the close's focus restoration on a later tick (`setTimeout(…, 0)` in the FocusScope cleanup) than the dialog's own mount focus, so the two race. Nothing in the tree's existing tests asserted `document.activeElement` at all, so the outcome was unmeasured.

I verified it end to end instead of guessing: the dialog wins, and `CollectionTree.row-menu.test.tsx` now pins it (keyboard-open → Delete → focus is inside the dialog and not on the row). I did **not** add guard logic in `RowActionsMenu` for hypothetical non-modal surfaces - that would be speculative complexity for a case the app does not have, and the test is what will catch it if one is ever added.

No engine work: this issue is app-only. `mkdocs build --strict` was not run (mkdocs is not installed in this environment); the docs change is prose inside an existing page and adds no links or headings.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit as the code: `docs/design-system.md` gains the `RowActionsMenu` keyboard contract in **Tree Navigation** (the click-answering rule, the `tabIndex` semantics and the focus return) and a matching clause in **Row Actions**, where "focus management ... for free" was the claim this bug falsified. `docs/app/COMPONENTS.md` has no `RowActionsMenu` section to update - the issue's doc note was conditional on one existing - and no component was added or moved, so its doc-map rule does not fire.

## Related Issues
Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTVYJvLXtvUJgd1UBYh2Xx