### PR TITLE
fix(app): a single-scope accessor's completion list offers that scope's own definitions

### DIFF
--- a/app/src/hooks/data-column-completion.test.tsx
+++ b/app/src/hooks/data-column-completion.test.tsx
@@ -62,7 +62,11 @@ vi.mock("@/lib/monaco-loader", () => ({
 
 /** No variables at all, so every suggestion below can only be a column. */
 vi.mock("./useVariableResolver", () => ({
-	useVariableResolver: () => ({ getAllVariables: () => ({}) }),
+	useVariableResolver: () => ({
+		getAllVariables: () => ({}),
+		getScopeVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
 }));
 
 vi.mock("./useActiveCollectionId", () => ({ useActiveCollectionId: () => "col_1" }));

--- a/app/src/hooks/script-completion-split.test.tsx
+++ b/app/src/hooks/script-completion-split.test.tsx
@@ -23,6 +23,13 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
+import {
+	stubAllVariables,
+	stubOrigins,
+	stubScopeVariables,
+	type ScopeDefinitions,
+} from "@/lib/scoped-variables.testkit";
+import type { VariableScope } from "@/types";
 
 interface Suggestion {
 	label: string;
@@ -57,10 +64,19 @@ vi.mock("@/lib/monaco-loader", () => ({
 	ensureMonaco: () => Promise.resolve(monacoStub),
 }));
 
-const variables: Record<string, { value: string; scope: string }> = {};
+/**
+ * What each scope defines; the resolver's three views are derived from it, so
+ * the merged list and a single-scope list cannot disagree here in a way they
+ * never could in the app. See `scoped-variables.testkit`.
+ */
+const defs: ScopeDefinitions = {};
 
 vi.mock("./useVariableResolver", () => ({
-	useVariableResolver: () => ({ getAllVariables: () => variables }),
+	useVariableResolver: () => ({
+		getAllVariables: () => stubAllVariables(defs),
+		getScopeVariables: (scope: VariableScope) => stubScopeVariables(defs, scope),
+		getVariableOrigins: (name: string) => stubOrigins(defs, name),
+	}),
 }));
 
 /** The providers scope themselves to the active tab; scoping is covered by `variable-completion-scope.test.tsx`. */
@@ -101,10 +117,10 @@ const pmLabels = (line: string) =>
 	suggestionsFrom(useScriptCompletionProvider, line).map((s) => s.label);
 
 beforeEach(() => {
-	for (const key of Object.keys(variables)) delete variables[key];
-	variables.apiHost = { value: "https://api.test", scope: "environment" };
-	variables.retries = { value: "3", scope: "collection" };
-	variables.traceId = { value: "abc", scope: "global" };
+	for (const scope of Object.keys(defs) as VariableScope[]) delete defs[scope];
+	defs.environment = { apiHost: { value: "https://api.test" } };
+	defs.collection = { retries: { value: "3" } };
+	defs.global = { traceId: { value: "abc" } };
 });
 
 describe("variable names in the script editors", () => {
@@ -147,7 +163,7 @@ describe("variable names in the script editors", () => {
 	});
 
 	it("hides a secret's value while still offering the name", () => {
-		variables.apiKey = { value: "s3cret", scope: "environment", secret: true } as never;
+		defs.environment = { ...defs.environment, apiKey: { value: "s3cret", secret: true } };
 		const item = suggestionsFrom(
 			useScriptVariableCompletionProvider,
 			'pm.environment.get("'
@@ -173,11 +189,14 @@ describe("replaceIn, which interpolates rather than looks up", () => {
 	});
 
 	it("closes the braces it opened, but not when they are already there", () => {
+		// By name, not by position: the merged list is built scope by scope and
+		// ordered by `sortText`, so which entry lands first is not this case's
+		// subject.
 		const opened = suggestionsFrom(
 			useScriptVariableCompletionProvider,
 			'pm.variables.replaceIn("{{'
-		)[0];
-		expect(opened.insertText).toBe("{{apiHost}}");
+		).find((s) => s.label === "apiHost");
+		expect(opened?.insertText).toBe("{{apiHost}}");
 	});
 });
 

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -25,6 +25,17 @@
  * resolves to `undefined`. `scriptVariableCompletionContext` decides which set
  * applies; this hook only renders it.
  *
+ * **And the scope answers for itself** (issue #1302). A single-scope list is the
+ * names that scope *defines*, through `getScopeVariables`, not the names whose
+ * ladder-winner happens to sit there: `pm.collectionVariables.get` reads the
+ * collection chain and answers from it whether or not the environment defines
+ * the name too, so a list drawn from the winners hid a collection's own
+ * `shop_domain` behind an environment that shadowed it - the one configuration
+ * where the read and the `{{name}}` beside it disagree, and so the one the list
+ * most owes an author. `detail` is that scope's own answer for the same reason,
+ * and where the answer is an empty row masking another scope's value,
+ * `describeScopedRead` says so in the words the chip above the editor uses.
+ *
  * **Collection scope is the whole chain, the same as in a body.** The engine
  * fills a script's collection scope from the request's collection *chain*
  * (issue #234, leaf shadowing ancestor), so an ancestor's variable resolves
@@ -57,6 +68,8 @@ import { useVariableResolver } from "./useVariableResolver";
 import { useActiveCollectionId } from "./useActiveCollectionId";
 import { useDataContract } from "./useDataContract";
 import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
+import { describeScopedRead } from "@/lib/referenced-variables";
+import type { ResolvedVariable } from "@/types";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 import { ITERATION_VARIABLES } from "@/lib/iteration-variables";
 import { DATA_NAMESPACE_PREFIX } from "@/lib/variable-resolution";
@@ -66,8 +79,24 @@ const SCRIPT_LANGUAGE = "javascript";
 
 const CLOSE_BRACES = "}}";
 
-/** The resolver's own precedence, so the winning definition sorts first. */
+/**
+ * The resolver's own precedence, so the winning definition sorts first.
+ *
+ * A single-scope list shares one scope, so this prefix is constant there and the
+ * key is already the alphabetical order such a list wants (#1302). A branch that
+ * dropped the prefix for those lists would order nothing differently.
+ */
 const SCOPE_ORDER: Record<string, number> = { environment: 0, collection: 1, global: 2 };
+
+/** The value the accessor returns, or the mask a secret gets instead of it. */
+function valueDetail(info: ResolvedVariable): string {
+	return info.secret ? "secret" : info.value || "(empty)";
+}
+
+/** `environment - Staging`, the spelling the chips and the popover already use. */
+function originLabel(info: ResolvedVariable): string {
+	return info.sourceName ? `${info.scope} - ${info.sourceName}` : info.scope;
+}
 
 /**
  * Between the scopes and the data columns, the same slot
@@ -99,7 +128,9 @@ export function useScriptVariableCompletionProvider() {
 	 * the same chain the engine hands the script.
 	 */
 	const collectionId = useActiveCollectionId();
-	const { getAllVariables } = useVariableResolver({ collectionId });
+	const { getAllVariables, getScopeVariables, getVariableOrigins } = useVariableResolver({
+		collectionId,
+	});
 	/*
 	 * `pm.iterationData.get("` completes columns, not variables (issue #600) -
 	 * the row is bound from the collection's data file, so the names come from
@@ -158,25 +189,51 @@ export function useScriptVariableCompletionProvider() {
 				const closing = !template || rest.startsWith(CLOSE_BRACES) ? "" : CLOSE_BRACES;
 				const wrap = (name: string) => (template ? `{{${name}${closing}` : name);
 
-				const variables = getAllVariables();
-				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(variables)
-					// `pm.environment.get` reads one scope; only the merged
-					// `pm.variables` sees them all.
-					.filter(([, info]) => context.scope === "all" || info.scope === context.scope)
-					.map(([name, info]) => ({
-						label: name,
-						kind: monaco.languages.CompletionItemKind.Variable,
-						insertText: wrap(name),
-						// The resolved value, which is the thing you are actually
-						// checking when you reach for the list.
-						detail: info.secret ? "secret" : info.value || "(empty)",
-						documentation: info.sourceName
-							? `${info.scope} - ${info.sourceName}`
-							: info.scope,
-						sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
-						filterText: wrap(name),
-						range,
-					}));
+				/*
+				 * The scope answers for itself (issue #1302). `pm.environment.get`
+				 * reads one scope and only the merged `pm.variables` sees them
+				 * all, so the merged read takes the ladder's winners and a
+				 * single-scope read takes that scope's own definitions - which are
+				 * not the same names. Filtering the winners by scope offered a
+				 * collection's `shop_domain` only while the environment did not
+				 * also define it, hiding from the list the very name the call
+				 * still reads, and printing the winner's value beside every name
+				 * it did offer.
+				 */
+				const scope = context.scope === "all" ? null : context.scope;
+				const variables = scope ? getScopeVariables(scope) : getAllVariables();
+				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(variables).map(
+					([name, info]) => {
+						/*
+						 * The trap at typing time rather than after a failed run
+						 * (#1196's second item): this scope answers emptily while
+						 * another holds the value, so the read returns `""` and the
+						 * `{{name}}` beside it does not. One sentence, from the same
+						 * function the chip above the editor reads - a second
+						 * cross-check here would be a copy that drifts from it.
+						 */
+						const shadowed = scope
+							? describeScopedRead(
+									{ name, via: "pm", reads: "scope", scope },
+									getVariableOrigins(name)
+								)
+							: null;
+						return {
+							label: name,
+							kind: monaco.languages.CompletionItemKind.Variable,
+							insertText: wrap(name),
+							// What this call returns, which is the thing you are
+							// actually checking when you reach for the list.
+							detail: shadowed ? shadowed.description : valueDetail(info),
+							documentation: shadowed
+								? `${originLabel(info)} - ${shadowed.note}`
+								: originLabel(info),
+							sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
+							filterText: wrap(name),
+							range,
+						};
+					}
+				);
 
 				/*
 				 * Declared columns, blended into the merged accessor and nowhere
@@ -309,5 +366,5 @@ export function useScriptVariableCompletionProvider() {
 		});
 
 		return () => disposable.dispose();
-	}, [monaco, getAllVariables, collectionId, dataColumns]);
+	}, [monaco, getAllVariables, getScopeVariables, getVariableOrigins, collectionId, dataColumns]);
 }

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -68,7 +68,7 @@ import { useVariableResolver } from "./useVariableResolver";
 import { useActiveCollectionId } from "./useActiveCollectionId";
 import { useDataContract } from "./useDataContract";
 import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
-import { describeScopedRead } from "@/lib/referenced-variables";
+import { describeScopedRead, sourceLabel } from "@/lib/referenced-variables";
 import type { ResolvedVariable } from "@/types";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 import { ITERATION_VARIABLES } from "@/lib/iteration-variables";
@@ -91,11 +91,6 @@ const SCOPE_ORDER: Record<string, number> = { environment: 0, collection: 1, glo
 /** The value the accessor returns, or the mask a secret gets instead of it. */
 function valueDetail(info: ResolvedVariable): string {
 	return info.secret ? "secret" : info.value || "(empty)";
-}
-
-/** `environment - Staging`, the spelling the chips and the popover already use. */
-function originLabel(info: ResolvedVariable): string {
-	return info.sourceName ? `${info.scope} - ${info.sourceName}` : info.scope;
 }
 
 /**
@@ -227,8 +222,8 @@ export function useScriptVariableCompletionProvider() {
 						// actually checking when you reach for the list.
 						detail: shadowed ? shadowed.description : valueDetail(info),
 						documentation: shadowed
-							? `${originLabel(info)} - ${shadowed.note}`
-							: originLabel(info),
+							? `${sourceLabel(info)} - ${shadowed.note}`
+							: sourceLabel(info),
 						sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
 						filterText: wrap(name),
 						range,

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -202,38 +202,38 @@ export function useScriptVariableCompletionProvider() {
 				 */
 				const scope = context.scope === "all" ? null : context.scope;
 				const variables = scope ? getScopeVariables(scope) : getAllVariables();
-				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(variables).map(
-					([name, info]) => {
-						/*
-						 * The trap at typing time rather than after a failed run
-						 * (#1196's second item): this scope answers emptily while
-						 * another holds the value, so the read returns `""` and the
-						 * `{{name}}` beside it does not. One sentence, from the same
-						 * function the chip above the editor reads - a second
-						 * cross-check here would be a copy that drifts from it.
-						 */
-						const shadowed = scope
-							? describeScopedRead(
-									{ name, via: "pm", reads: "scope", scope },
-									getVariableOrigins(name)
-								)
-							: null;
-						return {
-							label: name,
-							kind: monaco.languages.CompletionItemKind.Variable,
-							insertText: wrap(name),
-							// What this call returns, which is the thing you are
-							// actually checking when you reach for the list.
-							detail: shadowed ? shadowed.description : valueDetail(info),
-							documentation: shadowed
-								? `${originLabel(info)} - ${shadowed.note}`
-								: originLabel(info),
-							sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
-							filterText: wrap(name),
-							range,
-						};
-					}
-				);
+				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(
+					variables
+				).map(([name, info]) => {
+					/*
+					 * The trap at typing time rather than after a failed run
+					 * (#1196's second item): this scope answers emptily while
+					 * another holds the value, so the read returns `""` and the
+					 * `{{name}}` beside it does not. One sentence, from the same
+					 * function the chip above the editor reads - a second
+					 * cross-check here would be a copy that drifts from it.
+					 */
+					const shadowed = scope
+						? describeScopedRead(
+								{ name, via: "pm", reads: "scope", scope },
+								getVariableOrigins(name)
+							)
+						: null;
+					return {
+						label: name,
+						kind: monaco.languages.CompletionItemKind.Variable,
+						insertText: wrap(name),
+						// What this call returns, which is the thing you are
+						// actually checking when you reach for the list.
+						detail: shadowed ? shadowed.description : valueDetail(info),
+						documentation: shadowed
+							? `${originLabel(info)} - ${shadowed.note}`
+							: originLabel(info),
+						sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
+						filterText: wrap(name),
+						range,
+					};
+				});
 
 				/*
 				 * Declared columns, blended into the merged accessor and nowhere

--- a/app/src/hooks/useVariableResolver.origins.test.tsx
+++ b/app/src/hooks/useVariableResolver.origins.test.tsx
@@ -376,3 +376,106 @@ describe("the bound row as an origin", () => {
 		expect(origins.find((o) => o.winner)?.scope).toBe("environment");
 	});
 });
+
+/**
+ * `getScopeVariables` answers a different question from `getAllVariables`
+ * (issue #1302): what one scope holds, not what wins over every other one.
+ *
+ * `pm.collectionVariables.get` reads the collection chain and answers from it
+ * whether or not the environment defines the name too, so the completion list
+ * for that call is built from this rather than from the winners - and the two
+ * disagree in exactly the configuration the author most needs to see.
+ */
+describe("what one scope answers on its own", () => {
+	it("keeps a definition the environment shadows", () => {
+		const r = setup({
+			cols: [{ id: "c1", name: "Acme", variables: { shop_domain: v("shop.test") } }],
+			envs: [
+				{ id: "e1", name: "Staging", variables: { shop_domain: v("staging.shop.test") } },
+			],
+			activeCollectionId: "c1",
+			activeEnvironmentId: "e1",
+		});
+		expect(r.getScopeVariables("collection").shop_domain.value).toBe("shop.test");
+		expect(r.getScopeVariables("collection").shop_domain.sourceName).toBe("Acme");
+		// The ladder is untouched: the environment still wins everywhere else.
+		expect(r.getVariable("shop_domain")?.scope).toBe("environment");
+	});
+
+	it("gives the leaf collection's value, not its ancestor's", () => {
+		const r = setup({
+			cols: [
+				{ id: "root", name: "Acme", variables: { baseUrl: v("https://root.io") } },
+				{
+					id: "leaf",
+					name: "Leaf",
+					parentId: "root",
+					variables: { baseUrl: v("https://leaf.io") },
+				},
+			],
+			activeCollectionId: "leaf",
+		});
+		expect(r.getScopeVariables("collection").baseUrl.value).toBe("https://leaf.io");
+	});
+
+	it("looks past a disabled row to the enabled one beneath it", () => {
+		const r = setup({
+			cols: [
+				{ id: "root", name: "Acme", variables: { baseUrl: v("https://root.io") } },
+				{
+					id: "leaf",
+					name: "Leaf",
+					parentId: "root",
+					variables: { baseUrl: v("https://leaf.io", { enabled: false }) },
+				},
+			],
+			activeCollectionId: "leaf",
+		});
+		expect(r.getScopeVariables("collection").baseUrl.value).toBe("https://root.io");
+	});
+
+	it("drops a name whose every definition in that scope is disabled", () => {
+		const r = setup({
+			cols: [{ id: "c1", name: "Acme", variables: { retired: v("1", { enabled: false }) } }],
+			envs: [{ id: "e1", name: "Staging", variables: { retired: v("2") } }],
+			activeCollectionId: "c1",
+			activeEnvironmentId: "e1",
+		});
+		// `get` reads enabled rows only, so absence rather than present-and-empty.
+		expect("retired" in r.getScopeVariables("collection")).toBe(false);
+		expect(r.getScopeVariables("environment").retired.value).toBe("2");
+	});
+
+	it("holds no name the scope never defined", () => {
+		const r = setup({
+			globalVars: { traceId: v("abc") },
+			envs: [{ id: "e1", name: "Staging", variables: { host: v("staging.acme.io") } }],
+			activeEnvironmentId: "e1",
+		});
+		expect(Object.keys(r.getScopeVariables("collection"))).toEqual([]);
+		expect(Object.keys(r.getScopeVariables("environment"))).toEqual(["host"]);
+		expect(Object.keys(r.getScopeVariables("global"))).toEqual(["traceId"]);
+	});
+
+	it("keeps an empty row, which is a definition and answers the read", () => {
+		const r = setup({
+			cols: [{ id: "c1", name: "Acme", variables: { shop_domain: v("") } }],
+			envs: [
+				{ id: "e1", name: "Staging", variables: { shop_domain: v("staging.shop.test") } },
+			],
+			activeCollectionId: "c1",
+			activeEnvironmentId: "e1",
+		});
+		expect(r.getScopeVariables("collection").shop_domain.value).toBe("");
+	});
+
+	it("never reports the bound row, which is not a scope", () => {
+		const r = setup({
+			envs: [{ id: "e1", name: "Staging", variables: { email: v("staging@acme.io") } }],
+			activeEnvironmentId: "e1",
+			boundRow: { email: "alice@acme.io", extra: "x" },
+		});
+		expect(r.getScopeVariables("environment").email.value).toBe("staging@acme.io");
+		expect("extra" in r.getScopeVariables("environment")).toBe(false);
+	});
+});

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -58,6 +58,8 @@ import {
 	resolveTemplateWithRow,
 	type DataRowCells,
 } from "@/lib/variable-resolution";
+// The single-scope read's own rule, shared with the chip that explains it.
+import { scopeAnswer } from "@/lib/referenced-variables";
 import type { DataFileRow } from "@/services/data-files";
 
 interface UseVariableResolverOptions {
@@ -87,6 +89,15 @@ interface UseVariableResolverReturn {
 	getVariable: (name: string) => ResolvedVariable | null;
 	getAllVariables: () => Record<string, ResolvedVariable>;
 	/**
+	 * What one scope answers on its own: the names it defines through enabled
+	 * rows, valued as `pm.<scope>.get` would read them - independent of which
+	 * scope wins the whole ladder (issue #1302).
+	 *
+	 * Display-only, like `getVariableOrigins`. Execution reaches a single scope
+	 * through the engine, which walks that scope's own chain for the same reason.
+	 */
+	getScopeVariables: (scope: VariableScope) => Record<string, ResolvedVariable>;
+	/**
 	 * Every definition of a name, lowest precedence first, including the disabled
 	 * ones that never resolve. Empty array for a name nothing defines.
 	 *
@@ -94,6 +105,25 @@ interface UseVariableResolverReturn {
 	 * `VariableOrigin` for why the losers are worth keeping.
 	 */
 	getVariableOrigins: (name: string) => VariableOrigin[];
+}
+
+/** The writable scopes, lowest precedence first. */
+const VARIABLE_SCOPES: readonly VariableScope[] = ["global", "collection", "environment"];
+
+/**
+ * One definition as the value a reader gets - written once because the ladder's
+ * winner and a single scope's own answer are the same shape and must stay so.
+ */
+function resolvedFrom(origin: ScopeVariableOrigin): ResolvedVariable {
+	return {
+		value: origin.value,
+		scope: origin.scope,
+		secret: origin.secret,
+		sourceId: origin.sourceId,
+		sourceName: origin.sourceName,
+		type: origin.type,
+		typedValue: castByType(origin.value, origin.type),
+	};
 }
 
 /**
@@ -214,15 +244,38 @@ export function useVariableResolver(
 			// table) depends on such a name being absent rather than
 			// present-and-empty.
 			if (!won) continue;
-			result[name] = {
-				value: won.value,
-				scope: won.scope,
-				secret: won.secret,
-				sourceId: won.sourceId,
-				sourceName: won.sourceName,
-				type: won.type,
-				typedValue: castByType(won.value, won.type),
-			};
+			result[name] = resolvedFrom(won);
+		}
+		return result;
+	}, [originsByName]);
+
+	/**
+	 * What each scope answers **on its own** - the names it defines through
+	 * enabled rows, valued as its own accessor would read them (issue #1302).
+	 *
+	 * A different question from `variableMap`, and the difference is the point:
+	 * `pm.collectionVariables.get` reads the collection chain and answers from it
+	 * whether or not the environment also defines the name, so a list built by
+	 * filtering the ladder's winners hides a collection's own `shop_domain` for
+	 * no reason the caller can see. Same origins, same "last enabled wins" rule
+	 * (`scopeAnswer`, which `describeScopedRead` reads too), one rung of the
+	 * ladder instead of all of them.
+	 *
+	 * A name whose definitions in a scope are all disabled is absent here, for
+	 * the reason it is absent from `variableMap`: `get` reads enabled rows only,
+	 * so present-and-empty would offer a name the call cannot answer.
+	 */
+	const scopeVariableMaps = useMemo(() => {
+		const result: Record<VariableScope, Record<string, ResolvedVariable>> = {
+			global: {},
+			collection: {},
+			environment: {},
+		};
+		for (const [name, origins] of Object.entries(originsByName)) {
+			for (const scope of VARIABLE_SCOPES) {
+				const own = scopeAnswer(origins, scope);
+				if (own) result[scope][name] = resolvedFrom(own);
+			}
 		}
 		return result;
 	}, [originsByName]);
@@ -235,6 +288,13 @@ export function useVariableResolver(
 	const getAllVariables = useCallback(
 		(): Record<string, ResolvedVariable> => ({ ...variableMap }),
 		[variableMap]
+	);
+
+	const getScopeVariables = useCallback(
+		(scope: VariableScope): Record<string, ResolvedVariable> => ({
+			...scopeVariableMaps[scope],
+		}),
+		[scopeVariableMaps]
 	);
 
 	/**
@@ -343,6 +403,7 @@ export function useVariableResolver(
 		resolveObject,
 		getVariable,
 		getAllVariables,
+		getScopeVariables,
 		getVariableOrigins,
 	};
 }

--- a/app/src/hooks/variable-completion-scope.test.tsx
+++ b/app/src/hooks/variable-completion-scope.test.tsx
@@ -54,7 +54,7 @@ interface ProviderLike {
 	provideCompletionItems: (
 		model: { getLineContent: () => string },
 		position: { lineNumber: number; column: number }
-	) => { suggestions: Array<{ label: string }> };
+	) => { suggestions: Array<{ label: string; detail?: string; documentation?: string }> };
 }
 
 const registered: ProviderLike[] = [];
@@ -112,17 +112,20 @@ vi.mock("./useDataContract", () => ({ useDataContract: () => undefined }));
 import { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 import { useScriptVariableCompletionProvider } from "./useScriptVariableCompletionProvider";
 
-/** Labels the first registered provider offers for `line`, caret at its end. */
-function labelsFor(hook: () => void, line: string) {
+/** What the first registered provider offers for `line`, caret at its end. */
+function suggestionsFor(hook: () => void, line: string) {
 	registered.length = 0;
 	renderHook(hook);
 	expect(registered.length).toBeGreaterThan(0);
-	return registered[0]
-		.provideCompletionItems(
-			{ getLineContent: () => line },
-			{ lineNumber: 1, column: line.length + 1 }
-		)
-		.suggestions.map((s) => s.label);
+	return registered[0].provideCompletionItems(
+		{ getLineContent: () => line },
+		{ lineNumber: 1, column: line.length + 1 }
+	).suggestions;
+}
+
+/** Labels the first registered provider offers for `line`, caret at its end. */
+function labelsFor(hook: () => void, line: string) {
+	return suggestionsFor(hook, line).map((s) => s.label);
 }
 
 beforeEach(() => {
@@ -204,5 +207,108 @@ describe("the script list offers the ancestor chain the engine now walks (#234)"
 		activeCollectionId.current = undefined;
 		labelsFor(() => useScriptVariableCompletionProvider(), 'pm.variables.get("');
 		expect(scopes).toEqual([undefined]);
+	});
+});
+
+/**
+ * The list a single-scope accessor gets is that scope's own definitions
+ * (issue #1302).
+ *
+ * It used to be the winner map filtered by the winning scope, which answers a
+ * different question: `pm.collectionVariables.get` reads the collection chain
+ * and answers from it whether or not the environment defines the name too, so
+ * filtering by "which scope won the ladder" hid a collection's own variable
+ * behind an environment that shadowed it - and shadowed is exactly the case an
+ * author needs the list for, since it is the one where the scoped read and the
+ * `{{name}}` beside it disagree.
+ *
+ * Revert the hook to `getAllVariables()` filtered by `info.scope` and the first
+ * three of these fail: the name is not offered at all, so there is no detail to
+ * be wrong about.
+ */
+describe("a single-scope list is what that scope defines, not what it wins", () => {
+	beforeEach(() => {
+		activeCollectionId.current = "leaf";
+	});
+
+	it("offers a collection variable the environment shadows", () => {
+		defs.collection = { shop_domain: { value: "shop.test", sourceName: "Acme" } };
+		defs.environment = { shop_domain: { value: "staging.shop.test", sourceName: "Staging" } };
+
+		const labels = labelsFor(
+			() => useScriptVariableCompletionProvider(),
+			'pm.collectionVariables.get("'
+		);
+		expect(
+			labels,
+			"the call reads the collection chain, so the name is one it can answer"
+		).toContain("shop_domain");
+	});
+
+	it("shows that scope's own value, not the winner's", () => {
+		defs.collection = { shop_domain: { value: "shop.test", sourceName: "Acme" } };
+		defs.environment = { shop_domain: { value: "staging.shop.test", sourceName: "Staging" } };
+
+		const item = suggestionsFor(
+			() => useScriptVariableCompletionProvider(),
+			'pm.collectionVariables.get("'
+		).find((s) => s.label === "shop_domain");
+		expect(item?.detail).toBe("shop.test");
+		expect(item?.documentation).toBe("collection - Acme");
+	});
+
+	/**
+	 * #1196's second item, reachable only now that the trapped name is offered:
+	 * the collection row is enabled and empty, so the read returns `""` while
+	 * `{{shop_domain}}` resolves the environment's value - and the sentence comes
+	 * from `describeScopedRead`, the one the chip above the editor shows.
+	 */
+	it("says so when the scope's own row is empty and another scope holds the value", () => {
+		defs.collection = { shop_domain: { value: "", sourceName: "Acme" } };
+		defs.environment = { shop_domain: { value: "staging.shop.test", sourceName: "Staging" } };
+
+		const item = suggestionsFor(
+			() => useScriptVariableCompletionProvider(),
+			'pm.collectionVariables.get("'
+		).find((s) => s.label === "shop_domain");
+		expect(item?.detail).toBe('Empty at collection scope - this read returns ""');
+		expect(item?.documentation).toContain("environment - Staging holds the value");
+	});
+
+	it("stays quiet where the scope's own answer is the one that resolves", () => {
+		defs.collection = { shop_domain: { value: "shop.test", sourceName: "Acme" } };
+		defs.global = { shop_domain: { value: "global.shop.test" } };
+
+		const item = suggestionsFor(
+			() => useScriptVariableCompletionProvider(),
+			'pm.collectionVariables.get("'
+		).find((s) => s.label === "shop_domain");
+		expect(item?.detail).toBe("shop.test");
+		expect(item?.documentation).toBe("collection - Acme");
+	});
+
+	// `get` reads enabled rows only, so absence is the honest answer - the same
+	// one the winner map gives a name whose every definition is switched off.
+	it("leaves out a name whose definitions in that scope are all disabled", () => {
+		defs.collection = { retired: { value: "1", enabled: false } };
+		defs.environment = { retired: { value: "2" } };
+
+		const labels = labelsFor(
+			() => useScriptVariableCompletionProvider(),
+			'pm.collectionVariables.get("'
+		);
+		expect(labels).not.toContain("retired");
+		expect(
+			labelsFor(() => useScriptVariableCompletionProvider(), 'pm.environment.get("'),
+			"the environment's enabled row still answers there"
+		).toContain("retired");
+	});
+
+	it("still leaves out a name only another scope defines", () => {
+		defs.environment = { only_env: { value: "1" } };
+
+		expect(
+			labelsFor(() => useScriptVariableCompletionProvider(), 'pm.collectionVariables.get("')
+		).not.toContain("only_env");
 	});
 });

--- a/app/src/hooks/variable-completion-scope.test.tsx
+++ b/app/src/hooks/variable-completion-scope.test.tsx
@@ -42,6 +42,13 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
+import {
+	stubAllVariables,
+	stubOrigins,
+	stubScopeVariables,
+	type ScopeDefinitions,
+} from "@/lib/scoped-variables.testkit";
+import type { VariableScope } from "@/types";
 
 interface ProviderLike {
 	provideCompletionItems: (
@@ -72,13 +79,21 @@ vi.mock("@/lib/monaco-loader", () => ({
 /** The `collectionId` each provider handed the resolver, in call order. */
 const scopes: Array<string | undefined> = [];
 
-/** What the resolver reports - keyed the way `ResolvedVariable` is shaped. */
-const variables: Record<string, { value: string; scope: string; sourceId?: string }> = {};
+/**
+ * What each scope defines. The resolver's three views are derived from it
+ * (`scoped-variables.testkit`), so a case cannot describe a scope map that
+ * disagrees with the merged one - a state the real resolver cannot be in.
+ */
+const defs: ScopeDefinitions = {};
 
 vi.mock("./useVariableResolver", () => ({
 	useVariableResolver: (options?: { collectionId?: string }) => {
 		scopes.push(options?.collectionId);
-		return { getAllVariables: () => variables };
+		return {
+			getAllVariables: () => stubAllVariables(defs),
+			getScopeVariables: (scope: VariableScope) => stubScopeVariables(defs, scope),
+			getVariableOrigins: (name: string) => stubOrigins(defs, name),
+		};
 	},
 }));
 
@@ -114,7 +129,7 @@ beforeEach(() => {
 	scopes.length = 0;
 	registered.length = 0;
 	activeCollectionId.current = undefined;
-	for (const key of Object.keys(variables)) delete variables[key];
+	for (const scope of Object.keys(defs) as VariableScope[]) delete defs[scope];
 });
 
 describe("the Monaco completion providers resolve against the active collection", () => {
@@ -139,8 +154,10 @@ describe("the Monaco completion providers resolve against the active collection"
 describe("the body `{{` list offers the whole ancestor chain", () => {
 	it("offers a parent collection's variable, which `{{name}}` does resolve", () => {
 		activeCollectionId.current = "leaf";
-		variables.from_parent = { value: "1", scope: "collection", sourceId: "root" };
-		variables.from_leaf = { value: "2", scope: "collection", sourceId: "leaf" };
+		defs.collection = {
+			from_parent: { value: "1", sourceId: "root" },
+			from_leaf: { value: "2", sourceId: "leaf" },
+		};
 
 		const labels = labelsFor(() => useVariableCompletionProvider(), "{{");
 		expect(labels).toContain("from_parent");
@@ -151,9 +168,11 @@ describe("the body `{{` list offers the whole ancestor chain", () => {
 describe("the script list offers the ancestor chain the engine now walks (#234)", () => {
 	beforeEach(() => {
 		activeCollectionId.current = "leaf";
-		variables.from_parent = { value: "1", scope: "collection", sourceId: "root" };
-		variables.from_leaf = { value: "2", scope: "collection", sourceId: "leaf" };
-		variables.from_env = { value: "3", scope: "environment", sourceId: "e1" };
+		defs.collection = {
+			from_parent: { value: "1", sourceId: "root" },
+			from_leaf: { value: "2", sourceId: "leaf" },
+		};
+		defs.environment = { from_env: { value: "3", sourceId: "e1" } };
 	});
 
 	it("offers an ancestor's variable inside `pm.collectionVariables.get()`", () => {

--- a/app/src/lib/referenced-variables.ts
+++ b/app/src/lib/referenced-variables.ts
@@ -42,7 +42,12 @@ import {
 	describeColumnToken,
 	type DataTokenDescription,
 } from "./data-contract";
-import type { DataContractScope, VariableOrigin, VariableScope } from "@/types/domain";
+import type {
+	DataContractScope,
+	VariableOrigin,
+	VariableOriginScope,
+	VariableScope,
+} from "@/types/domain";
 
 /**
  * `pm.<accessor>.get("x")`, for every accessor whose first argument is a name.
@@ -300,8 +305,12 @@ function ladderWinner(origins: readonly VariableOrigin[]): VariableOrigin | null
  *
  * The value is never printed, only the source: the definition may be a secret,
  * and the popover's rule is that a secret shows a mask and never a value.
+ *
+ * Takes the two fields it reads rather than a whole origin, because the
+ * completion list names the same definition from a `ResolvedVariable` (#1302)
+ * and a second spelling of one vocabulary is what this exists to prevent.
  */
-function sourceLabel(origin: VariableOrigin): string {
+export function sourceLabel(origin: { scope: VariableOriginScope; sourceName?: string }): string {
 	return origin.sourceName ? `${origin.scope} - ${origin.sourceName}` : origin.scope;
 }
 

--- a/app/src/lib/referenced-variables.ts
+++ b/app/src/lib/referenced-variables.ts
@@ -247,11 +247,19 @@ export function describeColumnReference(
  * `useVariableResolver`, which pushes the collection chain root-first and marks
  * the last enabled definition the winner. A disabled row is looked past here for
  * the same reason it is there (D17).
+ *
+ * Exported because the completion list asks the same question of the same
+ * origins (#1302): `getScopeVariables` builds one entry per name from this, so
+ * what `pm.collectionVariables.get` is offered and what the chip beside it says
+ * come from one rule rather than two that can drift.
+ *
+ * Generic in the origin so a caller holding `ScopeVariableOrigin`s gets one
+ * back, rather than widening to a `"row"` scope this can never return.
  */
-function ownAnswer(
-	origins: readonly VariableOrigin[],
+export function scopeAnswer<T extends VariableOrigin>(
+	origins: readonly T[],
 	scope: VariableScope
-): VariableOrigin | null {
+): T | null {
 	for (let i = origins.length - 1; i >= 0; i--) {
 		const origin = origins[i];
 		if (origin.scope === scope && origin.enabled) return origin;
@@ -340,7 +348,7 @@ export function describeScopedRead(
 	const { name, scope } = reference;
 	if (scope === null) return null;
 
-	const own = ownAnswer(origins, scope);
+	const own = scopeAnswer(origins, scope);
 	// The healthy read: this scope answers, and answers with something.
 	if (own && own.value !== "") return null;
 

--- a/app/src/lib/scoped-variables.testkit.ts
+++ b/app/src/lib/scoped-variables.testkit.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One fixture, the three views of it `useVariableResolver` hands a caller.
+ *
+ * The Monaco completion suites stub the resolver out - they are about what a
+ * list offers, not about how the ladder is built, which
+ * `useVariableResolver.origins.test.tsx` covers against the real queries. What
+ * they cannot do is stub the three views *separately*: a scope map that does
+ * not agree with the merged map is a state the resolver cannot produce, and a
+ * case written against it proves nothing about the app. So a test declares the
+ * definitions - what each scope holds, which is what a user edits - and the
+ * views are derived here, once (issue #1302).
+ */
+
+import type { ResolvedVariable, ScopeVariableOrigin, VariableScope } from "@/types";
+
+/** A definition as a case writes it: the value, plus whatever the case is about. */
+export interface StubDefinition {
+	value: string;
+	secret?: boolean;
+	/** Absent counts as enabled, the way a stored definition's flag does (D17). */
+	enabled?: boolean;
+	sourceId?: string;
+	sourceName?: string;
+}
+
+/** What each scope defines, keyed by name. A scope may hold one definition per name. */
+export type ScopeDefinitions = Partial<Record<VariableScope, Record<string, StubDefinition>>>;
+
+/** Lowest precedence first, the order `useVariableResolver` pushes its origins in. */
+const SCOPES: readonly VariableScope[] = ["global", "collection", "environment"];
+
+function resolved(scope: VariableScope, def: StubDefinition): ResolvedVariable {
+	return {
+		value: def.value,
+		scope,
+		secret: def.secret,
+		sourceId: def.sourceId,
+		sourceName: def.sourceName,
+	};
+}
+
+/** Every definition of one name, lowest precedence first, the disabled ones kept. */
+export function stubOrigins(defs: ScopeDefinitions, name: string): ScopeVariableOrigin[] {
+	const origins: ScopeVariableOrigin[] = [];
+	for (const scope of SCOPES) {
+		const def = defs[scope]?.[name];
+		if (!def) continue;
+		origins.push({
+			scope,
+			sourceId: def.sourceId,
+			sourceName: def.sourceName,
+			value: def.value,
+			secret: def.secret,
+			enabled: def.enabled !== false,
+			winner: false,
+		});
+	}
+	// Last enabled wins, exactly as the resolver marks it.
+	for (let i = origins.length - 1; i >= 0; i--) {
+		if (origins[i].enabled) {
+			origins[i].winner = true;
+			break;
+		}
+	}
+	return origins;
+}
+
+/** What `pm.<scope>.get` reads: that scope's own enabled definitions. */
+export function stubScopeVariables(
+	defs: ScopeDefinitions,
+	scope: VariableScope
+): Record<string, ResolvedVariable> {
+	const result: Record<string, ResolvedVariable> = {};
+	for (const [name, def] of Object.entries(defs[scope] ?? {})) {
+		if (def.enabled === false) continue;
+		result[name] = resolved(scope, def);
+	}
+	return result;
+}
+
+/** What `{{name}}` and `pm.variables.get` read: the ladder's winner per name. */
+export function stubAllVariables(defs: ScopeDefinitions): Record<string, ResolvedVariable> {
+	const result: Record<string, ResolvedVariable> = {};
+	for (const scope of SCOPES) {
+		for (const [name, def] of Object.entries(defs[scope] ?? {})) {
+			if (def.enabled === false) continue;
+			result[name] = resolved(scope, def);
+		}
+	}
+	return result;
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1634,7 +1634,11 @@ winning value and is the escape from this trap - and the tooltip prints sources
 (`environment - Staging`), never values, because a shadowing definition may be a
 secret. The engine is correct here and untouched: `js_pm_scope_get` returns the
 stored empty string when an enabled row holds one, and `undefined` when none
-does, which is exactly what these two states say.
+does, which is exactly what these two states say. **The completion list inside
+the accessor now says the same thing at typing time** (issue #1302): it offers
+the scope's own definitions rather than the ladder's winners, so the trapped
+name is offered at all, and its `detail` is `describeScopedRead`'s sentence -
+one function, two surfaces, rather than a second cross-check written beside it.
 
 **A run-time token receives pointer events; the overlay does not.** The overlay
 is `pointer-events: none` so clicks reach the transparent input underneath and

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -434,6 +434,31 @@ cannot disagree about which definition won. A name whose every definition is
 disabled is absent from the map, not present-and-empty - the red token keys off
 absence, so a present-and-empty entry would paint it resolved and send "".
 
+### `getScopeVariables(scope)`
+
+Returns what **one** scope answers on its own: the names it defines through
+enabled rows, each valued as `pm.<scope>.get` would read it, independent of
+which scope wins the whole ladder (issue #1302).
+
+A different question from `getAllVariables`, and the difference is the point.
+`pm.collectionVariables.get` reads the collection chain and answers from it
+whether or not the environment defines the name too, so a caller that wants
+"what does this scope hold?" cannot get it by filtering the winners: a
+collection's own `shop_domain` disappears from that filter the moment an
+environment shadows it, which is the one configuration where the scoped read
+and the `{{name}}` beside it disagree. The completion list inside a
+single-scope accessor is built from this (below).
+
+Derived from the same origins as `variableMap`, through the same "last enabled
+wins" rule - `scopeAnswer` in `lib/referenced-variables.ts`, which
+`describeScopedRead` reads as well, so what a list offers and what the chip
+above the editor says about it cannot drift apart. A name whose definitions in
+that scope are all disabled is absent rather than present-and-empty, for the
+reason it is absent from `variableMap`: `get` reads enabled rows only.
+
+Display-only, like `getVariableOrigins`. The bound row never appears here - it
+is not a scope, and no accessor reads a single scope through it.
+
 ### `getVariableOrigins(name)`
 
 Returns every definition of a name, lowest precedence first, **including the
@@ -904,6 +929,20 @@ These rules make the offered set match what the call can actually read:
   variable offered there would be a name that returns `undefined`. Only the
   merged `pm.variables.get` lists all three, and it alone also lists the
   declared columns (below), because it alone reads both.
+- **And the scope answers for itself.** A single-scope list is the names that
+  scope *defines*, through enabled rows - `getScopeVariables` (above) - not the
+  names whose ladder-winner happens to sit there (issue #1302). The two are
+  different lists wherever a name is defined twice: a collection `shop_domain`
+  shadowed by the active environment is still a name
+  `pm.collectionVariables.get` reads and answers, so withholding it would hide
+  the very case the list is worth opening for. `detail` is that scope's own
+  answer for the same reason - its value, `(empty)` for an enabled empty row,
+  or `secret` for a masked one - rather than the winner's value, which the call
+  will not return. Where that answer is an empty row while another scope holds
+  a value, `detail` carries `describeScopedRead`'s sentence (*Empty at
+  collection scope - this read returns ""*) and the documentation names the
+  scope that holds it - the same words the chip above the editor uses, from the
+  same function.
 - **Collection variables come from the active tab.** Collection scope is
   explicit-only (see *Collection scope is explicit only* above) and a Monaco
   completion provider is registered once per *language*, not per editor, so it
@@ -917,7 +956,7 @@ These rules make the offered set match what the call can actually read:
   `pm.collectionVariables.get()` and the merged `pm.variables.get()` - it is a
   name the call can read. This list narrowed to the immediate collection while
   the engine did; the rule underneath is unchanged, which is that the list
-  offers exactly what the call resolves.
+  offers exactly what the call reads.
 - **`pm.iterationData` completes columns, not variables.** The row it reads is
   bound from the collection's data file, so the names offered inside
   `pm.iterationData.get("…")` and `.has("…")` are the declared columns of the


### PR DESCRIPTION
## Description

`pm.<scope>.get(`'s variable-name completion built its candidate list from `getAllVariables()` - the ladder-**winner** map - and filtered it by `info.scope === context.scope`. `info.scope` is the scope whose definition won the *whole* ladder, so a name reached a single-scope list only when that scope also beat every other one. Walk #1196's own scenario through it: `shop_domain` is defined at collection scope and non-empty in the active environment, the environment outranks the collection, so the name was filtered out of the `collection` list entirely - even though `pm.collectionVariables.get` reads the collection chain and answers from it whether or not the environment defines the name too. The author typing `pm.collectionVariables.get("shop_` got nothing. Every name the list *did* offer printed the winner's value as its `detail` rather than the value that call returns.

The candidate set moves from "names whose ladder-winner sits at this scope" to "names this scope itself defines through enabled rows". `useVariableResolver` grows `getScopeVariables(scope)`, derived from the same `originsByName` as `variableMap` and through the same "last enabled wins" rule - the existing `ownAnswer` in `lib/referenced-variables.ts`, exported as `scopeAnswer` so the completion list and the chip that explains a shadowed read share one implementation rather than two that drift. `detail` then reports that scope's own answer, and where that answer is an enabled empty row while another scope holds the value, `describeScopedRead` supplies the sentence - which closes #1196's item 2, unreachable before this change because the trapped name was never offered at all.

**Rejected alternative:** filtering `getVariableOrigins` inside the completion hook. It needs a name list the resolver does not expose, and would put a second copy of "last enabled at this scope" in a hook - the copy that does not receive the primitive's fixes.

**Decisions the issue asked to be recorded:**

- **`sortText` stays `SCOPE_ORDER[scope] + name`.** Inside a single-scope list every entry shares one scope, so that prefix is constant and the key already orders alphabetically by name; a branch dropping it for those lists would order nothing differently. The comment on `SCOPE_ORDER` says so.
- **Disabled definitions are absent, not present-and-empty.** `get` reads enabled rows only, so `scopeAnswer` looks past a disabled row to the enabled one beneath it in the same scope, and a name whose definitions in that scope are all disabled never enters the map - the same treatment `variableMap` gives it.

`pm.variables` (merged), `pm.iterationData`, `replaceIn`'s template mode, the data-column blending and the `$vu` / `$iteration` block are untouched: `mode: "template"` is only ever produced for the merged accessor, so wherever those blocks read `variables` it is still the winner map.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **603 files, 6668 tests, all green**; `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean. No pre-existing failures on the base commit. Engine untouched, so no C++ build or ctest run.

New cases, both layers mutation-checked:

- `useVariableResolver.origins.test.tsx` (+7, against the real queries): a shadowed definition survives in its own scope's map while the ladder still reports the environment; the leaf collection beats its ancestor; a disabled row is looked past to the enabled one beneath it; a name whose every definition in that scope is disabled is absent; an empty-but-enabled row is kept, because it answers the read; the bound row never appears, not being a scope.
- `variable-completion-scope.test.tsx` (+6): the shadowed name is offered under `pm.collectionVariables.get(`, with the collection's own value as `detail` and `collection - Acme` as its documentation; an empty collection row beside a non-empty environment shows `Empty at collection scope - this read returns ""` and names the environment that holds the value (#1196 item 2); a scope whose own answer resolves stays quiet; a name disabled at that scope, and one only another scope defines, are both absent.

Mutation checks run and confirmed: restoring the winner-map filter fails exactly the three shadowing cases, and dropping `scopeAnswer`'s `enabled` check fails the two disabled-row cases.

The three suites that stub the resolver now derive its three views from one fixture of per-scope definitions (`lib/scoped-variables.testkit.ts`), so a case cannot describe a scope map that disagrees with the merged one - a state the real resolver cannot be in. One pre-existing assertion in `script-completion-split.test.tsx` moved off `suggestions[0]` to a lookup by label: it was about brace-closing, not about which entry the merged list builds first.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commits: `docs/app/variable-resolution.md` gains a `getScopeVariables(scope)` reference section and the autocomplete bullet stating the new rule and what `detail` shows (its "offers exactly what the call resolves" line is now "what the call reads", which is the distinction this fix turns on); `docs/app/COMPONENTS.md`'s #1196 paragraph records that the same signal now appears at typing time.

Noted rather than filed, per the repo's rule that a follow-up earns an issue only when it changes what the app does: `useVariableCompletionProvider.ts` (the body `{{` list) still spells the `secret` / `(empty)` detail inline, the same two-line formula this hook now names as `valueDetail`. Worth folding together on the next change that touches both providers; it changes nothing a user sees today. The `sourceLabel` half of that duplication *is* fixed here - the hook calls the existing helper instead of rebuilding `environment - Staging` beside it.

## Related Issues
Closes #1302