### PR TITLE
fix(app, docs): let the chord win the palette row's trailing slot, and correct the row height two records still misstate - #1260

### DIFF
--- a/app/src/components/ui/command.chrome.test.tsx
+++ b/app/src/components/ui/command.chrome.test.tsx
@@ -116,12 +116,14 @@ describe("the command list's surface and its dividers", () => {
 });
 
 describe("the command list's density", () => {
-	it("leaves a row at the primitive's 32px rather than padding it to 44px", () => {
+	it("leaves a row at the primitive's 30px rather than padding it to 44px", () => {
 		const root = renderPalette();
 		const row = root.querySelector("[cmdk-item]");
 		expect(row, "a row should render").toBeTruthy();
-		// 14px of text in `py-1.5` is the 32px single-line row this app draws
-		// everywhere else, and the launcher metric besides.
+		// 14px of text in `py-1.5` is the single-line row this app draws
+		// everywhere else, and the launcher metric besides - 30.0px measured in
+		// Chromium (`abc2bd2`, `docs/app/COMPONENTS.md`), not the 32px this said
+		// before the measurement (#1260).
 		expect(tokens(row!)).toContain("py-1.5");
 		// The dialog used to override that to `py-3` from up here, where no
 		// scan of the row itself would ever see it.

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -151,12 +151,16 @@ const CommandDialog = ({
 					/*
 					 * No row overrides here at all any more (#1177). This
 					 * string used to force `px-2 py-3` and 20px icons onto every
-					 * row, which made a 32px row a 44px one - about six of them
+					 * row, which made a 30px row a 44px one - about six of them
 					 * in a 300px list, so anything past the second section was
 					 * below the fold with nothing on screen saying it existed.
-					 * `CommandItem`'s own `px-2 py-1.5` is the 32px single-line
-					 * row this app draws everywhere else, which is also the
-					 * launcher metric, so the fix is to stop overriding it.
+					 * `CommandItem`'s own `px-2 py-1.5` is the single-line row
+					 * this app draws everywhere else, which is also the
+					 * launcher metric, so the fix is to stop overriding it. It
+					 * measures 30.0px in Chromium against the built stylesheet
+					 * - `abc2bd2` took that measurement, and
+					 * `docs/app/COMPONENTS.md` records it along with the
+					 * eleven-row count that rests on it (#1260).
 					 *
 					 * The icon sizes went the same way and were never doing what
 					 * they said: `[&_[cmdk-item]_svg]:h-5` outranks the `h-3.5`

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -33,7 +33,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CommandPalette } from "./CommandPalette";
 import { useImportModalStore, useLayoutStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
-import { useLiveCommandSurfaceStore } from "@/lib/commands";
+import { useLiveCommandSurfaceStore, type CommandContext } from "@/lib/commands";
 import { CLOSE_TAB_CHORD } from "@/constants/shortcuts";
 import { chordKeys, isMac } from "@/lib/platform";
 import { formatRelativeTime } from "@/utils";
@@ -100,6 +100,28 @@ vi.mock("@/queries", () => ({
 vi.mock("@/hooks/useVariableResolver", () => ({
 	useVariableResolver: () => ({ resolveString: (s: string) => s }),
 }));
+
+/**
+ * The row no source produces yet: a command that also carries a recency stamp.
+ * `ranking.ts` sends anything stamped to Recents (#1197), so such a row reaches
+ * `PaletteRow` with a chord *and* an age to print - the collision the trailing
+ * slots guard against (#1260). `commandItems` has no code path that writes
+ * `recencyAt`, and that is the premise under test rather than an omission, so
+ * the stamp is applied here, to one row, by id.
+ */
+const stampedCommand = vi.hoisted(() => ({ id: null as string | null, at: 0 }));
+
+vi.mock("./sources/commandItems", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./sources/commandItems")>();
+	return {
+		commandItems: (ctx: CommandContext) =>
+			actual
+				.commandItems(ctx)
+				.map((item) =>
+					item.id === stampedCommand.id ? { ...item, recencyAt: stampedCommand.at } : item
+				),
+	};
+});
 
 function renderPalette() {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -178,6 +200,7 @@ beforeEach(() => {
 	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
 	useImportModalStore.setState({ isOpen: false });
 	useSettingsStore.setState({ selectedCategory: "appearance", highlightedKey: null });
+	stampedCommand.id = null;
 	useLiveCommandSurfaceStore.setState({ startLoadTest: null });
 });
 afterEach(cleanup);
@@ -542,6 +565,31 @@ describe("the launcher sections", () => {
 		// is worse than none, since nothing would answer it.
 		const row = screen.getByText("Import collection").closest("[cmdk-item]")!;
 		expect(row.querySelectorAll("kbd")).toHaveLength(0);
+	});
+
+	it("prints the chord and not the age on a Recents row carrying both", () => {
+		const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "inbox", entityId: null }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		stampedCommand.id = "command:close-tab";
+		stampedCommand.at = fiveMinutesAgo;
+		renderPalette();
+		open();
+
+		// The stamp is what put it in Recents, and no other row is dated.
+		expect(rowsUnder("Recents")).toEqual(['Close "Inbox"']);
+
+		const row = screen.getByText('Close "Inbox"').closest("[cmdk-item]")!;
+		const caps = [...row.querySelectorAll("kbd")].map((el) => el.textContent);
+		expect(caps).toEqual(chordKeys(CLOSE_TAB_CHORD));
+		// Drop the `!item.shortcut` guard in `PaletteRow` and this is the line
+		// that reds: both slots draw, each with its own `ml-auto`, so the age
+		// no longer pushes right and the row reads `⌘W  5m ago` with the
+		// spacing of neither.
+		expect(row.textContent).not.toContain(formatRelativeTime(fiveMinutesAgo));
 	});
 
 	it("puts the keyboard hints outside the band that scrolls", () => {

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -218,10 +218,15 @@ function PaletteRow({
 					{item.subtitle}
 				</span>
 			)}
-			{/* The two trailing slots below are mutually exclusive by
-			    construction, which is why neither guards against the other: a
-			    chord belongs to a command, and no command source stamps a
-			    recency.
+			{/* One of the two trailing slots below draws, never both, and the
+			    chord is the one that wins: a stamp is why a row is in Recents,
+			    but the chord is how the row is run, and how to run it outlasts
+			    when it last was. The recency carries the guard because it is
+			    the slot that yields. Both at once would print `⌘K  2m ago` with
+			    the spacing of neither - each carries `ml-auto`, so the second
+			    no longer pushes right (#1260). No source stamps a command row
+			    today; #1197 made one survivable by keeping such a row out of
+			    two sections at once, and this is the same premise held here.
 
 			    One cap per key, the `Kbd` docstring's own chord form, drawn from
 			    the chord the handler matches rather than a second spelling of
@@ -236,7 +241,7 @@ function PaletteRow({
 					))}
 				</span>
 			)}
-			{recency && (
+			{recency && !item.shortcut && (
 				<span className="ml-auto shrink-0 pl-3 text-xs text-muted-foreground">
 					{recency}
 				</span>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -931,7 +931,10 @@ Three things the rows and the frame say (#1176):
   one. The registry carries it as `Command.shortcut`, and twelve commands have one - seven of the
   action rows plus the five drawer-view commands generated alongside them; every other row
   prints nothing, because a plausible key that answers to nothing is worse than no key at all. A
-  `Recents` row prints its age there instead, that being the reason it is in the section.
+  `Recents` row prints its age there instead, that being the reason it is in the section. A row
+  that carries both - a chord-bound command with a recency stamp, which no source produces today -
+  prints the chord: the stamp is why the row is in the section, the chord is how the row is run
+  (#1260).
   `palette-parity.test.ts` is the check that keeps the two lists honest: every chord in
   `SHORTCUT_GROUPS` either carries a command here or an entry in that file's `NO_COMMAND` map
   giving the reason it does not, so a chord cannot go undiscoverable from both surfaces without


### PR DESCRIPTION
## Description

Root cause: `PaletteRow`'s two trailing slots (`app/src/modules/palette/PaletteResults.tsx`) were mutually exclusive by an assumption - "a chord belongs to a command, and no command source stamps a recency" - and so neither guarded against the other, while both carry `ml-auto`. Tracing confirmed the premise holds today (`sources/commandItems.ts:32` is the only writer of `shortcut`; `useTabItems`/`useEntityItems`/`useRunItems` are the only writers of `recencyAt`) but is enforced by nothing: `recentsOf` (`ranking.ts:266-269`) filters on `recencyAt !== undefined` with no kind restriction, so the day a source stamps a chord-bound command, that row lands in Recents with `showRecency=true` and prints `⌘W  5m ago` with the spacing of neither slot. The approach is the one the issue proposes - make the exclusion structural, with the chord winning, since the stamp is why the row is in Recents but the chord is how the row is run. The alternative considered and rejected was letting the recency win in its own section (it is the section's reason for existing), but a slot that says how to run the row outlasts one that says when it last ran, and the chord slot is the one the rest of the app's rows also use.

Item 2 is the stale row height. `command.tsx` cited a 32px `CommandItem` row; `abc2bd2` measured that same row at 30.0px in Chromium against the built stylesheet, which is what `docs/app/COMPONENTS.md:951` records and what the eleven-row count rests on. Corrected to cite the measurement rather than restate a number.

**Deliberate deviation from the issue spec (one file beyond "App changes (required)"):** the tracing found the *same* stale 32px figure in `command.chrome.test.tsx` - in the density guard's title and its comment - which the issue did not name. Correcting only `command.tsx` would have left the primitive and its own guard disagreeing by 2px, replacing one stale record with a new contradiction, so both lines were corrected. Comments and a test title only; no assertion changed.

`docs/app/COMPONENTS.md`'s "A row's trailing edge" bullet gains one clause for the precedence the code now enforces. The issue expected no doc change here, on the reading that the passage stays true either way - it does stay true, but it is the only record of what the trailing edge prints, and it had no home for the dual row, so the rule is written where the rest of that rule already lives. Verified while there: the doc's 30px figure and eleven-row count were already correct and did not move.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **593 files, 6536 tests, all passing** (the filtered invocation ran the whole suite; the whole suite is therefore the record).
- New case `prints the chord and not the age on a Recents row carrying both` (`CommandPalette.test.tsx`): stamps one command row by id through a partial mock of `./sources/commandItems` - the real module has no code path writing `recencyAt`, which is the premise under test - then asserts the row is Recents' only row, that its caps equal `chordKeys(CLOSE_TAB_CHORD)`, and that the formatted age does **not** appear.
- Mutation-checked: with the `!item.shortcut` guard removed, that case fails on the age assertion and the rest of the file stays green.
- `pnpm lint`, `pnpm type-check`, `pnpm format:check` clean.
- No engine change, so no engine build or ctest run: no C++ or CMake file is touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1260

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5JaHf2t2v8BgNWCMQUMaQ)_