### PR TITLE
test(app): read index.css through the testkit in two more guards - #1264

### DIFF
--- a/app/src/constants/color-schemes.test.ts
+++ b/app/src/constants/color-schemes.test.ts
@@ -21,12 +21,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { indexCss as css } from "@/lib/css-tokens.testkit";
 import { COLOR_SCHEMES, DEFAULT_COLOR_SCHEME, isColorScheme } from "./color-schemes";
-
-const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "index.css"), "utf8");
 
 // Every token a scheme block is expected to set. `--primary-fill` is the one
 // that carries a white label, so it must be present even though it is the only
@@ -60,8 +56,10 @@ function block(selector: string, dark: boolean): string | null {
 
 describe("accent colour schemes", () => {
 	it("reads a stylesheet that is actually populated", () => {
-		// vitest stubs CSS imports to "" - this file is read from disk for that
-		// reason, and a guard that scans an empty string passes for free.
+		// vitest stubs CSS imports to "" - the testkit reads the stylesheet off
+		// disk for that reason, and a guard that scans an empty string passes for
+		// free. The floor stays here: the import says where the text came from,
+		// this says the scan found something.
 		expect(css.length).toBeGreaterThan(1000);
 		expect(css).toContain("data-color-scheme");
 	});

--- a/app/src/constants/status-token-contrast.test.ts
+++ b/app/src/constants/status-token-contrast.test.ts
@@ -27,13 +27,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { indexCss as css } from "@/lib/css-tokens.testkit";
 import { ROLE_TOKEN } from "@/modules/dashboard/components/charts/uplot/uplotTheme";
-
-const cssPath = join(dirname(fileURLToPath(import.meta.url)), "..", "index.css");
-const css = readFileSync(cssPath, "utf8");
 
 /** Split `:root` from `.dark`, so a token defined in both resolves per theme. */
 const darkStart = css.indexOf(".dark {");


### PR DESCRIPTION
## Description

`css-tokens.testkit.ts` (from #1253 / PR #1263) reads `index.css` off disk rather than through the module graph, because **vitest stubs a CSS import to `""`** - a guard that imports the stylesheet scans an empty string and passes for free, the trap root `CLAUDE.md` names. Two guards still derived that read themselves, each with its own `here` / `cssPath` boilerplate and its own inline note about the stub. The duplicated part is not a parser, it is the *workaround*, which is the part that carries the trap - and a copy does not receive the original's fixes.

Both now import the one thing they need, under the spelling `design-system-doc.test.ts` already uses (`import { indexCss as css }`), so every helper below keeps reading the same local name and no assertion moves. Each file keeps its own per-theme HSL and selector-block parsing - the testkit does not offer it and should not grow it speculatively, since the two files parse for different questions - and each keeps its own non-empty floor: the floor is the assertion, the import is only where the text comes from.

**Alternative rejected:** migrating every remaining `index.css` reader. They are spread across `components/ui/` and the module trees and mostly want one token each, so a blanket migration is a large diff for a small gain. The argument for doing exactly these two is proximity to a hardcoded token list - they are the two most likely to be edited next by someone who has not read the trap - not tidiness.

**One correction to the issue's numbers.** #1264 says eleven files read `index.css` off disk, so nine would remain after these two. The live count is **twelve remaining**: the issue's figure came from a `readFileSync(join(...))` grep, and `app/src/constants/appearance.default-font.test.ts` and `appearance.bundled-faces.test.ts` reach the same file through `readFileSync(new URL(relative, import.meta.url))`, which that shape misses. It does not change the decision - the reason to leave them is cost against gain, not how many there are - but the number in the issue should not be trusted by whoever picks up that follow-up.

Out of scope per the issue, and untouched: `status-token-contrast.test.ts`'s `NEW_FAMILIES` list and the inline `["status-redirect", "status-no-response"]`. Those already name all three newer families, and deriving them from `familiesWithTextPair()` would be wrong rather than merely unnecessary - that function answers "has a `-text` pair", those lists mean "has a `-fill` tier".

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Test-only change (no source file, no doc value) - none of the four boxes fits.

## Testing

- `cd app && pnpm test` - **597 files / 6570 tests passed**, no failures. (The full suite ran rather than the two named files; the change is test-only and green across all of it.)
- `pnpm type-check` - renderer, electron and electron-tests projects all exit 0.
- `npx eslint` and `npx prettier --check` on the two touched files - clean. No repo-wide format run.
- **Mutation check**, as the issue asks: with the exported `indexCss` blanked to `""`, both files fail rather than pass on an empty scan - 18 of 21 cases fail. `color-schemes.test.ts` fails on its floor (`reads a stylesheet that is actually populated`). `status-token-contrast.test.ts` fails *earlier* than its floor, at module load, where `token("card")` throws for a token an empty stylesheet cannot supply - so the file cannot pass on an empty scan, but its floor case never gets to run to say so. That ordering predates this PR (the floor already sat below the module-level `CARD`) and is left as-is rather than reordered, since the acceptance criteria ask for no assertion to change.

No engine build or ctest run: no C++, no source file, and nothing outside two `.test.ts` files - per root `CLAUDE.md`, "if no test could possibly go from green to red, do not run tests" for the untouched half.

No pre-existing failures observed on this base (`fa5439e`).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the change *is* in tests; no assertion was added or edited, only the source of the string
- [x] I have updated documentation - none needed: `app/CLAUDE.md`'s testkit paragraph covers guards reading *outside* `app/` via `routed-inputs.testkit.ts`, and `index.css` is inside `app/`, so neither file's CI routing changes

## Related Issues
Closes #1264