### PR TITLE
test(app): size the step-repro row fixture to the property, not to 600 rows - #1280

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -85,10 +85,18 @@ a hidden performance budget for the handful that build thousands of rows and
 render them. The 5,000-step `ScenarioRunView` cases cost ~1.1s idle (~2.8s for
 the one that renders twice) and crossed 5s whenever the four cores were shared
 with an engine build, failing a run over machine load rather than over the code
-(#846). Give such a case an explicit `it(name, { timeout: N }, fn)` **with the
-measured cost and the multiplier in a comment**, so the next person under load
-does not raise it by reflex - and do not raise the global default, which would
-slow every genuinely hung test's failure to the new bound.
+(#846). It happened a second time at #1280, where a step-repro case rendered a
+600-row grid at 3.6-5.3s and went red at random under CI shard load.
+
+**Ask what the fixture size is _for_ before reaching for a timeout.** #1280's
+600 rows proved nothing 110 did not: the property was "past the grid's first
+window", and that window is 100, so right-sizing the fixture took the case from
+2.9s to under 600ms where a raised timeout would have kept paying the render on
+every run forever. Only where a case genuinely needs the large fixture, give it
+an explicit `it(name, { timeout: N }, fn)` **with the measured cost and the
+multiplier in a comment**, so the next person under load does not raise it by
+reflex - and do not raise the global default, which would slow every genuinely
+hung test's failure to the new bound.
 
 **A source scan cannot see a class that arrives in a variable.** The badge-hover
 guard scanned for `<Badge className="bg-…">` and missed both real instances,

--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -731,20 +731,39 @@ describe("arriving from a failed step", () => {
 
 	it("opens the list on the row that step bound, without a click", async () => {
 		rememberFile();
-		stubReadDataFile(async () => csvBytes(bigCsv(600)));
+		/*
+		 * A handful of rows past the grid's first window (`ROW_WINDOW_STEP`, 100
+		 * in `SendWithRowDialog.tsx`), which is the whole of the size this case
+		 * needs: a row the picker would not have shown by default is what a
+		 * step's repro exists to reach. It was 600 rows against a target at 500,
+		 * and rendering that grid in jsdom cost 3.6-5.3s - over vitest's 5s
+		 * default under CI shard contention, so the case went red at random
+		 * (issue #1280). The window itself belongs to "the grid's keyboard
+		 * model" below, which stubs an `IntersectionObserver` to get a real one.
+		 */
+		stubReadDataFile(async () => csvBytes(bigCsv(110)));
 		const execute = vi.fn(async () => {});
 
 		// What `openRequestWithDataRow` leaves behind for this tab: the request
 		// is already open, and the row is the half `openTab` cannot carry.
-		useTabsStore.setState({ dataRowTarget: { requestId: "req_a", rowIndex: 500 } });
+		useTabsStore.setState({ dataRowTarget: { requestId: "req_a", rowIndex: 105 } });
 		renderBar(execute, CONTRACT, "req_a");
 
+		const row = await screen.findByRole("row", { name: /user105@example\.test/ });
+		/*
+		 * Opened *on* the bound row, not merely opened. Every row is in the DOM
+		 * here - `useGrowingWindow` renders the lot where there is no
+		 * `IntersectionObserver` - so finding and clicking the row would pass
+		 * just as well for a picker that ignored the target and opened on row 1.
+		 * The footer is what names the selection, before anything is clicked.
+		 */
+		expect(screen.getByRole("button", { name: /^send row 106$/i })).toBeTruthy();
+
 		// Two clicks from the step card to the repro: the card's, and this one.
-		const row = await screen.findByRole("row", { name: /user500@example\.test/ });
 		fireEvent.click(row);
 
 		await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
-		expect(execute).toHaveBeenCalledWith({ id: "500", email: "user500@example.test" });
+		expect(execute).toHaveBeenCalledWith({ id: "105", email: "user105@example.test" });
 	});
 
 	it("consumes the target, so a later visit opens on nothing", async () => {


### PR DESCRIPTION
## Description

`send-with-row.test.tsx`'s "opens the list on the row that step bound, without a click" stubbed a 600-row CSV and rendered the send-with-row grid over it in jsdom. Measured on this container at `9dea4f2`: **2931ms** in a whole-file run, against vitest's 5s default (`app/vitest.config.ts` sets no `testTimeout`, and the file sets none). The app suite runs sharded on three OSes under contention, which is what pushed it over - it failed in a batch and passed alone, on both the new and the old master, so this is a standing random red rather than a regression.

**Root cause and approach.** 600 rows was never the property under test. What the case proves is that a step card's repro target opens the picker *on the row it names*, without a click, and the only size that matters to that is "past the grid's first window" - `ROW_WINDOW_STEP`, which is 100 in `SendWithRowDialog.tsx`. The fixture is now **110 rows against a target at row index 105**: window plus a handful, which holds that framing at a fifth of the DOM.

**The alternative I rejected:** giving the case an explicit `it(name, { timeout: N }, fn)`. `app/CLAUDE.md` sanctions that form for a case that genuinely needs a large fixture, and this one does not - a raised timeout would keep paying 3-5s of jsdom rendering on every run forever to assert something 110 rows assert. The issue prefers the smaller fixture for the same reason.

**Second half: the assertion did not discriminate.** `useGrowingWindow` renders the whole list where there is no `IntersectionObserver`, and jsdom has none - so *every* row is in the DOM in this test, and finding the bound row and clicking it would pass just as well for a picker that ignored the target and opened on row 1. The case is named "opens the list **on** the row that step bound" and only proved "opens". It now also asserts the footer reads `Send row 106` before anything is clicked, which is what names the selection.

The window's *real* behaviour is not this case's to hold, and the comment says so rather than implying jsdom enforces a window it does not: "the grid's keyboard model" below stubs an `IntersectionObserver` to get a genuine window and covers the past-the-window case at row 251. The comment points there so the next reader does not re-inflate this fixture.

**Docs, same commit.** `app/CLAUDE.md`'s "A render-heavy test asserts a wall clock it never wrote" paragraph is the doc for exactly this defect class, and its only prescribed remedy was the explicit timeout - the one this change rejected. Left alone it would send the next session to the wrong first move. It now records #1280 as the second occurrence of the class (after #846) and asks what the fixture size is *for* before a timeout is reached for, keeping the timeout prescription for the case that genuinely needs the large fixture.

Otherwise scope is held to the test file, as the issue specifies. `ROW_WINDOW_STEP` is referenced by name in a comment rather than exported and imported - that matches the convention already in this file (the keyboard-model case spells out "the window renders the first 100" the same way), and exporting a constant to widen the module's API for one test was not worth it. `bigCsv` is defined four times in this file; all four copies are byte-identical and none is touched here, and consolidating them is a separate cleanup rather than this issue's.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Full app suite, type-check, lint and format check, all run on this branch and green:

- `pnpm exec vitest run` - **6570 passed** across **597 files**, 0 failed, 417s
- `pnpm type-check` - clean (renderer, electron, electron-tests all exit 0)
- `pnpm lint` - exit 0. It prints two `TSSatisfiesExpression` advisories from `jsx-ast-utils`; those are stdout noise, not lint errors, they reproduce on the base commit `9dea4f2`, and they are already filed as #1261. Untouched here.
- `pnpm format:check` - "All matched files use Prettier code style!", `app/CLAUDE.md` included

The case itself, whole-file runs of `pnpm exec vitest run send-with-row.test.tsx --reporter=verbose`:

| | before | after |
|---|---|---|
| "opens the list on the row that step bound" | 2931ms | **538-589ms** over four runs |
| whole file (41 tests) | 19.95s | 13.97s |

A reviewer measured 0.7-1.4s for the same case using a `-t`-filtered single-test run while the machine was also running the full suite; whole-file runs, which is the shape CI uses, stayed in the 538-717ms band. Either way the margin under the 5s default is 4x or better, where before it was under 2x.

**Mutation checks** (each applied to `UrlBar/index.tsx`, run, then reverted):

1. `rememberRowIndex(dataRowTarget.rowIndex)` → `rememberRowIndex(0)` - the picker opens but on the wrong row. New test **fails** (`Unable to find ... name /^send row 106$/i`). I then re-ran that same mutation with only the *pre-existing* assertions in place: it **passes**. That is the hole this PR closes - the old case proved "opens", not "opens on the bound row". Independently reproduced by a reviewer against the pre-diff file.
2. `if (canBindRows) setRowMenuOpen(true)` → never opens. Test **fails** (`Unable to find role="row" and name /user105@example\.test/`), so the "without a click" half still discriminates too.

No engine change, so no engine build or ctest run - nothing under `engine/` could change colour. No test reads `app/CLAUDE.md`, so the doc edit needs no `routed-inputs.testkit.ts` registration.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1280