### PR TITLE
docs(building): correct the release artifact names from electron-builder.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -552,7 +552,7 @@ git push origin --tags
 Notes:
 
 - The `VERSION` file should be kept accurate. The workflow uses a pushed tag to identify the release and uploads matching artifacts.
-- Electron-generated filenames already include the version (for example `Vayu Setup 0.1.2.exe` and `Vayu-0.1.2-x86_64.AppImage`), so the workflow publishes them as-is.
+- Electron-generated filenames are whatever `artifactName` in `app/electron-builder.json` resolves to (for example `Vayu-0.1.2-x86_64.AppImage`, and `Vayu-x64.exe`, which carries no version at all), and the workflow publishes them as-is.
 - If you want the bump script to also create the tag and push, you may extend it, but this project requires an explicit tag push so releases remain deliberate.
 
 

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -153,11 +153,19 @@ The app will:
 
 ### Build Outputs
 
-Production builds are output to `app/release/`:
+Production builds are output to `app/release/`. `artifactName` in
+`electron-builder.json` is the source of truth for these names: the top-level
+pattern is `${productName}-${arch}.${ext}`, and the `mac` and `appImage` blocks
+override it to insert `${version}`, so the dmg, the zip and the AppImage carry
+a version while the exe and the deb do not.
 
-- **macOS**: `Vayu-0.1.1-universal.dmg`
-- **Windows**: `Vayu Setup 0.1.1.exe` (NSIS installer)
-- **Linux**: `Vayu-0.1.1.AppImage` and `vayu-client_0.1.1_amd64.deb`
+- **macOS**: `Vayu-<version>-universal.dmg` and `Vayu-<version>-universal.zip`.
+  The zip carries the macOS install and update path - `install.sh` downloads it
+  and `latest-mac.yml` names it - while the dmg is the drag-to-Applications
+  route. A single-arch build names that arch instead of `universal`, which is
+  what `python build.py` does on macOS.
+- **Windows**: `Vayu-<arch>.exe` (NSIS installer)
+- **Linux**: `Vayu-<version>-x86_64.AppImage` and `Vayu-amd64.deb`
 
 ### Electron Builder Configuration
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -187,11 +187,20 @@ This will:
 
 ### Output
 
-Production builds are created in `app/release/`:
+Production builds are created in `app/release/`. `artifactName` in
+`app/electron-builder.json` is the source of truth for these names: the
+top-level pattern is `${productName}-${arch}.${ext}`, and the `mac` and
+`appImage` blocks override it to insert `${version}`, so the dmg, the zip and
+the AppImage carry a version while the exe and the deb do not.
 
-- **macOS**: `Vayu-<version>.dmg`
-- **Windows**: `Vayu Setup <version>.exe`
-- **Linux**: `Vayu-<version>.AppImage` and `vayu-client_<version>_amd64.deb`
+- **macOS**: `Vayu-<version>-<arch>.dmg` and `Vayu-<version>-<arch>.zip`. The
+  zip carries the macOS install and update path - `install.sh` downloads it and
+  `latest-mac.yml` names it - while the dmg is the drag-to-Applications route.
+  `<arch>` is `universal` in a released build and the host arch (`x64` or
+  `arm64`) for a local `python build.py`, which has only the host-arch engine
+  to package.
+- **Windows**: `Vayu-<arch>.exe`, the NSIS installer.
+- **Linux**: `Vayu-<version>-x86_64.AppImage` and `Vayu-amd64.deb`.
 
 ### Testing Production Builds
 
@@ -208,12 +217,12 @@ chmod +x app/release/Vayu-*.AppImage
 ./app/release/Vayu-*.AppImage
 
 # Debian package
-sudo dpkg -i app/release/vayu-client_*.deb
+sudo dpkg -i app/release/Vayu-*.deb
 ```
 
 **Windows:**
 ```powershell
-.\app\release\Vayu Setup *.exe
+.\app\release\Vayu-x64.exe
 ```
 
 ## Advanced: Manual CMake Build


### PR DESCRIPTION
## Description

The two "Output" / "Build Outputs" lists named four artifacts electron-builder has never produced under this repo's config, and omitted the one that carries the macOS install and update path.

Root cause: `app/electron-builder.json` sets a **top-level** `artifactName` of `${productName}-${arch}.${ext}`, which every target inherits unless it overrides it - only `mac` and `appImage` do, inserting `${version}`. In app-builder-lib 26.15.2, `artifactPatternConfig()` (`platformPackager.js:548-553`) treats any user-set pattern as forced and discards the per-target defaults, so NSIS's default `"${productName} Setup ${version}${archSuffix}.${ext}"` and fpm's `"${name}_${version}_${arch}.${ext}"` are unreachable here. The exe is `Vayu-x64.exe` and the deb is `Vayu-amd64.deb`, both with no version at all. Confirmed three ways: the live v0.24.0 release assets, `install.sh`'s `asset_name()` (which already downloads `Vayu-${version}-universal.zip`), and the installed app-builder-lib source.

Approach: correct both lists from the config, add the macOS zip with a word on why it matters (`install.sh` downloads it and `latest-mac.yml` names it, so it is the install and update path; the dmg is only the drag-to-Applications route), and name `artifactName` as the source of truth in one line. **Rejected alternative:** spelling out each target's template string a third time in prose - that is exactly how these two pages drifted apart from the config and from each other, and the issue asks for the pointer instead.

One thing the pages could not share: the macOS arch token differs by build path. A released build is `universal`; `python build.py` passes `--mac dmg zip --{host_arch}` (`build.py:1577-1582`) because a local build has only the host-arch engine to merge, so it writes `x64`/`arm64`. Each page states the case its own instructions produce.

Deliberate deviations from the issue spec, both disclosed rather than deferred:

- The two shell snippets under "Testing Production Builds" (`docs/building.md`) used `vayu-client_*.deb` and `Vayu Setup *.exe`. They are the same defect one paragraph below the list and match no file that has ever been built, so they are corrected here rather than left to contradict the list above them.
- `CONTRIBUTING.md:555` carried the same false claim - "Electron-generated filenames already include the version (for example `Vayu Setup 0.1.2.exe` ...)". One line, same fact, corrected in the same commit rather than left as the last surviving copy of what this change retires.

The issue's third question - whether the `Vayu Setup ...` spelling was ever right for a local `--publish never` build - is answered no. Both paths run the same config (`electron:pack` on Windows/Linux locally and in CI), and the top-level `artifactName` wins on every one of them.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`mkdocs build --strict -f .github/mkdocs.yml` - green, before and after the edit (4.95s, no warnings promoted), and the docs workflow's Build job is green on this head. No test suite can go from green to red on this change: no source file is touched, and no test reads either page (`app/src/design-system-doc.test.ts` and `app/src/state-management-doc.test.ts` are the only doc-reading tests and neither looks at a building page). Per CLAUDE.md's verification-scaling rule, that is the whole check.

Names were verified against the v0.24.0 release assets: `Vayu-0.24.0-universal.dmg`, `Vayu-0.24.0-universal.zip`, `Vayu-0.24.0-x86_64.AppImage`, `Vayu-amd64.deb`, `Vayu-x64.exe`. After this change no occurrence of `Vayu Setup` or `vayu-client_` remains anywhere in the repo.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1186