### PR TITLE
perf(app): hold the first update check back a minute after launch - #1159

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -237,3 +237,21 @@ export const ISSUES_URL = `https://github.com/${REPO}/issues`;
 // Auto-updater
 /** Re-check for updates every 6 hours while the app stays open. */
 export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+/**
+ * How long after launch the session's first update check waits.
+ *
+ * On the silent platforms (Windows, Linux AppImage) a check that finds a
+ * release downloads it there and then, and `initAutoUpdater` runs a few lines
+ * after the window is created - so a 127MB NSIS pull, or an AppImage apply that
+ * reads the whole old image and writes a new one, used to begin at t=0 of a
+ * launch. In an API-testing client that transfer competes for the link with the
+ * user's own requests, and for the disk with the engine's startup work; with a
+ * release every day or two, a daily user paid it every second or third launch.
+ *
+ * A minute puts it past window creation, engine startup and the first requests
+ * a user makes, and costs nothing they can see: the release is still picked up
+ * by this launch, by the 6h cycle, or by the next one. Only the timing moves -
+ * which platforms download silently, the retry budget and every manual check
+ * path are unchanged.
+ */
+export const UPDATE_STARTUP_CHECK_DELAY_MS = 60 * 1000;

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1033,10 +1033,15 @@ app.whenReady().then(async () => {
 		void refreshSystemProxy(proxyResolution());
 	});
 
