### PR TITLE
fix(app): warn when a scoped script read's own scope answers emptily and another scope holds the value

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -82,7 +82,7 @@ Forgetting it fails loudly (`document is not defined`), never silently.
 sets no `testTimeout`, so every case gets the default 5s. A case that builds
 thousands of rows and renders them spends most of that budget idle and crosses
 it under machine or CI-shard load, failing over the environment rather than
-the code (#846, #1280). Ask what the fixture size is *for* before reaching for
+the code (#846, #1280). Ask what the fixture size is _for_ before reaching for
 a timeout: a property such as "past the grid's first window" needs a fixture
 one step past that window, not hundreds of rows. Only where a case genuinely
 needs the large fixture, give it an explicit `it(name, { timeout: N }, fn)`
@@ -101,7 +101,7 @@ missing from the other.** `responseFromExecuteResult` (live `/execute` body)
 and `responseFromRunResult` (a stored trace, from History) both build
 `ResponseState` and neither knows about the other. When you add a field to
 one, add it to both and assert they agree (`validation-funnels.test.ts` is the
-shape: drive both with the same input, compare). The engine stores the *same*
+shape: drive both with the same input, compare). The engine stores the _same_
 object it returned rather than letting each side derive its own.
 
 **Before measuring or changing a class, `rg` for it in the components.** A
@@ -110,7 +110,7 @@ conclusion about a combination the app never renders is not a finding.
 ## UI rules (enforced by tests - breaking one fails CI)
 
 - **Status colours have three tokens:** `--status-*` (dot/icon/tint),
-  `--status-*-text` (when the colour *is* the text), `--status-*-fill` (solid
+  `--status-*-text` (when the colour _is_ the text), `--status-*-fill` (solid
   chip under a white label). Using the bare fill as a foreground is the most
   common colour bug here. → `status-color-tokens.test.ts`
 - **`--primary` vs `--primary-fill`:** `--primary` is text/ring/chart and
@@ -174,9 +174,9 @@ conclusion about a combination the app never renders is not a finding.
   → `focus-indicator.test.ts`, `icon-button-labels.test.tsx`,
   `a11y-suppressions.test.ts`, plus the lint itself
 
-## Borders: what a rule sits *on*, never what it is
+## Borders: what a rule sits _on_, never what it is
 
-**A border is invisible or not depending on what it sits *on*, never on what it
+**A border is invisible or not depending on what it sits _on_, never on what it
 is.** `--border` is tuned for the canvas (1.14) and is the same colour as
 `--card` in dark (1.00), so a rule inside a card is simply absent. A card's own
 outline on `border-border` is correct, because that edge faces the canvas; both
@@ -195,7 +195,7 @@ vs 1.16, and the pair inverts in light), which is why sunken uses an alpha of
 
 The mistake is **enumerable, not impossible**: a `border-rule` under no
 declared surface silently falls back to the invisible default. So guard the
-*declarations* (`surface-rule.test.tsx`, `ImportModal.surface-rule.test.tsx`);
+_declarations_ (`surface-rule.test.tsx`, `ImportModal.surface-rule.test.tsx`);
 asserting `border-rule` is present proves nothing. The surface classes are in
 use across the tree; a new surface declares one rather than picking a token.
 On an element whose primitive already sets a background utility
@@ -232,6 +232,6 @@ later on an unrelated change. Those lists and the `app_doc_fixtures` /
 by `routed-inputs.test.ts`, which fails if either side changes alone. Take the
 path from the registry rather than spelling it again in the guard.
 
-Module READMEs carry the *why* for their feature and are easy to miss:
+Module READMEs carry the _why_ for their feature and are easy to miss:
 `app/src/modules/README.md`, plus one each for `welcome/`, `request-builder/`
 and `dashboard/`.

--- a/app/src/lib/referenced-variables.test.ts
+++ b/app/src/lib/referenced-variables.test.ts
@@ -17,16 +17,23 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { describeColumnReference, referencedVariables } from "./referenced-variables";
-import type { DataContractScope } from "@/types/domain";
+import {
+	describeColumnReference,
+	describeScopedRead,
+	referencedVariables,
+} from "./referenced-variables";
+import type { DataContractScope, VariableOrigin } from "@/types/domain";
 
 /** The names alone, for the cases that are about extraction and not syntax. */
 const names = (script: string) => referencedVariables(script).map((r) => r.name);
 
 describe("the pm API", () => {
 	it.each(["environment", "globals", "collectionVariables"])("reads pm.%s.get", (bucket) => {
+		const scope = { environment: "environment", globals: "global", collectionVariables: "collection" }[
+			bucket
+		];
 		expect(referencedVariables(`pm.${bucket}.get("token")`)).toEqual([
-			{ name: "token", via: "pm", reads: "scope" },
+			{ name: "token", via: "pm", reads: "scope", scope },
 		]);
 	});
 
@@ -58,7 +65,7 @@ describe("the pm API", () => {
 describe("templates", () => {
 	it("reads a {{name}}, and says it arrived as a template", () => {
 		expect(referencedVariables('const u = "{{base_url}}/orders"')).toEqual([
-			{ name: "base_url", via: "template", reads: null },
+			{ name: "base_url", via: "template", reads: null, scope: null },
 		]);
 	});
 
@@ -80,8 +87,8 @@ describe("the list the chips render", () => {
 	it("takes both syntaxes from one script", () => {
 		const script = 'pm.globals.get("run_id"); const u = "{{base_url}}";';
 		expect(referencedVariables(script)).toEqual([
-			{ name: "run_id", via: "pm", reads: "scope" },
-			{ name: "base_url", via: "template", reads: null },
+			{ name: "run_id", via: "pm", reads: "scope", scope: "global" },
+			{ name: "base_url", via: "template", reads: null, scope: null },
 		]);
 	});
 
@@ -93,14 +100,14 @@ describe("the list the chips render", () => {
 		 * win would report a resolving reference as inert.
 		 */
 		expect(referencedVariables('pm.environment.get("token") + "{{token}}"')).toEqual([
-			{ name: "token", via: "pm", reads: "scope" },
+			{ name: "token", via: "pm", reads: "scope", scope: "environment" },
 		]);
 	});
 
 	it("does not let a later template downgrade an earlier pm read", () => {
 		// The order-dependent half of the rule above: template first, pm second.
 		expect(referencedVariables('"{{token}}"; pm.globals.get("token");')).toEqual([
-			{ name: "token", via: "pm", reads: "scope" },
+			{ name: "token", via: "pm", reads: "scope", scope: "global" },
 		]);
 	});
 
@@ -131,13 +138,13 @@ describe("the list the chips render", () => {
 describe("the accessors that can see a bound row", () => {
 	it("reads pm.variables.get, and records that the row answers first", () => {
 		expect(referencedVariables('pm.variables.get("email")')).toEqual([
-			{ name: "email", via: "pm", reads: "merged" },
+			{ name: "email", via: "pm", reads: "merged", scope: null },
 		]);
 	});
 
 	it("reads pm.iterationData.get, whose only source is the row", () => {
 		expect(referencedVariables('pm.iterationData.get("email")')).toEqual([
-			{ name: "email", via: "pm", reads: "row" },
+			{ name: "email", via: "pm", reads: "row", scope: null },
 		]);
 	});
 
@@ -146,7 +153,7 @@ describe("the accessors that can see a bound row", () => {
 		// outside a data-driven run, so `?.` is the spelling in real scripts and
 		// a pattern that missed it would miss most of them.
 		expect(referencedVariables("pm.iterationData?.get('email')")).toEqual([
-			{ name: "email", via: "pm", reads: "row" },
+			{ name: "email", via: "pm", reads: "row", scope: null },
 		]);
 	});
 
@@ -159,14 +166,14 @@ describe("the accessors that can see a bound row", () => {
 		 */
 		expect(
 			referencedVariables('pm.environment.get("email"); pm.variables.get("email");')
-		).toEqual([{ name: "email", via: "pm", reads: "merged" }]);
+		).toEqual([{ name: "email", via: "pm", reads: "merged", scope: null }]);
 	});
 
 	it("does not let a scope accessor downgrade an earlier row read", () => {
 		// The order-dependent half: the row-reading call comes first this time.
 		expect(
 			referencedVariables('pm.variables.get("email"); pm.environment.get("email");')
-		).toEqual([{ name: "email", via: "pm", reads: "merged" }]);
+		).toEqual([{ name: "email", via: "pm", reads: "merged", scope: null }]);
 	});
 });
 
@@ -261,5 +268,182 @@ describe("what a reference says about itself as a column", () => {
 		// Nothing interpolates script text (decision D16), so a `{{email}}` here
 		// reads no column however the contract is written.
 		expect(describeFirst('const to = "{{email}}"', declared)).toBe(null);
+	});
+});
+
+/**
+ * The read that looks healthy and returns nothing (issue #1196).
+ *
+ * The owner hit this in real use: an enabled, empty `shop_domain` at collection
+ * scope - the usual leftover of a Postman import's initial-value placeholders -
+ * makes `pm.collectionVariables.get("shop_domain")` honestly return `''`, while
+ * `{{shop_domain}}` in the URL bar resolves the environment's real value through
+ * the full ladder. The engine was verified correct and is untouched; what was
+ * missing is any surface saying the two answers differ.
+ *
+ * Origins arrive in the order `useVariableResolver` builds them - globals, then
+ * the collection chain root-first, then the environment - because "the answer
+ * this accessor gives" is the *last enabled* definition of its own scope, and a
+ * helper that read them in any other order would agree with the resolver only by
+ * accident.
+ */
+const origin = (over: Partial<VariableOrigin> & { scope: VariableOrigin["scope"] }): VariableOrigin => ({
+	value: "",
+	enabled: true,
+	winner: false,
+	...over,
+});
+
+/** The reported scenario, as `referencedVariables` reports it. */
+const scopedRead = (script: string) => referencedVariables(script)[0];
+
+const COLLECTION_GET = 'pm.collectionVariables.get("shop_domain")';
+
+describe("a single-scope read whose own scope answers emptily", () => {
+	it("warns when the scope holds an enabled empty row and another scope holds the value", () => {
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "collection", sourceName: "Shop API", value: "" }),
+			origin({
+				scope: "environment",
+				sourceName: "Staging",
+				value: "shop.example.com",
+				winner: true,
+			}),
+		]);
+
+		expect(result).not.toBeNull();
+		// Amber, never destructive: the read works and the name resolves - it just
+		// does not resolve *here*.
+		expect(result?.tone).toBe("warning");
+		// Both facts the issue asks the tooltip to name: what this read returns,
+		// and where the value the author is looking at actually lives.
+		expect(result?.description).toContain("Empty at collection scope");
+		expect(result?.description).toContain('returns ""');
+		expect(result?.note).toContain("environment - Staging");
+		expect(result?.note).toContain('pm.variables.get("shop_domain")');
+	});
+
+	it("says undefined, not empty, when the scope defines the name nowhere", () => {
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "environment", sourceName: "Staging", value: "shop.example.com" }),
+		]);
+
+		expect(result?.tone).toBe("warning");
+		expect(result?.description).toContain("Not defined at collection scope");
+		expect(result?.description).toContain("returns undefined");
+	});
+
+	it("looks past a disabled row in its own scope, exactly as the engine does", () => {
+		// D17: a disabled definition is looked past rather than stopped at, so this
+		// accessor reaches nothing at all and the answer is `undefined`.
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "collection", value: "stale.example.com", enabled: false }),
+			origin({ scope: "environment", sourceName: "Staging", value: "shop.example.com" }),
+		]);
+
+		expect(result?.description).toContain("Not defined at collection scope");
+	});
+
+	it("takes the nearest enabled definition of its own scope, not the first", () => {
+		// Root-first, so the leaf's empty row is the one the accessor returns even
+		// though an ancestor in the same chain holds a value.
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "collection", sourceName: "Root", value: "root.example.com" }),
+			origin({ scope: "collection", sourceName: "Leaf", value: "" }),
+			origin({ scope: "environment", sourceName: "Staging", value: "shop.example.com" }),
+		]);
+
+		expect(result?.description).toContain("Empty at collection scope");
+	});
+
+	it("names the shadowing source without printing its value, which may be secret", () => {
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "collection", value: "" }),
+			origin({
+				scope: "environment",
+				sourceName: "Staging",
+				value: "sk_live_do_not_print",
+				secret: true,
+			}),
+		]);
+
+		expect(result?.note).toContain("environment - Staging");
+		expect(result?.note).not.toContain("sk_live_do_not_print");
+	});
+});
+
+describe("the reads that must stay silent", () => {
+	it("says nothing about a scope that answers with a value", () => {
+		expect(
+			describeScopedRead(scopedRead(COLLECTION_GET), [
+				origin({ scope: "collection", value: "shop.example.com", winner: true }),
+			])
+		).toBeNull();
+	});
+
+	it("says nothing when the name is empty everywhere - there is no contradiction", () => {
+		expect(
+			describeScopedRead(scopedRead(COLLECTION_GET), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "environment", sourceName: "Staging", value: "" }),
+			])
+		).toBeNull();
+	});
+
+	it("says nothing when nothing defines the name - that is the destructive chip's answer", () => {
+		expect(describeScopedRead(scopedRead(COLLECTION_GET), [])).toBeNull();
+	});
+
+	it("does not count a disabled definition elsewhere as the value that shadows", () => {
+		// A switched-off row answers nothing either, so `{{shop_domain}}` and this
+		// read agree and there is no trap to point at.
+		expect(
+			describeScopedRead(scopedRead(COLLECTION_GET), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "environment", value: "shop.example.com", enabled: false }),
+			])
+		).toBeNull();
+	});
+
+	it("never warns on the merged read, which returns the winning value", () => {
+		// `pm.variables.get` is the correct escape from this trap, so warning on it
+		// would point the author away from the fix.
+		expect(
+			describeScopedRead(scopedRead('pm.variables.get("shop_domain")'), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "environment", value: "shop.example.com", winner: true }),
+			])
+		).toBeNull();
+	});
+
+	it("never warns on a row read, whose only source is the bound row", () => {
+		expect(
+			describeScopedRead(scopedRead('pm.iterationData.get("shop_domain")'), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "environment", value: "shop.example.com" }),
+			])
+		).toBeNull();
+	});
+
+	it("never warns on a {{name}} the script merely contains", () => {
+		// Nothing substitutes it, so no answer about what a scope holds says
+		// anything true about this script.
+		expect(
+			describeScopedRead(scopedRead('const u = "{{shop_domain}}"'), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "environment", value: "shop.example.com" }),
+			])
+		).toBeNull();
+	});
+
+	it("does not treat a bound row as the scope that shadows", () => {
+		// The row is not a scope - `pm.iterationData` is its accessor, and
+		// `describeColumnReference` already paints reads of it.
+		expect(
+			describeScopedRead(scopedRead(COLLECTION_GET), [
+				origin({ scope: "collection", value: "" }),
+				origin({ scope: "row", value: "shop.example.com", winner: true }),
+			])
+		).toBeNull();
 	});
 });

