### PR TITLE
fix(app): derive the status-colour families from index.css, and correct what the doc says about amber - #1253

### DIFF
--- a/app/src/components/ui/status-color-tokens.test.ts
+++ b/app/src/components/ui/status-color-tokens.test.ts
@@ -17,7 +17,9 @@
  * Using the fill token as a foreground fails AA. The measured ratios live in
  * `docs/design-system.md` ("The bare token is the fill"), which is the one
  * record of them - every family fails at one end or the other, `destructive`
- * in dark, `status-warning` in both, the rest in light. That spread is the tell
+ * in dark, the three mode-consistent HTTP-status indicators (`status-warning`,
+ * `status-redirect`, `status-no-response`) in both, the rest in light. That
+ * spread is the tell
  * that this is not a dark-mode bug: it is the fill token standing in for the
  * foreground one, and which mode it breaks in just depends on where that fill
  * sits relative to the surface behind it.

--- a/app/src/components/ui/status-color-tokens.test.ts
+++ b/app/src/components/ui/status-color-tokens.test.ts
@@ -14,22 +14,13 @@
  * the readable *foreground*, darkened in light mode and lightened in dark so it
  * clears AA as small text or a small glyph.
  *
- * Using the fill token as a foreground fails AA. Measured live on `bg-card`
- * (contrast ratio; 4.5 is the floor for normal text, 3.0 for icons):
- *
- *   family           light bare   light -text   dark bare   dark -text
- *   destructive         4.87         5.48         1.73         5.40
- *   success             3.33         5.71         7.46         8.81
- *   warning             2.13         5.46         8.13         9.81
- *   status-success      2.30         5.71         7.53         8.81
- *   status-error        3.78         5.88         4.59         5.85
- *   status-stopped      2.79         5.73         6.23         7.40
- *   status-running      3.64         5.99         4.77         6.75
- *
- * `destructive` is the only family that fails in dark; the rest fail in light.
- * That inversion is the tell that this is not a dark-mode bug - it is the fill
- * token standing in for the foreground one, which shows up in whichever mode the
- * fill happens to sit closest to the surface behind it.
+ * Using the fill token as a foreground fails AA. The measured ratios live in
+ * `docs/design-system.md` ("The bare token is the fill"), which is the one
+ * record of them - every family fails at one end or the other, `destructive`
+ * in dark, `status-warning` in both, the rest in light. That spread is the tell
+ * that this is not a dark-mode bug: it is the fill token standing in for the
+ * foreground one, and which mode it breaks in just depends on where that fill
+ * sits relative to the surface behind it.
  *
  * So `text-<family>` is banned, including `hover:`/`focus:` prefixes and the
  * `/NN` opacity forms - a faded `-text` is no safer than a solid bare token, and
@@ -37,9 +28,13 @@
  * `bg-*`, `border-*` and `*-foreground` (the paired foreground for a solid fill)
  * are all correct uses of the bare token and are left alone.
  *
- * `status-warning` is deliberately absent from the list below: it has no `-text`
- * variant, because bare already measures 17.72 / 15.78 - banning it would only
- * force churn towards a token that does not exist.
+ * **The families are read out of `index.css`, not listed here.** A hand-written
+ * list held seven while the stylesheet had grown to ten, so `status-redirect`,
+ * `status-no-response` and `status-warning` were guarded by nothing - and the
+ * comment that had explained `status-warning`'s absence ("it has no `-text`
+ * variant") was describing a stylesheet that no longer existed (#1253). A
+ * family is now whatever declares both halves in the base palette, so the next
+ * token pair arrives guarded.
  *
  * **Known blind spot: inline styles.** This scans for the `text-<family>` class,
  * so `style={{ color: "hsl(var(--warning))" }}` walks straight past it.