-	// Start checking for updates once a window exists to receive events. The
-	// updater reads `mainWindow` at send time rather than being handed the window
-	// now: on macOS the app outlives its window, and a dock-activate builds a
-	// replacement that a captured reference would never reach.
+	// Arm the update checks once a window exists to receive events. The updater
+	// reads `mainWindow` at send time rather than being handed the window now: on
+	// macOS the app outlives its window, and a dock-activate builds a replacement
+	// that a captured reference would never reach.
+	//
+	// This arms them rather than running one: the first check waits out
+	// `UPDATE_STARTUP_CHECK_DELAY_MS`, so a silent platform's download does not
+	// start while the window, the engine and the user's first requests are still
+	// competing for the link and the disk.
 	initAutoUpdater(() => mainWindow);
 
 	app.on("activate", () => {

--- a/app/electron/updater.test.ts
+++ b/app/electron/updater.test.ts
@@ -22,6 +22,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { ROOT_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+import { UPDATE_CHECK_INTERVAL_MS, UPDATE_STARTUP_CHECK_DELAY_MS } from "./constants.js";
 
 type Handler = (arg: unknown) => void;
 
@@ -115,6 +116,11 @@ function failAttempt(err: Error): void {
 /** Let the retry's delay elapse so the second attempt runs. */
 async function letRetryRun(): Promise<void> {
 	await vi.advanceTimersByTimeAsync(2_000);
+}
+
+/** Let the launch delay elapse so the session's first check runs. */
+async function letStartupDelayPass(): Promise<void> {
+	await vi.advanceTimersByTimeAsync(UPDATE_STARTUP_CHECK_DELAY_MS);
 }
 
 afterEach(() => {
@@ -221,6 +227,81 @@ describe("checkForUpdatesNow", () => {
 	});
 });
 
+describe("when the session's first check runs", () => {
+	// On Windows and the Linux AppImage a check that finds a release downloads it
+	// on the spot, and `initAutoUpdater` is called moments after the window is
+	// created - so the transfer used to start at t=0 of a launch, against the
+	// user's own API traffic and the engine's startup disk work.
+
+	it("holds the first check back rather than starting one at launch", async () => {
+		vi.useFakeTimers();
+		const { initAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+
+		expect(checkForUpdates).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(UPDATE_STARTUP_CHECK_DELAY_MS - 1);
+		expect(checkForUpdates).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("waits on the notify platforms too, so there is one timing to reason about", async () => {
+		// macOS only fetches the feed, which is cheap - but a second timing rule
+		// would be a second thing to keep true.
+		vi.useFakeTimers();
+		const { initAutoUpdater } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+
+		expect(checkForUpdates).not.toHaveBeenCalled();
+		await letStartupDelayPass();
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets a check the user asks for during the wait stand in for it", async () => {
+		// Settings → General, or the menu item, moments after launch: the answer
+		// is the one the startup check would have got, so running it again when
+		// the delay elapses would be the same question twice.
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+
+		const pending = checkForUpdatesNow("renderer");
+		listeners.get("update-not-available")?.({});
+		await expect(pending).resolves.toMatchObject({ status: "up-to-date" });
+
+		await letStartupDelayPass();
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("drops the waiting check when the app quits before it comes due", async () => {
+		// `will-quit` runs while the delay is still pending on any launch shorter
+		// than a minute - the check must not fire into a torn-down updater.
+		vi.useFakeTimers();
+		const { initAutoUpdater, disposeAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+
+		disposeAutoUpdater();
+		await letStartupDelayPass();
+
+		expect(checkForUpdates).not.toHaveBeenCalled();
+	});
+
+	it("leaves the 6h cycle on its own clock", async () => {
+		// The delay moves the first check, not the interval: the second check of
+		// the session still lands 6h after launch, not 6h after the first one.
+		vi.useFakeTimers();
+		const { initAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+
+		await letStartupDelayPass();
+		listeners.get("update-not-available")?.({});
+		await vi.advanceTimersByTimeAsync(UPDATE_CHECK_INTERVAL_MS - UPDATE_STARTUP_CHECK_DELAY_MS);
+
+		expect(checkForUpdates).toHaveBeenCalledTimes(2);
+	});
+});
+
 describe("one transient is not the answer", () => {
 	// A mac check is three sequential HTTPS requests through Chromium's net
 	// stack, and the first one of the session runs on the coldest possible
@@ -280,7 +361,7 @@ describe("one transient is not the answer", () => {
 		// is in flight inherits its fate. It has to inherit the retry too.
 		vi.useFakeTimers();
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
-		initAutoUpdater(getWindow); // starts the startup check
+		initAutoUpdater(getWindow); // the startup check is still waiting out its delay
 		const first = checkForUpdatesNow("renderer");
 		const joined = checkForUpdatesNow("renderer");
 
@@ -313,6 +394,7 @@ describe("one transient is not the answer", () => {
 		vi.useFakeTimers();
 		const { initAutoUpdater } = await loadUpdater();
 		initAutoUpdater(getWindow);
+		await letStartupDelayPass(); // the startup check is in flight from here
 		checkForUpdates.mockClear();
 
 		// Nobody is waiting on the startup check - it still gets its retry.
@@ -514,6 +596,7 @@ describe("where the result is delivered", () => {
 		vi.useFakeTimers();
 		const { initAutoUpdater } = await loadUpdater();
 		initAutoUpdater(getWindow);
+		await letStartupDelayPass(); // a silent cycle is actually in flight
 		// No manual check in flight - the interval's events must not pop a
 		// dialog over whatever the user is doing.
 		listeners.get("update-not-available")?.({});

--- a/app/electron/updater.test.ts
+++ b/app/electron/updater.test.ts
@@ -296,8 +296,15 @@ describe("when the session's first check runs", () => {
 
 		await letStartupDelayPass();
 		listeners.get("update-not-available")?.({});
-		await vi.advanceTimersByTimeAsync(UPDATE_CHECK_INTERVAL_MS - UPDATE_STARTUP_CHECK_DELAY_MS);
 
+		// Up to a millisecond before the interval is due, the first check is still
+		// the only one - the delay must not have moved this boundary with it.
+		await vi.advanceTimersByTimeAsync(
+			UPDATE_CHECK_INTERVAL_MS - UPDATE_STARTUP_CHECK_DELAY_MS - 1
+		);
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1);
 		expect(checkForUpdates).toHaveBeenCalledTimes(2);
 	});
 });
@@ -361,7 +368,11 @@ describe("one transient is not the answer", () => {
 		// is in flight inherits its fate. It has to inherit the retry too.
 		vi.useFakeTimers();
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
-		initAutoUpdater(getWindow); // the startup check is still waiting out its delay
+		initAutoUpdater(getWindow);
+		// The click has to land on the startup check itself, so let the launch
+		// delay pass first: before it does there is a timer, not a check, and the
+		// click would simply start its own cycle.
+		await letStartupDelayPass();
 		const first = checkForUpdatesNow("renderer");
 		const joined = checkForUpdatesNow("renderer");
 

--- a/app/electron/updater.ts
+++ b/app/electron/updater.ts
@@ -11,7 +11,11 @@ import { app, dialog, ipcMain, shell } from "electron";
 // be pulled off the default import.
 import electronUpdater from "electron-updater";
 import { resolveUpdateStrategy, type UpdateStrategy } from "./updater-strategy.js";
-import { REPO, UPDATE_CHECK_INTERVAL_MS as CHECK_INTERVAL_MS } from "./constants.js";
+import {
+	REPO,
+	UPDATE_CHECK_INTERVAL_MS as CHECK_INTERVAL_MS,
+	UPDATE_STARTUP_CHECK_DELAY_MS as STARTUP_DELAY_MS,
+} from "./constants.js";
 
 const { autoUpdater } = electronUpdater;
 
@@ -114,6 +118,8 @@ let attempt = 0;
 /** The attempt whose failure has already been acted on - see `handleCheckFailure`. */
 let failedAttempt = 0;
 let retryTimer: NodeJS.Timeout | null = null;
+/** The session's first check, waiting out `STARTUP_DELAY_MS`. */
+let startupTimer: NodeJS.Timeout | null = null;
 
 /**
  * How the updater finds the window to talk to, asked fresh every time.
@@ -177,8 +183,37 @@ function runCheckAttempt(): void {
 	});
 }
 
+/** Drop the waiting first check - it ran, something replaced it, or we are quitting. */
+function clearStartupDelay(): void {
+	if (startupTimer) {
+		clearTimeout(startupTimer);
+		startupTimer = null;
+	}
+}
+
+/**
+ * Wait out `STARTUP_DELAY_MS`, then run the session's first check.
+ *
+ * Only the first one is delayed: the periodic cycle and every manual check keep
+ * their own timing, and a manual check made during the wait absorbs this one
+ * (`startCheckCycle` clears it) rather than being followed by a duplicate.
+ */
+function scheduleStartupCheck(): void {
+	clearStartupDelay();
+	startupTimer = setTimeout(() => {
+		startupTimer = null;
+		startCheckCycle();
+	}, STARTUP_DELAY_MS);
+	// Node keeps the process alive for a pending timer; a check that is not due
+	// yet must not hold up quit.
+	startupTimer.unref?.();
+}
+
 /** Start a check with a full retry budget. Every check path goes through here. */
 function startCheckCycle(): void {
+	// Whichever path gets here first is the session's first check; a startup one
+	// still waiting would only ask the same question again a moment later.
+	clearStartupDelay();
 	clearRetry();
 	attempt = 1;
 	failedAttempt = 0;
@@ -323,8 +358,16 @@ export function initAutoUpdater(getWindow: WindowAccessor): void {
 	// The startup and periodic checks retry on the same budget. They stay
 	// silent - `settleCheck` answers nobody when no one is waiting - but the
 	// startup one runs on the coldest network stack of the session, so it is
-	// the attempt that most needs a second try.
-	startCheckCycle();
+	// the attempt that most needs a second try. The wait ahead of it warms that
+	// stack rather than replacing the retry: a minute in, Wi-Fi may still be
+	// settling, and a check the user clicks during the wait starts its own
+	// cycle with the same budget.
+	//
+	// It is the *download* the wait is for. On the silent platforms the check
+	// pulls the release as soon as it finds one, and at t=0 that transfer
+	// competed with the user's own API traffic and with the engine's startup
+	// disk work (see `UPDATE_STARTUP_CHECK_DELAY_MS`).
+	scheduleStartupCheck();
 	intervalTimer = setInterval(() => startCheckCycle(), CHECK_INTERVAL_MS);
 }
 
@@ -466,6 +509,7 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
  * quit. The caller still gets its answer, so no promise is left hanging.
  */
 export function disposeAutoUpdater(): void {
+	clearStartupDelay();
 	if (intervalTimer) {
 		clearInterval(intervalTimer);
 		intervalTimer = null;


### PR DESCRIPTION
## Description

On the silent platforms (Windows, Linux AppImage) a check that finds a release downloads it on the spot, and `initAutoUpdater` is called moments after the window is created - so a 127MB NSIS pull, or an AppImage apply that reads the whole old image and writes a new one, began at t=0 of a launch. In an API-testing client that transfer competes for the link with the user's own requests and for the disk with the engine's startup work; with a release every day or two, a daily user paid it every second or third launch.

**Root cause and approach.** The silent *strategy* is documented and deliberate; the *timing* was un-owned - `initAutoUpdater` ended with a synchronous `startCheckCycle()`, and no delay, gate or constant existed anywhere near it. So the fix is the timing alone: the session's first check is now scheduled through `scheduleStartupCheck()`, which waits out the new `UPDATE_STARTUP_CHECK_DELAY_MS` (60s) on an unref'd timer, and `startCheckCycle()` clears a pending one so a check the user asks for during the wait stands in for it instead of being followed by a duplicate. `disposeAutoUpdater()` drops a waiting check, so a launch shorter than the delay leaves nothing armed. The 6h interval is still armed at init and keeps its own clock, the retry budget is untouched, and no consumer changes: the renderer's `UpdateBanner` / `useAppUpdate` and `UpdatesCard` react to `update:available` / `update:downloaded` / `update:check` and assume nothing about when the first check fires.

**The alternative rejected:** the issue's optional second half - keeping the check immediate on AppImage but setting `autoDownload = false` there and downloading from the `update-available` handler once idle. It buys nothing the delay does not (the cost deferred is the transfer either way) and costs a second, platform-conditional timing path plus a strategy branch to keep true. One rule for every platform is the cheaper thing to maintain, which is also why the delay applies on the notify platforms rather than being gated on `strategy === "silent"`.

The delay lives in `constants.ts` beside `UPDATE_CHECK_INTERVAL_MS` - the two schedule numbers together - following the existing `*_DELAY_MS` convention (`ENGINE_RESTART_BASE_DELAY_MS`, `ENGINE_PORT_RELEASE_DELAY_MS`); the in-flight budget (timeout, retry) stays local to `updater.ts`.

Two notes on the issue as filed, both cosmetic: every path it cites is `app/src/main/...`, which has never existed here - the real files are under `app/electron/` - and the line numbers have drifted (`updater.ts:327-328`, `main.ts:1012/1017/1040`). The mechanism it describes is confirmed exactly as written at `87d0d99`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **596 files, 6564 tests, all passing**. `pnpm type-check` clean on all three projects; `pnpm lint` exits 0 (the two `TSSatisfiesExpression` advisories printed are pre-existing, #1261); `prettier --check` clean on the four touched files. The engine is untouched, so no engine build or ctest run: no C++ test could change colour.

Five new cases in `electron/updater.test.ts` (`when the session's first check runs`), each mutation-checked against the specific mutation it exists to catch:

- no check at launch, none at delay-1ms, exactly one at the delay - the acceptance criterion, fake timers. Fails when `scheduleStartupCheck()` goes back to `startCheckCycle()`.
- the notify platforms wait too, so there is one timing rule to reason about. Same revert fails it.
- a manual check during the wait stands in for the startup one: one `checkForUpdates` call in total. Fails without `clearStartupDelay()` in `startCheckCycle`.
- `disposeAutoUpdater()` before the delay elapses leaves nothing to fire. Fails without the `clearStartupDelay()` in teardown.
- the 6h cycle keeps its own clock: one check at `interval - 1ms`, two at the interval. Fails when the `setInterval` is armed from inside the delayed callback instead of at init, which would push every later check back by the delay.

Two existing cases were adjusted rather than left reading true and testing nothing. `retries the periodic check without surfacing anything` now lets the delay pass, so it fails an attempt that is actually in flight; `retries the check a manual click joined` does the same, so the click lands on the startup check as its comment describes instead of joining a second manual check (a case `joins an in-flight check` already covers).

Reviewed adversarially by two read-only passes (acceptance criteria, repo conventions). Two findings survived and are fixed above: the 6h-cycle case did not discriminate the boundary, and the manual-join case had stopped exercising the startup check. One was discarded with reason: a manual click landing while a startup cycle's request is outstanding resets the shared `attempt` counter, which costs at most one extra round trip and is bounded by the same 30s budget. That behaviour is pre-existing - the old immediate check had the identical window, only a shorter one - and changing it is a different question from this issue's timing, so the diff leaves it alone and the restored test now covers the path.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Documentation: no `docs/` page states update-check timing (`docs/app/architecture.md:307` lists the preload bridge surface only), so the rationale is recorded where the decision is - the constant's comment in `constants.ts`, the `initAutoUpdater` comment, which previously justified the immediate check and would otherwise have gone stale, and the `main.ts` call-site comment. Adding timing prose to the preload-bridge bullet would have put it under a heading about a different thing.

## Related Issues
Closes #1159
Sub-issue of #1143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwGZUEmXjgvrgiFfgToTJJ