### PR TITLE
fix(app): one auto side-effect record per request, bounded by the open tabs

### DIFF
--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -19,6 +19,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from "react";
 import { RequestBuilderContext } from "./RequestBuilderContext";
 import { emptyDrafts, type BodyDrafts, type VariablesDraft } from "../utils/body-drafts";
+import { useAutoRecordSlot, UNSAVED_AUTO_KEY } from "./auto-record-slot";
 import { useVariableResolver, useSaveManager } from "@/hooks";
 import { resolveDataContract } from "@/lib/data-contract";
 import { useDataFileLimits } from "@/hooks/useDataFileLimits";
@@ -37,6 +38,8 @@ import {
 	useResponseStore,
 	useExecutionEventsStore,
 	useBoundRowStore,
+	useTabsStore,
+	type Tab,
 } from "@/stores";
 import { useRevealStore, type OperationRevealCommand } from "@/lib/graphql/reveal-store";
 import { apiService } from "@/services";
@@ -286,6 +289,14 @@ export default function RequestBuilderProvider({
 	}, []);
 
 	/*
+	 * Which request the three records below are read and written for. One
+	 * `RequestBuilderProvider` serves every request tab, so a slot holding a
+	 * single record held whichever request was in a mode last, and the request
+	 * before it kept what the app had changed for it (issue #1269).
+	 */
+	const autoRecordKey = request.id ?? UNSAVED_AUTO_KEY;
+
+	/*
 	 * The Content-Type row a body mode added on its way in, so leaving the mode
 	 * can remove it again. Here rather than in `BodyPanel` for the drafts' reason
 	 * and one of its own: the panel is unmounted whenever another tab is on
@@ -297,11 +308,11 @@ export default function RequestBuilderProvider({
 	 * drafts: the record names its own request and `switchContentType` drops one
 	 * belonging to another.
 	 */
-	const autoContentTypeRef = useRef<AutoHeader | null>(null);
-	const getAutoContentType = useCallback(() => autoContentTypeRef.current, []);
-	const setAutoContentType = useCallback((auto: AutoHeader | null) => {
-		autoContentTypeRef.current = auto;
-	}, []);
+	const {
+		get: getAutoContentType,
+		set: setAutoContentType,
+		retain: retainAutoContentTypes,
+	} = useAutoRecordSlot<AutoHeader>(autoRecordKey);
 
 	/*
 	 * The `Accept: text/event-stream` row the Event stream toggle added, so
@@ -311,11 +322,11 @@ export default function RequestBuilderProvider({
 	 * another tab - and then the header outlives the setting that needed it,
 	 * which is exactly the bug the record exists to prevent.
 	 */
-	const autoAcceptRef = useRef<AutoHeader | null>(null);
-	const getAutoAccept = useCallback(() => autoAcceptRef.current, []);
-	const setAutoAccept = useCallback((auto: AutoHeader | null) => {
-		autoAcceptRef.current = auto;
-	}, []);
+	const {
+		get: getAutoAccept,
+		set: setAutoAccept,
+		retain: retainAutoAccepts,
+	} = useAutoRecordSlot<AutoHeader>(autoRecordKey);
 
 	/*
 	 * The method the GraphQL body mode set, so leaving the mode can put back
@@ -324,11 +335,36 @@ export default function RequestBuilderProvider({
 	 * screen, and a record that does not outlive the panel leaves the method
 	 * changed with nothing left to change it back.
 	 */
