### PR TITLE
perf(app): the history percentile card gates on a predicate, not a series

### DIFF
--- a/app/src/modules/history/main/components/PerformanceTab.transforms.test.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.transforms.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Performance tab builds no series it does not plot (#1190).
+ *
+ * It used to build the whole percentile series in its own memo purely to read
+ * `.some((d) => d.p99 > 0)` for the card's render gate, while
+ * `LatencyPercentilesChart` built the identical series again from the identical
+ * array - so a loaded run's ticks were transformed twice on every render of the
+ * tab. This is the same smell #1152 removed from the live dashboard, and the
+ * rule the dashboard README now states ("A chart card's render gate asks a
+ * predicate, not a series"). Spying on the module is the only way to see it,
+ * since both copies produced the same numbers.
+ *
+ * `runId` is left off so `HistoricalChartsSection` stays out of the tree, as
+ * `MonitorSummary.test.tsx` does - it plots no percentiles, so it would only
+ * add uPlot canvases to what is a transform-count assertion.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { LoadTestMetrics, RunReport } from "@/types";
+import type { DashboardDerived } from "@/modules/dashboard/types";
+
+const spies = vi.hoisted(() => ({
+	buildPercentileChartData: vi.fn(),
+}));
+
+vi.mock("@/modules/dashboard/utils/metricsTransforms", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/modules/dashboard/utils/metricsTransforms")>();
+	return {
+		...actual,
+		buildPercentileChartData: (...args: Parameters<typeof actual.buildPercentileChartData>) => {
+			spies.buildPercentileChartData(...args);
+			return actual.buildPercentileChartData(...args);
+		},
+	};
+});
+
+const PerformanceTab = (await import("./PerformanceTab")).default;
+
+/** Ticks spanning several 0.5s buckets, so the chart has something to draw. */
+function ticks(n: number, p99: (i: number) => number): LoadTestMetrics[] {
+	return Array.from({ length: n }, (_, i) => ({
+		timestamp: i * 1000,
+		elapsed_seconds: i,
+		requests_completed: i * 100,
+		requests_failed: i * 2,
+		current_rps: 100 + i * 10,
+		current_concurrency: 10 + i * 5,
+		latency_p50_ms: 20 + i,
+		latency_p95_ms: 40 + i * 3,
+		latency_p99_ms: p99(i),
+		avg_latency_ms: 25 + i,
+		avg_queue_wait_ms: i * 0.5,
+		bytes_sent: i * 1000,
+		bytes_received: i * 5000,
+		status_codes: { "200": i * 90 },
+	}));
+}
+
+const withLatency = (n: number) => ticks(n, (i) => 80 + i * 8);
+/** A run that completed nothing: every tick reports a zero p99. */
+const withoutLatency = (n: number) => ticks(n, () => 0);
+
+const REPORT = {
+	metadata: { runId: "run_1", runType: "load", status: "completed" },
+	summary: {
+		totalRequests: 100,
+		failedRequests: 0,
+		requestsPerSecond: 10,
+		testDuration: 10,
+		errorRate: 0,
+	},
+	latency: { min: 1, max: 9, avg: 4, p50: 4, p90: 7, p95: 8, p99: 9 },
+} as unknown as RunReport;
+
+function derivedFor(mode: string): DashboardDerived {
+	return { mode, targetRps: 0 } as unknown as DashboardDerived;
+}
+
+function renderTab(timeSeries: LoadTestMetrics[], mode = "constant_concurrency") {
+	return render(
+		<PerformanceTab
+			report={REPORT}
+			derived={derivedFor(mode)}
+			timeSeries={timeSeries}
+			monitorSamples={[]}
+		/>
+	);
+}
+
+describe("PerformanceTab percentile series", () => {
+	beforeEach(() => {
+		spies.buildPercentileChartData.mockClear();
+	});
+
+	it("builds the percentile series once - inside the chart that plots it", () => {
+		const { rerender } = renderTab(withLatency(6));
+
+		// A gate that rebuilt the series to test it would make this 2.
+		expect(spies.buildPercentileChartData).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<PerformanceTab
+				report={REPORT}
+				derived={derivedFor("constant_concurrency")}
+				timeSeries={withLatency(7)}
+				monitorSamples={[]}
+			/>
+		);
+
+		expect(spies.buildPercentileChartData).toHaveBeenCalledTimes(2);
+	});
+
+	it("still shows the percentile card for a run whose ticks carry a p99", () => {
+		// The count above would also hold if the card had silently stopped
+		// rendering - then the transform would run zero times, not twice.
+		const { getByText } = renderTab(withLatency(6));
+		expect(getByText("Response Time Percentiles Over Time")).toBeTruthy();
+	});
+
+	it("builds nothing, and hides the card, when no tick reports a p99", () => {
+		const { queryByText } = renderTab(withoutLatency(6));
+		expect(queryByText("Response Time Percentiles Over Time")).toBeNull();
+		expect(spies.buildPercentileChartData).not.toHaveBeenCalled();
+	});
+
+	it("builds nothing on a ramp_up run, which plots the scatter instead", () => {
+		// The sharpest form of "no series it does not plot": this mode swaps in
+		// `ResponseTimeVsConcurrencyChart`, which builds no percentile series at
+		// all - so the only remaining caller would be a gate.
+		const { getByText } = renderTab(withLatency(6), "ramp_up");
+		expect(getByText("Response Time vs Concurrency")).toBeTruthy();
+		expect(spies.buildPercentileChartData).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -50,6 +50,11 @@ export default function PerformanceTab({
 	// tick rather than each bucket's last-write-wins sample, so it can only be
 	// more permissive than the `.some((d) => d.p99 > 0)` it replaces - and the
 	// chart's own two-point guard still decides whether anything is drawn.
+	//
+	// Memoised despite returning a boolean, as MetricsView does: the predicate
+	// stops at the first tick carrying a p99, but the run that has none - the
+	// one whose card this hides - is the case that scans every tick, and a
+	// loaded series runs to tens of thousands of them.
 	const hasPercentileData = useMemo(() => hasPercentileSignal(timeSeries), [timeSeries]);
 	const isRampUp = derived.mode === "ramp_up";
 

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -15,10 +15,7 @@ import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
-import {
-	isRateLimitedRun,
-	buildPercentileChartData,
-} from "@/modules/dashboard/utils/metricsTransforms";
+import { isRateLimitedRun, hasPercentileSignal } from "@/modules/dashboard/utils/metricsTransforms";
 import {
 	LatencyPercentilesChart,
 	ResponseTimeVsConcurrencyChart,
@@ -45,8 +42,15 @@ export default function PerformanceTab({
 	// history percentile chart / scatter can render the same views as the live
 	// dashboard. Mirror MetricsView's split: ramp_up → response-time-vs-concurrency
 	// scatter (capacity elbow), other modes → percentiles-over-time.
-	const percentileChartData = useMemo(() => buildPercentileChartData(timeSeries), [timeSeries]);
-	const hasPercentileData = percentileChartData.some((d) => d.p99 > 0);
+	//
+	// The gate asks a predicate, not a series (#1190, the rule #1152 wrote into
+	// modules/dashboard/README.md). The chart below builds the percentile series
+	// from this same array, so building it here too transformed a loaded run's
+	// ticks twice on every render of the tab. `hasPercentileSignal` reads every
+	// tick rather than each bucket's last-write-wins sample, so it can only be
+	// more permissive than the `.some((d) => d.p99 > 0)` it replaces - and the
+	// chart's own two-point guard still decides whether anything is drawn.
+	const hasPercentileData = useMemo(() => hasPercentileSignal(timeSeries), [timeSeries]);
 	const isRampUp = derived.mode === "ramp_up";
 
 	return (


### PR DESCRIPTION
## Description

`PerformanceTab` built the whole percentile series in its own memo purely to decide whether a card renders:

```ts
const percentileChartData = useMemo(() => buildPercentileChartData(timeSeries), [timeSeries]);
const hasPercentileData = percentileChartData.some((d) => d.p99 > 0);
```

The built array was never passed down. `LatencyPercentilesChart` then built the identical series again from the identical `timeSeries` array, so a loaded run's ticks were transformed twice on every render of the tab.

**Root cause / approach.** This is the same smell #1152 removed from `MetricsView` on the live path, and the rule that change wrote into `app/src/modules/dashboard/README.md` - *"a chart card's render gate asks a predicate, not a series"* - one import away from the file that broke it. The gate now asks `hasPercentileSignal(timeSeries)`, the predicate #1152 added for exactly this question, which allocates nothing. `PerformanceTab` already imports from that same module (`isRateLimitedRun`), so this adds no new coupling.

**The alternative I rejected:** writing a history-local `hasPercentileData` helper, to keep `modules/history` from reaching further into `modules/dashboard`. Rejected because a hand-rolled copy of a predicate does not receive the predicate's fixes - and the copy would have been the *third* spelling of one idea, which is precisely what #1152 set out to end. The cross-module import is established here already (nine non-test files under `modules/history/` import from `modules/dashboard/`, including this file).

**One documented behavioural difference,** inherited from the predicate and accepted by #1152: `hasPercentileSignal` is deliberately not bucket-aware, so it can only be *more* permissive than the series-derived check. `buildPercentileChartData` keeps each 0.5s bucket's last tick, so a bucket whose final tick reported no completions reads 0 in the built series while an earlier tick in it did not. It cannot go the other way - every point in the built series comes from a tick the predicate also scans. The chart's own two-point guard (`if (data[0].length < 2) return null`) still decides whether anything is drawn, and `metricsTransforms.test.ts` already pins that direction with a randomized equivalence test.

This is the one point worth your sign-off: it is a literal deviation from acceptance criterion 2 ("the same runs it does today"), sanctioned by the issue's own "Fix / solution pathway" note but strictly a widening, never a narrowing.

I also checked `HistoricalChartsSection.tsx`, as the issue asks: it has a generic `data.length < 2` guard and renders no percentile chart, so there is no equivalent gate there.

## Type of Change
- [x] Bug fix (a consistency / rule-adherence fix, not a measured hot spot - see the issue's "Why it was left out of #1152")
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`PerformanceTab` had no test file at all. The new `PerformanceTab.transforms.test.tsx` mirrors `MetricsView.transforms.test.tsx` - spying on the transform module, because both copies produced the same numbers, so nothing else can see the difference. Four cases:

- builds the percentile series **once** (inside the chart that plots it), and twice across two renders;
- still shows the card for a run whose ticks carry a p99 - so the count above cannot be satisfied by a card that silently stopped rendering;
- builds nothing, and hides the card, when no tick reports a p99;
- builds nothing on a `ramp_up` run, which plots the scatter instead - the sharpest form of "no series it does not plot", since that mode's chart builds no percentile series at all, leaving a gate as the only possible caller.

**Mutation-checked:** restoring the series-building gate fails three of the four cases (`expected "vi.fn()" to be called 1 times, but got 2 times`, and the two `not.toHaveBeenCalled()` cases). Restored after checking.

Commands run locally, all green:

- `cd app && pnpm test` - 591 files, 6489 tests passed (baseline on `master` was 590 / 6485; this PR adds 1 file / 4 tests)
- `cd app && pnpm type-check` - renderer, electron and electron-tests projects all exit 0
- `cd app && pnpm lint` - zero errors, zero warnings
- `cd app && pnpm format:check` - clean

No engine side, so no `build.py` / `ctest` run: the diff is two renderer files and no test there could change colour. No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: none, as the issue predicted - the rule this restores is already written in `app/src/modules/dashboard/README.md` (added by #1152), and `docs/app/COMPONENTS.md`'s descriptions of `PerformanceTab.tsx` ("Latency/throughput detail") and `metricsTransforms.ts` remain exactly as accurate as before this change.

## Related Issues
Closes #1190