--- a/app/src/lib/referenced-variables.test.ts
+++ b/app/src/lib/referenced-variables.test.ts
@@ -29,9 +29,11 @@ const names = (script: string) => referencedVariables(script).map((r) => r.name)
 
 describe("the pm API", () => {
 	it.each(["environment", "globals", "collectionVariables"])("reads pm.%s.get", (bucket) => {
-		const scope = { environment: "environment", globals: "global", collectionVariables: "collection" }[
-			bucket
-		];
+		const scope = {
+			environment: "environment",
+			globals: "global",
+			collectionVariables: "collection",
+		}[bucket];
 		expect(referencedVariables(`pm.${bucket}.get("token")`)).toEqual([
 			{ name: "token", via: "pm", reads: "scope", scope },
 		]);
@@ -287,7 +289,9 @@ describe("what a reference says about itself as a column", () => {
  * helper that read them in any other order would agree with the resolver only by
  * accident.
  */
-const origin = (over: Partial<VariableOrigin> & { scope: VariableOrigin["scope"] }): VariableOrigin => ({
+const origin = (
+	over: Partial<VariableOrigin> & { scope: VariableOrigin["scope"] }
+): VariableOrigin => ({
 	value: "",
 	enabled: true,
 	winner: false,

--- a/app/src/lib/referenced-variables.test.ts
+++ b/app/src/lib/referenced-variables.test.ts
@@ -440,6 +440,55 @@ describe("the reads that must stay silent", () => {
 		).toBeNull();
 	});
 
+	/*
+	 * The precedence half, and the reason "some other scope has a value" is not
+	 * the question. Both of these look like the trap from the shape of the
+	 * origins - own scope empty, another scope non-empty - and neither is one,
+	 * because the ladder's winner is the empty definition either way. Warning
+	 * here would paint healthy scripts amber, which is how a colour stops being
+	 * read at all.
+	 */
+	it("does not warn when a lower-precedence scope holds the value its own scope masks", () => {
+		// Collection outranks globals, so an enabled empty collection row is what
+		// `{{shop_domain}}` and `pm.variables.get` resolve to as well. The global
+		// value is masked by this read, not hidden from it.
+		expect(
+			describeScopedRead(scopedRead(COLLECTION_GET), [
+				origin({ scope: "global", value: "acme.example.com" }),
+				origin({ scope: "collection", value: "", winner: true }),
+			])
+		).toBeNull();
+	});
+
+	it("does not warn on an empty environment read, which nothing can shadow", () => {
+		// The environment is pushed last, so an enabled row there wins whatever it
+		// holds. An empty one makes every surface empty together.
+		expect(
+			describeScopedRead(scopedRead('pm.environment.get("shop_domain")'), [
+				origin({ scope: "collection", value: "acme.example.com" }),
+				origin({ scope: "environment", sourceName: "Staging", value: "", winner: true }),
+			])
+		).toBeNull();
+	});
+
+	it("names only the definition the merged read would actually return", () => {
+		// Two scopes hold a value and `pm.variables.get` can only return one of
+		// them. Listing the other would send the author to a row that answers
+		// nothing.
+		const result = describeScopedRead(scopedRead(COLLECTION_GET), [
+			origin({ scope: "global", value: "global.example.com" }),
+			origin({
+				scope: "environment",
+				sourceName: "Staging",
+				value: "env.example.com",
+				winner: true,
+			}),
+		]);
+
+		expect(result?.note).toContain("environment - Staging");
+		expect(result?.note).not.toContain("global");
+	});
+
 	it("does not treat a bound row as the scope that shadows", () => {
 		// The row is not a scope - `pm.iterationData` is its accessor, and
 		// `describeColumnReference` already paints reads of it.

--- a/app/src/lib/referenced-variables.ts
+++ b/app/src/lib/referenced-variables.ts
@@ -88,10 +88,15 @@ export type PmRead = "scope" | "merged" | "row";
 /**
  * What each accessor reads, and - for the single-scope three - which scope.
  *
- * One table rather than two, because both facts are answers about the same
- * accessor and a second table keyed by the same five names is how they come to
- * disagree. `scope` is null exactly where `reads` is not `"scope"`: the merged
+ * One table rather than two *here*, because both facts are answers about the
+ * same accessor and a second table keyed by the same five names is how they come
+ * to disagree. `scope` is null exactly where `reads` is not `"scope"`: the merged
  * read has no single scope to name, and the row is not a scope at all.
+ *
+ * `SCOPE_BY_ACCESSOR` in `script-variable-completion.ts` does key the same five
+ * names, and predates this. The two have not diverged; folding them together is
+ * worth doing on the next change that touches both, rather than widening a paint
+ * fix into that file.
  */
 interface PmAccessor {
 	reads: PmRead;
@@ -255,24 +260,41 @@ function ownAnswer(
 }
 
 /**
- * The other scopes holding a non-empty value for the name, as the tooltip prints
- * them - `environment - Staging`, the spelling `monaco-variable-tokens` and the
- * popover already use, so a reader meets one vocabulary and not a second.
+ * The definition that wins the whole ladder - what `{{name}}` substitutes and
+ * what `pm.variables.get` returns.
  *
- * Values are never printed, only sources: one of these definitions may be a
- * secret, and the popover's rule is that a secret shows a mask and never a
- * value. The row is skipped because it is not a scope - `pm.iterationData` is
- * its accessor and `describeColumnReference` already paints reads of it.
+ * Last enabled again, over every scope this time, which is exactly how
+ * `useVariableResolver` derives `variableMap`. **Precedence has to be read off
+ * the ladder rather than inferred from "some other scope has a value"**: an
+ * enabled row wins even when its value is empty, so a lower scope holding
+ * something is masked by the empty winner rather than masking it. Reading it as
+ * the latter warns on healthy scripts - an empty collection row beside a
+ * non-empty global is the collection's answer *and* the merged answer, with
+ * nothing to warn about.
+ *
+ * The row is skipped because it is not a scope. `pm.iterationData` is its
+ * accessor and `describeColumnReference` already paints reads of it; a bound row
+ * changing what a scoped read should say about itself is #1064's question, not
+ * this one's.
  */
-function shadowingSources(origins: readonly VariableOrigin[], scope: VariableScope): string[] {
-	const labels: string[] = [];
-	for (const origin of origins) {
-		if (origin.scope === scope || origin.scope === "row") continue;
-		if (!origin.enabled || origin.value === "") continue;
-		const label = origin.sourceName ? `${origin.scope} - ${origin.sourceName}` : origin.scope;
-		if (!labels.includes(label)) labels.push(label);
+function ladderWinner(origins: readonly VariableOrigin[]): VariableOrigin | null {
+	for (let i = origins.length - 1; i >= 0; i--) {
+		const origin = origins[i];
+		if (origin.scope !== "row" && origin.enabled) return origin;
 	}
-	return labels;
+	return null;
+}
+
+/**
+ * How the tooltip names a definition - `environment - Staging`, the spelling
+ * `monaco-variable-tokens` and the popover already use, so a reader meets one
+ * vocabulary and not a second.
+ *
+ * The value is never printed, only the source: the definition may be a secret,
+ * and the popover's rule is that a secret shows a mask and never a value.
+ */
+function sourceLabel(origin: VariableOrigin): string {
+	return origin.sourceName ? `${origin.scope} - ${origin.sourceName}` : origin.scope;
 }
 
 /**
@@ -293,10 +315,19 @@ function shadowingSources(origins: readonly VariableOrigin[], scope: VariableSco
  * `describeColumnToken` draws for an undeclared column, and the reason #604 took
  * destructive off this row in the first place.
  *
+ * **The contradiction is against the ladder's winner, not against "some other
+ * scope".** Those are different questions wherever the read's own scope is the
+ * one that wins: an empty collection row beside a non-empty global is the
+ * collection's answer and the merged answer alike, and an enabled environment
+ * row is unconditionally the winner, so neither can be shadowed by anything. A
+ * warning that fired on them would be amber on healthy scripts, which is the way
+ * this kind of paint stops being read at all.
+ *
  * Only the accessor's own scope is checked. `pm.variables` is the merged read
  * and returns the winning value, so it is correct by construction and must never
  * warn; a name written through two different single-scope accessors keeps the
- * first, by the same equal-claim rule that orders the row.
+ * first, by the same equal-claim rule that orders the row - so the second
+ * accessor's read of that name carries no chip of its own.
  *
  * Takes the origins rather than the resolver so it stays a pure join of "what
  * did the script write" and "what is defined", the way `describeColumnReference`
@@ -314,18 +345,20 @@ export function describeScopedRead(
 	if (own && own.value !== "") return null;
 
 	/*
-	 * Nothing else holds a value either, so there is no contradiction to report.
-	 * A name nothing defines is the destructive chip's business, and one that is
-	 * empty everywhere is empty exactly as the author left it.
+	 * What the rest of the app shows for this name. Nothing non-empty resolves,
+	 * so there is no contradiction to report: a name nothing defines is the
+	 * destructive chip's business, and one the ladder also answers emptily is
+	 * empty exactly as the author left it - including the case where this very
+	 * scope is the empty winner.
 	 */
-	const shadowing = shadowingSources(origins, scope);
-	if (shadowing.length === 0) return null;
+	const winner = ladderWinner(origins);
+	if (!winner || winner.value === "" || winner.scope === scope) return null;
 
 	return {
 		tone: "warning",
 		description: own
 			? `Empty at ${scope} scope - this read returns ""`
 			: `Not defined at ${scope} scope - this read returns undefined`,
-		note: `non-empty in ${shadowing.join(", ")}; pm.variables.get("${name}") reads that`,
+		note: `${sourceLabel(winner)} holds the value; pm.variables.get("${name}") reads that`,
 	};
 }

--- a/app/src/lib/referenced-variables.ts
+++ b/app/src/lib/referenced-variables.ts
@@ -42,7 +42,7 @@ import {
 	describeColumnToken,
 	type DataTokenDescription,
 } from "./data-contract";
-import type { DataContractScope } from "@/types/domain";
+import type { DataContractScope, VariableOrigin, VariableScope } from "@/types/domain";
 
 /**
  * `pm.<accessor>.get("x")`, for every accessor whose first argument is a name.
@@ -85,12 +85,26 @@ export type ReferenceSyntax = "pm" | "template";
  */
 export type PmRead = "scope" | "merged" | "row";
 
-const PM_READ_BY_ACCESSOR: Record<string, PmRead> = {
-	environment: "scope",
-	globals: "scope",
-	collectionVariables: "scope",
-	variables: "merged",
-	iterationData: "row",
+/**
+ * What each accessor reads, and - for the single-scope three - which scope.
+ *
+ * One table rather than two, because both facts are answers about the same
+ * accessor and a second table keyed by the same five names is how they come to
+ * disagree. `scope` is null exactly where `reads` is not `"scope"`: the merged
+ * read has no single scope to name, and the row is not a scope at all.
+ */
+interface PmAccessor {
+	reads: PmRead;
+	/** The one scope this accessor reads, or null when it does not read one. */
+	scope: VariableScope | null;
+}
+
+const PM_ACCESSORS: Record<string, PmAccessor> = {
+	environment: { reads: "scope", scope: "environment" },
+	globals: { reads: "scope", scope: "global" },
+	collectionVariables: { reads: "scope", scope: "collection" },
+	variables: { reads: "merged", scope: null },
+	iterationData: { reads: "row", scope: null },
 };
 
 /**
@@ -123,6 +137,16 @@ export interface VariableReference {
 	via: ReferenceSyntax;
 	/** What the accessor that named it reads; `null` for a `template` mention. */
 	reads: PmRead | null;
+	/**
+	 * The one scope a single-scope accessor reads, or `null` when the reference
+	 * does not name one (a `template` mention, `pm.variables`, `pm.iterationData`).
+	 *
+	 * Carried because `reads: "scope"` says only *that* one scope answers, never
+	 * *which* - and which is the whole of the question in issue #1196, where a
+	 * collection row that is enabled and empty answers `pm.collectionVariables`
+	 * while the environment holds the value the author is looking at.
+	 */
+	scope: VariableScope | null;
 }
 
 /**
@@ -140,7 +164,12 @@ export interface VariableReference {
  */
 export function referencedVariables(script: string): VariableReference[] {
 	const byName = new Map<string, VariableReference>();
-	const add = (name: string, via: ReferenceSyntax, reads: PmRead | null) => {
+	const add = (
+		name: string,
+		via: ReferenceSyntax,
+		reads: PmRead | null,
+		scope: VariableScope | null
+	) => {
 		if (name.length === 0) return;
 		const existing = byName.get(name);
 		// A repeat never downgrades what is there, so an equal claim keeps the
@@ -151,13 +180,16 @@ export function referencedVariables(script: string): VariableReference[] {
 		) {
 			return;
 		}
-		byName.set(name, { name, via, reads });
+		byName.set(name, { name, via, reads, scope });
 	};
 
 	for (const match of script.matchAll(PM_GET)) {
-		add(match[2], "pm", PM_READ_BY_ACCESSOR[match[1]]);
+		const accessor = PM_ACCESSORS[match[1]];
+		add(match[2], "pm", accessor.reads, accessor.scope);
 	}
-	for (const match of script.matchAll(VARIABLE_PATTERN)) add(match[1].trim(), "template", null);
+	for (const match of script.matchAll(VARIABLE_PATTERN)) {
+		add(match[1].trim(), "template", null, null);
+	}
 
 	return [...byName.values()];
 }
@@ -200,4 +232,100 @@ export function describeColumnReference(
 	if (reads !== "merged" || !contract) return null;
 	if (!contract.columns.includes(name) || definesVariable(name)) return null;
 	return describeBareColumnToken(contract);
+}
+
+/**
+ * The definition a single-scope accessor would actually return, or null.
+ *
+ * Last enabled wins, matching the engine's `lookup_variable`, which walks its
+ * scope's chain leaf-first and stops at the first enabled row - and matching
+ * `useVariableResolver`, which pushes the collection chain root-first and marks
+ * the last enabled definition the winner. A disabled row is looked past here for
+ * the same reason it is there (D17).
+ */
+function ownAnswer(
+	origins: readonly VariableOrigin[],
+	scope: VariableScope
+): VariableOrigin | null {
+	for (let i = origins.length - 1; i >= 0; i--) {
+		const origin = origins[i];
+		if (origin.scope === scope && origin.enabled) return origin;
+	}
+	return null;
+}
+
+/**
+ * The other scopes holding a non-empty value for the name, as the tooltip prints
+ * them - `environment - Staging`, the spelling `monaco-variable-tokens` and the
+ * popover already use, so a reader meets one vocabulary and not a second.
+ *
+ * Values are never printed, only sources: one of these definitions may be a
+ * secret, and the popover's rule is that a secret shows a mask and never a
+ * value. The row is skipped because it is not a scope - `pm.iterationData` is
+ * its accessor and `describeColumnReference` already paints reads of it.
+ */
+function shadowingSources(origins: readonly VariableOrigin[], scope: VariableScope): string[] {
+	const labels: string[] = [];
+	for (const origin of origins) {
+		if (origin.scope === scope || origin.scope === "row") continue;
+		if (!origin.enabled || origin.value === "") continue;
+		const label = origin.sourceName ? `${origin.scope} - ${origin.sourceName}` : origin.scope;
+		if (!labels.includes(label)) labels.push(label);
+	}
+	return labels;
+}
+
+/**
+ * What a **single-scope read** says about itself when its own scope answers
+ * emptily and another scope does not (issue #1196), or null when there is
+ * nothing to warn about.
+ *
+ * The trap this paints is invisible at every other surface: an enabled,
+ * empty `shop_domain` at collection scope makes `pm.collectionVariables.get`
+ * honestly return `''`, while `{{shop_domain}}` in the URL bar resolves the
+ * environment's real value through the full ladder. Both are correct - the
+ * engine was verified right and is untouched here - so the author sees a healthy
+ * token, a healthy chip, and a failing assertion, with nothing connecting them.
+ * A leftover empty row from a Postman import is the usual way in.
+ *
+ * Warning, never destructive: the read works and the name resolves, so this is
+ * "check this" rather than "nothing can ever answer this" - the same line
+ * `describeColumnToken` draws for an undeclared column, and the reason #604 took
+ * destructive off this row in the first place.
+ *
+ * Only the accessor's own scope is checked. `pm.variables` is the merged read
+ * and returns the winning value, so it is correct by construction and must never
+ * warn; a name written through two different single-scope accessors keeps the
+ * first, by the same equal-claim rule that orders the row.
+ *
+ * Takes the origins rather than the resolver so it stays a pure join of "what
+ * did the script write" and "what is defined", the way `describeColumnReference`
+ * takes a predicate rather than the map.
+ */
+export function describeScopedRead(
+	reference: VariableReference,
+	origins: readonly VariableOrigin[]
+): DataTokenDescription | null {
+	const { name, scope } = reference;
+	if (scope === null) return null;
+
+	const own = ownAnswer(origins, scope);
+	// The healthy read: this scope answers, and answers with something.
+	if (own && own.value !== "") return null;
+
+	/*
+	 * Nothing else holds a value either, so there is no contradiction to report.
+	 * A name nothing defines is the destructive chip's business, and one that is
+	 * empty everywhere is empty exactly as the author left it.
+	 */
+	const shadowing = shadowingSources(origins, scope);
+	if (shadowing.length === 0) return null;
+
+	return {
+		tone: "warning",
+		description: own
+			? `Empty at ${scope} scope - this read returns ""`
+			: `Not defined at ${scope} scope - this read returns undefined`,
+		note: `non-empty in ${shadowing.join(", ")}; pm.variables.get("${name}") reads that`,
+	};
 }

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.chips.test.tsx
@@ -26,6 +26,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { Collection } from "@/types";
 import ScriptTab from "./ScriptTab";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import type { VariableOrigin } from "@/types/domain";
 
 const mutation = {
 	mutateAsync: vi.fn(() => Promise.resolve()),
@@ -52,10 +54,20 @@ const contract: { value: { collectionName: string; columns: string[] } | undefin
 };
 const variables: { value: Record<string, { value: string; scope: string }> } = { value: {} };
 
+/**
+ * What `getVariableOrigins(name)` answers with - empty unless a case says
+ * otherwise. This is the list `describeScopedRead` (issue #1196) reads to see
+ * a losing definition `allVariables`, keyed on the winner alone, cannot show.
+ */
+const origins: { value: Record<string, VariableOrigin[]> } = { value: {} };
+
 vi.mock("@/hooks", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@/hooks")>()),
 	useDataContract: () => contract.value,
-	useVariableResolver: () => ({ getAllVariables: () => variables.value }),
+	useVariableResolver: () => ({
+		getAllVariables: () => variables.value,
+		getVariableOrigins: (name: string) => origins.value[name] ?? [],
+	}),
 }));
 
 // Monaco does not run in jsdom, and the editor is not what this guards.
@@ -92,6 +104,7 @@ beforeEach(() => {
 	mutation.mutateAsync.mockClear();
 	contract.value = undefined;
 	variables.value = {};
+	origins.value = {};
 });
 
 describe.each(["pre", "post"] as const)("%s-request script tab", (kind) => {
@@ -269,6 +282,127 @@ describe.each(["pre", "post"] as const)("%s-request script tab", (kind) => {
 			);
 
 			expect(chipFor(container, "auth_token")!.className).toContain("text-variable");
+		});
+	});
+
+	/**
+	 * A single-scope read whose own scope answers emptily while another scope
+	 * holds the value (issue #1196), on this tab's own chip - the same table
+	 * as the request panel, but a separate render tree, so a regression here
+	 * would not show up in that suite.
+	 *
+	 * `shop_domain` is the reported trap: an enabled, empty row at collection
+	 * scope makes `pm.collectionVariables.get("shop_domain")` honestly return
+	 * `""`, while the environment defines the same name for real. `allVariables`
+	 * (what the old accent-vs-nothing paint read) reports only the *winner* -
+	 * the environment's value - which is exactly what made this chip look
+	 * resolved while quietly returning empty. The fixture keeps that winner in
+	 * `allVariables`, or it would not reproduce what fooled the old chip.
+	 */
+	describe("a single-scope pm read whose own scope answers emptily (issue #1196)", () => {
+		const TRAP_SCRIPT = 'const d = pm.collectionVariables.get("shop_domain");';
+
+		const chipFor = (container: HTMLElement, text: string) =>
+			[...container.querySelectorAll<HTMLElement>('[data-slot="badge"]')].find(
+				(el) => el.textContent === text
+			);
+
+		// Mutation check: delete the `describeScopedRead` branch from ScriptTab
+		// (or make it always return null) and this case is the first to redden -
+		// the read falls through to the pm/accent pair and, because `allVariables`
+		// reports the name resolved, paints the accent that hid the bug.
+		it("warns, names the scope that answered empty and the scope that shadows it, and never prints the value", () => {
+			origins.value = {
+				shop_domain: [
+					{ scope: "collection", value: "", enabled: true, winner: false },
+					{
+						scope: "environment",
+						sourceName: "Staging",
+						value: "shop.example.com",
+						enabled: true,
+						winner: true,
+					},
+				],
+			};
+			variables.value = { shop_domain: { value: "shop.example.com", scope: "environment" } };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(TRAP_SCRIPT)} kind={kind} />
+			);
+
+			const chip = chipFor(container, "shop_domain")!;
+			expect(chip.className).toContain(DATA_TOKEN_TONE_CLASS.warning);
+			const title = chip.getAttribute("title")!;
+			expect(title).toContain("Empty at collection scope");
+			expect(title).toContain("environment - Staging");
+			// One of these definitions may be a secret; the tooltip names sources,
+			// never values.
+			expect(title).not.toContain("shop.example.com");
+		});
+
+		it("stays the ordinary accent chip when the accessor's own scope actually answers", () => {
+			/*
+			 * Same script, but the collection row holds a real value of its own.
+			 * The environment still wins the ladder - it outranks the collection,
+			 * so it is last and takes `winner` - and that is the point: warning on
+			 * "another scope wins" would fire on most healthy scripts. What decides
+			 * is whether the accessor's *own* scope answers, and here it does.
+			 */
+			origins.value = {
+				shop_domain: [
+					{
+						scope: "collection",
+						value: "collection.example.com",
+						enabled: true,
+						winner: false,
+					},
+					{
+						scope: "environment",
+						sourceName: "Staging",
+						value: "env.example.com",
+						enabled: true,
+						winner: true,
+					},
+				],
+			};
+			variables.value = { shop_domain: { value: "env.example.com", scope: "environment" } };
+			const { container } = render(
+				<ScriptTab collection={makeCollection(TRAP_SCRIPT)} kind={kind} />
+			);
+
+			const chip = chipFor(container, "shop_domain")!;
+			expect(chip.className).not.toContain(DATA_TOKEN_TONE_CLASS.warning);
+			// The paint this read fell back to before #1196 existed: a resolving
+			// pm read, the same accent the other tests in this file check for.
+			expect(chip.className).toContain("text-variable");
+		});
+
+		it("never warns for the merged pm.variables read of the same name", () => {
+			// `pm.variables` returns the winner by construction, so it is correct
+			// regardless of what a single scope answers - the trap above is
+			// specific to the single-scope accessors and must not leak into it.
+			origins.value = {
+				shop_domain: [
+					{ scope: "collection", value: "", enabled: true, winner: false },
+					{
+						scope: "environment",
+						sourceName: "Staging",
+						value: "shop.example.com",
+						enabled: true,
+						winner: true,
+					},
+				],
+			};
+			variables.value = { shop_domain: { value: "shop.example.com", scope: "environment" } };
+			const { container } = render(
+				<ScriptTab
+					collection={makeCollection('const d = pm.variables.get("shop_domain");')}
+					kind={kind}
+				/>
+			);
+
+			expect(chipFor(container, "shop_domain")!.className).not.toContain(
+				DATA_TOKEN_TONE_CLASS.warning
+			);
 		});
 	});
 });

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -37,6 +37,7 @@ import { useDraftSaveContext, useEntityDraft } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import {
 	describeColumnReference,
+	describeScopedRead,
 	referencedVariables,
 	TEMPLATE_IN_SCRIPT_NOTE,
 } from "@/lib/referenced-variables";
@@ -101,7 +102,9 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 	 * chain, which is the chain the engine hands a script running under it.
 	 */
 	const dataColumns = useDataContract(collection.id);
-	const { getAllVariables } = useVariableResolver({ collectionId: collection.id });
+	const { getAllVariables, getVariableOrigins } = useVariableResolver({
+		collectionId: collection.id,
+	});
 	// Once per render, not once per chip: `getAllVariables` spreads a fresh map
 	// on every call, so asking it inside the row would rebuild the scopes for
 	// each name in it.
@@ -217,6 +220,32 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 									}
 								>
 									{via === "pm" ? name : `{{${name}}}`}
+								</Badge>
+							);
+						}
+						/*
+						 * A single-scope read whose own scope answers emptily while
+						 * another scope holds the value (issue #1196). The accent
+						 * below says "a variable answers this", which is true of the
+						 * name and false of this read: an enabled, empty collection
+						 * row makes `pm.collectionVariables.get` return `''` while
+						 * `{{name}}` resolves the environment's value. Amber, and
+						 * `describeScopedRead`'s decision rather than a copy of it,
+						 * so this tab and the request panel cannot come to disagree.
+						 */
+						const scoped = describeScopedRead(reference, getVariableOrigins(name));
+						if (scoped) {
+							return (
+								<Badge
+									key={name}
+									variant="chip"
+									className={cn(
+										"font-mono text-[10px] bg-muted border-0",
+										DATA_TOKEN_TONE_CLASS[scoped.tone]
+									)}
+									title={`${scoped.description} - ${scoped.note}`}
+								>
+									{name}
 								</Badge>
 							);
 						}

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
@@ -29,6 +29,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import ScriptPanel from "./script/ScriptPanel";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import type { VariableOrigin } from "@/types/domain";
 
 /** Monaco does not run under jsdom; nothing here tests the editor. */
 vi.mock("@/components/ui", async (importOriginal) => ({
@@ -67,6 +69,13 @@ const contract: { value: { collectionName: string; columns: string[] } | undefin
 /** What `getAllVariables()` answers with - empty unless a case says otherwise. */
 const variables: { value: Record<string, { value: string; scope: string }> } = { value: {} };
 
+/**
+ * What `getVariableOrigins(name)` answers with - empty unless a case says
+ * otherwise. This is the list `describeScopedRead` (issue #1196) reads to see
+ * a losing definition `allVariables`, keyed on the winner alone, cannot show.
+ */
+const origins: { value: Record<string, VariableOrigin[]> } = { value: {} };
+
 /** The script under the panel - `SCRIPT` unless a case swaps it. */
 const script = { value: SCRIPT };
 
@@ -85,6 +94,7 @@ vi.mock("../../../context", () => ({
 		},
 		updateField: () => {},
 		getAllVariables: () => variables.value,
+		getVariableOrigins: (name: string) => origins.value[name] ?? [],
 		get dataColumns() {
 			return contract.value;
 		},
@@ -117,6 +127,7 @@ function chipFor(container: HTMLElement, name: string): HTMLElement {
 beforeEach(() => {
 	contract.value = undefined;
 	variables.value = {};
+	origins.value = {};
 	script.value = SCRIPT;
 });
 
@@ -288,5 +299,122 @@ describe("a column read through pm, by its bare name", () => {
 		const { container } = render(<ScriptPanel variant="pre" />);
 
 		expect(chipFor(container, "email").className).toContain("bg-destructive");
+	});
+});
+
+/**
+ * A single-scope read whose own scope answers emptily while another scope
+ * holds the value (issue #1196).
+ *
+ * `shop_domain` is the reported trap: a Postman import leaves an enabled,
+ * empty row at collection scope, and `pm.collectionVariables.get("shop_domain")`
+ * honestly returns `""`. Nothing about that is wrong on its own - but the
+ * environment defines the same name with a real value, `allVariables` reports
+ * the *winner* (the environment's), and a chip keyed on `allVariables` alone
+ * called this read healthy while it silently returned empty. The origins list
+ * is what tells the two apart, so `getAllVariables()` has to report the name
+ * resolved here exactly as it did when the bug was filed - a fixture that
+ * leaves `shop_domain` out of `allVariables` cannot reproduce what fooled the
+ * old chip in the first place.
+ */
+describe("a single-scope pm read whose own scope answers emptily (issue #1196)", () => {
+	const TRAP_SCRIPT = 'const d = pm.collectionVariables.get("shop_domain");';
+
+	// Mutation check: delete the `describeScopedRead` branch from ScriptPanel
+	// (or make it always return null) and this case is the first to redden -
+	// the chip falls back to the destructive/secondary pair and, because
+	// `allVariables` reports the name resolved, paints the healthy chip that
+	// hid the bug.
+	it("warns, names the scope that answered empty and the scope that shadows it, and never prints the value", () => {
+		origins.value = {
+			shop_domain: [
+				{ scope: "collection", value: "", enabled: true, winner: false },
+				{
+					scope: "environment",
+					sourceName: "Staging",
+					value: "shop.example.com",
+					enabled: true,
+					winner: true,
+				},
+			],
+		};
+		// The winner `allVariables` reports - exactly what made this chip look
+		// healthy before #1196's fix, so the fixture has to keep reporting it.
+		variables.value = { shop_domain: { value: "shop.example.com", scope: "environment" } };
+		script.value = TRAP_SCRIPT;
+
+		const { container } = render(<ScriptPanel variant="pre" />);
+		const chip = chipFor(container, "shop_domain");
+
+		expect(chip.className).toContain(DATA_TOKEN_TONE_CLASS.warning);
+		const title = chip.getAttribute("title")!;
+		expect(title).toContain("Empty at collection scope");
+		expect(title).toContain("environment - Staging");
+		// One of these definitions may be a secret; the tooltip names sources,
+		// never values.
+		expect(title).not.toContain("shop.example.com");
+	});
+
+	it("stays the ordinary healthy chip when the accessor's own scope actually answers", () => {
+		/*
+		 * Same script, but the collection row holds a real value of its own. The
+		 * environment still wins the ladder - it outranks the collection, so it is
+		 * last and takes `winner` - and that is the point: warning on "another
+		 * scope wins" would fire on most healthy scripts. What decides is whether
+		 * the accessor's *own* scope answers, and here it does.
+		 */
+		origins.value = {
+			shop_domain: [
+				{
+					scope: "collection",
+					value: "collection.example.com",
+					enabled: true,
+					winner: false,
+				},
+				{
+					scope: "environment",
+					sourceName: "Staging",
+					value: "env.example.com",
+					enabled: true,
+					winner: true,
+				},
+			],
+		};
+		variables.value = { shop_domain: { value: "env.example.com", scope: "environment" } };
+		script.value = TRAP_SCRIPT;
+
+		const { container } = render(<ScriptPanel variant="pre" />);
+		const chip = chipFor(container, "shop_domain");
+
+		expect(chip.className).not.toContain(DATA_TOKEN_TONE_CLASS.warning);
+		// The paint this read fell back to before #1196 ever existed: resolved,
+		// so the ordinary secondary chip - not the destructive one, and not amber.
+		expect(chip.className).toContain("bg-secondary");
+	});
+
+	it("never warns for the merged pm.variables read of the same name", () => {
+		// `pm.variables` returns the winner by construction, so it is correct
+		// regardless of what a single scope answers - the trap above is specific
+		// to the single-scope accessors and must not leak into this one.
+		origins.value = {
+			shop_domain: [
+				{ scope: "collection", value: "", enabled: true, winner: false },
+				{
+					scope: "environment",
+					sourceName: "Staging",
+					value: "shop.example.com",
+					enabled: true,
+					winner: true,
+				},
+			],
+		};
+		variables.value = { shop_domain: { value: "shop.example.com", scope: "environment" } };
+		script.value = 'const d = pm.variables.get("shop_domain");';
+
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		expect(chipFor(container, "shop_domain").className).not.toContain(
+			DATA_TOKEN_TONE_CLASS.warning
+		);
 	});
 });

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-panels.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-panels.test.tsx
@@ -74,6 +74,11 @@ vi.mock("../../../context", () => ({
 		},
 		updateField: () => {},
 		getAllVariables: () => ALL_VARIABLES,
+		// No origins, so no name here can be the shadowed-empty scoped read of
+		// issue #1196 and every chip keeps the paint these cases assert. That
+		// warning has its own suite (`script-data-chip.test.tsx`), which supplies
+		// the origins it needs.
+		getVariableOrigins: () => [],
 		// Distinct per end of the run, so a panel reading the wrong context key
 		// shows the other end's collection name / recorded script.
 		inheritedPreScripts: [{ origin: "collection", id: "c1", name: "PreChain", script: "x" }],

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
@@ -27,6 +27,7 @@ import LegacyScriptNotice from "../LegacyScriptNotice";
 import { SCRIPT_VARIANTS, type ScriptVariant } from "./script-variants";
 import {
 	describeColumnReference,
+	describeScopedRead,
 	referencedVariables,
 	TEMPLATE_IN_SCRIPT_NOTE,
 } from "@/lib/referenced-variables";
@@ -45,7 +46,7 @@ export interface ScriptPanelProps {
 export default function ScriptPanel({ variant }: ScriptPanelProps) {
 	const config = SCRIPT_VARIANTS[variant];
 	const context = useRequestBuilderContext();
-	const { request, updateField, getAllVariables } = context;
+	const { request, updateField, getAllVariables, getVariableOrigins } = context;
 	const [showVariables, setShowVariables] = useState(false);
 
 	const script = request[config.field];
@@ -192,6 +193,32 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 									title={TEMPLATE_IN_SCRIPT_NOTE}
 								>
 									{`{{${name}}}`}
+								</Badge>
+							);
+						}
+						/*
+						 * A single-scope read whose own scope answers emptily while
+						 * another scope holds the value (issue #1196). Below the
+						 * resolved/unresolved pair because `allVariables` answers
+						 * about the *winner*: a name the environment defines is in
+						 * that map, so `pm.collectionVariables.get("shop_domain")`
+						 * got the healthy chip while returning `''`. Amber, because
+						 * the read works and the name resolves - it just does not
+						 * resolve here.
+						 */
+						const scoped = describeScopedRead(reference, getVariableOrigins(name));
+						if (scoped) {
+							return (
+								<Badge
+									key={name}
+									variant="chip"
+									className={cn(
+										"font-mono text-xs bg-muted",
+										DATA_TOKEN_TONE_CLASS[scoped.tone]
+									)}
+									title={`${scoped.description} - ${scoped.note}`}
+								>
+									{name}
 								</Badge>
 							);
 						}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1620,9 +1620,14 @@ merged and row reads and for a template mention, and `describeScopedRead`
 (beside the helper, so the two surfaces cannot disagree) joins it against
 `useVariableResolver`'s `getVariableOrigins` - which both panels were already
 handed and neither read. The chip is amber when that scope's own **last enabled**
-definition is empty or absent while a different scope holds a non-empty one, and
-the tooltip names both facts: what the read returns, and where the value the
-author is looking at lives. Amber and not destructive, for the same reason the
+definition is empty or absent while **the ladder's winner** is a different scope
+holding a non-empty value, and the tooltip names both facts: what the read
+returns, and where the value the author is looking at lives. The winner is the
+test, not "some other scope has a value", because the two part company exactly
+where the read's own scope is the one that wins: an empty collection row beside a
+non-empty global is the collection's answer *and* the merged answer, and an
+enabled environment row wins whatever it holds, so neither can be shadowed by
+anything. Amber on those would be amber on healthy scripts. Amber and not destructive, for the same reason the
 undeclared column is: the read works and the name resolves, it just does not
 resolve there. The merged read never warns - `pm.variables.get` returns the
 winning value and is the escape from this trap - and the tooltip prints sources

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1606,6 +1606,31 @@ while the name is a declared column no scope defines, which is the line
 `VariableInput` already draws for a bare `{{email}}`. Everything else keeps the
 paint it had.
 
+**A reference also carries *which* scope it reads, and a scoped read that its
+own scope answers emptily is amber** (issue #1196). `reads: "scope"` said that
+one scope answers and never which, so both chip rows could only ask
+`allVariables` whether *any* scope defines the name - an answer about the winner
+of the full ladder. An enabled, empty `shop_domain` at collection scope
+therefore got the healthy accent while `pm.collectionVariables.get` returned
+`''` and `{{shop_domain}}` in the URL bar resolved the environment's value: a
+failing assertion with nothing on screen connecting it to its cause, and the
+usual way in is a Postman import's initial-value placeholder. Each reference now
+carries a `scope` of `environment`, `collection` or `global`, null for the
+merged and row reads and for a template mention, and `describeScopedRead`
+(beside the helper, so the two surfaces cannot disagree) joins it against
+`useVariableResolver`'s `getVariableOrigins` - which both panels were already
+handed and neither read. The chip is amber when that scope's own **last enabled**
+definition is empty or absent while a different scope holds a non-empty one, and
+the tooltip names both facts: what the read returns, and where the value the
+author is looking at lives. Amber and not destructive, for the same reason the
+undeclared column is: the read works and the name resolves, it just does not
+resolve there. The merged read never warns - `pm.variables.get` returns the
+winning value and is the escape from this trap - and the tooltip prints sources
+(`environment - Staging`), never values, because a shadowing definition may be a
+secret. The engine is correct here and untouched: `js_pm_scope_get` returns the
+stored empty string when an enabled row holds one, and `undefined` when none
+does, which is exactly what these two states say.
+
 **A run-time token receives pointer events; the overlay does not.** The overlay
 is `pointer-events: none` so clicks reach the transparent input underneath and
 place the caret, and each token wrapper opts back in for itself -


### PR DESCRIPTION
## Description

**Root cause.** `referencedVariables` recorded `reads: "scope"` but threw away *which* scope - `PM_GET`'s accessor capture was consumed inline to pick a `PmRead` and never stored. Both script chip surfaces were left asking `allVariables[name]`, which answers about the **winner of the full ladder**. So an enabled, empty `shop_domain` row at collection scope painted the healthy accent chip while `pm.collectionVariables.get("shop_domain")` honestly returned `''` and `{{shop_domain}}` in the URL bar resolved the environment's value: a failing assertion with nothing on screen connecting it to its cause. A Postman import's initial-value placeholder is the usual way in.

**Approach.** Each reference now carries its accessor's single `scope`, and `describeScopedRead` joins it against the resolver's existing `getVariableOrigins` - already provided on both surfaces and read by neither, the quiet half of this repo's written-but-never-read defect. It warns when the accessor's own scope answers emptily or not at all **while the ladder's winner is a different scope holding a value**. Amber, not destructive: the read works and the name resolves, it just does not resolve *there* - the line `describeColumnToken` already draws, and the paint #604 took off this row.

The winner is the test rather than "some other scope has a value", and the two part company exactly where the read's own scope wins: an empty collection row beside a non-empty global is the collection's answer *and* the merged answer, and an enabled environment row wins whatever it holds. Warning on those would be amber on healthy scripts. (My first cut got this wrong in both directions; `f6a3bd2` fixes it and pins the three cases where the rules diverge.)

**Alternative rejected.** Deriving the warning in each panel from `getAllVariables` plus a scope guess. That is the copy-per-surface shape `describeColumnReference` exists to prevent, and the winner map cannot express "empty here, non-empty there" at all. One decision in `lib/`, two consumers.

Tooltips print sources (`environment - Staging`), never values, because a shadowing definition may be a secret.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Locally on this branch: `pnpm test` **6655 passed / 603 files, 0 failed**; `pnpm type-check` clean; `pnpm lint` clean; `pnpm format:check` clean.

17 new cases. `referenced-variables.test.ts` (44 total) covers the reported scenario, the undefined-vs-empty split, disabled rows looked past, nearest-enabled-in-chain, secret masking, the three precedence cases above, and every read that must stay silent. `script-data-chip.test.tsx` and `ScriptTab.chips.test.tsx` each render the trap, a healthy scoped read that another scope still wins, and the merged read. Mutation-checked twice: neutering `describeScopedRead` reddens 5, dropping the precedence guards reddens 5.

Both chip suites mocked a resolver without `getVariableOrigins` and went red as soon as the panels read it; the harness now supplies origins. `script-panels.test.tsx` gets an empty list, since no name there can be the shadowed-empty read.

### One commit here is not this issue's work

`763cb7b` makes `app/CLAUDE.md` prettier-clean. `format:check` covers `md` and had been failing on that file since #1299, which predates this branch - `pr-tests.yml` triggers on `pull_request` only, so nothing re-checks `master` and the break sat there blocking every PR's `App quality checks`, and `CI gate` with it.

I had left it out at first, since `CLAUDE.md` says to format only files you touched, and flagged it for the repo owner in [this comment](https://github.com/athrvk/vayu/pull/1301#issuecomment-5520805510) instead. Folded in at the owner's direction.

It was not only a red tick. The quality job runs `Type-check frontend` *after* the format step, so **a failing format check had been skipping the type-check on every pull request** - the repo has had no CI type-check since #1299 merged. This commit restores it. The change itself is emphasis markers only (`_x_` where the page wrote `*x*`), 7 lines, no prose touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Deliberate deviations from the issue spec

- **Fix pathway item 2 (the same signal in the completion `detail`) is not implemented.** It has no reachable case today. `useScriptVariableCompletionProvider` filters candidates by `info.scope === context.scope` where `info.scope` is the *winner's* scope, so under `pm.collectionVariables.get(` the trapped name - won by the environment - is never offered at all; and the configuration that *is* offered (the empty definition winning) is not the trap, because then `{{name}}` resolves to `""` as well. Making it reachable means changing which names a list offers, which is a semantics change the issue explicitly scopes out ("paint and prose only"). Filed as #1302, which reuses `describeScopedRead` rather than adding a second cross-check.
- **Fix pathway item 3 (badging the shadowed row in the popover) is not implemented.** The issue marks it optional and implementer's judgment; the popover already renders `empty` and a shadowed-by list, so the reader who opens it is not the one being trapped.
- `PM_ACCESSORS` merges this module's own two accessor tables into one. `SCOPE_BY_ACCESSOR` in `script-variable-completion.ts` still keys the same five names; it predates this and has not diverged, and folding them together belongs to the next change that touches both rather than to a paint fix.
- `mkdocs build --strict` could not run locally (mkdocs is not installed in this environment). The docs edit is prose inside an existing section - no new heading, link or nav entry - so there is nothing for `--strict` to reject.

## Related Issues
Closes #1196