### PR TITLE
perf(engine): scope Windows' 1ms timer request to runs, and correct the records - #1161

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -78,7 +78,7 @@ AllowShortFunctionsOnASingleLine: None
 #
 # Exactly one include order in the engine is load-bearing, and it is pinned at
 # the site rather than by disabling the sorter everywhere:
-# `engine/src/platform/platform_windows.cpp` wraps `<windows.h>` /
+# `engine/src/platform/high_resolution_timer.cpp` wraps `<windows.h>` /
 # `<timeapi.h>` in `// clang-format off` because timeapi.h uses types
 # (MMRESULT, UINT, WINAPI) that windows.h defines, does not compile standalone,
 # and sorts first alphabetically. Nothing catches that but the Windows CI leg.

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -227,15 +227,17 @@ system resolver. Three rules make that safe:
 default, so both the 1ms poll above and the pacing loop's `sleep_for` leg
 (below ~500 RPS - a faster tick spins its remainder out instead) would return
 roughly fifteen times late. `timeBeginPeriod(1)` buys 1ms, and the engine holds
-that request **only while a run is sending**: each `RunContext` takes a
-refcounted `platform::HighResolutionTimerScope` when it is created and gives it
-back in `release_execution_resources`, beside the event loop it was for. The
+that request **only while a run is sending**: the event loop itself holds a
+refcounted `platform::HighResolutionTimerScope` for its lifetime, and
+`release_execution_resources` destroys the loop as the run is retained. The
 sidecar is resident for a whole app session and idle for nearly all of it, so
 the request is scoped to runs rather than to the process - a process-lifetime
-request is the classic Windows idle-power finding. Nesting is why it is
-refcounted: overlapping runs take it once between them, under a mutex that
-moves the count and the OS call together. Nothing on Linux or macOS is
-affected; the scope compiles to a counter there.
+request is the classic Windows idle-power finding. A design-mode scenario run
+builds no loop and asks for nothing. Nesting is why it is refcounted:
+overlapping runs take it once between them, under a mutex that moves the count
+and the OS call together, so one run finishing cannot hand the resolution back
+under another that is still sending. Nothing on Linux or macOS is affected; the
+scope compiles to a counter there.
 
 ### Run Manager
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -216,11 +216,26 @@ system resolver. Three rules make that safe:
 - Max concurrent requests per worker: 1000 (configurable)
 - Max connections per host: 100
 - Poll timeout: 1ms (kept short because a submission interrupts the poll via
-  `curl_multi_wakeup`)
+  `curl_multi_wakeup`; on Windows see **Timer resolution** below for what makes
+  a 1ms wait 1ms)
 - TCP keep-alive: 60s idle, 30s probe interval
 - Max response body per transfer: 32MB (`maxResponseBodyBytes`); a larger
   response fails that request rather than being buffered, since every in-flight
   request holds its own body
+
+**Timer resolution (Windows).** Windows waits at a ~15.6ms granularity by
+default, so both the 1ms poll above and the pacing loop's `sleep_for` leg
+(below ~500 RPS - a faster tick spins its remainder out instead) would return
+roughly fifteen times late. `timeBeginPeriod(1)` buys 1ms, and the engine holds
+that request **only while a run is sending**: each `RunContext` takes a
+refcounted `platform::HighResolutionTimerScope` when it is created and gives it
+back in `release_execution_resources`, beside the event loop it was for. The
+sidecar is resident for a whole app session and idle for nearly all of it, so
+the request is scoped to runs rather than to the process - a process-lifetime
+request is the classic Windows idle-power finding. Nesting is why it is
+refcounted: overlapping runs take it once between them, under a mutex that
+moves the count and the OS call together. Nothing on Linux or macOS is
+affected; the scope compiles to a counter there.
 
 ### Run Manager
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -983,7 +983,7 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs   # once, per clone
 **Includes are sorted**, and the tree was already 99.8% sorted before the gate
 landed, so this costs nothing and is one fewer thing for a reviewer to check by
 hand. Exactly one include order in the engine is load-bearing and is pinned at
-the site rather than by disabling the sorter: `engine/src/platform/platform_windows.cpp`
+the site rather than by disabling the sorter: `engine/src/platform/high_resolution_timer.cpp`
 wraps `<windows.h>` / `<timeapi.h>` in `// clang-format off`, because
 `timeapi.h` uses types `windows.h` defines, does not compile standalone, and
 sorts first alphabetically - a break only the Windows CI leg would catch. Pin a

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -255,9 +255,10 @@ engine/
   `ContinuationIndentWidth: 0`) are what the code is written to, not oversights;
   both are commented in the file. `engine/vendor/` sets `DisableFormat: true`.
   **Includes are sorted**, with exactly one pinned exemption: the
