### PR TITLE
fix(app, engine): say which bound thinned the tested responses - #1192

### DIFF
--- a/app/src/components/shared/SampleRetentionNote.test.tsx
+++ b/app/src/components/shared/SampleRetentionNote.test.tsx
@@ -10,9 +10,10 @@
 
 /**
  * The note exists to stop a sampled list from reading as a complete one, so the
- * cases that matter are the three ways it can lie: claiming completeness when
- * records were displaced, claiming a loss when there was none, and asserting
- * either against a run that never reported the counts.
+ * cases that matter are the four ways it can lie: claiming completeness when
+ * records were displaced, claiming a loss when there was none, asserting either
+ * against a run that never reported the counts, and calling a set uniform when
+ * the run's byte budget is what thinned it (issue #1192).
  */
 
 import { describe, it, expect } from "vitest";
@@ -56,6 +57,83 @@ describe("SampleRetentionNote", () => {
 
 		expect(screen.getByText(/998,000 further responses were displaced/)).toBeInTheDocument();
 		expect(screen.getByText(/1,000 tested/)).toBeInTheDocument();
+	});
+
+	// The store is bounded twice and one counter reports both, so the marker is
+	// the only thing that says whether the uniformity sentence is true. Drop the
+	// branch and this case reddens: the note claims a uniform sample of a run
+	// that was graded on its cheap-bodied part.
+	it("does not claim uniformity when the byte budget is what thinned the tested set", () => {
+		render(
+			<SampleRetentionNote
+				sampling={sampling({
+					responseSamplesDropped: 998_000,
+					responseSampleBudgetSpent: true,
+				})}
+				shown={1_000}
+				budget="responses"
+			/>
+		);
+
+		expect(
+			screen.getByText(/1,000 tested are drawn from the part of the run whose bodies fit/)
+		).toBeInTheDocument();
+		expect(screen.queryByText(/drawn uniformly from the whole run/)).not.toBeInTheDocument();
+	});
+
+	it("keeps the uniformity sentence for a run the count cap alone thinned", () => {
+		render(
+			<SampleRetentionNote
+				sampling={sampling({
+					responseSamplesDropped: 998_000,
+					responseSampleBudgetSpent: false,
+				})}
+				shown={1_000}
+				budget="responses"
+			/>
+		);
+
+		expect(
+			screen.getByText(/1,000 tested are drawn uniformly from the whole run/)
+		).toBeInTheDocument();
+	});
+
+	// A run recorded before the engine reported which bound applied. Weakening
+	// the copy for every such run costs the accurate message in the case that is
+	// nearly all of them, so absent reads as today's sentence - it just must not
+	// read as the budget-spent one, which would assert a bias nothing measured.
+	it("reads a run recorded before the marker as today's message, not as budget-spent", () => {
+		render(
+			<SampleRetentionNote
+				sampling={sampling({ responseSamplesDropped: 900 })}
+				shown={40}
+				budget="responses"
+			/>
+		);
+
+		expect(
+			screen.getByText(/40 tested are drawn uniformly from the whole run/)
+		).toBeInTheDocument();
+		expect(screen.queryByText(/whose bodies fit/)).not.toBeInTheDocument();
+	});
+
+	// The marker belongs to the response store alone; a trace surface reading it
+	// would describe the list on screen by a budget it was never charged to.
+	it("ignores the response-budget marker on a trace surface", () => {
+		render(
+			<SampleRetentionNote
+				sampling={sampling({
+					successTracesDropped: 29_000,
+					responseSampleBudgetSpent: true,
+				})}
+				shown={100}
+				budget="traces"
+			/>
+		);
+
+		expect(
+			screen.getByText(/100 shown are drawn uniformly from the whole run/)
+		).toBeInTheDocument();
 	});
 
 	it("says nothing when the run displaced nothing", () => {

--- a/app/src/components/shared/SampleRetentionNote.tsx
+++ b/app/src/components/shared/SampleRetentionNote.tsx
@@ -18,6 +18,12 @@
  * Silent unless there is something to say: a run that dropped nothing, or one
  * whose summary predates the counts, gets no notice at all. "Nothing was
  * displaced" and "we cannot tell" are both worse as prose than as absence.
+ *
+ * What it says about the tested responses depends on which bound thinned them:
+ * the count cap displaces an incumbent and leaves a uniform sample of the run,
+ * while a spent byte budget stops admitting and leaves the part of it whose
+ * bodies fit. `sampling.responseSampleBudgetSpent` is the engine's answer to
+ * which one happened (issue #1192).
  */
 
 import { Callout } from "./Callout";
@@ -57,11 +63,23 @@ export function SampleRetentionNote({
 	const noun = budget === "traces" ? "samples" : "responses";
 	const verb = budget === "traces" ? "shown" : "tested";
 
+	// The uniformity the reservoir buys holds for every bound but one: the
+	// response store's byte budget stops admitting rather than displacing, so a
+	// run that spent it was graded on the part of it whose bodies fit. An
+	// `undefined` marker is a run recorded before the engine reported which
+	// bound applied - it keeps today's sentence, because weakening the claim for
+	// every older run costs the accurate message in the case that is nearly all
+	// of them (only a target whose retained bodies average more than ~256 KiB
+	// can reach the budget at the defaults).
+	const budgetSpent = budget === "responses" && sampling.responseSampleBudgetSpent === true;
+
 	return (
 		<Callout severity="info" title="Bounded retention" className={className}>
 			{displaced.toLocaleString()} further {noun} were displaced by this run&apos;s retention
-			limit. The {shown.toLocaleString()} {verb} are drawn uniformly from the whole run, not
-			from its opening.
+			limit.{" "}
+			{budgetSpent
+				? `Its response-sample budget was spent, so the ${shown.toLocaleString()} tested are drawn from the part of the run whose bodies fit, not uniformly from the whole of it.`
+				: `The ${shown.toLocaleString()} ${verb} are drawn uniformly from the whole run, not from its opening.`}
 		</Callout>
 	);
 }

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2074,6 +2074,18 @@ export interface RunReport {
 		/** Responses displaced or dropped before test validation ran. */
 		responseSamplesDropped: number;
 		/**
+		 * Whether the run's response-sample **byte** budget
+		 * (`max_response_sample_bytes`) ended a sample. The count above cannot
+		 * say it: the store is bounded twice and both bounds report through it,
+		 * but only this one costs the tested set its uniformity - the count cap
+		 * displaces an incumbent, while a spent byte budget stops admitting, so
+		 * the run is graded on the part of it whose bodies fit.
+		 *
+		 * `undefined` is a run recorded before the marker existed, which is not
+		 * the same claim as `false` - see `SampleRetentionNote`.
+		 */
+		responseSampleBudgetSpent?: boolean;
+		/**
 		 * Per-status exemplars refused because the exemplar store was full
 		 * (`max_exemplar_results`). Only a target answering with more distinct
 		 * status codes than that limit can produce a non-zero figure.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1087,11 +1087,13 @@ retry is the reason for saying anything.
 
 One sentence, wherever a sampled set is displayed: how many records the run's
 bounded stores displaced, and that what is on screen is drawn uniformly from
-the whole run rather than its opening. Several surfaces show such a set - the
-dashboard's Sampled Requests card, the history Samples tab, and the shared
-`TestValidationSummary` (itself rendered in both the dashboard and the history
-Overview) - so the wording lives here once instead of being written out per
-surface and drifting.
+the whole run rather than its opening - except on the `responses` surface when
+the run's response-sample byte budget was spent, where it says instead that
+what is on screen is drawn from the part of the run whose bodies fit. Several
+surfaces show such a set - the dashboard's Sampled Requests card, the history
+Samples tab, and the shared `TestValidationSummary` (itself rendered in both
+the dashboard and the history Overview) - so the wording lives here once
+instead of being written out per surface and drifting.
 
 Renders nothing when the run displaced nothing, and nothing when the run
 reported no counts at all (an older summary): "nothing was dropped" and "we

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1206,8 +1206,15 @@ scripts are graded on. That buffer is bounded twice, and one counter reports
 both: by count (`max_response_samples`), which displaces an incumbent and so
 keeps the graded set uniform over the run, and by bytes
 (`max_response_sample_bytes`), which stops admitting once the retained bodies
-fill it. The renderer cannot tell which applied, which is why the note's
-uniformity sentence is not always true - issue #1192.
+fill it. The renderer now reads `sampling.responseSampleBudgetSpent` to tell
+which one applied (issue #1192): `true` means the byte budget ended at least
+one sample, so the graded set is drawn from the part of the run whose bodies
+fit rather than uniformly from the whole of it; `false` means only the count
+cap displaced anything, so the graded set stays uniform. The key is absent on
+a summary written before the marker existed, and absent keeps today's
+uniformity sentence rather than weakening it - only a target whose retained
+bodies average more than ~256 KiB reaches the budget at the defaults, so
+absent-as-uniform is the accurate message for nearly every older run.
 The renderer treats a non-zero count as "this list is a
 *sample* of a larger set": `SampleRetentionNote` (shared) renders under the
 dashboard's Sampled Requests, the history Samples tab and the Test Validation

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6366,7 +6366,7 @@ named it.
     "errorsDropped": 0, "successTracesDropped": 29000,
     "slowTracesDropped": 0, "responseSamplesDropped": 998000,
     "exemplarsDropped": 0, "sampleBodiesDropped": 12,
-    "responseBodiesCaptured": 23
+    "responseBodiesCaptured": 23, "responseSampleBudgetSpent": false
   },
   "monitor": {
     "samples": 60, "failures": 0,
@@ -6538,8 +6538,18 @@ target never produced. They differ in one way worth knowing: the count cap
 displaces an incumbent, so the tested set stays a uniform sample of the run,
 while an exhausted byte budget stops admitting - a run that spends it is graded
 on the part of the run whose bodies fit. The counter cannot say which bound
-applied, so the app's retention note states the uniform case for both; issue
-#1192 is that gap.
+applied on its own; `responseSampleBudgetSpent` is the answer (issue #1192).
+`true` means the byte budget ended at least one sample, so the tested set is
+drawn from the part of the run whose bodies fit; `false` means only the count
+cap displaced anything, so the tested set stays a uniform sample of the whole
+run. It is written by every run recorded since the marker existed, and is
+**absent** on a summary written before that - absent means "not known", not
+"not spent", which matters because weakening the uniform claim for every
+pre-marker run would cost the accurate message in the case that is nearly all
+of them: only a target whose retained bodies average more than ~256 KiB
+reaches the budget at the defaults. The app's retention note drops its
+uniformity sentence only when the key reads `true`; absent or `false` both
+keep it.
 
 Three of its keys are about captured responses rather than retention:
 `responseBodiesCaptured` is how many exchanges the run stored (see

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -2325,7 +2325,8 @@ The **language** is current; what is missing is the **host environment**:
   an exhausted byte budget simply stops admitting. Only a target whose retained
   bodies average more than ~256 KiB reaches it at the defaults; raise
   `maxResponseSampleBytes`, or lower `max_response_samples` so fewer, later
-  responses share the budget, if that matters for the run you are grading
+  responses share the budget, if that matters for the run you are grading. The
+  report says which one happened: `sampling.responseSampleBudgetSpent`
 - `samplesTested` in the report (`TestsSampled`) is the **size of that sample**,
   not the run's request count, and `sampling.responseSamplesDropped` beside it
   says how many responses the bound thinned away

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -497,9 +497,33 @@ class MetricsCollector {
      * count cap (`max_response_samples`) refuses or displaces a candidate; the
      * byte budget (`max_response_sample_bytes`) drops one whose body no longer
      * fits. Neither ever stores a truncated body - see the config field.
+     *
+     * The one thing the count loses is which bound applied, and the two differ
+     * in what they leave behind: a displaced incumbent keeps the retained set a
+     * uniform sample of the run, a spent byte budget stops admitting. That is
+     * what `response_sample_budget_spent()` beside this answers.
      */
     [[nodiscard]] size_t response_samples_dropped () const {
         return response_dropped_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Whether the byte budget ever ended a response sample.
+     *
+     * True means at least one sample was dropped because its body no longer fit
+     * `max_response_sample_bytes`, so the retained set is drawn from the part of
+     * the run whose bodies fit rather than uniformly from the whole of it. The
+     * drop count cannot say this: the count cap displaces an incumbent and stays
+     * uniform, and both bounds report through `response_samples_dropped()`
+     * (issue #1192).
+     *
+     * A flag rather than a second counter, deliberately. How many samples the
+     * budget ended is a number no reader acts on - what changes the reading of
+     * the report is that it was spent at all - and a second count beside the
+     * first would invite the sum, which is not the drop total.
+     */
+    [[nodiscard]] bool response_sample_budget_spent () const {
+        return response_budget_spent_.load (std::memory_order_relaxed);
     }
 
     /**
@@ -987,6 +1011,12 @@ class MetricsCollector {
     /// accepted (~k ln(n/k) of them) while what is held stays at k, and the
     /// budget would eventually freeze a reservoir that is nowhere near it.
     std::atomic<size_t> response_sample_bytes_{ 0 };
+    /// Set the first time a body no longer fits the budget above, and never
+    /// cleared: a run that spent the budget once is graded on the part of it
+    /// whose bodies fit, and a later release that frees room does not give the
+    /// dropped responses back. Read by the run summary as the one thing
+    /// `response_dropped_` cannot say (issue #1192).
+    std::atomic<bool> response_budget_spent_{ false };
 
     /**
      * @brief One reservoir per plan step, for a scenario load run's deferred

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -907,6 +907,17 @@ struct RunSummaryInputs {
 [[nodiscard]] nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs);
 
 /**
+ * @brief Snapshot what each bounded store thinned away, for the run summary.
+ *
+ * One copy so the completed-run and crashed-run summaries cannot report
+ * retention differently. Declared here rather than kept private because it is
+ * the only thing that carries a collector's counts into the stored summary: a
+ * field the collector grows and this forgets reaches no report, and nothing
+ * else in the engine would say so.
+ */
+[[nodiscard]] SamplingRetention read_retention (const MetricsCollector& mc);
+
+/**
  * @brief Wrap a per-tick stats object as a wire-ready SSE "metrics" event,
  * tagged with `id: <offset>` for Last-Event-ID resume. Extracted for testing.
  */

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -808,6 +808,11 @@ struct SamplingRetention {
     /// tab warn that the stored set may contain credentials. Deleted with the
     /// run, which makes `maxRunsRetained` the expiry for that data too.
     size_t response_bodies_captured = 0;
+    /// Whether the response-sample byte budget (`max_response_sample_bytes`)
+    /// ended at least one sample. The counts above cannot say it: both bounds
+    /// on that store report through `response_samples_dropped`, and only this
+    /// one costs the retained set its uniformity (issue #1192).
+    bool response_sample_budget_spent = false;
 };
 
 /**

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -601,6 +601,11 @@ bool MetricsCollector::claim_response_sample_bytes (size_t bytes) {
     response_sample_bytes_.fetch_add (bytes, std::memory_order_relaxed);
     if (before + bytes > config_.max_response_sample_bytes) {
         response_sample_bytes_.fetch_sub (bytes, std::memory_order_relaxed);
+        // Recorded here rather than at the two call sites, so a third store
+        // spending the same budget cannot forget to say so. This refusal is
+        // the whole of what makes the retained set non-uniform - see
+        // response_sample_budget_spent().
+        response_budget_spent_.store (true, std::memory_order_relaxed);
         return false;
     }
     return true;

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -33,22 +33,6 @@ inline int64_t now_ms () {
     .count ();
 }
 
-/// Snapshot what each bounded store thinned away, for the run summary. One
-/// copy so the completed-run and crashed-run summaries cannot report retention
-/// differently.
-SamplingRetention read_retention (const MetricsCollector& mc) {
-    SamplingRetention retention;
-    retention.errors_dropped               = mc.errors_dropped ();
-    retention.success_traces_dropped       = mc.success_results_dropped ();
-    retention.slow_traces_dropped          = mc.slow_results_dropped ();
-    retention.response_samples_dropped     = mc.response_samples_dropped ();
-    retention.exemplars_dropped            = mc.exemplar_results_dropped ();
-    retention.sample_bodies_dropped        = mc.sample_bodies_dropped ();
-    retention.response_bodies_captured     = mc.response_bodies_captured ();
-    retention.response_sample_budget_spent = mc.response_sample_budget_spent ();
-    return retention;
-}
-
 /**
  * @brief One deferred replay: a script, the samples it runs against, and the
  *        identity `pm.info` reports while it does.
@@ -197,6 +181,19 @@ std::vector<std::string>& failure_messages) {
     return totals;
 }
 } // namespace
+
+SamplingRetention read_retention (const MetricsCollector& mc) {
+    SamplingRetention retention;
+    retention.errors_dropped               = mc.errors_dropped ();
+    retention.success_traces_dropped       = mc.success_results_dropped ();
+    retention.slow_traces_dropped          = mc.slow_results_dropped ();
+    retention.response_samples_dropped     = mc.response_samples_dropped ();
+    retention.exemplars_dropped            = mc.exemplar_results_dropped ();
+    retention.sample_bodies_dropped        = mc.sample_bodies_dropped ();
+    retention.response_bodies_captured     = mc.response_bodies_captured ();
+    retention.response_sample_budget_spent = mc.response_sample_budget_spent ();
+    return retention;
+}
 
 /**
  * The run-level request and identity a single-request replay reads.

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -38,13 +38,14 @@ inline int64_t now_ms () {
 /// differently.
 SamplingRetention read_retention (const MetricsCollector& mc) {
     SamplingRetention retention;
-    retention.errors_dropped           = mc.errors_dropped ();
-    retention.success_traces_dropped   = mc.success_results_dropped ();
-    retention.slow_traces_dropped      = mc.slow_results_dropped ();
-    retention.response_samples_dropped = mc.response_samples_dropped ();
-    retention.exemplars_dropped        = mc.exemplar_results_dropped ();
-    retention.sample_bodies_dropped    = mc.sample_bodies_dropped ();
-    retention.response_bodies_captured = mc.response_bodies_captured ();
+    retention.errors_dropped               = mc.errors_dropped ();
+    retention.success_traces_dropped       = mc.success_results_dropped ();
+    retention.slow_traces_dropped          = mc.slow_results_dropped ();
+    retention.response_samples_dropped     = mc.response_samples_dropped ();
+    retention.exemplars_dropped            = mc.exemplar_results_dropped ();
+    retention.sample_bodies_dropped        = mc.sample_bodies_dropped ();
+    retention.response_bodies_captured     = mc.response_bodies_captured ();
+    retention.response_sample_budget_spent = mc.response_sample_budget_spent ();
     return retention;
 }
 
@@ -1689,7 +1690,14 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
         // by the Samples tab to warn about credentials, so it has to be
         // persisted rather than re-derived - the tab renders from the report
         // long after the collector is gone.
-        { "response_bodies_captured", inputs.retention.response_bodies_captured } };
+        { "response_bodies_captured", inputs.retention.response_bodies_captured },
+        // Which of the two bounds on the response-sample store thinned it. The
+        // count above says how much went unvalidated; this says whether what
+        // was kept is still a uniform sample of the run, which is the sentence
+        // the app's retention note prints (issue #1192). Always written, so an
+        // absent key means an engine too old to have looked - not a run that
+        // kept its uniformity.
+        { "response_sample_budget_spent", inputs.retention.response_sample_budget_spent } };
     // Omitted entirely when validation did not run, so the report keeps
     // distinguishing "no test script" from "a script that passed nothing".
     if (inputs.tests.has_value ()) {

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <chrono>
 #include <map>
+#include <optional>
 #include <thread>
 #include <utility>
 
@@ -188,6 +189,13 @@ struct ReportExtras {
     size_t response_samples_dropped = 0;
     size_t exemplars_dropped        = 0;
     size_t sample_bodies_dropped    = 0;
+    // Whether the response-sample byte budget ended a sample, which is what
+    // separates a still-uniform tested set from one drawn from the part of the
+    // run whose bodies fit (issue #1192). Empty is a summary written before the
+    // marker existed: the app cannot tell that run's case either way, so the
+    // key is left out rather than reported as `false` - "not spent" is a claim,
+    // and this one would be made about a run nothing looked at.
+    std::optional<bool> response_sample_budget_spent;
     // A scenario run's own tallies, read from the summary's `scenario` object.
     // `has_scenario` false leaves the section out entirely rather than showing
     // a load run four zeros - the section exists to say what a sequence did.
@@ -261,6 +269,16 @@ template <typename T>
 void read_number (const nlohmann::json& obj, const char* key, T& out) {
     if (obj.contains (key) && obj[key].is_number ()) {
         out = obj[key].get<T> ();
+    }
+}
+
+// Read a boolean out of a JSON object as an optional, so a key an older engine
+// never wrote stays *absent* rather than becoming `false`. A number reads as
+// nothing on purpose: the report says what the summary recorded, and a
+// malformed value is not a recording.
+void read_optional_bool (const nlohmann::json& obj, const char* key, std::optional<bool>& out) {
+    if (obj.contains (key) && obj[key].is_boolean ()) {
+        out = obj[key].get<bool> ();
     }
 }
 
@@ -393,6 +411,8 @@ void apply_summary_sampling (const nlohmann::json& summary, ReportExtras& extras
         read_number (sampling, "exemplars_dropped", extras.exemplars_dropped);
         read_number (sampling, "sample_bodies_dropped", extras.sample_bodies_dropped);
         read_number (sampling, "response_bodies_captured", extras.response_bodies_captured);
+        read_optional_bool (sampling, "response_sample_budget_spent",
+        extras.response_sample_budget_spent);
     }
 }
 
@@ -1173,7 +1193,10 @@ double target_rps) {
 
     // How much each bounded store thinned away. All zeros means the sampled
     // sets below are complete; non-zero means they are a uniform sample of the
-    // run (reservoir retention), not its opening.
+    // run (reservoir retention), not its opening - except where
+    // `responseSampleBudgetSpent` says the byte budget stopped admitting, which
+    // is the one bound that leaves the tested set drawn from the part of the
+    // run whose bodies fit.
     if (extras.has_sampling) {
         json_report["sampling"] = { { "errorsDropped", extras.errors_dropped },
             { "successTracesDropped", extras.success_traces_dropped },
@@ -1182,6 +1205,14 @@ double target_rps) {
             { "exemplarsDropped", extras.exemplars_dropped },
             { "sampleBodiesDropped", extras.sample_bodies_dropped },
             { "responseBodiesCaptured", extras.response_bodies_captured } };
+        // Only when the summary recorded it. Absent is a run written before the
+        // marker existed, which the app must be able to tell from a run that
+        // kept its uniformity - the same absent-vs-zero rule the section itself
+        // follows one level up.
+        if (extras.response_sample_budget_spent.has_value ()) {
+            json_report["sampling"]["responseSampleBudgetSpent"] =
+            *extras.response_sample_budget_spent;
+        }
     }
 
     add_optional_report_sections (extras, json_report);

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -1110,6 +1110,50 @@ TEST (MetricsCollectorSampleBudget, StepReservoirsShareTheRunsBudget) {
     EXPECT_EQ (collector.response_samples_dropped (), 8u);
 }
 
+// Issue #1192: the drop count cannot say which bound applied, and the two
+// leave different sets behind - a displaced incumbent keeps the retained set a
+// uniform sample of the run, a spent byte budget keeps the part of it whose
+// bodies fit. A run that never reaches the budget must not be marked, or the
+// app stops making the uniformity claim in the case where it holds. Remove the
+// store in claim_response_sample_bytes and the second half reddens.
+TEST (MetricsCollectorSampleBudget, OnlyTheByteBudgetMarksTheRetainedSetNonUniform) {
+    MetricsCollector count_capped ("run_count_cap", reservoir_config (4, 1'000'000));
+    for (int i = 0; i < 200; ++i) {
+        count_capped.record_response_sample (response_with_body (100));
+    }
+    ASSERT_GT (count_capped.response_samples_dropped (), 0u)
+    << "the count cap has to have displaced something for the two cases to "
+       "differ";
+    EXPECT_FALSE (count_capped.response_sample_budget_spent ())
+    << "a reservoir displacement leaves the retained set uniform over the run";
+
+    MetricsCollector budget_spent ("run_budget_spent", reservoir_config (1000, 250));
+    for (int i = 0; i < 10; ++i) {
+        budget_spent.record_response_sample (response_with_body (100));
+    }
+    EXPECT_TRUE (budget_spent.response_sample_budget_spent ());
+
+    budget_spent.release_response_samples ();
+    EXPECT_TRUE (budget_spent.response_sample_budget_spent ())
+    << "the summary is built after the retention window releases the bodies, "
+       "and freeing them does not give the dropped responses back";
+}
+
+// The per-step stores spend the same budget, so they mark the same fact - a
+// scenario run that spends it through its steps is graded on the part of the
+// run whose bodies fit, exactly as a single-request one is.
+TEST (MetricsCollectorSampleBudget, AStepStoreSpendingTheBudgetMarksItToo) {
+    MetricsCollector collector ("run_step_budget_marked", reservoir_config (10, 250));
+    collector.configure_step_samples ({ true, true });
+
+    for (int i = 0; i < 5; ++i) {
+        collector.record_step_response_sample (response_with_body (100), 0, {});
+        collector.record_step_response_sample (response_with_body (100), 1, {});
+    }
+
+    EXPECT_TRUE (collector.response_sample_budget_spent ());
+}
+
 // #1154's deferred half: the retention window keeps the tick topic and the
 // summary counters, not the bodies the deferred passes have already read. A
 // run against a large-bodied target used to hold its whole sample budget

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -539,3 +539,53 @@ TEST (RunManager, ConstructorStillAcceptsAPlainTestString) {
     RunContext ctx ("r", config);
     EXPECT_EQ (ctx.test_script, "pm.test(\"a\",()=>{});");
 }
+
+// The wiring nobody else covers: what a collector counted has to reach the
+// stored summary. A field the collector grows and `read_retention` forgets
+// reports as zero-or-false forever, which is this repo's most repeated defect -
+// so the two cases the byte-budget marker (issue #1192) exists to separate are
+// checked through the function that carries it, not off the collector alone.
+// Drop the assignment in read_retention and the first half reddens.
+TEST (ReadRetention, CarriesTheResponseSampleBudgetMarkerIntoTheSummary) {
+    MetricsCollectorConfig tight;
+    tight.expected_requests         = 100;
+    tight.response_sample_rate      = 1;
+    tight.max_response_samples      = 1000;
+    tight.max_response_sample_bytes = 250;
+    MetricsCollector spent ("run_read_retention_spent", tight);
+
+    vayu::Response response;
+    response.status_code     = 200;
+    response.body            = std::string (100, 'x');
+    response.timing.total_ms = 1.0;
+    for (int i = 0; i < 10; ++i) {
+        spent.record_response_sample (response);
+    }
+
+    RunSummaryInputs inputs;
+    inputs.retention = read_retention (spent);
+    EXPECT_TRUE (inputs.retention.response_sample_budget_spent);
+    EXPECT_GT (inputs.retention.response_samples_dropped, 0u);
+    EXPECT_TRUE (build_run_summary_payload (
+    inputs)["sampling"]["response_sample_budget_spent"]
+    .get<bool> ());
+
+    MetricsCollectorConfig roomy;
+    roomy.expected_requests         = 100;
+    roomy.response_sample_rate      = 1;
+    roomy.max_response_samples      = 2;
+    roomy.max_response_sample_bytes = 1'000'000;
+    MetricsCollector displaced ("run_read_retention_uniform", roomy);
+    for (int i = 0; i < 10; ++i) {
+        displaced.record_response_sample (response);
+    }
+
+    RunSummaryInputs uniform;
+    uniform.retention = read_retention (displaced);
+    EXPECT_GT (uniform.retention.response_samples_dropped, 0u)
+    << "the count cap has to have displaced something for the two to differ";
+    EXPECT_FALSE (uniform.retention.response_sample_budget_spent);
+    EXPECT_FALSE (build_run_summary_payload (
+    uniform)["sampling"]["response_sample_budget_spent"]
+    .get<bool> ());
+}

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -907,6 +907,52 @@ TEST_F (RunsRouteTest, ReportOmitsSamplingWhenTheSummaryPredatesIt) {
     EXPECT_FALSE (body.contains ("sampling"));
 }
 
+// Issue #1192: `responseSamplesDropped` counts both bounds on the response
+// sample store, and only one of them costs the tested set its uniformity. The
+// marker is what lets the app say which run it is looking at, so it has to
+// survive the summary -> report round trip in both states.
+TEST_F (RunsRouteTest, ReportSaysWhetherTheResponseSampleBudgetWasSpent) {
+    auto spent                                   = summary_inputs ();
+    spent.retention.response_sample_budget_spent = true;
+    seed ({ .id = "run_budget_spent", .start_time = 1000 });
+    db_->update_run_summary (
+    "run_budget_spent", vayu::core::build_run_summary_payload (spent).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_budget_spent");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body["sampling"].contains ("responseSampleBudgetSpent"));
+    EXPECT_TRUE (body["sampling"]["responseSampleBudgetSpent"].get<bool> ());
+
+    seed ({ .id = "run_count_capped", .start_time = 1000 });
+    db_->update_run_summary ("run_count_capped",
+    vayu::core::build_run_summary_payload (summary_inputs ()).dump ());
+
+    auto [ok, uniform] = vayu::http::routes::run_report_response (*db_, "run_count_capped");
+    ASSERT_EQ (ok, 200);
+    ASSERT_TRUE (uniform["sampling"].contains ("responseSampleBudgetSpent"))
+    << "a run that did not spend the budget says so, rather than reading like "
+       "a run nothing looked at";
+    EXPECT_FALSE (uniform["sampling"]["responseSampleBudgetSpent"].get<bool> ());
+}
+
+// A run recorded between the byte budget (#1155) and its marker (#1192) had
+// the budget and no record of whether it spent it. That is not the same claim
+// as "it kept its uniformity", so the key is left out rather than reported
+// false - the same absent-vs-zero rule the section itself follows.
+TEST_F (RunsRouteTest, ReportOmitsTheBudgetMarkerWhenTheSummaryPredatesIt) {
+    seed ({ .id = "run_no_marker", .start_time = 1000 });
+    auto summary = vayu::core::build_run_summary_payload (summary_inputs ());
+    summary["sampling"].erase ("response_sample_budget_spent");
+    db_->update_run_summary ("run_no_marker", summary.dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_marker");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("sampling"));
+    EXPECT_FALSE (body["sampling"].contains ("responseSampleBudgetSpent"));
+    EXPECT_EQ (body["sampling"]["responseSamplesDropped"].get<size_t> (), 900u)
+    << "the rest of the section still reads";
+}
+
 // Server vitals survive the summary -> report round trip in the shape the
 // scrape wrote them, so the section a reader sees is the one the run recorded.
 TEST_F (RunsRouteTest, ReportCarriesTheMonitorSummary) {


### PR DESCRIPTION
## Description

The response-sample store is bounded twice and both bounds report through one counter, so `SampleRetentionNote` stated the uniform case for both. Root cause: every drop lands on `response_dropped_`, and the two bounds leave different sets behind - the count cap displaces a uniformly chosen incumbent (uniform sample preserved), while a spent byte budget stops admitting, so the run is graded on the part of it whose bodies fit. The engine now records that one fact at the single `claim_response_sample_bytes` refusal - one site, so a third store spending the same budget cannot forget to say so - and carries it through every layer that holds the section: `SamplingRetention`, the stored snake_case summary (`response_sample_budget_spent`), the read-back, and the camelCase report (`responseSampleBudgetSpent`); the note then replaces its uniformity sentence when it reads true. The alternative considered and rejected was weakening the copy for every run whose marker is absent (a summary written before this landed): that costs the accurate message in the case that is nearly all of them, since only a target whose retained bodies average more than ~256 KiB reaches the budget at the defaults - so absent keeps today's sentence and only `true` changes it.

A second counter was rejected in favour of a flag: how many samples the budget ended is a number no reader acts on, and it would invite a sum that is not the drop total.

### Acceptance criteria

- A run that spent the byte budget is not described as a uniform sample - it reads "Its response-sample budget was spent, so the N tested are drawn from the part of the run whose bodies fit, not uniformly from the whole of it."
- A run thinned only by the count cap keeps today's message unchanged.
- A run recorded before the marker reads as not known: the engine omits the key rather than sending `false` (`std::optional<bool>` in `ReportExtras`, emitted only when the summary carried it), and the note keeps today's copy rather than claiming a bias nothing measured.
- Every layer that carries the section carries the key: collector accessor, `SamplingRetention`, stored summary, `apply_summary_sampling`, the camelCase report, `RunReport["sampling"]`, and the one component that reads it.

The second commit is a review finding of my own, worth calling out: `read_retention` - the only thing that carries a collector's counts into the stored summary - sat in an anonymous namespace, so both suites tested *around* it, and deleting its new assignment left every test green while a real run reported `false`. It is now declared beside `build_run_summary_payload` and pinned by a test that drives a real collector through both bounds.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t && ctest --preset linux-dev --output-on-failure` - **2840 tests, 100% passing**. Five new cases: only the byte budget marks the set non-uniform (a count-cap displacement does not), a per-step store spending the same budget marks it too, the marker survives the retention window's release, `read_retention` carries it into the stored summary for a real collector on both bounds, and the report round trip in both states plus the absent case when the stored summary predates the marker.
- `cd app && pnpm test` - **591 files, 6508 tests, all passing**, including 4 new `SampleRetentionNote` cases: budget-spent drops the uniformity sentence, marker-false keeps it, an absent marker keeps today's message rather than the budget-spent one, and a trace surface ignores the response-store marker.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean. Every changed engine file is `clang-format-19` clean.
- Mutation-checked: removing the `response_budget_spent_` store reddens the collector case, removing the `read_retention` assignment reddens the summary case, and removing the component branch reddens the app case.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit as the code: `docs/engine/api-reference.md` (the `sampling` example and the paragraph that named this issue as the open gap), `docs/app/api-integration.md` (the `report.sampling` contract), `docs/app/COMPONENTS.md` (the component entry's uniformity claim), and `docs/engine/scripting.md` (the load-script bullet that already explained the two bounds). `docs/engine/db-schema.md` was checked and left alone - it does not enumerate the section's keys.

## Related Issues
Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jcxnoe9pj2F8HniUHyAvCT