### PR TITLE
fix(engine): a load run's deferred script leaves by the run's transport policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -250,10 +250,10 @@ See [App Architecture - Sidecar](app/architecture.md#engine-sidecar-electronside
 ### Outbound Transport
 
 Every request the engine puts on the wire - a design send, a load run, an SSE
-stream, an OAuth token fetch, a spec import by URL, a monitor scrape - leaves
-through one transport policy, resolved from Settings > Network & connectivity
-at the point of use and applied by a single function
-(`detail::apply_transport_policy`). There is one hop between the engine and the
+stream, an OAuth token fetch, a spec import by URL, a monitor scrape, a script's
+own `pm.sendRequest` - leaves through one transport policy, resolved from
+Settings > Network & connectivity at the point of use and applied by a single
+function (`detail::apply_transport_policy`). There is one hop between the engine and the
 target and it is either absent or a proxy:
 
 ```

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1474,6 +1474,19 @@ It is a subset of `pm.response` and has no `to.*` assertion chain.
   nothing to say why. Before issue #1188 this fetch was the one read in the
   engine with no bound at all.
 
+**It leaves the way its execution leaves.** The fetch takes the transport policy
+its enclosing execution resolved - the proxy mode and URL, the bypass list, the
+custom CA bundle and the client-certificate registry - rather than whatever the
+daemon's own environment would pick up. A script that authenticates through
+`pm.sendRequest` and then lets the real request carry the session has to take the
+same route out of the machine, or one of the two is unreachable behind a
+corporate proxy (issue #705). Which policy that is follows the path, as the byte
+bound above does: a design-mode send's scripts take the one resolved for that
+send, and a load run's deferred `tests` script takes the one the run's own
+transfers left by - resolved once when the run starts and kept for it, so a
+Settings edit made while the run was in flight cannot send an assertion by a
+route the responses it is asserting on never took (issue #1256).
+
 **Not available to agents.** Vayu's MCP target allowlist is checked in the MCP
 server, against the composed URL, before it calls the engine - so a script-issued
 request never passes that gate. The engine therefore refuses script-issued

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -34,6 +34,7 @@
 #include "vayu/core/threshold_eval.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
+#include "vayu/http/transport_policy.hpp"
 
 namespace vayu::http {
 // A scenario run's steps send through the daemon's jar; the manager only passes
@@ -328,6 +329,32 @@ struct RunContext {
      * strategy thread's hot path.
      */
     std::optional<vayu::StreamBounds> stream_bounds;
+
+    /**
+     * The route every transfer of this run left by, kept so the deferred
+     * script pass can leave by it too (issue #1256).
+     *
+     * A copy of the `EventLoopConfig::transport` the run's transfers were sent
+     * under, written by `configure_event_loop` - the one place a load run
+     * resolves a policy - and read at the other end of the run by
+     * `validate_scripts`, which has no other way to reach it: the loop keeps
+     * its config behind its pImpl and is released before retention.
+     *
+     * Held rather than re-resolved there because the deferred `tests` script
+     * asserts on responses these transfers produced, and a `pm.sendRequest`
+     * that took a different proxy, CA bundle or client certificate than they
+     * did would report the target as broken over a `Settings` edit made while
+     * the run was in flight. Same reasoning as `scenario_runner.cpp`'s
+     * run-scoped `transport` (issue #705, epic decision 3 of #704), one run
+     * later in the lifecycle.
+     *
+     * The default - the environment pickup a bare `TransportPolicy` carries -
+     * only ever reaches a script through a `RunContext` built by hand, since
+     * `execute_load_test` configures the loop before anything can be sampled
+     * and is the only path to the validation pass. Written and read on the
+     * run's worker thread, so it needs no lock.
+     */
+    vayu::http::TransportPolicy transport;
 
     // High-performance in-memory metrics collector
     // Replaces direct DB writes for individual results during load tests

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -80,6 +80,12 @@ struct ScriptReplay {
     /// fetches belong to the budget sized for a run rather than for a body
     /// someone is watching for.
     size_t max_response_bytes = vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES;
+    /// The route a `pm.sendRequest` from this script leaves by (issue #1256) -
+    /// the run's own, carried from `RunContext::transport` rather than resolved
+    /// here. A script that authenticates through a proxy the run's transfers
+    /// went through, or presents the client certificate they presented, is the
+    /// case #705 exists for; the load path was the one caller that never set it.
+    vayu::http::TransportPolicy transport;
 };
 
 /**
@@ -136,6 +142,7 @@ std::vector<std::string>& failure_messages) {
             script_ctx.iteration          = sample.iteration;
             script_ctx.vu                 = sample.vu;
             script_ctx.max_response_bytes = replay.max_response_bytes;
+            script_ctx.transport          = replay.transport;
             if (replay.data_rows != nullptr && sample.data_row_index &&
             *sample.data_row_index < replay.data_rows->size ()) {
                 script_ctx.iteration_data = &(*replay.data_rows)[*sample.data_row_index];
@@ -252,6 +259,7 @@ vayu::http::routes::ScriptVariableScopes& scopes,
 const std::shared_ptr<RunContext>& context,
 const vayu::http::SseLimits& sse_limits,
 size_t max_response_bytes,
+const vayu::http::TransportPolicy& transport,
 bool verbose,
 ScriptValidation& validation,
 std::vector<std::string>& failure_messages) {
@@ -297,6 +305,7 @@ std::vector<std::string>& failure_messages) {
         step.name.empty () ? "step " + std::to_string (i + 1) + ": " : step.name + ": ";
         replay.sse_limits         = sse_limits;
         replay.max_response_bytes = max_response_bytes;
+        replay.transport          = transport;
 
         const auto totals = run_replay (engine, scopes, replay, failure_messages);
         validation.steps[i] = totals;
@@ -389,6 +398,16 @@ bool verbose) {
     // (issue #1188) - the load bound, because this pass is the load path's.
     const size_t script_response_bound =
     vayu::http::routes::load_response_body_bound (db);
+    // The route those fetches leave by (issue #1256), and the one value of this
+    // pass that is NOT re-read from the database here: it is the snapshot the
+    // run's own transfers were sent under, taken at `configure_event_loop` and
+    // kept on the context. A bound is what this pass may read *now*, so
+    // reading it now is right; a route is what the traffic being asserted on
+    // took, and a script that reached the target by a different one than the
+    // run did - a proxy edited mid-run, a client certificate registered since -
+    // would report a healthy target as broken. The run resolves it once, and
+    // both halves of the run use that one answer.
+    const vayu::http::TransportPolicy& script_transport = context->transport;
 
     // The run-level request and identity, for the single-request shape. A
     // scenario takes both off the plan step it is replaying instead, so it does
@@ -449,11 +468,12 @@ bool verbose) {
     std::vector<std::string> failure_messages;
 
     if (per_step) {
-        const ScriptValidationTotals totals = replay_scenario_steps (engine, scopes, context,
-        sse_limits, script_response_bound, verbose, validation, failure_messages);
-        sampled = totals.sampled;
-        passed  = totals.passed;
-        failed  = totals.failed;
+        const ScriptValidationTotals totals = replay_scenario_steps (engine,
+        scopes, context, sse_limits, script_response_bound, script_transport,
+        verbose, validation, failure_messages);
+        sampled                             = totals.sampled;
+        passed                              = totals.passed;
+        failed                              = totals.failed;
         // Every scripted step drew a blank, so the run validated nothing.
         if (sampled == 0) {
             return validation;
@@ -480,6 +500,7 @@ bool verbose) {
         replay.request_name       = script_request_name;
         replay.sse_limits         = sse_limits;
         replay.max_response_bytes = script_response_bound;
+        replay.transport          = script_transport;
 
         const auto totals = run_replay (engine, scopes, replay, failure_messages);
         sampled = totals.sampled;
@@ -1101,6 +1122,11 @@ int default_max_per_host) {
     // per change. Matching per transfer stays cheap because it reads this
     // snapshot, never the database.
     loop_config.transport = vayu::http::resolve_transport_policy (db);
+    // The same snapshot, kept for the deferred script pass at the other end of
+    // the run (issue #1256): a `pm.sendRequest` out of a `tests` script must
+    // leave the way the transfers it is asserting on left, and this is the one
+    // place a load run resolves that. See `RunContext::transport`.
+    context->transport = loop_config.transport;
     loop_config.max_response_body_bytes =
     vayu::http::routes::load_response_body_bound (db);
     // Only enable curl verbose if explicitly requested in config,

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -37,6 +37,8 @@
 #include "proxy_server.hpp"
 #include "temp_database.hpp"
 #include "tls_backend.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_plan.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/curl_options.hpp"
@@ -52,6 +54,23 @@ namespace vayu::http::routes {
 std::pair<int, nlohmann::json> import_fetch (const std::string& request_body,
 const vayu::http::TransportPolicy& transport);
 } // namespace vayu::http::routes
+
+namespace vayu::core {
+// Defined in run_manager.cpp, not declared in its header: the one place a load
+// run resolves a transport policy, and where it keeps the snapshot the deferred
+// script pass reads back (issue #1256). Borrowed here rather than exported,
+// because what the load-path traversal case below has to drive is the run's own
+// resolution - a policy the test hands over itself would assert nothing about
+// where the run got one.
+void configure_event_loop (vayu::db::Database& db,
+const nlohmann::json& config,
+const std::shared_ptr<RunContext>& context,
+size_t concurrency,
+double target_rps,
+int timeout_ms,
+int configured_workers,
+int default_max_per_host);
+} // namespace vayu::core
 
 namespace vayu::http {
 namespace {
@@ -773,6 +792,142 @@ TEST (TransportPolicyPaths, ScriptSendRequestTraversesManualProxy) {
     ASSERT_TRUE (result.success) << result.error_message;
     ASSERT_EQ (proxy.count (), 1u);
     EXPECT_EQ (proxy.seen ().front (), upstream.url ("/hello"));
+}
+
+/**
+ * The load path's deferred `tests` script, driven the way a run drives it
+ * (issue #1256).
+ *
+ * The case above says nothing about this one: it hands the context a policy,
+ * and the load path's failure was that nobody handed it one. So these start
+ * from the settings and go through `configure_event_loop` - the run's own
+ * resolution, the same call `execute_load_test` makes before its first transfer
+ * - and then replay the script the way the run does once the transfers are
+ * done. What is under test is the whole carry, not one assignment of it.
+ */
+class LoadRunScriptTransportTest : public TransportPolicyDbTest {
+    protected:
+    /// What a run started from the app carries: one sampled response to replay
+    /// against, and a `tests` script allowed to send.
+    static nlohmann::json run_config () {
+        return { { "response_sample_rate", 1 }, { "max_response_samples", 10 },
+            { "allowScriptRequests", true } };
+    }
+
+    /// The run resolving its own transport. One worker and one slot, because
+    /// nothing is ever submitted to the loop this builds - the transfers these
+    /// scripts assert on are the recorded samples below.
+    void configure_run (const std::shared_ptr<vayu::core::RunContext>& context) const {
+        vayu::core::configure_event_loop (*db_, context->config, context,
+        /*concurrency=*/1, /*target_rps=*/0.0, /*timeout_ms=*/5000,
+        /*configured_workers=*/1, /*default_max_per_host=*/1);
+    }
+
+    static vayu::Response sampled_response () {
+        vayu::Response response;
+        response.status_code     = 200;
+        response.status_text     = "OK";
+        response.body            = "{}";
+        response.timing.total_ms = 1.0;
+        return response;
+    }
+
+    /// A fetch whose failure is a thrown sentence, which is what the replay
+    /// records as a failure - a `pm.sendRequest` that never reached the proxy
+    /// still answers, so the proxy's own tally is the assertion that matters.
+    static std::string fetch_script (const std::string& url) {
+        return "pm.sendRequest('" +
+        url + "', function (err, res) { if (err) { throw new Error(err.message); } });";
+    }
+};
+
+// Mutation-check: drop either half of the carry - `context->transport =
+// loop_config.transport` in `configure_event_loop`, or `script_ctx.transport =
+// replay.transport` in `run_replay` - and the fetch leaves by the environment
+// pickup instead, so the proxy sees nothing.
+TEST_F (LoadRunScriptTransportTest, ADeferredScriptTraversesTheRunsProxy) {
+    MockUpstream upstream;
+    MockProxy proxy;
+    set_config ("proxyMode", "manual");
+    set_config ("proxyUrl", proxy.url ());
+
+    auto context =
+    std::make_shared<vayu::core::RunContext> ("run-script-transport", run_config ());
+    context->test_script = fetch_script (upstream.url ("/hello"));
+    configure_run (context);
+    context->metrics_collector->record_response_sample (sampled_response ());
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_HAS_VALUE (validation.run);
+    EXPECT_EQ (validation.run->failed, 0u);
+    ASSERT_EQ (proxy.count (), 1u);
+    EXPECT_EQ (proxy.seen ().front (), upstream.url ("/hello"));
+}
+
+// The scenario shape threads the policy through `replay_scenario_steps` rather
+// than setting it on the one replay, so reverting that line alone would leave
+// the case above green - the trap issue #1188's own per-step case fell into.
+TEST_F (LoadRunScriptTransportTest, ADeferredStepScriptTraversesTheRunsProxy) {
+    MockUpstream upstream;
+    MockProxy proxy;
+    set_config ("proxyMode", "manual");
+    set_config ("proxyUrl", proxy.url ());
+
+    auto context =
+    std::make_shared<vayu::core::RunContext> ("run-step-transport", run_config ());
+
+    auto execution = std::make_shared<vayu::core::ScenarioExecution> ();
+    execution->request.source        = "collection";
+    execution->request.collection_id = "col_1";
+    execution->request.iterations    = 1;
+
+    vayu::core::ScenarioStep step;
+    step.index          = 0;
+    step.name           = "Fetch";
+    step.post_script    = fetch_script (upstream.url ("/hello"));
+    step.request.method = HttpMethod::GET;
+    step.request.url    = upstream.url ("/hello");
+    execution->plan.steps.push_back (step);
+
+    context->scenario = execution;
+    configure_run (context);
+    context->metrics_collector->configure_step_samples ({ true });
+    context->metrics_collector->record_step_response_sample (sampled_response (), 0,
+    vayu::core::SampleIdentity{ /*iteration=*/0, /*vu=*/1, /*data_row_index=*/std::nullopt });
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_EQ (validation.steps.size (), 1u);
+    ASSERT_HAS_VALUE (validation.steps[0]);
+    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    ASSERT_EQ (proxy.count (), 1u);
+    EXPECT_EQ (proxy.seen ().front (), upstream.url ("/hello"));
+}
+
+// The other direction, which is what makes the two above about the *run's*
+// policy rather than about any policy: a run configured to bypass the proxy
+// keeps its script off it too. Without this, wiring the replay to a policy
+// resolved from anywhere at all would pass.
+TEST_F (LoadRunScriptTransportTest, ADeferredScriptStaysOffTheProxyWhenTheRunDoes) {
+    MockUpstream upstream;
+    MockProxy proxy;
+    // `off` writes an empty `CURLOPT_PROXY` rather than skipping the option, so
+    // the environment's own `http_proxy` cannot decide this one either way.
+    set_config ("proxyMode", "off");
+    set_config ("proxyUrl", proxy.url ());
+
+    auto context =
+    std::make_shared<vayu::core::RunContext> ("run-script-no-proxy", run_config ());
+    context->test_script = fetch_script (upstream.url ("/hello"));
+    configure_run (context);
+    context->metrics_collector->record_response_sample (sampled_response ());
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_HAS_VALUE (validation.run);
+    EXPECT_EQ (validation.run->failed, 0u);
+    EXPECT_EQ (proxy.count (), 0u);
 }
 
 TEST (TransportPolicyPaths, LoadRunTraversesManualProxy) {

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -899,8 +899,9 @@ TEST_F (LoadRunScriptTransportTest, ADeferredStepScriptTraversesTheRunsProxy) {
     const auto validation = vayu::core::validate_scripts (context, *db_, false);
 
     ASSERT_EQ (validation.steps.size (), 1u);
-    ASSERT_HAS_VALUE (validation.steps[0]);
-    EXPECT_EQ (validation.steps[0]->failed, 0u);
+    const auto& step_totals = validation.steps[0];
+    ASSERT_HAS_VALUE (step_totals);
+    EXPECT_EQ (step_totals->failed, 0u);
     ASSERT_EQ (proxy.count (), 1u);
     EXPECT_EQ (proxy.seen ().front (), upstream.url ("/hello"));
 }

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -12,6 +12,16 @@
  * end.
  */
 
+// Before the first include, because `curl/curl.h` below reaches `windows.h` -
+// whose `min` / `max` macros then break the `std::numeric_limits<...>::max ()`
+// in `load_pacing.hpp` that `vayu/core/run_manager.hpp` pulls in for the load
+// path's cases. `NOMINMAX` is PRIVATE to `vayu_core` (`engine/CMakeLists.txt`),
+// so this target never gets it - the same trap `client.hpp` documents for
+// `daemon.cpp`, and the reason it names its own enum rather than curl's.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <curl/curl.h>
 #include <gtest/gtest.h>
 #include <httplib.h>


### PR DESCRIPTION
## Description

A `pm.sendRequest` out of a load run's deferred `tests` script left through a
default-constructed `TransportPolicy` - the environment pickup - while every
transfer of the run it was asserting on left through `loop_config.transport`,
resolved once at run start from `proxyMode` / `proxyUrl` / `proxyBypass`.
`ScriptContext::transport` exists precisely so the two agree (#705); every
design-mode caller set it and the load path's one script caller (`run_replay`)
never did. Behind `proxyMode: manual` the script's fetch skipped the proxy the
run went through and reported a healthy target as broken; with `proxyMode: off`
it picked up the `HTTP_PROXY` the run deliberately bypassed; and against an mTLS
host it presented no certificate, the registry riding inside the same policy
(#706, #707).

**Root cause and approach.** The policy now reaches the deferred pass the way
#1188 carried the response byte bound: a field on `ScriptReplay` beside
`sse_limits` and `max_response_bytes`, threaded through `replay_scenario_steps`
for the per-step scenario shape as well as set on the single-request replay, and
assigned onto `script_ctx` in `run_replay`. The one decision worth stating is
**where the value comes from**, and this takes the run's own snapshot rather
than a fresh read: `configure_event_loop` - the one place a load run resolves a
policy - keeps it on `RunContext::transport`, and `validate_scripts` reads that.
The alternative I rejected is the one-liner `resolve_transport_policy (db)` in
`validate_scripts`, consistent with the `scriptTimeout` / `sse_limits` / byte
bound reads right beside it: a bound and a route are different questions. A
bound is what the pass may read *now*, so reading it now is right; a route is
what the traffic being asserted on actually took, and a run lasts minutes with
its settings editable throughout - so a re-read is exactly the "two halves of
one run resolving a proxy independently" the issue names. It is the reasoning
`scenario_runner.cpp` already applies to its own run-scoped `transport` (#705,
epic decision 3 of #704), one run later in the lifecycle.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t`, then `ctest --preset linux-dev --output-on-failure`
from `engine/`: **2835 tests run, 2835 passed, 0 failed**, including the three
new cases. No pre-existing failures on this base. The diff touches no app
surface, so the app suites were not run.

Three new cases in `transport_policy_test.cpp`'s "every outbound path traverses
the proxy" section, which was missing this path. They drive the whole carry
rather than one assignment of it - set `proxyMode` / `proxyUrl`, go through
`configure_event_loop` the way `execute_load_test` does, then replay - and each
mutation below was run, not reasoned about:

| Reverted line | Result |
|---|---|
| `script_ctx.transport = replay.transport` (`run_replay`) | both proxy cases fail |
| `context->transport = loop_config.transport` (`configure_event_loop`) | both proxy cases fail |
| `replay.transport = transport` (`replay_scenario_steps`) | **only** the per-step case fails |

- `ADeferredScriptTraversesTheRunsProxy` - the single-request shape.
- `ADeferredStepScriptTraversesTheRunsProxy` - the scenario shape threads the
  policy per step, so reverting that line alone leaves the case above green (the
  trap #1188's own per-step case fell into); it is a separate case for that
  reason.
- `ADeferredScriptStaysOffTheProxyWhenTheRunDoes` - the `off` direction, which
  is what makes these about the *run's* policy rather than about any policy.

`clang-format` 19 clean on the touched files; `clang-tidy` 19 clean on both
changed translation units. `mkdocs build --strict` was not run (mkdocs is not
installed in this environment); the docs edits add no links, anchors or nav
entries.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/scripting.md` had no statement about which
route a script's fetch takes at all - the `pm.sendRequest` section now says it
leaves the way its execution leaves, and which policy that is per path;
`docs/architecture.md`'s outbound-transport enumeration named every path but a
script's own send.

## Related Issues
Closes #1256