@@ -57,6 +52,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { familiesWithTextPair, indexCss } from "@/lib/css-tokens.testkit";
 
 const sources: Record<string, string> = import.meta.glob("/src/**/*.{ts,tsx}", {
 	query: "?raw",
@@ -64,16 +60,8 @@ const sources: Record<string, string> = import.meta.glob("/src/**/*.{ts,tsx}", {
 	eager: true,
 });
 
-/** Families with a `-text` foreground variant. One line each to add another. */
-const FAMILIES = [
-	"destructive",
-	"success",
-	"warning",
-	"status-success",
-	"status-error",
-	"status-stopped",
-	"status-running",
-];
+/** Families with a `-text` foreground variant, as `index.css` declares them. */
+const FAMILIES = familiesWithTextPair();
 
 /**
  * `text-<family>` not followed by `-` or a word character, so `-text` and
@@ -83,37 +71,73 @@ const FAMILIES = [
  */
 const bareForeground = (family: string) => new RegExp(`\\btext-${family}(?![-\\w])`);
 
+/** Every place a scanned source uses `family`'s fill token as a foreground. */
+function bareForegroundUses(files: Record<string, string>, family: string): string[] {
+	const pattern = bareForeground(family);
+	const offenders: string[] = [];
+	for (const [path, src] of Object.entries(files)) {
+		if (path.includes(".test.")) continue;
+		src.split("\n").forEach((line, i) => {
+			// Prose in comments may name the class; only code is scanned.
+			// The token can sit far from `className` - a ternary branch on
+			// its own line, a helper returning a class string - so the line
+			// is scanned whole rather than only inside a `className=`.
+			const code = line.replace(/^\s*(\/\/|\/?\*).*$/, "");
+			if (pattern.test(code)) {
+				offenders.push(`${path}:${i + 1}: ${line.trim().slice(0, 88)}`);
+			}
+		});
+	}
+	return offenders;
+}
+
+/** A stylesheet shaped like `index.css`'s base palette, for the cases below. */
+const palette = (declarations: string) => `@layer base {\n\t:root {\n${declarations}\n\t}\n}\n`;
+
 describe("status colours use the -text token for foreground", () => {
+	it("derives its families from the stylesheet (guards the derivation)", () => {
+		expect(indexCss.length).toBeGreaterThan(1000);
+		// Empty would make every case below vanish rather than fail.
+		expect(FAMILIES.length).toBeGreaterThan(0);
+		expect(FAMILIES).toContain("status-warning");
+	});
+
+	it("takes a family only while the stylesheet declares both halves", () => {
+		const both = "\t\t--status-warning: 38 92% 36%;\n\t\t--status-warning-text: 38 90% 30%;";
+		expect(familiesWithTextPair(palette(both))).toEqual(["status-warning"]);
+
+		const bareOnly = "\t\t--status-warning: 38 92% 36%;";
+		expect(familiesWithTextPair(palette(bareOnly))).toEqual([]);
+	});
+
+	it("leaves out a family whose `-text` only aliases the bare token", () => {
+		// `--primary-text: var(--primary)` is the live case: same colour, so
+		// there is no more readable variant to prefer and nothing to ban.
+		const aliased = "\t\t--primary: 24 90% 46%;\n\t\t--primary-text: var(--primary);";
+		expect(familiesWithTextPair(palette(aliased))).toEqual([]);
+	});
+
 	it("finds -text utilities to check (guards the scan itself)", () => {
+		const used = new RegExp(`\\btext-(?:${FAMILIES.join("|")})-text\\b`, "g");
 		const total = Object.values(sources).reduce<number>(
-			(n, src) =>
-				n +
-				((src as string).match(
-					/\btext-(?:[a-z-]*?)(?:destructive|success|warning|error|stopped|running)-text\b/g
-				)?.length ?? 0),
+			(n, src) => n + ((src as string).match(used)?.length ?? 0),
 			0
 		);
 		expect(total).toBeGreaterThan(50);
 	});
 
+	it("reports the bare token where a source uses one", () => {
+		const path = "/src/components/ui/fixture.tsx";
+		const bare = { [path]: `<span className="text-status-warning">4xx</span>` };
+		expect(bareForegroundUses(bare, "status-warning")).toHaveLength(1);
+
+		const fixed = { [path]: `<span className="text-status-warning-text">4xx</span>` };
+		expect(bareForegroundUses(fixed, "status-warning")).toEqual([]);
+	});
+
 	for (const family of FAMILIES) {
 		it(`uses no bare \`text-${family}\`, which is the fill token`, () => {
-			const pattern = bareForeground(family);
-			const offenders: string[] = [];
-			for (const [path, src] of Object.entries(sources)) {
-				if (path.includes(".test.")) continue;
-				(src as string).split("\n").forEach((line, i) => {
-					// Prose in comments may name the class; only code is scanned.
-					// The token can sit far from `className` - a ternary branch on
-					// its own line, a helper returning a class string - so the line
-					// is scanned whole rather than only inside a `className=`.
-					const code = line.replace(/^\s*(\/\/|\/?\*).*$/, "");
-					if (pattern.test(code)) {
-						offenders.push(`${path}:${i + 1}: ${line.trim().slice(0, 88)}`);
-					}
-				});
-			}
-			expect(offenders).toEqual([]);
+			expect(bareForegroundUses(sources, family)).toEqual([]);
 		});
 	}
 });

--- a/app/src/design-system-doc.test.ts
+++ b/app/src/design-system-doc.test.ts
@@ -21,27 +21,13 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 import { DOC_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+import { declaredValues, indexCss as css } from "@/lib/css-tokens.testkit";
 
 /** Repository-relative, so CI can route the page this reads. See the testkit. */
 const [DESIGN_SYSTEM_DOC] = DOC_READING_GUARDS.designSystem.paths;
 
-const here = dirname(fileURLToPath(import.meta.url));
-const css = readFileSync(join(here, "index.css"), "utf8");
 const doc = readFileSync(fromRepoRoot(DESIGN_SYSTEM_DOC), "utf8");
-
-/** Every declared value for a token, anywhere in the stylesheet. */
-function declaredValues(): Map<string, Set<string>> {
-	const out = new Map<string, Set<string>>();
-	for (const m of css.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)) {
-		const value = m[2].split(/\s+/).join(" ").trim();
-		if (!out.has(m[1])) out.set(m[1], new Set());
-		out.get(m[1])!.add(value);
-	}
-	return out;
-}
 
 // The doc aligns values in columns, so `240  4% 42%` has runs of spaces. An
 // earlier version of this scan required single spaces and silently matched

--- a/app/src/lib/css-tokens.testkit.ts
+++ b/app/src/lib/css-tokens.testkit.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What `index.css` declares, for the guards that check the stylesheet against
+ * something else.
+ *
+ * Two guards now ask the same question of the same file - `design-system-doc`
+ * asks "does the doc quote a value this stylesheet declares", and
+ * `status-color-tokens` asks "which families declare a `-text` foreground" -
+ * and both answers come out of one parse. The parse lives here rather than in
+ * either guard because a second copy of it would not receive the first one's
+ * fixes: the value regex already had to learn that the doc aligns values in
+ * columns, and a copy written today would start without that.
+ *
+ * `status-color-tokens` used to answer its half by hand, listing the seven
+ * families someone had noticed. The stylesheet had since grown three more
+ * (`status-redirect`, `status-no-response`, `status-warning`), so three
+ * families with a real `-text` pair were guarded by nothing - #1253.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The stylesheet, read off disk rather than imported. vitest stubs a CSS import
+ * to `""`, and a guard that scans an empty string passes for free.
+ */
+export const indexCss: string = readFileSync(join(here, "..", "index.css"), "utf8");
+
+/** Every declared value for a token, anywhere in the stylesheet. */
+export function declaredValues(css: string = indexCss): Map<string, Set<string>> {
+	const out = new Map<string, Set<string>>();
+	for (const m of css.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)) {
+		const value = m[2].split(/\s+/).join(" ").trim();
+		if (!out.has(m[1])) out.set(m[1], new Set());
+		out.get(m[1])!.add(value);
+	}
+	return out;
+}
+
+/** An HSL triple the palette states outright, rather than aliasing with `var()`. */
+const OWN_COLOUR = /^[\d.]+ [\d.]+% [\d.]+%$/;
+
+/**
+ * The base `:root` palette - the vocabulary the `.dark` block and every accent
+ * scheme re-tune, and the only block where a token's own definition lives.
+ *
+ * Tokens that alias another (`--primary-text: var(--primary)`) are left out:
+ * the value they hold is the one they point at, so they declare no colour of
+ * their own. Anything a scheme block overrides is left out too, by only reading
+ * this block - `--primary-text` is a literal in the graphite scheme and an alias
+ * here, and it is the base palette that says what the token is *for*.
+ */
+export function basePalette(css: string = indexCss): Map<string, string> {
+	const block = /^\t:root \{([\s\S]*?)\n\t\}/m.exec(css)?.[1] ?? "";
+	const out = new Map<string, string>();
+	for (const m of block.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)) {
+		const value = m[2].split(/\s+/).join(" ").trim();
+		if (OWN_COLOUR.test(value)) out.set(m[1], value);
+	}
+	return out;
+}
+
+/**
+ * The colour families that ship a bare token and a `-text` foreground of its
+ * own - `destructive`, `success`, `warning` and the `status-*` set.
+ *
+ * A family qualifies by declaring both halves as colours in the base palette.
+ * `primary` therefore does not: `--primary-text` aliases `--primary`, so there
+ * is no second, more readable colour to prefer and nothing to ban. Should it
+ * ever be given a colour of its own, it becomes the same case as the rest and
+ * joins the list here rather than waiting to be noticed.
+ */
+export function familiesWithTextPair(css: string = indexCss): string[] {
+	const palette = basePalette(css);
+	return [...palette.keys()]
+		.filter((name) => !name.endsWith("-text") && palette.has(`${name}-text`))
+		.sort();
+}

