### PR TITLE
fix(app): keep the palette's two lead sections disjoint, and correct three records - #1197

### DIFF
--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -575,6 +575,31 @@ describe("the list's height", () => {
 		// declarations ship and the smaller one wins on source order.
 		expect(cls).not.toContain("max-h-[300px]");
 	});
+
+	it("pins the row padding the row count is counted in", () => {
+		/*
+		 * The cap is one input to "about eleven rows"; the row's own height is
+		 * the other, and a padding change would halve the visible count with the
+		 * assertion above still green - jsdom has no layout, so nothing here can
+		 * measure the rows themselves. So pin the padding they are drawn with:
+		 * `CommandItem`'s `px-2 py-1.5` is the 32px single-line row, read off a
+		 * rendered palette row rather than the primitive, since a caller's
+		 * `className` goes through tailwind-merge and can replace it - which is
+		 * exactly what `command.chrome.test.tsx`'s density read of the bare
+		 * primitive cannot see.
+		 *
+		 * The row *count* itself stays a manual measurement: eleven rows and two
+		 * headings in Chromium at a 768px window, nine at 600px (#1177).
+		 */
+		renderPalette();
+		open();
+
+		const row = document.querySelector('[data-slot="command-item"]');
+		expect(row).not.toBeNull();
+		const cls = (row?.getAttribute("class") ?? "").split(/\s+/);
+		expect(cls).toContain("px-2");
+		expect(cls).toContain("py-1.5");
+	});
 });
 
 /**

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -582,8 +582,9 @@ describe("the list's height", () => {
 		 * the other, and a padding change would halve the visible count with the
 		 * assertion above still green - jsdom has no layout, so nothing here can
 		 * measure the rows themselves. So pin the padding they are drawn with:
-		 * `CommandItem`'s `px-2 py-1.5` is the 32px single-line row, read off a
-		 * rendered palette row rather than the primitive, since a caller's
+		 * `CommandItem`'s `px-2 py-1.5` is the row measured at 30.0px in
+		 * Chromium, read off a rendered palette row rather than the primitive,
+		 * since a caller's
 		 * `className` goes through tailwind-merge and can replace it - which is
 		 * exactly what `command.chrome.test.tsx`'s density read of the bare
 		 * primitive cannot see.

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -85,9 +85,11 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	/*
 	 * The sections above the fixed order, in the order they render. Each holds
 	 * rows lifted out of the sections below rather than copied into it - two
-	 * rows carrying the same `value` would both read as selected - so at most
-	 * one of these is ever populated at a time: the top result answers a typed
-	 * query, Recents and the verbs answer an empty one.
+	 * rows carrying the same `value` would both read as selected - so no row
+	 * reaches this list twice. The top result answers a typed query and Recents
+	 * and the verbs both answer an empty one, so the two of them do render
+	 * together; a row that qualifies for both belongs to Recents, the earlier
+	 * section, and `ranking.ts` has already taken it out of the other.
 	 */
 	const lead: LeadSection[] = [
 		{ key: "top", heading: TOP_RESULT_LABEL, items: ranked.top },

--- a/app/src/modules/palette/ranking.test.ts
+++ b/app/src/modules/palette/ranking.test.ts
@@ -274,6 +274,25 @@ describe("the empty query's lead sections", () => {
 		expect(ranked.groups.map((g) => g.kind)).toEqual(["settings"]);
 	});
 
+	it("gives a dated command to Recents alone, not to both sections", () => {
+		/*
+		 * The two predicates overlap: a verb is a `command` row, a recent is one
+		 * carrying a stamp, and a row can answer both. No source stamps a
+		 * command today, so this is the guard on the day one does - without the
+		 * exclusion in `rankPalette` the row renders under both headings, under
+		 * one cmdk `value`, and `total` counts it twice.
+		 */
+		const items = [
+			item({ id: "dated-verb", kind: "command", recencyAt: 3000 }),
+			item({ id: "verb", kind: "command" }),
+		];
+		const ranked = rankPalette(items, "");
+		expect(ranked.recents.map((i) => i.id)).toEqual(["dated-verb"]);
+		expect(ranked.quickActions.map((i) => i.id)).toEqual(["verb"]);
+		expect(rendered(items, "")).toEqual(["dated-verb", "verb"]);
+		expect(ranked.total).toBe(2);
+	});
+
 	it("has neither section once something is typed", () => {
 		const items = [
 			item({ id: "verb", kind: "command", title: "Import collection" }),

--- a/app/src/modules/palette/ranking.ts
+++ b/app/src/modules/palette/ranking.ts
@@ -129,7 +129,9 @@ export interface RankedPalette {
 	/**
 	 * The verbs the palette offers: at the head of the empty query, and again
 	 * when a typed query matched nothing at all. In between - a query with
-	 * results - they rank as the `command` section they have always been.
+	 * results - they rank as the `command` section they have always been. On the
+	 * empty query, minus any verb Recents already holds: the row renders there
+	 * instead, one section up.
 	 */
 	quickActions: PaletteItem[];
 	/** The familiar fixed order, minus whatever was promoted or lifted. */
@@ -153,16 +155,28 @@ export interface RankedPalette {
  *
  * The empty query answers that question with two sections of its own, above the
  * fixed order: Recents, and the verbs. Both are *lifted* out of the sections
- * their rows belong to rather than copied into the new ones - the same rule the
- * top result follows, and for the same reason: two rows carrying the same cmdk
- * `value` would both read as selected.
+ * their rows belong to - and out of each other - rather than copied into the
+ * new ones, the same rule the top result follows and for the same reason: two
+ * rows carrying the same cmdk `value` would both read as selected.
  */
 export function rankPalette(items: PaletteItem[], query: string): RankedPalette {
 	const needle = query.trim();
 	if (needle === "") {
-		const quickActions = verbsOf(items);
+		/*
+		 * The lead sections render in the order they are built and the earlier
+		 * one owns the row, which is the precedence the top result already sets.
+		 * The two predicates are independent - a verb is a `command` row, a
+		 * recent is one carrying a `recencyAt` stamp - and nothing stops a row
+		 * from answering both, so without the exclusion one added stamp would
+		 * put a row under both headings: two rows carrying one cmdk `value`,
+		 * reading as selected together, counted twice in `total`. No source
+		 * stamps a command today, so this changes no screen; it is what keeps
+		 * the one that does from arming the defect silently.
+		 */
 		const recents = recentsOf(items);
-		const lifted = new Set([...quickActions, ...recents].map((item) => item.id));
+		const recentIds = new Set(recents.map((item) => item.id));
+		const quickActions = verbsOf(items).filter((item) => !recentIds.has(item.id));
+		const lifted = new Set([...recents, ...quickActions].map((item) => item.id));
 		const groups = groupsOf(
 			items.filter((item) => !lifted.has(item.id)),
 			(ofKind) => rankForEmptyQuery(ofKind)

--- a/app/src/modules/palette/sources/useSettingsItems.ts
+++ b/app/src/modules/palette/sources/useSettingsItems.ts
@@ -26,8 +26,8 @@
  *   which rows are settings results is decided once, here. Their order on
  *   screen is not: `ranking.ts` re-sorts every section by the score it gave the
  *   row, so the palette can list what it kept in an order the sidebar would
- *   not, deliberately, since the palette ranks these rows against six other
- *   kinds and the sidebar ranks them against each other.
+ *   not, deliberately, since the palette scores these rows by the one measure
+ *   it scores every other kind by and the sidebar ranks them among themselves.
  */
 
 import { useMemo } from "react";

--- a/app/src/modules/palette/sources/useSettingsItems.ts
+++ b/app/src/modules/palette/sources/useSettingsItems.ts
@@ -21,8 +21,13 @@
  *   registry; indexing them here would put every settings screen in the group
  *   twice, under two rows that do the same thing.
  * - **It does not own a matcher.** `searchSettings` is the sidebar's ranking,
- *   and a palette that ranked settings differently from the settings sidebar
- *   would be two answers to one question. One index, one ranking, two UIs.
+ *   and a palette that matched settings differently from the settings sidebar
+ *   would be two answers to one question. One index, one matcher, two UIs -
+ *   which rows are settings results is decided once, here. Their order on
+ *   screen is not: `ranking.ts` re-sorts every section by the score it gave the
+ *   row, so the palette can list what it kept in an order the sidebar would
+ *   not, deliberately, since the palette ranks these rows against six other
+ *   kinds and the sidebar ranks them against each other.
  */
 
 import { useMemo } from "react";

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -868,6 +868,13 @@ would both read as selected, and both would be counted. A row past the Recents c
 reachable in the section it was not lifted from. Neither section is a `PaletteKind`: no source
 produces one, so a kind for it would be a shape nothing returns.
 
+They lift out of **each other** too, by the order they render: Recents is built first and the
+verbs exclude whatever it took (#1197). The two tests are independent - a verb is a `command` row,
+a recent is one carrying a `recencyAt` stamp - so a stamped command would otherwise sit under both
+headings, which is the duplicate the lift exists to prevent. No source stamps a command today, so
+this decides nothing on screen; it is what keeps the first one that does from arming the defect
+silently, and `ranking.test.ts` pins it.
+
 Once something is typed, four rules apply:
 
 - **The best match is promoted to a `Top result` section**, lifted out of its own section rather


### PR DESCRIPTION
## Description

Root cause: the empty query's two lead sections are built from independent tests over one row list - `verbsOf` keeps `kind === "command"`, `recentsOf` keeps anything carrying a `recencyAt` stamp - and nothing made them disjoint. The `lifted` set de-duped them against the fixed-order groups below, never against each other, so a row answering both tests would render under both headings (one cmdk `value`, so both copies read as selected) and `total` would count it twice. Unreachable today only because no source stamps a `command` row; one added stamp arms it silently.

Approach: Recents is built first and the verbs exclude what it took - the precedence the top result already sets, where the earlier-rendered section owns the row. Rejected the other direction (filtering Recents against the verbs): it would keep the verb list identical on the empty-query and the no-match paths, but it inverts that precedence and would make the first `recencyAt` stamp on a command do nothing at all, which is a stranger thing to debug than a verb appearing one section higher.

Also in scope from the issue:

- **Two stale comments restated.** `useSettingsItems`' "one index, one ranking, two UIs" now says what ships: the index decides which rows are settings results, `ranking.ts` decides their order, and the palette can legitimately order them differently from the sidebar because it scores them by the one measure it scores every kind by. `PaletteResults`' "at most one of these is ever populated at a time" was never true of Recents beside the verbs - it now states the rule that is true, that no row reaches the list twice and a row qualifying for both belongs to the earlier section.
- **The density promise gets its second input under test.** The list cap was pinned; the row height was not, so a padding change could have halved the visible count with everything green. The height test now also reads a rendered palette row's `px-2 py-1.5` - off a palette row rather than the bare primitive, since a caller's `className` goes through tailwind-merge and can replace it where `command.chrome.test.tsx`'s primitive read cannot see it - and states that the row count itself stays a manual Chromium measurement.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - 591 files, 6504 tests, all passing.
- `cd app && pnpm vitest run src/modules/palette` - 5 files, 89 tests passing (87 before this branch; the two added are below).
- Mutation check on the new guard: removing the `.filter((item) => !recentIds.has(item.id))` in `ranking.ts` reds `ranking.test.ts > the empty query's lead sections > gives a dated command to Recents alone, not to both sections` - the row renders twice and `total` becomes 3. Restoring it greens.
- `cd app && pnpm type-check`, `pnpm lint`, `pnpm prettier --check` on the touched app files - all clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, for the `docs/app/COMPONENTS.md` paragraph.
- No engine change, so no engine build or ctest run: nothing in this diff could turn a C++ test.

No pre-existing failures were observed on the base commit.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Two notes on deliberate deviation from the issue text:

- The issue expected no doc change. `docs/app/COMPONENTS.md` states the lift rule only against the sections *below* the lead pair, so shipping a rule between them and leaving that paragraph would have made it the stale record the rest of this PR is fixing. One paragraph added, in the same commit.
- Review turned up two adjacent things this diff does not fix, filed as #1260 rather than folded in: the palette row's chord and recency slots are mutually exclusive by the same assumption this PR hardened the ranking against, and `ui/command.tsx` still cites the 32px row height that #1177 measured at 30.0px and replaced in the docs. The second one is why the second commit here exists - the new test comment had copied that superseded figure.

## Related Issues

Closes #1197
