### PR TITLE
fix(app): let a restart the user asked for read as a start, not a failure - #1227

### DIFF
--- a/app/src/components/layout/Dock.pending-restart.test.tsx
+++ b/app/src/components/layout/Dock.pending-restart.test.tsx
@@ -52,6 +52,7 @@ beforeEach(() => {
 	useEngineStore.setState({
 		engineStatus: "connected",
 		engineError: null,
+		engineStartWindow: null,
 		pendingRestart: false,
 		restartRequiredKeys: [],
 	});
@@ -108,5 +109,43 @@ describe("the Dock's pending-restart signal", () => {
 		// a failed restart must not clear it.
 		expect(useEngineStore.getState().pendingRestart).toBe(true);
 		expect(signal()).not.toBeNull();
+	});
+});
+
+/**
+ * The other half of #1227's seam.
+ *
+ * The health poll classifies a failed poll against the engine store's start
+ * window (`queries/health.ts`), and a restart is a cold start - the daemon is
+ * killed and a fresh one repeats the whole startup with the port down. So the
+ * restart has to open that window, and close it again if the main process says
+ * no engine is coming up after all. Asserted on the store rather than on the
+ * label, because the poll that turns it into a label does not run here; the two
+ * meet in `Dock.restart-status.test.tsx`.
+ */
+describe("the restart's own start window", () => {
+	it("opens before the engine is killed, so the poll reads a cold start", async () => {
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
+		renderDock();
+
+		fireEvent.click(signal()!);
+
+		await waitFor(() => expect(restartEngine).toHaveBeenCalledTimes(1));
+		// Opened by the click, not by the outcome: the port is already down while
+		// the IPC call is still in flight.
+		expect(useEngineStore.getState().engineStartWindow).not.toBeNull();
+	});
+
+	it("closes again when the main process reports the restart failed", async () => {
+		restartEngine.mockResolvedValue({ success: false, error: "engine did not come back" });
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
+		renderDock();
+
+		fireEvent.click(signal()!);
+
+		await waitFor(() => expect(useToastStore.getState().toasts.length).toBe(1));
+		// Nothing is starting, so the next failed poll owes the user its reason
+		// rather than a spinner over an engine nobody is bringing up.
+		expect(useEngineStore.getState().engineStartWindow).toBeNull();
 	});
 });

--- a/app/src/components/layout/Dock.restart-status.test.tsx
+++ b/app/src/components/layout/Dock.restart-status.test.tsx
@@ -38,6 +38,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { Dock } from "./Dock";
 import { useHealthQuery } from "@/queries/health";
+import { queryKeys } from "@/queries/keys";
 import { useEngineStore } from "@/stores";
 
 // The Dock prints the app version, which Vite `define`s at build time.
