### PR TITLE
refactor(VariableInput): read the token ladder from the classifier, not a second copy

### DIFF
--- a/app/src/components/shared/VariableInput/data-column-paint.test.tsx
+++ b/app/src/components/shared/VariableInput/data-column-paint.test.tsx
@@ -127,7 +127,7 @@ describe("a bare token naming a declared column, undefined in every scope", () =
 	}
 
 	it("paints as the same muted, informational tone as {{data.column}}", () => {
-		// Revert the `boundColumn` check in `renderOverlayContent` and this token
+		// Revert the bare-column rung of `classifyVariableToken` and this token
 		// falls through to `EditableVariable` with `resolved={false}` instead -
 		// `text-destructive-text`, the exact false alarm #1007 exists to close.
 		const overlay = bareOverlayOf("https://x/{{email}}", contract);

--- a/app/src/components/shared/VariableInput/index.tsx
+++ b/app/src/components/shared/VariableInput/index.tsx
@@ -19,16 +19,15 @@
  * - Autocomplete dropdown when typing {{
  * - Click variables to open edit popover with current value
  *
- * A bare `{{name}}` that names a declared data column and that no scope
- * defines paints as a bound-column runtime token rather than an undefined
- * variable (issue #1007) - see the `boundColumn` check in
- * `renderOverlayContent` and `describeBareColumnToken`.
- *
- * `{{$vu}}` and `{{$iteration}}` paint as run-time tokens too (issue #1101):
- * they address the reserved identity namespace, which no scope can answer, so
- * the "not defined, click to create" treatment marked the one case that always
- * works - and marked it identically to `{{$vus}}`, a typo that reaches the wire
- * in braces.
+ * What a `{{token}}` *is* is not decided here: `classifyVariableToken`
+ * (`@/lib/variable-token-kind`) owns that ladder for every surface that paints
+ * one, this overlay and the Monaco decorations alike (issues #1220, #1239).
+ * So a bare `{{name}}` that names a declared data column and that no scope
+ * defines paints as a bound-column run-time token rather than an undefined
+ * variable (issue #1007), and `{{$vu}}` / `{{$iteration}}` paint as run-time
+ * tokens (issue #1101) - both because the classifier says so, in the order
+ * `resolveTemplate` resolves them. This file decides only what each answer
+ * looks like.
  */
 
 import {
@@ -37,7 +36,6 @@ import {
 	useCallback,
 	useMemo,
 	useEffect,
-	useLayoutEffect,
 	type KeyboardEvent,
 	type ChangeEvent,
 } from "react";
@@ -52,13 +50,10 @@ import { isCommitEnter } from "@/lib/keyboard";
 import { cn } from "@/lib/utils";
 import type { ResolvedVariable, VariableScope, VariableSupport } from "@/types";
 import EditableVariable from "./EditableVariable";
-import RuntimeToken, { type RuntimeTokenProps } from "./RuntimeToken";
+import RuntimeToken from "./RuntimeToken";
 import { VARIABLE_PATTERN } from "@/constants/variables";
 import { variableCompletionContext } from "@/lib/variable-completion";
-import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
-import { isDataVariableName } from "@/lib/variable-resolution";
-import { iterationVariable } from "@/lib/iteration-variables";
-import { describeDataToken, describeBareColumnToken } from "@/lib/data-contract";
+import { classifyVariableToken, type VariableTokenKind } from "@/lib/variable-token-kind";
 
 interface VariableInputProps {
 	value: string;
@@ -92,8 +87,24 @@ interface VariableInputProps {
 /** Stable identity for the no-scope case, so the memos below do not re-run. */
 const NO_VARIABLES: Record<string, ResolvedVariable> = {};
 
-/** The generator table by name, for the overlay's token lookup. */
-const DYNAMIC_BY_NAME = new Map(DYNAMIC_VARIABLES.map((v) => [v.name, v]));
+/**
+ * One `{{token}}` the strip paints: what the name addresses, and where its text
+ * sits in `value`.
+ *
+ * Decided before the paint rather than inside it (issue #1239), which is what
+ * lets the strip count its own stops without reading the DOM it just rendered.
+ */
+interface OverlayToken {
+	/** The name as written inside the braces. */
+	name: string;
+	/** What that name is, from the one ladder every token surface reads. */
+	kind: VariableTokenKind;
+	/**
+	 * The token's own span of `value`, as the attributes a click reads back -
+	 * see `placeCaretAtTokenEdge`.
+	 */
+	bounds: { "data-token-start": number; "data-token-end": number };
+}
 
 /**
  * The tokens the roving strip walks, in painted order.
@@ -177,6 +188,49 @@ export default function VariableInput({
 	 * nowhere to write. The literal the user typed is the honest thing to show.
 	 */
 	const hasVariables = Boolean(variables) && segments.some((s) => s.type === "variable");
+
+	/**
+	 * The tokens the strip paints, in painted order, each already classified.
+	 *
+	 * The five ordered checks are `classifyVariableToken`'s - the same ladder the
+	 * Monaco decorations read, rather than a second copy of it written here
+	 * (issue #1239). Two copies would answer one `{{name}}` differently, and the
+	 * same name would read as a bound column in the URL field and an undefined
+	 * variable in the body beneath it.
+	 *
+	 * The offsets are accumulated over every segment, tokens and the text between
+	 * them alike, because the segments tile the whole string - so a token's bounds
+	 * are exact and a click can put the caret back beside it.
+	 */
+	const overlayTokens = useMemo(() => {
+		const tokens: OverlayToken[] = [];
+		let offset = 0;
+		for (const seg of segments) {
+			const start = offset;
+			offset += seg.content.length;
+			if (seg.type !== "variable" || !seg.varName) continue;
+			tokens.push({
+				name: seg.varName,
+				kind: classifyVariableToken(seg.varName, {
+					variables: allVariables,
+					dataColumns: variables?.dataColumns,
+				}),
+				bounds: { "data-token-start": start, "data-token-end": offset },
+			});
+		}
+		return tokens;
+	}, [segments, allVariables, variables?.dataColumns]);
+
+	/**
+	 * Which token of the strip holds the Tab stop, as the strip stands now.
+	 *
+	 * Derived rather than corrected in an effect: editing the field re-paints the
+	 * strip, and the token that held the stop may be gone - a stop past the end
+	 * falls back to the first token, in the same render rather than one later.
+	 * The count comes from `overlayTokens`, so nothing here reads back the DOM it
+	 * has just painted to learn how many tokens it painted.
+	 */
+	const activeStop = activeTokenIndex < overlayTokens.length ? activeTokenIndex : 0;
 
 	/*
 	 * Check if we should show autocomplete.
@@ -473,20 +527,6 @@ export default function VariableInput({
 		if (index !== -1) setActiveTokenIndex(index);
 	};
 
-	/*
-	 * Editing the field re-paints the strip, and the token that held the Tab stop
-	 * may be gone. Healed from the rendered strip rather than by counting tokens
-	 * a second time: the painter decides what is a token through five ordered
-	 * checks, and a second copy of that decision is exactly the drift this file
-	 * has been bitten by before.
-	 */
-	useLayoutEffect(() => {
-		const tokens = overlayRef.current?.querySelectorAll(TOKEN_STOPS);
-		if (tokens && tokens.length > 0 && activeTokenIndex >= tokens.length) {
-			setActiveTokenIndex(0);
-		}
-	}, [activeTokenIndex, segments]);
-
 	// Handle focus - show plain suggestions if available
 	const handleFocus = () => {
 		if (suggestions.length > 0 && !showSuggestions) {
@@ -570,144 +610,71 @@ export default function VariableInput({
 		inputRef.current?.focus();
 	};
 
-	// Render the overlay content with variable tokens
+	/**
+	 * Paint what `overlayTokens` decided, and nothing else.
+	 *
+	 * Two shapes rather than five (issue #1239): every run-time case - a `data.*`
+	 * column, an identity name, a bare bound column, a generator - is one
+	 * `RuntimeToken`, because they differ only in the words of the tooltip and
+	 * the tone. Which of the two a name takes is `classifyVariableToken`'s answer,
+	 * read above; the ordering that produces it is documented there.
+	 */
 	const renderOverlayContent = () => {
 		if (!value) return null;
 
 		/*
-		 * Where each segment's text starts in `value`. The segments tile the
-		 * whole string (matches plus the slices between them), so a running
-		 * count is exact - and it is what lets a click on a run-time token put
-		 * the caret back on the right side of it, see `placeCaretAtTokenEdge`.
-		 */
-		let offset = 0;
-		/*
 		 * Position of the next token in the strip. Every token counts, both kinds
 		 * (issue #1238): a run-time token opens no popover, but its tooltip is the
 		 * whole of what it has to say, so it is a stop like any other.
+		 *
+		 * `overlayTokens` holds one entry per variable segment, in this order and
+		 * on this same condition, so the position is also the index into it.
 		 */
-		let tokenPosition = 0;
-		/** The stop this token holds; exactly one of them is `0`. */
-		const nextStop = () => (tokenPosition++ === activeTokenIndex ? 0 : -1);
-
-		/*
-		 * One wrapper for all four run-time cases. They differ only in the words of
-		 * the tooltip and the tone - which is the reason `RuntimeToken` is one
-		 * component rather than three - so the tab-stop wiring they now also share
-		 * is written once rather than in four places for it to drift between.
-		 */
-		const runtimeToken = (
-			key: string,
-			bounds: { "data-token-start": number; "data-token-end": number },
-			token: RuntimeTokenProps
-		) => (
-			<span
-				key={key}
-				data-variable-token
-				data-runtime-token
-				{...bounds}
-				// The tooltip is this token's entire content, and a tooltip opens on
-				// a pointer event the overlay's `pointer-events: none` never
-				// delivered (issue #604).
-				style={{ pointerEvents: "auto" }}
-			>
-				<RuntimeToken {...token} tabIndex={nextStop()} disabled={disabled} />
-			</span>
-		);
+		let position = 0;
 
 		return segments.map((seg, i) => {
-			const start = offset;
-			offset += seg.content.length;
-			const tokenBounds = { "data-token-start": start, "data-token-end": offset };
-
 			if (seg.type === "variable" && seg.varName) {
-				/*
-				 * The reserved namespace is read *before* the scopes, exactly as
-				 * `resolveTemplate` reads it: `data.*` is disjoint from the tiers,
-				 * so a variable someone happened to name `data.email` must not
-				 * answer for the column - and must not paint the token as though
-				 * it had. Only a collection run's iteration binds one.
-				 */
-				if (isDataVariableName(seg.varName)) {
-					/*
-					 * Three states now rather than one (issue #600): a declared
-					 * column, a column no contract in scope declares, and - when
-					 * nothing in the chain declares anything - phase 1's neutral
-					 * token, unchanged. `describeDataToken` owns which is which.
-					 */
-					const data = describeDataToken(seg.varName, variables?.dataColumns);
-					return runtimeToken(`${i}-${seg.varName}`, tokenBounds, {
-						name: seg.varName,
-						description: data.description,
-						note: data.note,
-						tone: data.tone,
-					});
+				const { name, kind, bounds } = overlayTokens[position];
+				/** The stop this token holds; exactly one of them is `0`. */
+				const tabIndex = position++ === activeStop ? 0 : -1;
+				const key = `${i}-${name}`;
+
+				if (kind.state === "runtime") {
+					return (
+						<span
+							key={key}
+							data-variable-token
+							data-runtime-token
+							{...bounds}
+							// The tooltip is this token's entire content, and a
+							// tooltip opens on a pointer event the overlay's
+							// `pointer-events: none` never delivered (issue #604).
+							style={{ pointerEvents: "auto" }}
+						>
+							<RuntimeToken
+								name={name}
+								description={kind.description}
+								note={kind.note}
+								tone={kind.tone}
+								tabIndex={tabIndex}
+								disabled={disabled}
+							/>
+						</span>
+					);
 				}
-				/*
-				 * The identity namespace is reserved the same way (issue
-				 * #994), so it is decided in the same tier - before the
-				 * scopes, not beside the generator table below. The
-				 * difference is load-bearing: a scope that defines `$guid`
-				 * wins and takes the editable token, but `lookupVariable`
-				 * answers `$vu` ahead of every scope, so a variable someone
-				 * happens to name `$vu` shadows nothing and must not paint
-				 * as though it had. Nothing binds it until the iteration
-				 * that sends the request, which is what the note says.
-				 */
-				const identity = iterationVariable(seg.varName);
-				if (identity) {
-					return runtimeToken(`${i}-${seg.varName}`, tokenBounds, {
-						name: identity.name,
-						description: identity.description,
-						note: "not generated here",
-					});
-				}
-				const varInfo = allVariables[seg.varName];
-				/*
-				 * A bare token whose name is a declared column, and which no scope
-				 * defines, is bound by a run's row exactly as `{{data.name}}` is
-				 * (issue #1007) - painting it as an undefined variable would offer
-				 * to create one that a bind will never consult (`EditableVariable`'s
-				 * `resolved={false}` treatment, below). A scope that DOES define the
-				 * name is left alone: it keeps painting as that variable, unchanged
-				 * - shadowing the column in the paint is a separate design question.
-				 */
-				const boundColumn =
-					!varInfo && variables?.dataColumns?.columns.includes(seg.varName)
-						? variables.dataColumns
-						: undefined;
-				if (boundColumn) {
-					const data = describeBareColumnToken(boundColumn);
-					return runtimeToken(`${i}-${seg.varName}`, tokenBounds, {
-						name: seg.varName,
-						description: data.description,
-						note: data.note,
-						tone: data.tone,
-					});
-				}
-				// A generator only shows through when nothing defines the name -
-				// the same order the resolver uses, so the token cannot describe a
-				// value the request will not carry.
-				const dynamic = varInfo ? undefined : DYNAMIC_BY_NAME.get(seg.varName);
-				if (dynamic) {
-					return runtimeToken(`${i}-${seg.varName}`, tokenBounds, {
-						name: dynamic.name,
-						description: dynamic.description,
-						note: "generated per use",
-					});
-				}
-				const position = nextStop();
+
+				const varInfo = kind.info;
 				return (
 					<span
-						key={`${i}-${seg.varName}`}
+						key={key}
 						data-variable-token
 						style={{ pointerEvents: "auto" }} // Make variable tokens clickable
 					>
 						<EditableVariable
 							// One Tab stop for the whole strip; the arrows move
 							// between tokens - `handleOverlayKeyDown`.
-							tabIndex={position}
-							name={seg.varName}
+							tabIndex={tabIndex}
+							name={name}
 							value={varInfo?.value || ""}
 							scope={varInfo?.scope || "global"}
 							resolved={!!varInfo}

--- a/app/src/components/shared/VariableInput/index.tsx
+++ b/app/src/components/shared/VariableInput/index.tsx
@@ -229,6 +229,13 @@ export default function VariableInput({
 	 * falls back to the first token, in the same render rather than one later.
 	 * The count comes from `overlayTokens`, so nothing here reads back the DOM it
 	 * has just painted to learn how many tokens it painted.
+	 *
+	 * The fallback is a fallback and not a reset: `activeTokenIndex` still holds
+	 * the token the reader last put focus on, so a stop that comes back into
+	 * range - retype three variables, delete two, type them again - is theirs
+	 * again rather than the first token's. That is the roving-tabindex rule the
+	 * rest of the app follows; the effect this replaced could not, having only
+	 * the state itself to write its correction to.
 	 */
 	const activeStop = activeTokenIndex < overlayTokens.length ? activeTokenIndex : 0;
 

--- a/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
+++ b/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
@@ -320,6 +320,29 @@ describe("the token strip", () => {
 		expect(document.activeElement).toBe(tokens(container)[0]);
 	});
 
+	/*
+	 * The stop is an index, and retyping the field can leave it past the end of
+	 * the strip that index addressed. It is clamped from the classified tokens,
+	 * in the render that paints them - the layout effect that used to heal it
+	 * read the rendered strip back to learn how many tokens it had just painted
+	 * (issue #1239). Drop the clamp and this reds: the one surviving token keeps
+	 * `-1`, so the strip holds no stop at all and its tooltips leave the tab
+	 * order with it.
+	 */
+	it("returns the Tab stop to the first token when the field is retyped shorter", () => {
+		const { container, input } = renderHarness({ initial: "{{alpha}}/{{beta}}/{{gamma}}" });
+
+		tokens(container)[0].focus();
+		fireEvent.keyDown(tokens(container)[0], { key: "End" });
+		expect(tokens(container)[2]).toHaveAttribute("tabindex", "0");
+
+		type(input, "{{alpha}}");
+
+		const strip = tokens(container);
+		expect(strip).toHaveLength(1);
+		expect(strip[0]).toHaveAttribute("tabindex", "0");
+	});
+
 	it("leaves the tab order entirely when the field is disabled", () => {
 		const { container } = render(
 			<TooltipProvider delayDuration={0}>

--- a/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
+++ b/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
@@ -343,6 +343,27 @@ describe("the token strip", () => {
 		expect(strip[0]).toHaveAttribute("tabindex", "0");
 	});
 
+	/*
+	 * The other half of that rule, and the one place this differs from the effect
+	 * it replaced: the fallback does not overwrite where the reader was. The
+	 * effect had nowhere to put a temporary answer, so it reset the stop for good
+	 * and a strip that grew back opened at its first token; the derived clamp
+	 * hands the stop back to the token the reader had actually chosen, which is
+	 * what a roving tabindex does everywhere else in the app.
+	 */
+	it("hands the stop back to the chosen token when the strip grows again", () => {
+		const { container, input } = renderHarness({ initial: "{{alpha}}/{{beta}}/{{gamma}}" });
+
+		tokens(container)[0].focus();
+		fireEvent.keyDown(tokens(container)[0], { key: "End" });
+		type(input, "{{alpha}}");
+		type(input, "{{alpha}}/{{beta}}/{{gamma}}");
+
+		const strip = tokens(container);
+		expect(strip.filter((t) => t.getAttribute("tabindex") === "0")).toHaveLength(1);
+		expect(strip[2]).toHaveAttribute("tabindex", "0");
+	});
+
 	it("leaves the tab order entirely when the field is disabled", () => {
 		const { container } = render(
 			<TooltipProvider delayDuration={0}>

--- a/app/src/lib/variable-token-kind.ts
+++ b/app/src/lib/variable-token-kind.ts
@@ -23,10 +23,10 @@
  * "what is this token" differently, and the same `{{name}}` would read as a
  * column in a URL and an undefined variable in the body beneath it.
  *
- * `VariableInput` still holds its own copy of the ladder inline; #1239 (split
- * the decision from the paint) is the issue that adopts this module there,
- * because doing it here would be rewriting a 180-line render function this
- * change has no other reason to touch.
+ * `VariableInput` adopted this module in #1239 (split the decision from the
+ * paint), and the ladder now exists only here: its overlay classifies each
+ * token before painting it, which is also how its roving strip counts its own
+ * stops without reading back the DOM it has just rendered.
  */
 
 import { DYNAMIC_VARIABLES } from "./dynamic-variables";

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1470,9 +1470,10 @@ same reason - there is deliberately **no re-export shim** in
 scope; without one it is a plain text field, since a token would paint a name
 "not defined" and open an editor with nowhere to write.
 
-**A token has four states, and the overlay decides between them in the order
-`resolveTemplate` does** - reserved namespaces first, then the scopes, then the
-generator table:
+**A token has four states, decided in the order `resolveTemplate` decides
+them** - reserved namespaces first, then the scopes, then the generator table.
+The overlay paints that decision rather than making it; `classifyVariableToken`
+makes it, for every surface (see below):
 
 | Token | Painted by | Looks like |
 |-------|-----------|------------|

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1496,8 +1496,9 @@ opens the same `VariablePopover`, positioned over the token's screen
 rectangle. The decision of *what a token is* is shared: `classifyVariableToken`
 (`lib/variable-token-kind.ts`) lifts the same ladder this section describes
 out of the paint, so the editors and the overlay answer one `{{name}}`
-identically. `VariableInput` still holds its own copy of the ladder inline -
-issue #1239 is what adopts this module there. Script editors are excluded:
+identically - the overlay classifies each `{{name}}` once per repaint, before
+any paint, and its five ordered checks exist nowhere else (issue #1239).
+Script editors are excluded:
 the engine never interpolates script source, so `{{name}}` there is literal
 text except inside `pm.variables.replaceIn`. Read-only editors (response
 body, raw request/response, the settings preview) are excluded too - a


### PR DESCRIPTION
## Description

`renderOverlayContent` decided what a `{{token}}` was in five ordered checks of its own - `data.*`, the identity namespace, a bare bound column, a generator, then the scopes - the same ladder `classifyVariableToken` (`lib/variable-token-kind.ts`) already holds for the Monaco decorations. **Root cause:** the module was extracted for #1220 without adopting it in the surface it was extracted from, because that meant reshaping the render function and that change had no other reason to touch it; the module's own docblock and `docs/app/COMPONENTS.md` both said so and named this issue. Two copies of a load-bearing ordering is the drift `app/CLAUDE.md` keeps finding: they would eventually answer one `{{name}}` differently, and the same name would read as a bound column in the URL field and an undefined variable in the body beneath it.

**Approach:** classify before painting. `overlayTokens` is one `useMemo` over `segments` that hands each name to `classifyVariableToken` and records the bounds a click reads back (`data-token-start` / `data-token-end`), so the painter becomes a two-way dispatch on `kind.state`: one `RuntimeToken` wrapper for every run-time answer - they differ only in the words of the tooltip and the tone, which is why that is one component - and one `EditableVariable` wrapper for a name that addresses the scopes. Deciding first is also what retires the `useLayoutEffect` that healed the roving strip's Tab stop by `querySelectorAll`-ing the strip it had just painted: the token count comes from `overlayTokens`, so a stop left past the end of a retyped field is clamped in the same render rather than one later - the shape this file already uses for the suggestion list's `activeValue`.

**Rejected alternative:** keeping the heal as an effect and only feeding it the memoised count. It satisfies the "no DOM read-back" half and leaves a state correction one render behind the paint that caused it, for a value the render can simply derive - and an effect whose only job is to fix state it could have computed is the thing the surrounding code already avoids.

Two things the issue's Problem section overstates, verified against the live code and called out rather than silently followed: the function was 163 lines, not ~180 (the figure came from a comment written before the last change to it), and the four run-time paints were **already** factored into one shared `runtimeToken` wrapper - only the classification was still duplicated. So this collapses five decisions into one call and five paints into two shapes; it does not de-duplicate wrappers that were already shared. The editable token deliberately still carries no `data-token-start` / `data-token-end`: only a run-time token needs them, because only it swallows the click that would otherwise place the caret (#604).

### Deliberate deviation, in one edge case

Retiring the heal changes what happens when the strip shrinks past the held stop and then grows back. The effect wrote its correction into `activeTokenIndex` itself, so a strip that came back opened on its **first** token; the derived clamp treats the fallback as a fallback, so the stop returns to the token the reader had actually chosen. That is the roving-tabindex rule the rest of the app follows, and the effect could not follow it, having only the state itself to write a temporary answer to. Stated at the clamp and pinned by a test rather than left to be discovered. Nothing else about the strip changes: one stop however many tokens, arrows and Home/End, `-1` throughout when the field is disabled.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor (no change to what any token paints)

## Testing

`cd app && pnpm test` - **591 files, 6502 tests, all passing** on the current head (`master` merged in at `89aaefb`, cleanly, no conflicts); `pnpm type-check` and `pnpm lint` clean, `pnpm format:check` clean on every touched file under `app/`. No pre-existing failures on either base commit. CI was green on the pre-merge head across all four app jobs, quality checks and CodeQL.

The existing token suites are the specification and pass **unedited** - `data-column-paint`, `data-variable-token`, `dynamic-variable-token`, `iteration-variable-token`, `variable-token-font`, `runtime-token-interaction` and `keyboard-navigation` between them pin every rung of the ladder, both shadowing directions (a scope defining `$guid` wins and takes the editable token, a scope naming `$vu` shadows nothing), the pointer-events contract, the token bounds a click reads, and the roving strip. The one edit inside an existing test is a comment that named `renderOverlayContent`'s `boundColumn` check and now names the rung of `classifyVariableToken` that decides it.

The issue suggests adding a direct unit test of the precedence pairs; `app/src/lib/variable-token-kind.test.ts` already pins all three of them (`data.email` losing to the column, `$guid` losing to a same-named variable, `$vu` beating one), so nothing was added there.

Two cases are new, for the tab-stop behaviour the deleted effect had none for, both mutation-checked:

- **"returns the Tab stop to the first token when the field is retyped shorter"** - End moves the stop to the third token, the field is retyped down to one, and the survivor must hold `tabindex="0"`. Dropping the clamp (`activeStop = activeTokenIndex`) reds it: the strip is then left with no stop at all and its tooltips leave the tab order with it.
- **"hands the stop back to the chosen token when the strip grows again"** - the deviation above. Restoring the deleted `useLayoutEffect` reds it, which is the point: it is the one behaviour the two implementations disagree on.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commits as the code. `docs/app/COMPONENTS.md` promised this adoption as future work ("`VariableInput` still holds its own copy of the ladder inline - issue #1239 is what adopts this module there") and now describes what is there; the sentence three paragraphs above it that opened the token-state table with "the overlay decides between them" is corrected for the same reason. The `variable-token-kind.ts` docblock carried the same promise and the same correction. No page, link or anchor was added, so the MkDocs nav is untouched.

## Related Issues

Closes #1239