### PR TITLE
docs(tooling): name the working targeted-test form, warn off `pnpm test -- &lt;pattern&gt;` - #1281

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,11 @@ there, it does not make it fast; see `docs/engine/building.md`. A
 rebuild ~2.5min; the app suite ~90s. Running
 both after retouching a doc comment reads as diligence and is just latency. Ask
 what a failure would even look like before running anything: **if no test could
-possibly go from green to red, do not run tests.** CI runs the full matrix on
-every push, so a local full-suite run is for *your* confidence, not for coverage.
+possibly go from green to red, do not run tests.** CI runs the checks your diff
+can actually affect - `pr-tests.yml` triggers on every pull request against
+`master`, and each work job is gated on its own tree being touched - so a local
+full-suite run is for *your* confidence, not for coverage. A branch with no pull
+request open has no CI behind it at all.
 
 Concrete cases where the answer is simply "don't":
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ cd app && pnpm format:check  # Prettier
 **Filter the app suite with `pnpm test <pattern>`, never
 `pnpm test -- <pattern>`.** pnpm forwards the literal `--` into the script and
 vitest then reads what follows as not-a-filter, so the double-dash form runs all
-~500 files while looking like a targeted run - the npm muscle memory costs
+~600 files while looking like a targeted run - the npm muscle memory costs
 minutes and reads as "the suite is slow". The bare form answers a miss in about
 a second (`No test files found`). Flags need no separator either:
 `pnpm test --shard=1/2` is the form CI runs. `pnpm exec vitest run <pattern>` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,11 +97,21 @@ tests in ~2 min. If you keep vcpkg elsewhere, set `VCPKG_ROOT` and it is honored
 
 ```bash
 python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure
-cd app && pnpm test          # vitest
+cd app && pnpm test          # vitest, the whole app suite
+cd app && pnpm test Trash    # only the files matching "Trash"
 cd app && pnpm type-check
 cd app && pnpm lint          # ESLint (TS/TSX)
 cd app && pnpm format:check  # Prettier
 ```
