### PR TITLE
fix(engine): an inbox records a path past the regex route limit

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3249,12 +3249,19 @@ started, and a running listener keeps what it was started with:
 | `inboxMaxCaptures` | 500 | 1 - 10000 | Captures retained per inbox, oldest evicted first. Also the ceiling on one `limit` of the capture list |
 | `inboxLivePollIntervalMs` | 250 | 25 - 5000 | How often a watched inbox checks for new captures - the delay between a webhook landing and its event |
 
-Two are **not** settings, deliberately. A request over **8 MiB** is refused at
+Three are **not** settings, deliberately. A request over **8 MiB** is refused at
 the transport with a `413` and recorded nowhere: that bounds what an
 unauthenticated remote caller can make the engine buffer, which is not the local
 user's preference to spend. The canned response's **`delayMs` is capped at
 30000**: it holds a listener thread for its whole duration and a stop waits on
-that join, so it bounds how long a stop can be made to take.
+that join, so it bounds how long a stop can be made to take. The **request
+target** - path and query together - is capped at **8192 bytes** by the
+transport, past which it answers `414`.
+
+Below that cap the path's length does not matter, and "any path" is meant
+literally: an inbox routes every request to its capture without matching the
+path against anything, so a signed callback URL, a per-delivery token in the
+path or a deeply nested tenant route is recorded like any other (issue #1140).
 
 ### POST /inbox/start
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -154,7 +154,11 @@ alive at that point. All four managers run that lifecycle - bind, wait for the a
 join, release - through one shared `ManagedListener`
 (`engine/include/vayu/http/managed_listener.hpp`), so a fix to it reaches every listener rather than
 one of four copies; what stays per-manager is the route registration, the error each bind failure
-answers with, and the OAuth attempt TTL sweep. The mock server is the one built on the helper rather
+answers with, and the OAuth attempt TTL sweep. Since #1140 a manager may hand it the
+`httplib::Server` those routes are registered on, too: the inbox hands it a subclass that routes
+every request as one path, so that a path too long for cpp-httplib's regex matcher still reaches its
+capture, and the other three take the plain server the listener builds for itself. The mock server
+is the one built on the helper rather
 than ported to it: #505 extracted it before this listener existed, which was the whole point of
 extracting it when the third one landed.
 

--- a/engine/include/vayu/http/managed_listener.hpp
+++ b/engine/include/vayu/http/managed_listener.hpp
@@ -55,6 +55,16 @@ namespace vayu::http {
 class ManagedListener {
     public:
     ManagedListener ();
+    /**
+     * Take a server the owner built, for a listener that needs one a plain
+     * `httplib::Server` cannot be - the webhook inbox routes every request as
+     * one path through a `Server` subclass, so that a path cpp-httplib's regex
+     * matcher would refuse still reaches its handler (see routes/inbox.cpp).
+     *
+     * Throws `std::invalid_argument` on a null server rather than letting it
+     * read back as a listener `stop()` has already released.
+     */
+    explicit ManagedListener (std::unique_ptr<httplib::Server> server);
     /// Stops and joins, so a manager destroying its records never leaks a thread.
     ~ManagedListener ();
 

--- a/engine/src/http/managed_listener.cpp
+++ b/engine/src/http/managed_listener.cpp
@@ -55,7 +55,16 @@ ClaimRegistry& registry () {
 } // namespace
 
 ManagedListener::ManagedListener ()
-: server_ (std::make_unique<httplib::Server> ()) {
+: ManagedListener (std::make_unique<httplib::Server> ()) {
+}
+
+ManagedListener::ManagedListener (std::unique_ptr<httplib::Server> server)
+: server_ (std::move (server)) {
+    if (!server_) {
+        throw std::invalid_argument (
+        "ManagedListener was handed no server - every accessor would then read "
+        "as a listener stop() had already released");
+    }
 }
 
 ManagedListener::~ManagedListener () {

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -123,9 +123,11 @@ std::string path_of (const std::string& target) {
  * recording the body is what a capture is for; it also takes a `const
  * Request&`, so it cannot rewrite the path either. `process_request`'s
  * `setup_request` callback is the one hook that sees a mutable `Request` ahead
- * of routing, and overriding `process_and_close_socket` - the protected virtual
- * cpp-httplib's own `SSLServer` extends the same way - is how a caller reaches
- * it.
+ * of routing, and overriding `process_and_close_socket` reaches it. That one is
+ * *private* in `httplib::Server`, which is no obstacle: access control governs
+ * who may call a virtual, not who may override it, and it is how cpp-httplib's
+ * own `SSLServer` extends the same function. `process_request` and the members
+ * the override reads are protected.
  */
 class AnyPathServer final : public httplib::Server {
     public:
@@ -134,7 +136,7 @@ class AnyPathServer final : public httplib::Server {
     /// already spells.
     static constexpr const char* ROUTE = "/";
 
-    protected:
+    private:
     bool process_and_close_socket (::socket_t sock) override {
         // Mirrors httplib::Server::process_and_close_socket. The one difference
         // is the `setup_request` callback below, which that one passes as null -

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -128,6 +128,12 @@ std::string path_of (const std::string& target) {
  * who may call a virtual, not who may override it, and it is how cpp-httplib's
  * own `SSLServer` extends the same function. `process_request` and the members
  * the override reads are protected.
+ *
+ * The mirror below is a copy of library code, and it has an exit on record
+ * rather than by default: #1283 tracks upstreaming a public request-setup hook
+ * (or a matcher-free default handler) to cpp-httplib, after which this class
+ * and its version assert go and the two inbox tests that pin this behaviour
+ * stay as they are.
  */
 class AnyPathServer final : public httplib::Server {
     public:
@@ -144,8 +150,9 @@ class AnyPathServer final : public httplib::Server {
         // override that reaches the callback.
         static_assert (std::string_view (CPPHTTPLIB_VERSION) == "0.53.1",
         "cpp-httplib moved: re-read Server::process_and_close_socket, "
-        "confirm this override still mirrors it, then update this "
-        "assert (issue #1140).");
+        "confirm this override still mirrors it, then update this assert - "
+        "or retire the mirror entirely if the release carries a public "
+        "request-setup hook (issue #1283).");
 
         std::string remote_addr;
         int remote_port = 0;

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -76,6 +76,99 @@ std::string query_of (const std::string& target) {
     return pos == std::string::npos ? std::string{} : target.substr (pos + 1);
 }
 
+/**
+ * The decoded path of a request target, without the query string.
+ *
+ * Exactly what cpp-httplib's own request-line parser puts in `Request::path` -
+ * `decode_path_component` of everything before the first '?', the fragment
+ * having already been cut from the target. A capture derives the path here
+ * rather than reading `req.path`, because the inbox listener routes every
+ * request as one literal path; see `AnyPathServer`.
+ */
+std::string path_of (const std::string& target) {
+    const auto pos = target.find ('?');
+    return httplib::decode_path_component (
+    pos == std::string::npos ? target : target.substr (0, pos));
+}
+
+/**
+ * The inbox's listener: one handler, reached by every request whatever its path.
+ *
+ * cpp-httplib chooses a handler by matching `Request::path`, and the only
+ * matcher of its two that can span path segments is the regex one - which,
+ * since 0.53.1, refuses any path longer than
+ * `CPPHTTPLIB_REGEX_ROUTE_PATH_MAX_LENGTH` (256) before it reaches
+ * `std::regex_match`. The `.*` route per method this replaces was subject to
+ * that, so a webhook delivered to a longer path drew httplib's own 404 and was
+ * never recorded - no row, nothing in the list, no sign anything arrived
+ * (issue #1140). Long paths are ordinary in the traffic an inbox exists to
+ * receive: signed callback URLs, per-delivery tokens in the path, deeply
+ * nested tenant routes.
+ *
+ * An inbox has nothing to route - one handler answers every method and path -
+ * so rather than ask the matcher a question whose answer is always yes, every
+ * request is routed **as** `ROUTE` and the handlers register on that literal,
+ * which `make_matcher` answers with a `PathParamsMatcher` that compares it as a
+ * string. No regex runs against an inbox's traffic at all, so nothing bounds
+ * the path it accepts but httplib's own 8192-byte request-target cap.
+ *
+ * Raising the limit instead would be the wrong lever twice over: it is a
+ * compile-time macro read by an `inline` function, so a value for this
+ * translation unit alone is an ODR violation, and raising it globally hands
+ * `std::regex_match` up to that 8192-byte target - the per-character recursion
+ * the limit exists to bound - on the one listener that may bind past loopback.
+ *
+ * The mock server's fix for the same defect (#1139) does not port here.
+ * `set_pre_routing_handler` runs before cpp-httplib reads the body, and
+ * recording the body is what a capture is for; it also takes a `const
+ * Request&`, so it cannot rewrite the path either. `process_request`'s
+ * `setup_request` callback is the one hook that sees a mutable `Request` ahead
+ * of routing, and overriding `process_and_close_socket` - the protected virtual
+ * cpp-httplib's own `SSLServer` extends the same way - is how a caller reaches
+ * it.
+ */
+class AnyPathServer final : public httplib::Server {
+    public:
+    /// The path every request is routed as, and so the pattern the handlers
+    /// register on. Any literal would do; "/" is the one an inbox's own URL
+    /// already spells.
+    static constexpr const char* ROUTE = "/";
+
+    protected:
+    bool process_and_close_socket (::socket_t sock) override {
+        // Mirrors httplib::Server::process_and_close_socket. The one difference
+        // is the `setup_request` callback below, which that one passes as null -
+        // and `process_request` is its only caller, so there is no narrower
+        // override that reaches the callback.
+        static_assert (std::string_view (CPPHTTPLIB_VERSION) == "0.53.1",
+        "cpp-httplib moved: re-read Server::process_and_close_socket, "
+        "confirm this override still mirrors it, then update this "
+        "assert (issue #1140).");
+
+        std::string remote_addr;
+        int remote_port = 0;
+        httplib::detail::get_remote_ip_and_port (sock, remote_addr, remote_port);
+
+        std::string local_addr;
+        int local_port = 0;
+        httplib::detail::get_local_ip_and_port (sock, local_addr, local_port);
+
+        bool websocket_upgraded = false;
+        const auto ret = httplib::detail::process_server_socket (svr_sock_,
+        sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_,
+        read_timeout_usec_, write_timeout_sec_, write_timeout_usec_,
+        [&] (httplib::Stream& strm, bool close_connection, bool& connection_closed) {
+            return process_request (
+            strm, remote_addr, remote_port, local_addr, local_port,
+            close_connection, connection_closed,
+            [] (httplib::Request& req) { req.path = ROUTE; }, &websocket_upgraded);
+        });
+
+        httplib::detail::drain_and_close_socket (sock);
+        return ret;
+    }
+};
+
 /// Read a canned response's content type without assuming the caller's casing.
 std::string content_type_of (const std::map<std::string, std::string>& headers) {
     for (const auto& [name, value] : headers) {
@@ -395,7 +488,7 @@ struct InboxManager::Inbox {
     /// limits and the canned response above it while the accept loop is alive.
     /// Its listening state *is* the inbox's `running` - a stopped inbox keeps
     /// its record, so there is nothing else for `running` to mean.
-    ManagedListener listener;
+    ManagedListener listener{ std::make_unique<AnyPathServer> () };
 
     InboxInfo info_locked () const {
         InboxInfo info;
@@ -447,10 +540,13 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
         capture_row.inbox_id    = raw->id;
         capture_row.received_at = routes::now_ms ();
         capture_row.method      = req.method;
-        capture_row.path        = req.path;
-        capture_row.query       = query_of (req.target);
-        capture_row.headers     = headers_to_json (req.headers).dump ();
-        capture_row.body_bytes  = static_cast<int64_t> (req.body.size ());
+        // Not `req.path`: the listener routes every request as one literal path
+        // so that no path length can miss the handler, so what arrived is only
+        // still on the target. See AnyPathServer.
+        capture_row.path       = path_of (req.target);
+        capture_row.query      = query_of (req.target);
+        capture_row.headers    = headers_to_json (req.headers).dump ();
+        capture_row.body_bytes = static_cast<int64_t> (req.body.size ());
         capture_row.body_truncated = capture_row.body_bytes > raw->limits.max_body_bytes;
         capture_row.body        = capture_row.body_truncated ?
                req.body.substr (0, static_cast<size_t> (raw->limits.max_body_bytes)) :
@@ -495,15 +591,18 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
         }
     };
 
-    // Every method cpp-httplib will route, on every path. CONNECT, TRACE and
-    // PRI are the remainder and are not routable - a webhook is never one.
+    // Every method cpp-httplib will route, on the one literal path the listener
+    // routes every request as - which is how a path of any length reaches the
+    // capture rather than being refused by a regex route (AnyPathServer, issue
+    // #1140). CONNECT, TRACE and PRI are the remainder and are not routable - a
+    // webhook is never one.
     httplib::Server& svr = inbox->listener.server ();
-    svr.Get (".*", capture); // also serves HEAD
-    svr.Post (".*", capture);
-    svr.Put (".*", capture);
-    svr.Patch (".*", capture);
-    svr.Delete (".*", capture);
-    svr.Options (".*", capture);
+    svr.Get (AnyPathServer::ROUTE, capture); // also serves HEAD
+    svr.Post (AnyPathServer::ROUTE, capture);
+    svr.Put (AnyPathServer::ROUTE, capture);
+    svr.Patch (AnyPathServer::ROUTE, capture);
+    svr.Delete (AnyPathServer::ROUTE, capture);
+    svr.Options (AnyPathServer::ROUTE, capture);
 
     const auto started =
     inbox->listener.start (request.bind, request.port, "inbox " + inbox->id);

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -285,6 +285,59 @@ TEST_F (InboxListenerTest, RecordsWhatArrivedOnAnyMethodAndPath) {
     EXPECT_EQ (newest.front ().method, "DELETE");
 }
 
+TEST_F (InboxListenerTest, RecordsAPathPastTheRegexRouteLimitWithItsBody) {
+    // cpp-httplib 0.53.1 refuses a regex route outright for any path longer
+    // than CPPHTTPLIB_REGEX_ROUTE_PATH_MAX_LENGTH (256) rather than risk
+    // std::regex_match's per-character recursion. The `.*` route per method
+    // this listener used to register was subject to that, so a webhook
+    // delivered to a longer path drew httplib's own 404 and was never recorded
+    // at all - no row, no sign anything arrived (issue #1140). Put those
+    // registrations back in place of AnyPathServer and the size assertion below
+    // goes red: nothing is stored.
+    const std::string long_path = "/hooks/" + std::string (300, 'a');
+    ASSERT_GT (long_path.size (), 256u)
+    << "the path must clear the limit to test it";
+
+    auto started = start ();
+    auto client  = client_for (started.info);
+
+    auto posted = client.Post (long_path + "?attempt=2", "{\"id\":7}", "application/json");
+    ASSERT_TRUE (posted) << "POST to the inbox failed";
+    EXPECT_EQ (posted->status, 200);
+
+    auto captures = db_->get_inbox_requests_paginated (started.info.inbox_id, 10, 0);
+    ASSERT_EQ (captures.size (), 1u);
+    const auto& capture = captures.front ();
+    EXPECT_EQ (capture.path, long_path);
+    EXPECT_EQ (capture.query, "attempt=2");
+    // The body is the half a pre-routing handler could not have recorded, which
+    // is why this listener routes rather than answers ahead of the body read.
+    EXPECT_EQ (capture.body, "{\"id\":7}");
+    EXPECT_FALSE (capture.body_truncated);
+
+    // A body-less method on the same path is routed the same way.
+    ASSERT_TRUE (client.Get (long_path));
+    EXPECT_EQ (db_->count_inbox_requests (started.info.inbox_id), 2);
+}
+
+TEST_F (InboxListenerTest, RecordsThePathDecodedAsHttplibItselfWould) {
+    // The path is read off the target now that routing rewrites `req.path`, so
+    // it has to stay the *decoded* path cpp-httplib put there before - the
+    // column, the wire and the URL the app rebuilds from it all mean that.
+    auto started = start ();
+    auto client  = client_for (started.info);
+
+    ASSERT_TRUE (client.Post ("/hooks/a%20b/caf%C3%A9?q=1%202", "{}", "application/json"));
+
+    auto captures = db_->get_inbox_requests_paginated (started.info.inbox_id, 1, 0);
+    ASSERT_EQ (captures.size (), 1u);
+    EXPECT_EQ (captures.front ().path, "/hooks/a b/caf\xC3\xA9");
+    // The query is still the raw string off the wire, undecoded, as it always
+    // was - httplib's own client re-spells the space as '+' on the way out, and
+    // a capture shows what arrived rather than a reading of it.
+    EXPECT_EQ (captures.front ().query, "q=1+2");
+}
+
 TEST_F (InboxListenerTest, ServesTheCannedResponseIncludingItsDelay) {
     InboxStartRequest request;
     request.response.status   = 500;

--- a/engine/tests/managed_listener_test.cpp
+++ b/engine/tests/managed_listener_test.cpp
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -189,6 +190,35 @@ TEST (ManagedListener, RegisteringARouteAfterStopFailsLoudly) {
     ASSERT_GT (listener.start ("127.0.0.1").port, 0);
     listener.stop ();
     EXPECT_THROW (listener.server (), std::logic_error);
+}
+
+TEST (ManagedListener, AListenerHandedNoServerRefusesAtConstruction) {
+    // A listener owning nothing reads exactly like a stopped one - `server ()`
+    // throws the same way for both - so the two are told apart here, where the
+    // caller that passed the null is still on the stack.
+    EXPECT_THROW ((void)ManagedListener (nullptr), std::invalid_argument);
+}
+
+TEST (ManagedListener, ADeliberateServerIsTheOneTheListenerServesOn) {
+    // The inbox hands its listener an `httplib::Server` subclass (#1140); what
+    // this pins is that the one handed over is the one routes register on and
+    // requests are served by, not a replacement built inside.
+    auto server            = std::make_unique<httplib::Server> ();
+    httplib::Server* given = server.get ();
+
+    ManagedListener listener (std::move (server));
+    EXPECT_EQ (&listener.server (), given);
+
+    listener.server ().Get ("/ping", [] (const httplib::Request&, httplib::Response& res) {
+        res.set_content ("pong", "text/plain");
+    });
+    const int port = listener.start ("127.0.0.1").port;
+    ASSERT_GT (port, 0);
+
+    httplib::Client client ("127.0.0.1", port);
+    auto response = client.Get ("/ping");
+    ASSERT_TRUE (response);
+    EXPECT_EQ (response->body, "pong");
 }
 
 TEST (ManagedListener, StartingATwiceStartedListenerRefusesRatherThanLeaking) {


### PR DESCRIPTION
## Description

The inbox registered its catch-all as a `.*` route per method, and since cpp-httplib 0.53.1 a regex route refuses any path longer than `CPPHTTPLIB_REGEX_ROUTE_PATH_MAX_LENGTH` (256) before it reaches `std::regex_match`. A webhook delivered to a longer path drew httplib's own 404 and was **never recorded** - no row, nothing in the inbox list, no sign anything arrived. Long paths are ordinary in the traffic an inbox exists to receive.

**Root cause and approach.** The inbox was asking cpp-httplib's *route matcher* to decide whether a request is captured, and it has nothing to route: one handler answers every method and path. So rather than ask the matcher a question whose answer is always yes, the listener routes every request **as** one literal path and the handlers register on that literal - which `make_matcher` answers with a `PathParamsMatcher`, a string compare with no length limit. No regex runs against an inbox's traffic at all now, which removes the bound rather than raising it. The one hook cpp-httplib gives a mutable `Request` ahead of routing is `process_request`'s `setup_request` callback, and overriding `process_and_close_socket` reaches it - a *private* virtual, which is no obstacle (access control governs who may call a virtual, not who may override it) and is how cpp-httplib's own `SSLServer` extends the same function. A `static_assert` on the pinned version makes a cpp-httplib bump re-read that override rather than drift past it silently. `ManagedListener` already owned its server through a `unique_ptr`, so it gained a constructor taking one its owner built. The capture then reads the path off `req.target` through httplib's public `decode_path_component`, which is exactly what its own request-line parser puts in `Request::path` - the sibling of the `query_of` the row already used.

**The alternatives, and why each was rejected** - the issue asked for this decision to be made deliberately:

- **Raise `CPPHTTPLIB_REGEX_ROUTE_PATH_MAX_LENGTH`.** Wrong twice over. It is a compile-time macro read by an `inline` function, so a value for one translation unit alone is an ODR violation; and raising it globally hands `std::regex_match` up to httplib's 8192-byte request-target cap of attacker-controlled path - the per-character recursion the limit exists to bound - on the one listener that may bind past loopback. `mock_server.cpp` already recorded the same objection for #1139.
- **A non-regex catch-all.** `PathParamsMatcher`'s marker is `/:` and a param captures only as far as the next `/`, so there is no multi-segment spelling. Registering one route per segment depth bounds capture by depth instead of by length and still drops the deep case silently - a stopgap, not a fix.
- **Port #1139's pre-routing handler.** It runs before the body is read, and recording the body is what a capture is for; it also takes a `const Request&`, so it cannot rewrite the path either.
- **Content-reader handlers.** Registration goes through the same matcher, so the length limit applies first.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- New in `engine/tests/inbox_test.cpp`, beside the existing catch-all test:
  - `RecordsAPathPastTheRegexRouteLimitWithItsBody` - a 307-character path, asserting the row exists with its path, query and **body** intact, plus a body-less GET on the same path.
  - `RecordsThePathDecodedAsHttplibItselfWould` - a percent-encoded path, asserting the stored path is still the decoded one and the query is still the raw string, since the path now comes off the target.
- New in `engine/tests/managed_listener_test.cpp`, covering the new constructor: a null server is refused at construction, and a server handed over is the one routes register on and requests are served by.
- **Mutation-checked**: putting the `.*` registrations and the plain `ManagedListener` back reddens `RecordsAPathPastTheRegexRouteLimitWithItsBody` (nothing is stored) while the existing `RecordsWhatArrivedOnAnyMethodAndPath` stays green - the defect reproduces exactly where the issue says it does.
- `python build.py -e -t` then `ctest --preset linux-dev` - **2865 tests, all passing** (2861 on the base commit, so +4 and nothing else moved).
- `clang-format-19 --dry-run -Werror` clean on all five changed C++ files; `clang-tidy-19 -p engine/build` clean on `inbox.cpp`, `managed_listener.cpp`, `inbox_test.cpp` and `managed_listener_test.cpp`.
- `mkdocs build --strict` was **not** run - mkdocs is not installed in this environment. The docs edits are prose inside existing sections, with no new link, heading or nav entry.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commits: `docs/engine/api-reference.md`'s Webhook Inbox "Bounds" paragraph - the request-target cap is named as the third non-setting bound, and "any path" is stated as literal below it; and `docs/engine/architecture.md`'s shared-listener paragraph, whose enumeration of what stays per-manager gains the `httplib::Server` a manager may now hand it. One doc was checked and needs no change: `docs/engine/db-schema.md`'s `path` column still reads "Decoded path, no query" - the derivation moved, the value did not.

## Related Issues
Closes #1140