### PR TITLE
fix(editors): a way out of Monaco, the ⌘I bridge, and a name per editor

### DIFF
--- a/app/src/components/layout/icon-button-labels.test.tsx
+++ b/app/src/components/layout/icon-button-labels.test.tsx
@@ -28,43 +28,13 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { openingTags, summarize } from "@/lib/jsx-opening-tags.testkit";
 
 const sources = import.meta.glob("/src/**/*.tsx", {
 	query: "?raw",
 	import: "default",
 	eager: true,
 });
-
-/**
- * Extract complete `<Button ...>` opening tags. A regex cannot do this: JSX
- * props hold arrow functions (`onClick={(e) => …}`) and object literals whose
- * `>` and `}` would end the match early - which is exactly the bug that made an
- * earlier version of this test flag already-labelled buttons. So scan with a
- * brace/string-aware cursor and end the tag only at a top-level `>`.
- */
-function buttonOpeningTags(src: string): string[] {
-	const tags: string[] = [];
-	const re = /<Button\b/g;
-	let m: RegExpExecArray | null;
-	while ((m = re.exec(src))) {
-		let depth = 0; // {} nesting
-		let quote: string | null = null;
-		let i = m.index + m[0].length;
-		for (; i < src.length; i++) {
-			const c = src[i];
-			if (quote) {
-				if (c === quote) quote = null;
-				continue;
-			}
-			if (c === '"' || c === "'" || c === "`") quote = c;
-			else if (c === "{") depth++;
-			else if (c === "}") depth--;
-			else if (c === ">" && depth === 0) break;
-		}
-		tags.push(src.slice(m.index, i + 1));
-	}
-	return tags;
-}
 
 const isIconButton = (tag: string) => /size=["']icon["']/.test(tag);
 
@@ -73,7 +43,7 @@ const hasAccessibleName = (tag: string) =>
 
 describe("icon-only buttons have accessible names", () => {
 	const iconTags = Object.entries(sources).flatMap(([path, src]) =>
-		buttonOpeningTags(src as string)
+		openingTags(src as string, "Button")
 			.filter(isIconButton)
 			.map((tag) => ({ path, tag }))
 	);
@@ -89,7 +59,7 @@ describe("icon-only buttons have accessible names", () => {
 	it("names every icon-only Button", () => {
 		const offenders = iconTags
 			.filter(({ tag }) => !hasAccessibleName(tag))
-			.map(({ path, tag }) => `${path}: ${tag.replace(/\s+/g, " ").slice(0, 90)}`);
+			.map(({ path, tag }) => summarize(path, tag));
 		expect(offenders).toEqual([]);
 	});
 });

--- a/app/src/components/shared/response-viewer/ResponseBody.tsx
+++ b/app/src/components/shared/response-viewer/ResponseBody.tsx
@@ -331,6 +331,7 @@ export default function ResponseBody({
 						// syntax colours is the third of the three passes the
 						// threshold exists to avoid.
 						language={isLargeBody || viewMode === "raw" ? "plaintext" : language}
+						ariaLabel="Response body"
 						value={formattedBody}
 						readOnly
 						fontSize={compact ? 12 : 13}

--- a/app/src/components/ui/code-editor.aria-label.test.tsx
+++ b/app/src/components/ui/code-editor.aria-label.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Every editor says what it is.
+ *
+ * Monaco's default accessible name is "Editor content", so a dozen panes with
+ * no `ariaLabel` all announce the same three words - the request body, the test
+ * script and the response are one control to a screen reader. `CodeEditorProps`
+ * makes the prop required, which is the strong half of this: a mount site
+ * cannot compile without one.
+ *
+ * The type cannot say the labels are *distinct*, though, and a copy-pasted
+ * mount is how they stop being. That is what the scan below holds, along with
+ * refusing an empty string - which satisfies the type and names nothing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { openingTags, summarize } from "@/lib/jsx-opening-tags.testkit";
+
+const sources = import.meta.glob("/src/**/*.tsx", {
+	query: "?raw",
+	import: "default",
+	eager: true,
+});
+
+/** Mount sites, minus the ones in test files - those repeat labels on purpose. */
+const mounts = Object.entries(sources)
+	.filter(([path]) => !path.includes(".test."))
+	.flatMap(([path, src]) =>
+		openingTags(src as string, "CodeEditor").map((tag) => ({ path, tag }))
+	);
+
+/** `ariaLabel="Request body"` → `Request body`; a bound expression → null. */
+function literalLabel(tag: string): string | null {
+	return /ariaLabel="([^"]*)"/.exec(tag)?.[1] ?? null;
+}
+
+const hasLabel = (tag: string) => /\bariaLabel[=\s]/.test(tag);
+
+describe("every CodeEditor names itself", () => {
+	it("finds mount sites to check (guards the scan itself)", () => {
+		// A renamed component or a broken glob matches nothing, and every
+		// assertion below then passes over an empty list. The floor sits well
+		// under the real count so retiring one pane does not trip it.
+		expect(mounts.length).toBeGreaterThan(4);
+	});
+
+	it("passes an ariaLabel at every mount", () => {
+		const offenders = mounts
+			.filter(({ tag }) => !hasLabel(tag))
+			.map(({ path, tag }) => summarize(path, tag));
+		expect(offenders).toEqual([]);
+	});
+
+	it("gives no editor an empty name, which the type would accept", () => {
+		const offenders = mounts
+			.filter(({ tag }) => literalLabel(tag)?.trim() === "")
+			.map(({ path, tag }) => summarize(path, tag));
+		expect(offenders).toEqual([]);
+	});
+
+	it("gives no two editors the same name", () => {
+		// Only the literal labels: the two script panels take theirs from
+		// `SCRIPT_VARIANTS` and the collection tab from its `kind`, and a scan
+		// cannot follow either - the same limit `app/CLAUDE.md` records for
+		// class names arriving in a variable.
+		const literals = mounts
+			.map(({ path, tag }) => ({ path, label: literalLabel(tag) }))
+			.filter((m): m is { path: string; label: string } => m.label !== null);
+		const seen = new Map<string, string>();
+		const duplicates: string[] = [];
+		for (const { path, label } of literals) {
+			const first = seen.get(label);
+			if (first) duplicates.push(`"${label}" at ${first} and ${path}`);
+			else seen.set(label, path);
+		}
+		expect(duplicates).toEqual([]);
+	});
+});

--- a/app/src/components/ui/code-editor.chords.test.tsx
+++ b/app/src/components/ui/code-editor.chords.test.tsx
@@ -19,13 +19,20 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import type * as Monaco from "monaco-editor";
 import { CodeEditor } from "./code-editor";
-import { SEND_CHORD, LOAD_TEST_CHORD } from "@/constants/shortcuts";
+import {
+	SEND_CHORD,
+	LOAD_TEST_CHORD,
+	TOGGLE_CONTEXT_BAR_CHORD,
+	LEAVE_EDITOR_CHORD,
+} from "@/constants/shortcuts";
 import { chordKeybinding } from "@/lib/editor-chords";
+import { chordKeys } from "@/lib/platform";
 
 const addCommand = vi.fn();
+const getContainerDomNode = vi.fn(() => document.createElement("div"));
 
 /** Monaco's two enums, with the real values for the keys in play. */
 const monaco = {
@@ -33,9 +40,19 @@ const monaco = {
 	KeyCode: { Enter: 3, Digit1: 22, KeyA: 31 },
 } as unknown as typeof Monaco;
 
+/** Options the wrapper handed Monaco on the last render. */
+let lastOptions: Record<string, unknown> = {};
+
 vi.mock("@monaco-editor/react", () => ({
-	Editor: ({ onMount }: { onMount?: (e: unknown, m: unknown) => void }) => {
-		onMount?.({ addCommand }, monaco);
+	Editor: ({
+		onMount,
+		options,
+	}: {
+		onMount?: (e: unknown, m: unknown) => void;
+		options?: Record<string, unknown>;
+	}) => {
+		lastOptions = options ?? {};
+		onMount?.({ addCommand, getContainerDomNode }, monaco);
 		return <div data-testid="editor" />;
 	},
 }));
@@ -52,20 +69,80 @@ vi.mock("@/lib/monaco-loader", () => ({
 }));
 
 describe("CodeEditor keyboard wiring", () => {
-	it("registers the send and load-test chords on every instance", () => {
+	it("registers the send, load-test, context-bar and leave chords on every instance", () => {
 		addCommand.mockClear();
-		render(<CodeEditor value="" language="json" />);
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
+		// ⌘I is in the list because Monaco binds it for `triggerSuggest` and
+		// stops it: drop it and the context bar stops toggling from an editor,
+		// which is invisible from `Shell`, where the handler still looks correct.
 		expect(addCommand.mock.calls.map((c) => c[0])).toEqual([
 			chordKeybinding(SEND_CHORD, monaco),
 			chordKeybinding(LOAD_TEST_CHORD, monaco),
+			chordKeybinding(TOGGLE_CONTEXT_BAR_CHORD, monaco),
+			chordKeybinding(LEAVE_EDITOR_CHORD, monaco),
 		]);
 	});
 
 	it("still runs the caller's own onMount", () => {
 		addCommand.mockClear();
 		const onMount = vi.fn();
-		render(<CodeEditor value="" language="json" onMount={onMount} />);
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" onMount={onMount} />);
 		expect(onMount).toHaveBeenCalledTimes(1);
-		expect(addCommand).toHaveBeenCalledTimes(2);
+		expect(addCommand).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe("CodeEditor accessibility options", () => {
+	it("names the editor for a screen reader, instead of Monaco's default", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="GraphQL variables" />);
+		expect(lastOptions.ariaLabel).toBe("GraphQL variables");
+	});
+
+	it("lets Tab leave a read-only editor, where it has nothing to indent", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Response body" readOnly />);
+		expect(lastOptions.tabFocusMode).toBe(true);
+	});
+
+	it("keeps Tab indenting an editable one, which has the chord and the hint instead", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
+		expect(lastOptions.tabFocusMode).toBe(false);
+	});
+});
+
+/**
+ * A chord nothing advertises is a chord nobody presses.
+ *
+ * On focus rather than always: the hint is worth its place over the content
+ * only while someone is in the editor it is the way out of, and every editable
+ * pane in the app would otherwise carry a standing badge.
+ */
+describe("the leave-editor hint", () => {
+	const hint = () => screen.queryByText("Leave editor");
+
+	it("stays out of the way until the editor has focus", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
+		expect(hint()).toBeNull();
+	});
+
+	it("appears when focus enters, spelling the chord from the registry", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
+		fireEvent.focus(screen.getByTestId("editor"));
+		expect(hint()).toBeInTheDocument();
+		for (const cap of chordKeys(LEAVE_EDITOR_CHORD)) {
+			expect(screen.getByText(cap)).toBeInTheDocument();
+		}
+	});
+
+	it("goes again when focus leaves", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
+		fireEvent.focus(screen.getByTestId("editor"));
+		fireEvent.blur(screen.getByTestId("editor"));
+		expect(hint()).toBeNull();
+	});
+
+	it("never shows on a read-only editor, which Tab already leaves", () => {
+		render(<CodeEditor value="" language="json" ariaLabel="Response body" readOnly />);
+		fireEvent.focus(screen.getByTestId("editor"));
+		expect(hint()).toBeNull();
 	});
 });

--- a/app/src/components/ui/code-editor.loading.test.tsx
+++ b/app/src/components/ui/code-editor.loading.test.tsx
@@ -76,7 +76,7 @@ describe("the editor waits for Monaco", () => {
 	it("shows the placeholder, and no editor, until the load resolves", async () => {
 		const { CodeEditor } = await freshEditor(() => ({ monaco: fakeMonaco }));
 
-		render(<CodeEditor value="" language="json" />);
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
 
 		// The mutation check: render `<Editor>` without the `useLoadedMonaco`
 		// gate and this passes an editor straight through, which is the
@@ -93,7 +93,7 @@ describe("the editor waits for Monaco", () => {
 	it("swaps the placeholder for the editor once Monaco is there", async () => {
 		const { CodeEditor } = await freshEditor(() => ({ monaco: fakeMonaco }));
 
-		render(<CodeEditor value="" language="json" />);
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
 		await act(async () => {});
 
 		expect(screen.getByTestId("editor")).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe("a failed load says so", () => {
 			throw new Error("chunk load failed");
 		});
 
-		render(<CodeEditor value="" language="json" />);
+		render(<CodeEditor value="" language="json" ariaLabel="Request body" />);
 		await act(async () => {});
 
 		expect(screen.getByRole("alert")).toHaveTextContent(/editor failed to load/i);

--- a/app/src/components/ui/code-editor.tsx
+++ b/app/src/components/ui/code-editor.tsx
@@ -118,10 +118,24 @@ const DEFAULT_OPTIONS = {
  * Caps come from `chordKeys` and the `Kbd` primitive, like every other chord
  * this app puts on screen: a hand-rolled badge here would be a second spelling
  * of a modifier `lib/platform.ts` already spells per platform.
+ *
+ * Not `UrlBar`'s `Hint`, which is the app's other chord-on-focus pattern: that
+ * one is a Radix `Tooltip` around a `TooltipTrigger asChild`, and Monaco's
+ * `<Editor>` is not a ref-forwarding child a trigger can attach to. The shape
+ * here is instead the floating-surface one every popover uses - `bg-popover`,
+ * a border, a shadow.
+ *
+ * The border is not decoration and not `border-rule`. This chip is the one
+ * surface in the app that floats over *Monaco's* canvas rather than over a
+ * declared app surface, so there is no `--rule` to inherit and it would fall
+ * back to the invisible default. The fill cannot separate it either: Monaco's
+ * dark background is #1e1e1e against a `--popover` of #1a1a1f, and both are
+ * white in light. `border-border-strong` is the edge that reads on both, and
+ * it is the token `Kbd` itself is built from.
  */
 function LeaveEditorHint() {
 	return (
-		<div className="pointer-events-none absolute bottom-1.5 right-3 z-10 flex items-center gap-1 rounded-md bg-card px-1.5 py-1 shadow-sm">
+		<div className="pointer-events-none absolute bottom-1.5 right-3 z-10 flex items-center gap-1 rounded-md border border-border-strong bg-popover px-1.5 py-1 text-popover-foreground shadow-md">
 			<span className="text-[10px] leading-none text-muted-foreground">Leave editor</span>
 			{chordKeys(LEAVE_EDITOR_CHORD).map((cap) => (
 				<Kbd key={cap} size="sm">

--- a/app/src/components/ui/code-editor.tsx
+++ b/app/src/components/ui/code-editor.tsx
@@ -27,6 +27,9 @@ import { useClientSettingsStore } from "@/stores";
 import { selectMonoStack } from "@/stores/client-settings-store";
 import { registerEditorChords } from "@/lib/editor-chords";
 import { ensureMonaco, useLoadedMonaco } from "@/lib/monaco-loader";
+import { LEAVE_EDITOR_CHORD } from "@/constants/shortcuts";
+import { chordKeys } from "@/lib/platform";
+import { Kbd } from "./kbd";
 import { Skeleton } from "./skeleton";
 import { cn } from "@/lib/utils";
 
@@ -103,9 +106,46 @@ const DEFAULT_OPTIONS = {
 	cursorSmoothCaretAnimation: "on",
 } satisfies EditorOptions;
 
+/**
+ * The way out of the Tab trap, beside the editor that has one.
+ *
+ * Only while the editor holds focus: a keyboard user is told the chord at the
+ * moment they need it, and the dozen editors in the app do not each carry a
+ * standing badge over their content. Read-only editors never show it - they run
+ * with `tabFocusMode` on, so Tab already leaves them and there is no trap to
+ * advertise a way out of.
+ *
+ * Caps come from `chordKeys` and the `Kbd` primitive, like every other chord
+ * this app puts on screen: a hand-rolled badge here would be a second spelling
+ * of a modifier `lib/platform.ts` already spells per platform.
+ */
+function LeaveEditorHint() {
+	return (
+		<div className="pointer-events-none absolute bottom-1.5 right-3 z-10 flex items-center gap-1 rounded-md bg-card px-1.5 py-1 shadow-sm">
+			<span className="text-[10px] leading-none text-muted-foreground">Leave editor</span>
+			{chordKeys(LEAVE_EDITOR_CHORD).map((cap) => (
+				<Kbd key={cap} size="sm">
+					{cap}
+				</Kbd>
+			))}
+		</div>
+	);
+}
+
 export interface CodeEditorProps {
 	value: string;
 	language: string;
+	/**
+	 * What this editor is, for a screen reader - "Request body", "Test script".
+	 *
+	 * Required rather than optional, and per call site rather than derived from
+	 * `language`: two editors can share a language and never the same job (the
+	 * GraphQL variables pane and the request body are both `json`), and a dozen
+	 * panes all announcing Monaco's default "Editor content" is the same as none
+	 * of them announcing anything. `code-editor.aria-label.test.tsx` holds the
+	 * labels distinct; the type holds them present.
+	 */
+	ariaLabel: string;
 	/** Coalesces Monaco's `string | undefined` to a plain string. */
 	onChange?: (value: string) => void;
 	/** CSS height; use "100%" inside flex containers. */
@@ -121,6 +161,7 @@ export interface CodeEditorProps {
 export function CodeEditor({
 	value,
 	language,
+	ariaLabel,
 	onChange,
 	height = "100%",
 	readOnly = false,
@@ -134,6 +175,7 @@ export function CodeEditor({
 	const monoStack = useClientSettingsStore(selectMonoStack);
 	const monaco = useLoadedMonaco();
 	const [loadFailed, setLoadFailed] = useState(false);
+	const [hasFocus, setHasFocus] = useState(false);
 
 	useEffect(() => {
 		let active = true;
@@ -203,24 +245,50 @@ export function CodeEditor({
 	}
 
 	return (
-		<Editor
-			className={className}
-			height={height}
-			language={language}
-			value={value}
-			theme={isDark ? "vs-dark" : "vs"}
-			onChange={onChange ? (v) => onChange(v ?? "") : undefined}
-			onMount={handleMount}
-			options={{
-				...DEFAULT_OPTIONS,
-				...prefOptions,
-				readOnly,
-				...options,
-				// `scrollbar` is a nested object, so a caller passing one of its keys
-				// would otherwise replace the whole thing and silently drop the
-				// wheel-propagation default above. Merge it a level deeper.
-				scrollbar: { ...DEFAULT_OPTIONS.scrollbar, ...options?.scrollbar },
+		/*
+		 * The wrapper exists for the hint, which has to be positioned against the
+		 * editor's own box. `className` and `height` stay on it rather than on
+		 * `<Editor>` so every call site's layout reads exactly as it did - and so
+		 * the two states above, which already render their own box, keep the same
+		 * shape as this one.
+		 */
+		<div
+			className={cn("relative", className)}
+			style={{ height }}
+			onFocus={() => setHasFocus(true)}
+			onBlur={(e) => {
+				// Monaco moves focus between its own nodes (the hidden textarea, the
+				// find widget); only focus leaving the editor entirely counts.
+				if (!e.currentTarget.contains(e.relatedTarget)) setHasFocus(false);
 			}}
-		/>
+		>
+			<Editor
+				height="100%"
+				language={language}
+				value={value}
+				theme={isDark ? "vs-dark" : "vs"}
+				onChange={onChange ? (v) => onChange(v ?? "") : undefined}
+				onMount={handleMount}
+				options={{
+					...DEFAULT_OPTIONS,
+					...prefOptions,
+					readOnly,
+					ariaLabel,
+					/*
+					 * Tab moves focus in an editor nobody can type into: there is no
+					 * indentation to insert, so Monaco's default is a keyboard trap
+					 * (WCAG 2.1.2) with nothing on the other side of it. The editable
+					 * editors keep Tab and get `LEAVE_EDITOR_CHORD` plus the hint above.
+					 */
+					tabFocusMode: readOnly,
+					...options,
+					// `scrollbar` is a nested object, so a caller passing one of its keys
+					// would otherwise replace the whole thing and silently drop the
+					// wheel-propagation default above. Merge it a level deeper.
+					scrollbar: { ...DEFAULT_OPTIONS.scrollbar, ...options?.scrollbar },
+				}}
+			/>
+			{!readOnly && hasFocus && <LeaveEditorHint />}
+		</div>
 	);
 }

--- a/app/src/constants/shortcuts.test.ts
+++ b/app/src/constants/shortcuts.test.ts
@@ -27,6 +27,7 @@ import {
 	TOGGLE_DRAWER_CHORD,
 	TOGGLE_CONTEXT_BAR_CHORD,
 	SETTINGS_CHORD,
+	LEAVE_EDITOR_CHORD,
 	DRAWER_VIEW_CHORDS,
 	TAB_CHORDS,
 	matchesChord,
@@ -183,13 +184,14 @@ describe("no press matches two chords", () => {
 		CLOSE_TAB_CHORD,
 		TOGGLE_DRAWER_CHORD,
 		TOGGLE_CONTEXT_BAR_CHORD,
+		LEAVE_EDITOR_CHORD,
 		...Object.values(DRAWER_VIEW_CHORDS),
 		...TAB_CHORDS,
 	];
 
 	// ⇧⌘S is Services and ⌘S is Save - the pair the old shifted branch had to be
 	// written around, by returning early for every shifted press.
-	it.each(["s", "w", "b", "i", "e", "h", "u", ",", "Enter"])(
+	it.each(["s", "w", "b", "i", "m", "e", "h", "u", ",", "Enter"])(
 		"Ctrl+%s, shifted or not, matches at most one",
 		(key) => {
 			for (const shift of [false, true]) {

--- a/app/src/constants/shortcuts.ts
+++ b/app/src/constants/shortcuts.ts
@@ -70,6 +70,31 @@ export const TOGGLE_CONTEXT_BAR_CHORD: Chord = {
 export const SETTINGS_CHORD: Chord = { mod: true, key: ",", label: "Open settings" };
 
 /**
+ * Move focus out of a code editor.
+ *
+ * Monaco's Tab indents, which is right for a code editor and a keyboard trap
+ * for anyone who reached one by tabbing (WCAG 2.1.2). Monaco's own way out is
+ * `editor.action.toggleTabFocusMode`, and it cannot simply be advertised: its
+ * binding is Ctrl+M, which on macOS is ⌃⇧M - a modifier this registry has no
+ * word for - while the ⌘M the platform *would* spell it as is Minimize.
+ *
+ * So the app declares its own exit, here, where the Keyboard Shortcuts panel
+ * lists it for free and `lib/editor-chords.ts` binds it. ⇧ sits beside Monaco's
+ * Ctrl+M rather than taking it over, and CtrlCmd+Shift+M is claimed by neither
+ * the standalone editor nor the native menu.
+ *
+ * Read-only editors carry no such chord: `tabFocusMode` is simply on for them
+ * (`ui/code-editor.tsx`), Tab having no editing meaning in text nobody can type
+ * into. The chord is for the editors where Tab still has to indent.
+ */
+export const LEAVE_EDITOR_CHORD: Chord = {
+	mod: true,
+	shift: true,
+	key: "M",
+	label: "Move focus out of the editor",
+};
+
+/**
  * The drawer view switchers, keyed by the view they activate.
  *
  * ⌘S is Save, so Services takes the shifted pair - free in both maps: the
@@ -147,6 +172,7 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
 		chords: Object.values(DRAWER_VIEW_CHORDS).filter((chord) => chord !== SETTINGS_CHORD),
 	},
 	{ id: "tabs", title: "Tabs", chords: TAB_CHORDS },
+	{ id: "editors", title: "Editors", chords: [LEAVE_EDITOR_CHORD] },
 ];
 
 /**

--- a/app/src/constants/shortcuts.ts
+++ b/app/src/constants/shortcuts.ts
@@ -83,9 +83,12 @@ export const SETTINGS_CHORD: Chord = { mod: true, key: ",", label: "Open setting
  * Ctrl+M rather than taking it over, and CtrlCmd+Shift+M is claimed by neither
  * the standalone editor nor the native menu.
  *
- * Read-only editors carry no such chord: `tabFocusMode` is simply on for them
- * (`ui/code-editor.tsx`), Tab having no editing meaning in text nobody can type
- * into. The chord is for the editors where Tab still has to indent.
+ * Read-only editors have no trap to escape: `tabFocusMode` is simply on for
+ * them (`ui/code-editor.tsx`), Tab having no editing meaning in text nobody can
+ * type into, so they show no hint. The binding is still registered there - it
+ * costs one `addCommand` and doing the same thing on every instance is cheaper
+ * to keep true than a `readOnly` branch through the bridge - it is just
+ * redundant with the Tab that already works.
  */
 export const LEAVE_EDITOR_CHORD: Chord = {
 	mod: true,

--- a/app/src/lib/editor-chords.test.ts
+++ b/app/src/lib/editor-chords.test.ts
@@ -23,16 +23,38 @@
  * asserts that the handler acts on it.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import type * as Monaco from "monaco-editor";
-import { chordKeybinding, dispatchChord, registerEditorChords } from "./editor-chords";
-import { SEND_CHORD, LOAD_TEST_CHORD, SAVE_CHORD, SETTINGS_CHORD } from "@/constants/shortcuts";
+import {
+	chordKeybinding,
+	dispatchChord,
+	focusAfterEditor,
+	registerEditorChords,
+} from "./editor-chords";
+import {
+	SEND_CHORD,
+	LOAD_TEST_CHORD,
+	SAVE_CHORD,
+	SETTINGS_CHORD,
+	TOGGLE_CONTEXT_BAR_CHORD,
+	LEAVE_EDITOR_CHORD,
+} from "@/constants/shortcuts";
 
 /** The two enums the bridge reads, with Monaco's real values. */
 const monaco = {
 	KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512, WinCtrl: 256 },
 	KeyCode: { Enter: 3, Digit1: 22, KeyA: 31 },
 } as unknown as typeof Monaco;
+
+/** An editor stub: the two methods the bridge calls, and nothing else. */
+function fakeEditor(container?: HTMLElement) {
+	const addCommand = vi.fn();
+	const editor = {
+		addCommand,
+		getContainerDomNode: () => container ?? document.createElement("div"),
+	} as unknown as Monaco.editor.IStandaloneCodeEditor;
+	return { editor, addCommand };
+}
 
 describe("chordKeybinding", () => {
 	it("gives Send the CtrlCmd+Enter binding Monaco expects", () => {
@@ -86,20 +108,35 @@ describe("dispatchChord", () => {
 
 describe("registerEditorChords", () => {
 	it("binds both Enter chords on the editor it is given", () => {
-		const addCommand = vi.fn();
-		registerEditorChords(
-			{ addCommand } as unknown as Monaco.editor.IStandaloneCodeEditor,
-			monaco
+		const { editor, addCommand } = fakeEditor();
+		registerEditorChords(editor, monaco);
+		expect(addCommand.mock.calls.map((c) => c[0])).toContainEqual(2048 | 3);
+		expect(addCommand.mock.calls.map((c) => c[0])).toContainEqual(2048 | 1024 | 3);
+	});
+
+	it("binds the context-bar toggle, which Monaco claims for triggerSuggest", () => {
+		// The reason this one is here at all and S, W and B are not: Monaco has
+		// CtrlCmd+I as a secondary `triggerSuggest` binding and stops the event,
+		// so ⌘I never reached `Shell` from inside an editor. Drop it from
+		// `BRIDGED_CHORDS` and this case is the only thing that notices.
+		const { editor, addCommand } = fakeEditor();
+		registerEditorChords(editor, monaco);
+		expect(addCommand.mock.calls.map((c) => c[0])).toContainEqual(
+			chordKeybinding(TOGGLE_CONTEXT_BAR_CHORD, monaco)
 		);
-		expect(addCommand.mock.calls.map((c) => c[0])).toEqual([2048 | 3, 2048 | 1024 | 3]);
+	});
+
+	it("binds the way out of the Tab trap", () => {
+		const { editor, addCommand } = fakeEditor();
+		registerEditorChords(editor, monaco);
+		expect(addCommand.mock.calls.map((c) => c[0])).toContainEqual(
+			chordKeybinding(LEAVE_EDITOR_CHORD, monaco)
+		);
 	});
 
 	it("dispatches the chord when Monaco runs the command", () => {
-		const addCommand = vi.fn();
-		registerEditorChords(
-			{ addCommand } as unknown as Monaco.editor.IStandaloneCodeEditor,
-			monaco
-		);
+		const { editor, addCommand } = fakeEditor();
+		registerEditorChords(editor, monaco);
 		const seen: KeyboardEvent[] = [];
 		const listener = (e: Event) => seen.push(e as KeyboardEvent);
 		window.addEventListener("keydown", listener);
@@ -109,5 +146,94 @@ describe("registerEditorChords", () => {
 		expect(seen).toHaveLength(1);
 		expect(seen[0].key).toBe("Enter");
 		expect(seen[0].shiftKey).toBe(false);
+	});
+
+	it("moves focus out of the editor when the leave command runs", () => {
+		const container = document.createElement("div");
+		const after = document.createElement("button");
+		document.body.append(container, after);
+
+		const { editor, addCommand } = fakeEditor(container);
+		registerEditorChords(editor, monaco);
+		const leave = addCommand.mock.calls.find(
+			(c) => c[0] === chordKeybinding(LEAVE_EDITOR_CHORD, monaco)
+		);
+		leave?.[1]();
+
+		expect(document.activeElement).toBe(after);
+	});
+});
+
+/**
+ * The exit itself.
+ *
+ * Monaco's Tab handling cannot run in jsdom, so what is testable is where focus
+ * lands - which is the half that can silently regress into `<body>` (#1218) or
+ * back into the editor it just left.
+ */
+describe("focusAfterEditor", () => {
+	afterEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	/** An editor container with `before`/`after` siblings around it. */
+	function scene(): { container: HTMLElement; before: HTMLElement; after: HTMLElement } {
+		const before = document.createElement("button");
+		before.textContent = "before";
+		const container = document.createElement("div");
+		const inside = document.createElement("textarea");
+		container.append(inside);
+		const after = document.createElement("button");
+		after.textContent = "after";
+		document.body.append(before, container, after);
+		return { container, before, after };
+	}
+
+	it("lands on the next focusable element after the editor", () => {
+		const { container, after } = scene();
+		expect(focusAfterEditor(container)).toBe(true);
+		expect(document.activeElement).toBe(after);
+	});
+
+	it("never lands inside the editor, which the next Tab would walk back into", () => {
+		const { container } = scene();
+		focusAfterEditor(container);
+		expect(container.contains(document.activeElement)).toBe(false);
+	});
+
+	it("goes backwards when the editor is the last thing on the page", () => {
+		const { container, before, after } = scene();
+		after.remove();
+		expect(focusAfterEditor(container)).toBe(true);
+		expect(document.activeElement).toBe(before);
+	});
+
+	it("skips a disabled control, which Tab skips too", () => {
+		const { container, after } = scene();
+		after.setAttribute("disabled", "");
+		const next = document.createElement("a");
+		next.href = "#x";
+		document.body.append(next);
+		focusAfterEditor(container);
+		expect(document.activeElement).toBe(next);
+	});
+
+	it("skips anything hidden from assistive technology", () => {
+		const { container, after } = scene();
+		after.setAttribute("aria-hidden", "true");
+		const next = document.createElement("button");
+		document.body.append(next);
+		focusAfterEditor(container);
+		expect(document.activeElement).toBe(next);
+	});
+
+	it("reports that focus did not move when there is nowhere to move it", () => {
+		const container = document.createElement("div");
+		document.body.append(container);
+		expect(focusAfterEditor(container)).toBe(false);
+	});
+
+	it("does nothing without a container, rather than throwing at the caller", () => {
+		expect(focusAfterEditor(null)).toBe(false);
 	});
 });

--- a/app/src/lib/editor-chords.ts
+++ b/app/src/lib/editor-chords.ts
@@ -24,7 +24,12 @@
 
 import type * as Monaco from "monaco-editor";
 import type { MonacoApi } from "./monaco-api";
-import { SEND_CHORD, LOAD_TEST_CHORD } from "@/constants/shortcuts";
+import {
+	SEND_CHORD,
+	LOAD_TEST_CHORD,
+	TOGGLE_CONTEXT_BAR_CHORD,
+	LEAVE_EDITOR_CHORD,
+} from "@/constants/shortcuts";
 import { isMac, type Chord } from "@/lib/platform";
 
 /**
@@ -70,18 +75,97 @@ export function dispatchChord(chord: Chord): void {
 }
 
 /**
- * Bind the window chords an editor would otherwise swallow.
+ * The window chords an editor would otherwise swallow.
  *
- * Only the two Enter chords: everything else in the map is a letter or a digit
- * Monaco does not claim, so it reaches `window` on its own.
+ * Enter for the two send chords, because Monaco owns Enter and `ownsEnterKey`
+ * excludes editors from the window handler on purpose (#938).
+ *
+ * ⌘I for the opposite reason, and it is the correction of what this comment
+ * used to claim - that "everything else in the map is a letter or a digit
+ * Monaco does not claim". I is claimed: the standalone editor binds CtrlCmd+I
+ * as a secondary keybinding for `triggerSuggest` on every platform, and its
+ * keybinding service calls `preventDefault` *and* `stopPropagation` for any
+ * binding it resolves, so the context-bar toggle died at the editor instead of
+ * reaching `Shell`'s bubble-phase listener. S, W, B, comma, the digits and the
+ * ⇧ view chords really are unbound there and still arrive on their own.
+ */
+const BRIDGED_CHORDS: readonly Chord[] = [SEND_CHORD, LOAD_TEST_CHORD, TOGGLE_CONTEXT_BAR_CHORD];
+
+/**
+ * What a Tab press can land on, as the browser decides it.
+ *
+ * `tabindex="-1"` is excluded rather than included: those nodes are focusable
+ * by script only, so landing on one puts the user where Tab did not offer to
+ * go and where the next Tab continues from somewhere they cannot see.
+ */
+const FOCUSABLE_SELECTOR = [
+	"a[href]",
+	"button:not([disabled])",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	'[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Move focus to the first focusable element after `container`, or - when the
+ * editor is the last thing on the page - back to the nearest one before it.
+ *
+ * This is the editor's way out, so the target has to be somewhere Tab would
+ * have gone. Focusing the container itself is not: Monaco's textarea is *inside*
+ * it, so the next Tab would walk straight back in.
+ *
+ * Whether a candidate is visible is read back from `document.activeElement`
+ * rather than decided in advance. A `display: none` element ignores `.focus()`,
+ * so the read is exact where a geometric test would be a guess - and it is the
+ * one check jsdom, which has no layout and reports every element as zero-sized,
+ * can still answer honestly.
+ *
+ * Returns whether focus actually moved, so a caller can tell "nowhere to go"
+ * from "went somewhere".
+ */
+export function focusAfterEditor(container: HTMLElement | null | undefined): boolean {
+	if (!container) return false;
+
+	const outside = Array.from(document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+		(el) => !container.contains(el) && !el.closest("[aria-hidden='true'],[inert],[hidden]")
+	);
+	const firstAfter = outside.findIndex(
+		(el) => (container.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+	);
+	// Everything after the editor in document order, then everything before it
+	// walked backwards - Tab's order, then Shift+Tab's when Tab has run out.
+	const order =
+		firstAfter === -1
+			? [...outside].reverse()
+			: [...outside.slice(firstAfter), ...outside.slice(0, firstAfter).reverse()];
+
+	for (const el of order) {
+		el.focus();
+		if (document.activeElement === el) return true;
+	}
+	return false;
+}
+
+/**
+ * Bind, on one editor instance, the chords the app owns inside Monaco: the
+ * window chords above, re-dispatched, and the exit from the Tab trap, which is
+ * the one chord that acts here rather than at `window` - there is no window
+ * handler for "leave *this* editor", and a re-dispatch would have nothing to
+ * tell one which editor it was.
  */
 export function registerEditorChords(
 	editor: Monaco.editor.IStandaloneCodeEditor,
 	monaco: MonacoApi
 ): void {
-	for (const chord of [SEND_CHORD, LOAD_TEST_CHORD]) {
+	for (const chord of BRIDGED_CHORDS) {
 		const binding = chordKeybinding(chord, monaco);
 		if (binding === null) continue;
 		editor.addCommand(binding, () => dispatchChord(chord));
+	}
+
+	const leave = chordKeybinding(LEAVE_EDITOR_CHORD, monaco);
+	if (leave !== null) {
+		editor.addCommand(leave, () => focusAfterEditor(editor.getContainerDomNode()));
 	}
 }

--- a/app/src/lib/editor-chords.ts
+++ b/app/src/lib/editor-chords.ts
@@ -121,8 +121,14 @@ const FOCUSABLE_SELECTOR = [
  * one check jsdom, which has no layout and reports every element as zero-sized,
  * can still answer honestly.
  *
- * Returns whether focus actually moved, so a caller can tell "nowhere to go"
- * from "went somewhere".
+ * Document order, not the tab order proper: a positive `tabIndex` would come
+ * first in a real Tab press and does not here. Nothing in `app/src` uses one,
+ * and the day something does, this is the line to revisit.
+ *
+ * Returns whether focus moved. Nothing acts on `false` - when an editor is the
+ * only focusable thing on the page there is no better place to send focus than
+ * where it already is - so the reader is `editor-chords.test.ts`, which is what
+ * makes "nowhere to go" a case rather than an assumption.
  */
 export function focusAfterEditor(container: HTMLElement | null | undefined): boolean {
 	if (!container) return false;

--- a/app/src/lib/jsx-opening-tags.testkit.ts
+++ b/app/src/lib/jsx-opening-tags.testkit.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Pull complete JSX opening tags for one component out of a source file.
+ *
+ * A regex cannot do this: JSX props hold arrow functions (`onClick={(e) => …}`)
+ * and object literals whose `>` and `}` end a naive match early - which is
+ * exactly the bug that made an earlier icon-button guard flag buttons that were
+ * already labelled. So the cursor tracks `{}` nesting and string literals, and
+ * ends a tag only at a top-level `>`.
+ *
+ * It lives here, beside no single guard, because a second guard now needs it
+ * (`code-editor.aria-label.test.tsx`) and a hand-rolled copy of this scanner
+ * would not receive the fix above - the repeat defect `app/CLAUDE.md` names.
+ */
+
+/**
+ * Every `<Name ...>` opening tag in `src`, each returned whole - from the `<`
+ * to the `>` that closes it, self-closing or not.
+ *
+ * `Name` is matched on a word boundary, so `<Button` does not also collect
+ * `<ButtonGroup`.
+ */
+export function openingTags(src: string, name: string): string[] {
+	const tags: string[] = [];
+	const re = new RegExp(`<${name}\\b`, "g");
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(src))) {
+		let depth = 0; // {} nesting
+		let quote: string | null = null;
+		let i = match.index + match[0].length;
+		for (; i < src.length; i++) {
+			const c = src[i];
+			if (quote) {
+				if (c === quote) quote = null;
+				continue;
+			}
+			if (c === '"' || c === "'" || c === "`") quote = c;
+			else if (c === "{") depth++;
+			else if (c === "}") depth--;
+			else if (c === ">" && depth === 0) break;
+		}
+		tags.push(src.slice(match.index, i + 1));
+	}
+	return tags;
+}
+
+/** A tag flattened to one line, for a readable failure message. */
+export function summarize(path: string, tag: string, max = 90): string {
+	return `${path}: ${tag.replace(/\s+/g, " ").slice(0, max)}`;
+}

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -256,6 +256,7 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 				<CodeEditor
 					height="320px"
 					language="javascript"
+					ariaLabel={`Collection ${isPre ? "pre-request" : "post-request"} script`}
 					value={script}
 					onChange={setScript}
 					fontSize={12}

--- a/app/src/modules/palette/CommandPalette.ctrl-k.test.tsx
+++ b/app/src/modules/palette/CommandPalette.ctrl-k.test.tsx
@@ -104,3 +104,40 @@ describe("off macOS", () => {
 		expect(useLayoutStore.getState().paletteOpen).toBe(false);
 	});
 });
+
+/**
+ * Claiming the key means stopping it, not only preventing its default.
+ *
+ * Monaco treats ⌘K as a chord *leader*, so a merely-prevented event still
+ * reached it and put the editor into chord mode behind the open palette: the
+ * next keystroke answered "not a command" in its status bar. Nothing about the
+ * palette looked wrong, which is why this is pinned here.
+ */
+describe("the chord stops at the palette", () => {
+	/** What the focused control sees, listening below the window's capture. */
+	function pressWithSpy(target: Element, key: string, mods: { ctrl?: boolean }) {
+		const seen = vi.fn();
+		target.addEventListener("keydown", seen);
+		fireEvent.keyDown(target, {
+			key,
+			code: `Key${key.toUpperCase()}`,
+			ctrlKey: !!mods.ctrl,
+			bubbles: true,
+		});
+		target.removeEventListener("keydown", seen);
+		return seen;
+	}
+
+	it("keeps Ctrl+K from reaching the control below it", async () => {
+		const { field } = await mountOn("linux");
+		expect(pressWithSpy(field, "k", { ctrl: true })).not.toHaveBeenCalled();
+	});
+
+	it("stops that chord and no other key", async () => {
+		// The scope the comment above the listener promises. Ctrl+J is nobody's
+		// chord here, so it must arrive at the field untouched.
+		const { field } = await mountOn("linux");
+		expect(pressWithSpy(field, "j", { ctrl: true })).toHaveBeenCalledTimes(1);
+		expect(pressWithSpy(field, "k", {})).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -114,6 +114,19 @@ export function CommandPalette() {
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (!matchesChord(e, PALETTE_CHORD)) return;
 			e.preventDefault();
+			/*
+			 * And stopped here, not merely prevented. `preventDefault` cancels the
+			 * browser's own action and nothing else: the event still finished its
+			 * journey to Monaco, which treats ⌘K as a chord *leader* and entered
+			 * chord mode behind the open palette - so the next key typed in the
+			 * editor answered "not a command" in its status bar. Capturing a key and
+			 * leaving it in flight is half a claim.
+			 *
+			 * Scoped to this one chord like the capture phase itself: the `return`
+			 * above is the only other way out of this handler, so no other key is
+			 * stopped.
+			 */
+			e.stopPropagation();
 			// Toggling rather than only opening: the chord that summoned it is
 			// the one a user presses again to dismiss it.
 			setPaletteOpen(!useLayoutStore.getState().paletteOpen);

--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
@@ -428,6 +428,7 @@ export default function BodyPanel() {
 											? "xml"
 											: "plaintext"
 								}
+								ariaLabel="Request body"
 								value={request.body || ""}
 								onChange={(v) => updateField("body", v ?? "")}
 								onMount={handleEditorMount}

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/GraphQLBody.tsx
@@ -752,6 +752,7 @@ export function GraphQLBody({
 					<CodeEditor
 						height="100%"
 						language="graphql"
+						ariaLabel="GraphQL query"
 						value={query}
 						onChange={(q) => write({ query: q ?? "" })}
 						onMount={handleQueryMount}
@@ -803,6 +804,7 @@ export function GraphQLBody({
 					<CodeEditor
 						height="100%"
 						language="json"
+						ariaLabel="GraphQL variables"
 						value={variables}
 						onChange={(v) => {
 							setVariables(v ?? "");

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
@@ -248,6 +248,7 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 				<CodeEditor
 					height="350px"
 					language="javascript"
+					ariaLabel={config.editorLabel}
 					value={script}
 					onChange={(value) => updateField(config.field, value ?? "")}
 				/>

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -34,6 +34,8 @@ export type ScriptVariant = "pre" | "post";
 export interface ScriptVariantConfig {
 	/** The `RequestState` field this panel edits. */
 	field: Extract<keyof RequestState, "preRequestScript" | "testScript">;
+	/** What the editor announces itself as. Both panels mount one `CodeEditor`. */
+	editorLabel: string;
 	/** Collection scripts that run before this one, when the host supplies them. */
 	inheritedKey: Extract<
 		keyof RequestBuilderContextValue,
@@ -65,6 +67,7 @@ const CODE_CLASS = "bg-muted px-1 rounded-md";
 export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 	pre: {
 		field: "preRequestScript",
+		editorLabel: "Pre-request script",
 		inheritedKey: "inheritedPreScripts",
 		legacyKey: "legacyPreScript",
 		intro: (
@@ -167,6 +170,7 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 	},
 	post: {
 		field: "testScript",
+		editorLabel: "Test script",
 		inheritedKey: "inheritedPostScripts",
 		legacyKey: "legacyPostScript",
 		intro: (

--- a/app/src/modules/request-builder/components/ResponseViewer/RawRequestResponse.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/RawRequestResponse.tsx
@@ -92,6 +92,7 @@ export default function RawRequestResponse({ rawRequest, response }: RawRequestR
 		<CodeEditor
 			height="100%"
 			language="http"
+			ariaLabel="Raw request and response"
 			value={rawRequest ? `${markLines(rawRequest, SENT_MARKER)}\n${received}` : received}
 			readOnly
 			/*

--- a/app/src/modules/settings/main/panels/EditorPanel.tsx
+++ b/app/src/modules/settings/main/panels/EditorPanel.tsx
@@ -150,7 +150,12 @@ export default function EditorPanel() {
 				</CardHeader>
 				<CardContent>
 					<div className="h-48 overflow-hidden rounded-md border border-border">
-						<CodeEditor value={SAMPLE} language="javascript" readOnly />
+						<CodeEditor
+							value={SAMPLE}
+							language="javascript"
+							ariaLabel="Editor settings preview"
+							readOnly
+						/>
 					</div>
 				</CardContent>
 			</Card>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1725,10 +1725,17 @@ to keep from each answering that separately (#938, #1213).
   never to the container itself, whose textarea the next Tab would walk straight
   back into.
 
-**Read-only editors carry no exit chord**: `tabFocusMode` is simply on for them,
-Tab having nothing to indent in text nobody can type into. Editable ones keep
-Tab and show a `Kbd` hint naming the chord *while they hold focus* - at the
-moment it is wanted, rather than as a standing badge over a dozen panes.
+**A read-only editor has no trap to escape**: `tabFocusMode` is simply on for
+it, Tab having nothing to indent in text nobody can type into, so it shows no
+hint. The binding is still registered there, redundantly - one `addCommand` on
+every instance is cheaper to keep true than a `readOnly` branch threaded through
+the bridge. Editable editors keep Tab and show a `Kbd` hint naming the chord
+*while they hold focus* - at the moment it is wanted, rather than as a standing
+badge over a dozen panes. The hint is the app's one surface floating over
+Monaco's own canvas rather than a declared app surface, so it carries
+`border-border-strong` explicitly: there is no `--rule` for `border-rule` to
+inherit, and neither theme's `--popover` separates from the editor background on
+its own.
 
 ⌘K is not bound here at all. It belongs to `CommandPalette`, on the capture
 phase, which both prevents **and stops** it: preventing alone left the event in

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -110,7 +110,7 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 
 - **One uniform layout for every tab** - `Drawer` (left) + a content column holding `TabStrip` over main + `ContextBar`. No tab type takes over the row. This is deliberate: the Dock's drawer switchers always have a Drawer to act on, so they can never be dead. (Settings used to full-take-over and suppress the Drawer, which left those buttons doing nothing while Settings was open.)
 - **Left navigation is always the Drawer.** Every main view that needs a category/entity list uses the shared Drawer for it - never its own left rail. `SettingsMain` and `VariablesMain` are pure content panes; their category trees live in the Drawer (`settings` / `variables` views). Follow this pattern for any new view - do not add a second sidebar inside the main area.
-- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U/S/T (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). Every one of them is a `Chord` in `constants/shortcuts.ts`, matched by `matchesChord` - the same registry the Dock's tooltips advertise from, so no surface can claim a chord the handler does not listen for. They were fourteen hand-rolled comparisons until #938, which is how AltGr (Ctrl+Alt on European Windows layouts) came to fire Save and close tabs, and how ⌘1-9 came to be dead on AZERTY. ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble.
+- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U/S/T (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). Every one of them is a `Chord` in `constants/shortcuts.ts`, matched by `matchesChord` - the same registry the Dock's tooltips advertise from, so no surface can claim a chord the handler does not listen for. They were fourteen hand-rolled comparisons until #938, which is how AltGr (Ctrl+Alt on European Windows layouts) came to fire Save and close tabs, and how ⌘1-9 came to be dead on AZERTY. ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble. ⌘I is in the map and still needs help reaching it: Monaco claims CtrlCmd+I for `triggerSuggest`, so the bridge in `lib/editor-chords.ts` re-dispatches it from inside an editor (see [`code-editor`](#code-editor)), as it does the two send chords.
 - **Drawer:** toggles visibility via `toggleDrawer()` (state in `useLayoutStore`); always resizable 220–480px.
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Every surface but `RequestBuilder` is `React.lazy`** (#1146), behind one Suspense boundary inside the tab panel whose fallback is a `DetailSkeleton` naming the pane. Only one surface is mounted at a time, so a boundary per branch would be the same fallback written eight times. `RequestBuilder` stays eager because it is what most sessions open into. Two consequences worth knowing: a surface must be imported from its own file rather than its module barrel (`@/modules/settings` also exports the Drawer's `SettingsCategoryTree`, so importing the barrel here would put the settings surface back in the entry chunk), and a lazy branch is still one component per tab type - the boundary does not remount tab content, which `shell-tab-identity.test.tsx` holds.
@@ -1638,7 +1638,7 @@ since it is always under the provider.
 
 Primitives built on Radix UI + cmdk:
 
-`badge`, `button`, `card`, `collapsible`, `command`, `delete-confirm-dialog`, `dialog`, `dropdown-menu`, `info-chip`, `input`, `secret-input` (masked field with a reveal toggle - client secret / passwords, and the variables table's secret rows, which is where the pattern was extracted from), `kbd`, `label`, `popover`, `resizable`, `scroll-area`, `select`, `progress`, `separator`, `skeleton`, `suggestion-list`, `switch`, `tabs`, `textarea`, `tooltip`, plus variable-aware inputs: `variable-autocomplete`, `variable-popover`, `variable-scope-badge`, and markdown: `markdown-view`, `markdown-editor`.
+`badge`, `button`, `card`, `code-editor`, `collapsible`, `command`, `delete-confirm-dialog`, `dialog`, `dropdown-menu`, `info-chip`, `input`, `secret-input` (masked field with a reveal toggle - client secret / passwords, and the variables table's secret rows, which is where the pattern was extracted from), `kbd`, `label`, `popover`, `resizable`, `scroll-area`, `select`, `progress`, `separator`, `skeleton`, `suggestion-list`, `switch`, `tabs`, `textarea`, `tooltip`, plus variable-aware inputs: `variable-autocomplete`, `variable-popover`, `variable-scope-badge`, and markdown: `markdown-view`, `markdown-editor`.
 
 ### `dialog`
 
@@ -1691,6 +1691,61 @@ fix, leaving the original outline-less in dark. The border stays a prop
 (default `border-border`, pass `border-rule` on a declared surface) because
 `border-rule` falls back to the invisible default where no surface declares one.
 `dashboard/components/shared.tsx` re-exports it so existing imports resolve.
+
+### `code-editor`
+
+The single wrapper around Monaco. Every shared editor setting lives here so it
+changes in one place, and it is also where Monaco is *loaded* - `ensureMonaco()`
+on first mount, a skeleton until it resolves (see `lib/monaco-setup.ts` above).
+The other half of its job is making an editor behave like the rest of the app,
+because Monaco's defaults are not this app's and there are a dozen mount sites
+to keep from each answering that separately (#938, #1213).
+
+**Keyboard.** `lib/editor-chords.ts` binds, on every instance:
+
+- **The two send chords** (⌘↵, ⇧⌘↵), re-dispatched on `document.body` for the
+  one window handler to decide. Monaco owns Enter and `ownsEnterKey` excludes
+  editors from that handler on purpose, so without the bridge ⌘↵ inserted a
+  newline in the body, GraphQL and script panes.
+- **⌘I**, the context-bar toggle, for the opposite reason: Monaco binds
+  CtrlCmd+I as a secondary `triggerSuggest` keybinding on every platform and its
+  keybinding service stops what it resolves, so the chord died at the editor
+  instead of reaching `Shell`'s bubble-phase listener. S, W, B, `,`, the digits
+  and the ⇧ view chords really are unbound in the standalone editor and arrive
+  on their own - which is what the bridge's comment used to claim about **all**
+  of them.
+- **⇧⌘M, the way out.** Monaco's Tab indents, which is right for a code editor
+  and a keyboard trap for anyone who reached one by tabbing (WCAG 2.1.2).
+  Monaco's own exit, `editor.action.toggleTabFocusMode`, cannot simply be
+  advertised: it is Ctrl+M, which on macOS means ⌃⇧M - a modifier `Chord` has no
+  word for - while the ⌘M this registry *would* render is Minimize. So the app
+  declares `LEAVE_EDITOR_CHORD` and the Keyboard Shortcuts panel lists it like
+  any other. It moves focus to the first focusable element after the editor's
+  container, walking backwards when the editor is the last thing on the page -
+  never to the container itself, whose textarea the next Tab would walk straight
+  back into.
+
+**Read-only editors carry no exit chord**: `tabFocusMode` is simply on for them,
+Tab having nothing to indent in text nobody can type into. Editable ones keep
+Tab and show a `Kbd` hint naming the chord *while they hold focus* - at the
+moment it is wanted, rather than as a standing badge over a dozen panes.
+
+⌘K is not bound here at all. It belongs to `CommandPalette`, on the capture
+phase, which both prevents **and stops** it: preventing alone left the event in
+flight, and Monaco - which treats ⌘K as a chord *leader* - entered chord mode
+behind the open palette, so the next keystroke answered "not a command" in its
+status bar.
+
+**`ariaLabel` is required.** Monaco's default accessible name is "Editor
+content", so a dozen unlabelled panes are one control to a screen reader. It is
+per call site rather than derived from `language`, because two editors can share
+a language and never a job (the GraphQL variables pane and a JSON body are both
+`json`). The type holds the prop present; `code-editor.aria-label.test.tsx`
+holds the labels non-empty and distinct, with a floor under the mount count so a
+broken scan cannot pass vacuously. The two script panels take theirs from
+`SCRIPT_VARIANTS`, the collection script tab from its `kind` - a scan cannot
+follow either, which is the same limit that applies to class names arriving in
+a variable.
 
 ### Markdown (`markdown-view`, `markdown-editor`)
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1183,6 +1183,30 @@ roving tabindex focuses the row), or focus sits on a control inside it. `:has()`
 is descendant-only and does not cover the first, hence the `:focus-visible`
 selector alongside it.
 
+**Focus must be able to leave, and a Monaco editor is where it could not.** A
+ring that says where focus is means nothing if Tab cannot move it on. Monaco
+indents with Tab - right for a code editor, and a keyboard trap for anyone who
+reached one by tabbing (WCAG 2.1.2). Two rules, both held in `ui/code-editor.tsx`
+rather than at the dozen mount sites:
+
+- **A read-only editor runs with `tabFocusMode` on.** There is no indentation to
+  insert in text nobody can type into, so Tab simply moves focus and no trap
+  exists to escape.
+- **An editable editor advertises the way out while it holds focus.** ⇧⌘M
+  (`LEAVE_EDITOR_CHORD`) moves focus to the first focusable element after the
+  editor, and a `Kbd` hint names it in the editor's bottom-right corner - on
+  focus, not always, so a dozen panes do not each carry a standing badge over
+  their content. The caps come from `chordKeys`, like every other chord this app
+  puts on screen; a hand-rolled badge would be a second place a modifier is
+  spelled.
+
+The general rule behind both: **any component that takes over a key the browser
+uses for navigation owes the user a documented way back**, and that way back is a
+`Chord` in `constants/shortcuts.ts` so the Keyboard Shortcuts panel lists it
+without being told. Guarded by `code-editor.chords.test.tsx` (the chord is
+registered, the hint appears on focus and never on a read-only editor) and
+`shortcuts.listed.test.ts` (it reaches the panel).
+
 ---
 
 ## Row Actions


### PR DESCRIPTION
## Description

Four defects in `app/src/components/ui/code-editor.tsx`, the one wrapper every editor passes through, plus the chord bridge beside it. All four were Monaco's defaults leaking through a boundary that configures nothing about focus or naming.

**Root cause and approach.** The wrapper bridges exactly two Enter chords out of Monaco and says nothing else, so Monaco's own behaviour is the app's: Tab indents with no advertised exit (WCAG 2.1.2 keyboard trap), ⌘/Ctrl+I resolves inside Monaco as a secondary `triggerSuggest` binding and is stopped before `Shell`'s bubble-phase listener sees it, ⌘K is claimed by the palette's capture listener but left in flight so Monaco still enters chord mode, and no editor carries an accessible name. The fix stays in the wrapper and the bridge, per the issue - a dozen call sites is what #938 already ruled out. A new `LEAVE_EDITOR_CHORD` (⇧⌘M / Ctrl+Shift+M) is declared in `constants/shortcuts.ts`, so the Keyboard Shortcuts panel lists it for free, and bound in `registerEditorChords` to move focus to the first focusable element after the editor; read-only editors instead get `tabFocusMode` outright, Tab having nothing to indent in text nobody can type into; editable ones show a `Kbd` hint while focused.

**Rejected alternatives.** Turning `tabFocusMode` on for *every* editor removes the trap in one line but takes Tab away from the body and script panes, where indentation is real editing. Binding **Escape** as the exit is the more discoverable convention, but Monaco resolves Escape for its own widgets (suggest, find) and an editor inside a dialog would then eat the Escape that closes the dialog. Re-using Monaco's own Ctrl+M is not spellable here: on macOS that binding is ⌃⇧M, a modifier `Chord` has no word for, and the ⌘M this registry *would* render is Minimize.

### What changed

- **`constants/shortcuts.ts`** - `LEAVE_EDITOR_CHORD` plus a new `editors` group in `SHORTCUT_GROUPS`. CtrlCmd+Shift+M is claimed by neither the standalone editor (which takes CtrlCmd+M / ⌃⇧M) nor the native menu; the collision sweep in `shortcuts.test.ts` now covers `m`.
- **`lib/editor-chords.ts`** - `TOGGLE_CONTEXT_BAR_CHORD` joins the bridged list, and the comment claiming "everything else in the map is a letter or a digit Monaco does not claim" is corrected, I being the counterexample. New `focusAfterEditor`, which walks document order after the editor's container and falls back to walking backwards when the editor is last on the page. It never focuses the container itself: Monaco's textarea is inside it, so the next Tab would walk straight back in.
- **`ui/code-editor.tsx`** - required `ariaLabel` prop mapped to Monaco's own option; `tabFocusMode: readOnly`; a focus-tracked `LeaveEditorHint` built from `chordKeys` and the `Kbd` primitive.
- **`palette/CommandPalette.tsx`** - `stopPropagation` after `preventDefault`, scoped to the one chord the `return` above it lets through.
- **Eight mount sites** get a distinct label. The two script panels take theirs from `SCRIPT_VARIANTS` (a new `editorLabel` field) rather than branching in the panel, which that file exists to prevent; the collection script tab derives its from `kind`.

### Two decisions worth a reviewer's eye

**The hint spells its border token instead of inheriting one.** It is the app's only surface that floats over *Monaco's* canvas rather than over a declared app surface, so `border-rule` has no `--rule` to inherit and would fall back to the invisible default - and the fill cannot separate it either, Monaco's dark background being `#1e1e1e` against a `--popover` of `#1a1a1f`, and both being white in light. It takes the floating-surface shape every popover here uses, with the explicit `border-border-strong` that `Kbd` is itself built from. It is also not `UrlBar`'s tooltip `Hint`, the app's other chord-on-focus pattern: Monaco's `<Editor>` is not a ref-forwarding child a Radix `TooltipTrigger asChild` can attach to.

**The exit chord is registered on read-only editors too**, where it is redundant with the Tab that already works. One `addCommand` on every instance is cheaper to keep true than a `readOnly` branch threaded through the bridge; only the *hint* is gated on `!readOnly`.

### Deliberate deviation from the issue

The issue's fix pathway suggests moving focus "to the editor's container node (or the next focusable sibling)". Only the second is implemented - the container is inside the editor's own tab order, so focusing it is not an exit.

One thing the issue did not ask for: the aria-label guard needs the brace/string-aware JSX tag cursor that `icon-button-labels.test.tsx` already wrote (a regex ends early on `onClick={(e) => …}`, which was a real bug in an earlier version of that guard). Copying it would be the hand-rolled-copy defect `CLAUDE.md` names, so it moved to `lib/jsx-opening-tags.testkit.ts` and both guards read it. Behaviour-identical, just parameterised on the tag name.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green, plus `mkdocs build --strict -f .github/mkdocs.yml` for the docs.

- **6286 tests / 573 files pass**, no pre-existing failures on this base (`07facd8`).
- `editor-chords.test.ts`: +9 cases - the ⌘I and leave bindings are registered (mutation check: drop `TOGGLE_CONTEXT_BAR_CHORD` from `BRIDGED_CHORDS` and only that case reddens), the leave command actually moves focus, and seven `focusAfterEditor` cases covering next/previous/disabled/`aria-hidden`/nothing-to-focus/no-container.
- `code-editor.chords.test.tsx`: +7 - all four bindings registered, `ariaLabel` reaches Monaco's options, `tabFocusMode` on read-only and off editable, and the hint appearing on focus, going on blur, and never on a read-only editor.
- `code-editor.aria-label.test.tsx` (new): source scan over every non-test `<CodeEditor>` with a non-empty floor (`> 4`, against 8 real mounts) - every mount passes an `ariaLabel`, none is empty, no two literals collide.
- `CommandPalette.ctrl-k.test.tsx`: +2 - Ctrl+K does not reach the control below the capture listener, and Ctrl+J and a bare K still do. **Mutation-checked**: removing `stopPropagation` fails exactly the first of those.
- `shortcuts.listed.test.ts` and `KeyboardShortcutsPanel.test.tsx` pick the chord up on their own - the latter asserts `getByText(chord.label)` for every registry entry, so the new chord's label is proven to reach the panel without either file being touched. That is the registry working as designed rather than an item skipped.

No engine change, so no `build.py` / ctest run - this is app-only.

The Tab-trap exit itself cannot be exercised in jsdom (no layout, no Monaco keybinding service); the chord registration, the focus landing, and the settings-panel listing are the testable surface, as the issue notes. One known limit, documented in the source: `focusAfterEditor` walks document order, which is not the tab order proper where a positive `tabIndex` exists - nothing in `app/src` uses one.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1213
Part of #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5fArxYxzG4NTE4Cgd6qo