### PR TITLE
feat(palette): offer Send from the command palette, on the builder's live draft - #1243

### DIFF
--- a/app/src/lib/commands/index.ts
+++ b/app/src/lib/commands/index.ts
@@ -7,6 +7,11 @@
 
 export { COMMANDS, availableCommands, commandById } from "./registry";
 export { baseCommandContext } from "./context";
-export { useLiveCommandSurfaceStore, useRegisterLoadTestSurface } from "./live-surfaces";
+export {
+	useLiveCommandSurfaceStore,
+	useRegisterLoadTestSurface,
+	useRegisterSendRequestSurface,
+} from "./live-surfaces";
+export type { LiveSurfaceSlot } from "./live-surfaces";
 export { commandTitle } from "./types";
 export type { Command, CommandContext, CommandGroup, CommandSurfaces } from "./types";

--- a/app/src/lib/commands/live-surfaces.ts
+++ b/app/src/lib/commands/live-surfaces.ts
@@ -9,73 +9,121 @@
  * The channel a *mounted feature* contributes a command surface through.
  *
  * `CommandSurfaces` was originally the palette host's own set: three dialogs it
- * mounts itself, so it can always offer them. One action does not fit that
- * shape. Starting a load test needs the request builder's **live editor draft**
- * - the URL, headers, body and auth as currently typed, before autosave has run
- * - and that draft exists only inside `RequestBuilderProvider`, which the
+ * mounts itself, so it can always offer them. Two actions do not fit that shape.
+ * Starting a load test - and sending - needs the request builder's **live editor
+ * draft** - the URL, headers, body and auth as currently typed, before autosave
+ * has run - and that draft exists only inside `RequestBuilderProvider`, which the
  * palette is a sibling of. A command reaching for the saved request instead
  * would run the *old* URL after an edit and report it as the run the user asked
  * for: a near-miss that reads as a bug, which is why #526 shipped the registry
- * without this command rather than approximating it.
+ * without these commands rather than approximating them.
  *
  * So the mounted feature hands its own handler out, and the palette merges what
  * is registered into the surfaces it offers. The alternative - reading the draft
  * out of the provider from outside it, or recomposing the payload in the command
  * - would be a second copy of `buildExecBody` and the single-active-run policy,
  * exactly the "hand-rolled copy of a primitive" defect the registry exists to
- * remove. Nothing about the load test moves; only its *reachability* changes.
+ * remove. Nothing about either action moves; only its *reachability* changes.
  *
- * **One slot, one contributor.** A registry of arbitrary named surfaces would be
- * a framework built for a second caller that does not exist yet. When one
- * arrives - a "Send request" command has the same live-draft problem - it joins
- * this file as a second slot, rather than inventing a second channel.
+ * **Two named slots, not a registry.** The second one arrived in #1243, the
+ * caller this file's first version said it was waiting for: Send has the
+ * identical live-draft problem, so it joined as a slot rather than as a second
+ * channel. `LiveSurfaceSlot` stays a closed union, spelled the same way on
+ * `CommandSurfaces` - a third slot is a decision taken here, not a name a caller
+ * can invent by passing a string.
  *
  * **The clear is identity-checked.** Unmount effects run before the next mount's
  * effects, so switching request tabs clears then registers in the right order -
  * but a remount that ever lands the other way round would otherwise leave the
  * slot empty with a builder on screen. Comparing identity makes the clear a
  * no-op for anyone but the current holder.
+ *
+ * **A contribution can be conditional.** A slot holding a handler is what makes
+ * its command appear, so a feature that can only *sometimes* perform the action
+ * passes `null` the rest of the time and the row goes away with it - which is
+ * the honest answer for Send, whose own button is replaced by Stop mid-stream
+ * and disabled with an empty URL. A registered handler that quietly declined
+ * would be a palette row that answers to nothing.
  */
 
 import { useCallback, useEffect, useRef } from "react";
 import { create } from "zustand";
 
+/** The slots a mounted feature can fill, named once for both directions. */
+export type LiveSurfaceSlot = "startLoadTest" | "sendRequest";
+
 interface LiveCommandSurfaceState {
 	/** The mounted request builder's start-load-test handler, or null. */
 	startLoadTest: (() => void) | null;
-	registerStartLoadTest: (handler: () => void) => void;
-	/** Drops `handler` if it is still the registered one. */
-	clearStartLoadTest: (handler: () => void) => void;
+	/**
+	 * The mounted request builder's send handler, or null - including while that
+	 * builder is on screen but could not send (a run in flight, an empty URL).
+	 */
+	sendRequest: (() => void) | null;
+	registerSurface: (slot: LiveSurfaceSlot, handler: () => void) => void;
+	/** Drops `handler` from `slot` if it is still the registered one. */
+	clearSurface: (slot: LiveSurfaceSlot, handler: () => void) => void;
+}
+
+/**
+ * A one-slot patch, written where the compiler can see which key it sets - a
+ * computed key would need a cast, and a cast here is how the two slots would
+ * start accepting a third name nobody declared.
+ */
+function fill(
+	slot: LiveSurfaceSlot,
+	handler: (() => void) | null
+): Partial<LiveCommandSurfaceState> {
+	return slot === "startLoadTest" ? { startLoadTest: handler } : { sendRequest: handler };
 }
 
 export const useLiveCommandSurfaceStore = create<LiveCommandSurfaceState>((set) => ({
 	startLoadTest: null,
-	registerStartLoadTest: (handler) => set({ startLoadTest: handler }),
-	clearStartLoadTest: (handler) =>
-		set((state) => (state.startLoadTest === handler ? { startLoadTest: null } : state)),
+	sendRequest: null,
+	registerSurface: (slot, handler) => set(fill(slot, handler)),
+	clearSurface: (slot, handler) =>
+		set((state) => (state[slot] === handler ? fill(slot, null) : state)),
 }));
 
 /**
- * Publish `handler` as the live start-load-test surface for as long as the
- * caller is mounted.
+ * Publish `handler` in `slot` for as long as the caller is mounted and passes a
+ * handler at all; `null` withdraws the contribution without unmounting.
  *
  * The registered function is a **stable** wrapper over a ref rather than
- * `handler` itself. The builder's own `startLoadTest` closes over the draft, so
- * its identity changes on every keystroke; registering that directly would write
- * to this store - and re-render the palette - once per character typed. The
- * wrapper is written once and reads the current handler when it is called.
+ * `handler` itself. The builder's own handlers close over the draft, so their
+ * identity changes on every keystroke; registering that directly would write to
+ * this store - and re-render the palette - once per character typed. The wrapper
+ * is written once and reads the current handler when it is called.
  */