+
+**Filter the app suite with `pnpm test <pattern>`, never
+`pnpm test -- <pattern>`.** pnpm forwards the literal `--` into the script and
+vitest then reads what follows as not-a-filter, so the double-dash form runs all
+~500 files while looking like a targeted run - the npm muscle memory costs
+minutes and reads as "the suite is slow". The bare form answers a miss in about
+a second (`No test files found`). Flags need no separator either:
+`pnpm test --shard=1/2` is the form CI runs. `pnpm exec vitest run <pattern>` is
+the explicit equivalent.
 
 CMake presets: `linux-dev`, `linux-prod`, `macos-dev`, `macos-prod`,
 `windows-dev`, `windows-prod`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,8 +337,8 @@ TEST(HttpClientTest, SendsGetRequest) {
 ### App (TypeScript)
 
 The app is tested with [Vitest](https://vitest.dev/). Tests live beside the code
-they cover as `*.test.ts` / `*.test.tsx`, and CI runs the whole suite on every
-push.
+they cover as `*.test.ts` / `*.test.tsx`. CI runs the suite on every pull
+request that touches the app, on all three platforms.
 
 ```bash
 cd app
@@ -358,8 +358,8 @@ pnpm test:watch
 
 **Do not write `pnpm test -- <pattern>`.** pnpm forwards the literal `--` into
 the script and vitest then ignores the filter, so that form quietly runs the
-whole suite instead of the file you asked for. Flags need no separator either:
-`pnpm test --shard=1/2` is the form CI runs.
+whole suite instead of the file you asked for. Flags need no separator either -
+pass them straight through.
 
 Conventions for writing app tests - the default `node` environment, when to ask
 for `jsdom`, and the timeout rule for render-heavy cases - are in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,10 +336,34 @@ TEST(HttpClientTest, SendsGetRequest) {
 
 ### App (TypeScript)
 
-Currently, the app does not have automated tests. If you add tests:
+The app is tested with [Vitest](https://vitest.dev/). Tests live beside the code
+they cover as `*.test.ts` / `*.test.tsx`, and CI runs the whole suite on every
+push.
 
-- Use Vitest for unit tests
-- Use Playwright for E2E tests (if needed)
+```bash
+cd app
+
+# Run the whole app suite
+pnpm test
+
+# Run only the files matching a pattern
+pnpm test VariablesCategoryTree
+
+# The same run, spelled out
+pnpm exec vitest run VariablesCategoryTree
+
+# Re-run on change
+pnpm test:watch
+```
+
+**Do not write `pnpm test -- <pattern>`.** pnpm forwards the literal `--` into
+the script and vitest then ignores the filter, so that form quietly runs the
+whole suite instead of the file you asked for. Flags need no separator either:
+`pnpm test --shard=1/2` is the form CI runs.
+
+Conventions for writing app tests - the default `node` environment, when to ask
+for `jsdom`, and the timeout rule for render-heavy cases - are in
+`app/CLAUDE.md`.
 
 ## Documentation
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -3,6 +3,11 @@
 Renderer and Electron main process for Vayu. Apache-2.0. See the repo root
 `CLAUDE.md` for build commands, commit rules and repo-wide conventions.
 
+Tests run from this directory: `pnpm test` for the whole suite,
+`pnpm test <pattern>` for the files matching it. Never `pnpm test -- <pattern>` -
+pnpm forwards the literal `--` and vitest drops the filter, so that form runs
+everything.
+
 ## Conventions
 
 - Strict TypeScript - no `any`, no `@ts-ignore` without justification. `pnpm lint`


### PR DESCRIPTION
## Description

`app/package.json` runs `vitest run`, and pnpm forwards a literal `--` into the script, so `pnpm test -- <pattern>` reaches vitest as `vitest run -- <pattern>`, the filter is dropped, and all ~600 files run while the invocation looks targeted. Root cause is the argument-forwarding difference from npm, not vitest config. The approach is documentation only: name the working form and its mechanism in the three files a contributor or session actually reads before running tests. The alternative considered and rejected was the wrapper script the issue sketches (`"test": "node scripts/vitest-run.mjs"` stripping a leading `--`) - it makes the broken form work, but it puts test-running knowledge in a third place and hides a pnpm behaviour every other script in the repo still has; the issue itself prefers the documentation fix unless a wrapper is warranted for another reason, and nothing else warrants one.

Measured on this branch's base (`9dea4f2`):

| Invocation | Result |
|---|---|
| `pnpm test -- zzz-no-such-test-zzz` | expands to `vitest run -- zzz-no-such-test-zzz`, still running the full suite when killed at 45 s |
| `pnpm test zzz-no-such-test-zzz` | `No test files found, exiting with code 1` in ~2 s |
| `pnpm exec vitest run zzz-no-such-test-zzz` | same, ~1 s |

Changes:

- **`CLAUDE.md`** Testing: a filtered example in the command block (`pnpm test Trash`), plus the rule with its mechanism. Flag forwarding is unaffected, so the `pnpm test --shard=1/2` form CI already runs is called out as correct.
- **`app/CLAUDE.md`**: the same two forms in the intro, where a session reading the app guide meets them.
- **`CONTRIBUTING.md`**: the `### App (TypeScript)` testing subsection is where this line belongs, and it claimed "the app does not have automated tests" (and offered Playwright, which the repo does not use) - false since long before this issue, and it could not host the guidance while it was false. It now names Vitest, the co-located `*.test.ts(x)` files, the four run commands, the `--` warning, and points at `app/CLAUDE.md` for the writing conventions. This is a deliberate widening of the issue's "one line in CONTRIBUTING.md": the surrounding paragraph had to be true first.

A sweep of every tracked file found **no existing occurrence of the broken form** in the repo (the only `--`-adjacent usages, `.github/workflows/pr-tests.yml:506` and `app/.gitignore:55`, are the correct no-separator flag form), and no file that documented a targeted run at all. So there is nothing to correct in place - the gap was that the working form was written down nowhere.

### Second commit: two claims the review pass caught

- The suite is **597 files** (563 under `app/src`, 34 under `app/electron`), not the "~500" the issue estimated and the first commit repeated.
- "CI runs the whole suite on every push" was wrong twice: `pr-tests.yml` triggers on `pull_request` to `master` only, and its `app` job is path-gated. It now reads "on every pull request that touches the app, on all three platforms".
- `CONTRIBUTING.md` also loses the `--shard=1/2` example, the one sentence that was byte-identical to the root guide; a contributor filtering a local run does not pass shard flags.

### Third commit: #1286 folded in

The same overstatement sat a few lines above the edit, in `CLAUDE.md`'s own Testing paragraph: "CI runs the full matrix on every push", used as the justification for *not* running a suite locally. It was filed separately as #1286 to keep this PR to its issue; folded in here at the owner's request. It now names the real gate - one trigger (`pull_request` to `master`), each work job gated on its own tree - and states the case the old sentence hid: a branch with no pull request open has no CI behind it at all.

`rg "every push"` over the tree now returns only the three docs-site lines (`README.md:168`, `CONTRIBUTING.md:371`, `app/electron/constants.ts:226`), which describe `docs.yml` publishing on push to `master` and are accurate.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Docs-only change, so per `CLAUDE.md`'s "scale the verification" rule no suite could go from green to red. What was verified is that every command the docs now print does what they say:

- `cd app && pnpm test zzz-no-such-test-zzz` - exits 1 with `No test files found` in ~2 s (the issue's acceptance probe).
- `cd app && pnpm exec vitest run zzz-no-such-test-zzz` - same, 1.0 s.
- `cd app && pnpm test -- zzz-no-such-test-zzz` - reproduces the defect: full suite, killed at 45 s.
- `cd app && pnpm test VariablesCategoryTree` - 3 files, 25 tests passed, 4.45 s.
- `cd app && pnpm test Trash` - 3 files, 33 tests passed, 3.95 s.
- `pnpm exec prettier --check CLAUDE.md` from `app/` - clean (the only edited file inside prettier's domain; the two outside `app/` are unformatted by repo policy and were left that way).
- No em-dashes introduced (the only U+2014/U+2013 in the three files are pre-existing lines this diff does not touch).
- The CI claims in the new prose were checked against `.github/workflows/pr-tests.yml` itself: `on: pull_request: branches: [master]` (`:43-46`), the `app` job's `if:` gate (`:439`), and the Windows `shard: 1/2` matrix entries.

CI on the first two commits skipped every work job with `CI gate` green, which is the expected shape for a change touching no app or engine path. No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable: documentation only, and a source-scanning guard against a form that appears nowhere in the repo would be speculative
- [x] I have updated documentation

## Related Issues

Closes #1281
Closes #1286