### PR TITLE
fix(app): give a History run copy its own identity for the records it files

### DIFF
--- a/app/src/modules/history/main/DesignRunView.memory-key.test.tsx
+++ b/app/src/modules/history/main/DesignRunView.memory-key.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which identity the run copy files its per-builder memory under (issue #1272).
+ *
+ * The copy is id-less on purpose - `seedFromRun` sets `id: null`, one of the
+ * two gates that stop an edited copy from rewriting the saved request - so the
+ * provider cannot derive an identity for it and is told one. What the provider
+ * does with that identity is asserted through the real thing in
+ * `request-builder/context/auto-records-per-request.test.tsx`; what one line of
+ * JSX cannot say for itself is that this view still passes it, which is the
+ * whole of the fix on this side.
+ *
+ * In a file of its own because it stubs the provider out, and the rest of
+ * `DesignRunView.test.tsx` needs the real one.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DesignRunView from "./DesignRunView";
+import type { Run } from "@/types";
+
+vi.mock("@/hooks/useEngine", () => ({
+	useEngine: () => ({ executeRequest: vi.fn(), composeRequest: vi.fn() }),
+}));
+
+vi.mock("@/queries", async () => {
+	const actual = await vi.importActual<typeof import("@/queries")>("@/queries");
+	return {
+		...actual,
+		// Settled, request deleted: the orphan seed, which is the shortest path
+		// to a mounted provider. The identity asked about is the run's either way.
+		useRequestQuery: () => ({
+			data: undefined,
+			isLoading: false,
+			isError: false,
+			error: null,
+			refetch: vi.fn(),
+		}),
+		useCollectionAncestors: () => [],
+	};
+});
+
+/** The props the view mounted the provider with, captured rather than rendered. */
+let providerProps: Record<string, unknown> = {};
+
+vi.mock("@/modules/request-builder/context", async () => {
+	const actual = await vi.importActual<typeof import("@/modules/request-builder/context")>(
+		"@/modules/request-builder/context"
+	);
+	return {
+		...actual,
+		// Children dropped: the builder's layout has nothing to say here, and
+		// rendering it would need the real context this stub is replacing.
+		RequestBuilderProvider: (props: Record<string, unknown>) => {
+			providerProps = props;
+			return null;
+		},
+	};
+});
+
+const run = {
+	id: "run_42",
+	type: "design",
+	status: "completed",
+	startTime: 1_750_000_000_000,
+	endTime: 1_750_000_000_300,
+	requestId: null,
+	environmentId: null,
+	configSnapshot: { method: "GET", url: "https://api.example.test/" },
+	result: { timestamp: 1_750_000_000_000, statusCode: 200, statusText: "OK", latencyMs: 12 },
+} as unknown as Run;
+
+describe("DesignRunView - the copy declares which run it is", () => {
+	it("files the builder's memory under the run id, not under the copy's null id", () => {
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(
+			<QueryClientProvider client={client}>
+				<DesignRunView run={run} />
+			</QueryClientProvider>
+		);
+
+		expect(providerProps.memoryKey).toBe("run_42");
+		// And the id stays null: the identity is declared beside it, never as it.
+		expect((providerProps.initialRequest as { id: string | null }).id).toBeNull();
+	});
+});

--- a/app/src/modules/history/main/DesignRunView.tsx
+++ b/app/src/modules/history/main/DesignRunView.tsx
@@ -371,6 +371,13 @@ export default function DesignRunView({ run }: DesignRunViewProps) {
 			<div className="flex-1 min-h-0">
 				<RequestBuilderProvider
 					initialRequest={seed.request}
+					/* The copy has no request id and must not grow one - that null
+					   is one of the two gates detaching it - but the provider still
+					   has to tell two open run tabs apart when it files what a
+					   setting changed. The run id is the identity it files under
+					   (issue #1272); it names this tab, so the same open-tab sweep
+					   bounds it. */
+					memoryKey={run.id}
 					initialResponse={initialResponse}
 					inheritedPreScripts={seed.collectionPreScripts}
 					inheritedPostScripts={seed.collectionPostScripts}

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -69,6 +69,18 @@ interface RequestBuilderProviderProps {
 	children: ReactNode;
 	initialRequest?: Partial<RequestState>;
 	/**
+	 * The identity this builder files its per-builder memory under - the three
+	 * auto side-effect records and the picker's row index (issue #1272).
+	 *
+	 * Defaults to `request.id`, which is what a request tab wants. The History
+	 * run view passes its run id, because the copy it renders is deliberately
+	 * id-less (`design-run-seed.ts` sets `id: null`, one of the two gates that
+	 * detach it) and two open run tabs would otherwise be one identity. Pass an
+	 * id the tab strip can name - a record keyed under it is bounded by that
+	 * tab, exactly as a request's is.
+	 */
+	memoryKey?: string;
+	/**
 	 * Starting response for a builder with no id, which cannot read the store.
 	 * Used by the History run view, where the response comes from the run.
 	 *
@@ -122,6 +134,7 @@ interface RequestBuilderProviderProps {
 export default function RequestBuilderProvider({
 	children,
 	initialRequest,
+	memoryKey: declaredMemoryKey,
 	initialResponse,
 	inheritedPreScripts,
 	inheritedPostScripts,
@@ -290,12 +303,18 @@ export default function RequestBuilderProvider({
 	}, []);
 
 	/*
-	 * Which request the three records below are read and written for. One
-	 * `RequestBuilderProvider` serves every request tab, so a slot holding a
-	 * single record held whichever request was in a mode last, and the request
-	 * before it kept what the app had changed for it (issue #1269).
+	 * The one identity every per-builder map here is read and written under: the
+	 * three records below and the picker's row index further down. One
+	 * `RequestBuilderProvider` serves every tab, so a slot holding a single
+	 * record held whichever request was in a mode last, and the request before
+	 * it kept what the app had changed for it (issue #1269).
+	 *
+	 * A request tab is its request; a builder over something else says so with
+	 * `memoryKey`, because two id-less builders are not one builder (issue
+	 * #1272). Spelled once rather than per map - the maps share a sweep, and two
+	 * spellings of one rule are how they drift apart.
 	 */
-	const autoRecordKey = request.id ?? UNSAVED_AUTO_KEY;
+	const memoryKey = declaredMemoryKey ?? request.id ?? UNSAVED_AUTO_KEY;
 
 	/*
 	 * The Content-Type row a body mode added on its way in, so leaving the mode
@@ -313,7 +332,7 @@ export default function RequestBuilderProvider({
 		get: getAutoContentType,
 		set: setAutoContentType,
 		retain: retainAutoContentTypes,
-	} = useAutoRecordSlot<AutoHeader>(autoRecordKey);
+	} = useAutoRecordSlot<AutoHeader>(memoryKey);
 
 	/*
 	 * The `Accept: text/event-stream` row the Event stream toggle added, so
@@ -327,7 +346,7 @@ export default function RequestBuilderProvider({
 		get: getAutoAccept,
 		set: setAutoAccept,
 		retain: retainAutoAccepts,
-	} = useAutoRecordSlot<AutoHeader>(autoRecordKey);
+	} = useAutoRecordSlot<AutoHeader>(memoryKey);
 
 	/*
 	 * The method the GraphQL body mode set, so leaving the mode can put back
@@ -340,10 +359,10 @@ export default function RequestBuilderProvider({
 		get: getAutoMethod,
 		set: setAutoMethod,
 		retain: retainAutoMethods,
-	} = useAutoRecordSlot<AutoMethod>(autoRecordKey);
+	} = useAutoRecordSlot<AutoMethod>(memoryKey);
 
 	// What bounds these three is stated with the row memory below, which the
-	// same sweep bounds (issue #1271): one rule over every per-request map the
+	// same sweep bounds (issue #1271): one rule over every per-builder map the
 	// provider holds, rather than one rule each.
 
 	const { data: collections = [] } = useCollectionsQuery();
@@ -393,18 +412,11 @@ export default function RequestBuilderProvider({
 	const { maxRows: dataFileMaxRows } = useDataFileLimits();
 	const sendWithRow = useSendWithRow(dataColumns, dataFileMaxRows);
 	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
-	/*
-	 * An unsaved request has no id and cannot be switched away from and back to
-	 * as itself, so every one of them shares this key - the provider's one name
-	 * for an id-less builder, which the auto-record slots above file under too.
-	 * They can never collide: a request tab holds exactly one draft.
-	 */
-	const rowMemoryKey = request.id ?? UNSAVED_AUTO_KEY;
-	const lastRowIndex = rowIndexByRequest[rowMemoryKey] ?? null;
+	// Filed under the same identity as the records above, for the same reason.
+	const lastRowIndex = rowIndexByRequest[memoryKey] ?? null;
 	const rememberRowIndex = useCallback(
-		(index: number) =>
-			setRowIndexByRequest((previous) => ({ ...previous, [rowMemoryKey]: index })),
-		[rowMemoryKey]
+		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [memoryKey]: index })),
+		[memoryKey]
 	);
 	/*
 	 * A Send that carries no row leaves the request bound to none (issue #1062).
@@ -421,11 +433,11 @@ export default function RequestBuilderProvider({
 	const forgetRowIndex = useCallback(
 		() =>
 			setRowIndexByRequest((previous) => {
-				if (!(rowMemoryKey in previous)) return previous;
-				const { [rowMemoryKey]: _forgotten, ...rest } = previous;
+				if (!(memoryKey in previous)) return previous;
+				const { [memoryKey]: _forgotten, ...rest } = previous;
 				return rest;
 			}),
-		[rowMemoryKey]
+		[memoryKey]
 	);
 	const retainRowIndexes = useCallback(
 		(live: ReadonlySet<string>) =>
@@ -434,10 +446,10 @@ export default function RequestBuilderProvider({
 	);
 
 	/*
-	 * What bounds every per-request map above: the open request tabs (issues
-	 * #1269, #1271). An entry - a record, or a picked row index - is only ever
-	 * read by the request it is filed under, so once that request has no tab it
-	 * can never be read again, and a per-request store that nothing prunes is
+	 * What bounds every per-builder map above: the open tabs (issues #1269,
+	 * #1271, #1272). An entry - a record, or a picked row index - is only ever
+	 * read by the builder it is filed under, so once that builder has no tab it
+	 * can never be read again, and a per-builder store that nothing prunes is
 	 * how a map becomes a leak. `MAX_OPEN_TABS` caps the tab strip, so this caps
 	 * the maps.
 	 *
@@ -448,14 +460,22 @@ export default function RequestBuilderProvider({
 	 * read during render - so `retainKeys` returns the map it was given when it
 	 * drops nothing, and React bails out.
 	 *
-	 * The id-less key survives the sweep: it names no tab, and the History run
-	 * copy that uses it is the one builder whose memory nothing else could keep.
+	 * A run tab is swept like a request tab, because the History copy it holds
+	 * now files under its run id (issue #1272) and that id names a tab like any
+	 * other. Run ids and request ids come from different tables and cannot
+	 * collide; a run tab holding no builder - a load test, a scenario - only
+	 * ever keeps a key nothing wrote.
+	 *
+	 * The id-less key survives the sweep: it names no tab, and a builder that
+	 * declares no identity of its own is the one whose memory nothing else
+	 * could keep.
 	 */
 	useEffect(() => {
 		const retainOpen = (tabs: readonly Tab[]) => {
 			const live = new Set<string>([UNSAVED_AUTO_KEY]);
 			for (const tab of tabs) {
-				if (tab.type === "request" && tab.entityId !== null) live.add(tab.entityId);
+				if (tab.entityId === null) continue;
+				if (tab.type === "request" || tab.type === "run") live.add(tab.entityId);
 			}
 			retainAutoContentTypes(live);
 			retainAutoAccepts(live);

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -415,7 +415,8 @@ export default function RequestBuilderProvider({
 	// Filed under the same identity as the records above, for the same reason.
 	const lastRowIndex = rowIndexByRequest[memoryKey] ?? null;
 	const rememberRowIndex = useCallback(
-		(index: number) => setRowIndexByRequest((previous) => ({ ...previous, [memoryKey]: index })),
+		(index: number) =>
+			setRowIndexByRequest((previous) => ({ ...previous, [memoryKey]: index })),
 		[memoryKey]
 	);
 	/*

--- a/app/src/modules/request-builder/context/auto-record-slot.ts
+++ b/app/src/modules/request-builder/context/auto-record-slot.ts
@@ -29,19 +29,24 @@
 import { useCallback, useRef } from "react";
 
 /**
- * The key a record is filed under while the builder holds no saved request -
- * the provider's one name for an id-less builder, read by the Send-with-row
- * picker's memory as well as by the slots here (issue #1271). One convention
- * spelled twice is how two spellings of it drift apart.
+ * The key a record is filed under while the builder names no identity at all -
+ * the provider's one fallback, read by the Send-with-row picker's memory as
+ * well as by the slots here (issue #1271). One convention spelled twice is how
+ * two spellings of it drift apart.
  *
- * A request tab is always opened against a request the backend has already
- * created (`useNewRequest`), so what reaches this key is the editable copy
- * History renders for a stored run. Every such copy shares the one bucket,
- * which is what the rules already do with a `requestId` of `null` - `null ===
- * null` passes their ownership check - so two run tabs open at once interfere
- * exactly as they did before this keying, no better and no worse. Giving that
- * copy an identity of its own is issue #1272; it needs one the provider is not
- * handed today.
+ * A builder says which identity it files under with the provider's `memoryKey`
+ * prop, defaulting to `request.id`. A request tab is always opened against a
+ * request the backend has already created (`useNewRequest`), and the editable
+ * copy History renders for a stored run - the one builder with no request id -
+ * passes its run id (issue #1272), so nothing reaches this key in the app
+ * today. It stays as the answer for a builder that has neither, because the
+ * alternative is every such builder sharing whichever key was written last:
+ * the rules read a `requestId` of `null` against another `null` as a match, so
+ * a shared bucket is handed out as owned rather than refused.
+ *
+ * It is the one key the open-tab sweep never drops. That is what it costs: a
+ * key naming no tab cannot be bounded by the tabs, which is the second reason
+ * to declare an identity that does.
  */
 export const UNSAVED_AUTO_KEY = "__unsaved__";
 
@@ -58,8 +63,10 @@ interface AutoRecordSlot<T> {
 }
 
 /**
- * @param requestKey which request the accessors read and write - `request.id`,
- * or {@link UNSAVED_AUTO_KEY} when there is none.
+ * @param requestKey which builder the accessors read and write for - the
+ * provider's resolved `memoryKey`: the request's id, the identity a builder
+ * over something else declared, or {@link UNSAVED_AUTO_KEY} when it has
+ * neither.
  */
 export function useAutoRecordSlot<T>(requestKey: string): AutoRecordSlot<T> {
 	const byRequest = useRef(new Map<string, T>());

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -26,6 +26,11 @@
  * and `applyStreamToggle` below make exactly the calls the panels make, in the
  * same order, through the real rules.
  *
+ * A builder that is not a saved request has no id to be keyed by and declares
+ * one instead (issue #1272) - the History run copy, which passes its run id.
+ * The block for it asserts what the id-less key could not give two such copies
+ * at once: a record each, and a bound, since a declared identity names a tab.
+ *
  * The last two blocks are the Send-with-row picker's row memory (issue #1271),
  * here rather than in a file of its own because what they check is the same
  * open-tab sweep: it bounds every per-request map the provider holds, and a
@@ -87,6 +92,20 @@ function Probe() {
 
 const tree = (id: string | null) => (
 	<RequestBuilderProvider initialRequest={{ id, name: "r" } as Partial<RequestState>}>
+		<Probe />
+	</RequestBuilderProvider>
+);
+
+/**
+ * A builder over something that is not a saved request: the copy History
+ * renders for a stored run, which is id-less on purpose and says which run it
+ * is with `memoryKey` (issue #1272).
+ */
+const runTree = (runId: string) => (
+	<RequestBuilderProvider
+		initialRequest={{ id: null, name: "r" } as Partial<RequestState>}
+		memoryKey={runId}
+	>
 		<Probe />
 	</RequestBuilderProvider>
 );
@@ -217,6 +236,96 @@ describe("what bounds the records", () => {
 
 		await act(async () => rerender(tree(null)));
 		expect(ctx.getAutoContentType()).not.toBeNull();
+	});
+});
+
+describe("a builder that is not a saved request says which one it is", () => {
+	/*
+	 * Two run tabs, and the copy in each has `id: null` - the gate that stops an
+	 * edited copy from rewriting the saved request. Before issue #1272 they were
+	 * one identity: both filed under the id-less key, and the rules read a
+	 * `requestId` of `null` against another `null` as a match, so the second copy
+	 * into GraphQL was handed the first one's record and told it was already in
+	 * the mode.
+	 */
+	const RUN_TABS: Tab[] = [
+		{ id: "tab_run_a", type: "run", entityId: "run_a" },
+		{ id: "tab_run_b", type: "run", entityId: "run_b" },
+	];
+
+	beforeEach(() => {
+		useTabsStore.setState({ openTabs: [...RUN_TABS], activeTabId: "tab_run_a" });
+	});
+
+	it("gives the second open run tab its own POST and its own record", async () => {
+		const { rerender } = render(runTree("run_a"));
+
+		let a = applyModeChange(fresh(null), "graphql");
+		expect(headerNames(a)).toEqual(["Content-Type"]);
+		expect(a.method).toBe("POST");
+
+		// The other run tab. Same provider instance, same id-less copy - only the
+		// declared identity differs, and that is what has to carry it.
+		await act(async () => rerender(runTree("run_b")));
+		const b = applyModeChange(fresh(null), "graphql");
+		expect(headerNames(b)).toEqual(["Content-Type"]);
+		expect(b.method).toBe("POST");
+
+		// And the first copy can still leave the mode it entered.
+		await act(async () => rerender(runTree("run_a")));
+		a = applyModeChange(a, "none");
+		expect(headerNames(a)).toEqual([]);
+		expect(a.method).toBe("GET");
+	});
+
+	it("answers with nothing for a run copy that has entered no mode", async () => {
+		const { rerender } = render(runTree("run_a"));
+		applyModeChange(fresh(null), "graphql");
+
+		await act(async () => rerender(runTree("run_b")));
+		expect(ctx.getAutoContentType()).toBeNull();
+		expect(ctx.getAutoMethod()).toBeNull();
+	});
+
+	it("forgets a run copy's records when its tab closes", async () => {
+		// A declared identity names a tab, so it joins the sweep rather than
+		// being exempt from it the way the id-less key has to be.
+		const { rerender } = render(runTree("run_a"));
+		applyModeChange(fresh(null), "graphql");
+		applyStreamToggle(fresh(null), true);
+
+		await act(async () => useTabsStore.getState().closeTab("tab_run_a"));
+
+		await act(async () => rerender(runTree("run_a")));
+		expect(ctx.getAutoContentType()).toBeNull();
+		expect(ctx.getAutoAccept()).toBeNull();
+		expect(ctx.getAutoMethod()).toBeNull();
+	});
+
+	it("keeps the records of the run tab that is still open", async () => {
+		const { rerender } = render(runTree("run_a"));
+		applyModeChange(fresh(null), "graphql");
+
+		await act(async () => useTabsStore.getState().closeTab("tab_run_b"));
+
+		await act(async () => rerender(runTree("run_a")));
+		expect(ctx.getAutoMethod()).toEqual({
+			requestId: null,
+			method: "POST",
+			previous: "GET",
+		});
+	});
+
+	it("keeps the picked row of each run tab apart", async () => {
+		// The row memory is filed under the same identity, so it divides with it.
+		const { rerender } = render(runTree("run_a"));
+		await act(async () => ctx.rememberRowIndex(2));
+
+		await act(async () => rerender(runTree("run_b")));
+		expect(ctx.lastRowIndex).toBeNull();
+
+		await act(async () => rerender(runTree("run_a")));
+		expect(ctx.lastRowIndex).toBe(2);
 	});
 });
 

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -267,9 +267,15 @@ describe("a builder that is not a saved request says which one it is", () => {
 		// The other run tab. Same provider instance, same id-less copy - only the
 		// declared identity differs, and that is what has to carry it.
 		await act(async () => rerender(runTree("run_b")));
-		const b = applyModeChange(fresh(null), "graphql");
+		let b = applyModeChange(fresh(null), "graphql");
 		expect(headerNames(b)).toEqual(["Content-Type"]);
 		expect(b.method).toBe("POST");
+
+		// Each copy leaves the mode on its own record, so the second one going
+		// first must not be the first one's exit.
+		b = applyModeChange(b, "none");
+		expect(headerNames(b)).toEqual([]);
+		expect(b.method).toBe("GET");
 
 		// And the first copy can still leave the mode it entered.
 		await act(async () => rerender(runTree("run_a")));

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1883,26 +1883,45 @@ alternative and is wrong in the same direction as the bug - it strands the first
 request's header at the moment of the switch rather than at the second request's
 mode change.
 
-What bounds the maps is the open request tabs. A record can only ever be read by
-the request it names, so once that request has no tab it is unreachable, and a
-per-request store that nothing prunes is how a map becomes a leak; `tabs-store`
+What bounds the maps is the open tabs. A record can only ever be read by the
+builder it names, so once that builder has no tab it is unreachable, and a
+per-builder store that nothing prunes is how a map becomes a leak; `tabs-store`
 is subscribed to rather than selected from, because a provider that re-rendered
 on every tab focus would charge the request the user is working in for it.
-`MAX_OPEN_TABS` caps the tab strip, so it caps the maps. The one key that
-survives the sweep is the id-less one, shared by any builder holding no saved
-request: it names no tab, and the editable copy History renders for a stored run
-is what uses it. Two such copies open at once share that one bucket and
-interfere as they always have, since the rules read a `requestId` of `null`
-against another `null` as a match; giving that copy an identity of its own is
-issue #1272.
+`MAX_OPEN_TABS` caps the tab strip, so it caps the maps. Both request tabs and
+run tabs are swept, by their `entityId` - a request id and a run id respectively,
+from different tables and so unable to collide. A run tab holding no builder at
+all (a load test, a scenario) only ever keeps a key nothing wrote.
+
+**Which identity a builder files under is one value, resolved once** (issue
+#1272): `memoryKey ?? request.id ?? UNSAVED_AUTO_KEY`, read by every per-builder
+map the provider holds - the three slots above and the picker's row memory
+below. A request tab is its request and passes nothing. The editable copy
+History renders for a stored run passes the run id, because `design-run-seed.ts`
+gives that copy `id: null` on purpose - a null id is one of the two gates that
+stop an edited copy from rewriting the saved request - so every open run copy
+used to share the id-less bucket. That was not a near miss: the rules read a
+`requestId` of `null` against another `null` as a match, so the second run tab
+to pick GraphQL was handed the first one's record, accepted it as its own and
+took the "already in this mode" branch - its method was never set to `POST`, and
+its record was the other tab's. A prop rather than a field on `RequestState`
+that only History would set: `request.id` stays honestly null, and no request
+grows a "which run am I" field for one caller. A run id names a tab, so those
+records are bounded by the same sweep rather than exempt from it.
+
+`UNSAVED_AUTO_KEY` is what remains for a builder declaring neither - nothing in
+the app today - and it is the one key the sweep cannot drop, since a key naming
+no tab cannot be bounded by the tabs. It is kept rather than removed because the
+alternative for such a builder is sharing whichever key was written last, which
+the `null === null` ownership check hands out as owned rather than refusing.
 
 **The same sweep bounds the Send-with-row picker's memory** (issue #1271), the
 provider's other per-request map: which row index each request was last sent
 with (`rowIndexByRequest`, issues #659 and #1062). It survives a tab switch and
 a return, because neither of those is a send - and it goes when the tab does,
 for the reason above, since the request it was picked for can no longer be
-switched to. Two maps, one rule, one sweep, and one name for the request that
-has no id: `UNSAVED_AUTO_KEY` is what both file an id-less builder under.
+switched to. Two maps, one rule, one sweep, and one identity: the key resolved
+above is the key both file under.
 
 The row memory is `useState` rather than a ref - `lastRowIndex` is read while
 rendering - so its half of the sweep is a `setState`, and `retainKeys`


### PR DESCRIPTION
## Description

The editable copy History renders for a stored run is deliberately id-less - `design-run-seed.ts` sets `id: null`, one of the two gates that stop an edited copy from rewriting the saved request - so every such copy filed the provider's per-builder memory under one shared key (`UNSAVED_AUTO_KEY`). That is not a near miss: the rules read a `requestId` of `null` against another `null` as a match, so with two run tabs open, the second copy to pick GraphQL was handed the first one's record, accepted it as its own and took the "already in this mode" branch - its method was never set to `POST`, and its record was the other tab's.

**Root cause and approach.** The identity was being *derived* from `request.id`, and the one builder that is not a saved request has no id to derive it from. The provider now takes a `memoryKey` prop naming the identity a builder files under, defaulting to `request.id`, and `DesignRunView` passes the run id. The key is resolved once (`memoryKey ?? request.id ?? UNSAVED_AUTO_KEY`) and read by every per-builder map the provider holds - the three auto side-effect slots and the picker's row memory - rather than spelled per map; and because a run id names a tab, run tabs join the open-tab sweep, so these records are bounded exactly as a request's are instead of being exempt the way the id-less key must be. `UNSAVED_AUTO_KEY` stays as the fallback for a builder declaring neither (nothing in the app today), because the alternative for such a builder is sharing whichever key was written last.

**The alternative rejected:** a field on `RequestState` that only the History copy sets, so the provider could derive the identity from `initialRequest`. That puts a "which run am I" field on every request for one caller, and makes `request.id` less than honest - the null is load-bearing (`useSaveManager` early-returns on `!entityId`, the response store is keyed by request id, `useLastDesignRunQuery` is disabled by it). A prop keeps the null exactly as it is.

Out of scope, as the issue states: the rules' `null === null` ownership check. It is correct for a pure function handed whatever the caller has; the identity problem was the caller's. `switchAutoHeader` and `switchGraphQLMethod` are untouched, tests included.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `app/src/modules/request-builder/context/auto-records-per-request.test.tsx` - 13 cases to 18. Two run tabs each getting their own `POST` and header row, each leaving the mode on its own record (the second one leaving first, so its exit cannot be read as the first one's), a copy that entered no mode reading back nothing, the tab-close bound now that a declared identity names a tab, records of a still-open run tab kept, and the picker's row memory dividing with the same identity.
- New `app/src/modules/history/main/DesignRunView.memory-key.test.tsx` - 1 case: the view passes the run id and leaves the copy's id null. In a file of its own because it stubs the provider out, and the rest of `DesignRunView.test.tsx` needs the real one.
- Mutation-checked in three directions: ignoring the declared key fails 4 of the 5 new context cases; sweeping request tabs only fails the "still open" case, since `run_a`'s records go when `run_b`'s tab closes; dropping the prop from `DesignRunView` fails the wiring guard.
- `cd app && pnpm test` - 597 files, 6565 tests, all passing (596 / 6559 on the base commit, so +1 file and +6 cases, nothing else moved).
- `pnpm lint`, `pnpm format:check`, `pnpm type-check` clean. `pnpm lint` still prints the two `TSSatisfiesExpression` advisories from `jsx-ast-utils`; they print on the base commit too and are #1261, not this change.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit as the code: `docs/app/state-management.md`, the "the headers a setting added" section. The bound paragraph now says the sweep covers request tabs and run tabs by their `entityId`; a new paragraph states the one resolved identity, why the prop rather than a field on `RequestState`, and what `UNSAVED_AUTO_KEY` is now for and why it is kept. The `###` heading is unchanged, so the anchors that link to it still resolve.

## Related Issues
Closes #1272