-export function useRegisterLoadTestSurface(handler: () => void): void {
+function useRegisterSurface(slot: LiveSurfaceSlot, handler: (() => void) | null): void {
 	const latest = useRef(handler);
 	useEffect(() => {
 		latest.current = handler;
 	}, [handler]);
 
-	const stable = useCallback(() => latest.current(), []);
+	const stable = useCallback(() => latest.current?.(), []);
+
+	// The *offer*, not the handler: a slot changes hands when a feature starts or
+	// stops being able to act, never when the draft behind it is edited.
+	const offered = handler !== null;
 
 	useEffect(() => {
-		const { registerStartLoadTest, clearStartLoadTest } = useLiveCommandSurfaceStore.getState();
-		registerStartLoadTest(stable);
-		return () => clearStartLoadTest(stable);
-	}, [stable]);
+		if (!offered) return;
+		const { registerSurface, clearSurface } = useLiveCommandSurfaceStore.getState();
+		registerSurface(slot, stable);
+		return () => clearSurface(slot, stable);
+	}, [slot, stable, offered]);
+}
+
+/** Publish the mounted builder's start-load-test handler. */
+export function useRegisterLoadTestSurface(handler: () => void): void {
+	useRegisterSurface("startLoadTest", handler);
+}
+
+/**
+ * Publish the mounted builder's send handler, or `null` while it could not send
+ * - see `canSendRequest`, the one predicate that decides which.
+ */
+export function useRegisterSendRequestSurface(handler: (() => void) | null): void {
+	useRegisterSurface("sendRequest", handler);
 }

