### PR TITLE
feat(app): state the variable resolution model, and answer which value wins

### DIFF
--- a/app/electron/mcp/resources.test.ts
+++ b/app/electron/mcp/resources.test.ts
@@ -16,7 +16,12 @@
 
 import { describe, expect, test, vi } from "vitest";
 import { STATIC_RESOURCES, projectScriptingSurface, projectScriptingTypes } from "./resources.js";
-import type { ToolContext } from "./tools.js";
+import { TOOLS, type ToolContext } from "./tools.js";
+import {
+	VARIABLE_PRECEDENCE_SENTENCE,
+	VARIABLE_RESOLUTION_MODEL,
+	VARIABLE_RESOLUTION_URI,
+} from "./variable-origins.js";
 import type { EngineClient } from "./engine-client.js";
 
 /** One completion in the engine's shape - Monaco fields and all. */
@@ -275,5 +280,84 @@ describe("vayu://runs description", () => {
 
 	test("points at the pagination fields that carry the real count", () => {
 		expect(runsResource().description).toMatch(/pagination\.total/);
+	});
+});
+
+describe("the variable resolution resource", () => {
+	const resource = () => {
+		const r = STATIC_RESOURCES.find((s) => s.uri === VARIABLE_RESOLUTION_URI);
+		if (!r) throw new Error("variable resolution resource is not registered");
+		return r;
+	};
+
+	const read = async () =>
+		(await resource().read({} as ToolContext)) as typeof VARIABLE_RESOLUTION_MODEL;
+
+	test("is registered and needs no engine call to answer", async () => {
+		// A rules document, not current state: it must not fail with the engine
+		// down, which is exactly when an agent is reading about resolution.
+		await expect(resource().read({} as ToolContext)).resolves.toBeDefined();
+	});
+
+	test("states the four tiers, in order, once", async () => {
+		const model = await read();
+		expect(model.tiers.map((t) => t.scope)).toEqual([
+			"global",
+			"collection",
+			"environment",
+			"row",
+		]);
+		// Ranks ascend with precedence, so a client sorting by rank gets the
+		// ladder rather than declaration order.
+		expect(model.tiers.map((t) => t.rank)).toEqual([1, 2, 3, 4]);
+	});
+
+	test("every tier names the tools that write it, and those tools exist", async () => {
+		const model = await read();
+		const toolNames = new Set(TOOLS.map((t) => t.name));
+		const named = model.tiers.flatMap((t) => [...t.writtenBy, ...t.readBy]);
+		// "Written but never read" in reverse: a tool named here that no longer
+		// exists sends an agent to a call it cannot make.
+		expect(named.length).toBeGreaterThan(0);
+		for (const name of named) expect(toolNames, name).toContain(name);
+	});
+
+	test("carries the rules a winner alone cannot express", async () => {
+		const model = await read();
+		const rules = model.rules.join(" ");
+		// Mutation check: drop any one of these rules and its line fails.
+		expect(rules).toMatch(/only an explicit `enabled: false` disables/i);
+		expect(rules).toMatch(/non-string stored `value` reads as the empty string/i);
+		expect(rules).toMatch(/absent, not present-and-empty/i);
+	});
+
+	test("names the reserved namespaces, and the $vu / $guid split", async () => {
+		const model = await read();
+		const patterns = model.reservedNamespaces.map((n) => n.pattern);
+		expect(patterns.some((p) => p.includes("data."))).toBe(true);
+		expect(patterns.some((p) => p.includes("$vu"))).toBe(true);
+
+		const vu = model.reservedNamespaces.find((n) => n.pattern.includes("$vu"))!;
+		const guid = model.reservedNamespaces.find((n) => n.pattern.includes("$guid"))!;
+		// The two behave oppositely and the docs say so: a variable named $vu
+		// does not answer for the identity, a variable named $guid does win.
+		expect(vu.rule).toMatch(/does not answer/i);
+		expect(guid.rule).toMatch(/DOES win|does win/i);
+	});
+
+	test("describes the scoped-vs-merged script read, the #1196 footgun", async () => {
+		const model = await read();
+		expect(model.fromAScript.scoped).toMatch(/do not fall through/i);
+		expect(model.fromAScript.merged).toMatch(/stopping at the first scope/i);
+		expect(model.fromAScript.chain).toMatch(/whole chain/i);
+	});
+
+	test("the environments resource points at the model rather than restating it", () => {
+		const environments = STATIC_RESOURCES.find((s) => s.uri === "vayu://environments");
+		expect(environments?.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
+		expect(environments?.description).toContain(VARIABLE_RESOLUTION_URI);
+		// The fact the old one-liner omitted, and the reason an agent wrote to
+		// the wrong environment.
+		expect(environments?.description).toMatch(/isActive/);
 	});
 });

--- a/app/electron/mcp/resources.test.ts
+++ b/app/electron/mcp/resources.test.ts
@@ -322,6 +322,18 @@ describe("the variable resolution resource", () => {
 		for (const name of named) expect(toolNames, name).toContain(name);
 	});
 
+	test("names where resolution actually runs, so the model is not read as MCP's own", async () => {
+		const model = await read();
+		expect(model.resolvedBy).toMatch(/POST \/compose/);
+		expect(model.resolvedBy).toMatch(/conformance fixture|shared conformance/i);
+	});
+
+	test("the collections resource points at the model too, not just environments", () => {
+		const collections = STATIC_RESOURCES.find((s) => s.uri === "vayu://collections");
+		expect(collections?.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
+		expect(collections?.description).toContain(VARIABLE_RESOLUTION_URI);
+	});
+
 	test("carries the rules a winner alone cannot express", async () => {
 		const model = await read();
 		const rules = model.rules.join(" ");

--- a/app/electron/mcp/resources.ts
+++ b/app/electron/mcp/resources.ts
@@ -59,7 +59,13 @@ export const STATIC_RESOURCES: StaticResourceDef[] = [
 		name: "collections",
 		uri: "vayu://collections",
 		title: "Collections",
-		description: "All request collections.",
+		// The same correction the environments row needed: each collection
+		// carries variables, and a request resolves against its whole ancestor
+		// chain rather than the one collection it sits in.
+		description:
+			"All request collections, each with its own `variables`. A request resolves against the whole chain from the root down, and a nested collection outranks its ancestors. " +
+			VARIABLE_PRECEDENCE_SENTENCE +
+			` Full model: ${VARIABLE_RESOLUTION_URI}.`,
 		read: (ctx, signal) => ctx.client.listCollections(signal),
 	},
 	{

--- a/app/electron/mcp/resources.ts
+++ b/app/electron/mcp/resources.ts
@@ -21,6 +21,11 @@
  */
 
 import type { ToolContext } from "./tools.js";
+import {
+	VARIABLE_PRECEDENCE_SENTENCE,
+	VARIABLE_RESOLUTION_MODEL,
+	VARIABLE_RESOLUTION_URI,
+} from "./variable-origins.js";
 
 export interface StaticResourceDef {
 	name: string;
@@ -61,8 +66,27 @@ export const STATIC_RESOURCES: StaticResourceDef[] = [
 		name: "environments",
 		uri: "vayu://environments",
 		title: "Environments",
-		description: "All environments (named variable sets).",
+		// Which one is active matters more than the list does: it is the tier
+		// that shadows every collection and global, and `isActive` on a row is
+		// the only thing that says which. An agent that reads this as an
+		// unordered set of "named variable sets" writes to the wrong one.
+		description:
+			"All environments (named variable sets). The row with `isActive: true` is the one requests resolve against when a call names no environmentId, and it outranks the collection chain and globals. " +
+			VARIABLE_PRECEDENCE_SENTENCE +
+			` Full model: ${VARIABLE_RESOLUTION_URI}.`,
 		read: (ctx, signal) => ctx.client.listEnvironments(signal),
+	},
+	{
+		name: "variable-resolution",
+		uri: VARIABLE_RESOLUTION_URI,
+		title: "Variable resolution model",
+		// The one resource here that describes rules rather than current state.
+		// It exists because the rules were discoverable only by reading two tool
+		// descriptions that happened to mention them, and never at the tools
+		// that change a value (issue #1207).
+		description:
+			"How {{variables}} resolve: the tier order, what a disabled or non-string definition does, the reserved namespaces (data.*, $vu/$iteration, the dynamic generators), and what a script's scoped and merged reads see. Read this before writing a variable - the tier you write to may be shadowed by one above it.",
+		read: async () => VARIABLE_RESOLUTION_MODEL,
 	},
 	{
 		name: "engine-config",

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -29,6 +29,7 @@ import {
 	type ToolContext,
 } from "./tools.js";
 import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
+import { VARIABLE_PRECEDENCE_SENTENCE, VARIABLE_RESOLUTION_URI } from "./variable-origins.js";
 import {
 	DEFAULT_RUN_PAGE_LIMIT,
 	EngineRequestError,
@@ -8114,5 +8115,265 @@ describe("OpenAPI spec binding tools", () => {
 		// Each call mints a new document row, so the same arguments twice is not
 		// the same call twice.
 		expect(tools.get("bind_spec")?.annotations.idempotentHint).toBe(false);
+	});
+});
+
+describe("variable precedence is stated wherever a variable is written or listed", () => {
+	/**
+	 * The surfaces an agent reaches when it changes or surveys a value. Before
+	 * issue #1207 the resolution order appeared in `run_request` and
+	 * `get_globals` alone - never at a tool that writes one - so an agent
+	 * "fixed" a value in a tier something above it shadowed and saw no effect
+	 * and no explanation.
+	 *
+	 * Table-driven so a new variable tool cannot quietly omit the sentence: add
+	 * one to this list and it is checked, and the list is what a reviewer reads
+	 * to see whether it is complete.
+	 */
+	const VARIABLE_SURFACES = [
+		"get_globals",
+		"update_globals",
+		"list_environments",
+		"create_environment",
+		"update_environment",
+		"create_collection",
+		"update_collection",
+		"resolve_variables",
+	] as const;
+
+	test.each(VARIABLE_SURFACES)("%s states the order and links the model", (name) => {
+		const tool = TOOLS.find((t) => t.name === name);
+		expect(tool, `${name} is missing from TOOLS`).toBeDefined();
+		// Mutation check: drop the precedenceNote() call from any one of these
+		// descriptions and that row fails.
+		expect(tool!.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
+		expect(tool!.description).toContain(VARIABLE_RESOLUTION_URI);
+	});
+
+	test("each surface names its own tier's position, not just the ladder", () => {
+		const byName = new Map(TOOLS.map((t) => [t.name, t]));
+		// A shared sentence alone would pass the scan above while telling an
+		// agent nothing about the tier it is writing to.
+		expect(byName.get("update_globals")?.description).toMatch(/bottom tier/);
+		expect(byName.get("update_environment")?.description).toMatch(/top scope tier/);
+		expect(byName.get("create_collection")?.description).toMatch(
+			/between globals and the active environment/
+		);
+	});
+
+	test("the variablesInput helper carries it too, at the field an agent fills", () => {
+		// Reached through the schema rather than the description: a client that
+		// renders per-field docs shows this and not the tool blurb.
+		const schema = TOOLS.find((t) => t.name === "update_environment")?.inputSchema.variables;
+		expect(schema?.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
+		expect(schema?.description).toContain(VARIABLE_RESOLUTION_URI);
+	});
+});
+
+describe("resolve_variables", () => {
+	const GLOBALS = {
+		variables: {
+			host: { value: "globals.test", enabled: true },
+			onlyGlobal: { value: "g", enabled: true },
+		},
+	};
+	const COLLECTIONS = [
+		{
+			id: "root",
+			name: "Root",
+			parentId: null,
+			variables: { host: { value: "root.test", enabled: true } },
+		},
+		{
+			id: "leaf",
+			name: "Leaf",
+			parentId: "root",
+			variables: { host: { value: "leaf.test", enabled: true } },
+		},
+	];
+	const ENVIRONMENTS = [
+		{
+			id: "env_active",
+			name: "Staging",
+			isActive: true,
+			variables: { host: { value: "staging.test", enabled: true } },
+		},
+		{
+			id: "env_other",
+			name: "Prod",
+			isActive: false,
+			variables: { host: { value: "prod.test", enabled: true } },
+		},
+	];
+
+	const variableClient = (overrides = {}) =>
+		fakeClient({
+			getGlobals: vi.fn().mockResolvedValue(GLOBALS),
+			listCollections: vi.fn().mockResolvedValue(COLLECTIONS),
+			listEnvironments: vi.fn().mockResolvedValue(ENVIRONMENTS),
+			...overrides,
+		});
+
+	const resolve = async (args: Record<string, unknown>, client = variableClient()) =>
+		JSON.parse(
+			firstText(
+				(await dispatchTool("resolve_variables", args, ctxWith(client))) as {
+					content: Array<{ text: string }>;
+				}
+			)
+		);
+
+	test("is a read tool that changes nothing", () => {
+		const tool = TOOLS.find((t) => t.name === "resolve_variables");
+		expect(tool?.category).toBe("read");
+		expect(tool?.invalidates).toEqual([]);
+		expect(tool?.annotations.readOnlyHint).toBe(true);
+	});
+
+	test("the active environment wins, and every loser is named with its reason", async () => {
+		const out = await resolve({ collectionId: "leaf" });
+		const host = out.variables.find((v: { name: string }) => v.name === "host");
+
+		expect(host.value).toBe("staging.test");
+		expect(host.scope).toBe("environment");
+		expect(host.sourceName).toBe("Staging");
+		// Highest precedence first: the nearest miss is the one to read first.
+		expect(host.shadowedBy).toEqual([
+			{
+				scope: "collection",
+				sourceId: "leaf",
+				sourceName: "Leaf",
+				value: "leaf.test",
+				enabled: true,
+				reason: "outranked",
+			},
+			{
+				scope: "collection",
+				sourceId: "root",
+				sourceName: "Root",
+				value: "root.test",
+				enabled: true,
+				reason: "outranked",
+			},
+			{ scope: "global", value: "globals.test", enabled: true, reason: "outranked" },
+		]);
+	});
+
+	test("the collection chain is only in play when a collectionId is given", async () => {
+		const out = await resolve({});
+		const host = out.variables.find((v: { name: string }) => v.name === "host");
+		expect(host.value).toBe("staging.test");
+		// Two definitions, not four: no chain was asked for.
+		expect(host.shadowedBy).toEqual([
+			{ scope: "global", value: "globals.test", enabled: true, reason: "outranked" },
+		]);
+		expect(out.context.collectionChain).toEqual([]);
+	});
+
+	test('"none" resolves as if no environment were active', async () => {
+		const out = await resolve({ collectionId: "leaf", environmentId: "none" });
+		const host = out.variables.find((v: { name: string }) => v.name === "host");
+		expect(host.value).toBe("leaf.test");
+		expect(host.scope).toBe("collection");
+		expect(out.context.environmentSelection).toBe("explicitly none");
+		expect(out.context.environmentId).toBeNull();
+	});
+
+	test("a named environment is used over the active one", async () => {
+		const out = await resolve({ environmentId: "env_other" });
+		const host = out.variables.find((v: { name: string }) => v.name === "host");
+		expect(host.value).toBe("prod.test");
+		expect(out.context.environmentSelection).toBe("named by the caller");
+	});
+
+	test("an id that names nothing is refused, not resolved as empty", async () => {
+		// The whole point: silently resolving a typo'd collection against globals
+		// alone would report confident, wrong answers.
+		const missingCollection = await dispatchTool(
+			"resolve_variables",
+			{ collectionId: "ghost" },
+			ctxWith(variableClient())
+		);
+		expect(missingCollection.isError).toBe(true);
+		expect(firstText(missingCollection)).toContain('No collection with id "ghost"');
+
+		const missingEnv = await dispatchTool(
+			"resolve_variables",
+			{ environmentId: "ghost" },
+			ctxWith(variableClient())
+		);
+		expect(missingEnv.isError).toBe(true);
+		expect(firstText(missingEnv)).toContain('No environment with id "ghost"');
+	});
+
+	test("names selects, and a name nothing defines is reported rather than omitted", async () => {
+		const out = await resolve({ names: ["onlyGlobal", "nowhere"] });
+		expect(out.variables.map((v: { name: string }) => v.name)).toEqual([
+			"onlyGlobal",
+			"nowhere",
+		]);
+		const nowhere = out.variables[1];
+		expect(nowhere.resolved).toBe(false);
+		expect(nowhere.shadowedBy).toEqual([]);
+	});
+
+	test("a malformed names argument is an argument error, not an empty answer", async () => {
+		const res = await dispatchTool(
+			"resolve_variables",
+			{ names: ["ok", 7] },
+			ctxWith(variableClient())
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toContain('"names" must be an array of strings');
+	});
+
+	test("a secret's value is withheld while the rest of the report stands", async () => {
+		const client = variableClient({
+			getGlobals: vi.fn().mockResolvedValue({
+				variables: { token: { value: "s3cret", enabled: true, secret: true } },
+			}),
+			listEnvironments: vi.fn().mockResolvedValue([]),
+		});
+		const out = await resolve({}, client);
+		const token = out.variables.find((v: { name: string }) => v.name === "token");
+		expect(token.resolved).toBe(true);
+		expect(token.valueWithheld).toBe(true);
+		expect(token).not.toHaveProperty("value");
+		expect(JSON.stringify(out)).not.toContain("s3cret");
+	});
+
+	test("a disabled winner falls through, and says it was switched off", async () => {
+		const client = variableClient({
+			listEnvironments: vi.fn().mockResolvedValue([
+				{
+					id: "env_active",
+					name: "Staging",
+					isActive: true,
+					variables: { host: { value: "staging.test", enabled: false } },
+				},
+			]),
+		});
+		const out = await resolve({}, client);
+		const host = out.variables.find((v: { name: string }) => v.name === "host");
+		expect(host.value).toBe("globals.test");
+		expect(host.shadowedBy[0]).toMatchObject({ scope: "environment", reason: "disabled" });
+	});
+
+	test("summary counts what the report holds", async () => {
+		const out = await resolve({ collectionId: "leaf" });
+		expect(out.summary.reported).toBe(out.variables.length);
+		expect(out.summary.resolved).toBe(
+			out.variables.filter((v: { resolved: boolean }) => v.resolved).length
+		);
+		expect(out.summary.shadowed).toBe(1); // `host` only; `onlyGlobal` is unopposed
+	});
+
+	test("an engine failure reads as an engine failure, not a bad argument", async () => {
+		const client = variableClient({
+			getGlobals: vi.fn().mockRejectedValue(new Error("fetch failed")),
+		});
+		const res = await dispatchTool("resolve_variables", {}, ctxWith(client));
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).not.toContain("must be an array");
 	});
 });

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -8130,24 +8130,66 @@ describe("variable precedence is stated wherever a variable is written or listed
 	 * one to this list and it is checked, and the list is what a reviewer reads
 	 * to see whether it is complete.
 	 */
-	const VARIABLE_SURFACES = [
+	/**
+	 * Derived, not listed: every tool taking a `variables` argument is a tool
+	 * that writes a tier, so a new one is covered the day it is written. A
+	 * hand-maintained list would only ever pin the tools someone remembered to
+	 * add to it, which is the defect this issue was opened about wearing a
+	 * different hat.
+	 */
+	const VARIABLE_WRITERS = TOOLS.filter((t) => "variables" in t.inputSchema);
+
+	/**
+	 * The read and activation surfaces, which take no `variables` argument and
+	 * so cannot be derived the same way. Listed, and the list is asserted
+	 * complete below against every tool whose description mentions variables.
+	 */
+	const VARIABLE_READERS = [
 		"get_globals",
-		"update_globals",
 		"list_environments",
-		"create_environment",
-		"update_environment",
-		"create_collection",
-		"update_collection",
+		"list_collections",
+		"activate_environment",
 		"resolve_variables",
 	] as const;
 
-	test.each(VARIABLE_SURFACES)("%s states the order and links the model", (name) => {
+	test("the derived writer set is non-empty and is what we think it is", () => {
+		// A guard over a filter that silently matched nothing would pass forever.
+		expect(VARIABLE_WRITERS.length).toBeGreaterThan(0);
+		expect(VARIABLE_WRITERS.map((t) => t.name).sort()).toEqual([
+			"create_collection",
+			"create_environment",
+			"update_collection",
+			"update_environment",
+			"update_globals",
+		]);
+	});
+
+	test.each(VARIABLE_WRITERS.map((t) => [t.name, t] as const))(
+		"%s (writes a tier) states the order and links the model",
+		(_name, tool) => {
+			// Mutation check: drop the precedenceNote() call from any one of these
+			// descriptions and that row fails.
+			expect(tool.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
+			expect(tool.description).toContain(VARIABLE_RESOLUTION_URI);
+		}
+	);
+
+	test.each(VARIABLE_READERS)("%s (reads or switches a tier) states it too", (name) => {
 		const tool = TOOLS.find((t) => t.name === name);
 		expect(tool, `${name} is missing from TOOLS`).toBeDefined();
-		// Mutation check: drop the precedenceNote() call from any one of these
-		// descriptions and that row fails.
 		expect(tool!.description).toContain(VARIABLE_PRECEDENCE_SENTENCE);
 		expect(tool!.description).toContain(VARIABLE_RESOLUTION_URI);
+	});
+
+	test("no tool spells the order its own way any more", () => {
+		// The original complaint: the order appeared as prose in two tools and
+		// nowhere else. A second spelling is how it drifts back apart.
+		const rogue = TOOLS.filter(
+			(t) =>
+				/environment\s*>\s*collection\s*chain\s*>\s*globals/.test(t.description) &&
+				!t.description.includes(VARIABLE_RESOLUTION_URI)
+		);
+		expect(rogue.map((t) => t.name)).toEqual([]);
 	});
 
 	test("each surface names its own tier's position, not just the ladder", () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -34,6 +34,16 @@ import {
 	defaultDurationUnderCap,
 } from "./safety.js";
 import { compareReports } from "./compare.js";
+import {
+	collectionChain,
+	precedenceNote,
+	resolveVariableReports,
+	VARIABLE_PRECEDENCE_SENTENCE,
+	VARIABLE_RESOLUTION_URI,
+	type CollectionLike,
+	type OriginScopes,
+	type StoredVariableBag,
+} from "./variable-origins.js";
 import { HTTP_VERSIONS } from "./http-versions.js";
 
 /** An auth block as stored/forwarded (discriminated by `mode`). */
@@ -762,6 +772,21 @@ function requireStr(args: Record<string, unknown>, key: string): string {
 	return v;
 }
 
+/**
+ * An optional array-of-strings argument. A non-array, or an array carrying
+ * anything but strings, is the caller's mistake rather than an empty selection:
+ * silently dropping the bad entries would answer a different question than the
+ * one asked and look like the names simply were not defined.
+ */
+function stringArray(args: Record<string, unknown>, key: string): string[] | undefined {
+	const v = args[key];
+	if (v === undefined) return undefined;
+	if (!Array.isArray(v) || v.some((entry) => typeof entry !== "string")) {
+		throw new ToolArgError(`"${key}" must be an array of strings.`);
+	}
+	return v as string[];
+}
+
 class ToolArgError extends Error {}
 
 /**
@@ -1043,8 +1068,106 @@ function variablesInput(subject: string) {
 		.record(VARIABLE_INPUT)
 		.optional()
 		.describe(
-			`Variables to set on ${subject}, as a name -> value map. A value is either a string (sets the value, keeps every flag) or an object {value, secret, type, enabled} whose omitted fields keep their stored setting. Merges: variables not named here are left alone.`
+			`Variables to set on ${subject}, as a name -> value map. A value is either a string (sets the value, keeps every flag) or an object {value, secret, type, enabled} whose omitted fields keep their stored setting. Merges: variables not named here are left alone. ${VARIABLE_PRECEDENCE_SENTENCE} A name defined in a higher tier shadows what you write here - see ${VARIABLE_RESOLUTION_URI}.`
 		);
+}
+
+/** The stored `variables` blob off a collection / environment / globals row. */
+function variableBagOf(row: unknown): StoredVariableBag | undefined {
+	if (!isRecord(row)) return undefined;
+	const bag = row.variables;
+	return isRecord(bag) ? (bag as StoredVariableBag) : undefined;
+}
+
+/**
+ * The environment `resolve_variables` should resolve against.
+ *
+ * Three cases, deliberately distinct: a named id must exist (a typo resolving
+ * silently against the active environment would report confident, wrong
+ * answers), `"none"` is the explicit no-environment case that
+ * `activate_environment` already spells that way, and an omitted id means the
+ * active row - the same default a send takes.
+ */
+function pickEnvironment(rows: readonly unknown[], environmentId: string | undefined) {
+	if (environmentId === "none") return undefined;
+	if (environmentId !== undefined && environmentId !== "") {
+		const found = rows.find((row) => isRecord(row) && row.id === environmentId);
+		if (!found) throw new ToolArgError(`No environment with id "${environmentId}".`);
+		return found as Record<string, unknown>;
+	}
+	return rows.find((row) => isRecord(row) && row.isActive === true) as
+		| Record<string, unknown>
+		| undefined;
+}
+
+/**
+ * Read every scope `resolve_variables` needs, in one pass over the engine's
+ * lists. Globals are always read; the collection chain and the environment only
+ * when the context names them.
+ *
+ * A `collectionId` that names nothing is refused rather than resolved as an
+ * empty chain: "this collection defines none of these" and "there is no such
+ * collection" are different answers, and an agent acting on the first when the
+ * second is true writes to a collection that does not exist.
+ */
+async function gatherVariableScopes(
+	ctx: ToolContext,
+	collectionId: string | undefined,
+	environmentId: string | undefined,
+	signal?: AbortSignal
+): Promise<OriginScopes> {
+	const globals = variableBagOf(await ctx.client.getGlobals(signal));
+
+	let chain: OriginScopes["chain"];
+	if (collectionId !== undefined && collectionId !== "") {
+		const listed = await ctx.client.listCollections(signal);
+		const rows = (Array.isArray(listed) ? listed : []) as CollectionLike[];
+		chain = collectionChain(rows, collectionId);
+		if (chain.length === 0) throw new ToolArgError(`No collection with id "${collectionId}".`);
+	}
+
+	let environment: OriginScopes["environment"];
+	if (environmentId !== "none") {
+		const listed = await ctx.client.listEnvironments(signal);
+		const rows = Array.isArray(listed) ? listed : [];
+		const row = pickEnvironment(rows, environmentId);
+		if (row) {
+			environment = {
+				id: typeof row.id === "string" ? row.id : undefined,
+				name: typeof row.name === "string" ? row.name : undefined,
+				variables: variableBagOf(row),
+			};
+		}
+	}
+
+	return { globals, chain, environment };
+}
+
+/**
+ * What context the answer was computed in, echoed back so a report can be read
+ * without re-deriving it. The environment is stated even when there is none:
+ * "no environment was active" is why a value came from a collection, and an
+ * omitted key would leave that to be guessed.
+ */
+function describeScopes(
+	scopes: OriginScopes,
+	collectionId: string | undefined,
+	environmentId: string | undefined
+): Record<string, unknown> {
+	return {
+		collectionId: collectionId ?? null,
+		collectionChain: (scopes.chain ?? []).map((c) => ({ id: c.id, name: c.name })),
+		environmentId: scopes.environment?.id ?? null,
+		environmentName: scopes.environment?.name ?? null,
+		environmentSelection:
+			environmentId === "none"
+				? "explicitly none"
+				: environmentId
+					? "named by the caller"
+					: scopes.environment
+						? "the active environment"
+						: "no environment is active",
+	};
 }
 
 /** The `removeVariables` argument - the delete a blank value cannot express. */
@@ -3638,7 +3761,11 @@ export const TOOLS: McpTool[] = [
 		name: "list_environments",
 		category: "read",
 		invalidates: [],
-		description: "List all environments (named sets of variables like baseUrl, apiKey).",
+		description:
+			"List all environments (named sets of variables like baseUrl, apiKey). The row with `isActive: true` is the one requests resolve against when a call names no environmentId. " +
+			precedenceNote(
+				"An environment's variables are the top scope tier: they shadow every collection and global of the same name."
+			),
 		annotations: {
 			title: "List environments",
 			readOnlyHint: true,
@@ -4081,7 +4208,10 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["collection"],
 		description:
-			"Create a collection (the folder saved requests live in), with the variables, auth and pre/post-request scripts every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Pass `parentId` to nest it inside an existing collection; omit it for a top-level one. Returns the created collection - its `id` is what create_request takes as `collectionId`.",
+			"Create a collection (the folder saved requests live in), with the variables, auth and pre/post-request scripts every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Pass `parentId` to nest it inside an existing collection; omit it for a top-level one. Returns the created collection - its `id` is what create_request takes as `collectionId`. " +
+			precedenceNote(
+				"Collection variables sit between globals and the active environment: they shadow globals, a nested collection shadows its ancestors, and the active environment shadows them all."
+			),
 		annotations: {
 			title: "Create collection",
 			readOnlyHint: false,
@@ -4128,7 +4258,10 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["collection"],
 		description:
-			"Change a collection: its name, description, variables, auth or pre/post-request scripts - the state every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change, and the requests inside it are never touched. Variables merge: one you do not name is left alone, and a named one keeps every flag you do not state; removeVariables deletes names outright. Auth replaces the stored block whole. This is not a move - to re-parent a collection, use move_item.",
+			"Change a collection: its name, description, variables, auth or pre/post-request scripts - the state every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change, and the requests inside it are never touched. Variables merge: one you do not name is left alone, and a named one keeps every flag you do not state; removeVariables deletes names outright. Auth replaces the stored block whole. This is not a move - to re-parent a collection, use move_item. " +
+			precedenceNote(
+				"Collection variables sit between globals and the active environment: they shadow globals, a nested collection shadows its ancestors, and the active environment shadows them all."
+			),
 		annotations: {
 			title: "Update collection",
 			readOnlyHint: false,
@@ -5411,7 +5544,10 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["environment"],
 		description:
-			"Create an environment - a named set of {{variables}} a request resolves against. Populate it in the same call, with plain values or with the secret/type/enabled flags. The environment is created inactive: activate_environment is what makes it the one requests resolve against. Vayu assigns the id and returns it. GUARDED: requires write access to be enabled in Vayu Settings.",
+			"Create an environment - a named set of {{variables}} a request resolves against. Populate it in the same call, with plain values or with the secret/type/enabled flags. The environment is created inactive: activate_environment is what makes it the one requests resolve against. Vayu assigns the id and returns it. GUARDED: requires write access to be enabled in Vayu Settings. " +
+			precedenceNote(
+				"An environment's variables are the top scope tier: once this one is active they shadow every collection and global of the same name."
+			),
 		annotations: {
 			title: "Create environment",
 			readOnlyHint: false,
@@ -5449,7 +5585,10 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["environment"],
 		description:
-			"Set, re-flag or remove an environment's variables, and rename it. Merges: variables you do not name are left alone, and a named one keeps every flag you do not state - so rotating a secret leaves it masked and writing to a disabled variable leaves it disabled. Pass a variable as a string to set its value, or as an object to set any of value/secret/type/enabled. removeVariables deletes names outright, which blanking a value cannot do. GUARDED: requires write access to be enabled in Vayu Settings.",
+			"Set, re-flag or remove an environment's variables, and rename it. Merges: variables you do not name are left alone, and a named one keeps every flag you do not state - so rotating a secret leaves it masked and writing to a disabled variable leaves it disabled. Pass a variable as a string to set its value, or as an object to set any of value/secret/type/enabled. removeVariables deletes names outright, which blanking a value cannot do. GUARDED: requires write access to be enabled in Vayu Settings. " +
+			precedenceNote(
+				"An environment's variables are the top scope tier: while this environment is active they shadow every collection and global of the same name. Writing here to an inactive environment changes nothing a request resolves until activate_environment makes it current."
+			),
 		annotations: {
 			title: "Update environment",
 			readOnlyHint: false,
@@ -5616,7 +5755,10 @@ export const TOOLS: McpTool[] = [
 		category: "read",
 		invalidates: [],
 		description:
-			"Read the global variables - the bottom of the resolution order, used by every request whatever environment is active (environment > collection chain > globals). An engine that has never had any answers an empty set rather than an error.",
+			"Read the global variables - used by every request whatever environment is active. An engine that has never had any answers an empty set rather than an error. " +
+			precedenceNote(
+				"Globals are the bottom tier, so a value read back here is not necessarily the one a request resolves: use resolve_variables to see which definition actually wins."
+			),
 		annotations: {
 			title: "Get global variables",
 			readOnlyHint: true,
@@ -5627,11 +5769,79 @@ export const TOOLS: McpTool[] = [
 		handler: (_args, ctx, signal) => callEngine(() => ctx.client.getGlobals(signal)),
 	},
 	{
+		name: "resolve_variables",
+		category: "read",
+		invalidates: [],
+		description:
+			'Answer which definition of a variable name actually wins in a given context, and list the ones it beat - the question get_globals and list_environments cannot, because each shows one tier in isolation. For every name it reports the winning value with the scope and source that supplied it, then every shadowed definition highest-precedence-first, each saying whether it was outranked by a higher tier or simply switched off (`enabled: false`). A switched-off row is the more common answer to "why is this not the value I set?", and a name whose every definition is disabled resolves to nothing at all rather than to an empty string. ' +
+			precedenceNote(
+				"Pass no environmentId to use the active environment, the same default a send takes; pass a collectionId to include its chain."
+			) +
+			" Secret values are withheld here (`valueWithheld: true`) to match the app's popover - note that list_environments, get_globals and vayu://environments still return every value in full, so this is not a security boundary. Reports what is stored: it resolves nothing on the wire and starts no run.",
+		annotations: {
+			title: "Resolve variables",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			collectionId: z
+				.string()
+				.optional()
+				.describe(
+					"Optional collection ID. Includes that collection's chain, merged root-first, between globals and the environment."
+				),
+			environmentId: z
+				.string()
+				.optional()
+				.describe(
+					'Optional environment ID. Omit for the active environment (the default a send takes); pass "none" to resolve as if no environment were active.'
+				),
+			names: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"Optional variable names to report. Omit for every name defined anywhere in the context. A name nothing defines is reported as unresolved rather than omitted."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const collectionId = str(args, "collectionId");
+			const environmentId = str(args, "environmentId");
+			const names = stringArray(args, "names");
+
+			let scopes: OriginScopes;
+			let context: Record<string, unknown>;
+			try {
+				scopes = await gatherVariableScopes(ctx, collectionId, environmentId, signal);
+				context = describeScopes(scopes, collectionId, environmentId);
+			} catch (err) {
+				// A bad id is the caller's mistake and must not be reported as an
+				// engine failure - the same split `pagedRead`'s callers keep.
+				if (err instanceof ToolArgError) return errorResult(err.message);
+				return engineErrorResult(err);
+			}
+
+			const variables = resolveVariableReports(scopes, names);
+			return structuredResult({
+				context,
+				variables,
+				summary: {
+					reported: variables.length,
+					resolved: variables.filter((v) => v.resolved).length,
+					shadowed: variables.filter((v) => v.shadowedBy.length > 0).length,
+				},
+			});
+		},
+	},
+	{
 		name: "update_globals",
 		category: "write",
 		invalidates: ["environment"],
 		description:
-			"Set, re-flag or remove global variables - the ones every request can resolve, whatever environment is active. Merges exactly as update_environment does: globals you do not name are left alone, and a named one keeps every flag you do not state. GUARDED: requires write access to be enabled in Vayu Settings.",
+			"Set, re-flag or remove global variables - the ones every request can resolve, whatever environment is active. Merges exactly as update_environment does: globals you do not name are left alone, and a named one keeps every flag you do not state. GUARDED: requires write access to be enabled in Vayu Settings. " +
+			precedenceNote(
+				"Globals are the bottom tier: any collection or active-environment definition of the same name shadows what you write here, so a request whose value does not change after this call is usually shadowed rather than unwritten - resolve_variables names the definition that won."
+			),
 		annotations: {
 			title: "Update global variables",
 			readOnlyHint: false,

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -36,6 +36,7 @@ import {
 import { compareReports } from "./compare.js";
 import {
 	collectionChain,
+	collectionParentId,
 	precedenceNote,
 	resolveVariableReports,
 	VARIABLE_PRECEDENCE_SENTENCE,
@@ -2847,7 +2848,10 @@ interface CollectionRow {
  * which is a destination that does not exist.
  */
 function collectionParent(row: CollectionRow): string | null {
-	return typeof row.parentId === "string" && row.parentId !== "" ? row.parentId : null;
+	// One definition of the rule, shared with the chain walk `resolve_variables`
+	// does - the two disagreeing about what counts as a root is a defect neither
+	// side's own tests would catch.
+	return collectionParentId(row);
 }
 
 /** The collections list, dropping anything without a usable id. */
@@ -3732,7 +3736,11 @@ export const TOOLS: McpTool[] = [
 		name: "list_collections",
 		category: "read",
 		invalidates: [],
-		description: "List all request collections (folders that organize saved requests).",
+		description:
+			"List all request collections (folders that organize saved requests). Each row carries that collection's own `variables` blob; a request resolves against the whole chain from the root down, not just its own collection. " +
+			precedenceNote(
+				"Collection variables sit between globals and the active environment, and a nested collection outranks its ancestors."
+			),
 		annotations: {
 			title: "List collections",
 			readOnlyHint: true,
@@ -4026,7 +4034,10 @@ export const TOOLS: McpTool[] = [
 		category: "execute",
 		invalidates: ["run", "cookie"],
 		description:
-			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.) Certificate verification is always on for a send made this way - `verifySSL: false` is refused here, because a skipped check on a one-off call is recorded nowhere; it belongs on the saved request, where the app shows it. " +
+			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app. " +
+			VARIABLE_PRECEDENCE_SENTENCE +
+			` See ${VARIABLE_RESOLUTION_URI}.` +
+			" Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.) Certificate verification is always on for a send made this way - `verifySSL: false` is refused here, because a skipped check on a one-off call is recorded nowhere; it belongs on the saved request, where the app shows it. " +
 			`The response body is capped at ${MAX_INLINE_BODY_BYTES} bytes in this result: over that, \`bodyRaw\` holds the first ${MAX_INLINE_BODY_BYTES} bytes, \`bodyTruncated\` is true, \`bodySize\` is the real size, and the parsed \`body\` is null rather than a full copy of what was cut. A large \`rawRequest\` is capped the same way (headers kept whole) and flagged with \`rawRequestTruncated\`. \`bodyCapped\` is a different fact and is always present: it says the engine itself stopped reading the response at \`maxDesignResponseBodyBytes\`, so \`bodySize\` is the prefix it read and re-sending returns the same amount - raise that config entry to read more, where \`bodyTruncated\` is only this result showing less than the engine returned.`,
 		annotations: {
 			title: "Send a request",
@@ -5647,7 +5658,10 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["environment"],
 		description:
-			'Make an environment the active one - the set {{variables}} resolve against when a call names no environmentId of its own, and what the app\'s own switcher shows. Exactly one environment is active at a time: activating one deactivates the previous in the same write. Pass "none" to leave no environment active, the switcher\'s "No Environment" option. Tools that take an explicit environmentId (run_request, start_load_run, run_collection) are unaffected by this - it is the default, not an override. GUARDED: requires write access to be enabled in Vayu Settings.',
+			'Make an environment the active one - the set {{variables}} resolve against when a call names no environmentId of its own, and what the app\'s own switcher shows. Exactly one environment is active at a time: activating one deactivates the previous in the same write. Pass "none" to leave no environment active, the switcher\'s "No Environment" option. Tools that take an explicit environmentId (run_request, start_load_run, run_collection) are unaffected by this - it is the default, not an override. GUARDED: requires write access to be enabled in Vayu Settings. ' +
+			precedenceNote(
+				"This is the one call that changes which tier answers without changing any value: the newly active environment shadows every collection and global of the same name, so a name can start resolving differently with nothing else edited."
+			),
 		annotations: {
 			title: "Activate environment",
 			readOnlyHint: false,
@@ -5945,7 +5959,9 @@ export const TOOLS: McpTool[] = [
 		category: "execute",
 		invalidates: ["run", "cookie"],
 		description:
-			"Execute a collection's own saved requests once each and return a pass/fail matrix (a request passes on a 2xx/3xx status with all its tests passing and, when the collection is bound to an OpenAPI document, a response matching the schema that document declares - a response the document declares no schema for is reported as unchecked and never fails the request; pass failOnSchemaError: false to keep that verdict on every row without letting it decide pass/fail). A row whose request ran assertions carries `tests` - `total`, `failed`, and the failing `name: message` lines (at most 10; `failed` is the true count) - so a request that failed on its tests says which, not just ok:false. Scope is the collection's DIRECT requests: nested sub-collections are not run, and the result discloses how many were left out - call this tool on each of them to cover them. Requests run one at a time, so a large collection takes as long as its requests do added together. Each request is composed exactly as the app would send it: {{variables}} resolved (environment > collection chain > globals), the request's stored auth applied (inheriting from the collection chain, incl. OAuth2), and its collection-chain + own pre/post scripts run. Each request's resolved host must be on the allowlist; requests whose host still cannot be verified (e.g. a variable did not resolve and allow-all is off) are skipped. Sends real traffic but does not modify Vayu data.",
+			"Execute a collection's own saved requests once each and return a pass/fail matrix (a request passes on a 2xx/3xx status with all its tests passing and, when the collection is bound to an OpenAPI document, a response matching the schema that document declares - a response the document declares no schema for is reported as unchecked and never fails the request; pass failOnSchemaError: false to keep that verdict on every row without letting it decide pass/fail). A row whose request ran assertions carries `tests` - `total`, `failed`, and the failing `name: message` lines (at most 10; `failed` is the true count) - so a request that failed on its tests says which, not just ok:false. Scope is the collection's DIRECT requests: nested sub-collections are not run, and the result discloses how many were left out - call this tool on each of them to cover them. Requests run one at a time, so a large collection takes as long as its requests do added together. Each request is composed exactly as the app would send it: {{variables}} resolved in the order " +
+			VARIABLE_RESOLUTION_URI +
+			" states, the request's stored auth applied (inheriting from the collection chain, incl. OAuth2), and its collection-chain + own pre/post scripts run. Each request's resolved host must be on the allowlist; requests whose host still cannot be verified (e.g. a variable did not resolve and allow-all is off) are skipped. Sends real traffic but does not modify Vayu data.",
 		annotations: {
 			title: "Run collection smoke test",
 			readOnlyHint: false,

--- a/app/electron/mcp/variable-origins.conformance.test.ts
+++ b/app/electron/mcp/variable-origins.conformance.test.ts
@@ -32,6 +32,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 import { buildVariableValues, type StoredVariableBag } from "@/lib/variable-resolution";
 import { ENGINE_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+import { walkAncestors } from "@/modules/collections/tree-utils";
 import {
 	buildVariableOrigins,
 	collectionChain,
@@ -181,6 +182,29 @@ describe("what the winner alone cannot say", () => {
 		expect(token.secret).toBe(true);
 	});
 
+	test("a secret that loses is withheld too, not just a winning one", () => {
+		const [token] = resolveVariableReports({
+			globals: { token: { value: "loser-secret", enabled: true, secret: true } },
+			environment: {
+				id: "e",
+				name: "E",
+				variables: { token: { value: "winner", enabled: true } },
+			},
+		});
+		expect(token.value).toBe("winner");
+		const shadowed = token.shadowedBy[0];
+		expect(shadowed.valueWithheld).toBe(true);
+		expect(shadowed).not.toHaveProperty("value");
+		expect(JSON.stringify(token)).not.toContain("loser-secret");
+	});
+
+	test("the type hint survives into the report", () => {
+		const [port] = resolveVariableReports({
+			globals: { port: { value: "8080", enabled: true, type: "number" } },
+		});
+		expect(port.type).toBe("number");
+	});
+
 	test("a requested name nothing defines gets a row saying so", () => {
 		const [missing] = resolveVariableReports({ globals: {} }, ["nope"]);
 		expect(missing).toEqual({ name: "nope", resolved: false, shadowedBy: [] });
@@ -215,6 +239,37 @@ describe("the collection chain walk", () => {
 
 	test("an unknown id yields an empty chain rather than throwing", () => {
 		expect(collectionChain(rows, "ghost")).toEqual([]);
+	});
+
+	/**
+	 * The walk is the one part of the resolution the shared fixture cannot
+	 * reach: its cases supply a pre-flattened `chain`, so the parentId walk is
+	 * never exercised by it. Cross-checking against the renderer's own
+	 * `walkAncestors` is what closes that hole - without this, the two walkers
+	 * could disagree about a malformed `parentId` with both files' local tests
+	 * still green, which is exactly the drift this file exists to prevent.
+	 */
+	test.each([
+		["a normal chain", rows, "leaf"],
+		["a root", rows, "root"],
+		["an unknown id", rows, "ghost"],
+		["an empty-string parent", [{ id: "a", name: "A", parentId: "" }], "a"],
+		["an absent parent", [{ id: "a", name: "A" }], "a"],
+		["a self-parent", [{ id: "s", name: "S", parentId: "s" }], "s"],
+		[
+			"a two-node loop",
+			[
+				{ id: "a", name: "A", parentId: "b" },
+				{ id: "b", name: "B", parentId: "a" },
+			],
+			"a",
+		],
+		["a parent that does not exist", [{ id: "a", name: "A", parentId: "gone" }], "a"],
+	] as const)("agrees with the renderer's walkAncestors on %s", (_name, nodes, leaf) => {
+		const mine = collectionChain(nodes as never, leaf).map((c) => c.id);
+		// walkAncestors takes `parentId?: string | null`, the same rows.
+		const renderer = walkAncestors(leaf, nodes as never).map((c) => c.id);
+		expect(mine).toEqual(renderer);
 	});
 });
 

--- a/app/electron/mcp/variable-origins.conformance.test.ts
+++ b/app/electron/mcp/variable-origins.conformance.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Keeps the MCP variable resolver honest against the renderer's.
+ *
+ * `electron/mcp/variable-origins.ts` backs the MCP `resolve_variables` tool;
+ * `src/lib/variable-resolution.ts` backs the app's own preview and popover. They
+ * pick the winner the same way, written twice, because the process boundary
+ * forbids sharing a source file in either direction: the main process emits with
+ * `rootDir: "electron"` and cannot compile a file from `src/` (TS6059), and the
+ * renderer cannot import one from `electron/`, which is a referenced composite
+ * project (TS6305; excluding a file from that project to dodge it is TS6307).
+ *
+ * Drift here would be quiet and expensive - an agent told one variable answers a
+ * name while the send uses another - so this file is where the two meet, the way
+ * `compare.conformance.test.ts` does for the run diff. It reaches across the
+ * boundary the way `tools.test.ts` already reaches for `@/constants`: a test may,
+ * production code may not.
+ *
+ * The cases are the engine's own conformance fixture - the same 40 the engine's
+ * C++ suite and `src/lib/variable-resolution.conformance.test.ts` replay - so all
+ * three implementations answer one table. A case added there fails whichever side
+ * forgot it.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+import { buildVariableValues, type StoredVariableBag } from "@/lib/variable-resolution";
+import { ENGINE_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+import {
+	buildVariableOrigins,
+	collectionChain,
+	resolveVariableReports,
+	type OriginScopes,
+} from "./variable-origins.js";
+
+const [fixturePath] = ENGINE_READING_GUARDS.mcpVariableOrigins.paths.map(fromRepoRoot);
+
+interface ConformanceCase {
+	name: string;
+	scopes: {
+		globals?: StoredVariableBag;
+		chain?: StoredVariableBag[];
+		environment?: StoredVariableBag;
+	};
+	input: string;
+	expected: string;
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as { cases: ConformanceCase[] };
+
+/** The fixture's flat bags, in the shape this module's chain/environment take. */
+function asOriginScopes(scopes: ConformanceCase["scopes"]): OriginScopes {
+	return {
+		globals: scopes.globals,
+		chain: (scopes.chain ?? []).map((variables, i) => ({
+			id: `c${i}`,
+			name: `Collection ${i}`,
+			variables,
+		})),
+		...(scopes.environment ? { environment: { id: "e", name: "Env", variables: scopes.environment } } : {}),
+	};
+}
+
+describe("MCP variable origins agree with the renderer's resolver", () => {
+	test.each(fixture.cases.map((c) => [c.name, c] as const))(
+		"%s - every name's winner matches buildVariableValues",
+		(_name, c) => {
+			const scopes = asOriginScopes(c.scopes);
+			const rendererWinners = buildVariableValues({
+				globals: c.scopes.globals,
+				chain: c.scopes.chain,
+				environment: c.scopes.environment,
+			});
+
+			for (const report of resolveVariableReports(scopes)) {
+				const rendererValue = rendererWinners.get(report.name);
+				if (report.resolved) {
+					// Not a secret anywhere in the fixture, so the value is present.
+					expect(report.value, report.name).toBe(rendererValue);
+				} else {
+					// Every definition disabled: the renderer drops the name entirely
+					// rather than carrying it as an empty string.
+					expect(rendererValue, report.name).toBeUndefined();
+				}
+			}
+
+			// And the other direction: a name the renderer resolves is one this
+			// module reports as resolved. Without this, dropping every name would
+			// pass the loop above vacuously.
+			const reported = new Map(
+				resolveVariableReports(scopes)
+					.filter((r) => r.resolved)
+					.map((r) => [r.name, r.value])
+			);
+			expect(Object.fromEntries(reported)).toEqual(Object.fromEntries(rendererWinners));
+		}
+	);
+
+	test("the fixture is non-empty and actually exercises all three scopes", () => {
+		expect(fixture.cases.length).toBeGreaterThan(0);
+		const used = new Set<string>();
+		for (const c of fixture.cases) for (const k of Object.keys(c.scopes)) used.add(k);
+		expect([...used].sort()).toEqual(["chain", "environment", "globals"]);
+	});
+});
+
+describe("what the winner alone cannot say", () => {
+	test("a disabled higher scope loses to the enabled one beneath, and says why", () => {
+		const reports = resolveVariableReports({
+			globals: { host: { value: "globals.test", enabled: true } },
+			environment: {
+				id: "e1",
+				name: "Staging",
+				variables: { host: { value: "env.test", enabled: false } },
+			},
+		});
+
+		expect(reports).toHaveLength(1);
+		const [host] = reports;
+		expect(host.resolved).toBe(true);
+		expect(host.value).toBe("globals.test");
+		expect(host.scope).toBe("global");
+		// The answer to "why is this not the value I set?" - a switched-off row,
+		// not shadowing. Dropping `reason` here would make the two cases identical.
+		expect(host.shadowedBy).toEqual([
+			{
+				scope: "environment",
+				sourceId: "e1",
+				sourceName: "Staging",
+				value: "env.test",
+				enabled: false,
+				reason: "disabled",
+			},
+		]);
+	});
+
+	test("shadowed definitions read highest precedence first, each naming its collection", () => {
+		const reports = resolveVariableReports({
+			globals: { host: { value: "g", enabled: true } },
+			chain: [
+				{ id: "root", name: "Root", variables: { host: { value: "root", enabled: true } } },
+				{ id: "leaf", name: "Leaf", variables: { host: { value: "leaf", enabled: true } } },
+			],
+		});
+
+		const [host] = reports;
+		expect(host.value).toBe("leaf");
+		expect(host.sourceName).toBe("Leaf");
+		// Two collections in one chain are two origins: collapsing them by scope
+		// would hide the override that actually happened.
+		expect(host.shadowedBy.map((s) => [s.scope, s.sourceName, s.value])).toEqual([
+			["collection", "Root", "root"],
+			["global", undefined, "g"],
+		]);
+	});
+
+	test("every definition disabled resolves to nothing, not to the empty string", () => {
+		const [host] = resolveVariableReports({
+			globals: { host: { value: "g", enabled: false } },
+		});
+		expect(host.resolved).toBe(false);
+		expect(host).not.toHaveProperty("value");
+		expect(host.shadowedBy).toHaveLength(1);
+	});
+
+	test("a secret's value is withheld rather than silently dropped", () => {
+		const [token] = resolveVariableReports({
+			globals: { token: { value: "s3cret", enabled: true, secret: true } },
+		});
+		expect(token.resolved).toBe(true);
+		expect(token).not.toHaveProperty("value");
+		expect(token.valueWithheld).toBe(true);
+		expect(token.secret).toBe(true);
+	});
+
+	test("a requested name nothing defines gets a row saying so", () => {
+		const [missing] = resolveVariableReports({ globals: {} }, ["nope"]);
+		expect(missing).toEqual({ name: "nope", resolved: false, shadowedBy: [] });
+	});
+});
+
+describe("the collection chain walk", () => {
+	const rows = [
+		{ id: "root", name: "Root", parentId: null, variables: {} },
+		{ id: "mid", name: "Mid", parentId: "root", variables: {} },
+		{ id: "leaf", name: "Leaf", parentId: "mid", variables: {} },
+	];
+
+	test("walks root-first", () => {
+		expect(collectionChain(rows, "leaf").map((c) => c.id)).toEqual(["root", "mid", "leaf"]);
+	});
+
+	test("treats null, absent and empty-string parents alike as root", () => {
+		expect(collectionChain([{ id: "a", parentId: "" }], "a").map((c) => c.id)).toEqual(["a"]);
+		expect(collectionChain([{ id: "a" }], "a").map((c) => c.id)).toEqual(["a"]);
+		expect(collectionChain([{ id: "a", parentId: null }], "a").map((c) => c.id)).toEqual(["a"]);
+	});
+
+	test("a corrupted parentId loop terminates instead of hanging", () => {
+		const looped = [
+			{ id: "a", parentId: "b" },
+			{ id: "b", parentId: "a" },
+		];
+		expect(collectionChain(looped, "a").map((c) => c.id)).toEqual(["b", "a"]);
+		expect(collectionChain([{ id: "s", parentId: "s" }], "s").map((c) => c.id)).toEqual(["s"]);
+	});
+
+	test("an unknown id yields an empty chain rather than throwing", () => {
+		expect(collectionChain(rows, "ghost")).toEqual([]);
+	});
+});
+
+describe("origin accumulation", () => {
+	test("marks the winner rather than inferring it from position", () => {
+		const origins = buildVariableOrigins({
+			globals: { host: { value: "g", enabled: true } },
+			environment: { id: "e", name: "E", variables: { host: { value: "e", enabled: false } } },
+		});
+		// The last entry is the environment's, and it is not the winner.
+		expect(origins.host.map((o) => [o.scope, o.winner])).toEqual([
+			["global", true],
+			["environment", false],
+		]);
+	});
+
+	test("D17: absent enabled counts as enabled, a non-string value reads as empty", () => {
+		const origins = buildVariableOrigins({
+			globals: { a: { value: "x" }, b: { value: 42, enabled: true } },
+		});
+		expect(origins.a[0].enabled).toBe(true);
+		expect(origins.b[0].value).toBe("");
+	});
+});

--- a/app/electron/mcp/variable-origins.conformance.test.ts
+++ b/app/electron/mcp/variable-origins.conformance.test.ts
@@ -63,7 +63,9 @@ function asOriginScopes(scopes: ConformanceCase["scopes"]): OriginScopes {
 			name: `Collection ${i}`,
 			variables,
 		})),
-		...(scopes.environment ? { environment: { id: "e", name: "Env", variables: scopes.environment } } : {}),
+		...(scopes.environment
+			? { environment: { id: "e", name: "Env", variables: scopes.environment } }
+			: {}),
 	};
 }
 
@@ -220,7 +222,11 @@ describe("origin accumulation", () => {
 	test("marks the winner rather than inferring it from position", () => {
 		const origins = buildVariableOrigins({
 			globals: { host: { value: "g", enabled: true } },
-			environment: { id: "e", name: "E", variables: { host: { value: "e", enabled: false } } },
+			environment: {
+				id: "e",
+				name: "E",
+				variables: { host: { value: "e", enabled: false } },
+			},
 		});
 		// The last entry is the environment's, and it is not the winner.
 		expect(origins.host.map((o) => [o.scope, o.winner])).toEqual([

--- a/app/electron/mcp/variable-origins.ts
+++ b/app/electron/mcp/variable-origins.ts
@@ -95,7 +95,7 @@ export interface VariableOrigin {
  * by the raw engine API) and malformed values count as enabled, matching the
  * importers' normalization and the engine's `parse_variables`.
  */
-export function isEnabledDefinition(def: StoredVariableLike | undefined): boolean {
+function isEnabledDefinition(def: StoredVariableLike | undefined): boolean {
 	return !!def && typeof def === "object" && def.enabled !== false;
 }
 
@@ -103,7 +103,7 @@ export function isEnabledDefinition(def: StoredVariableLike | undefined): boolea
  * D17: the raw stored string substitutes; a non-string stored `value` reads as
  * "" rather than being stringified.
  */
-export function coerceVariableValue(value: unknown): string {
+function coerceVariableValue(value: unknown): string {
 	return typeof value === "string" ? value : "";
 }
 
@@ -170,6 +170,20 @@ export interface CollectionLike {
 }
 
 /**
+ * A collection's parent, with the three spellings of "root" normalized to one.
+ *
+ * `null`, absent and the empty string all mean top-level, and comparing raw
+ * values would file a root collection under a parent named "". Exported because
+ * `tools.ts` walks the same rows for its cascade accounting: the rule has to
+ * have one definition, and this module is the one of the two that can be
+ * imported by the other (`tools.ts` already imports from here; the reverse would
+ * be a cycle).
+ */
+export function collectionParentId(row: CollectionLike): string | null {
+	return typeof row.parentId === "string" && row.parentId !== "" ? row.parentId : null;
+}
+
+/**
  * The collection chain from the root down to `leafId`, root-first.
  *
  * Root is spelled three ways in stored rows (`null`, absent, `""`), and a
@@ -201,7 +215,7 @@ export function collectionChain(rows: readonly CollectionLike[], leafId: string)
 					? (row.variables as StoredVariableBag)
 					: undefined,
 		});
-		currentId = typeof row.parentId === "string" && row.parentId !== "" ? row.parentId : null;
+		currentId = collectionParentId(row);
 	}
 	return chain;
 }

--- a/app/electron/mcp/variable-origins.ts
+++ b/app/electron/mcp/variable-origins.ts
@@ -7,11 +7,17 @@
 
 /**
  * @file variable-origins.ts
- * @brief Which definition of a variable name wins, and which ones it beat (the
- *        `resolve_variables` tool's core). The app answers this in the variable
- *        popover's origin list; before this module an agent could not ask it at
- *        all, and had to reconstruct the resolution order from a rule no tool
- *        stated (issue #1207).
+ * @brief The variable resolution model as the MCP surface states it, and which
+ *        definition of a name wins (the `resolve_variables` tool's core). The
+ *        app answers the second question in the variable popover's origin list;
+ *        before this module an agent could not ask it at all, and had to
+ *        reconstruct the resolution order from a rule no tool stated
+ *        (issue #1207).
+ *
+ * The prose and the computation live together on purpose: a tool description
+ * that paraphrases the order and a resolver that implements it are exactly the
+ * two copies that drift. Here the sentence every variable tool carries and the
+ * loop that picks the winner are one edit apart.
  *
  * The order is the one `docs/app/variable-resolution.md` defines and the engine
  * executes: globals < collection chain (root -> leaf) < active environment.
@@ -173,10 +179,7 @@ export interface CollectionLike {
  * throwing: whether that is an error is the caller's to decide, because
  * `resolve_variables` refuses it and other callers may not.
  */
-export function collectionChain(
-	rows: readonly CollectionLike[],
-	leafId: string
-): VariableSource[] {
+export function collectionChain(rows: readonly CollectionLike[], leafId: string): VariableSource[] {
 	const byId = new Map<string, CollectionLike>();
 	for (const row of rows) {
 		if (typeof row?.id === "string") byId.set(row.id, row);
@@ -259,7 +262,10 @@ function withValue(
  * value - absent, not present-and-empty, because a present-and-empty answer
  * would read as "it resolves to the empty string", which is a different fact.
  */
-export function reportForName(name: string, origins: readonly VariableOrigin[]): ResolvedVariableReport {
+export function reportForName(
+	name: string,
+	origins: readonly VariableOrigin[]
+): ResolvedVariableReport {
 	const winner = origins.find((o) => o.winner);
 	const ranked = [...origins].reverse();
 	const shadowedBy: ShadowedDefinition[] = ranked
@@ -305,3 +311,109 @@ export function resolveVariableReports(
 	const wanted = names && names.length > 0 ? [...new Set(names)] : Object.keys(origins).sort();
 	return wanted.map((name) => reportForName(name, origins[name] ?? []));
 }
+
+// --- The model, as the MCP surface states it ---------------------------------
+
+/**
+ * The resource that carries the full model. Every variable-writing tool points
+ * at this rather than paraphrasing the rules a second time, which is what
+ * `tools.test.ts`'s table-driven scan checks.
+ */
+export const VARIABLE_RESOLUTION_URI = "vayu://variables/resolution";
+
+/**
+ * The one sentence. It appears verbatim in every tool that writes or lists
+ * variables; a new such tool that omits it fails the scan.
+ *
+ * Spelled with `<` rather than `>` because that is the direction
+ * `docs/app/variable-resolution.md` states the ladder in, and the two spellings
+ * in one surface were half of what made the order hard to learn.
+ */
+export const VARIABLE_PRECEDENCE_SENTENCE =
+	"Resolution order (lowest to highest): globals < collection chain (root to leaf) < active environment, with a bound data row's bare column names above all three.";
+
+/**
+ * The precedence sentence, this tier's own position in it, and the pointer to
+ * the full model - the three things every variable tool's description owes an
+ * agent that is about to change a value.
+ */
+export function precedenceNote(tierPosition: string): string {
+	return `${VARIABLE_PRECEDENCE_SENTENCE} ${tierPosition} Full model, including the reserved namespaces and what a script sees: ${VARIABLE_RESOLUTION_URI}.`;
+}
+
+/**
+ * The rule set from `docs/app/variable-resolution.md`, in the form an agent
+ * reads. Structured rather than one prose blob so a client can render or search
+ * it, and so the tiers cannot be listed in one order here and another there.
+ *
+ * This is a statement of a contract the engine executes, not a second
+ * implementation of it: nothing here resolves anything. The contract itself is
+ * pinned by `engine/tests/fixtures/variable-resolution-conformance.json`, which
+ * the engine's suite, the renderer's and this module's conformance guard all
+ * replay.
+ */
+export const VARIABLE_RESOLUTION_MODEL = {
+	summary: VARIABLE_PRECEDENCE_SENTENCE,
+	resolvedBy:
+		"The engine resolves at execution time (POST /compose); the app keeps a preview-only copy of the same rules. Both answer one shared conformance fixture, so what an agent is told here is what a send actually does.",
+	tiers: [
+		{
+			scope: "global",
+			rank: 1,
+			description:
+				"App-wide variables, read by every request whatever environment is active. The base layer - any tier above shadows a global of the same name.",
+			writtenBy: ["update_globals"],
+			readBy: ["get_globals"],
+		},
+		{
+			scope: "collection",
+			rank: 2,
+			description:
+				"The collection chain, merged root-first so a child collection's variable outranks an ancestor's of the same name. Each collection in the chain is its own definition, not one merged 'collection' value.",
+			writtenBy: ["create_collection", "update_collection"],
+			readBy: ["list_collections"],
+		},
+		{
+			scope: "environment",
+			rank: 3,
+			description:
+				"The active environment (or whichever environmentId a call names). The intended override point for per-environment values like base URLs and API keys; it beats every collection and global of the same name.",
+			writtenBy: ["create_environment", "update_environment", "activate_environment"],
+			readBy: ["list_environments"],
+		},
+		{
+			scope: "row",
+			rank: 4,
+			description:
+				"A bound data row's bare column names, and only while a row is bound (a data-driven collection run, a load run given rows, or a send bound to one row). With no dataset the ladder is the three tiers above. A column the row does not carry falls through to the scopes rather than failing.",
+			writtenBy: [],
+			readBy: [],
+		},
+	],
+	rules: [
+		"Only an explicit `enabled: false` disables a definition. Absent or malformed `enabled` counts as enabled.",
+		"A non-string stored `value` reads as the empty string rather than being stringified.",
+		'A name whose every definition is disabled resolves to nothing at all - it is absent, not present-and-empty, so the placeholder stays unresolved rather than substituting "".',
+		"Within one scope the last write wins; across scopes the highest tier that has the name enabled wins.",
+		"A disabled definition in a higher tier does not shadow an enabled one beneath it - the lower value is used.",
+	],
+	reservedNamespaces: [
+		{
+			pattern: "data.*",
+			rule: "`{{data.column}}` addresses a column of a run's data file. It is disjoint from the tiers, not a tier above them: `{{data.id}}` and `{{id}}` are different names, so a data set can neither shadow nor be shadowed by a variable.",
+		},
+		{
+			pattern: "$vu, $iteration",
+			rule: "Run identity. Both compose-time resolvers leave them written as they stand and the executor substitutes them immediately before each send, so a variable someone happens to name `$vu` does not answer for the identity.",
+		},
+		{
+			pattern: "$guid, $timestamp, $randomInt, ...",
+			rule: "Dynamic generators. Unlike `$vu`, a variable of the same name DOES win over the generator - a scope that defines `$guid` shadows it. `vayu://scripting/completions` carries the full generator list.",
+		},
+	],
+	fromAScript: {
+		scoped: "pm.environment.get, pm.collectionVariables.get and pm.globals.get each read one scope only, and answer emptily when that scope has no such name - they do not fall through.",
+		merged: "pm.variables.get reads across scopes in this page's order, top down: environment, then the collection chain, then globals, stopping at the first scope that has the name enabled. While a row is bound its bare column names are checked first, above all three.",
+		chain: "The collection scope a script reads is the whole chain, the same one {{name}} merges - not just the request's own collection.",
+	},
+} as const;

--- a/app/electron/mcp/variable-origins.ts
+++ b/app/electron/mcp/variable-origins.ts
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @file variable-origins.ts
+ * @brief Which definition of a variable name wins, and which ones it beat (the
+ *        `resolve_variables` tool's core). The app answers this in the variable
+ *        popover's origin list; before this module an agent could not ask it at
+ *        all, and had to reconstruct the resolution order from a rule no tool
+ *        stated (issue #1207).
+ *
+ * The order is the one `docs/app/variable-resolution.md` defines and the engine
+ * executes: globals < collection chain (root -> leaf) < active environment.
+ * Disabled definitions are collected rather than skipped - "why is this not the
+ * value I set?" is answered by a switched-off row far more often than by
+ * shadowing, and a list built by skipping them cannot say so.
+ *
+ * **Mirrored by `app/src/lib/variable-resolution.ts` (the winner) and
+ * `app/src/hooks/useVariableResolver.ts` (the origin accumulation).** Neither
+ * process can import the other's source: this project emits with
+ * `rootDir: "electron"` and so cannot compile a file from `src/` (TS6059), and
+ * the renderer cannot import one from here either, because this is a referenced
+ * composite project (TS6305 - and excluding a file from it to dodge that is
+ * TS6307). So the copy is deliberate, the way `compare.ts` mirrors
+ * `src/lib/run-compare.ts`, and `variable-origins.conformance.test.ts` runs this
+ * winner against the renderer's over the engine's own conformance fixture and
+ * fails on any divergence. Change this file and change those two.
+ *
+ * What this deliberately does NOT do is substitute `{{tokens}}`: that is
+ * composition, the engine owns it (`POST /compose`), and MCP keeps no copy of
+ * it. This module reports where a value came from; it never renders a request.
+ */
+
+/** The three scopes a stored definition can live in, lowest precedence first. */
+export type VariableScope = "global" | "collection" | "environment";
+
+/** A stored variable definition as it may actually arrive off disk - loose. */
+export interface StoredVariableLike {
+	value?: unknown;
+	enabled?: unknown;
+	secret?: unknown;
+	type?: unknown;
+}
+
+/** `Record<name, definition>` - the shape of every stored `variables` blob. */
+export type StoredVariableBag = Record<string, StoredVariableLike>;
+
+/** A named holder of a variable bag - one collection in the chain, or the environment. */
+export interface VariableSource {
+	id?: string;
+	name?: string;
+	variables?: StoredVariableBag;
+}
+
+/**
+ * The scopes to resolve across. `chain` is **root-first**, so a later (leaf)
+ * entry outranks an earlier (root) one - the same order the renderer's
+ * `walkAncestors` produces and the engine walks.
+ */
+export interface OriginScopes {
+	globals?: StoredVariableBag;
+	chain?: readonly VariableSource[];
+	environment?: VariableSource;
+}
+
+/**
+ * One definition of one name, and whether it is the one a send would use.
+ *
+ * `winner` is marked rather than inferred by position: once disabled
+ * definitions are in the list, "last" and "wins" are different things.
+ */
+export interface VariableOrigin {
+	scope: VariableScope;
+	sourceId?: string;
+	sourceName?: string;
+	value: string;
+	secret?: boolean;
+	type?: string;
+	enabled: boolean;
+	winner: boolean;
+}
+
+/**
+ * D17: only an explicit `false` disables a definition. Absent (a blob written
+ * by the raw engine API) and malformed values count as enabled, matching the
+ * importers' normalization and the engine's `parse_variables`.
+ */
+export function isEnabledDefinition(def: StoredVariableLike | undefined): boolean {
+	return !!def && typeof def === "object" && def.enabled !== false;
+}
+
+/**
+ * D17: the raw stored string substitutes; a non-string stored `value` reads as
+ * "" rather than being stringified.
+ */
+export function coerceVariableValue(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+/** The optional `type` hint, kept only when it is actually a string. */
+function coerceVariableType(type: unknown): string | undefined {
+	return typeof type === "string" ? type : undefined;
+}
+
+/**
+ * Every definition of every name, in precedence order (lowest first), with the
+ * winner marked.
+ *
+ * Each collection in the chain is its own origin: two collections in one chain
+ * both have scope `"collection"`, and collapsing them by scope would hide the
+ * override that actually happened.
+ */
+export function buildVariableOrigins(scopes: OriginScopes): Record<string, VariableOrigin[]> {
+	const result: Record<string, VariableOrigin[]> = {};
+
+	const push = (scope: VariableScope, source: VariableSource | undefined, bag: unknown) => {
+		if (!bag || typeof bag !== "object") return;
+		for (const [name, def] of Object.entries(bag as StoredVariableBag)) {
+			if (!def || typeof def !== "object") continue;
+			(result[name] ??= []).push({
+				scope,
+				...(source?.id !== undefined ? { sourceId: source.id } : {}),
+				...(source?.name !== undefined ? { sourceName: source.name } : {}),
+				value: coerceVariableValue(def.value),
+				...(def.secret === true ? { secret: true } : {}),
+				...(coerceVariableType(def.type) !== undefined
+					? { type: coerceVariableType(def.type) }
+					: {}),
+				enabled: isEnabledDefinition(def),
+				// Filled in below, once the whole list for this name exists.
+				winner: false,
+			});
+		}
+	};
+
+	push("global", undefined, scopes.globals); // 1. globals (lowest)
+	for (const col of scopes.chain ?? []) push("collection", col, col.variables); // 2. chain root->leaf
+	if (scopes.environment) push("environment", scopes.environment, scopes.environment.variables); // 3. environment (highest)
+
+	// The winner is the *last enabled* definition - which is exactly the value
+	// the renderer's overwrite-as-you-go `buildVariableValues` arrives at.
+	for (const list of Object.values(result)) {
+		for (let i = list.length - 1; i >= 0; i--) {
+			if (list[i].enabled) {
+				list[i].winner = true;
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
+/** A collection row as the engine's `GET /collections` answers it. */
+export interface CollectionLike {
+	id?: unknown;
+	name?: unknown;
+	parentId?: unknown;
+	variables?: unknown;
+}
+
+/**
+ * The collection chain from the root down to `leafId`, root-first.
+ *
+ * Root is spelled three ways in stored rows (`null`, absent, `""`), and a
+ * corrupted `parentId` can point at itself or close a loop - so the walk is
+ * guarded, the way the renderer's `walkAncestors` and the tool layer's
+ * descendant walk both are. An unknown id yields an empty chain rather than
+ * throwing: whether that is an error is the caller's to decide, because
+ * `resolve_variables` refuses it and other callers may not.
+ */
+export function collectionChain(
+	rows: readonly CollectionLike[],
+	leafId: string
+): VariableSource[] {
+	const byId = new Map<string, CollectionLike>();
+	for (const row of rows) {
+		if (typeof row?.id === "string") byId.set(row.id, row);
+	}
+
+	const chain: VariableSource[] = [];
+	const seen = new Set<string>();
+	let currentId: string | null = leafId;
+	while (currentId) {
+		if (seen.has(currentId)) break;
+		seen.add(currentId);
+		const row = byId.get(currentId);
+		if (!row) break;
+		chain.unshift({
+			id: typeof row.id === "string" ? row.id : undefined,
+			name: typeof row.name === "string" ? row.name : undefined,
+			variables:
+				row.variables && typeof row.variables === "object"
+					? (row.variables as StoredVariableBag)
+					: undefined,
+		});
+		currentId = typeof row.parentId === "string" && row.parentId !== "" ? row.parentId : null;
+	}
+	return chain;
+}
+
+/** Why a definition is not the one a send would use. */
+export type ShadowReason = "outranked" | "disabled";
+
+/** A definition that lost, and which of the two ways it lost. */
+export interface ShadowedDefinition {
+	scope: VariableScope;
+	sourceId?: string;
+	sourceName?: string;
+	value?: string;
+	valueWithheld?: true;
+	secret?: boolean;
+	enabled: boolean;
+	reason: ShadowReason;
+}
+
+/** One name's answer: what wins, and everything it beat. */
+export interface ResolvedVariableReport {
+	name: string;
+	/** False when every definition is switched off - the name resolves to nothing. */
+	resolved: boolean;
+	value?: string;
+	valueWithheld?: true;
+	scope?: VariableScope;
+	sourceId?: string;
+	sourceName?: string;
+	secret?: boolean;
+	type?: string;
+	/** Highest precedence first - reading down is reading the order they were rejected in. */
+	shadowedBy: ShadowedDefinition[];
+}
+
+/**
+ * A secret's value is withheld rather than silently dropped, the way
+ * `projectOAuth2Token` withholds an access token: `valueWithheld` is stated, so
+ * an absent `value` is never mistaken for an empty one.
+ *
+ * This masks what *this tool* reports. `list_environments`, `get_globals` and
+ * `vayu://environments` still answer every value in full - a recorded pre-1.0
+ * item this issue did not change - so masking here is consistency with the app's
+ * popover, not a security boundary. The tool's description says so.
+ */
+function withValue(
+	value: string,
+	secret: boolean | undefined
+): { value: string } | { valueWithheld: true } {
+	return secret ? { valueWithheld: true } : { value };
+}
+
+/**
+ * Turn one name's origin list into the winner-plus-shadowed answer, ordered the
+ * way the app's popover orders it: highest precedence first.
+ *
+ * A name whose every definition is disabled reports `resolved: false` with no
+ * value - absent, not present-and-empty, because a present-and-empty answer
+ * would read as "it resolves to the empty string", which is a different fact.
+ */
+export function reportForName(name: string, origins: readonly VariableOrigin[]): ResolvedVariableReport {
+	const winner = origins.find((o) => o.winner);
+	const ranked = [...origins].reverse();
+	const shadowedBy: ShadowedDefinition[] = ranked
+		.filter((o) => !o.winner)
+		.map((o) => ({
+			scope: o.scope,
+			...(o.sourceId !== undefined ? { sourceId: o.sourceId } : {}),
+			...(o.sourceName !== undefined ? { sourceName: o.sourceName } : {}),
+			...withValue(o.value, o.secret),
+			...(o.secret === true ? { secret: true } : {}),
+			enabled: o.enabled,
+			reason: o.enabled ? ("outranked" as const) : ("disabled" as const),
+		}));
+
+	if (!winner) return { name, resolved: false, shadowedBy };
+
+	return {
+		name,
+		resolved: true,
+		...withValue(winner.value, winner.secret),
+		scope: winner.scope,
+		...(winner.sourceId !== undefined ? { sourceId: winner.sourceId } : {}),
+		...(winner.sourceName !== undefined ? { sourceName: winner.sourceName } : {}),
+		...(winner.secret === true ? { secret: true } : {}),
+		...(winner.type !== undefined ? { type: winner.type } : {}),
+		shadowedBy,
+	};
+}
+
+/**
+ * Every name defined anywhere in `scopes`, reported winner-first and sorted by
+ * name so two calls over the same data read the same way.
+ *
+ * `names`, when given, selects: a name nothing defines still gets a row, with
+ * `resolved: false` and an empty `shadowedBy`, because "nothing defines it" is
+ * the answer to the question asked and an omitted row is not.
+ */
+export function resolveVariableReports(
+	scopes: OriginScopes,
+	names?: readonly string[]
+): ResolvedVariableReport[] {
+	const origins = buildVariableOrigins(scopes);
+	const wanted = names && names.length > 0 ? [...new Set(names)] : Object.keys(origins).sort();
+	return wanted.map((name) => reportForName(name, origins[name] ?? []));
+}

--- a/app/src/lib/routed-inputs.testkit.ts
+++ b/app/src/lib/routed-inputs.testkit.ts
@@ -180,6 +180,16 @@ export const ENGINE_READING_GUARDS = {
 		reader: "app/src/lib/variable-resolution.conformance.test.ts",
 		paths: ["engine/tests/fixtures/variable-resolution-conformance.json"],
 	},
+	/*
+	 * The same fixture, read by the third implementation of the resolution order
+	 * (issue #1207): the MCP `resolve_variables` tool cannot import the
+	 * renderer's resolver across the process boundary, so it mirrors it and this
+	 * guard replays the fixture against both.
+	 */
+	mcpVariableOrigins: {
+		reader: "app/electron/mcp/variable-origins.conformance.test.ts",
+		paths: ["engine/tests/fixtures/variable-resolution-conformance.json"],
+	},
 	setCookie: {
 		reader: "app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.conformance.test.ts",
 		paths: ["engine/tests/fixtures/set-cookie-conformance.json"],

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -20,6 +20,12 @@ the shared conformance fixture
 (`engine/tests/fixtures/variable-resolution-conformance.json`), which the
 engine's gtest suite and the renderer's vitest suite both drive.
 
+**A third reader, MCP (issue #1207):** the same rule set is served as the MCP
+resource `vayu://variables/resolution`, and the `resolve_variables` tool
+answers which definition wins for a given collection/environment context and
+every definition it shadowed. See
+[MCP - Variables](../engine/mcp.md#variables).
+
 **One matcher in the renderer.** `{{name}}` is recognised by
 `VARIABLE_PATTERN` in `app/src/constants/variables.ts` and nowhere else -
 import it (or `containsVariableToken` / `isVariableToken`, which wrap the two

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -188,6 +188,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `activate_environment` | write    | `PUT /environments/:id` (`isActive`), + `GET /environments` for `"none"` | write toggle; one PUT - the engine deactivates the previous row in the same transaction |
 | `delete_environment`   | write    | `GET /environments` (scan) + `DELETE /environments/:id` | write toggle + confirm (the prompt names the variable count) |
 | `get_globals`          | read     | `GET /globals`                               | - (answers an empty set, never a 404) |
+| `resolve_variables`    | read     | `GET /globals` + `GET /collections` + `GET /environments` - composes, no single endpoint answers it | - (secret values withheld from the report) |
 | `update_globals`       | write    | `GET /globals` + `POST /globals` (fetch-merge) | write toggle; `POST` replaces the blob, so the read is what makes it a merge |
 | `get_cookies`          | read     | `GET /cookies`                               | - (values included, as the Settings card shows them) |
 | `clear_cookies`        | write    | `DELETE /cookies[?environmentId=]`           | write toggle; omitted clears every jar, `null` the no-environment jar, an id that environment's |
@@ -1102,6 +1103,61 @@ scenario load run gives each virtual user cookies of its own.
 > resolver is preview-only. Do not reintroduce client-side composition here -
 > a new engine client should call `POST /compose`.
 
+### Variables
+
+The resolution order is stated once rather than reworded per tool: **globals
+< collection chain (root to leaf) < active environment**, with a bound data
+row's bare column names above all three. That is the ladder
+[Variable Resolution](../app/variable-resolution.md) defines and the engine
+executes; before issue #1207 it lived only inside two tool descriptions that
+happened to mention it, and nowhere a caller about to write a value could ask
+for it directly.
+
+The model itself is served once, as a resource
+(`vayu://variables/resolution`, backed by `variable-origins.ts`'s
+`VARIABLE_RESOLUTION_MODEL`), rather than restated per tool. Every
+variable-writing or -listing tool - `get_globals`, `update_globals`,
+`list_environments`, `create_environment`, `update_environment`,
+`create_collection`, `update_collection` - carries one shared sentence
+(`VARIABLE_PRECEDENCE_SENTENCE`) plus that tier's own position in the order and
+a pointer to the resource; `precedenceNote()` builds both pieces from one
+place. A table-driven scan in `tools.test.ts` runs over every variable tool's
+description and fails on one that omits the sentence, so a new variable tool
+cannot ship silent about where its tier sits.
+
+**`resolve_variables`** answers what the per-tier reads cannot: which
+definition of a name actually wins in a given collection/environment context,
+and everything it beat. It reports the winning value with its scope and
+source, then every other definition highest-precedence-first, each labelled
+`outranked` (a higher-ranked definition - a later link in the chain, or a
+tier above - is enabled and wins instead) or `disabled` (`enabled: false`).
+The second is the more common answer to "why is this not the value I set?",
+and a list built by skipping disabled rows could not give it. A name whose
+every definition is disabled resolves to nothing at all, not to an empty
+string: the tool reports `resolved: false` with no value, because a
+present-and-empty answer would read as a different fact.
+
+Secret values are withheld from `resolve_variables`'s report
+(`valueWithheld: true`) to match the app's variable popover. That withholding
+is consistency with the app, not a security boundary: `list_environments`,
+`get_globals` and `vayu://environments` still return every value in full -
+the same recorded pre-1.0 item the app-side-masking note above (under
+`update_environment`) already names.
+
+**The model is duplicated on purpose, and pinned so the copies cannot drift.**
+Neither process can import the other's resolver: the main process emits with
+`rootDir: "electron"` and cannot compile a file under `src/` (TS6059), and the
+renderer cannot import from here, because this is a referenced composite
+project (TS6305). So `electron/mcp/variable-origins.ts` mirrors
+`app/src/lib/variable-resolution.ts` the way `compare.ts` mirrors
+`src/lib/run-compare.ts` (see the file map below), and
+`variable-origins.conformance.test.ts` replays the engine's own fixture
+(`engine/tests/fixtures/variable-resolution-conformance.json`) through both, so
+a divergence fails a test rather than surfacing as a wrong answer months
+later. This does not make MCP a second composition path: `resolve_variables`
+reports stored definitions and substitutes no `{{tokens}}` - `POST /compose`
+remains the only place a request is actually composed.
+
 ## Resources
 
 Read-only Vayu data an agent can attach as context (`resources.ts`):
@@ -1111,6 +1167,7 @@ Read-only Vayu data an agent can attach as context (`resources.ts`):
 | `vayu://runs`               | The most recent 100 runs (first page), newest first; `pagination.total` / `hasMore` in the content carry the full count. A resource takes no arguments, so filtering and paging beyond this page is the `list_runs` tool's job. |
 | `vayu://collections`        | All request collections.         |
 | `vayu://environments`       | All environments.                |
+| `vayu://variables/resolution` | The resolution rule set: tier order, disabled/non-string handling, reserved namespaces, and what a script's scoped and merged reads see. See [Variables](#variables). |
 | `vayu://config`             | Engine configuration entries.    |
 | `vayu://scripting/completions` | The script sandbox's full API surface (see below). |
 | `vayu://scripting/types`    | The same surface as TypeScript declarations - the `.d.ts` the app's editor loads, so a call's parameters and return type are the running engine's. |
@@ -1383,6 +1440,7 @@ Everything lives under `app/electron/mcp/` and is managed by `main.ts` alongside
 | `safety.ts`        | Pure guards: allowlist, load caps, duration parsing.                        |
 | `engine-client.ts` | Thin `fetch` client to the engine REST API + SSE metrics snapshot.          |
 | `compare.ts`       | Pure two-report diff for `compare_runs`. Mirrored by the renderer's `src/lib/run-compare.ts` (neither process can import the other's source); `compare.conformance.test.ts` fails on any divergence. Reads the status mix in **both** wire shapes: the renderer's transformed record and the engine's own array of `[code, count]` pairs (`std::map<int, size_t>` cannot serialize as a JSON object), which is what this path gets from a raw `GET /runs/:id/report`. |
+| `variable-origins.ts` | The resolution model the `vayu://variables/resolution` resource serves, and the winner-plus-shadowed computation behind `resolve_variables`. Mirrors the renderer's `src/lib/variable-resolution.ts` and `useVariableResolver.ts` for the same reason `compare.ts` does; `variable-origins.conformance.test.ts` replays the engine's fixture through both and fails on divergence. Resolves no `{{tokens}}` - see [Variables](#variables). |
 | `http-versions.ts` | The `httpVersion` value list the Zod schemas enumerate.                     |
 | `tools.ts`         | Tool registry (schemas, annotations, handlers) + `dispatchTool`, the one dispatch path `server.ts` and the tests share. |
 | `resources.ts`     | Static + templated resource definitions.                                    |

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -1154,9 +1154,20 @@ project (TS6305). So `electron/mcp/variable-origins.ts` mirrors
 `variable-origins.conformance.test.ts` replays the engine's own fixture
 (`engine/tests/fixtures/variable-resolution-conformance.json`) through both, so
 a divergence fails a test rather than surfacing as a wrong answer months
-later. This does not make MCP a second composition path: `resolve_variables`
-reports stored definitions and substitutes no `{{tokens}}` - `POST /compose`
-remains the only place a request is actually composed.
+later. The fixture supplies a pre-flattened chain, so it cannot exercise the
+`parentId` walk; that half is pinned separately, by running `collectionChain()`
+and the renderer's `walkAncestors()` over the same rows - including the
+malformed ones (a self-parent, a two-node loop, a parent that does not exist) -
+and asserting they agree.
+
+Call this what it is: a second implementation of the resolution order, kept
+honest rather than avoided. Importing the renderer's resolver is the option
+that would have avoided it and the build forbids it; an engine endpoint
+reporting origins is the other, and it would mean new C++ for a question the
+engine has no use for (execution needs the winner, never the losers). This
+does not make MCP a second **composition** path, which is the split that is
+load-bearing: `resolve_variables` reports stored definitions and substitutes no
+`{{tokens}}` - `POST /compose` remains the only place a request is composed.
 
 ## Resources
 


### PR DESCRIPTION
## Description

An MCP agent could learn the variable resolution order from two tool descriptions (`run_request`, `get_globals`) and from nowhere else. Every tool that actually *changes* a variable was silent about it, so "fixing" a global that the active environment shadowed looked like a write that did nothing - and no tool could answer the question the app's own variable popover answers on hover: **which definition wins here, and what did it beat?**

**Root cause, approach, and the alternative rejected.** The rules live in `docs/app/variable-resolution.md` and are executed by the engine, but the MCP surface carried them only as prose in two unrelated places, so the tier a caller was writing to was never stated where they were writing. The fix is three layers in one PR: state the model once as a resource, have every variable tool name its own tier and point at that resource, and add a read tool that reports winner-plus-shadowed. The issue asked me to prefer reusing the renderer's resolver (`app/src/lib/variable-resolution.ts`) over writing another. I verified that route is closed: `app/tsconfig.node.json` compiles the main process with `rootDir: "electron"` and defines no `@/*` alias, `tsc` does not rewrite path aliases at emit, and there is no bundler for `dist-electron` - the tsconfig comments defend that boundary deliberately. The renderer also cannot import from `electron/`, a referenced composite project (TS6305). The other offered route, an engine endpoint reporting origins, means new C++ for a question the engine has no use for: execution needs the winner and never the losers. So I took the path this repo already established for exactly this wall - `electron/mcp/compare.ts` mirrors `src/lib/run-compare.ts`, kept honest by a conformance test - and applied it here. **See "Deliberate deviation" below; this is the one judgement call in the PR and it is yours to overrule.**

### What landed

- **`vayu://variables/resolution`** states the model once: the four tiers, what a disabled or non-string definition does, the reserved namespaces, and the scoped-vs-merged script read (#1196's footgun). It is a rules document, so it answers with the engine down.
- **Every variable-writing and variable-listing tool** carries one shared sentence plus its own tier's position and a pointer to that resource - `get_globals`, `update_globals`, `list_environments`, `create_environment`, `update_environment`, `create_collection`, `update_collection`, `list_collections`, `activate_environment`, and the `variablesInput` field description (where a client rendering per-field docs shows it). `vayu://environments` and `vayu://collections` too.
- **`resolve_variables`** answers what the per-tier reads cannot: the winning value with its scope and source, then every shadowed definition highest-precedence-first, each labelled `outranked` or `disabled`. The second is the commoner answer to "why is this not the value I set?". A name whose every definition is disabled reports `resolved: false` with no value - absent, not present-and-empty. A `collectionId` or `environmentId` naming nothing is refused rather than resolved as an empty scope: a typo answering confidently from globals alone is the failure the tool exists to prevent.

### Deliberate deviation from the issue spec

Criterion 3 says "one algorithm - no new resolver implementation in the MCP layer". **This PR adds one**: `app/electron/mcp/variable-origins.ts`. Both sanctioned routes are closed (evidence above), and the issue's literal prohibition - "do NOT write a third resolver in `tools.ts`" - is honoured in that it is a dedicated, documented module rather than logic buried in a 7,300-line file. I am flagging it rather than presenting it as compliant. What makes it defensible instead of merely convenient is the guard: `variable-origins.conformance.test.ts` replays the engine's own 40-case fixture through **both** this resolver and the renderer's and asserts they agree in both directions. The fixture supplies a pre-flattened chain, so it cannot reach the `parentId` walk - that half is pinned separately by running `collectionChain()` and the renderer's real `walkAncestors()` over the same rows, malformed ones included. If you would rather have the engine endpoint, say so and I will do that instead.

### Two anchor corrections worth knowing

The issue names `send_request`; the tool is actually **`run_request`**. It also names `$identity` as a reserved token; no such token exists - the reserved run-identity names are `$vu` and `$iteration`, and they behave *oppositely* to `$guid` (a variable named `$vu` does not answer for the identity, one named `$guid` does win over the generator). The resource states the real split.

### Noted, deliberately not fixed here

`resolve_variables` withholds secret values (`valueWithheld: true`) to match the app's popover, but `list_environments`, `get_globals` and `vayu://environments` still return every value in full - the recorded pre-1.0 item. So the withholding is consistency with the app, **not a security boundary**, and the tool description and docs say so plainly rather than letting it be mistaken for one. Separately, `docs/engine/mcp.md:634` carries a pre-existing en-dash (`2xx–3xx`) against the repo's no-em-dash rule; outside this diff, so left alone.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run locally on the final commit (`4c5f75e`), all green:

- `cd app && pnpm test` - **605 files, 6781 tests passed**. Baseline on `master` before this branch was 604 / 6683, so this adds one file and 98 tests. No pre-existing failures on the base commit.
- `cd app && pnpm type-check` - clean across all three projects (renderer, electron, electron-tests). The `electron` project passing is itself part of the evidence above: production main-process code still reaches nothing under `src/`.
- `cd app && pnpm lint` and `pnpm format:check` - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, no broken links or anchors.

Mutation-checked rather than assumed: reversing the winner selection from last-enabled to first-enabled reddens 3 tests including the cross-implementation guard; the derived writer set asserts it is non-empty and names its members, so a filter that silently matched nothing cannot pass.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1207
