### PR TITLE
ci(scripts): lint the JavaScript outside app/, and route it there - #1166

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -68,6 +68,7 @@ jobs:
       installer: ${{ steps.area.outputs.installer }}
       build_script: ${{ steps.area.outputs.build_script }}
       scripts: ${{ steps.area.outputs.scripts }}
+      repo_js: ${{ steps.area.outputs.repo_js }}
     steps:
       # Two invocations, because `predicate-quantifier` applies to the whole
       # action and the two kinds of filter need opposite ones. This one answers
@@ -341,8 +342,35 @@ jobs:
               - '**/*.py'
               - 'scripts/pre-commit'
               - '.github/workflows/pr-tests.yml'
+            # The first-party JavaScript outside `app/` (#1166) - the perf
+            # harnesses under `scripts/perf/` today. ESLint is configured a
+            # directory away and reached none of it, prettier's domain is
+            # `app/` by policy and `scripts` above lints shell and Python, so
+            # these files were checked by nothing. The lint that now covers
+            # them rides `App quality checks`, where Node and ESLint already
+            # are, so this filter is ORed into *that* job's condition rather
+            # than gating one of its own.
+            #
+            # Globs rather than a list, for the reason `scripts` gives: the
+            # lint step takes its files from `git ls-files`, so a script added
+            # tomorrow is linted the day it lands and this filter has to be
+            # able to see the same file. `app/**` is excluded because the app's
+            # own tree has its own config, `engine/vendor/**` because upstream's
+            # sources are not ours to keep clean - the same two exclusions the
+            # lint step applies, held to it by
+            # `app/src/lib/repo-js-lint-routing.test.ts`.
+            repo_js:
+              - '*.mjs'
+              - '**/*.mjs'
+              - '*.cjs'
+              - '**/*.cjs'
+              - '*.js'
+              - '**/*.js'
+              - '.github/workflows/pr-tests.yml'
+              - '!app/**'
+              - '!engine/vendor/**'
 
-      # The routing, said out loud. Every job below is gated on these six
+      # The routing, said out loud. Every job below is gated on these
       # booleans, and until this step existed the only way to answer "why did
       # the engine matrix run on a change that touched no engine source" was to
       # re-evaluate the globs by hand - which is how the doc-routing defect
@@ -375,7 +403,11 @@ jobs:
     name: App quality checks
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true'
+    # The second clause is the JavaScript outside `app/` (#1166): its lint runs
+    # here, so an edit to one of those files has to be able to reach this job.
+    # Bare rather than ANDed with `code`, to read as the app clause's sibling -
+    # `code` is true for any of those paths anyway, none of them being Markdown.
+    if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.repo_js == 'true'
     permissions:
       contents: read
     timeout-minutes: 15
@@ -406,6 +438,37 @@ jobs:
         working-directory: app
         run: pnpm lint
 
+      # The first-party JavaScript outside `app/` (#1166). It rides this job
+      # because this is where Node and the app's ESLint install already are:
+      # `Script lint` is deliberately a runner that needs no Node, and standing
+      # one up there for two files would buy an app install - an Electron
+      # download included - to lint them.
+      #
+      # Run from the repository root, not from `app/`: ESLint matches a
+      # config's `files` patterns against the working directory, while the
+      # config resolves its own imports from where it sits. That split is why
+      # the config lives under `app/` and is invoked from here; its header
+      # carries the long version.
+      #
+      # `git ls-files` rather than a list, and an empty list fails rather than
+      # passes, for the reasons `Script lint` gives at both points. The two
+      # exclusions are that job's `engine/vendor/` rule plus `app/`, whose tree
+      # has its own config and its own lint step above.
+      - name: Lint JavaScript outside app/
+        shell: bash
+        run: |
+          mapfile -t files < <(git ls-files -- '*.mjs' '*.cjs' '*.js' | grep -v '^app/' | grep -v '^engine/vendor/')
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::No JavaScript outside app/ to check - the file list is broken, not the tree"
+            exit 1
+          fi
+          printf '  %s\n' "${files[@]}"
+          app/node_modules/.bin/eslint \
+            --config app/eslint.repo-js.config.mjs \
+            --report-unused-disable-directives \
+            --max-warnings 0 \
+            "${files[@]}"
+
       - name: Check frontend formatting
         working-directory: app
         run: pnpm format:check