--- a/app/src/lib/commands/palette-parity.test.ts
+++ b/app/src/lib/commands/palette-parity.test.ts
@@ -38,11 +38,6 @@ const NO_COMMAND = new Map<Chord, string>([
 		"the palette cannot offer a row that opens the palette you are already in",
 	],
 	[
-		shortcuts.SEND_CHORD,
-		"Send needs the request builder's live draft, the way run-load-test does; " +
-			"nothing contributes it through live-surfaces yet - #1243",
-	],
-	[
 		shortcuts.LEAVE_EDITOR_CHORD,
 		"scoped to the editor that has focus; the palette takes focus away, so " +
 			"there would be no editor to leave by the time it ran",

--- a/app/src/lib/commands/registry.test.ts
+++ b/app/src/lib/commands/registry.test.ts
@@ -24,6 +24,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { COMMANDS, availableCommands, commandById } from "./registry";
 import { baseCommandContext } from "./context";
 import { commandTitle, type Command, type CommandContext, type CommandSurfaces } from "./types";
+import { SEND_CHORD } from "@/constants/shortcuts";
 import { useImportModalStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
@@ -151,11 +152,39 @@ describe("availability", () => {
 		expect(availableCommands(contributed).map((c) => c.id)).toContain("run-load-test");
 	});
 
+	/*
+	 * Send is the second such entry (#1243), and its contribution is narrower
+	 * still: the builder withdraws it while a send would be refused, so the row
+	 * follows the Send button rather than the builder's mere presence.
+	 */
+	it("hides the send command until a mounted builder contributes it", () => {
+		const requestTab: CommandContext = {
+			activeTab: { id: "t1", type: "request", entityId: "r1" },
+			activeTabLabel: "Charge card",
+			activeCollection: null,
+			surfaces: surfaces(),
+		};
+		expect(availableCommands(requestTab).map((c) => c.id)).not.toContain("send-request");
+
+		const contributed: CommandContext = {
+			...requestTab,
+			surfaces: { ...surfaces(), sendRequest: () => {} },
+		};
+		expect(availableCommands(contributed).map((c) => c.id)).toContain("send-request");
+	});
+
 	it("names the target of a contextual command, so Enter holds no surprise", () => {
 		const ctx = fullContext();
 		expect(commandTitle(commandById("run-collection"), ctx)).toBe('Run "Payments"');
 		expect(commandTitle(commandById("close-tab"), ctx)).toBe('Close "Payments"');
 		expect(commandTitle(commandById("run-load-test"), ctx)).toBe('Load test "Payments"');
+		expect(commandTitle(commandById("send-request"), ctx)).toBe('Send "Payments"');
+	});
+
+	it("prints the send chord on the row, from the chord itself", () => {
+		// Not a second spelling of ⌘↵ (#938): the row and the handler read one
+		// definition, so a chord that moves moves on both.
+		expect(commandById("send-request").shortcut).toBe(SEND_CHORD);
 	});
 
 	it("falls back to a generic close title when nothing knows the label", () => {
@@ -166,6 +195,7 @@ describe("availability", () => {
 		};
 		expect(commandTitle(commandById("close-tab"), ctx)).toBe("Close tab");
 		expect(commandTitle(commandById("run-load-test"), ctx)).toBe("Load test this request");
+		expect(commandTitle(commandById("send-request"), ctx)).toBe("Send this request");
 	});
 });
 
@@ -209,6 +239,16 @@ describe("performing", () => {
 		};
 		commandById("run-load-test").perform(ctx);
 		expect(started).toBe(1);
+	});
+
+	it("sends through the contributed handler, never a copy of one", () => {
+		let sent = 0;
+		const ctx: CommandContext = {
+			...fullContext(),
+			surfaces: { ...surfaces(), sendRequest: () => sent++ },
+		};
+		commandById("send-request").perform(ctx);
+		expect(sent).toBe(1);
 	});
 
 	it("hands the collection to the host rather than running it itself", () => {

--- a/app/src/lib/commands/registry.ts
+++ b/app/src/lib/commands/registry.ts
@@ -33,6 +33,7 @@ import {
 	Play,
 	Plus,
 	Save,
+	Send,
 	Settings,
 	SunMoon,
 	X,
@@ -44,6 +45,7 @@ import {
 	LOAD_TEST_CHORD,
 	NEW_REQUEST_CHORD,
 	SAVE_CHORD,
+	SEND_CHORD,
 	SETTINGS_CHORD,
 	TOGGLE_CONTEXT_BAR_CHORD,
 	TOGGLE_DRAWER_CHORD,
@@ -107,6 +109,30 @@ const ACTION_COMMANDS: readonly Command[] = [
 		perform: (ctx) => {
 			if (ctx.activeCollection) ctx.surfaces?.runCollection(ctx.activeCollection);
 		},
+	},
+	{
+		id: "send-request",
+		// Named like the other contextual commands, and for the same reason: the
+		// row says which request Enter puts on the wire.
+		title: (ctx) => (ctx.activeTabLabel ? `Send "${ctx.activeTabLabel}"` : "Send this request"),
+		keywords: ["execute", "fire", "call", "http", "request", "run"],
+		group: "action",
+		// The app has no send mark of its own - the URL bar's Send is a text
+		// button - so the palette takes lucide's, which is the glyph the action
+		// already reads as everywhere else.
+		icon: Send,
+		// The builder's window handler matches this chord and calls the very
+		// `sendRequest` below.
+		shortcut: SEND_CHORD,
+		/*
+		 * Contributed by the mounted builder, like the load test under it - and
+		 * withdrawn while sending is not possible. Send is Stop for the whole of
+		 * an open stream (#574) and does nothing with an empty URL, so a row that
+		 * stayed on screen there would be one the palette offers and the app
+		 * refuses: `canSendRequest` is the single predicate both routes ask.
+		 */
+		available: (ctx) => ctx.surfaces?.sendRequest !== undefined,
+		perform: (ctx) => ctx.surfaces?.sendRequest?.(),
 	},
 	{
 		id: "run-load-test",

--- a/app/src/lib/commands/types.ts
+++ b/app/src/lib/commands/types.ts
@@ -63,6 +63,14 @@ export interface CommandSurfaces {
 	 * builder; absent whenever none is mounted.
 	 */
 	startLoadTest?: () => void;
+	/**
+	 * Send the request the builder currently holds, again from the live draft
+	 * rather than the saved copy (#1243). Contributed by the mounted request
+	 * builder, and only while it could actually send: absent with no builder on
+	 * screen, and absent for the window in which the builder's own Send button is
+	 * disabled or has become Stop.
+	 */
+	sendRequest?: () => void;
 }
 
 /**

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -201,7 +201,7 @@ beforeEach(() => {
 	useImportModalStore.setState({ isOpen: false });
 	useSettingsStore.setState({ selectedCategory: "appearance", highlightedKey: null });
 	stampedCommand.id = null;
-	useLiveCommandSurfaceStore.setState({ startLoadTest: null });
+	useLiveCommandSurfaceStore.setState({ startLoadTest: null, sendRequest: null });
 });
 afterEach(cleanup);
 
@@ -726,6 +726,31 @@ describe("commands", () => {
 		pressEnter();
 
 		expect(started).toHaveBeenCalledTimes(1);
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+	});
+
+	/* The same join, for the second live slot (#1243). */
+	it("offers the send command only while a mounted builder contributes it", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+		expect(screen.queryByText('Send "Request"')).not.toBeInTheDocument();
+		cleanup();
+
+		const sent = vi.fn();
+		useLiveCommandSurfaceStore.setState({ sendRequest: sent });
+		renderPalette();
+		open();
+		expect(screen.getByText('Send "Request"')).toBeInTheDocument();
+
+		typeQuery('Send "Req');
+		pressEnter();
+
+		expect(sent).toHaveBeenCalledTimes(1);
 		expect(useLayoutStore.getState().paletteOpen).toBe(false);
 	});
 

--- a/app/src/modules/palette/useCommandSurfaces.ts
+++ b/app/src/modules/palette/useCommandSurfaces.ts
@@ -21,12 +21,14 @@
  * from here reaches the Appearance panel's radio group the same way an OS theme
  * change does.
  *
- * A fourth surface is **not** hosted here, and cannot be: starting a load test
- * needs the request builder's live editor draft, which exists only inside a
- * provider the palette is a sibling of. The mounted builder contributes it
- * through `lib/commands/live-surfaces.ts` and this hook merges what is
- * registered, so the command is offered while a builder is on screen and absent
- * the rest of the time.
+ * Two more surfaces are **not** hosted here, and cannot be: starting a load test
+ * and sending both need the request builder's live editor draft, which exists
+ * only inside a provider the palette is a sibling of. The mounted builder
+ * contributes them through `lib/commands/live-surfaces.ts` and this hook merges
+ * what is registered, so those commands are offered while a builder is on screen
+ * and absent the rest of the time. Send is withdrawn for a second reason as
+ * well - the builder stops offering it while it could not send at all - so its
+ * row tracks the Send button rather than merely the builder's presence.
  */
 
 import { useCallback, useMemo, useState } from "react";
@@ -49,6 +51,7 @@ export function useCommandSurfaces(): UseCommandSurfacesReturn {
 	const { isDark, setTheme } = useElectronTheme();
 	const [runTarget, setRunTarget] = useState<Collection | null>(null);
 	const startLoadTest = useLiveCommandSurfaceStore((s) => s.startLoadTest);
+	const sendRequest = useLiveCommandSurfaceStore((s) => s.sendRequest);
 
 	const dismissRunDialog = useCallback(() => setRunTarget(null), []);
 
@@ -69,8 +72,9 @@ export function useCommandSurfaces(): UseCommandSurfacesReturn {
 			runCollection: setRunTarget,
 			toggleThemeMode,
 			...(startLoadTest ? { startLoadTest } : {}),
+			...(sendRequest ? { sendRequest } : {}),
 		}),
-		[newRequest, toggleThemeMode, startLoadTest]
+		[newRequest, toggleThemeMode, startLoadTest, sendRequest]
 	);
 
 	return { surfaces, pickerProps, runTarget, dismissRunDialog };

--- a/app/src/modules/request-builder/components/RequestBuilderLayout.tsx
+++ b/app/src/modules/request-builder/components/RequestBuilderLayout.tsx
@@ -25,6 +25,7 @@ import { useRequestBuilderContext } from "../context";
 import { SEND_CHORD, LOAD_TEST_CHORD, matchesChord } from "@/constants/shortcuts";
 import { ownsEnterKey } from "@/lib/keyboard";
 import { isModalOpen } from "@/lib/modal";
+import { canSendRequest } from "../utils/send-gate";
 import RequestBreadcrumb from "./RequestBreadcrumb";
 import UrlBar from "./UrlBar";
 import RequestTabs from "./RequestTabs";
@@ -77,19 +78,14 @@ export default function RequestBuilderLayout() {
 			if (isModalOpen()) return;
 
 			/*
-			 * Don't trigger if the request is already in flight or URL is empty.
-			 *
-			 * `isStreaming` is the second half of "in flight": once the engine has
-			 * answered and the socket is open, `isExecuting` goes false while the
-			 * run is very much still running (`RequestBuilderProvider` clears it
-			 * deliberately, so the Events tab is not hidden behind "Sending…").
-			 * Send *is* Stop for the whole of that window (#574), and the chord now
-			 * matches the button: it does nothing rather than silently replacing
-			 * the open stream with a new one - the run being replaced being exactly
-			 * the one the button in front of you would stop. Stopping is
-			 * destructive, so it stays a deliberate click.
+			 * Don't trigger if the request is already in flight or the URL is
+			 * empty. The predicate lives in `utils/send-gate.ts` because the
+			 * palette's Send row asks the same question through
+			 * `SendRequestCommandSurface`, and the two must not drift (#1243); the
+			 * reasoning behind it - in particular why `isStreaming` counts - is
+			 * written there.
 			 */
-			if (isExecuting || isStreaming || request.url.trim().length === 0) return;
+			if (!canSendRequest({ url: request.url, isExecuting, isStreaming })) return;
 
 			if (isSend) {
 				event.preventDefault();

--- a/app/src/modules/request-builder/components/SendRequestCommandSurface.tsx
+++ b/app/src/modules/request-builder/components/SendRequestCommandSurface.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's second contribution to the command registry: "send what
+ * is on screen right now" (#1243).
+ *
+ * A component rather than a hook call in `RequestBuilder`, for the reason
+ * `LoadTestCommandSurface` beside it gives: the handler it publishes lives
+ * *inside* `RequestBuilderProvider`, and the builder's own component sits
+ * outside the provider it renders.
+ *
+ * It renders nothing, and it is mounted from `modules/request-builder/index.tsx`
+ * alone - `DesignRunView`'s detached copy of a past run simply does not render
+ * it, so "exactly one contributor" holds by construction rather than by a
+ * runtime guard.
+ *
+ * **The contribution is withdrawn while a send would be refused.** Unlike the
+ * load test, whose gate is a property of the builder (a detached copy has no
+ * handler at all), Send's gate moves during a session: it is unavailable with an
+ * empty URL and for the whole of an open stream, where the button in front of
+ * the user reads Stop. Passing `null` there takes the palette row away with it,
+ * rather than leaving a row that would answer to nothing.
+ */
+
+import { useCallback } from "react";
+import { useRegisterSendRequestSurface } from "@/lib/commands";
+import { useRequestBuilderContext } from "../context";
+import { canSendRequest } from "../utils/send-gate";
+
+export default function SendRequestCommandSurface(): null {
+	const { request, isExecuting, isStreaming, executeRequest } = useRequestBuilderContext();
+
+	// No row: Send-with-row is a distinct action with its own picker, and a
+	// palette row that silently re-bound the last row would be sending something
+	// other than what it says. `executeRequest` un-binds it, as the chord does.
+	const send = useCallback(() => void executeRequest(), [executeRequest]);
+
+	const sendable = canSendRequest({ url: request.url, isExecuting, isStreaming });
+	useRegisterSendRequestSurface(sendable ? send : null);
+
+	return null;
+}

--- a/app/src/modules/request-builder/data-columns-compose.test.tsx
+++ b/app/src/modules/request-builder/data-columns-compose.test.tsx
@@ -95,6 +95,7 @@ vi.mock("./context", () => ({
 }));
 vi.mock("./components/RequestBuilderLayout", () => ({ default: () => null }));
 vi.mock("./components/LoadTestCommandSurface", () => ({ default: () => null }));
+vi.mock("./components/SendRequestCommandSurface", () => ({ default: () => null }));
 vi.mock("./components/LoadTestConfigDialog", () => ({
 	default: (props: Record<string, unknown>) => {
 		dialogProps = props;

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -26,6 +26,7 @@ import { RequestBuilderProvider } from "./context";
 import RequestBuilderLayout from "./components/RequestBuilderLayout";
 import LoadTestConfigDialog from "./components/LoadTestConfigDialog";
 import LoadTestCommandSurface from "./components/LoadTestCommandSurface";
+import SendRequestCommandSurface from "./components/SendRequestCommandSurface";
 import { useTabsStore, useSessionStore, useDashboardStore, useToastStore } from "@/stores";
 import {
 	useRequestQuery,
@@ -808,10 +809,12 @@ export default function RequestBuilder() {
 				onStartLoadTest={handleStartLoadTest}
 			>
 				<RequestBuilderLayout />
-				{/* Renders nothing. Publishes this builder's live draft to the
-				    command registry, so the palette's "Load test …" runs the
-				    request as currently edited rather than as last saved. */}
+				{/* Render nothing. They publish this builder's live draft to the
+				    command registry, so the palette's "Load test …" and "Send …"
+				    act on the request as currently edited rather than as last
+				    saved. */}
 				<LoadTestCommandSurface />
+				<SendRequestCommandSurface />
 			</RequestBuilderProvider>
 
 			{/* Load Test Configuration Dialog */}

--- a/app/src/modules/request-builder/load-test-command-surface.test.tsx
+++ b/app/src/modules/request-builder/load-test-command-surface.test.tsx
@@ -133,7 +133,7 @@ describe("the request builder contributes its live draft to the command registry
 
 		// A previous builder's unmount arriving late must not empty the slot the
 		// builder now on screen owns.
-		act(() => useLiveCommandSurfaceStore.getState().clearStartLoadTest(() => {}));
+		act(() => useLiveCommandSurfaceStore.getState().clearSurface("startLoadTest", () => {}));
 
 		expect(registered()).toBe(current);
 	});

--- a/app/src/modules/request-builder/send-request-command-surface.test.tsx
+++ b/app/src/modules/request-builder/send-request-command-surface.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Send's live-draft channel, end to end: what the palette actually sends (#1243).
+ *
+ * Two properties, and both are the reason this file exists rather than a
+ * store-level test. The first is the one that kept Send out of the palette until
+ * now - a command reaching for the *saved* request would put the old URL on the
+ * wire after an edit and report it as the send the user asked for; revert the
+ * wiring to the stored request and "as edited, not as stored" fails on the URL it
+ * was handed.
+ *
+ * The second is the gate. The builder withdraws the contribution whenever a send
+ * would be refused - an empty URL, a request in flight, an open stream where
+ * Send is Stop (#574) - so the palette row is absent exactly when the Send button
+ * is disabled or gone. Drop the `canSendRequest` call in the surface and the
+ * three withdrawal cases fail with a handler registered.
+ *
+ * The provider is mocked down to the same seams `load-test-command-surface` uses:
+ * variable resolution, the save manager and the query hooks have nothing to do
+ * with which draft crosses the channel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { RequestBuilderProvider, useRequestBuilderContext } from "./context";
+import SendRequestCommandSurface from "./components/SendRequestCommandSurface";
+import { useLiveCommandSurfaceStore } from "@/lib/commands";
+import { useExecutionEventsStore } from "@/stores";
+import type { RequestState } from "./types";
+
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		resolveObject: (o: unknown) => o,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
+	useSaveManager: () => ({ forceSave: vi.fn(), status: "idle", isSaving: false }),
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	useConfigQuery: () => ({ data: { entries: [] } }),
+}));
+
+/** Edits the draft the way the URL bar does. */
+function UrlEditor() {
+	const { updateField } = useRequestBuilderContext();
+	return (
+		<>
+			<button onClick={() => updateField("url", "https://api.test/edited")}>edit url</button>
+			<button onClick={() => updateField("url", "   ")}>clear url</button>
+		</>
+	);
+}
+
+type Execute = (request: RequestState, dataRow?: Record<string, unknown>) => Promise<null>;
+
+function Harness({ onExecute, url }: { onExecute?: Execute; url?: string }) {
+	const initialRequest: Partial<RequestState> = {
+		id: "req_1",
+		name: "Charge card",
+		url: url ?? "https://api.test/saved",
+	};
+	return (
+		<RequestBuilderProvider
+			initialRequest={initialRequest}
+			collectionId="col_1"
+			{...(onExecute ? { onExecute } : {})}
+		>
+			<UrlEditor />
+			<SendRequestCommandSurface />
+		</RequestBuilderProvider>
+	);
+}
+
+const registered = () => useLiveCommandSurfaceStore.getState().sendRequest;
+
+/** An `onExecute` that never settles - the builder stays "in flight". */
+function pendingExecute(): { execute: Execute; calls: RequestState[] } {
+	const calls: RequestState[] = [];
+	return {
+		calls,
+		execute: (request) => {
+			calls.push(request);
+			return new Promise<null>(() => {});
+		},
+	};
+}
+
+beforeEach(() => {
+	useLiveCommandSurfaceStore.setState({ sendRequest: null });
+	useExecutionEventsStore.setState({ isStreaming: false, requestId: null });
+});
+
+describe("the request builder contributes Send to the command registry", () => {
+	it("registers nothing until a builder is mounted", () => {
+		expect(registered()).toBeNull();
+	});
+
+	it("publishes a handler while a mounted builder could send", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} />);
+		expect(registered()).not.toBeNull();
+	});
+
+	it("sends the request as edited, not as stored", () => {
+		const { execute, calls } = pendingExecute();
+		render(<Harness onExecute={execute} />);
+
+		act(() => screen.getByText("edit url").click());
+		act(() => registered()?.());
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({ url: "https://api.test/edited" });
+	});
+
+	it("sends with no bound row, so the row a picker last chose is not resent", () => {
+		const onExecute = vi.fn<Execute>(async () => null);
+		render(<Harness onExecute={onExecute} />);
+
+		act(() => registered()?.());
+
+		// Send-with-row is a distinct action with its own picker; this is the
+		// plain Send, and `executeRequest` un-binds the last row for it.
+		expect(onExecute).toHaveBeenCalledTimes(1);
+		expect(onExecute.mock.calls[0]?.[1]).toBeUndefined();
+	});
+
+	it("keeps one registration across draft edits, so typing does not churn the store", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} />);
+		const first = registered();
+
+		act(() => screen.getByText("edit url").click());
+
+		expect(registered()).toBe(first);
+	});
+
+	it("offers nothing while the URL is empty, the way the Send button is disabled", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} url="  " />);
+		expect(registered()).toBeNull();
+	});
+
+	it("withdraws the offer when the draft's URL is emptied", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} />);
+		expect(registered()).not.toBeNull();
+
+		act(() => screen.getByText("clear url").click());
+
+		expect(registered()).toBeNull();
+	});
+
+	it("withdraws the offer while a send is in flight", () => {
+		const { execute, calls } = pendingExecute();
+		render(<Harness onExecute={execute} />);
+
+		act(() => registered()?.());
+
+		// A second pick would be a second request behind the first, which the
+		// chord refuses too - so the row goes away rather than sitting there.
+		expect(calls).toHaveLength(1);
+		expect(registered()).toBeNull();
+	});
+
+	it("withdraws the offer while this builder's stream is open, where Send is Stop", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} />);
+		expect(registered()).not.toBeNull();
+
+		act(() => useExecutionEventsStore.setState({ isStreaming: true, requestId: "req_1" }));
+
+		expect(registered()).toBeNull();
+	});
+
+	it("clears the surface on unmount, so a closed tab leaves no dead handler", () => {
+		const { unmount } = render(<Harness onExecute={vi.fn(async () => null)} />);
+		expect(registered()).not.toBeNull();
+
+		unmount();
+
+		expect(registered()).toBeNull();
+	});
+
+	it("leaves the clear to the current holder, so a remount out of order still stands", () => {
+		render(<Harness onExecute={vi.fn(async () => null)} />);
+		const current = registered();
+
+		act(() => useLiveCommandSurfaceStore.getState().clearSurface("sendRequest", () => {}));
+
+		expect(registered()).toBe(current);
+	});
+});

