### PR TITLE
docs(app): the layout diagram names what Shell actually renders

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2035,11 +2035,14 @@ the only one.
 ## Layout Structure
 
 ```
-Shell
-├── Drawer (aside)               220–480px, default 260px - PanelResizeHandle
-│   ├── ActivityBar          w-11 (44px)  bg-panel border-r border-border
-│   └── the active view      bg-panel border-r border-border  (collapsible)
-└── content column (flex-1)      TabStrip, then main + ContextBar
+Shell                            flex flex-col h-full bg-background
+├── row (flex-1)
+│   ├── Drawer (aside)       220–480px, default 260px, bg-panel - one of the six
+│   │                        views, plus its PanelResizeHandle on the right edge
+│   └── content column       TabStrip, then main beside the ContextBar
+│                            (220–480px, its handle on the left edge)
+└── Dock                     h-[var(--dock-height)] border-t border-border - the
+                             view switcher, along the bottom of the window
 ```
 
 ### The panels that resize, and the one handle that resizes them


### PR DESCRIPTION
## Description

A follow-up to #1325, which merged a minute before this commit reached the branch. It fixes a defect that PR introduced.

#1325 rewrote the Layout Structure diagram in `docs/design-system.md` because the section around it documented the sidebar through `useResizable`, the hook that PR deleted. The rewrite carried `ActivityBar` and `SidebarPanel` over from the version it replaced. Neither exists: a repo-wide search for either name in `app/src` returns nothing. `Drawer.tsx` renders one of six views plus its `PanelResizeHandle`, and the view switcher is `Dock`, a bar along the bottom of the window rather than a 44px vertical strip inside the drawer. The `border-r border-border` the diagram attributed to those rows is not on the drawer either - the `<aside>` is `relative flex shrink-0 bg-panel`.

Every claim in the replacement was read off the source: the 220-480px clamp (`PANEL_MIN_WIDTH` / `PANEL_MAX_WIDTH` in `constants/layout.ts`), the 260px default (`DEFAULT_DRAWER_WIDTH`), `bg-panel`, which edge each handle sits on (`side="right"` in `Drawer.tsx`, `side="left"` in `ContextBar.tsx`), and the Dock's `h-[var(--dock-height)] border-t border-border`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test design-system-doc` - 4 tests passing (the guard that checks this doc's values against `index.css`).
- Prose only, one file, no code touched. `mkdocs build --strict` is not installable in this environment; the change adds no links and no headings, so the docs Build job is the check.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - prose only, and the existing doc guard already covers this file
- [x] I have updated documentation

## Related Issues

Follows up #1325 (#1323).

### Note for the reviewer

The `### ActivityBar` and `### SidebarPanel` subsections immediately below this diagram, and the `app/src/components/layout/Sidebar.tsx` row in the file table near the end of the doc, describe the same non-existent components. `git log -L` dates them to the doc's original commit, long before either of these PRs, so they are pre-existing rot rather than fallout from #1325 and are left alone here - but a reader following this section downward still hits them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5jG7nriC3P3ktyVAmanYG)_