@@ -431,10 +494,11 @@ jobs:
     # it lists is source or fixture, never Markdown, so `code` is true whenever
     # it is - and is left bare to read as the clause beside it. The root clause
     # must be bare: half of it is `README.md`, which `code` rejects, so an AND
-    # there would restore exactly the hole it closes. `quality` deliberately
-    # keeps the plain condition: eslint reads TS/TSX, prettier's domain is
-    # `app/` and tsc reads none of these files, so nothing it runs can change
-    # colour over an edit to one.
+    # there would restore exactly the hole it closes. `quality` needs none of
+    # these three: eslint reads TS/TSX, prettier's domain is `app/` and tsc
+    # reads none of these files, so nothing it runs can change colour over an
+    # edit to one. It carries a clause of its own for a fourth input instead -
+    # the JavaScript outside `app/` that #1166 put under eslint.
     if: (needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true') || needs.changes.outputs.app_doc_fixtures == 'true' || needs.changes.outputs.app_engine_inputs == 'true' || needs.changes.outputs.app_root_inputs == 'true'
     permissions:
       contents: read
@@ -1157,11 +1221,17 @@ jobs:
       - name: Test the stale-vcpkg-baseline self-heal
         run: python3 scripts/test/vcpkg_baseline_test.py
 
-  # The repository's two unlinted languages (#887). Both checks are seconds of
-  # work on a runner that needs neither a C++ toolchain nor Node, so they share
-  # one Linux job rather than riding a matrix that would run each of them two or
-  # three times for one answer - the same reasoning that gave `quality` its own
-  # job.
+  # Shell and Python (#887) - the two languages nothing else in this workflow
+  # reads. Both checks are seconds of work on a runner that needs neither a C++
+  # toolchain nor Node, so they share one Linux job rather than riding a matrix
+  # that would run each of them two or three times for one answer - the same
+  # reasoning that gave `quality` its own job.
+  #
+  # JavaScript outside `app/` was the third such language until #1166. It is
+  # linted by ESLint, which needs the Node toolchain this job is defined by not
+  # having, so it is checked in `App quality checks` where that toolchain is
+  # already stood up - not here. This job's name outlives that: what it lints is
+  # what a runner without Node can lint.
   #
   # Both take their files from `git ls-files`, not an enumerated list. The list
   # this replaces had drifted to five of the twelve tracked shell scripts, and an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,13 @@ assert **both** branches.
   `.prettierignore` now enforces that boundary mechanically: prettier's domain
   is `app/`, so a root-resolved run or an editor's format-on-save cannot reflow
   a doc. Format only files you touched that were clean before.
+- **ESLint's domain is wider than prettier's**: `app/` under
+  `app/eslint.config.mjs`, and the first-party JavaScript *outside* `app/`
+  (`scripts/perf/*.{mjs,cjs}` today) under `app/eslint.repo-js.config.mjs`, run
+  from the repository root by the `App quality checks` job (#1166). Both are
+  still `--fix`-free by the rule above. A new `.mjs`/`.cjs` anywhere but `app/`
+  is linted the day it lands, with no CI edit - see `CONTRIBUTING.md` for the
+  local command.
 - **"Written but never read" is this codebase's most repeated defect** - found
   nine times: state one layer records and no layer displays (SSE errors,
   save-failure reasons, an import phase, parsed cookie attributes), and config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,25 @@ violation, an unformatted file or a type error fails CI. Where a rule genuinely
 cannot be satisfied, suppress it on the single line with a comment saying why -
 an unexplained `eslint-disable` is treated as a defect.
 
+That job also lints the JavaScript that lives **outside** `app/` - the perf
+harnesses under `scripts/perf/` today, anything under `scripts/` or `.github/`
+tomorrow. It is a fourth step rather than part of `pnpm lint`, because ESLint
+matches a config's patterns against the directory it runs in, so the repository
+tree needs a run of its own from the repository root:
+
+```bash
+app/node_modules/.bin/eslint --config app/eslint.repo-js.config.mjs \
+  $(git ls-files -- '*.mjs' '*.cjs' '*.js' | grep -v '^app/' | grep -v '^engine/vendor/')
+```
+
+The config is plain ESLint recommended with Node globals - no TypeScript, React
+or Prettier plugin, since these are Node scripts with no tsc behind them and
+prettier's domain is `app/` alone. Its header says why it sits under `app/`
+while describing the tree above it. The file list comes from `git ls-files` for
+the reason the shell and Python scans do, and the `repo_js` filter that routes a
+change here is derived from that same list by
+`app/src/lib/repo-js-lint-routing.test.ts`, so neither half can move alone.
+
 ### Shell and Python (tooling)
 
 The installer, the git hook, the test harnesses and `build.py` are the

--- a/app/eslint.repo-js.config.mjs
+++ b/app/eslint.repo-js.config.mjs
@@ -1,0 +1,61 @@
+// ESLint for the first-party JavaScript that lives OUTSIDE `app/` - today the
+// two perf harnesses under `scripts/perf/`, tomorrow whatever else lands under
+// `scripts/` or `.github/`. Until #1166 those files were checked by nothing:
+// ESLint is scoped to `app/`, prettier's domain is `app/` by policy, and the
+// `Script lint` job covers shell and Python only.
+//
+// `app/eslint.config.mjs` cannot grow a block for them. Flat config resolves
+// `files` patterns against the base path and forbids patterns that climb out of
+// it with `..`, so a pattern written there always means "under `app/`" - which
+// is why that file's own `scripts/**` block matches `app/scripts/`, not this
+// repository's `scripts/`.
+//
+// This config lives in `app/` even though it describes the tree above it,
+// because the two halves resolve from different places: ESLint loads a config
+// as an ES module, so `@eslint/js` and `globals` below resolve from this file's
+// directory upwards, and `app/node_modules` is the only place in the repository
+// where ESLint is installed - while the `files` patterns are matched against
+// the base path, which is the working directory ESLint runs in. Run it from the
+// repository root and the patterns below mean what they say:
+//
+//   app/node_modules/.bin/eslint --config app/eslint.repo-js.config.mjs <files>
+//
+// No TypeScript, React or Prettier plugin, deliberately: these are plain Node
+// scripts with no tsc behind them and no prettier over them.
+
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+	// Everything ESLint is handed comes from the caller's file list, but a stray
+	// invocation (`eslint .` from the root, an editor's on-save run) must not
+	// wander into the app's own tree - which has its own config - or into
+	// vendored upstream sources, which are not ours to keep clean. Same rule the
+	// shell and Python scans apply with `grep -v '^engine/vendor/'`.
+	{
+		ignores: ["app/**", "engine/vendor/**", "**/node_modules/**"],
+	},
+
+	js.configs.recommended,
+
+	// `.mjs` is ESM by extension, whatever a package.json says. There is no
+	// package.json outside `app/`, so `.js` is CommonJS by Node's own rule -
+	// a file that wants ESM out here has to be named `.mjs` to run at all, and
+	// parsing it as anything else would be a lie about how Node loads it.
+	{
+		files: ["**/*.mjs"],
+		languageOptions: {
+			ecmaVersion: "latest",
+			sourceType: "module",
+			globals: globals.node,
+		},
+	},
+	{
+		files: ["**/*.cjs", "**/*.js"],
+		languageOptions: {
+			ecmaVersion: "latest",
+			sourceType: "commonjs",
+			globals: globals.node,
+		},
+	},
+];

--- a/app/eslint.repo-js.config.mjs
+++ b/app/eslint.repo-js.config.mjs
@@ -42,12 +42,18 @@ export default [
 	// package.json outside `app/`, so `.js` is CommonJS by Node's own rule -
 	// a file that wants ESM out here has to be named `.mjs` to run at all, and
 	// parsing it as anything else would be a lie about how Node loads it.
+	//
+	// The two global tables differ for the same reason: `globals.node` includes
+	// `require`, `module`, `exports` and `__dirname`, which an ES module does not
+	// have - `require("node:fs")` in a `.mjs` is a `ReferenceError` the moment
+	// Node loads it, and handing that block the CommonJS table would have
+	// `no-undef` bless it. `globals.nodeBuiltin` is the same table without them.
 	{
 		files: ["**/*.mjs"],
 		languageOptions: {
 			ecmaVersion: "latest",
 			sourceType: "module",
-			globals: globals.node,
+			globals: globals.nodeBuiltin,
 		},
 	},
 	{

--- a/app/package.json
+++ b/app/package.json
@@ -101,6 +101,7 @@
 		"eslint-plugin-prettier": "^5.5.6",
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"eslint-plugin-react-refresh": "^0.4.26",
+		"globals": "^17.12.0",
 		"jsdom": "^29.1.1",
 		"postcss": "^8.5.23",
 		"rimraf": "^6.1.3",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.26
         version: 0.4.26(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: ^17.12.0
+        version: 17.12.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -3010,6 +3013,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.12.0:
+    resolution: {integrity: sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -7804,6 +7811,8 @@ snapshots:
     optional: true
 
   globals@14.0.0: {}
+
+  globals@17.12.0: {}
 
   globalthis@1.0.4:
     dependencies:

--- a/app/src/lib/repo-js-lint-routing.test.ts
+++ b/app/src/lib/repo-js-lint-routing.test.ts
@@ -46,7 +46,28 @@ function lintStep(): string {
 	return [lines[start], ...(end === -1 ? rest : rest.slice(0, end))].join("\n");
 }
 
+/**
+ * The job the lint step belongs to, from its own line back to the nearest job
+ * key. Which job it is matters as much as that some job names the filter: a
+ * clause that drifts onto another job's condition leaves the substring in the
+ * file and the lint step unreachable, which is the drift this file exists for.
+ */
+function jobRunningLint(): string {
+	const lines = workflow.split("\n");
+	const step = lines.findIndex((line) => line.trim() === `- name: ${STEP_NAME}`);
+	if (step === -1) return "";
+
+	const isJobKey = (line: string) => /^ {2}[A-Za-z0-9_-]+:$/.test(line);
+	const start = lines.slice(0, step).findLastIndex(isJobKey);
+	if (start === -1) return "";
+
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex(isJobKey);
+	return [lines[start], ...(end === -1 ? rest : rest.slice(0, end))].join("\n");
+}
+
 const step = lintStep();
+const job = jobRunningLint();
 
 /** `git ls-files -- '*.mjs' '*.cjs' '*.js'` - the extensions, as written. */
 const pathspec = [...step.matchAll(/'(\*\.[a-z]+)'/g)].map((match) => match[1]);
@@ -80,8 +101,9 @@ describe("JavaScript outside app/", () => {
 	 */
 	it("has something to scan", () => {
 		expect(step.length).toBeGreaterThan(200);
+		expect(job.length).toBeGreaterThan(step.length);
 		expect(pathspec.length).toBeGreaterThan(0);
-		expect(prefixesDropped).toEqual(["app/", "engine/vendor/"]);
+		expect([...prefixesDropped].sort()).toEqual(["app/", "engine/vendor/"]);
 		expect(lintedFiles().length).toBeGreaterThan(0);
 	});
 
@@ -102,18 +124,25 @@ describe("JavaScript outside app/", () => {
 	});
 
 	/*
-	 * A filter nothing reads routes nowhere. The lint runs in `App quality
-	 * checks`, so that job's condition is the one that has to name it.
+	 * A filter nothing reads routes nowhere, and a filter the wrong job reads
+	 * routes somewhere useless - so the condition asserted is the one belonging
+	 * to whichever job the step is written into, found from the step rather than
+	 * named here.
 	 */
 	it("is exported by the changes job and read by the job that lints", () => {
 		expect(workflow).toContain(`${FILTER}: \${{ steps.area.outputs.${FILTER} }}`);
-		expect(workflow).toContain(`needs.changes.outputs.${FILTER} == 'true'`);
+		expect(job).toMatch(
+			new RegExp(`^\\s*if: .*needs\\.changes\\.outputs\\.${FILTER} == 'true'`, "m")
+		);
 	});
 
 	/*
 	 * The config is the third thing that can drift: an extension linted and
 	 * routed, with no block in the config to give it a parser, is linted as
-	 * whatever ESLint defaults to rather than as what Node runs.
+	 * whatever ESLint defaults to rather than as what Node runs. Its `ignores`
+	 * are held to the step's own exclusions for the other direction - a run
+	 * started by hand or by an editor takes the config's word for what is out of
+	 * bounds, where the step takes `grep`'s.
 	 */
 	it("lints every extension against a config block written for it", () => {
 		expect(existsSync(fromRepoRoot(configPath)), configPath).toBe(true);
@@ -121,6 +150,9 @@ describe("JavaScript outside app/", () => {
 		const config = readFileSync(fromRepoRoot(configPath), "utf8");
 		for (const glob of pathspec) {
 			expect(config, glob).toContain(`"**/${glob}"`);
+		}
+		for (const prefix of prefixesDropped) {
+			expect(config, prefix).toContain(`"${prefix}**"`);
 		}
 	});
 });

--- a/app/src/lib/repo-js-lint-routing.test.ts
+++ b/app/src/lib/repo-js-lint-routing.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The wiring that makes the JavaScript outside `app/` reach the lint that reads
+ * it (#1166).
+ *
+ * That lint takes its files from `git ls-files`, so it covers a script added
+ * tomorrow - but only on a pull request that routes to the job it runs in. The
+ * filter and the file list are two spellings of one set, in two languages, in
+ * one file: a `.jsx` harness added to the lint's pathspec and not to the filter
+ * would be linted by a job that never runs on it, which is #1118's defect in the
+ * gate that exists to end it.
+ *
+ * So the filter is derived here from the lint step rather than compared with a
+ * third copy of the list: the entries `repo_js` must carry are exactly what the
+ * step's own pathspec and exclusions imply, and either side moving alone is red.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { WORKFLOW_PATH, fromRepoRoot, repoRoot, routedPaths } from "./routed-inputs.testkit";
+
+const FILTER = "repo_js";
+const STEP_NAME = "Lint JavaScript outside app/";
+
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+/**
+ * The lint step's shell, from its `- name:` line to the next step's. Read as
+ * text for the reason `routedPaths` is: `app/` declares no YAML parser, and one
+ * step's `run:` block is a shape a regular expression can honestly describe.
+ */
+function lintStep(): string {
+	const lines = workflow.split("\n");
+	const start = lines.findIndex((line) => line.trim() === `- name: ${STEP_NAME}`);
+	if (start === -1) return "";
+
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((line) => /^\s*- name: /.test(line));
+	return [lines[start], ...(end === -1 ? rest : rest.slice(0, end))].join("\n");
+}
+
+const step = lintStep();
+
+/** `git ls-files -- '*.mjs' '*.cjs' '*.js'` - the extensions, as written. */
+const pathspec = [...step.matchAll(/'(\*\.[a-z]+)'/g)].map((match) => match[1]);
+
+/** `| grep -v '^app/'` - the prefixes the step drops, as written. */
+const prefixesDropped = [...step.matchAll(/grep -v '\^([^']+)'/g)].map((match) => match[1]);
+
+const configPath = /--config (\S+)/.exec(step)?.[1] ?? "";
+
+/**
+ * The files that lint would run on today. From `git ls-files`, the same source
+ * the step uses: a list written out here would be the copy this test exists to
+ * refuse, and would go stale the day a third harness lands.
+ */
+function lintedFiles(): string[] {
+	const tracked = execFileSync("git", ["ls-files", "--", ...pathspec], {
+		cwd: repoRoot,
+		encoding: "utf8",
+	});
+	return tracked
+		.split("\n")
+		.filter(Boolean)
+		.filter((file) => !prefixesDropped.some((prefix) => file.startsWith(prefix)));
+}
+
+describe("JavaScript outside app/", () => {
+	/*
+	 * A version of this that found no step would derive an empty filter from an
+	 * empty pathspec and compare nothing, passing forever - the empty-string
+	 * failure mode this repository has already shipped once.
+	 */
+	it("has something to scan", () => {
+		expect(step.length).toBeGreaterThan(200);
+		expect(pathspec.length).toBeGreaterThan(0);
+		expect(prefixesDropped).toEqual(["app/", "engine/vendor/"]);
+		expect(lintedFiles().length).toBeGreaterThan(0);
+	});
+
+	/*
+	 * The filter, derived from the lint rather than trusted beside it: both glob
+	 * forms per extension (the bare one for a root-level file, the nested one for
+	 * everything below), this workflow so a change to the split routes to itself,
+	 * and the step's own two exclusions.
+	 */
+	it("routes every file the lint reads, and no other", () => {
+		const expected = [
+			...pathspec.flatMap((glob) => [glob, `**/${glob}`]),
+			".github/workflows/pr-tests.yml",
+			...prefixesDropped.map((prefix) => `!${prefix}**`),
+		];
+
+		expect([...routedPaths(workflow, FILTER)].sort()).toEqual([...expected].sort());
+	});
+
+	/*
+	 * A filter nothing reads routes nowhere. The lint runs in `App quality
+	 * checks`, so that job's condition is the one that has to name it.
+	 */
+	it("is exported by the changes job and read by the job that lints", () => {
+		expect(workflow).toContain(`${FILTER}: \${{ steps.area.outputs.${FILTER} }}`);
+		expect(workflow).toContain(`needs.changes.outputs.${FILTER} == 'true'`);
+	});
+
+	/*
+	 * The config is the third thing that can drift: an extension linted and
+	 * routed, with no block in the config to give it a parser, is linted as
+	 * whatever ESLint defaults to rather than as what Node runs.
+	 */
+	it("lints every extension against a config block written for it", () => {
+		expect(existsSync(fromRepoRoot(configPath)), configPath).toBe(true);
+
+		const config = readFileSync(fromRepoRoot(configPath), "utf8");
+		for (const glob of pathspec) {
+			expect(config, glob).toContain(`"**/${glob}"`);
+		}
+	});
+});

--- a/app/src/lib/repo-js-lint-routing.test.ts
+++ b/app/src/lib/repo-js-lint-routing.test.ts
@@ -58,7 +58,10 @@ function jobRunningLint(): string {
 	if (step === -1) return "";
 
 	const isJobKey = (line: string) => /^ {2}[A-Za-z0-9_-]+:$/.test(line);
-	const start = lines.slice(0, step).findLastIndex(isJobKey);
+	let start = -1;
+	for (let line = step - 1; line >= 0 && start === -1; line--) {
+		if (isJobKey(lines[line])) start = line;
+	}
 	if (start === -1) return "";
 
 	const rest = lines.slice(start + 1);

--- a/docs/building.md
+++ b/docs/building.md
@@ -371,7 +371,9 @@ The project uses GitHub Actions for automated builds:
   - Runs on every pull request
   - Tests engine and frontend on Linux/Windows/macOS
   - Lint, formatting and type-check run once, on their own Linux job, rather
-    than in front of a suite they cannot affect
+    than in front of a suite they cannot affect. That job also runs ESLint over
+    the JavaScript outside `app/` (`scripts/perf/*.{mjs,cjs}` today), from the
+    repository root and against its own config - it is where Node already is
   - `Script lint` does the same for the other two languages: shellcheck
     (v0.10.0) over every tracked shell script and ruff (0.15.8) over every
     tracked `.py`, both file lists taken from `git ls-files` so a script added


### PR DESCRIPTION
## Description

`scripts/perf/measure-app.mjs` and `scripts/perf/startup-harness.cjs` are checked by nothing today: ESLint is configured a directory away (`app/eslint.config.mjs`), prettier's domain is `app/` by policy, and `Script lint` covers shell and Python. A syntax error surfaced only when the weekly perf workflow ran them; an unused binding or a typo'd global surfaced never.

**Root cause and approach.** The gap is two-sided, and the verification comment on the issue is right that fixing one side ships dead code. (1) No lint reads those files - and `app/eslint.config.mjs` cannot grow a block for them, because flat config matches `files` patterns against the base path and forbids patterns that climb out of it with `..`, so that file's own `scripts/**` block means `app/scripts/`. (2) No path filter routes them: the `scripts` filter lists shell and Python globs only, so a pull request touching only `scripts/perf/*.mjs` matched no area at all and would skip a new lint step as silently as it skipped everything else.

So: a second flat config, `app/eslint.repo-js.config.mjs` - recommended rules plus Node globals, no TypeScript, React or Prettier plugin - invoked from the repository root by the `App quality checks` job, and a new `repo_js` filter ORed into that job's condition. The config lives under `app/` while describing the tree above it because the two halves resolve from different places: ESLint loads a config as an ES module, so its imports resolve from its own directory (and `app/node_modules` is the only place ESLint is installed), while `files` patterns are matched against the working directory. Its header carries that reasoning.

**The alternative rejected.** Adding the lint to `Script lint`, which is where a reader would look for it. That job is defined by needing neither a C++ toolchain nor Node; giving it ESLint means `pnpm install --frozen-lockfile` in `app/` - an Electron download included - to lint two files. `App quality checks` already has Node, the install and an ESLint invocation. A repo-root `package.json` with its own eslint devDependency was rejected for the same reason plus a second one: a second dependency tree means a second ESLint version to keep in step.

**One deviation from the issue text, and one adjacent finding left alone.** The issue says `app/scripts/electron-dev.mjs` "is inside `app/` and so is already covered". It is not: `pnpm lint` runs `eslint . --ext ts,tsx`, so `app/`'s own `.mjs`/`.cjs` files are never linted, and the `scripts/**/*.{mjs,cjs,js}` block in `app/eslint.config.mjs` is configured-but-unreachable. That is a different file set with a different fix (the app's own lint invocation), so it is filed as #1294 rather than folded in here - this PR's file list excludes `app/**` deliberately.

`globals` joins the app's devDependencies (one package, no transitive deps) so `no-undef` has a table to check against rather than being switched off. The two blocks take different tables: `globals.nodeBuiltin` for `.mjs`, because `require`/`module`/`__dirname` are not defined in an ES module and blessing them would let a runtime `ReferenceError` lint clean, and `globals.node` for `.cjs`/`.js`, which is what those run as.

## Type of Change
- [x] Bug fix (a CI gate that could not fire)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Run locally at `8616031`, re-run after the review commit `b4c4f4f`:

- `cd app && pnpm test` - **598 files, 6574 tests, all passing**, including the new `repo-js-lint-routing.test.ts` (4 cases). Re-run after the review commit: `repo-js-lint-routing` + `routed-inputs`, 16 cases, green.
- `cd app && pnpm type-check` - three tsc projects, all exit 0.
- `cd app && pnpm lint` - clean. It prints two `TSSatisfiesExpression` advisories from `jsx-ast-utils`; those are pre-existing on `master` and are #1261 / PR #1291, not this change.
- `cd app && pnpm format:check` - clean (both new files under `app/` are prettier-clean).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, for the `docs/building.md` edit.
- The CI lint step, replicated verbatim in bash from the repository root: lists the two files and exits 0. In CI, `App quality checks` passed on the first commit with the step in place.
- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow, plus a read-back of `changes.outputs`, `quality.if` and the quality job's step list.

Engine untouched, so no engine build or ctest run - no C++ or CMake file is in the diff.

**Mutation checks** (the acceptance criteria, proven rather than assumed - each reverted after):

1. *A lint defect in a `.mjs`/`.cjs` outside `app/` fails.* `const neverUsed = procces.argv;` appended to `startup-harness.cjs`: exit 1 on `no-unused-vars` and `no-undef`.
2. *A `.mjs` using CommonJS fails.* `require("node:fs")` in a `.mjs`: exit 1 on `no-undef` (and the same file lints clean as `.cjs`, correctly).
3. *The guard catches drift from the filter side.* Deleted `- '**/*.cjs'` from `repo_js`: `routes every file the lint reads, and no other` fails.
4. *And from the lint side.* Added `'*.jsx'` to the step's pathspec only: that case fails, and so does `lints every extension against a config block written for it`.
5. *And from the routing side.* Moved the `|| repo_js == 'true'` clause off `quality` onto `Script lint`: `is exported by the changes job and read by the job that lints` fails - the assertion is scoped to the job the step is written into, not a whole-file substring search.
6. *And from the config's ignores.* Deleted `"app/**"` from the config's `ignores`: the config case fails.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `CONTRIBUTING.md` gains the local command and the config's rationale under "Formatting and Linting"; `CLAUDE.md` gains the ESLint-domain bullet beside the prettier-domain one; `docs/building.md`'s CI section names the new pass; the `Script lint` job's "two unlinted languages" comment now says what it covers and where JavaScript went instead, and the `app` job's comment about `quality` keeping the plain condition is corrected.

## Related Issues
Closes #1166
Files it: #1294 (the app's own `.mjs`/`.cjs`, unlinted by `--ext ts,tsx`)