--- a/app/src/modules/request-builder/utils/send-gate.test.ts
+++ b/app/src/modules/request-builder/utils/send-gate.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The one predicate the Send chord and the palette's Send row both ask (#1243).
+ *
+ * Each case below is a state in which the builder's own Send control is absent
+ * or disabled; a `true` here would be the palette offering what the button in
+ * front of the user refuses.
+ */
+
+import { describe, it, expect } from "vitest";
+import { canSendRequest } from "./send-gate";
+
+const READY = { url: "https://api.test/x", isExecuting: false, isStreaming: false };
+
+describe("when a send may run", () => {
+	it("allows a send with a URL and nothing in flight", () => {
+		expect(canSendRequest(READY)).toBe(true);
+	});
+
+	it("refuses a request that is already in flight", () => {
+		expect(canSendRequest({ ...READY, isExecuting: true })).toBe(false);
+	});
+
+	it("refuses one whose stream is still open - Send is Stop there (#574)", () => {
+		expect(canSendRequest({ ...READY, isStreaming: true })).toBe(false);
+	});
+
+	it("refuses an empty URL, whitespace included", () => {
+		expect(canSendRequest({ ...READY, url: "" })).toBe(false);
+		expect(canSendRequest({ ...READY, url: "   " })).toBe(false);
+	});
+});