-	const autoMethodRef = useRef<AutoMethod | null>(null);
-	const getAutoMethod = useCallback(() => autoMethodRef.current, []);
-	const setAutoMethod = useCallback((auto: AutoMethod | null) => {
-		autoMethodRef.current = auto;
-	}, []);
+	const {
+		get: getAutoMethod,
+		set: setAutoMethod,
+		retain: retainAutoMethods,
+	} = useAutoRecordSlot<AutoMethod>(autoRecordKey);
+
+	/*
+	 * What bounds the three slots: the open request tabs. A record is only ever
+	 * read by the request it names, so once that request has no tab it can never
+	 * be read again - and a per-request store that nothing prunes is how a ref
+	 * becomes a leak. `MAX_OPEN_TABS` caps the tab strip, so this caps the slots.
+	 *
+	 * Subscribed to rather than selected, like the reveal command above: pruning
+	 * writes to a ref, and a provider that re-rendered on every tab focus would
+	 * pay for it on the request the user is actually working in. The id-less key
+	 * survives - it names no tab, and the History run copy that uses it is the
+	 * one builder whose records nothing else could keep.
+	 */
+	useEffect(() => {
+		const retainOpen = (tabs: readonly Tab[]) => {
+			const live = new Set<string>([UNSAVED_AUTO_KEY]);
+			for (const tab of tabs) {
+				if (tab.type === "request" && tab.entityId !== null) live.add(tab.entityId);
+			}
+			retainAutoContentTypes(live);
+			retainAutoAccepts(live);
+			retainAutoMethods(live);
+		};
+		return useTabsStore.subscribe((s) => retainOpen(s.openTabs));
+	}, [retainAutoContentTypes, retainAutoAccepts, retainAutoMethods]);
 
 	const { data: collections = [] } = useCollectionsQuery();
 

--- a/app/src/modules/request-builder/context/auto-record-slot.ts
+++ b/app/src/modules/request-builder/context/auto-record-slot.ts
@@ -31,15 +31,18 @@ import { useCallback, useRef } from "react";
 /**
  * The key a record is filed under while the builder holds no saved request.
  *
- * Shares one bucket for every such builder, which is what the rules already do
- * with a `requestId` of `null` - `null === null` passes their ownership check.
  * A request tab is always opened against a request the backend has already
- * created (`useNewRequest`), so the only builder that reaches this key is the
- * read-only copy History renders for a stored run.
+ * created (`useNewRequest`), so what reaches this key is the editable copy
+ * History renders for a stored run. Every such copy shares the one bucket,
+ * which is what the rules already do with a `requestId` of `null` - `null ===
+ * null` passes their ownership check - so two run tabs open at once interfere
+ * exactly as they did before this keying, no better and no worse. Giving that
+ * copy an identity of its own is issue #1272; it needs one the provider is not
+ * handed today.
  */
 export const UNSAVED_AUTO_KEY = "__unsaved__";
 