@@ -115,6 +116,79 @@ describe("the Dock during a restart the user asked for", () => {
 		expect(reasonAffordance()).toBeNull();
 		// The spinner the contradiction stood beside is still up.
 		expect(screen.getByRole("button", { name: /Restarting…/i })).toBeTruthy();
+	});
+
+	it("is not talked out of the window by an answer from the engine it just killed", async () => {
+		// The poll can have a question already out when the click lands, and that
+		// answer describes the process the restart is about to kill. Letting it
+		// close the window opened a moment earlier would put the next failed poll
+		// back on the unreachable path - the exact contradiction this file exists
+		// to prevent, reached the long way round.
+		getHealth.mockResolvedValueOnce({ status: "ok", version: "1.0.0", workers: 8 });
+		restartEngine.mockReturnValue(new Promise(() => {}));
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
+
+		const client = makeClient();
+		renderDock(client);
+		await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+
+		// A poll in flight against an engine that is still alive. Held open by
+		// hand: the interleaving is the whole case, so it cannot be left to a
+		// timer.
+		let answerTheOldEngine!: (value: unknown) => void;
+		getHealth.mockReturnValue(
+			new Promise((resolve) => {
+				answerTheOldEngine = resolve;
+			})
+		);
+		const inFlight = client.refetchQueries({ queryKey: queryKeys.health.status() });
+		// The precondition, asserted rather than assumed: a case whose poll had
+		// already settled before the click would prove nothing and still pass.
+		expect(client.getQueryState(queryKeys.health.status())?.fetchStatus).toBe("fetching");
+
+		fireEvent.click(restartButton());
+		await waitFor(() => expect(restartEngine).toHaveBeenCalledTimes(1));
+		expect(useEngineStore.getState().engineStartWindow).not.toBeNull();
+
+		await act(async () => {
+			// A different payload, so structural sharing cannot hide the update.
+			answerTheOldEngine({ status: "ok", version: "1.0.0", workers: 9 });
+			await inFlight;
+		});
+
+		getHealth.mockImplementation(() =>
+			Promise.reject(new Error("connect ECONNREFUSED 127.0.0.1:9876"))
+		);
+		await act(async () => {
+			await client.refetchQueries({ queryKey: queryKeys.health.status() });
+		});
+
+		await waitFor(() => expect(screen.getByText("Starting…")).toBeTruthy());
+		expect(screen.queryByText("Disconnected")).toBeNull();
+	});
+
+	it("does not sit on Starting… over an engine nobody is bringing up", async () => {
+		// A restart the main process reports as failed leaves nothing coming up,
+		// so the strip owes the user its reason again on the next failed poll.
+		getHealth.mockResolvedValueOnce({ status: "ok", version: "1.0.0", workers: 8 });
+		restartEngine.mockResolvedValue({ success: false, error: "engine did not come back" });
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
+
+		const client = makeClient();
+		renderDock(client);
+		await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+
+		getHealth.mockImplementation(() => Promise.reject(new Error("socket hang up")));
+		fireEvent.click(restartButton());
+		await waitFor(() => expect(useEngineStore.getState().engineStartWindow).toBeNull());
+
+		await act(async () => {
+			await client.refetchQueries({ queryKey: queryKeys.health.status() });
+		});
+
+		await waitFor(() => expect(screen.getByText("Disconnected")).toBeTruthy());
+		expect(screen.queryByText("Starting…")).toBeNull();
+		expect(reasonAffordance()).not.toBeNull();
 	});
 
 	it("still says Disconnected, with its reason, when the engine drops on its own", async () => {

--- a/app/src/components/layout/Dock.restart-status.test.tsx
+++ b/app/src/components/layout/Dock.restart-status.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One strip cannot say two things about the same engine (#1227).
+ *
+ * A restart the user asked for kills the daemon and spawns a fresh one that
+ * repeats the whole cold start, with the port down for all of it. The health
+ * poll kept classifying that silence as an engine that had answered and
+ * stopped - so the Dock painted "Disconnected" and a raw transport string
+ * beside its own "Restarting…" spinner, and the louder of the two described a
+ * failure the user had just requested.
+ *
+ * Both halves of the fix meet here, which is why this is a rendered end-to-end
+ * case rather than another store assertion: `useEngineRestart` opens the start
+ * window, `useHealthQuery` classifies the failed poll against it, and the Dock
+ * is what the user actually reads. The second case is the mutation check
+ * pointing the other way - an engine that drops on its own must still owe a
+ * reason, so a window that were simply always open would redden it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const getHealth = vi.fn();
+// Only the health call is stubbed. The Dock's three service lists fail against
+// no engine, which is the state these cases want anyway: nothing is listening.
+vi.mock("@/services/api", () => ({ apiService: { getHealth: () => getHealth() } }));
+
+import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { Dock } from "./Dock";
+import { useHealthQuery } from "@/queries/health";
+import { useEngineStore } from "@/stores";
+
+// The Dock prints the app version, which Vite `define`s at build time.
+vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
+
+const restartEngine = vi.fn();
+
+/** What `App` does: mounts the poll once, above the strip that renders it. */
+function HealthPoll() {
+	useHealthQuery();
+	return null;
+}
+
+function makeClient() {
+	// `retry` belongs to the hook; only the delay between its attempts can be
+	// flattened here, and the default backoff outlasts `waitFor`.
+	return new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+}
+
+function renderDock(client: QueryClient) {
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<HealthPoll />
+				<Dock />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+const restartButton = () => screen.getByRole("button", { name: /Restart pending/i });
+
+/** The affordance `starting` must not grow: the focusable error tooltip. */
+const reasonAffordance = () => document.querySelector("[tabindex='0'] .lucide-info");
+
+beforeEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+	getHealth.mockReset();
+	useEngineStore.setState({
+		engineStatus: "starting",
+		engineError: null,
+		engineStartWindow: null,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+	});
+	restartEngine.mockResolvedValue({ success: true });
+	(window as unknown as { electronAPI: unknown }).electronAPI = { restartEngine };
+});
+
+describe("the Dock during a restart the user asked for", () => {
+	it("says Starting…, not Disconnected, while the engine is coming back", async () => {
+		getHealth.mockResolvedValueOnce({ status: "ok", version: "1.0.0", workers: 8 });
+		// Left pending on purpose: this is the window the user is looking at
+		// *during* the round trip, which is when the port is down.
+		restartEngine.mockReturnValue(new Promise(() => {}));
+		useEngineStore.getState().addRestartRequiredKey("dbCacheSize");
+
+		const client = makeClient();
+		renderDock(client);
+		await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+
+		getHealth.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:9876"));
+		fireEvent.click(restartButton());
+		await waitFor(() => expect(restartEngine).toHaveBeenCalledTimes(1));
+
+		// The poll the restart's own invalidate would have run 1.5s later; nothing
+		// here depends on that wait, only on the port being down when it lands.
+		await act(async () => {
+			await client.refetchQueries();
+		});
+
+		await waitFor(() => expect(screen.getByText("Starting…")).toBeTruthy());
+		expect(screen.queryByText("Disconnected")).toBeNull();
+		expect(reasonAffordance()).toBeNull();
+		// The spinner the contradiction stood beside is still up.
+		expect(screen.getByRole("button", { name: /Restarting…/i })).toBeTruthy();
+	});
+
+	it("still says Disconnected, with its reason, when the engine drops on its own", async () => {
+		// No restart, so no window: the same failed poll has to read the other way.
+		getHealth.mockResolvedValueOnce({ status: "ok", version: "1.0.0", workers: 8 });
+
+		const client = makeClient();
+		renderDock(client);
+		await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+
+		getHealth.mockRejectedValue(new Error("socket hang up"));
+		await act(async () => {
+			await client.refetchQueries();
+		});
+
+		await waitFor(() => expect(screen.getByText("Disconnected")).toBeTruthy());
+		expect(useEngineStore.getState().engineError).toContain("socket hang up");
+		expect(reasonAffordance()).not.toBeNull();
+	});
+});

--- a/app/src/hooks/useEngineRestart.ts
+++ b/app/src/hooks/useEngineRestart.ts
@@ -25,6 +25,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEngineStore, useToastStore } from "@/stores";
+import { queryKeys } from "@/queries/keys";
 import { TIMING } from "@/config/timing";
 
 export function useEngineRestart(): { restart: () => Promise<void>; isRestarting: boolean } {
@@ -59,6 +60,13 @@ export function useEngineRestart(): { restart: () => Promise<void>; isRestarting
 		// classifies, so a restart whose engine never comes back still spends the
 		// window and reaches `unreachable` with its reason, on a cold launch's
 		// budget.
+		//
+		// The poll may already have a question out to the engine about to be
+		// killed, and an answer it sent while alive would report a process that no
+		// longer exists. Since a success closes the window, that straggler would
+		// close this one and hand the failures that follow back to the dead-engine
+		// path. Drop it rather than let it speak for the engine replacing it.
+		await queryClient.cancelQueries({ queryKey: queryKeys.health.status() });
 		openEngineStartWindow(Date.now());
 		try {
 			const result = await window.electronAPI.restartEngine();

--- a/app/src/hooks/useEngineRestart.ts
+++ b/app/src/hooks/useEngineRestart.ts
@@ -10,10 +10,11 @@
  *
  * Two places offer the action - the Settings banner beside the setting that
  * asked for it, and the Dock, which is on screen when Settings is not - and the
- * sequence is the same either way: restart, wait for the daemon to come back,
+ * sequence is the same either way: open a start window so the health poll reads
+ * the coming silence as a cold start, restart, wait for the daemon to come back,
  * refetch everything the old instance answered, then lower the pending flag.
- * A second copy of that would be a second place for the invalidate or the flag
- * to be forgotten.
+ * A second copy of that would be a second place for the invalidate, the window
+ * or the flag to be forgotten.
  *
  * Failure is a toast, not a `window.alert`. The alert this replaced blocked the
  * whole renderer on a modal the user could only dismiss, and from the Dock it
@@ -30,6 +31,8 @@ export function useEngineRestart(): { restart: () => Promise<void>; isRestarting
 	const [isRestarting, setIsRestarting] = useState(false);
 	const queryClient = useQueryClient();
 	const clearRestartRequired = useEngineStore((s) => s.clearRestartRequired);
+	const openEngineStartWindow = useEngineStore((s) => s.openEngineStartWindow);
+	const closeEngineStartWindow = useEngineStore((s) => s.closeEngineStartWindow);
 	const showToast = useToastStore((s) => s.showToast);
 
 	const restart = useCallback(async () => {
@@ -45,9 +48,25 @@ export function useEngineRestart(): { restart: () => Promise<void>; isRestarting
 		}
 
 		setIsRestarting(true);
+		// The engine the health poll is watching is about to be killed and replaced
+		// by one that repeats the whole cold start - orphan reconciliation, inbox
+		// cleanup, the page-reclaim rewrite - with the port down for all of it. Say
+		// so before it happens: without a start window the poll reads that silence
+		// as an engine that answered and stopped, and paints "Disconnected" with a
+		// transport error beside this very button's "Restarting…" (#1227).
+		//
+		// Evidence, not a status. `useHealthQuery` remains the only thing that
+		// classifies, so a restart whose engine never comes back still spends the
+		// window and reaches `unreachable` with its reason, on a cold launch's
+		// budget.
+		openEngineStartWindow(Date.now());
 		try {
 			const result = await window.electronAPI.restartEngine();
 			if (!result.success) {
+				// Nothing is coming up after all. Closing the window puts the next
+				// failed poll back on the unreachable path, so the strip cannot sit
+				// on "Starting…" over an engine nobody is starting.
+				closeEngineStartWindow();
 				showToast({
 					message: `Failed to restart engine: ${result.error ?? "unknown error"}`,
 					variant: "error",
@@ -66,7 +85,13 @@ export function useEngineRestart(): { restart: () => Promise<void>; isRestarting
 		} finally {
 			setIsRestarting(false);
 		}
-	}, [queryClient, clearRestartRequired, showToast]);
+	}, [
+		queryClient,
+		clearRestartRequired,
+		openEngineStartWindow,
+		closeEngineStartWindow,
+		showToast,
+	]);
 
 	return { restart, isRestarting };
 }

--- a/app/src/queries/health.test.ts
+++ b/app/src/queries/health.test.ts
@@ -55,7 +55,12 @@ beforeEach(() => {
 	// Implementation too, not just the call record: a queued `…Once` rejection
 	// left behind by a case that ended early is a failure in the next test.
 	getHealth.mockReset();
-	useEngineStore.setState({ engineStatus: "starting", engineError: null, recovery: null });
+	useEngineStore.setState({
+		engineStatus: "starting",
+		engineError: null,
+		recovery: null,
+		engineStartWindow: null,
+	});
 });
 
 describe("useHealthQuery", () => {
@@ -187,18 +192,16 @@ describe("useHealthQuery - a cold start is not a dead engine", () => {
 		};
 	}
 
-	it("classifies a failed poll by how long the session has been waiting", () => {
-		// The decision itself, without a clock: the hook feeds it the elapsed time.
-		expect(engineStatusAfterFailedPoll(false, 0)).toBe("starting");
-		expect(engineStatusAfterFailedPoll(false, TIMING.ENGINE_STARTUP_GRACE_MS - 1)).toBe(
-			"starting"
-		);
-		expect(engineStatusAfterFailedPoll(false, TIMING.ENGINE_STARTUP_GRACE_MS)).toBe(
-			"unreachable"
-		);
-		// An engine that answered once proved it could serve, so its silence is
-		// news immediately - the grace is for engines that never started.
-		expect(engineStatusAfterFailedPoll(true, 0)).toBe("unreachable");
+	it("classifies a failed poll by how long the engine has been coming up", () => {
+		// The decision itself, without a clock: the hook feeds it both times, and
+		// zero stands in for the moment the window opened.
+		expect(engineStatusAfterFailedPoll(0, 0)).toBe("starting");
+		expect(engineStatusAfterFailedPoll(0, TIMING.ENGINE_STARTUP_GRACE_MS - 1)).toBe("starting");
+		expect(engineStatusAfterFailedPoll(0, TIMING.ENGINE_STARTUP_GRACE_MS)).toBe("unreachable");
+		// No window open means nothing is coming up: an engine that answered proved
+		// it could serve, so its silence is news immediately - the grace is for
+		// engines that have not finished starting.
+		expect(engineStatusAfterFailedPoll(null, 0)).toBe("unreachable");
 	});
 
 	it("records no reason while the launch is inside the grace window", async () => {
@@ -258,6 +261,24 @@ describe("useHealthQuery - a cold start is not a dead engine", () => {
 		expect(useEngineStore.getState().engineError).toContain("socket hang up");
 	});
 
+	it("holds the window open across a poll that never succeeded", async () => {
+		// The window is opened once, on mount, and a launch's repeated failures
+		// must not consume it: only the clock closes it. Without this, a second
+		// failed poll inside the budget could still read `unreachable`.
+		const client = clientWithFastRetries();
+		getHealth.mockRejectedValue(new Error("Network error: fetch failed"));
+
+		const { result } = renderHook(() => useHealthQuery(), { wrapper: wrapperFor(client) });
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("starting"));
+
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		expect(useEngineStore.getState().engineStatus).toBe("starting");
+		expect(useEngineStore.getState().engineStartWindow).not.toBeNull();
+	});
+
 	it("waits exactly as long as the main process waits for the same engine", () => {
 		// Two files that share no module graph (`tsconfig.json` includes `src`,
 		// `tsconfig.node.json` includes `electron`), asking the same question from
@@ -273,5 +294,115 @@ describe("useHealthQuery - a cold start is not a dead engine", () => {
 
 		const budget = /ENGINE_HEALTH_POLL_BUDGET_MS\s*=\s*(\d+)/.exec(constants)?.[1];
 		expect(Number(budget)).toBe(TIMING.ENGINE_STARTUP_GRACE_MS);
+	});
+});
+
+/**
+ * A restart is a cold start too (#1227).
+ *
+ * `useEngineRestart` kills the running engine and spawns a fresh one that
+ * repeats the whole startup housekeeping, with the port down for all of it - so
+ * the poll's failures during that window describe an engine coming up, not one
+ * that died. The seam between the two paths is the store's start window: the
+ * restart opens it, and this is the half that proves the poll reads it. The
+ * other half - that the restart path really does open it - is
+ * `Dock.pending-restart.test.tsx`, and both together are asserted end to end in
+ * `Dock.restart-status.test.tsx`.
+ */
+describe("useHealthQuery - a restart is a cold start", () => {
+	function clientWithFastRetries() {
+		return new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+	}
+
+	function wrapperFor(client: QueryClient) {
+		return function Wrapper({ children }: { children: ReactNode }) {
+			return createElement(QueryClientProvider, { client }, children);
+		};
+	}
+
+	/**
+	 * A refusal per attempt, as the transport really delivers them.
+	 *
+	 * These cases turn on two *consecutive* failed polls reading differently, and
+	 * the hook re-reads a failure when the query hands it a new one. One reused
+	 * `Error` is one unchanged value, so the second poll would never be classified
+	 * at all - a property of the fixture, not of the engine.
+	 */
+	function rejectWith(message: string) {
+		getHealth.mockImplementation(() => Promise.reject(new Error(message)));
+	}
+
+	/** Connect, then hand back the hook with the launch's own window spent. */
+	async function connected(client: QueryClient) {
+		getHealth.mockResolvedValueOnce({ status: "ok", version: "1.0.0", workers: 8 });
+		const { result } = renderHook(() => useHealthQuery(), { wrapper: wrapperFor(client) });
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("connected"));
+		expect(useEngineStore.getState().engineStartWindow).toBeNull();
+		return result;
+	}
+
+	it("calls the silence a start when the app itself asked for the restart", async () => {
+		const client = clientWithFastRetries();
+		const result = await connected(client);
+
+		// What `useEngineRestart` does before it invokes the IPC.
+		useEngineStore.getState().openEngineStartWindow(Date.now());
+		rejectWith("connect ECONNREFUSED 127.0.0.1:9876");
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		// Reverting the re-open reddens this: the poll would see an engine that
+		// answered and stopped, and paint the failure the user themselves asked for.
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("starting"));
+		// The Dock's tooltip hangs off this being null.
+		expect(useEngineStore.getState().engineError).toBeNull();
+	});
+
+	it("still gives up on a restart whose engine never comes back", async () => {
+		const client = clientWithFastRetries();
+		const result = await connected(client);
+
+		const restartedAt = Date.now();
+		const now = vi.spyOn(Date, "now").mockReturnValue(restartedAt);
+		useEngineStore.getState().openEngineStartWindow(restartedAt);
+		rejectWith("connect ECONNREFUSED 127.0.0.1:9876");
+		await act(async () => {
+			await result.current.refetch();
+		});
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("starting"));
+
+		// Same budget as a cold launch, spent from the restart rather than from
+		// the session's start.
+		now.mockReturnValue(restartedAt + TIMING.ENGINE_STARTUP_GRACE_MS + 1);
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("unreachable"));
+		expect(useEngineStore.getState().engineError).toContain("ECONNREFUSED");
+		now.mockRestore();
+	});
+
+	it("goes back to owing a reason once a restart is reported failed", async () => {
+		const client = clientWithFastRetries();
+		const result = await connected(client);
+
+		useEngineStore.getState().openEngineStartWindow(Date.now());
+		rejectWith("socket hang up");
+		await act(async () => {
+			await result.current.refetch();
+		});
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("starting"));
+
+		// What `useEngineRestart` does when the main process reports failure:
+		// nothing is coming up, so the strip must not sit on "Starting…".
+		useEngineStore.getState().closeEngineStartWindow();
+		await act(async () => {
+			await result.current.refetch();
+		});
+
+		await waitFor(() => expect(useEngineStore.getState().engineStatus).toBe("unreachable"));
+		expect(useEngineStore.getState().engineError).toContain("socket hang up");
 	});
 });

--- a/app/src/queries/health.ts
+++ b/app/src/queries/health.ts
@@ -34,12 +34,19 @@ export function healthPollIntervalMs(status: "error" | "pending" | "success"): n
 }
 
 /**
- * What a failed poll means, given the launch it failed on.
+ * What a failed poll means, given the start it failed on.
  *
  * A refused connection is the same transport error either way, so the failure
- * itself cannot tell a cold start from a dead engine - only its place in the
- * session can. An engine that answered once and stopped is unreachable
- * immediately, with no grace: it proved it could serve, so its silence is news.
+ * itself cannot tell an engine coming up from one that is not coming - only
+ * whether a start is in flight can. `windowOpenedAt` is `null` when none is, and
+ * an engine that answered with nothing starting is unreachable immediately, with
+ * no grace: it proved it could serve, so its silence is news.
+ *
+ * Judged against the window rather than against the session's own age, because
+ * the app itself restarts the engine (`useEngineRestart`) and the process that
+ * comes back does the same cold-start work as the first one. Reading the session
+ * instead called every restart a failure, since an engine had answered - the one
+ * this one replaced (#1227).
  *
  * Derived here rather than pushed from the main process. `sidecar.ts` knows more
  * precisely - it holds the child handle and raises `EngineNotReadyError` on the
@@ -48,11 +55,11 @@ export function healthPollIntervalMs(status: "error" | "pending" | "success"): n
  * source of truth for one label.
  */
 export function engineStatusAfterFailedPoll(
-	hasEverConnected: boolean,
-	msSinceMount: number
+	windowOpenedAt: number | null,
+	now: number
 ): "starting" | "unreachable" {
-	if (hasEverConnected) return "unreachable";
-	return msSinceMount < TIMING.ENGINE_STARTUP_GRACE_MS ? "starting" : "unreachable";
+	if (windowOpenedAt === null) return "unreachable";
+	return now - windowOpenedAt < TIMING.ENGINE_STARTUP_GRACE_MS ? "starting" : "unreachable";
 }
 
 /**
@@ -60,29 +67,34 @@ export function engineStatusAfterFailedPoll(
  * Updates engine store with connection status
  */
 export function useHealthQuery() {
-	const { setEngineStatus, setEngineError, setEngineRecovery } = useEngineStore();
+	const {
+		setEngineStatus,
+		setEngineError,
+		setEngineRecovery,
+		openEngineStartWindow,
+		closeEngineStartWindow,
+	} = useEngineStore();
 	const queryClient = useQueryClient();
 
 	/**
-	 * When this session started counting, and whether the engine has ever
-	 * answered it - the two facts that separate a cold start from a dead engine.
+	 * The launch's own start window, opened where the wait actually begins.
 	 *
-	 * Mount is the right zero: the hook is mounted once by `App`, at first paint,
-	 * which is when the main process spawned the engine and started spending its
-	 * own budget on the same wait. Stamped in an effect rather than in the render
-	 * that declares the ref, because a clock read during render is impure
+	 * Mount is the right moment: the hook is mounted once by `App`, at first
+	 * paint, which is when the main process spawned the engine and started
+	 * spending its own budget on the same wait. Opened in an effect rather than
+	 * in render, because a clock read during render is impure
 	 * (`react-hooks/purity`) - and nothing can have polled before this runs,
 	 * provided this effect stays declared ahead of the sync effect below. In the
-	 * other order a launch's first failure would measure against zero, land far
-	 * past the grace window, and report the failure this issue exists to hide -
-	 * which is what "records no reason…" in `health.test.ts` catches.
+	 * other order a launch's first failure would find no window open at all and
+	 * report the failure this exists to hide - which is what "records no
+	 * reason…" in `health.test.ts` catches.
+	 *
+	 * The window lives in the engine store rather than in a ref here, because the
+	 * restart path opens one too (#1227); see `engine-store.ts`.
 	 */
-	const mountedAt = useRef(0);
-	const hasEverConnected = useRef(false);
-
 	useEffect(() => {
-		mountedAt.current = Date.now();
-	}, []);
+		openEngineStartWindow(Date.now());
+	}, [openEngineStartWindow]);
 
 	/**
 	 * Set by a poll that failed, cleared by the recovery it earns.
@@ -108,7 +120,9 @@ export function useHealthQuery() {
 	// Sync query state with app store
 	useEffect(() => {
 		if (query.isSuccess && query.data?.status === "ok") {
-			hasEverConnected.current = true;
+			// Whatever start this poll was waiting on is over; from here a silence
+			// is an engine that stopped rather than one that has not arrived.
+			closeEngineStartWindow();
 			setEngineStatus("connected");
 			setEngineError(null);
 			// Absent means a clean start, so it clears rather than being left
@@ -133,9 +147,15 @@ export function useHealthQuery() {
 			}
 		} else if (query.isError) {
 			sawDisconnect.current = true;
+			// Read, not subscribed. A window opened while the query's last state is
+			// still a success - which is exactly what a restart does - would re-run
+			// this effect into the branch above and close the window it had just
+			// opened. So the window is consulted when a poll settles, and the poll
+			// after it is what re-reads a window that closed meanwhile; a failing
+			// poll is already on the fast cadence.
 			const status = engineStatusAfterFailedPoll(
-				hasEverConnected.current,
-				Date.now() - mountedAt.current
+				useEngineStore.getState().engineStartWindow,
+				Date.now()
 			);
 			setEngineStatus(status);
 			// A launch still inside the grace window has nothing to report yet, and
@@ -156,6 +176,7 @@ export function useHealthQuery() {
 		setEngineStatus,
 		setEngineError,
 		setEngineRecovery,
+		closeEngineStartWindow,
 		queryClient,
 	]);
 

--- a/app/src/stores/engine-store.ts
+++ b/app/src/stores/engine-store.ts
@@ -24,12 +24,13 @@ import type { EngineRecovery } from "@/types/domain";
  * launch condition as well as a crash. One flag made both wear the crash's
  * wording and its error affordance, from first paint, on every launch.
  *
- * - `starting` - no poll has ever succeeded, and the engine is still inside the
- *   budget the main process gives a cold one. Says nothing is wrong yet.
+ * - `starting` - no poll has succeeded since the engine now coming up began
+ *   coming up, and it is still inside the budget the main process gives a cold
+ *   one. Says nothing is wrong yet.
  * - `connected` - a poll answered `ok`.
  * - `unreachable` - a poll failed after that budget was spent, or an engine that
- *   had answered before stopped answering. This is the state that owes the user
- *   a reason, and `engineError` carries it.
+ *   had answered stopped answering with no start in flight. This is the state
+ *   that owes the user a reason, and `engineError` carries it.
  */
 export type EngineStatus = "starting" | "connected" | "unreachable";
 
@@ -57,6 +58,29 @@ interface EngineState {
 	 */
 	recovery: EngineRecovery | null;
 
+	/**
+	 * When the engine that is currently coming up began coming up, or `null` when
+	 * none is - the evidence a failed poll is classified against.
+	 *
+	 * It is a window rather than a "has ever connected" flag because a cold start
+	 * is not only the app's first (issue #1227). `useEngineRestart` kills the
+	 * running engine and spawns a fresh one that repeats the whole startup
+	 * housekeeping the budget exists for, with the port down for all of it; a
+	 * flag would call that silence a failure, on the evidence of an engine that
+	 * no longer exists.
+	 *
+	 * Opened by whoever knows an engine is starting: the health poll on mount,
+	 * which is when the main process spawns the first one, and the restart path,
+	 * which spawns the next. Closed by the poll an engine answers, and by a
+	 * restart the main process reports as failed - after which nothing is coming
+	 * up and a silent port owes the user its reason again.
+	 *
+	 * Kept here rather than in `useHealthQuery`'s refs, where it lived until
+	 * #1227, because the restart path has to reach it. Deliberately evidence and
+	 * not a status: the poll stays the only thing that classifies.
+	 */
+	engineStartWindow: number | null;
+
 	// Restart required notification
 	pendingRestart: boolean;
 	restartRequiredKeys: string[]; // Keys of configs that were changed and require restart
@@ -65,6 +89,8 @@ interface EngineState {
 	setEngineStatus: (status: EngineStatus) => void;
 	setEngineError: (error: string | null) => void;
 	setEngineRecovery: (recovery: EngineRecovery | null) => void;
+	openEngineStartWindow: (openedAt: number) => void;
+	closeEngineStartWindow: () => void;
 
 	// Restart actions
 	addRestartRequiredKey: (key: string) => void;
@@ -77,6 +103,9 @@ export const useEngineStore = create<EngineState>()((set) => ({
 	engineStatus: "starting",
 	engineError: null,
 	recovery: null,
+	// Closed until the health poll mounts and opens it. Nothing can have polled
+	// before that, and a window left open here would be one no engine is inside.
+	engineStartWindow: null,
 	pendingRestart: false,
 	restartRequiredKeys: [],
 
@@ -84,6 +113,8 @@ export const useEngineStore = create<EngineState>()((set) => ({
 	setEngineStatus: (status) => set({ engineStatus: status }),
 	setEngineError: (error) => set({ engineError: error }),
 	setEngineRecovery: (recovery) => set({ recovery }),
+	openEngineStartWindow: (openedAt) => set({ engineStartWindow: openedAt }),
+	closeEngineStartWindow: () => set({ engineStartWindow: null }),
 
 	// Restart actions
 	addRestartRequiredKey: (key) =>

--- a/app/src/stores/engine-store.ts
+++ b/app/src/stores/engine-store.ts
@@ -75,6 +75,14 @@ interface EngineState {
 	 * restart the main process reports as failed - after which nothing is coming
 	 * up and a silent port owes the user its reason again.
 	 *
+	 * A window nobody closes is spent rather than cleared: an engine that simply
+	 * never arrives leaves its opening time here, expired. So this is not a "is
+	 * something starting" flag and must not be read as one - only
+	 * `engineStatusAfterFailedPoll` interprets it, and an expired timestamp and a
+	 * `null` mean the same thing to it. Clearing it on expiry would need a writer
+	 * watching a clock nothing else watches, to say what the timestamp already
+	 * says.
+	 *
 	 * Kept here rather than in `useHealthQuery`'s refs, where it lived until
 	 * #1227, because the restart path has to reach it. Deliberately evidence and
 	 * not a status: the poll stays the only thing that classifies.

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1420,11 +1420,23 @@ localhost never changes - so nothing else would ever revisit their error state
 once the engine came back.
 
 A failed poll does not mean `engineStatus` becomes `unreachable` outright:
-`engineStatusAfterFailedPoll` (`queries/health.ts`) reads `starting` for a
-launch whose engine has never yet answered and is still inside
-`TIMING.ENGINE_STARTUP_GRACE_MS` (45s) of its own mount, and `unreachable`
+`engineStatusAfterFailedPoll` (`queries/health.ts`) reads `starting` while an
+engine is known to be coming up and is still inside
+`TIMING.ENGINE_STARTUP_GRACE_MS` (45s) of the moment it began, and `unreachable`
 otherwise - past that window, or after an engine that had answered stops
-answering. That 45s is the same budget the main process spends on a cold
+answering with nothing starting. The moment it began is `engineStartWindow` on
+`engine-store`, opened by this hook on mount - which is when the main process
+spawns the engine and starts spending its own budget on the same wait - and
+again by `useEngineRestart` before it invokes the restart IPC, because a restart
+kills the daemon and spawns a fresh one that repeats the whole cold start with
+the port down for all of it (#1227). Measuring from the hook's mount alone
+called every such restart a failure, since an engine had answered: the one this
+one replaced. The restart opens the window and never writes `engineStatus`, so
+this hook remains the only thing that classifies; a restart the main process
+reports as failed closes the window again, and the next failed poll goes back
+to owing the user its reason.
+
+That 45s is the same budget the main process spends on a cold
 engine before it gives up and logs `EngineNotReadyError`
 (`ENGINE_HEALTH_POLL_BUDGET_MS` in `electron/constants.ts`) - it is the same
 question asked from the other side of the process boundary - and since the

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -432,6 +432,7 @@ Merged store managing engine connection status and restart-required notification
   engineStatus: EngineStatus  // "starting" | "connected" | "unreachable"
   engineError: string | null
   recovery: EngineRecovery | null  // What the engine's startup did to the database
+  engineStartWindow: number | null  // When the engine now coming up began, or null
   pendingRestart: boolean
   restartRequiredKeys: string[]  // Config keys requiring restart
 }
@@ -443,6 +444,7 @@ const {
   engineStatus, setEngineStatus,
   engineError, setEngineError,
   recovery, setEngineRecovery,
+  engineStartWindow, openEngineStartWindow, closeEngineStartWindow,
   pendingRestart, addRestartRequiredKey, clearRestartRequired,
 } = useEngineStore();
 ```
@@ -452,15 +454,28 @@ written by the same poll that writes `engineError` and read by `RecoveryBanner`.
 `null` is a clean start; a value means the engine restored the database from its
 backup or deleted it as unrecoverable.
 
-`engineStatus` is `starting` while no poll has yet succeeded and the launch is
-still inside its grace window, `connected` once a poll has answered `ok`, and
-`unreachable` once a poll fails past that window or an engine that had
-answered stops answering. `engineError` is what the failed health poll
-recorded (`queries/health.ts`), and it is `null` in every state but
-`unreachable`: a launch still inside its grace window has no failure to report.
-The Dock's connection indicator renders it in a tooltip, for `unreachable`
-alone - "Disconnected" on its own read the same for a refused connection, a
-timeout and a TLS failure.
+`engineStatus` is `starting` while no poll has succeeded since the engine now
+coming up began coming up and it is still inside its grace window, `connected`
+once a poll has answered `ok`, and `unreachable` once a poll fails past that
+window or an engine that had answered stops answering with nothing starting.
+`engineError` is what the failed health poll recorded (`queries/health.ts`), and
+it is `null` in every state but `unreachable`: an engine still inside its grace
+window has no failure to report. The Dock's connection indicator renders it in a
+tooltip, for `unreachable` alone - "Disconnected" on its own read the same for a
+refused connection, a timeout and a TLS failure.
+
+`engineStartWindow` is the evidence that decision is made against: the moment
+the engine now coming up began coming up, or `null` when none is. It is a
+window rather than a "has ever connected" flag because a cold start is not only
+the app's first (#1227) - `useEngineRestart` kills the running engine and spawns
+a fresh one that repeats the whole startup housekeeping, with the port down for
+all of it, and a flag called that silence a failure on the evidence of an engine
+that no longer existed. **Two paths open it - `useHealthQuery` on mount and the
+restart path before it invokes the IPC - and it is deliberately evidence rather
+than a status, so `useHealthQuery` stays the only writer of `engineStatus`.** It
+is closed by the poll an engine answers, and by a restart the main process
+reports as failed, after which the next failed poll owes the user its reason
+again.
 
 **Non-persisted** (cleared on app restart).
 
@@ -1357,7 +1372,9 @@ into a pane that can never load on every restart.
 - **`useHealthQuery()`** - Health check, polled every
   `TIMING.HEALTH_CHECK_INTERVAL_MS`; it is what sets `engineStatus` /
   `engineError` on `engine-store`, and is where the starting-vs-unreachable
-  decision gets made, so the connection indicator follows it
+  decision gets made, so the connection indicator follows it. It reads that
+  decision off `engineStartWindow`, which `useEngineRestart` also opens - the
+  restart supplies the evidence, the poll still does the classifying
 - **`useConfigQuery()`** / **`useUpdateConfigMutation()`** - Engine configuration
   (`QUERY_CACHE.CONFIG_STALE_TIME_MS`); also the home of the live chart window,
   which is engine config rather than a renderer preference

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -475,7 +475,11 @@ restart path before it invokes the IPC - and it is deliberately evidence rather
 than a status, so `useHealthQuery` stays the only writer of `engineStatus`.** It
 is closed by the poll an engine answers, and by a restart the main process
 reports as failed, after which the next failed poll owes the user its reason
-again.
+again. A window nobody closes is spent rather than cleared - an engine that
+never arrives leaves its opening time in place, expired - so this is not an "is
+something starting" flag and must not be read as one: only
+`engineStatusAfterFailedPoll` interprets it, and to that an expired timestamp
+and a `null` mean the same thing.
 
 **Non-persisted** (cleared on app restart).
 


### PR DESCRIPTION
## Description

A manual engine restart kills the daemon and spawns a fresh one that repeats the whole cold start - orphan reconciliation, inbox cleanup, the page-reclaim rewrite - with the port down for all of it. #1164's rule classified the poll failures that follow off a `hasEverConnected` ref, and an engine *had* answered, so the silence read as `unreachable`: the Dock painted "Disconnected" plus a raw transport string in a focusable tooltip, directly beside its own "Restarting…" spinner. One strip, two contradictory claims, and the louder one described a failure the user had just requested.

**Root cause:** the grace window was measured from `useHealthQuery`'s mount and gated by a "has ever connected" ref, both private to the hook. That encodes "a cold start is the app's first one", which stopped being true once the app could restart the engine itself.

**Approach:** move the two refs out of the hook and into the engine store as one fact - `engineStartWindow: number | null`, the moment the engine now coming up began, or `null` when none is. A window rather than a flag, because a flag calls the second cold start a failure on the evidence of an engine that no longer exists. `useHealthQuery` opens it on mount, where the wait actually begins, and closes it on the poll an engine answers; `useEngineRestart` opens it before invoking the IPC and closes it again if the main process reports the restart failed. The restart supplies *evidence*, never a status, so `useHealthQuery` remains the only writer of `engineStatus` (AC4) and a restart whose engine never returns still spends the window and reaches `unreachable` with its reason on a cold launch's budget.

**Alternative rejected:** a `beginEngineRestart()` action that sets `engineStatus: "starting"` directly, the other shape the issue names. It makes `useEngineRestart` a second writer of `engineStatus` racing the poll that is still running (1s error cadence against the 1.5s restart wait), and it would have to clear `engineError` in the same breath to keep the documented invariant that only `unreachable` carries a reason. Writing the evidence instead leaves one classifier and one place that pairs status with reason.

Two implementation notes worth a reviewer's eye:

- The sync effect **reads** the window (`useEngineStore.getState()`) rather than subscribing to it. A window opened while the query's last settled state is still a success would re-run that effect into its success branch and close the window it had just opened. So the window is consulted when a poll settles, and the poll after it re-reads a window that closed meanwhile; a failing poll is already on the 1s cadence.
- The restart **cancels the health poll in flight** before opening the window. Without that there is a second route back to the original bug: the poll can have a question already out when the click lands, and that answer - sent by the engine about to be killed - closes the window the click just opened, handing every failure that follows back to the dead-engine path. This is not theoretical; it is reproduced by a rendered case in this PR (see below). The invalidate the restart already runs brings the poll back once the new engine is up.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **604 files, 6678 tests, all passing.** `pnpm type-check`, `pnpm lint` and `pnpm format:check` all clean. No engine change, so no C++ build or ctest run: the issue scopes this to `app/` and the diff touches nothing under `engine/`. No pre-existing failures observed.

New coverage, each mutation-checked (the mutation was applied, the failure observed, the code restored):

- `queries/health.test.ts` - a new "a restart is a cold start" block: a failed poll under a re-opened window is `starting` with no reason; that window still expires into `unreachable` **with** its reason on the same 45s budget; and a window closed by a failed restart puts the next failed poll back on the unreachable path. Plus a case pinning that repeated failures inside one window do not consume it, and the classifier's truth table updated for the new signature.
- `components/layout/Dock.pending-restart.test.tsx` - the restart path opens the window before the engine is killed (on the click, not on the outcome), and closes it when the main process reports failure.
- `components/layout/Dock.restart-status.test.tsx` (new) - four rendered end-to-end cases, because this is where the two halves meet: real `useHealthQuery` + real `Dock`. (1) Click Restart, let the poll fail, and the strip says "Starting…" with no `Disconnected` and no reason affordance while the spinner is still up. (2) The in-flight-poll race above. (3) A restart reported failed goes to "Disconnected" with its reason rather than sitting on "Starting…". (4) The mutation check pointing the other way - an engine that drops on its own must still say "Disconnected" with its reason, so a window that were simply always open would redden it.

Mutation results: removing the restart's `openEngineStartWindow` reddens 2 cases; removing the failed-restart `closeEngineStartWindow` reddens 1; removing the success-path close reddens 5; removing the `cancelQueries` reddens the race case.

Two fixture details found along the way, both documented in the tests because each is a way for a case to pass while proving nothing:

- The new cases turn on two *consecutive* failed polls classifying differently, and the sync effect re-reads a failure only when the query hands it a new one. A single reused `Error` instance is one unchanged dependency, so those cases build a fresh rejection per attempt, as the transport really delivers them.
- The race case asserts its own precondition - the health query is `fetchStatus: "fetching"` when the click lands. A first version of it used an unfiltered `refetchQueries`, left the poll settled before the click, and passed green against the unfixed code. That is how the race stayed hidden on the first attempt, so the precondition is now asserted rather than assumed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commits, per CLAUDE.md: `docs/app/state-management.md` (the engine store's shape, the new field, its two openers, and the fact that an expired window is spent rather than cleared - so it is not an "is something starting" flag) and `docs/app/api-integration.md`'s Health Checking section, which stated the grace window was measured from the hook's own mount - no longer true.

Not filed as follow-ups, since neither changes what the app does: `app/electron/mcp/tools.ts`'s `get_engine_health` polls the engine directly from the main process and is untouched by a renderer-store change (it already tolerates a mid-restart engine); and `useEngineRestart`'s `isRestarting` is per-mount `useState`, so a restart started from the Dock leaves Settings' own spinner down - both pre-existing and out of this issue's scope.

## Related Issues
Closes #1227