--- a/app/src/modules/request-builder/utils/send-gate.ts
+++ b/app/src/modules/request-builder/utils/send-gate.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * When a Send may actually run - one predicate, two routes.
+ *
+ * The window handler in `RequestBuilderLayout` and the palette contribution in
+ * `SendRequestCommandSurface` both have to answer this, and a second spelling of
+ * it is the drift this file exists to prevent: the chord would refuse a send the
+ * palette still offered, on the one screen where they must agree.
+ *
+ * `isStreaming` is the second half of "in flight": once the engine has answered
+ * and the socket is open, `isExecuting` goes false while the run is very much
+ * still running (`RequestBuilderProvider` clears it deliberately, so the Events
+ * tab is not hidden behind "Sending…"). Send *is* Stop for the whole of that
+ * window (#574), and neither route may quietly replace the open stream with a
+ * new one - the run being replaced being exactly the one the button in front of
+ * you would stop. Stopping is destructive, so it stays a deliberate click.
+ *
+ * The URL bar reads the two halves separately rather than calling this, because
+ * it does not refuse a send there - it renders a different control: Stop while a
+ * stream is open, a disabled Send otherwise.
+ */
+export function canSendRequest(state: {
+	url: string;
+	isExecuting: boolean;
+	isStreaming: boolean;
+}): boolean {
+	return !state.isExecuting && !state.isStreaming && state.url.trim().length > 0;
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -807,7 +807,7 @@ run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
   welcome screen's picker only on the welcome tab, the tree's run dialog only while the drawer
   is open), so the palette mounts its own - the same components, driven by the same calls. It
   also merges the surfaces a *mounted feature* contributes (the request builder's live draft,
-  for "Load test …") - see [Command Registry](#command-registry-libcommands).
+  for "Load test …" and "Send …") - see [Command Registry](#command-registry-libcommands).
 - **`types.ts`** - the `PaletteItem` shape, the fixed group order, and `rankForEmptyQuery`.
 - **`ranking.ts`** - what renders and in what order, decided once. See Ranking below.
 - **`PaletteResults.tsx`** - grouping and rendering, and nothing else: it asks `ranking.ts` what
@@ -930,8 +930,8 @@ Three things the rows and the frame say (#1176):
 - **A row's trailing edge tells you what already runs it.** A command bound to a chord prints that
   chord's key-caps - one `Kbd` per key, through `chordKeys`, from the `Chord` in
   `constants/shortcuts.ts` that the handler itself matches (#938) and never a second spelling of
-  one. The registry carries it as `Command.shortcut`, and twelve commands have one - seven of the
-  action rows plus the five drawer-view commands generated alongside them; every other row
+  one. The registry carries it as `Command.shortcut`, and thirteen commands have one - eight of
+  the action rows plus the five drawer-view commands generated alongside them; every other row
   prints nothing, because a plausible key that answers to nothing is worse than no key at all. A
   `Recents` row prints its age there instead, that being the reason it is in the section. A row
   that carries both - a chord-bound command with a recency stamp, which no source produces today -
@@ -1005,16 +1005,16 @@ in step or could enumerate them.
   `shortcut` is the `Chord` from `constants/shortcuts.ts` that already runs this command - the
   object the handler matches, so a surface printing it cannot advertise a key nothing answers
   (#938) - and is present only where such a chord genuinely exists.
-- **`registry.ts`** - the roster. Actions (new request, import, run collection, load test, close
-  tab, save, toggle drawer, toggle context bar, toggle theme, open settings) plus one command per
-  drawer view - **generated** from `constants/drawer-views.ts`, the same table the Dock's strip
+- **`registry.ts`** - the roster. Actions (new request, import, run collection, send, load test,
+  close tab, save, toggle drawer, toggle context bar, toggle theme, open settings) plus one
+  command per drawer view - **generated** from `constants/drawer-views.ts`, the same table the Dock's strip
   reads, filtered to drop Settings (which `open-settings` already covers, tab and all) - plus one
   command per settings section, **generated** from `app-panels.ts` and `engine-categories.ts` so
   a section added there appears here without an edit and cannot be named differently.
 - **`context.ts`** - `baseCommandContext()`, the React-free snapshot for a caller that is not a
   render (the native-menu bridge). `hooks/useCommandContext.ts` is the full version.
-- **`live-surfaces.ts`** - the channel a *mounted feature* contributes a surface through. One
-  slot, one contributor: the request builder's start-load-test handler.
+- **`live-surfaces.ts`** - the channel a *mounted feature* contributes a surface through. Two
+  named slots, start-load-test and send, both contributed by the mounted request builder.
 
 Two rules make it work without a dependency-injection tangle:
 
@@ -1033,9 +1033,9 @@ outlives any one mounted view. `CommandSurfaces` covers the rest, and it has two
 - **Host-owned** (`newRequest`, `runCollection`, `toggleThemeMode`) - dialogs and hooks that are
   React but that *any* rendering caller can mount for itself. The palette does exactly that in
   `useCommandSurfaces`, so offering `surfaces` at all means offering these three.
-- **Contributed by a mounted feature** (`startLoadTest`) - state that exists only inside one
-  component tree and cannot be lifted without copying it. Starting a load test needs the request
-  builder's **live editor draft**, before autosave has run; the palette is a sibling of
+- **Contributed by a mounted feature** (`startLoadTest`, `sendRequest`) - state that exists only
+  inside one component tree and cannot be lifted without copying it. Starting a load test needs
+  the request builder's **live editor draft**, before autosave has run; the palette is a sibling of
   `RequestBuilderProvider`, so a command reading a store would find only the last *saved* request
   and would silently run the old URL after an edit. The builder publishes its own handler through
   `live-surfaces.ts` (`useRegisterLoadTestSurface`, mounted by
@@ -1045,21 +1045,35 @@ outlives any one mounted view. `CommandSurfaces` covers the rest, and it has two
   Nothing about the load test moves: the single-active-run policy, the ceilings check and
   `LoadTestConfigDialog` all stay in the builder.
 
+  Send has the identical live-draft problem, so it fills the second slot the same way -
+  `useRegisterSendRequestSurface`, mounted by
+  `modules/request-builder/components/SendRequestCommandSurface.tsx`. Its contribution is
+  conditional where the load test's is not: the builder passes `null` in place of the handler
+  whenever `canSendRequest` (`utils/send-gate.ts`) says a send would be refused - a request already
+  in flight, this builder's own stream open (where the button reads Stop), or an empty URL - and
+  the row disappears with it rather than sitting on screen offering something the Send button
+  would refuse.
+
 The rejected alternative is worth naming, because it is the tempting one: reading the draft out
 of the provider from outside it, or recomposing the payload inside the command, would be a second
 copy of `buildExecBody` and of the run policy - the "hand-rolled copy of a primitive" defect this
 registry exists to remove.
 
-The channel is deliberately **one slot with one contributor**, not a registry of arbitrary named
-surfaces. A second feature with the same live-draft problem (a "Send request" command has it)
-joins that file as a second slot rather than inventing a second channel - but not before it
-exists.
+The channel is deliberately a **closed union of named slots**, not a registry of arbitrary named
+surfaces. Send had the same live-draft problem, and #1243 gave it the second slot rather than a
+second channel: `LiveSurfaceSlot` is `"startLoadTest" | "sendRequest"` and nothing else, so a
+third feature with this problem is a decision taken in `live-surfaces.ts`, not a name a caller
+can invent by passing a string.
 
 Consumers: `modules/palette/sources/commandItems.ts` (the Commands and Settings groups) and
 `hooks/useMenuActions.ts` (Preferences… → `open-settings`). `lib/commands/registry.test.ts` walks
 the roster and asserts every entry says something and that the settings roster still covers both
 catalogues; `modules/request-builder/load-test-command-surface.test.tsx` holds the live channel to
 handing over the request *as edited*, and to clearing itself on unmount.
+`modules/request-builder/send-request-command-surface.test.tsx` holds the same for Send - the
+request crossing the channel *as edited*, not as last saved - plus the gate: it asserts the row is
+absent while the URL is empty, while a send is already in flight, and while this builder's own
+stream is open.
 
 ## Toaster (`components/shared/Toaster.tsx`)
 


### PR DESCRIPTION
## Description

Send was the one chord the palette-parity guard (#1219) excused rather than covered: the action needs the request builder's **live editor draft**, and nothing contributed that draft through `lib/commands/live-surfaces.ts`. A command reaching for the saved request instead would put the old URL on the wire after an edit and report it as the send the user asked for - the near-miss #526 declined to ship.

**Root cause and approach.** `live-surfaces.ts` had one slot (`startLoadTest`) and a note naming Send as the second caller it was waiting for; this adds that slot rather than a second channel. `LiveSurfaceSlot` stays a closed union spelled the same way on `CommandSurfaces`, and the two subtle parts of the channel - the identity-checked clear and the stable ref wrapper that keeps a keystroke from writing to the store - are now shared by both slots instead of copied for the new one, so a fix to either reaches both. The store's actions become `registerSurface(slot, handler)` / `clearSurface(slot, handler)` for that reason.

**The one deliberate deviation from the issue.** The issue's acceptance criterion says the palette offers Send "while a request builder is mounted". The contribution here is narrower: `SendRequestCommandSurface` withdraws the handler while a send would be refused - an empty URL, a request in flight, an open stream where Send is Stop (#574) - so the row is absent exactly when the builder's own Send button is disabled or has become Stop. The rejected alternative was registering unconditionally and letting `perform` decline: that leaves a palette row which answers to nothing, and would let a pick silently replace the open stream the button in front of the user would stop. `canSendRequest` (`modules/request-builder/utils/send-gate.ts`) is the single predicate the window chord and the palette contribution both ask, so the two routes cannot drift; `RequestBuilderLayout` now calls it instead of spelling the gate inline.

Not changed: the URL bar keeps reading the two halves separately, because it does not refuse a send there - it renders a different control (Stop while streaming, a disabled Send otherwise). The `SEND_CHORD` excuse is deleted from `palette-parity.test.ts`'s `NO_COMMAND`, which is what its "excuses no chord twice over" case exists to force.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **599 files, 6589 tests, all passing** (up from 6574: 11 new cases in `send-request-command-surface.test.tsx`, 4 in `utils/send-gate.test.ts`, plus new cases in `registry.test.ts` and `CommandPalette.test.tsx`). No pre-existing failures on this base.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` green. `pnpm lint` still prints the two pre-existing `TSSatisfiesExpression` advisories from jsx-ast-utils (#1261), unrelated to this diff.
- Mutation checks, run rather than assumed: dropping the `canSendRequest` call in `SendRequestCommandSurface` fails the four withdrawal cases (empty URL, URL emptied, send in flight, stream open); leaving the `SEND_CHORD` entry in `NO_COMMAND` fails "excuses no chord twice over"; wiring the command to the saved request instead of the live draft fails "sends the request as edited, not as stored".
- Engine untouched, so no engine build or ctest run - per CLAUDE.md's verification-scaling rule.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/app/COMPONENTS.md`, same commit)

## Related Issues
Closes #1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3Fb4fVTMMngczHLV8fBvu