-  `<windows.h>` / `<timeapi.h>` pair in `src/platform/platform_windows.cpp`,
-  wrapped in `// clang-format off` because timeapi.h needs windows.h's types
-  and sorts first alphabetically. If you hit a second such case, pin it at the
+  `<windows.h>` / `<timeapi.h>` pair in
+  `src/platform/high_resolution_timer.cpp` (it moved there with the 1ms timer
+  request in #1161), wrapped in `// clang-format off` because timeapi.h needs
+  windows.h's types and sorts first alphabetically. If you hit a second such case, pin it at the
   site the same way - do not turn the sorter off for the tree.
   Before editing the config, read the note at the top of it - a "tidier" value
   costs a five-figure-line rewrite.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -478,6 +478,9 @@ add_library(vayu_core STATIC
     # The only TU that sees VAYU_VERSION_STRING for the User-Agent - keep it
     # that way, or a version bump invalidates the whole compile cache (#659).
     src/core/user_agent.cpp
+    # Beside PLATFORM_SOURCES rather than in it: the refcount and the scope
+    # compile everywhere, only the two timeapi calls inside are Windows' (#1161).
+    src/platform/high_resolution_timer.cpp
     ${PLATFORM_SOURCES}
 )
 

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -98,6 +98,9 @@ constexpr size_t MAX_PER_HOST = 200;
 /// Timeout for a worker's curl_multi_poll in milliseconds. Deliberately short:
 /// it only bounds how long a worker with active transfers blocks waiting for
 /// IO, and submit() interrupts the poll via curl_multi_wakeup anyway.
+/// On Windows a 1ms wait is only 1ms because the run holds
+/// `platform::HighResolutionTimerScope`; at the OS default this poll would
+/// return after ~15.6ms (issue #1161).
 constexpr int POLL_TIMEOUT_MS = 1;
 /// DNS cache timeout in seconds (avoids DNS resolver saturation).
 /// Governs both curl's own cache and the pre-resolution pin cache.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -35,6 +35,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/transport_policy.hpp"
+#include "vayu/platform/platform.hpp"
 
 namespace vayu::http {
 // A scenario run's steps send through the daemon's jar; the manager only passes
@@ -177,6 +178,15 @@ struct EngineDefaults {
 
 struct RunContext {
     std::string run_id;
+    /// Windows' 1 ms timer resolution, held for exactly as long as this run is
+    /// sending (issue #1161). It is an execution resource like the loop below
+    /// and goes back with it in `release_execution_resources`, not 60-90s
+    /// later when the sweeper drops the last reference to a retained run: the
+    /// two things that need it - the loop's 1 ms `curl_multi_poll` and the
+    /// sub-500-RPS pacing sleeps - have both stopped by then. Engaged from the
+    /// constructor rather than from the worker thread so that no path into a
+    /// run can start sending without it. A no-op off Windows.
+    std::optional<vayu::platform::HighResolutionTimerScope> timer_resolution{ std::in_place };
     std::unique_ptr<vayu::http::EventLoop> event_loop;
     // Orders the metrics thread's reads of `event_loop` against its
     // publication (#956). start_run spawns the metrics thread before the
@@ -243,6 +253,10 @@ struct RunContext {
         }
         load_data.reset ();
         scenario.reset ();
+        // The 1 ms timer request goes back here rather than with the context:
+        // the loop that polled at 1 ms has just been moved out, and an idle
+        // Windows sidecar holding the request is what issue #1161 is about.
+        timer_resolution.reset ();
         // The sample reservoirs, but not the collector: the two deferred passes
         // that read them have run by now - both finish before the summary is
         // written, and the paths that reach retention without them are the ones

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -35,7 +35,6 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/http/transport_policy.hpp"
-#include "vayu/platform/platform.hpp"
 
 namespace vayu::http {
 // A scenario run's steps send through the daemon's jar; the manager only passes
@@ -178,15 +177,8 @@ struct EngineDefaults {
 
 struct RunContext {
     std::string run_id;
-    /// Windows' 1 ms timer resolution, held for exactly as long as this run is
-    /// sending (issue #1161). It is an execution resource like the loop below
-    /// and goes back with it in `release_execution_resources`, not 60-90s
-    /// later when the sweeper drops the last reference to a retained run: the
-    /// two things that need it - the loop's 1 ms `curl_multi_poll` and the
-    /// sub-500-RPS pacing sleeps - have both stopped by then. Engaged from the
-    /// constructor rather than from the worker thread so that no path into a
-    /// run can start sending without it. A no-op off Windows.
-    std::optional<vayu::platform::HighResolutionTimerScope> timer_resolution{ std::in_place };
+    /// The loop also carries Windows' 1 ms timer resolution for its lifetime
+    /// (issue #1161), so releasing it below gives that back too.
     std::unique_ptr<vayu::http::EventLoop> event_loop;
     // Orders the metrics thread's reads of `event_loop` against its
     // publication (#956). start_run spawns the metrics thread before the
@@ -253,10 +245,6 @@ struct RunContext {
         }
         load_data.reset ();
         scenario.reset ();
-        // The 1 ms timer request goes back here rather than with the context:
-        // the loop that polled at 1 ms has just been moved out, and an idle
-        // Windows sidecar holding the request is what issue #1161 is about.
-        timer_resolution.reset ();
         // The sample reservoirs, but not the collector: the two deferred passes
         // that read them have run by now - both finish before the summary is
         // written, and the paths that reach retention without them are the ones

--- a/engine/include/vayu/http/event_loop/event_loop_impl.hpp
+++ b/engine/include/vayu/http/event_loop/event_loop_impl.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "vayu/http/event_loop.hpp"
+#include "vayu/platform/platform.hpp"
 
 namespace vayu::http::detail {
 
@@ -71,6 +72,17 @@ class EventLoopImpl {
     private:
     void submit (std::unique_ptr<TransferData> data);
 
+    /// Windows' 1 ms timer resolution, held for exactly as long as this loop
+    /// exists (issue #1161). The loop is the consumer that needs it - each
+    /// worker asks `curl_multi_poll` for a `POLL_TIMEOUT_MS = 1` wait, which
+    /// the OS default rounds to ~15.6ms - and the rate-limited pacing loop
+    /// that sleeps beside it below ~500 RPS is coextensive with it. A loop
+    /// exists only while a run is sending, so an idle sidecar - which it is
+    /// for nearly all of an app session - asks for nothing, and a design-mode
+    /// scenario run, which builds no loop, asks for nothing either. First
+    /// member so it is taken before a worker can poll and given back after
+    /// the last one has stopped. A no-op off Windows.
+    vayu::platform::HighResolutionTimerScope timer_resolution;
     EventLoopConfig config;
     std::vector<std::unique_ptr<EventLoopWorker>> workers;
     std::atomic<size_t> next_worker{ 0 };

--- a/engine/include/vayu/platform/platform.hpp
+++ b/engine/include/vayu/platform/platform.hpp
@@ -184,25 +184,54 @@ constexpr char path_separator () {
  */
 std::string path_join (const std::string& base, const std::string& component);
 
-#if VAYU_PLATFORM_WINDOWS
 // ============================================================================
-// High-Resolution Timer (Windows)
+// High-Resolution Timer
 // ============================================================================
 /**
- * @brief Enable 1 ms system timer resolution for accurate short sleeps
+ * @brief Holds the system's 1 ms timer resolution for as long as it lives
  *
- * On Windows the default timer resolution is ~15.6 ms, which makes
- * std::this_thread::sleep_for(microseconds) round to 15 ms and severely
- * limits high-RPS load testing. Calling this at startup allows sub-millisecond
- * pacing (e.g. 60k+ RPS). Call disable_high_resolution_timer() at shutdown.
+ * Windows only in effect - on every other platform the class is an empty
+ * bracket the counter still records, so the balance is one invariant tested
+ * everywhere rather than on one CI leg (`high_resolution_timer_holders`).
+ *
+ * Windows' default timer resolution is ~15.6 ms, and `timeBeginPeriod (1)`
+ * lowers it to 1 ms. Two consumers need that, and **both live only while a run
+ * is sending** (issue #1161):
+ *
+ * - the event loop's `curl_multi_poll (..., POLL_TIMEOUT_MS)`, which asks for a
+ *   1 ms wait per iteration and gets ~15.6 ms without this;
+ * - the rate-limited pacing loop's `sleep_for` leg, which runs below ~500 RPS
+ *   (above it the tick's remainder is spun out instead - see
+ *   `wait_for_next_tick`), where a 2.5 ms sleep would likewise round to ~15.6.
+ *
+ * So the request is scoped to runs and not to the process: the sidecar is
+ * resident for the whole app session and idle for almost all of it, and a
+ * process-lifetime request is the classic Windows battery finding. Each run's
+ * `RunContext` holds one of these from its construction until
+ * `release_execution_resources` drops it beside the event loop it was for.
+ *
+ * Nesting is safe: the underlying request is refcounted, taken by the first
+ * holder and released by the last, under a mutex - the count and the OS call
+ * move together, so a run starting as another finishes cannot end with the
+ * resolution released while a live run needs it.
  */
-void enable_high_resolution_timer ();
+class HighResolutionTimerScope {
+    public:
+    HighResolutionTimerScope ();
+    ~HighResolutionTimerScope ();
+    HighResolutionTimerScope (const HighResolutionTimerScope&) = delete;
+    HighResolutionTimerScope& operator= (const HighResolutionTimerScope&) = delete;
+    HighResolutionTimerScope (HighResolutionTimerScope&&)            = delete;
+    HighResolutionTimerScope& operator= (HighResolutionTimerScope&&) = delete;
+};
 
 /**
- * @brief Restore default system timer resolution
- * Must be called to match each enable_high_resolution_timer().
+ * @brief How many scopes hold the 1 ms request right now
+ *
+ * The refcount itself, so a test can state the invariant the scope exists for -
+ * that what a run takes, a run gives back - on a platform where the OS call is
+ * compiled out.
  */
-void disable_high_resolution_timer ();
-#endif
+[[nodiscard]] int high_resolution_timer_holders ();
 
 } // namespace vayu::platform

--- a/engine/include/vayu/platform/platform.hpp
+++ b/engine/include/vayu/platform/platform.hpp
@@ -206,9 +206,12 @@ std::string path_join (const std::string& base, const std::string& component);
  *
  * So the request is scoped to runs and not to the process: the sidecar is
  * resident for the whole app session and idle for almost all of it, and a
- * process-lifetime request is the classic Windows battery finding. Each run's
- * `RunContext` holds one of these from its construction until
- * `release_execution_resources` drops it beside the event loop it was for.
+ * process-lifetime request is the classic Windows battery finding. The holder
+ * is the event loop itself (`detail::EventLoopImpl`), which exists only while
+ * a run is sending and is destroyed by `release_execution_resources` as the
+ * run is retained - so nothing has to remember to give the request back, and
+ * a design-mode scenario run, which sends sequentially and builds no loop,
+ * never asks for it.
  *
  * Nesting is safe: the underlying request is refcounted, taken by the first
  * holder and released by the last, under a mutex - the count and the OS call

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -569,9 +569,22 @@ class ConstantLoadStrategy : public LoadStrategy {
     /**
      * Wait out the remainder of a tick. Oversleeping is self-correcting - the
      * next tick accrues the extra elapsed time - so the sleep can be the full
-     * remainder; on Windows short waits still spin, since 15.6ms timer
-     * rounding would make sub-tick sleeps bursty. @p context is read only by
-     * that spin, so the leg without it leaves the parameter unused.
+     * remainder; on Windows short waits spin instead.
+     *
+     * Not because of 15.6ms rounding, which is what this said until issue
+     * #1161 read the two mechanisms against each other: a run holds
+     * `HighResolutionTimerScope` for as long as it sends, so in-process the
+     * resolution is already 1ms. The spin is for the residual - even at 1ms,
+     * `sleep_for(1000us)` returns at ~1-2ms, and a tick is exactly 1000us from
+     * 1000 RPS up (`tick_us` below), so sleeping the remainder would make an
+     * open-loop generator's arrivals bursty and its latency numbers dishonest.
+     * The 2000us threshold puts every tick from ~500 RPS on the spin and
+     * leaves the sleep to the slower ticks, which are long enough to absorb
+     * the overshoot - and which are the reason the 1ms request is taken at
+     * all, along with the event loop's 1ms `curl_multi_poll`.
+     *
+     * @p context is read only by that spin, so the leg without it leaves the
+     * parameter unused.
      */
     static void wait_for_next_tick ([[maybe_unused]] const std::shared_ptr<RunContext>& context,
     std::chrono::steady_clock::time_point next_tick) {

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -572,16 +572,18 @@ class ConstantLoadStrategy : public LoadStrategy {
      * remainder; on Windows short waits spin instead.
      *
      * Not because of 15.6ms rounding, which is what this said until issue
-     * #1161 read the two mechanisms against each other: a run holds
-     * `HighResolutionTimerScope` for as long as it sends, so in-process the
-     * resolution is already 1ms. The spin is for the residual - even at 1ms,
-     * `sleep_for(1000us)` returns at ~1-2ms, and a tick is exactly 1000us from
-     * 1000 RPS up (`tick_us` below), so sleeping the remainder would make an
-     * open-loop generator's arrivals bursty and its latency numbers dishonest.
-     * The 2000us threshold puts every tick from ~500 RPS on the spin and
-     * leaves the sleep to the slower ticks, which are long enough to absorb
-     * the overshoot - and which are the reason the 1ms request is taken at
-     * all, along with the event loop's 1ms `curl_multi_poll`.
+     * #1161 read the two mechanisms against each other: this run's event loop
+     * holds `platform::HighResolutionTimerScope` for as long as it exists, so
+     * in-process the resolution is already 1ms while a run is sending, on the
+     * pacing thread as much as in the loop. The spin is for the residual -
+     * even at 1ms, `sleep_for(1000us)` returns at ~1-2ms, and a tick is
+     * exactly 1000us from 1000 RPS up (`tick_us` below), so sleeping the
+     * remainder would make an open-loop generator's arrivals bursty and its
+     * latency numbers dishonest. The 2000us threshold puts every tick from
+     * ~500 RPS on the spin and leaves the sleep to the slower ticks, which are
+     * long enough to absorb a 1ms overshoot - and which would round to ~15.6ms
+     * without the loop's request, so the sleep leg is the second thing that
+     * request buys.
      *
      * @p context is read only by that spin, so the leg without it leaves the
      * parameter unused.

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -152,11 +152,6 @@ int run_daemon (std::span<char* const> args) {
         g_running.store (false);
     });
 
-#if VAYU_PLATFORM_WINDOWS
-    // Enable 1 ms timer resolution so short sleeps are accurate (high-RPS load tests)
-    vayu::platform::enable_high_resolution_timer ();
-#endif
-
     // Initialize database
     std::string db_path = vayu::platform::path_join (db_dir, "vayu.db");
     vayu::db::Database db (db_path);
@@ -257,10 +252,6 @@ int run_daemon (std::span<char* const> args) {
     run_manager.shutdown ();
 
     vayu::http::global_cleanup ();
-
-#if VAYU_PLATFORM_WINDOWS
-    vayu::platform::disable_high_resolution_timer ();
-#endif
 
     // Release lock file
     vayu::platform::release_file_lock (g_lock_handle);

--- a/engine/src/platform/high_resolution_timer.cpp
+++ b/engine/src/platform/high_resolution_timer.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file high_resolution_timer.cpp
+ * @brief The refcounted 1 ms timer request, and the one OS call behind it
+ *
+ * Portable on purpose, unlike its two neighbours in this directory: the
+ * refcount, the scope and the balance rule are the same everywhere, and only
+ * the two `timeapi.h` calls are Windows'. Splitting it the other way - the
+ * count here, the call in `platform_windows.cpp` - would spread one mechanism
+ * over three files and leave the invariant testable on one CI leg only.
+ */
+
+#include "vayu/platform/platform.hpp"
+
+#include <mutex>
+
+#if VAYU_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+// clang-format off
+// The second of the engine's two exemptions from `SortIncludes` (issue #886,
+// the first is in platform_windows.cpp): timeapi.h uses MMRESULT, UINT and
+// WINAPI, which windows.h defines, so it does not compile standalone - and
+// alphabetically it sorts first.
+#include <windows.h>
+#include <timeapi.h>
+// clang-format on
+#endif
+
+namespace vayu::platform {
+
+namespace {
+
+/**
+ * The refcount and the mutex that pairs it with the OS call.
+ *
+ * A function-local static rather than two namespace-scope objects: nothing
+ * here is built before `main` (engine/CLAUDE.md), and the pairing has to be a
+ * mutex rather than an atomic counter. With a bare `fetch_sub`, a run
+ * finishing and a run starting can interleave so that the release lands
+ * *after* the acquire - a correct count over a resolution the OS has already
+ * put back, for as long as the new run lasts.
+ */
+struct TimerRequest {
+    std::mutex mutex;
+    int holders = 0;
+};
+
+TimerRequest& timer_request () {
+    static TimerRequest request;
+    return request;
+}
+
+/// The whole of what is platform-specific here. Called under the mutex.
+void apply_timer_resolution ([[maybe_unused]] bool requested) {
+#if VAYU_PLATFORM_WINDOWS
+    if (requested) {
+        (void)timeBeginPeriod (1);
+    } else {
+        (void)timeEndPeriod (1);
+    }
+#endif
+}
+
+} // namespace
+
+HighResolutionTimerScope::HighResolutionTimerScope () {
+    TimerRequest& request = timer_request ();
+    std::lock_guard<std::mutex> lock (request.mutex);
+    if (request.holders++ == 0) {
+        apply_timer_resolution (true);
+    }
+}
+
+HighResolutionTimerScope::~HighResolutionTimerScope () {
+    TimerRequest& request = timer_request ();
+    std::lock_guard<std::mutex> lock (request.mutex);
+    // A destructor is total (engine/CLAUDE.md): neither the count nor the OS
+    // call throws, so there is nothing here to catch.
+    if (--request.holders == 0) {
+        apply_timer_resolution (false);
+    }
+}
+
+int high_resolution_timer_holders () {
+    TimerRequest& request = timer_request ();
+    std::lock_guard<std::mutex> lock (request.mutex);
+    return request.holders;
+}
+
+} // namespace vayu::platform

--- a/engine/src/platform/high_resolution_timer.cpp
+++ b/engine/src/platform/high_resolution_timer.cpp
@@ -28,10 +28,11 @@
 #define NOMINMAX
 #endif
 // clang-format off
-// The second of the engine's two exemptions from `SortIncludes` (issue #886,
-// the first is in platform_windows.cpp): timeapi.h uses MMRESULT, UINT and
+// The engine's one exemption from `SortIncludes` (issue #886), which moved
+// here with the timer request it is for: timeapi.h uses MMRESULT, UINT and
 // WINAPI, which windows.h defines, so it does not compile standalone - and
-// alphabetically it sorts first.
+// alphabetically it sorts first. Nothing catches that but the Windows CI leg,
+// which is why this is pinned rather than left to the sorter.
 #include <windows.h>
 #include <timeapi.h>
 // clang-format on

--- a/engine/src/platform/platform_windows.cpp
+++ b/engine/src/platform/platform_windows.cpp
@@ -26,15 +26,7 @@
 #include <process.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-// clang-format off
-// The only include order in the engine that a sort would break, hence the one
-// exemption from `SortIncludes` (issue #886). timeapi.h uses MMRESULT, UINT and
-// WINAPI, which windows.h defines, so it does not compile standalone - and
-// alphabetically it sorts first. Nothing here catches that but the Windows CI
-// leg, which is why this is pinned rather than left to the sorter.
 #include <windows.h>
-#include <timeapi.h>
-// clang-format on
 
 #include <atomic>
 #include <fstream>
@@ -253,32 +245,9 @@ std::string path_join (const std::string& base, const std::string& component) {
     }
 }
 
-// ============================================================================
-// High-Resolution Timer
-// ============================================================================
-// Windows default timer resolution is ~15.6 ms, which makes short sleeps
-// round to 15 ms and caps load-test throughput (~1k RPS). timeBeginPeriod(1)
-// sets 1 ms resolution so sleep_for(microseconds) is accurate (60k+ RPS).
-
-namespace {
-int g_timer_resolution_refcount = 0;
-}
-
-void enable_high_resolution_timer () {
-    if (g_timer_resolution_refcount++ == 0) {
-        (void)timeBeginPeriod (1);
-    }
-}
-
-void disable_high_resolution_timer () {
-    if (g_timer_resolution_refcount <= 0) {
-        return;
-    }
-    --g_timer_resolution_refcount;
-    if (g_timer_resolution_refcount == 0) {
-        (void)timeEndPeriod (1);
-    }
-}
+// The 1 ms timer request used to live here, held for the process' whole life.
+// It is `HighResolutionTimerScope` in high_resolution_timer.cpp now, taken by
+// each run and released with it (issue #1161).
 
 } // namespace vayu::platform
 

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(vayu_tests
     sse_stream_test.cpp
     server_bind_test.cpp
     numeric_flag_test.cpp
+    high_resolution_timer_test.cpp
     argument_rules_test.cpp
     transport_policy_test.cpp
     tls_verification_test.cpp

--- a/engine/tests/high_resolution_timer_test.cpp
+++ b/engine/tests/high_resolution_timer_test.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/high_resolution_timer_test.cpp
+ * @brief The 1 ms timer request's refcount: what a scope takes, it gives back
+ *
+ * The OS call behind it is Windows-only, but the refcount and the balance rule
+ * are not, so these run on every leg (issue #1161). What they hold is the
+ * invariant a run-scoped request needs: an idle engine holds nothing, nesting
+ * takes the request once, and concurrent runs starting and finishing cannot
+ * leave the count - or the resolution the count stands for - stuck either way.
+ */
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "vayu/platform/platform.hpp"
+
+namespace vayu::platform {
+namespace {
+
+TEST (HighResolutionTimer, NothingIsHeldByAnIdleEngine) {
+    EXPECT_EQ (high_resolution_timer_holders (), 0);
+}
+
+TEST (HighResolutionTimer, AScopeTakesTheRequestAndGivesItBack) {
+    {
+        const HighResolutionTimerScope scope;
+        EXPECT_EQ (high_resolution_timer_holders (), 1);
+    }
+    EXPECT_EQ (high_resolution_timer_holders (), 0);
+}
+
+// Two runs overlap all the time - one starting while another drains - so the
+// second holder must not re-take the request and the first release must not
+// hand it back under the run still sending.
+TEST (HighResolutionTimer, NestedScopesCountAndTheLastOneReleases) {
+    auto outer = std::make_unique<HighResolutionTimerScope> ();
+    EXPECT_EQ (high_resolution_timer_holders (), 1);
+
+    auto inner = std::make_unique<HighResolutionTimerScope> ();
+    EXPECT_EQ (high_resolution_timer_holders (), 2);
+
+    outer.reset ();
+    EXPECT_EQ (high_resolution_timer_holders (), 1);
+
+    inner.reset ();
+    EXPECT_EQ (high_resolution_timer_holders (), 0);
+}
+
+// The reason the refcount is a mutex and not a bare atomic: the count and the
+// OS call have to move together. This is the shape that used to be a plain
+// `int` written from one thread only, and would now be written from every run
+// worker at once.
+TEST (HighResolutionTimer, ConcurrentHoldersBalanceToZero) {
+    constexpr int thread_count      = 8;
+    constexpr int scopes_per_thread = 200;
+
+    std::atomic<bool> start{ false };
+    std::atomic<int> negative_readings{ 0 };
+    std::vector<std::thread> threads;
+    threads.reserve (thread_count);
+
+    for (int i = 0; i < thread_count; ++i) {
+        threads.emplace_back ([&] () {
+            while (!start.load ()) {
+                std::this_thread::yield ();
+            }
+            for (int n = 0; n < scopes_per_thread; ++n) {
+                const HighResolutionTimerScope scope;
+                // Never negative and never zero while this thread holds one:
+                // a lost increment or a double release shows up here.
+                if (high_resolution_timer_holders () < 1) {
+                    negative_readings.fetch_add (1);
+                }
+            }
+        });
+    }
+
+    start.store (true);
+    for (auto& thread : threads) {
+        thread.join ();
+    }
+
+    EXPECT_EQ (negative_readings.load (), 0);
+    EXPECT_EQ (high_resolution_timer_holders (), 0);
+}
+
+} // namespace
+} // namespace vayu::platform

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -320,6 +320,44 @@ TEST (RunManagerRetention, RetainReleasesTheMachineryAndKeepsTheTopic) {
     EXPECT_TRUE (found->closed.load ());
 }
 
+// Windows' 1 ms timer resolution is one of those execution resources since
+// issue #1161: a run takes it because its event loop polls at 1ms and its
+// pacing sleeps below ~500 RPS would otherwise round to ~15.6ms, and an idle
+// engine - which the sidecar is for almost all of an app session - holds
+// nothing. Retention is what has to give it back: a retained run has stopped
+// sending, and the 60-90s window would otherwise be a run's worth of held
+// resolution per run.
+TEST (RunManagerRetention, RetainGivesBackTheHighResolutionTimer) {
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
+
+    RunManager mgr;
+    nlohmann::json cfg;
+    auto ctx = std::make_shared<RunContext> ("run_z", cfg);
+    mgr.register_run ("run_z", ctx);
+
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 1);
+
+    mgr.retain_run ("run_z");
+
+    // Still reachable as a retained run, holding nothing of the machinery.
+    auto found = mgr.get_run_or_retained ("run_z");
+    ASSERT_NE (found, nullptr);
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
+}
+
+// A run that never reaches retention - one refused, or one whose context is
+// dropped by a failing spawn - gives the request back all the same, because
+// the scope is a member and not a pair of calls to remember.
+TEST (RunManagerRetention, ADroppedContextGivesBackTheHighResolutionTimer) {
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
+    {
+        nlohmann::json cfg;
+        RunContext ctx ("run_dropped", cfg);
+        EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 1);
+    }
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
+}
+
 TEST (BuildTickPayload, WrapsStatsAsSseEventWithOffsetId) {
     nlohmann::json stats;
     stats["totalRequests"] = 42;

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -8,6 +8,7 @@
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
+#include "vayu/platform/platform.hpp"
 
 using namespace vayu::core;
 
@@ -321,18 +322,21 @@ TEST (RunManagerRetention, RetainReleasesTheMachineryAndKeepsTheTopic) {
 }
 
 // Windows' 1 ms timer resolution is one of those execution resources since
-// issue #1161: a run takes it because its event loop polls at 1ms and its
-// pacing sleeps below ~500 RPS would otherwise round to ~15.6ms, and an idle
-// engine - which the sidecar is for almost all of an app session - holds
-// nothing. Retention is what has to give it back: a retained run has stopped
-// sending, and the 60-90s window would otherwise be a run's worth of held
-// resolution per run.
+// issue #1161: the loop asks curl for a 1ms poll, which the OS default would
+// round to ~15.6ms, so the loop holds the request for its lifetime. Retention
+// is what gives it back - a retained run has stopped sending, and the 60-90s
+// window would otherwise be a run's worth of held resolution per run, on a
+// sidecar that is idle for almost all of an app session.
 TEST (RunManagerRetention, RetainGivesBackTheHighResolutionTimer) {
     EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
 
     RunManager mgr;
     nlohmann::json cfg;
     auto ctx = std::make_shared<RunContext> ("run_z", cfg);
+    vayu::http::EventLoopConfig loop_cfg;
+    loop_cfg.num_workers    = 1;
+    loop_cfg.max_concurrent = 1;
+    ctx->publish_event_loop (std::make_unique<vayu::http::EventLoop> (loop_cfg));
     mgr.register_run ("run_z", ctx);
 
     EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 1);
@@ -345,14 +349,29 @@ TEST (RunManagerRetention, RetainGivesBackTheHighResolutionTimer) {
     EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
 }
 
-// A run that never reaches retention - one refused, or one whose context is
-// dropped by a failing spawn - gives the request back all the same, because
-// the scope is a member and not a pair of calls to remember.
-TEST (RunManagerRetention, ADroppedContextGivesBackTheHighResolutionTimer) {
+// The narrowing that binding the request to the loop buys: a design-mode
+// scenario run sends its steps sequentially and builds no event loop, so it
+// asks for no timer resolution at all - where a request taken per run would
+// have held 1ms resolution for the length of every collection run.
+TEST (RunManagerRetention, ARunWithNoEventLoopAsksForNoTimerResolution) {
+    nlohmann::json cfg;
+    RunContext ctx ("run_sequential", cfg);
+    ctx.scenario = std::make_shared<const ScenarioExecution> ();
+
+    EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
+}
+
+// A loop that never reaches retention - a run that threw before its context
+// was retained, or a manager destroyed under it - gives the request back all
+// the same, because the scope is a member of the loop and not a pair of calls
+// to remember.
+TEST (RunManagerRetention, ADroppedEventLoopGivesBackTheHighResolutionTimer) {
     EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);
     {
-        nlohmann::json cfg;
-        RunContext ctx ("run_dropped", cfg);
+        vayu::http::EventLoopConfig loop_cfg;
+        loop_cfg.num_workers    = 1;
+        loop_cfg.max_concurrent = 1;
+        const vayu::http::EventLoop loop (loop_cfg);
         EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 1);
     }
     EXPECT_EQ (vayu::platform::high_resolution_timer_holders (), 0);


### PR DESCRIPTION
## Description

`timeBeginPeriod(1)` was acquired at daemon boot (`daemon.cpp:155-158`) and released only at shutdown (`:261-263`), so a sidecar that is resident for a whole app session and idle for nearly all of it held the 1ms request the entire time - the classic Windows idle-power finding, on a refcounted API only ever used at depth 1.

The two rationales in the tree also justified each other with the wrong reason, and here the fix adapts one of the issue's own claims. The timer's doc named the pacing sleeps, which at >=500 RPS never sleep (the tick's remainder is spun out instead); the spin's comment named 15.6ms rounding, which is false in-process while the request is held. But the pacing sleeps are not a non-consumer either: **below** ~500 RPS the tick exceeds the 2000us spin threshold and the loop really does `sleep_for`, where a 2.5ms sleep at the OS default would return at ~15.6ms. Verified against the code: `tick_us = max(1e6/rps, 1000)` is exactly 1000us from 1000 RPS up, and the spin/sleep boundary falls between 499 RPS (`tick_us = 2004`, sleeps) and 500 RPS (`tick_us = 2000`, spins). So there are two consumers - the event loop's `curl_multi_poll(..., POLL_TIMEOUT_MS = 1)` and the sub-500-RPS pacing sleeps - and **both live only while a run is sending**, which is what makes run-scoping the right shape rather than a compromise.

**Approach.** `platform::HighResolutionTimerScope` (new `engine/src/platform/high_resolution_timer.cpp`) is the request as an RAII holder, refcounted under a mutex. The mutex is the design point: with a bare atomic counter, a finishing run's release can land *after* a starting run's acquire, leaving a live run at 15.6ms with a count that reads correct - so the count and the OS call move together. The holder is `detail::EventLoopImpl`, i.e. the loop itself: it exists only while a run is sending, `release_execution_resources` already destroys it as the run is retained, and a loop dropped on any other path releases the request by destruction, so nothing has to remember to give it back.

**Alternatives rejected.**
- *A scope per `RunContext`* (what the first commit here did, and what the issue's `spawn_run`/`active_count()==0` sketch implies): a design-mode scenario run sends its steps sequentially and builds no event loop, so that shape asks Windows for 1ms resolution through every collection run with neither consumer present. Binding to the loop is strictly tighter and drops an `std::optional` member and its explicit reset.
- *Keeping the mechanism Windows-only in `platform_windows.cpp`*, per the file split this directory otherwise follows: it would make the balance invariant - the whole point of a refcount - testable on one CI leg only, and leave the RAII member in portable code wrapped in `#if`. Instead the refcount and the scope are portable and the `#if` is the two `timeapi.h` calls alone. That moved `timeapi.h` and the engine's one `SortIncludes` exemption to the new file, so `engine/CLAUDE.md`, `.clang-format`'s note and `docs/engine/building.md` - which all named `platform_windows.cpp` - were repointed in the same change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cmake --build build` (the `linux-dev` preset `build.py -e -t` configures) clean, then `ctest --preset linux-dev --output-on-failure`: **2872/2872 passed**, 57s. No pre-existing failures on this base.
- `clang-format-19 --dry-run -Werror` clean on every touched file; `mkdocs build --strict` green for the two docs pages.
- New `engine/tests/high_resolution_timer_test.cpp` (4 cases): an idle engine holds nothing; a scope takes the request and gives it back; nested scopes take it once and the last one releases; 8 threads x 200 scopes balance to zero with no holder ever reading a count below 1 while it holds one.
- `engine/tests/run_manager_test.cpp` gains 3 cases at the existing retention seam: a run with a published loop holds the request and `retain_run` gives it back; a run with **no** loop (the design-mode shape) asks for nothing; a dropped loop releases it too.
- Mutation-checked in both directions, actually run rather than reasoned: dropping the decrement in `~HighResolutionTimerScope` reddens 5 of the 6 timer cases (the idle-engine one runs first and still passes, correctly); removing the `timer_resolution` member from `EventLoopImpl` reddens exactly the two retention cases that assert the loop holds it. Both restored and the suite re-run green.

**Deliberate deviation from the acceptance criteria.** The second criterion asks for before/after load-test pacing benchmarks. There are none to show honestly from here: the pacing code is untouched (the spin stays, per the throughput guard), and off Windows the scope compiles to a mutex-guarded counter taken once per event loop - so a Linux benchmark would measure nothing this diff changes, and the platform where it *would* differ needs a Windows host to measure on. Worth a Windows run before merge if you want the number; the change adds one lock acquisition per run, not per request.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1161