### PR TITLE
fix(app): bound the row picker's memory by the open tabs, one sweep for both maps

### DIFF
--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -30,6 +30,7 @@ import { useCallback, useState } from "react";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 
 import { RequestBuilderContext } from "../../context";
+import { UNSAVED_AUTO_KEY } from "../../context/auto-record-slot";
 import type { RequestBuilderContextValue } from "../../types";
 import { createDefaultRequestState } from "../../utils/request-state";
 import { emptyDrafts } from "../../utils/body-drafts";
@@ -145,7 +146,7 @@ function Harness({
 	 * pick of its own.
 	 */
 	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
-	const rowMemoryKey = requestId ?? "__unsaved__";
+	const rowMemoryKey = requestId ?? UNSAVED_AUTO_KEY;
 	const rememberRowIndex = useCallback(
 		(index: number) =>
 			setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -20,6 +20,7 @@ import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } fro
 import { RequestBuilderContext } from "./RequestBuilderContext";
 import { emptyDrafts, type BodyDrafts, type VariablesDraft } from "../utils/body-drafts";
 import { useAutoRecordSlot, UNSAVED_AUTO_KEY } from "./auto-record-slot";
+import { retainKeys } from "./retain-keys";
 import { useVariableResolver, useSaveManager } from "@/hooks";
 import { resolveDataContract } from "@/lib/data-contract";
 import { useDataFileLimits } from "@/hooks/useDataFileLimits";
@@ -341,30 +342,9 @@ export default function RequestBuilderProvider({
 		retain: retainAutoMethods,
 	} = useAutoRecordSlot<AutoMethod>(autoRecordKey);
 
-	/*
-	 * What bounds the three slots: the open request tabs. A record is only ever
-	 * read by the request it names, so once that request has no tab it can never
-	 * be read again - and a per-request store that nothing prunes is how a ref
-	 * becomes a leak. `MAX_OPEN_TABS` caps the tab strip, so this caps the slots.
-	 *
-	 * Subscribed to rather than selected, like the reveal command above: pruning
-	 * writes to a ref, and a provider that re-rendered on every tab focus would
-	 * pay for it on the request the user is actually working in. The id-less key
-	 * survives - it names no tab, and the History run copy that uses it is the
-	 * one builder whose records nothing else could keep.
-	 */
-	useEffect(() => {
-		const retainOpen = (tabs: readonly Tab[]) => {
-			const live = new Set<string>([UNSAVED_AUTO_KEY]);
-			for (const tab of tabs) {
-				if (tab.type === "request" && tab.entityId !== null) live.add(tab.entityId);
-			}
-			retainAutoContentTypes(live);
-			retainAutoAccepts(live);
-			retainAutoMethods(live);
-		};
-		return useTabsStore.subscribe((s) => retainOpen(s.openTabs));
-	}, [retainAutoContentTypes, retainAutoAccepts, retainAutoMethods]);
+	// What bounds these three is stated with the row memory below, which the
+	// same sweep bounds (issue #1271): one rule over every per-request map the
+	// provider holds, rather than one rule each.
 
 	const { data: collections = [] } = useCollectionsQuery();
 
@@ -415,10 +395,11 @@ export default function RequestBuilderProvider({
 	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
 	/*
 	 * An unsaved request has no id and cannot be switched away from and back to
-	 * as itself, so every one of them shares this key. They can never collide:
-	 * a request tab holds exactly one draft.
+	 * as itself, so every one of them shares this key - the provider's one name
+	 * for an id-less builder, which the auto-record slots above file under too.
+	 * They can never collide: a request tab holds exactly one draft.
 	 */
-	const rowMemoryKey = request.id ?? "__unsaved__";
+	const rowMemoryKey = request.id ?? UNSAVED_AUTO_KEY;
 	const lastRowIndex = rowIndexByRequest[rowMemoryKey] ?? null;
 	const rememberRowIndex = useCallback(
 		(index: number) =>
@@ -446,6 +427,43 @@ export default function RequestBuilderProvider({
 			}),
 		[rowMemoryKey]
 	);
+	const retainRowIndexes = useCallback(
+		(live: ReadonlySet<string>) =>
+			setRowIndexByRequest((previous) => retainKeys(previous, live)),
+		[]
+	);
+
+	/*
+	 * What bounds every per-request map above: the open request tabs (issues
+	 * #1269, #1271). An entry - a record, or a picked row index - is only ever
+	 * read by the request it is filed under, so once that request has no tab it
+	 * can never be read again, and a per-request store that nothing prunes is
+	 * how a map becomes a leak. `MAX_OPEN_TABS` caps the tab strip, so this caps
+	 * the maps.
+	 *
+	 * Subscribed to rather than selected, like the reveal command above: a
+	 * provider that re-rendered on every tab focus would pay for it on the
+	 * request the user is actually working in. The three slots prune a ref, so
+	 * they cannot re-render at all; the row memory is state - `lastRowIndex` is
+	 * read during render - so `retainKeys` returns the map it was given when it
+	 * drops nothing, and React bails out.
+	 *
+	 * The id-less key survives the sweep: it names no tab, and the History run
+	 * copy that uses it is the one builder whose memory nothing else could keep.
+	 */
+	useEffect(() => {
+		const retainOpen = (tabs: readonly Tab[]) => {
+			const live = new Set<string>([UNSAVED_AUTO_KEY]);
+			for (const tab of tabs) {
+				if (tab.type === "request" && tab.entityId !== null) live.add(tab.entityId);
+			}
+			retainAutoContentTypes(live);
+			retainAutoAccepts(live);
+			retainAutoMethods(live);
+			retainRowIndexes(live);
+		};
+		return useTabsStore.subscribe((s) => retainOpen(s.openTabs));
+	}, [retainAutoContentTypes, retainAutoAccepts, retainAutoMethods, retainRowIndexes]);
 
 	/**
 	 * The row the preview resolves against - the picked one, once the file it

--- a/app/src/modules/request-builder/context/auto-record-slot.ts
+++ b/app/src/modules/request-builder/context/auto-record-slot.ts
@@ -29,7 +29,10 @@
 import { useCallback, useRef } from "react";
 
 /**
- * The key a record is filed under while the builder holds no saved request.
+ * The key a record is filed under while the builder holds no saved request -
+ * the provider's one name for an id-less builder, read by the Send-with-row
+ * picker's memory as well as by the slots here (issue #1271). One convention
+ * spelled twice is how two spellings of it drift apart.
  *
  * A request tab is always opened against a request the backend has already
  * created (`useNewRequest`), so what reaches this key is the editable copy

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -25,6 +25,11 @@
  * `Select` commits, and a Select does not commit in jsdom. `applyModeChange`
  * and `applyStreamToggle` below make exactly the calls the panels make, in the
  * same order, through the real rules.
+ *
+ * The last two blocks are the Send-with-row picker's row memory (issue #1271),
+ * here rather than in a file of its own because what they check is the same
+ * open-tab sweep: it bounds every per-request map the provider holds, and a
+ * rule with two callers is worth asserting from both.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -35,6 +40,7 @@ import { useRequestBuilderContext } from "./RequestBuilderContext";
 import { switchContentType } from "../components/RequestTabs/panels/body/content-type";
 import { switchGraphQLMethod } from "../components/RequestTabs/panels/body/graphql-method";
 import { switchAutoHeader } from "../utils/auto-header";
+import { retainKeys } from "./retain-keys";
 import { useTabsStore, type Tab } from "@/stores";
 import type { BodyMode, HttpMethod, KeyValueItem } from "@/types";
 import type { RequestBuilderContextValue, RequestState } from "../types";
@@ -211,5 +217,68 @@ describe("what bounds the records", () => {
 
 		await act(async () => rerender(tree(null)));
 		expect(ctx.getAutoContentType()).not.toBeNull();
+	});
+});
+
+describe("what bounds the picker's row memory", () => {
+	it("forgets a request's picked row when its tab closes", async () => {
+		const { rerender } = render(tree("req_a"));
+		await act(async () => ctx.rememberRowIndex(2));
+		expect(ctx.lastRowIndex).toBe(2);
+
+		await act(async () => useTabsStore.getState().closeTab("tab_a"));
+
+		await act(async () => rerender(tree("req_a")));
+		expect(ctx.lastRowIndex).toBeNull();
+	});
+
+	it("keeps the picked row of a request whose tab is still open", async () => {
+		const { rerender } = render(tree("req_a"));
+		await act(async () => ctx.rememberRowIndex(2));
+
+		// B's tab goes; A's pick is not B's and has no business going with it.
+		await act(async () => useTabsStore.getState().closeTab("tab_b"));
+
+		await act(async () => rerender(tree("req_a")));
+		expect(ctx.lastRowIndex).toBe(2);
+	});
+
+	it("keeps the picked row of a builder that has no request id", async () => {
+		const { rerender } = render(tree(null));
+		await act(async () => ctx.rememberRowIndex(1));
+
+		await act(async () => useTabsStore.getState().closeTab("tab_a"));
+
+		await act(async () => rerender(tree(null)));
+		expect(ctx.lastRowIndex).toBe(1);
+	});
+});
+
+describe("retainKeys", () => {
+	/*
+	 * The sweep runs on every tabs-store change, and the row memory is state, so
+	 * the guard below is what keeps a tab focus from re-rendering the provider.
+	 * Asserted here rather than through the provider because a `setState` that
+	 * returns an equal-but-new object re-renders the provider and *nothing*
+	 * else: the context value is memoized on `lastRowIndex`, which such a write
+	 * leaves untouched, so no child can see the difference.
+	 */
+	it("returns the map it was given when every key is still live", () => {
+		const previous = { req_a: 2, req_b: 0 };
+		expect(retainKeys(previous, new Set(["req_a", "req_b", "req_c"]))).toBe(previous);
+	});
+
+	it("returns a new map with only the live keys when one is dropped", () => {
+		const previous = { req_a: 2, req_b: 0 };
+		const kept = retainKeys(previous, new Set(["req_b"]));
+		expect(kept).not.toBe(previous);
+		expect(kept).toEqual({ req_b: 0 });
+	});
+
+	it("returns the empty map it was given rather than a new one", () => {
+		// The ordinary case: nothing has been picked, and every tab close would
+		// otherwise write a fresh object.
+		const previous = {};
+		expect(retainKeys(previous, new Set(["req_a"]))).toBe(previous);
 	});
 });

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -33,7 +33,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useEffect } from "react";
+import { useEffect, Profiler } from "react";
 import { render, act } from "@testing-library/react";
 import RequestBuilderProvider from "./RequestBuilderProvider";
 import { useRequestBuilderContext } from "./RequestBuilderContext";
@@ -251,6 +251,42 @@ describe("what bounds the picker's row memory", () => {
 
 		await act(async () => rerender(tree(null)));
 		expect(ctx.lastRowIndex).toBe(1);
+	});
+
+	it("stops re-rendering the provider once the tabs-store changes drop nothing", async () => {
+		/*
+		 * The sweep runs on *every* tabs-store write - the subscription takes the
+		 * whole state - and the row memory is the one map it prunes with a
+		 * `setState`. Without `retainKeys`' identity guard that would be a new
+		 * object each time, so every tab focus would re-render the provider for
+		 * the life of the session.
+		 *
+		 * Counted through a `Profiler` because the render is all there is to see:
+		 * the context value is memoized on `lastRowIndex`, which such a write
+		 * leaves untouched, so no child of the provider can tell the difference.
+		 *
+		 * The first focus after a pick still commits once - React renders a
+		 * component that has just changed state one more time before it can bail
+		 * out - so what is asserted is the steady state after that, which is what
+		 * the guard is actually for.
+		 */
+		let commits = 0;
+		render(
+			<Profiler id="provider" onRender={() => (commits += 1)}>
+				{tree("req_a")}
+			</Profiler>
+		);
+		await act(async () => ctx.rememberRowIndex(2));
+		await act(async () => useTabsStore.getState().focusTab("tab_b"));
+
+		const settled = commits;
+		await act(async () => useTabsStore.getState().focusTab("tab_a"));
+		await act(async () => useTabsStore.getState().focusTab("tab_b"));
+		expect(commits).toBe(settled);
+
+		// And the counter is live: the write that *does* drop a key renders.
+		await act(async () => useTabsStore.getState().closeTab("tab_a"));
+		expect(commits).toBeGreaterThan(settled);
 	});
 });
 