-export interface AutoRecordSlot<T> {
+interface AutoRecordSlot<T> {
 	/** The record for the request on screen, or null if it has none. */
 	get: () => T | null;
 	/** Files a record against the request on screen; null forgets it. */

--- a/app/src/modules/request-builder/context/auto-record-slot.ts
+++ b/app/src/modules/request-builder/context/auto-record-slot.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One reversible-side-effect record *per request*, for one setting (issue
+ * #1269).
+ *
+ * The three settings that change something on their way in - the body mode's
+ * `Content-Type`, the Event stream toggle's `Accept`, the GraphQL mode's `POST`
+ * - each remember what they changed so that leaving the setting can take it
+ * back. Each record names the request it belongs to and the rules that read
+ * them (`utils/auto-header.ts`, `panels/body/graphql-method.ts`) drop one
+ * naming another request, which is the right answer to "is this record mine?"
+ * and no answer at all to "where did the other request's record go?": one
+ * `RequestBuilderProvider` serves every request tab, so a single slot per
+ * setting meant the second request into a mode overwrote the first one's
+ * record, and the first request kept the header row - or the method - the app
+ * had changed for it, with nothing left that knew it was the app's.
+ *
+ * So the storage is keyed the way the record always was. The accessors stay
+ * argument-free: the provider knows which request is on screen, and a caller
+ * that had to pass the id could pass the wrong one.
+ */
+
+import { useCallback, useRef } from "react";
+
+/**
+ * The key a record is filed under while the builder holds no saved request.
+ *
+ * Shares one bucket for every such builder, which is what the rules already do
+ * with a `requestId` of `null` - `null === null` passes their ownership check.
+ * A request tab is always opened against a request the backend has already
+ * created (`useNewRequest`), so the only builder that reaches this key is the
+ * read-only copy History renders for a stored run.
+ */
+export const UNSAVED_AUTO_KEY = "__unsaved__";
+
+export interface AutoRecordSlot<T> {
+	/** The record for the request on screen, or null if it has none. */
+	get: () => T | null;
+	/** Files a record against the request on screen; null forgets it. */
+	set: (record: T | null) => void;
+	/**
+	 * Drops every record whose key is not in `live`. Stable across renders, so
+	 * a subscription can hold it.
+	 */
+	retain: (live: ReadonlySet<string>) => void;
+}
+
+/**
+ * @param requestKey which request the accessors read and write - `request.id`,
+ * or {@link UNSAVED_AUTO_KEY} when there is none.
+ */
+export function useAutoRecordSlot<T>(requestKey: string): AutoRecordSlot<T> {
+	const byRequest = useRef(new Map<string, T>());
+
+	const get = useCallback(() => byRequest.current.get(requestKey) ?? null, [requestKey]);
+
+	const set = useCallback(
+		(record: T | null) => {
+			if (record === null) byRequest.current.delete(requestKey);
+			else byRequest.current.set(requestKey, record);
+		},
+		[requestKey]
+	);
+
+	const retain = useCallback((live: ReadonlySet<string>) => {
+		for (const key of byRequest.current.keys()) {
+			if (!live.has(key)) byRequest.current.delete(key);
+		}
+	}, []);
+
+	return { get, set, retain };
+}

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One provider serves every request tab, so what the three reversible-setting
+ * records are keyed by is a property of the provider, not of the rules that
+ * read them (issue #1269).
+ *
+ * The rules themselves are tested as logic - `utils/auto-header.test.ts`,
+ * `panels/body/graphql-method.test.ts` - and cannot see this: each is handed a
+ * record and answers for it. What could not be seen from there is that a second
+ * request entering the same mode used to overwrite the first request's record,
+ * leaving the first with a header row, or a method, the app had changed for it
+ * and nothing left that knew it was the app's.
+ *
+ * The panels are stood in for rather than driven, as in
+ * `body-drafts-lifetime.test.tsx`: `BodyPanel` only writes when a Radix
+ * `Select` commits, and a Select does not commit in jsdom. `applyModeChange`
+ * and `applyStreamToggle` below make exactly the calls the panels make, in the
+ * same order, through the real rules.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useEffect } from "react";
+import { render, act } from "@testing-library/react";
+import RequestBuilderProvider from "./RequestBuilderProvider";
+import { useRequestBuilderContext } from "./RequestBuilderContext";
+import { switchContentType } from "../components/RequestTabs/panels/body/content-type";
+import { switchGraphQLMethod } from "../components/RequestTabs/panels/body/graphql-method";
+import { switchAutoHeader } from "../utils/auto-header";
+import { useTabsStore, type Tab } from "@/stores";
+import type { BodyMode, HttpMethod, KeyValueItem } from "@/types";
+import type { RequestBuilderContextValue, RequestState } from "../types";
+
+// The provider is wired to variable resolution, the save manager and several
+// TanStack Query hooks. None of them matter to where a record is filed.
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+	}),
+	useSaveManager: () => ({ forceSave: vi.fn(), status: "idle", isSaving: false }),
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	useConfigQuery: () => ({ data: { entries: [] } }),
+}));
+
+/** What the tab strip is holding while a case runs. */
+const TABS: Tab[] = [
+	{ id: "tab_a", type: "request", entityId: "req_a" },
+	{ id: "tab_b", type: "request", entityId: "req_b" },
+];
+
+/** The live context, re-captured on every render the provider does. */
+let ctx: RequestBuilderContextValue;
+
+function Probe() {
+	const value = useRequestBuilderContext();
+	useEffect(() => {
+		ctx = value;
+	});
+	return null;
+}
+
+const tree = (id: string | null) => (
+	<RequestBuilderProvider initialRequest={{ id, name: "r" } as Partial<RequestState>}>
+		<Probe />
+	</RequestBuilderProvider>
+);
+
+/** Just enough of a request for the two rules under test. */
+interface Draft {
+	id: string | null;
+	headers: KeyValueItem[];
+	method: HttpMethod;
+	stream: boolean;
+}
+
+const fresh = (id: string | null): Draft => ({ id, headers: [], method: "GET", stream: false });
+
+/** The two writes `BodyPanel.handleModeChange` makes, in its order. */
+function applyModeChange(draft: Draft, mode: BodyMode): Draft {
+	const contentType = switchContentType(mode, draft.headers, draft.id, ctx.getAutoContentType());
+	ctx.setAutoContentType(contentType.auto);
+
+	const graphqlMethod = switchGraphQLMethod(mode, draft.method, draft.id, ctx.getAutoMethod());
+	ctx.setAutoMethod(graphqlMethod.auto);
+
+	return { ...draft, headers: contentType.headers, method: graphqlMethod.method };
+}
+
+/** The write `SettingsPanel.handleStreamChange` makes for the Event stream toggle. */
+function applyStreamToggle(draft: Draft, stream: boolean): Draft {
+	const next = switchAutoHeader(
+		"Accept",
+		stream ? "text/event-stream" : null,
+		draft.headers,
+		draft.id,
+		ctx.getAutoAccept()
+	);
+	ctx.setAutoAccept(next.auto);
+	return { ...draft, headers: next.headers, stream };
+}
+
+const headerNames = (draft: Draft) => draft.headers.map((row) => row.key);
+
+beforeEach(() => {
+	useTabsStore.setState({ openTabs: [...TABS], activeTabId: "tab_a" });
+});
+
+describe("a record per request, not per setting", () => {
+	it("lets the first request leave GraphQL after a second one has entered it", async () => {
+		const { rerender } = render(tree("req_a"));
+
+		let a = applyModeChange(fresh("req_a"), "graphql");
+		expect(headerNames(a)).toEqual(["Content-Type"]);
+		expect(a.method).toBe("POST");
+
+		// The user switches to request B and picks GraphQL there too. One provider
+		// serves both tabs, so B's records land in the same three slots.
+		await act(async () => rerender(tree("req_b")));
+		const b = applyModeChange(fresh("req_b"), "graphql");
+		expect(headerNames(b)).toEqual(["Content-Type"]);
+		expect(b.method).toBe("POST");
+
+		// Back to A, and out of GraphQL. Both of the app's changes come back out.
+		await act(async () => rerender(tree("req_a")));
+		a = applyModeChange(a, "none");
+		expect(headerNames(a)).toEqual([]);
+		expect(a.method).toBe("GET");
+	});
+
+	it("keeps the Event stream toggle's Accept row reversible on the request that armed it", async () => {
+		const { rerender } = render(tree("req_a"));
+
+		let a = applyStreamToggle(fresh("req_a"), true);
+		expect(headerNames(a)).toEqual(["Accept"]);
+
+		await act(async () => rerender(tree("req_b")));
+		applyStreamToggle(fresh("req_b"), true);
+
+		await act(async () => rerender(tree("req_a")));
+		a = applyStreamToggle(a, false);
+		expect(headerNames(a)).toEqual([]);
+	});
+
+	it("answers with nothing for a request that has entered no mode", async () => {
+		// Guards the two cases above: they would also pass if every request read
+		// one shared record back.
+		const { rerender } = render(tree("req_a"));
+		applyModeChange(fresh("req_a"), "graphql");
+
+		await act(async () => rerender(tree("req_b")));
+		expect(ctx.getAutoContentType()).toBeNull();
+		expect(ctx.getAutoMethod()).toBeNull();
+	});
+});
+
+describe("what bounds the records", () => {
+	it("forgets a request's records when its tab closes", async () => {
+		const { rerender } = render(tree("req_a"));
+		applyModeChange(fresh("req_a"), "graphql");
+		applyStreamToggle(fresh("req_a"), true);
+
+		await act(async () => useTabsStore.getState().closeTab("tab_a"));
+
+		await act(async () => rerender(tree("req_a")));
+		expect(ctx.getAutoContentType()).toBeNull();
+		expect(ctx.getAutoAccept()).toBeNull();
+		expect(ctx.getAutoMethod()).toBeNull();
+	});
+
+	it("keeps the records of the tabs that are still open", async () => {
+		const { rerender } = render(tree("req_a"));
+		const a = applyModeChange(fresh("req_a"), "graphql");
+
+		await act(async () => useTabsStore.getState().closeTab("tab_b"));
+
+		await act(async () => rerender(tree("req_a")));
+		expect(ctx.getAutoContentType()).toEqual({
+			requestId: "req_a",
+			rowId: a.headers[0].id,
+			value: "application/json",
+		});
+	});
+
+	it("keeps the records of a builder that has no request id", async () => {
+		// The History run copy is read-only-ish but still mounts the panels, and it
+		// names no tab - so the open-tab bound is not what can decide its records.
+		const { rerender } = render(tree(null));
+		applyModeChange(fresh(null), "graphql");
+
+		await act(async () => useTabsStore.getState().closeTab("tab_a"));
+
+		await act(async () => rerender(tree(null)));
+		expect(ctx.getAutoContentType()).not.toBeNull();
+	});
+});

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -113,7 +113,10 @@ export interface BodyConfig {
  * which name it is working on.
  *
  * Ephemeral, like the body drafts - `requestId` says whose row it is, and a
- * record belonging to another request is dropped rather than applied.
+ * record belonging to another request is dropped rather than applied. The
+ * provider keeps one record per request (issue #1269), so the rule reading this
+ * one is normally handed the record it owns; the check stays because the rule
+ * is a pure function that cannot know that.
  */
 export interface AutoHeader {
 	requestId: string | null;
@@ -406,6 +409,11 @@ export interface RequestBuilderContextValue {
 	 * provider for the same reasons as the drafts above - and for one more: the
 	 * record has to outlive the panel, or the header outlives the mode that
 	 * needed it, which is the bug it exists to fix.
+	 *
+	 * These accessors answer for the request on screen, and each slot holds one
+	 * record per request (issue #1269) - one provider serves every request tab,
+	 * so a slot holding a single record stranded the header the app had added to
+	 * whichever request entered the mode first.
 	 */
 	getAutoContentType: () => AutoHeader | null;
 	setAutoContentType: (auto: AutoHeader | null) => void;

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1890,8 +1890,11 @@ is subscribed to rather than selected from, because pruning writes to a ref and
 a provider that re-rendered on every tab focus would charge the request the user
 is working in for it. `MAX_OPEN_TABS` caps the tab strip, so it caps the maps.
 The one key that survives the sweep is the id-less one, shared by any builder
-holding no saved request: it names no tab, and the read-only copy History
-renders for a stored run is what uses it.
+holding no saved request: it names no tab, and the editable copy History renders
+for a stored run is what uses it. Two such copies open at once share that one
+bucket and interfere as they always have, since the rules read a `requestId` of
+`null` against another `null` as a match; giving that copy an identity of its
+own is issue #1272.
 
 In the provider rather than in the panels for the drafts' reason and one of its
 own: Radix unmounts an inactive `TabsContent`, so a panel-local record is gone

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1844,9 +1844,11 @@ Three things it is deliberate about:
   panel wrote are identical apart from their id, and only ours may be removed.
 - **A row whose value has been edited is no longer ours** - retyping it is a
   decision, so it stays and the record is dropped. Merely disabling it is not.
-- **A record naming another request is dropped, not applied.** One provider
-  serves every request tab, and row ids are not unique across a duplicated
-  request.
+- **A record naming another request is dropped, not applied.** Row ids are not
+  unique across a duplicated request, so the rule asks whose record it has been
+  handed rather than trusting the caller. Since issue #1269 the provider cannot
+  hand it the wrong one (see below); the check stays because the rule is a pure
+  function, and the storage is not the only thing that could ever call it.
 
 The third slot, `AutoMethod`, is not a fourth `AutoHeader` (issue #1228). A new
 request is a GET, and GraphQL over GET is a different transport - the document
@@ -1866,6 +1868,30 @@ request is dropped rather than applied. A GET still reaches GraphQL through the
 door this side effect does not touch - the user picks GET back, or an import
 wrote one - which is when the Query pane header's `BadgeText` names the
 transport that will be used.
+
+**Each slot holds one record per request, bounded by the open tabs** (issue
+#1269). One provider serves every request tab, and a slot holding a single
+record held whichever request entered the mode last: the request before it kept
+the `Content-Type` row, or the `POST`, that the app had added for it, with
+nothing left that knew it was the app's - the very bug the records exist to
+prevent, one request removed. So a slot is a map from request id to record
+(`context/auto-record-slot.ts`), keyed the way the record already named itself,
+and the accessors keep their argument-free shape: the provider knows which
+request is on screen, and a caller that had to pass the id could pass the wrong
+one. Resetting the records when the active request changes was the smaller
+alternative and is wrong in the same direction as the bug - it strands the first
+request's header at the moment of the switch rather than at the second request's
+mode change.
+
+What bounds the maps is the open request tabs. A record can only ever be read by
+the request it names, so once that request has no tab it is unreachable, and a
+per-request store that nothing prunes is how a ref becomes a leak; `tabs-store`
+is subscribed to rather than selected from, because pruning writes to a ref and
+a provider that re-rendered on every tab focus would charge the request the user
+is working in for it. `MAX_OPEN_TABS` caps the tab strip, so it caps the maps.
+The one key that survives the sweep is the id-less one, shared by any builder
+holding no saved request: it names no tab, and the read-only copy History
+renders for a stored run is what uses it.
 
 In the provider rather than in the panels for the drafts' reason and one of its
 own: Radix unmounts an inactive `TabsContent`, so a panel-local record is gone


### PR DESCRIPTION
## Description

`RequestBuilderProvider` is mounted once for the whole app (`Shell` renders `<RequestBuilder />` at the same position for every request tab, with no per-tab key), and each of the three reversible-side-effect slots - the body mode's `Content-Type`, the Event stream toggle's `Accept` (#574), the GraphQL mode's `POST` (#1228) - held a **single** record. The record names its request and both rules drop one naming another, which answers "is this record mine?" and not "where did the other request's record go?": the second request into a mode overwrote the first one's record, so the first kept the header row - and the method - the app had changed for it, permanently, with nothing left that knew it was the app's.

**Root cause and approach.** The record was already keyed by request; the *storage* was not. Each slot becomes a map from request id to record behind a small shared hook (`context/auto-record-slot.ts`), keyed the way the record already named itself. The accessors keep their argument-free shape - the provider knows which request is on screen, and a caller that had to pass the id could pass the wrong one - so `auto-header.ts` and `graphql-method.ts` keep their rules, their signatures and their tests unedited, and their "not mine, drop it" check stays because they are pure functions that cannot know where the record came from. What bounds the maps is the open request tabs: a record can only ever be read by the request it names, so once that request has no tab it is unreachable, and `MAX_OPEN_TABS` caps the tab strip. `tabs-store` is subscribed to rather than selected from (the pattern the provider already uses for the GraphQL reveal command), because pruning writes to a ref and a provider re-rendering on every tab focus would charge the request the user is working in for it. **The alternative rejected:** resetting the records when the active request changes - smaller, and wrong in the same direction as the bug, since it strands the first request's header at the moment of the switch rather than at the second request's mode change.

Two things found while here and deliberately left out of this diff, each filed rather than folded in:

- **#1272** - the id-less key (`UNSAVED_AUTO_KEY`, the spelling `rowIndexByRequest` already uses) is one shared bucket, and History renders an editable copy of *every* stored run with no request id, so two run tabs open at once still interfere. That is not a regression here - before this change a single record collided with every request, id-less or not - and fixing it needs an identity the provider is not handed today. The second commit says so where the key is defined and in the doc, rather than letting the comment read as a claim of isolation.
- **#1271** - `rowIndexByRequest`, the provider's other per-request map, has no bound at all.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- New: `app/src/modules/request-builder/context/auto-records-per-request.test.tsx` - 6 cases. Two requests both entering GraphQL and the first still able to leave it (header row removed, method back to `GET`); the same for the Event stream toggle's `Accept`; a request that entered no mode reading back nothing; the tab-close bound; records of still-open tabs kept; the id-less builder's records kept.
- Mutation-checked both halves: keying every record under one slot (the pre-fix shape) fails 5 of the 6; making the prune a no-op fails the tab-close case.
- `cd app && pnpm test` - 596 files, 6552 tests, all passing (595 / 6546 on the base commit, so +1 file and +6 cases, nothing else moved).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` clean. `pnpm lint` still prints the two `TSSatisfiesExpression` advisories from `jsx-ast-utils`; they print on the base commit too and are #1261, not this change.
- The panels are stood in for rather than driven: `BodyPanel` only writes when a Radix `Select` commits and a Select does not commit in jsdom, so the test makes exactly the calls `handleModeChange` and `handleStreamChange` make, in their order, through the real rules. Same reasoning as the sibling `body-drafts-lifetime.test.tsx`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/state-management.md`'s "the headers a setting added" section - the "named slots rather than one map keyed by header name" rationale stays true and gains the distinction from a map keyed by *request*, the "record naming another request" bullet says why the check survives a storage that can no longer hand it the wrong one, and a new paragraph states the bound and what the id-less key shares. `docs/app/COMPONENTS.md` was checked and needs no change: it says the record lives in the provider and that the method moves through a third slot, both still true. The `###` heading text is unchanged, so the two anchors COMPONENTS.md links to still resolve.

## Related Issues
Closes #1269