--- a/app/src/lib/css-tokens.testkit.ts
+++ b/app/src/lib/css-tokens.testkit.ts
@@ -71,7 +71,8 @@ export function basePalette(css: string = indexCss): Map<string, string> {
 
 /**
  * The colour families that ship a bare token and a `-text` foreground of its
- * own - `destructive`, `success`, `warning` and the `status-*` set.
+ * own. Which families those are is the stylesheet's answer, not a list kept
+ * here - writing one out is what this function exists to stop.
  *
  * A family qualifies by declaring both halves as colours in the base palette.
  * `primary` therefore does not: `--primary-text` aliases `--primary`, so there

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -274,29 +274,41 @@ whole of the rule, and it is worth stating separately because the failure mode i
 easy to miss: a bare token used as a foreground still *looks* like the right
 colour, it is just too close in luminance to the surface behind it. Measured on
 `bg-card` in the running app (contrast ratio; **bold fails** the 4.5 floor for
-normal text, and the two worst also fail the 3.0 floor for icons):
+normal text, and the four values under 3.0 fail the 3.0 icon floor as well):
 
-| family           | light bare | light `-text` | dark bare | dark `-text` |
-|------------------|-----------:|--------------:|----------:|-------------:|
-| `destructive`    |       4.87 |          5.48 |  **1.73** |         5.40 |
-| `success`        |   **3.33** |          5.71 |      7.46 |         8.81 |
-| `warning`        |   **2.13** |          5.46 |      8.13 |         9.81 |
-| `status-success` |   **2.30** |          5.71 |      7.53 |         8.81 |
-| `status-error`   |   **3.78** |          5.88 |      4.59 |         5.85 |
-| `status-stopped` |   **2.79** |          5.73 |      6.23 |         7.40 |
-| `status-running` |   **3.64** |          5.99 |      4.77 |         6.75 |
-| `status-warning` |      17.72 |         17.72 |     15.78 |        15.78 |
+| family              | light bare | light `-text` | dark bare | dark `-text` |
+|---------------------|-----------:|--------------:|----------:|-------------:|
+| `destructive`       |       4.87 |          5.48 |  **1.73** |         5.40 |
+| `success`           |   **3.33** |          5.71 |      7.46 |         8.81 |
+| `warning`           |   **2.13** |          5.46 |      8.13 |         9.81 |
+| `status-success`    |   **2.30** |          5.71 |      7.53 |         8.81 |
+| `status-error`      |   **3.78** |          5.88 |      4.59 |         5.85 |
+| `status-stopped`    |   **2.79** |          5.73 |      6.23 |         7.40 |
+| `status-running`    |   **3.64** |          5.99 |      4.77 |         6.75 |
+| `status-warning`    |   **3.98** |          5.46 |  **4.35** |         9.81 |
+| `status-redirect`   |   **4.34** |          7.86 |  **3.99** |         5.64 |
+| `status-no-response`|   **3.98** |          6.69 |  **4.34** |         6.71 |
 
-Note the inversion: `destructive` is the only family that fails in **dark**,
-every other family fails in **light**. That rules out "a dark-mode bug" as the
-diagnosis - the single cause is the fill token standing in for the foreground
-one, and which mode it breaks in just depends on where that fill sits relative to
-the surface. `destructive` on `bg-destructive/10` and on `bg-background` measures
-worse still (4.14 / 4.43 light, 1.69 / 1.99 dark), so a tinted error chip is the
-worst case, not the safe one.
+Which mode a family fails in is not a property of the mode. `destructive` fails
+in **dark** alone, the six above it in **light** alone, and the last three - the
+mode-consistent indicators added for HTTP status - in **both**, because a value
+tuned to read as a dot on either card is by construction near the middle. That
+spread rules out "a dark-mode bug" as the diagnosis: the single cause is the fill
+token standing in for the foreground one, and which mode it shows up in just
+depends on where that fill sits relative to the surface. `destructive` on
+`bg-destructive/10` and on `bg-background` measures worse still (4.14 / 4.43
+light, 1.69 / 1.99 dark), so a tinted error chip is the worst case, not the safe
+one.
 
-`status-warning` is the exception: it has no `-text` variant, because the bare
-token already measures 17.72 / 15.78. Leave it as-is.
+`status-warning` used to be recorded here as an exception with no `-text`
+variant. It has one - `--status-warning-text`, holding the same value as
+`--warning-text` in both themes, which is why its `-text` column repeats that
+row's figures rather than stating a second number for one colour. The bare amber
+is the family's worst case rather than its safe one: 3.98 on the card, 3.63 on
+`--background`, 3.38 on `--muted` / `--accent` and 3.54 on its own `/10` tint, so
+it clears the 3.0 icon floor everywhere and the 4.5 text floor nowhere. The
+`-text` variant clears both on all four (5.46 / 4.98 / 4.64 / 4.86 light), its
+worst being the `--muted` case the light-amber floor above is quoted from.
 
 Icons count. 1.73 fails the non-text threshold as surely as the text one, so a
 red `AlertCircle` is in scope, not just the sentence next to it. So are opacity
@@ -314,7 +326,10 @@ a `Trash2` at `size="icon"`. Putting a text label in it would stop it passing.
 `app/src/components/ui/status-color-tokens.test.ts` enforces this: it fails on
 any `text-<family>` in `app/src` (including `hover:`/`focus:` prefixes and `/NN`
 opacity forms) while allowing `bg-*`, `border-*` and `*-foreground`, which are
-correct uses of the fill token.
+correct uses of the fill token. It reads the families out of `index.css` - every
+token declaring both a bare value and a `-text` one in the base palette - rather
+than listing them, so a family added to the stylesheet arrives guarded. A
+hand-written list held seven while the stylesheet had ten.
 
 **Non-text contrast (WCAG 1.4.11) is a separate 3.0 bar**, and it applies to
 things text contrast never touches: focus rings, control boundaries, and the
@@ -507,6 +522,12 @@ same "good / bad / busy" signal on either surface. Distinct from `--success` /
 --status-running: 217 91% 60%;   /* blue-500   - running */
 --status-stopped: 25 95% 53%;    /* orange-500 - stopped */
 /* pending → text-muted-foreground / bg-muted-foreground */
+
+/* The HTTP-status half of the same family, added with that vocabulary below.
+   Amber cannot follow the -500 convention - see the note further down. */
+--status-redirect: 258 60% 62%;     /* violet  - 3xx, redirect */
+--status-no-response: 240 5% 52%;   /* neutral - status 0, nothing came back */
+--status-warning: 38 92% 36%;       /* amber   - 4xx, client error */
 ```
 
 **A status colour has three jobs, and three tokens.** The base value above is

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -307,8 +307,11 @@ row's figures rather than stating a second number for one colour. The bare amber
 is the family's worst case rather than its safe one: 3.98 on the card, 3.63 on
 `--background`, 3.38 on `--muted` / `--accent` and 3.54 on its own `/10` tint, so
 it clears the 3.0 icon floor everywhere and the 4.5 text floor nowhere. The
-`-text` variant clears both on all four (5.46 / 4.98 / 4.64 / 4.86 light), its
-worst being the `--muted` case the light-amber floor above is quoted from.
+`-text` variant clears both on all four (5.46 / 4.98 / 4.64 / 4.86 light). Its
+worst is the `--muted` case the light-amber floor above is quoted from, and the
+two figures differ in the last place - 4.64 computed from the declared triple,
+4.63 measured in the browser, which quantises to 8-bit channels first. That is
+the size of the gap between the two methods across this whole page.
 
 Icons count. 1.73 fails the non-text threshold as surely as the text one, so a
 red `AlertCircle` is in scope, not just the sentence next to it. So are opacity


### PR DESCRIPTION
## Description

**Root cause.** `status-color-tokens.test.ts` enforced its rule over a list of families written by hand, and the stylesheet outgrew it. `index.css` declares ten families with a `-text` pair; the list held seven, so `status-redirect`, `status-no-response` and `status-warning` had a real foreground token and no guard over their bare one. The comment explaining the last one's absence - "it has no `-text` variant, because bare already measures 17.72 / 15.78" - and its twin at `docs/design-system.md:298` were describing a stylesheet that no longer exists: `--status-warning-text` is declared in both themes (`index.css:342,652`) and ten source files already use it.

**Approach.** Derive the list instead of restating it. A family is a token that declares *both* halves as colours in the base `:root` palette. That rule answers the `primary` question on its own: `--primary-text: var(--primary)` is an alias, so `primary` declares no second, more readable colour and there is nothing to ban - and on the day it is given one, it joins the guard rather than waiting to be noticed. The parse itself moves to `lib/css-tokens.testkit.ts`, because `design-system-doc.test.ts` was already doing it and a second copy would not receive the first one's fixes (its value regex has already had to learn that the doc aligns values in columns).

**Rejected alternative:** deriving from every `--token:` declaration in the file, which is the obvious reading of "any `--X` whose `--X-text` is also declared". It pulls in `primary`, because the graphite accent scheme overrides `--primary-text` with a literal (`index.css:546`) - and `text-primary` is a correct, deliberate utility in 47 places, so the guard would have gone red on landing. The base palette is where a token's own definition lives; scheme blocks re-tune it.

The amber ratios were then recomputed rather than restated, and `--status-warning` turns out to be the family's worst case, not its safe one.

### The measurements

WCAG 1.4.3 from the declared HSL triples. The method reproduces every existing row of the doc's table within **0.04**, which is what makes the eleventh row's disagreement a finding rather than a different ruler:

| family | doc light bare / `-text` | recomputed | doc dark bare / `-text` | recomputed |
|---|---|---|---|---|
| `destructive` | 4.87 / 5.48 | 4.87 / 5.49 | 1.73 / 5.40 | 1.73 / 5.36 |
| `success` | 3.33 / 5.71 | 3.35 / 5.68 | 7.46 / 8.81 | 7.45 / 8.80 |
| `warning` | 2.13 / 5.46 | 2.14 / 5.46 | 8.13 / 9.81 | 8.09 / 9.79 |
| `status-success` | 2.30 / 5.71 | 2.30 / 5.68 | 7.53 / 8.81 | 7.53 / 8.80 |
| `status-error` | 3.78 / 5.88 | 3.78 / 5.87 | 4.59 / 5.85 | 4.57 / 5.83 |
| `status-stopped` | 2.79 / 5.73 | 2.78 / 5.74 | 6.23 / 7.40 | 6.21 / 7.37 |
| `status-running` | 3.64 / 5.99 | 3.63 / 5.98 | 4.77 / 6.75 | 4.77 / 6.76 |
| **`status-warning`** | **17.72 / 17.72** | **3.98 / 5.46** | **15.78 / 15.78** | **4.35 / 9.81** |

**No other row is restated**, per the issue's instruction: the deltas above are all <= 0.04 and are the browser-versus-formula difference, not drift, so the hand-measured figures stand as they are.

Two independent corroborations that 3.98 is right and 17.72 is not: `docs/design-system.md:227` already records **3.98** on the card for `--series-warning`, which is the identical triple `38 92% 36%`; and `index.css:319-324` records amber-500 at 2.14, the neighbouring value. 17.72 is not a ratio either amber produces against any surface `index.css` declares.

The new row's `-text` columns repeat the `warning` row's figures deliberately: `--warning-text` and `--status-warning-text` hold the *same* HSL in both themes, and a second number for one colour is the drift #1252 spent a diff removing.

`status-redirect` and `status-no-response` gain rows too, since the guard now covers them and the table is what justifies the ban per family. All three fail 4.5 in **both** themes - a value tuned to read as a dot on either card is by construction near the middle - which contradicted the paragraph under the table claiming `destructive` is the only family failing in dark. That paragraph is rewritten rather than left standing next to a table that now disproves it.

### Deliberate deviations from the issue

- **The comment's copy of the ratio table is deleted, not extended.** The issue asks only that the "no `-text` variant" sentence go. But the header comment carried a second copy of the doc's eight-row table, and keeping it meant either adding a duplicate `status-warning` row or leaving the copy knowingly short. It now cites `docs/design-system.md` as the one record - the same "one number for one fact" move #1252 made.
- **The caption above the table said "the two worst also fail the 3.0 floor for icons".** Four of its values are under 3.0 (1.73, 2.13, 2.30, 2.79), and were before this change. Corrected in passing because it is the sentence introducing the table whose numbers this diff changes, and `app/CLAUDE.md:184` asks for exactly that: "if you change a value, read the sentence around it."
- **The issue names `app/src/components/ui/design-system-doc.test.ts`.** The file is at `app/src/design-system-doc.test.ts`.
- **The issue lists nine `text-status-warning-text` call sites**; there are ten - `app/src/constants/http-status.ts:108` is the tenth. No code change was needed at any of them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **591 files, 6511 tests, all passing.** The base commit (`a332853`) was run first and is green at 591 / 6504, so there are no pre-existing failures to report and the delta is exactly the 7 cases added: 4 named cases plus 3 more per-family scans, the families having gone from 7 to 10. `pnpm type-check`, `pnpm lint` and `pnpm format:check` are clean. `mkdocs build --strict` builds.

Three mutation checks, each run by breaking the thing and confirming the red:

1. **The newly covered family is really covered.** Changing `http-status.ts:108` from `text-status-warning-text` to the bare `text-status-warning` reds "uses no bare `text-status-warning`, which is the fill token", naming the file and line. Under the old hardcoded list that edit was silent.
2. **The scan is really scanning.** Making `bareForeground`'s pattern unmatchable reds "reports the bare token where a source uses one" and nothing else - so that fixture case is load-bearing rather than decorative.
3. **The new doc values are really checked.** Changing one digit of `--status-redirect` in the doc's `css` block reds `design-system-doc.test.ts` with `doc says "258 60% 61%", index.css has "258 60% 62%"`.

The derivation itself is pinned by two cases over a fixture stylesheet rather than the real one, so they state the rule instead of the current answer: a family with both halves derives, the same family with the `-text` declaration removed drops out (rather than throwing), and a family whose `-text` only aliases the bare token never appears.

Two floors are kept, both of which fail loudly rather than silently: the `-text` utility count (> 50, now built from the derived families rather than a second hardcoded alternation baked into a regex literal), and a new assertion that the derived list is non-empty - an empty one would make every per-family case *vanish* rather than fail, which is worse than the drift being fixed.

Not run: the engine build or `ctest`. Nothing under `engine/` is touched, per the root `CLAUDE.md` rule on scaling verification to what a change could break.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/design-system.md` gains the corrected amber row and two more, a rewritten paragraph under the table, a replacement for the "it has no `-text` variant" claim that records the four-surface measurement the issue asked for (3.98 card / 3.63 background / 3.38 muted / 3.54 on its own `/10` tint for the bare token; 5.46 / 4.98 / 4.64 / 4.86 for `-text`), the three missing tokens in the `css` block, and a line saying the guard derives its families. `docs/app/COMPONENTS.md` and `app/CLAUDE.md:125-128` describe the three-token split and the guard's rule, both unchanged by this diff. No heading renamed, no page, link or nav entry added or moved.

The new module reads only `app/src/index.css`, which is inside `app/`, so it needs no entry in `routed-inputs.testkit.ts`; `routed-inputs.test.ts` passes unedited.

## Related Issues

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8wDS1rZKDGtQ9vKewHZRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8wDS1rZKDGtQ9vKewHZRR)_