--- a/app/src/modules/request-builder/context/retain-keys.ts
+++ b/app/src/modules/request-builder/context/retain-keys.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The open-tab sweep's answer for a per-request map held as state (issue
+ * #1271).
+ *
+ * `useAutoRecordSlot`'s `retain` is the same rule over a ref: it deletes in
+ * place, and a ref that shrinks re-renders nothing. `rowIndexByRequest` is
+ * `useState` instead - `lastRowIndex` is read during render - so its sweep is a
+ * `setState`, and a `setState` that returns a new object every time a tab is
+ * focused would charge the request the user is working in for a map that did
+ * not change. Hence the identity guard: `previous` itself when every key is
+ * still live, which React compares with `Object.is` and bails out on.
+ */
+export function retainKeys<T>(
+	previous: Record<string, T>,
+	live: ReadonlySet<string>
+): Record<string, T> {
+	const kept = Object.entries(previous).filter(([key]) => live.has(key));
+	if (kept.length === Object.keys(previous).length) return previous;
+	return Object.fromEntries(kept);
+}

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1885,16 +1885,30 @@ mode change.
 
 What bounds the maps is the open request tabs. A record can only ever be read by
 the request it names, so once that request has no tab it is unreachable, and a
-per-request store that nothing prunes is how a ref becomes a leak; `tabs-store`
-is subscribed to rather than selected from, because pruning writes to a ref and
-a provider that re-rendered on every tab focus would charge the request the user
-is working in for it. `MAX_OPEN_TABS` caps the tab strip, so it caps the maps.
-The one key that survives the sweep is the id-less one, shared by any builder
-holding no saved request: it names no tab, and the editable copy History renders
-for a stored run is what uses it. Two such copies open at once share that one
-bucket and interfere as they always have, since the rules read a `requestId` of
-`null` against another `null` as a match; giving that copy an identity of its
-own is issue #1272.
+per-request store that nothing prunes is how a map becomes a leak; `tabs-store`
+is subscribed to rather than selected from, because a provider that re-rendered
+on every tab focus would charge the request the user is working in for it.
+`MAX_OPEN_TABS` caps the tab strip, so it caps the maps. The one key that
+survives the sweep is the id-less one, shared by any builder holding no saved
+request: it names no tab, and the editable copy History renders for a stored run
+is what uses it. Two such copies open at once share that one bucket and
+interfere as they always have, since the rules read a `requestId` of `null`
+against another `null` as a match; giving that copy an identity of its own is
+issue #1272.
+
+**The same sweep bounds the Send-with-row picker's memory** (issue #1271), the
+provider's other per-request map: which row index each request was last sent
+with (`rowIndexByRequest`, issues #659 and #1062). It survives a tab switch and
+a return, because neither of those is a send - and it goes when the tab does,
+for the reason above, since the request it was picked for can no longer be
+switched to. Two maps, one rule, one sweep, and one name for the request that
+has no id: `UNSAVED_AUTO_KEY` is what both file an id-less builder under.
+
+The row memory is `useState` rather than a ref - `lastRowIndex` is read while
+rendering - so its half of the sweep is a `setState`, and `retainKeys`
+(`context/retain-keys.ts`) returns the map it was handed when every key is still
+live. Without that identity guard the provider would re-render on every tab
+focus, which is exactly the cost the subscription was chosen to avoid.
 
 In the provider rather than in the panels for the drafts' reason and one of its
 own: Radix unmounts an inactive `TabsContent`, so a panel-local record is gone

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -230,9 +230,12 @@ send is about to put on the wire, not composition's guess at it.
 both send *without* a row, so the pick is cleared by one: a row left standing
 across a plain Send would put the file's value in every preview beside a request
 that had just gone out with the environment's, which is this same disagreement
-arrived at from the other side. Nothing else clears it - the picker's memory
+arrived at from the other side. Nothing else *clears* it - the picker's memory
 still survives a tab switch and a return (issue #659), because neither of those
-is a send.
+is a send. Closing the request's tab does drop it, which is not the same act: it
+ends the memory rather than unbinding the row, and it is what bounds a map the
+provider would otherwise hold for the life of the session (issue #1271, see
+[`state-management.md`](state-management.md#requestbuildercontext---the-headers-a-setting-added)).
 
 **Why the renderer can show this and composition cannot.** A plan is composed
 once, before any row exists to bind, so composition still defers both


### PR DESCRIPTION
## Description

`RequestBuilderProvider` held two kinds of per-request memory and bounded one of them. The three auto-record slots (#1269) retain the open request tabs; `rowIndexByRequest` - the Send-with-row picker's index per request (#659, #1062) - is a `Record` that only ever lost the *current* request's key, on a plain Send. Nothing else removed one, so every request whose row was picked stayed in the map for the life of the provider, which is the life of the app session.

**The plan.** Root cause is a per-request map with no retention rule, in a provider that is never unmounted - the same shape the auto slots had before #1269. The fix hangs off the mechanism that already exists: the tabs-store subscription in the same provider already computes the live key set, so pruning the row memory is one more call inside it, not a second sweep. The sweep moves down to sit below the row memory it now also bounds, so what bounds *every* per-request map the provider holds is stated once, in one place, beside both. The alternative considered and rejected was giving the row memory its own retention (a second subscription, or pruning it on the request-change effect): it would have put two rules for one question in one file, which is how the two spellings of the id-less key - the thing this PR also ends - came about in the first place.

The one substantive difference from the auto slots: `rowIndexByRequest` is `useState`, not a ref, because `lastRowIndex` is read during render. Its half of the sweep is therefore a `setState`, and one that wrote a new object on every tabs-store change would re-render the provider on every tab focus - exactly the cost the subscription was chosen to avoid. `retainKeys` (`context/retain-keys.ts`) is that rule as a pure function: it returns the map it was handed when every key is still live, and React bails out on `Object.is`.

**Deliberate deviation from the issue's file list.** The issue scopes the change to `RequestBuilderProvider.tsx` (plus `auto-record-slot.ts` for the key). `retainKeys` is a third file so the guard can be asserted as a function as well as through the provider; it is 26 lines including the reason it exists, and it is the repo's extracted-testable-core pattern.

`docs/app/variable-resolution.md` is also touched, one sentence beyond the issue's docs list: its "Nothing else clears it" line describes the picker's memory and would read as false once a tab close drops it.

`rowMemoryKey` also stops spelling `"__unsaved__"` itself and reads `UNSAVED_AUTO_KEY`, so the provider has one name for an id-less builder - as does `send-with-row.test.tsx`, whose harness reimplements the row memory and carried the third copy of the literal. Nothing about the id-less bucket's behaviour changes: it is still exempt from the sweep because it names no tab (giving the History run copy an identity of its own remains #1272).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **596 files, 6559 tests, all passing**. `pnpm type-check` and `pnpm lint` clean (lint still prints the two known `TSSatisfiesExpression` advisories from jsx-ast-utils, #1261, which are pre-existing on `master` and do not fail the run). `mkdocs build --strict -f .github/mkdocs.yml` passes, which is what checks the new cross-doc anchor link.

Seven new cases in `context/auto-records-per-request.test.tsx` - beside the auto-record cases rather than in a file of their own, because what they exercise is the same open-tab sweep:

- a request's picked row is gone once its tab closes;
- a request whose tab is still open keeps its own pick;
- an id-less builder keeps its pick when a tab closes, since the id-less key names no tab;
- the provider stops re-rendering once the tabs-store changes drop nothing - a `Profiler` counts the commits, since the context value is memoized on `lastRowIndex` and no child can see an equal-but-new map. It asserts the steady state, because React renders a component that has just changed state once more before it can bail out; the same case then closes a tab to prove the counter is live;
- `retainKeys` returns the map it was given when every key is live, returns a new pruned map when one is dropped, and returns an empty map unchanged.

Mutation-checked twice. With `retainRowIndexes(live)` deleted from the sweep, "forgets a request's picked row when its tab closes" fails and the rest pass. With `retainKeys`' identity guard deleted, the provider-level render case fails alongside the two unit cases - so the guard is pinned where its cost lands, not only where it is written.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1271