### PR TITLE
docs(design-system), test(app): the region-cycle row, and the jsx-a11y suppressions held to a list - #1282

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -202,8 +202,11 @@ white-on-`--primary` never occurs because fills use `--primary-fill`).
   the same class string, and the three `jsx-a11y` rules configured rather than
   obeyed as written. `eslint-plugin-jsx-a11y` recommended runs on every `.tsx`
   under `pnpm lint`, so a hand-rolled `role="button"` without a tab stop or a
-  key handler now fails CI at the line. → `focus-indicator.test.ts`,
-  `icon-button-labels.test.tsx`, plus the lint itself
+  key handler now fails CI at the line. The rules it cannot see are suppressed
+  at the line, and that section enumerates every one of them: adding a
+  suppression means adding it there, with its reason, and raising a ceiling
+  (#1282). → `focus-indicator.test.ts`, `icon-button-labels.test.tsx`,
+  `a11y-suppressions.test.ts`, plus the lint itself
 
 ## Borders: what a rule sits _on_, never what it is
 

--- a/app/src/components/a11y-suppressions.test.ts
+++ b/app/src/components/a11y-suppressions.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The `jsx-a11y` rules suppressed at the line, held to a ceiling and to a list.
+ *
+ * #1216 turned the recommended set on and read its 58-error baseline rather than
+ * allowlisting it: three rules are configured in `app/eslint.config.mjs` because
+ * the pattern they flag is the correct one here, and the rest are suppressed one
+ * line at a time. Each of those carries its reason, and
+ * `--report-unused-disable-directives` retires a stale one, so the mechanism is
+ * honest - but a rule-level configuration is visible in one place while a
+ * line-level one is visible only to whoever opens that file, and nothing stopped
+ * the count growing one justified line at a time.
+ *
+ * So the sites are enumerated in `docs/design-system.md` and this guard reads
+ * both halves. The count is a ceiling in the shape `type-scale.test.ts` uses for
+ * font weights: it may come down when a suppression goes, and raising it is an
+ * edit someone has to make on purpose. The doc list is compared site by site
+ * rather than only in total, because a suppression that moves from a tree to a
+ * dialog is a different claim about the same number.
+ *
+ * The scan reads raw lines and does *not* blank comments, unlike the other
+ * source scans in this directory: here the comment is the thing being counted.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, globSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { DOC_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * The most directives this repository may carry.
+ *
+ * A ceiling, not a count to hold: 16 is what #1216 left behind, and the number
+ * moves down with the list in the doc when a site is fixed rather than
+ * suppressed. Raising it means adding a site to the doc too, which is where the
+ * reason has to convince the next reader.
+ */
+const CEILING = 16;
+
+/** The reason marker eslint itself understands, and this repository writes. */
+const REASON = " -- ";
+
+const RULE = /jsx-a11y\/[a-z-]+/g;
+
+const scanned = globSync("**/*.{ts,tsx}", { cwd: srcRoot }).filter(
+	(file) => !file.includes(".test.") && !file.includes(".testkit.")
+);
+
+interface Directive {
+	/** Relative to `app/src`, POSIX-spelled, as the doc lists it. */
+	readonly file: string;
+	readonly line: number;
+	readonly rules: readonly string[];
+	readonly reason: string;
+}
+
+/**
+ * A reason on the previous line counts too - a wrapped block comment above the
+ * directive says as much as a trailing one - which is why this reads the line
+ * before rather than only the text after the marker.
+ */
+function reasonFor(lines: readonly string[], at: number): string {
+	const inline = lines[at].split(REASON).slice(1).join(REASON);
+	if (inline.trim() !== "") return inline.replace(/\*\/\s*}?\s*$/, "").trim();
+
+	const previous = (lines[at - 1] ?? "").trim();
+	const comment = /^(?:\/\/|\/\*|\*)\s*(.+?)(?:\*\/)?$/.exec(previous);
+	return comment && !comment[1].includes("eslint-disable") ? comment[1].trim() : "";
+}
+
+const directives: Directive[] = scanned.flatMap((file) => {
+	const lines = readFileSync(join(srcRoot, file), "utf8").split(/\r?\n/);
+	return lines.flatMap((line, at) =>
+		line.includes("eslint-disable") && line.includes("jsx-a11y/")
+			? [
+					{
+						file: file.split("\\").join("/"),
+						line: at + 1,
+						rules: [...new Set(line.split(REASON)[0].match(RULE) ?? [])].sort(),
+						reason: reasonFor(lines, at),
+					},
+				]
+			: []
+	);
+});
+
+/** One entry per file, which is the granularity the doc list is written at. */
+function bySite(entries: readonly Directive[]): Map<string, { count: number; rules: string[] }> {
+	const sites = new Map<string, { count: number; rules: string[] }>();
+	for (const entry of entries) {
+		const site = sites.get(entry.file) ?? { count: 0, rules: [] };
+		site.count += 1;
+		site.rules = [...new Set([...site.rules, ...entry.rules])].sort();
+		sites.set(entry.file, site);
+	}
+	return sites;
+}
+
+const sites = bySite(directives);
+
+describe("the jsx-a11y suppressions", () => {
+	it("scans a real set of files and directives", () => {
+		// Both floors, for the reason `focus-indicator.test.ts` gives: a broken
+		// glob empties the file list, and a rewritten directive spelling empties
+		// the directive list while the files still scan. 16 directives in 12
+		// files when this was written.
+		expect(scanned.length).toBeGreaterThan(100);
+		expect(directives.length).toBeGreaterThan(10);
+	});
+
+	it("stays under the ceiling", () => {
+		expect(
+			directives.length,
+			`Fix the site, or - if the suppression is the right answer - add it to the Accessibility section of docs/design-system.md and raise this ceiling on purpose:\n${directives
+				.map(({ file, line, rules }) => `${file}:${line} ${rules.join(", ")}`)
+				.join("\n")}`
+		).toBeLessThanOrEqual(CEILING);
+	});
+
+	it("gives every directive a reason", () => {
+		const unreasoned = directives
+			.filter((entry) => entry.reason === "")
+			.map(
+				({ file, line, rules }) =>
+					`${file}:${line} suppresses ${rules.join(", ")} with no reason. Write it after ' -- ' on the directive, naming the file that provides the missing half.`
+			);
+
+		expect(unreasoned.join("\n")).toBe("");
+	});
+});
+
+describe("the doc's list of suppressions", () => {
+	const [DOC] = DOC_READING_GUARDS.a11ySuppressions.paths;
+	const doc = readFileSync(fromRepoRoot(DOC), "utf8");
+
+	/** The Accessibility section alone, so a bullet elsewhere cannot answer. */
+	const afterHeading = doc.slice(doc.indexOf("\n## Accessibility") + 1);
+	const section = afterHeading.slice(0, afterHeading.indexOf("\n## ", 1));
+
+	/**
+	 * The bullets as `path (count) - rules`. A bullet wraps across lines, so each
+	 * is read from its `- ` to the next one and flowed to a single line first -
+	 * the shape `row-persistence-claims.test.ts` reads hand-wrapped prose in. The
+	 * allowlist bullets above name a rule rather than a path and no count, so
+	 * they fall out here rather than needing to be skipped by position.
+	 */
+	const listed = section
+		.split(/\n- /)
+		.slice(1)
+		.map((bullet) => /^`([^`]+)` \((\d+)\)/.exec(bullet.replace(/\s+/g, " ")))
+		.filter((match): match is RegExpExecArray => match !== null)
+		.map((match) => ({
+			file: match[1],
+			count: Number(match[2]),
+			rules: [...new Set(match.input.match(RULE) ?? [])].sort(),
+		}));
+
+	it("read the section", () => {
+		// The proof the block below rests on: a heading that moved, or a list
+		// rewritten into another shape, fails here rather than passing by
+		// matching nothing.
+		expect(section.length).toBeGreaterThan(1000);
+		expect(section).toContain("a11y-suppressions.test.ts");
+		expect(listed.length).toBeGreaterThanOrEqual(10);
+	});
+
+	it("lists exactly the sites the sources carry", () => {
+		const asText = (entries: { file: string; count: number; rules: readonly string[] }[]) =>
+			entries
+				.map(({ file, count, rules }) => `${file} (${count}) ${rules.join(", ")}`)
+				.sort()
+				.join("\n");
+
+		expect(asText(listed)).toBe(asText([...sites].map(([file, site]) => ({ file, ...site }))));
+	});
+
+	it("states the totals the sources hold", () => {
+		const totals = /\*\*(\d+) directives across (\d+) files\*\*/.exec(section);
+		expect(totals, "the Accessibility section no longer states its totals").not.toBeNull();
+
+		const [, count, files] = totals as RegExpExecArray;
+		expect(Number(count)).toBe(directives.length);
+		expect(Number(files)).toBe(sites.size);
+	});
+});

--- a/app/src/components/a11y-suppressions.test.ts
+++ b/app/src/components/a11y-suppressions.test.ts
@@ -67,8 +67,14 @@ interface Directive {
  * A reason on the previous line counts too - a wrapped block comment above the
  * directive says as much as a trailing one - which is why this reads the line
  * before rather than only the text after the marker.
+ *
+ * Exported for the cases at the bottom of this file, the way
+ * `focus-indicator.test.ts` exports its class-string reader. All 16 sites write
+ * their reason inline today, so the previous-line arm has no fixture in the
+ * repository to prove it: unread code in a guard is how a guard starts passing
+ * for the wrong reason.
  */
-function reasonFor(lines: readonly string[], at: number): string {
+export function reasonFor(lines: readonly string[], at: number): string {
 	const inline = lines[at].split(REASON).slice(1).join(REASON);
 	if (inline.trim() !== "") return inline.replace(/\*\/\s*}?\s*$/, "").trim();
 
@@ -190,5 +196,49 @@ describe("the doc's list of suppressions", () => {
 		const [, count, files] = totals as RegExpExecArray;
 		expect(Number(count)).toBe(directives.length);
 		expect(Number(files)).toBe(sites.size);
+	});
+});
+
+describe("the reason reader", () => {
+	// The guard above is only as good as this: read the reason too loosely and a
+	// bare directive passes, too strictly and a legal spelling is called
+	// unreasoned. Every arm gets a case, including the one no site uses yet.
+	/** The reason the guard would read for the last directive in `source`. */
+	const reasonAt = (source: string) => {
+		const lines = source.split("\n");
+		const at = lines.reduce(
+			(last, line, i) => (line.includes("eslint-disable") ? i : last),
+			-1
+		);
+		return reasonFor(lines, at);
+	};
+
+	it("reads a reason written after the marker", () => {
+		expect(
+			reasonAt("// eslint-disable-next-line jsx-a11y/no-autofocus -- a dialog field")
+		).toBe("a dialog field");
+	});
+
+	it("stops at the end of a JSX comment rather than keeping its delimiter", () => {
+		expect(
+			reasonAt("{/* eslint-disable-next-line jsx-a11y/no-autofocus -- a dialog field */}")
+		).toBe("a dialog field");
+	});
+
+	it("takes the line above when the directive carries no reason", () => {
+		expect(
+			reasonAt("// a dialog field\n// eslint-disable-next-line jsx-a11y/no-autofocus")
+		).toBe("a dialog field");
+	});
+
+	it("refuses a bare directive, and a second directive above it", () => {
+		expect(reasonAt("const x = 1;\n// eslint-disable-next-line jsx-a11y/no-autofocus")).toBe(
+			""
+		);
+		expect(
+			reasonAt(
+				"// eslint-disable-next-line jsx-a11y/no-autofocus\n// eslint-disable-next-line jsx-a11y/no-autofocus"
+			)
+		).toBe("");
 	});
 });

--- a/app/src/lib/routed-inputs.testkit.ts
+++ b/app/src/lib/routed-inputs.testkit.ts
@@ -92,6 +92,17 @@ export const DOC_READING_GUARDS = {
 		reader: "app/src/components/ui/type-scale.test.ts",
 		paths: ["docs/design-system.md"],
 	},
+	/*
+	 * The third reader of that page, and the second of its prose (#1282): the
+	 * Accessibility section enumerates the `jsx-a11y` rules suppressed at the
+	 * line, and the guard holds that list to what `app/src` actually carries. A
+	 * site edited out of the doc alone is the drift it exists to catch, so the
+	 * page is one of its inputs in the same sense the sources are.
+	 */
+	a11ySuppressions: {
+		reader: "app/src/components/a11y-suppressions.test.ts",
+		paths: ["docs/design-system.md"],
+	},
 	rendererState: {
 		reader: "app/src/state-management-doc.test.ts",
 		paths: [

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1329,6 +1329,8 @@ see.
 | A hand-rolled `role="button"` is focusable and answers Enter/Space | `jsx-a11y/interactive-supports-focus`, `jsx-a11y/click-events-have-key-events` |
 | A `role="treeitem"` carries `aria-selected` | `jsx-a11y/role-has-required-aria-props` |
 | A `<label>` names a control | `jsx-a11y/label-has-associated-control` |
+| Every region of the window is a stop in the F6 cycle | `region-focus.test.ts`, `region-focus.markers.test.ts` |
+| A `jsx-a11y` suppression carries a reason and is listed below | `a11y-suppressions.test.ts` |
 
 **A tooltip is not a name.** Radix supplies `aria-describedby` while a tooltip is
 open, which is a description; before it opens - and to a screen reader reading
@@ -1374,7 +1376,64 @@ correct one here:
   arrow/Page/Home/End and all.
 
 Everything else is suppressed at the line it happens on, with the reason and the
-file that provides the missing half.
+file that provides the missing half. **16 directives across 12 files**, listed
+here because a rule-level configuration is visible in one place and a line-level
+one is visible only to whoever opens that file - and because nothing otherwise
+stops the count growing one justified line at a time. `a11y-suppressions.test.ts`
+reads this list and the sources together: a site added, moved or removed without
+the list following fails, an unreasoned directive fails, and the count is a
+ceiling that comes down when a suppression goes rather than a budget to spend.
+
+Paths are relative to `app/src`, and the count in brackets is directive lines,
+not rule names - two of these lines silence two rules at once.
+
+- `components/layout/TabStrip.tsx` (2) - `jsx-a11y/interactive-supports-focus`
+  on the tablist, whose tab stop is the active tab;
+  `jsx-a11y/click-events-have-key-events` on the close affordance, which is
+  Delete or Backspace on the focused row and a `tabIndex={-1}` pointer target
+  here.
+- `components/layout/Dock.tsx` (1) - `jsx-a11y/no-noninteractive-tabindex`: the
+  Radix `TooltipTrigger` wires focus and blur to the tooltip holding the engine
+  error text, which is the only keyboard path to it.
+- `components/layout/PanelResizeHandle.tsx` (1) -
+  `jsx-a11y/no-noninteractive-element-interactions`: the window splitter, with
+  its arrow/Page/Home/End handling in the `onKeyDown` beside it.
+- `components/shared/VariableInput/index.tsx` (2) -
+  `jsx-a11y/click-events-have-key-events` and
+  `jsx-a11y/no-static-element-interactions` on the box that widens the hit area
+  around a native input, and `no-static-element-interactions` again on the
+  `pointerEvents: none` overlay whose keydown delegates for the tokens inside it.
+- `modules/collections/CollectionTree.tsx` (1) -
+  `jsx-a11y/interactive-supports-focus`, the roving tab stop seeded by
+  `useRovingTreeFocus`.
+- `modules/collections/CollectionItem.tsx` (1) -
+  `jsx-a11y/click-events-have-key-events`: Enter and Space arrive through the
+  tree, which clicks the row's `[data-tree-activate]` button.
+- `modules/collections/RequestItem.tsx` (1) -
+  `jsx-a11y/click-events-have-key-events`, the same tree path as its sibling
+  above.
+- `modules/variables/sidebar/VariablesCategoryTree.tsx` (2) -
+  `jsx-a11y/interactive-supports-focus` on the tree and
+  `jsx-a11y/click-events-have-key-events` on its rows.
+- `modules/services/ServicesPanel.tsx` (1) -
+  `jsx-a11y/click-events-have-key-events` and
+  `jsx-a11y/no-static-element-interactions`: the drawer-row hit area, which
+  delegates only the clicks landing on the row's own padding.
+- `modules/request-builder/components/LoadTestConfigDialog/ProfilePicker.tsx`
+  (1) - `jsx-a11y/interactive-supports-focus`: a radiogroup, where the selected
+  `role="radio"` holds the stop and the `onKeyDown` moves selection and focus
+  together.
+- `modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx` (1) -
+  `jsx-a11y/no-noninteractive-element-interactions`, the second window splitter.
+- `modules/request-builder/components/RequestTabs/panels/body/graphql-explorer/SchemaExplorer.tsx`
+  (2) - `jsx-a11y/interactive-supports-focus` on the tree, and
+  `jsx-a11y/role-has-required-aria-props` because this tree has no selection
+  model: a row inserts into the query and nothing stays selected, so
+  `aria-selected` is omitted rather than faked.
+
+Test files are outside the count. Four directives live in two of them, each a
+fixture modelling one of the patterns above rather than a component the app
+ships.
 
 ---
 


### PR DESCRIPTION
## Description

The two records #1216 and #1219 left incomplete, verified against master `6abd352` before writing.

**Root cause and approach.** Both halves are the same defect in different form: a rule that is enforced but not indexed. #1219's F6 / Shift+F6 region cycling landed before the Accessibility table existed, so it is described in the Focus &amp; Interaction States prose and absent from the table a contributor is actually pointed at - it gets a row naming `region-focus.test.ts` and `region-focus.markers.test.ts`. #1216 shipped three rule-level `jsx-a11y` configurations (documented, and visible in one file) plus **16 line-level directives across 12 files**, each carrying its reason with `--report-unused-disable-directives` retiring stale ones - an honest mechanism with no list and no ceiling, so the count could grow one justified line at a time and nobody would see the shape of it. The list now lives in the Accessibility section and `a11y-suppressions.test.ts` holds both halves to each other. **The alternative I rejected:** listing the sites as `file:line` pairs. Line numbers move on every edit above them, so the list would have gone stale on unrelated diffs and taught contributors to re-run a script rather than read it; the guard compares per *file* - directive count and the set of rules suppressed there - which still fails when a site is added, removed, or moved between files, and does not fail when a component grows a line.

Three drifts between the issue's Problem section and the code, corrected here rather than copied:

- The issue cites `app/src/lib/region-focus.ts`. The file is `app/src/components/layout/region-focus.ts`.
- It gives the Focus &amp; Interaction States section as "1278-1297". That is the region-cycling *prose*; the section heading is at `docs/design-system.md:1143`.
- It gives the allowlist prose as "1355-1372"; it is 1360-1374, and 1352-1358 is the composite-widget paragraph that explains the line-level disables.

The counts the issue states - 16 directives, 12 non-test files, three configured rules - are exact. Four further directives live in two test files (`useRovingTreeFocus.test.tsx`, `GraphQLBody.explorer.test.tsx`); they are fixtures modelling the same patterns, so the scan excludes test and testkit files the way `focus-indicator.test.ts` does, and the doc says so rather than leaving the difference to be rediscovered.

The guard reads a page outside `app/`, so it registers in `routed-inputs.testkit.ts` as `DOC_READING_GUARDS.a11ySuppressions` and takes the path from there rather than spelling it again. `docs/design-system.md` was already routed by two other guards, so the `app_doc_fixtures` filter in `pr-tests.yml` needs no change - `routed-inputs.test.ts` confirms it.

The second commit answers a review finding on the first: `reasonFor` has two arms and every one of the 16 sites uses the inline one, so the previous-line arm the issue asks for by name had nothing exercising it. It is exported and read by four cases now, the way `focus-indicator.test.ts` exports its class-string reader.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app &amp;&amp; pnpm test` (full suite, on the first commit) - **598 files, 6576 tests passed**, no pre-existing failures on this base.
- `cd app &amp;&amp; pnpm test a11y-suppressions` - **10 passed** (6 guard cases, 4 reason-reader cases).
- `cd app &amp;&amp; pnpm test a11y-suppressions routed-inputs` - 22 passed; `pnpm test routed-inputs design-system-doc type-scale region-focus` - 47 passed (the guards that already read this page, plus the two the new table row names).
- `pnpm type-check` clean, `pnpm lint` clean (it still prints the two pre-existing `TSSatisfiesExpression` advisories from jsx-ast-utils tracked in #1261; exit 0), `prettier --check` clean on every file this touches. `docs/design-system.md` was hand-edited and never formatted - it is prettier-ignored at the repository root.
- `mkdocs build --strict -f .github/mkdocs.yml` - built, no warnings.

Six mutation checks, each run and restored:

| Mutation | Fails |
|---|---|
| A doc bullet's count changed from `(2)` to `(3)` | `lists exactly the sites the sources carry` |
| The prose totals changed to `15 directives across 12 files` | `states the totals the sources hold` |
| An unreasoned `jsx-a11y` directive appended to a source file | `stays under the ceiling`, `gives every directive a reason`, and both doc comparisons |
| The previous-line arm of `reasonFor` removed | `takes the line above when the directive carries no reason` |
| The JSX comment delimiter left in the reason | `stops at the end of a JSX comment rather than keeping its delimiter` |

The scan reads raw lines and deliberately does *not* blank comments - here the comment is the thing being counted - and asserts two floors (files scanned, directives found) plus a third on the doc side (section length, and that it names its guard) so a broken glob, a rewritten directive spelling or a heading that moved cannot pass by matching nothing.

One review finding deliberately not acted on: the guard checks that a reason is *present*, not that it is *good* (`-- x` would pass). That is the issue's literal ask, and the repository's existing exemption lists (`focus-indicator.test.ts`'s `why`) hold the same line - a length or word-count threshold would be arbitrary policing that a determined author routes around anyway.

No engine build or ctest run: the diff is one Markdown section, one vitest guard and a registry entry, nothing that could take a C++ test from green to red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpLW5xopc94zz9xcrBgqza