### PR TITLE
fix(scripts): a clicked snippet reaches the editor, and lands where the explorer's insertions do

### DIFF
--- a/app/src/components/shared/ScriptSnippets.test.tsx
+++ b/app/src/components/shared/ScriptSnippets.test.tsx
@@ -98,25 +98,33 @@ function open() {
 
 describe("ScriptSnippets", () => {
 	it("starts collapsed, because the editor is what the panel is for", () => {
-		render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 
 		expect(screen.queryByPlaceholderText(/filter snippets/i)).not.toBeInTheDocument();
 	});
 
 	it("remembers being opened, in the store that survives the tab unmount", () => {
-		const { unmount } = render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		const { unmount } = render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 		open();
 
 		expect(useLayoutStore.getState().scriptSnippetsCollapsed).toBe(false);
 
 		// The Radix tab switch: the panel goes away and comes back.
 		unmount();
-		render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 		expect(screen.getByPlaceholderText(/filter snippets/i)).toBeInTheDocument();
 	});
 
 	it("offers a pre-request editor its own templates and the shared one", () => {
-		render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 		open();
 
 		expect(screen.getByText("Set a header")).toBeInTheDocument();
@@ -127,7 +135,9 @@ describe("ScriptSnippets", () => {
 	});
 
 	it("offers a test editor the assertions instead", () => {
-		render(<ScriptSnippets context="test" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="test" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 		open();
 
 		expect(screen.getByText("Test: Status code")).toBeInTheDocument();
@@ -135,7 +145,7 @@ describe("ScriptSnippets", () => {
 	});
 
 	it("hands the caller the template, placeholders and all", () => {
-		const onInsert = vi.fn();
+		const onInsert = vi.fn(() => ({ placement: "cursor" as const }));
 		render(<ScriptSnippets context="pre" onInsert={onInsert} />);
 		open();
 
@@ -149,16 +159,88 @@ describe("ScriptSnippets", () => {
 		);
 	});
 
+	/*
+	 * The insertion lands out of sight of the list that asked for it, so the
+	 * list says what happened - the GraphQL explorer's pattern, and its wording.
+	 */
+	describe("saying what happened", () => {
+		function insertFirst() {
+			fireEvent.click(screen.getByText("Set a header").closest("[cmdk-item]")!);
+		}
+
+		it("names the template and where it went", () => {
+			render(
+				<ScriptSnippets
+					context="pre"
+					onInsert={() => ({ placement: "end-of-script" as const })}
+				/>
+			);
+			open();
+			insertFirst();
+
+			expect(
+				screen.getByText("Inserted Set a header at the end of the script.")
+			).toBeTruthy();
+		});
+
+		it("speaks again when the same template is inserted twice", () => {
+			render(
+				<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+			);
+			open();
+			insertFirst();
+			const first = screen.getByText("Inserted Set a header at the cursor.");
+			insertFirst();
+
+			/*
+			 * A live region only announces when its text changes, so the second
+			 * insertion has to arrive as a different node - keyed, as
+			 * `ResponseAnnouncer` and the explorer both are. Same text, new
+			 * element: silence here reads as the click not landing.
+			 */
+			expect(screen.getByText("Inserted Set a header at the cursor.")).not.toBe(first);
+		});
+
+		it("shows a refusal on screen, not only to a screen reader", () => {
+			render(<ScriptSnippets context="pre" onInsert={() => null} />);
+			open();
+			insertFirst();
+
+			// The whole defect this surface was fixed for was a click that, to a
+			// sighted user, did nothing.
+			const notice = screen.getByRole("status");
+			expect(notice.textContent).toMatch(/no editor to go into/i);
+		});
+
+		it("clears the refusal once an insertion lands", () => {
+			let answer: { placement: "cursor" } | null = null;
+			const { rerender } = render(<ScriptSnippets context="pre" onInsert={() => answer} />);
+			open();
+			insertFirst();
+			expect(screen.queryByRole("status")).toBeTruthy();
+
+			answer = { placement: "cursor" };
+			rerender(<ScriptSnippets context="pre" onInsert={() => answer} />);
+			insertFirst();
+
+			expect(screen.queryByRole("status")).toBeNull();
+		});
+	});
+
 	it("says so when the engine is not answering, rather than looking empty", () => {
 		query.value = { data: undefined, isPending: false, isError: true };
-		render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 		open();
 
 		expect(screen.getByText(/engine, which is not answering/i)).toBeInTheDocument();
 	});
 
 	it("counts what it is holding, so a collapsed header still says there is something", () => {
-		render(<ScriptSnippets context="pre" onInsert={() => {}} />);
+		render(
+			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+		);
 
 		expect(screen.getByRole("button", { name: /snippets/i }).textContent).toContain("2");
 	});

--- a/app/src/components/shared/ScriptSnippets.tsx
+++ b/app/src/components/shared/ScriptSnippets.tsx
@@ -29,6 +29,7 @@
  * tab switch, which unmounts the panel.
  */
 
+import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
 	Collapsible,
@@ -45,17 +46,28 @@ import {
 import { useScriptCompletionsQuery } from "@/queries";
 import { useLayoutStore } from "@/stores";
 import { countSnippets, snippetsForContext } from "@/lib/script-snippets";
+import type { SnippetInsertion, SnippetPlacement } from "@/lib/editor-snippet";
 import { cn } from "@/lib/utils";
 
 export interface ScriptSnippetsProps {
 	/** Which editor this list sits under. */
 	context: "pre" | "test";
 	/**
-	 * Insert the template at the cursor. The host owns the editor instance, so
-	 * it owns the insertion; this list only says which template was chosen.
+	 * Insert the template. The host owns the editor instance, so it owns the
+	 * insertion; this list says which template was chosen and narrates what came
+	 * back.
 	 */
-	onInsert: (snippet: string) => void;
+	onInsert: (snippet: string) => SnippetInsertion | null;
 }
+
+/**
+ * How each landing reads out loud, in the shape the GraphQL explorer's
+ * `PLACEMENT_PHRASE` set: "Inserted X <phrase>."
+ */
+const PLACEMENT_PHRASE: Record<SnippetPlacement, string> = {
+	cursor: "at the cursor",
+	"end-of-script": "at the end of the script",
+};
 
 export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
 	const collapsed = useLayoutStore((s) => s.scriptSnippetsCollapsed);
@@ -64,6 +76,40 @@ export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
 
 	const groups = snippetsForContext(data?.completions, context);
 	const total = countSnippets(groups);
+
+	/*
+	 * What just happened, said out loud - the explorer's pattern and its reason
+	 * (`GraphQLBody.tsx`): an insertion lands out of sight of the list that
+	 * asked for it, and a live region only speaks when its text *changes*, so
+	 * the same template twice would be silent the second time and read as the
+	 * click not landing. The sequence number is what makes the repeat audible.
+	 */
+	const [announcement, setAnnouncement] = useState<{ text: string; seq: number }>({
+		text: "",
+		seq: 0,
+	});
+	const say = (text: string) => setAnnouncement((prev) => ({ text, seq: prev.seq + 1 }));
+
+	/*
+	 * The one outcome with nothing to look at. An insertion shows itself in the
+	 * editor; a refusal reaching `sr-only` text alone is a click that, to a
+	 * sighted user, did nothing - which is the defect this whole surface was
+	 * fixed for. Cleared by the next insertion that lands.
+	 */
+	const [notice, setNotice] = useState("");
+
+	const insert = (snippet: string, label: string) => {
+		const result = onInsert(snippet);
+		if (!result) {
+			const refusal =
+				"That snippet had no editor to go into. Click in the editor and try again.";
+			setNotice(refusal);
+			say(refusal);
+			return;
+		}
+		setNotice("");
+		say(`Inserted ${label} ${PLACEMENT_PHRASE[result.placement]}.`);
+	};
 
 	return (
 		<Collapsible open={!collapsed} onOpenChange={(open) => setCollapsed(!open)}>
@@ -86,6 +132,15 @@ export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
 				Snippets
 				{total > 0 && <span className="ml-1 tabular-nums opacity-70">{total}</span>}
 			</CollapsibleTrigger>
+
+			{notice && (
+				<p className="mt-2 text-xs text-muted-foreground" role="status">
+					{notice}
+				</p>
+			)}
+			<span key={announcement.seq} className="sr-only" aria-live="polite">
+				{announcement.text}
+			</span>
 
 			<CollapsibleContent className="mt-2">
 				{!collapsed && (
@@ -118,7 +173,9 @@ export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
 												<CommandItem
 													key={snippet.label}
 													value={`${group} ${snippet.label} ${snippet.filterText ?? ""}`}
-													onSelect={() => onInsert(snippet.insertText)}
+													onSelect={() =>
+														insert(snippet.insertText, snippet.label)
+													}
 													className="cursor-pointer flex-col items-start gap-0.5"
 												>
 													<span className="font-mono text-xs">

--- a/app/src/lib/editor-snippet.contract.test.ts
+++ b/app/src/lib/editor-snippet.contract.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The half of the snippet insertion that lives in `monaco-editor`, checked
+ * against the copy this app actually ships.
+ *
+ * `editor-snippet.test.ts` proves what the app does with a controller it is
+ * given. It cannot prove the controller exists, because a fake is what it hands
+ * itself - and that gap is exactly how `"editor.action.insertSnippet"` shipped:
+ * a plausible id, no such action in this build, no error, no effect (#1223).
+ *
+ * So this reads the installed package. Monaco does not run under jsdom, and
+ * standing an editor up to insert into it would be a browser test the suite has
+ * no place for; what is checkable here is the one fact the app depends on and
+ * cannot see: that the snippet controller is registered as an editor
+ * contribution under the id `editor-snippet.ts` asks for. A `monaco-editor`
+ * upgrade that renames or unregisters it fails here, in a case that says why,
+ * rather than in a click that does nothing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Resolved from the package's own manifest rather than from its entry point:
+ * `monaco-editor`'s `main` is the bundled `min/` build, while the app imports
+ * the `esm/` tree that Vite splits - so the entry is the wrong anchor and
+ * pnpm's store layout is not a path anyone should hardcode.
+ */
+const require_ = createRequire(import.meta.url);
+const CONTROLLER_PATH = join(
+	dirname(require_.resolve("monaco-editor/package.json")),
+	"esm",
+	"vs",
+	"editor",
+	"contrib",
+	"snippet",
+	"browser",
+	"snippetController2.js"
+);
+
+describe("the snippet controller this app drives", () => {
+	const source = readFileSync(CONTROLLER_PATH, "utf-8");
+
+	it("is registered under the id editor-snippet.ts asks for", () => {
+		expect(source).toMatch(/this\.ID = ['"]snippetController2['"]/);
+		expect(source).toMatch(/registerEditorContribution\(\s*SnippetController2\w*\.ID/);
+	});
+
+	it("still takes the template through insert()", () => {
+		expect(source).toMatch(/insert\(template(,\s*opts)?\)\s*\{/);
+	});
+
+	/*
+	 * The negative half, and the reason this file exists: the action id the
+	 * first implementation used belongs to VS Code's workbench, and the
+	 * standalone editor registers nothing by that name. If a future Monaco
+	 * adds one, `editor.trigger` becomes a legitimate second door and this
+	 * case is the place to reconsider - but nothing should quietly rely on it
+	 * while it is absent.
+	 */
+	it("registers no editor.action.insertSnippet, which is what made the wrong id silent", () => {
+		expect(source).not.toContain("editor.action.insertSnippet");
+	});
+
+	it("read the file it thinks it read", () => {
+		expect(source.length).toBeGreaterThan(2_000);
+		expect(source).toContain("SnippetController2");
+	});
+});

--- a/app/src/lib/editor-snippet.test.ts
+++ b/app/src/lib/editor-snippet.test.ts
@@ -25,11 +25,27 @@
 
 import { describe, it, expect } from "vitest";
 import type * as Monaco from "monaco-editor";
-import { insertSnippetAtCursor } from "./editor-snippet";
+import { insertSnippetAtCursor, snippetLanding } from "./editor-snippet";
 
-function fakeEditor({ withController = true }: { withController?: boolean } = {}) {
+interface FakeOptions {
+	withController?: boolean;
+	/** The document, one string per line. */
+	lines?: string[];
+	/** Where the caret sits, 1-based as Monaco counts. */
+	cursor?: { lineNumber: number; column: number };
+	/** A selection, when the author has one. Its end is where a caret would go. */
+	selectionEnd?: { lineNumber: number; column: number };
+}
+
+function fakeEditor({
+	withController = true,
+	lines = [""],
+	cursor = { lineNumber: 1, column: 1 },
+	selectionEnd,
+}: FakeOptions = {}) {
 	const events: string[] = [];
 	const inserted: string[] = [];
+	let position = cursor;
 
 	const controller = {
 		getId: () => "snippetController2",
@@ -52,9 +68,22 @@ function fakeEditor({ withController = true }: { withController?: boolean } = {}
 		},
 		getContribution: (id: string) =>
 			withController && id === "snippetController2" ? controller : null,
+		getModel: () => ({
+			getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? "",
+			getLineMaxColumn: (lineNumber: number) => (lines[lineNumber - 1] ?? "").length + 1,
+		}),
+		getPosition: () => position,
+		setPosition: (next: { lineNumber: number; column: number }) => {
+			events.push("setPosition");
+			position = next;
+		},
+		getSelection: () =>
+			selectionEnd
+				? { getEndPosition: () => selectionEnd }
+				: { getEndPosition: () => cursor },
 	} as unknown as Monaco.editor.IStandaloneCodeEditor;
 
-	return { editor, events, inserted };
+	return { editor, events, inserted, positionNow: () => position };
 }
 
 describe("insertSnippetAtCursor", () => {
@@ -73,7 +102,76 @@ describe("insertSnippetAtCursor", () => {
 
 		insertSnippetAtCursor(editor, "pm.response.json();");
 
-		expect(events).toEqual(["focus", "insert"]);
+		expect(events.indexOf("focus")).toBeLessThan(events.indexOf("insert"));
+	});
+
+	/*
+	 * Where it lands. The click is on a list, so it cannot move the caret, and
+	 * the caret is wherever the author last left it - including the middle of a
+	 * statement, or over a selection. Every template is a whole statement, so
+	 * neither case may be taken literally. Both of these were measured against
+	 * a real editor before they were written down (see the module comment).
+	 */
+	describe("where the template lands", () => {
+		it("goes to the end of the caret's line, never into it", () => {
+			const { editor, inserted, positionNow } = fakeEditor({
+				lines: ["const t = Date.now();"],
+				cursor: { lineNumber: 1, column: 12 },
+			});
+
+			insertSnippetAtCursor(editor, "pm.environment.set();");
+
+			/*
+			 * Column 12 is inside `Date.now()`. Inserting there splits the
+			 * statement into `const t = D` and `ate.now();` however much
+			 * whitespace is wrapped around the template, which is why the column
+			 * is discarded rather than padded.
+			 */
+			expect(positionNow()).toEqual({ lineNumber: 1, column: 22 });
+			expect(inserted).toEqual(["\npm.environment.set();"]);
+		});
+
+		it("lands on a blank line without pushing it down", () => {
+			const { editor, inserted, positionNow } = fakeEditor({
+				lines: ["if (ok) {", "\t", "}"],
+				cursor: { lineNumber: 2, column: 1 },
+			});
+
+			insertSnippetAtCursor(editor, "pm.environment.set();");
+
+			// After the indentation, which is what the author was lining up.
+			expect(positionNow()).toEqual({ lineNumber: 2, column: 2 });
+			expect(inserted).toEqual(["pm.environment.set();"]);
+		});
+
+		it("collapses a selection instead of replacing it", () => {
+			const { editor, inserted, positionNow } = fakeEditor({
+				lines: ["const keep = 1;", "const alsoKeep = 2;"],
+				cursor: { lineNumber: 1, column: 7 },
+				selectionEnd: { lineNumber: 1, column: 11 },
+			});
+
+			insertSnippetAtCursor(editor, "pm.environment.set();");
+
+			/*
+			 * `SnippetSession` builds its edit from the selection, so left alone
+			 * this click would have replaced the selected `keep` - measured:
+			 * `const pm.environment.set(); = 1;`. The caret goes to the end of
+			 * the selection's line, and the line survives intact.
+			 */
+			expect(positionNow()).toEqual({ lineNumber: 1, column: 16 });
+			expect(inserted).toEqual(["\npm.environment.set();"]);
+		});
+
+		it("still inserts when the editor can offer no model or position", () => {
+			const { editor, inserted } = fakeEditor();
+			// A stubbed editor in another suite, or one mid-teardown: the
+			// landing rule is a refinement, never a precondition.
+			(editor as unknown as { getModel: () => null }).getModel = () => null;
+
+			expect(insertSnippetAtCursor(editor, "pm.response.json();")).toBe(true);
+			expect(inserted).toEqual(["pm.response.json();"]);
+		});
 	});
 
 	it("reports failure when the editor carries no snippet controller", () => {
@@ -95,5 +193,21 @@ describe("insertSnippetAtCursor", () => {
 
 		expect(insertSnippetAtCursor(editor, "")).toBe(false);
 		expect(events).toEqual([]);
+	});
+});
+
+/*
+ * The rule on its own: one question about the line the caret is on - is there
+ * code on it already, or is it the empty line the author left for this.
+ */
+describe("snippetLanding", () => {
+	it.each([
+		["", ""],
+		["   ", ""],
+		["\t\t", ""],
+		["const t = 1;", "\n"],
+		["\tpm.test();", "\n"],
+	])("%o", (line, before) => {
+		expect(snippetLanding(line as string)).toEqual({ before });
 	});
 });

--- a/app/src/lib/editor-snippet.test.ts
+++ b/app/src/lib/editor-snippet.test.ts
@@ -8,50 +8,81 @@
 /**
  * Inserting a template at the cursor (#1223).
  *
- * Monaco does not run under vitest, so what is checkable here is the contract
- * with it: the snippet reaches the *snippet controller* rather than being
- * spliced in as text - the difference between tab stops and a script containing
- * `${1:200}` - and the editor is focused first, since the click that asked for
- * the insertion landed on a list beside it.
+ * **The first version of this suite passed against code that did nothing.** It
+ * mocked the editor as a bare object with a `trigger` spy and asserted that
+ * `insertSnippetAtCursor` called it with `"editor.action.insertSnippet"` - so it
+ * checked the call the app makes, never that Monaco answers it. It does not:
+ * that command is VS Code's workbench, and the standalone editor registers the
+ * snippet controller as a *contribution* instead. `trigger` ignores an id it
+ * cannot resolve, so clicking a snippet silently did nothing while the suite
+ * stayed green.
+ *
+ * The fake below is therefore shaped like the real editor rather than like the
+ * call: `trigger` resolves nothing (as Monaco's does for an unknown action) and
+ * the only working door is `getContribution("snippetController2").insert`.
+ * Mutation check: put the `trigger` spelling back and every case here reddens.
  */
 
 import { describe, it, expect } from "vitest";
 import type * as Monaco from "monaco-editor";
 import { insertSnippetAtCursor } from "./editor-snippet";
 
-function fakeEditor() {
-	const calls: Array<{ order: number; action: string; payload: unknown }> = [];
-	let order = 0;
+function fakeEditor({ withController = true }: { withController?: boolean } = {}) {
+	const events: string[] = [];
+	const inserted: string[] = [];
+
+	const controller = {
+		getId: () => "snippetController2",
+		dispose: () => {},
+		insert: (template: string) => {
+			events.push("insert");
+			inserted.push(template);
+		},
+	};
+
 	const editor = {
-		focus: () => {
-			calls.push({ order: order++, action: "focus", payload: undefined });
+		focus: () => events.push("focus"),
+		/*
+		 * Monaco resolves the id against the editor's own action map and returns
+		 * without complaint when nothing matches - which is the whole reason the
+		 * wrong id was invisible. The fake does the same: no throw, no effect.
+		 */
+		trigger: (_source: string, _handlerId: string, _payload: unknown) => {
+			events.push("trigger");
 		},
-		trigger: (_source: string, action: string, payload: unknown) => {
-			calls.push({ order: order++, action, payload });
-		},
+		getContribution: (id: string) =>
+			withController && id === "snippetController2" ? controller : null,
 	} as unknown as Monaco.editor.IStandaloneCodeEditor;
-	return { editor, calls };
+
+	return { editor, events, inserted };
 }
 
 describe("insertSnippetAtCursor", () => {
-	it("drives Monaco's snippet controller, so placeholders become tab stops", () => {
-		const { editor, calls } = fakeEditor();
+	it("hands the template to the editor's snippet controller", () => {
+		const { editor, inserted } = fakeEditor();
 
 		expect(insertSnippetAtCursor(editor, 'pm.test("${1:name}", function () {});')).toBe(true);
 
-		const insert = calls.find((c) => c.action === "editor.action.insertSnippet");
-		expect(insert, "the snippet controller is the only correct door").toBeTruthy();
-		expect(insert?.payload).toEqual({ snippet: 'pm.test("${1:name}", function () {});' });
+		// Verbatim: the placeholders are what the controller turns into tab
+		// stops, and expanding them here would defeat the whole point.
+		expect(inserted).toEqual(['pm.test("${1:name}", function () {});']);
 	});
 
 	it("focuses the editor before inserting", () => {
-		const { editor, calls } = fakeEditor();
+		const { editor, events } = fakeEditor();
 
 		insertSnippetAtCursor(editor, "pm.response.json();");
 
-		const focus = calls.find((c) => c.action === "focus");
-		const insert = calls.find((c) => c.action === "editor.action.insertSnippet");
-		expect(focus!.order).toBeLessThan(insert!.order);
+		expect(events).toEqual(["focus", "insert"]);
+	});
+
+	it("reports failure when the editor carries no snippet controller", () => {
+		const { editor, events } = fakeEditor({ withController: false });
+
+		// The honest answer for a Monaco build that no longer registers it under
+		// this id - which is what a silent `trigger` could never tell us.
+		expect(insertSnippetAtCursor(editor, "pm.response.json();")).toBe(false);
+		expect(events).toEqual([]);
 	});
 
 	it("does nothing when no editor has mounted yet", () => {
@@ -59,10 +90,10 @@ describe("insertSnippetAtCursor", () => {
 		expect(insertSnippetAtCursor(undefined, "pm.response.json();")).toBe(false);
 	});
 
-	it("refuses an empty template rather than trigger an empty edit", () => {
-		const { editor, calls } = fakeEditor();
+	it("refuses an empty template rather than open an empty snippet session", () => {
+		const { editor, events } = fakeEditor();
 
 		expect(insertSnippetAtCursor(editor, "")).toBe(false);
-		expect(calls).toHaveLength(0);
+		expect(events).toEqual([]);
 	});
 });

--- a/app/src/lib/editor-snippet.test.ts
+++ b/app/src/lib/editor-snippet.test.ts
@@ -71,6 +71,8 @@ function fakeEditor({
 		getModel: () => ({
 			getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? "",
 			getLineMaxColumn: (lineNumber: number) => (lines[lineNumber - 1] ?? "").length + 1,
+			getLineCount: () => lines.length,
+			getValueLength: () => lines.join("\n").length,
 		}),
 		getPosition: () => position,
 		setPosition: (next: { lineNumber: number; column: number }) => {
@@ -90,7 +92,9 @@ describe("insertSnippetAtCursor", () => {
 	it("hands the template to the editor's snippet controller", () => {
 		const { editor, inserted } = fakeEditor();
 
-		expect(insertSnippetAtCursor(editor, 'pm.test("${1:name}", function () {});')).toBe(true);
+		expect(insertSnippetAtCursor(editor, 'pm.test("${1:name}", function () {});')).toEqual({
+			placement: "cursor",
+		});
 
 		// Verbatim: the placeholders are what the controller turns into tab
 		// stops, and expanding them here would defeat the whole point.
@@ -163,13 +167,46 @@ describe("insertSnippetAtCursor", () => {
 			expect(inserted).toEqual(["\npm.environment.set();"]);
 		});
 
+		it("appends to the end when the caret is Monaco's default rather than the author's", () => {
+			const { editor, inserted, positionNow } = fakeEditor({
+				lines: ["const first = 1;", "const second = 2;"],
+				cursor: { lineNumber: 1, column: 1 },
+			});
+
+			const result = insertSnippetAtCursor(editor, "pm.environment.set();");
+
+			/*
+			 * 1:1 on a script nobody has clicked into is Monaco's default, not a
+			 * decision - and the GraphQL explorer answers the same question the
+			 * same way, appending a new operation rather than splicing at offset
+			 * 0 (`insert-skeleton.ts`).
+			 */
+			expect(result).toEqual({ placement: "end-of-script" });
+			expect(positionNow()).toEqual({ lineNumber: 2, column: 18 });
+			expect(inserted).toEqual(["\npm.environment.set();"]);
+		});
+
+		it("takes 1:1 literally in an empty script, where it is the only place to be", () => {
+			const { editor, inserted } = fakeEditor({
+				lines: [""],
+				cursor: { lineNumber: 1, column: 1 },
+			});
+
+			expect(insertSnippetAtCursor(editor, "pm.environment.set();")).toEqual({
+				placement: "cursor",
+			});
+			expect(inserted).toEqual(["pm.environment.set();"]);
+		});
+
 		it("still inserts when the editor can offer no model or position", () => {
 			const { editor, inserted } = fakeEditor();
 			// A stubbed editor in another suite, or one mid-teardown: the
 			// landing rule is a refinement, never a precondition.
 			(editor as unknown as { getModel: () => null }).getModel = () => null;
 
-			expect(insertSnippetAtCursor(editor, "pm.response.json();")).toBe(true);
+			expect(insertSnippetAtCursor(editor, "pm.response.json();")).toEqual({
+				placement: "cursor",
+			});
 			expect(inserted).toEqual(["pm.response.json();"]);
 		});
 	});
@@ -179,19 +216,19 @@ describe("insertSnippetAtCursor", () => {
 
 		// The honest answer for a Monaco build that no longer registers it under
 		// this id - which is what a silent `trigger` could never tell us.
-		expect(insertSnippetAtCursor(editor, "pm.response.json();")).toBe(false);
+		expect(insertSnippetAtCursor(editor, "pm.response.json();")).toBeNull();
 		expect(events).toEqual([]);
 	});
 
 	it("does nothing when no editor has mounted yet", () => {
-		expect(insertSnippetAtCursor(null, "pm.response.json();")).toBe(false);
-		expect(insertSnippetAtCursor(undefined, "pm.response.json();")).toBe(false);
+		expect(insertSnippetAtCursor(null, "pm.response.json();")).toBeNull();
+		expect(insertSnippetAtCursor(undefined, "pm.response.json();")).toBeNull();
 	});
 
 	it("refuses an empty template rather than open an empty snippet session", () => {
 		const { editor, events } = fakeEditor();
 
-		expect(insertSnippetAtCursor(editor, "")).toBe(false);
+		expect(insertSnippetAtCursor(editor, "")).toBeNull();
 		expect(events).toEqual([]);
 	});
 });

--- a/app/src/lib/editor-snippet.ts
+++ b/app/src/lib/editor-snippet.ts
@@ -39,6 +39,17 @@ import type * as Monaco from "monaco-editor";
  */
 const SNIPPET_CONTROLLER = "snippetController2";
 
+/**
+ * Where a template ended up, so the caller can say so - the same shape and the
+ * same reason as the GraphQL explorer's `InsertPlacement` (`insert-skeleton.ts`):
+ * an insertion the user cannot see is one they cannot trust landed.
+ */
+export type SnippetPlacement = "cursor" | "end-of-script";
+
+export interface SnippetInsertion {
+	placement: SnippetPlacement;
+}
+
 /** The half of `SnippetController2` this module uses. */
 interface SnippetInserter extends Monaco.editor.IEditorContribution {
 	insert(template: string): void;
@@ -67,18 +78,18 @@ export function snippetLanding(lineText: string): { before: string } {
 }
 
 /**
- * Whether the snippet reached the editor's snippet controller. `false` means it
- * did not - there was no editor, no template, or no controller on it - and the
- * caller decides whether that is worth saying out loud.
+ * Where the snippet landed, or `null` when it could not land at all - there was
+ * no editor, no template, or no controller on it. The caller says so out loud;
+ * this only reports.
  */
 export function insertSnippetAtCursor(
 	editor: Monaco.editor.IStandaloneCodeEditor | null | undefined,
 	snippet: string
-): boolean {
-	if (!editor || !snippet) return false;
+): SnippetInsertion | null {
+	if (!editor || !snippet) return null;
 
 	const controller = editor.getContribution<SnippetInserter>(SNIPPET_CONTROLLER);
-	if (!controller || typeof controller.insert !== "function") return false;
+	if (!controller || typeof controller.insert !== "function") return null;
 
 	/*
 	 * Focus first. The click that asked for this landed on the snippets list, so
@@ -103,12 +114,26 @@ export function insertSnippetAtCursor(
 	const position = selection ? selection.getEndPosition() : editor.getPosition();
 	if (!model || !position) {
 		controller.insert(snippet);
-		return true;
+		return { placement: "cursor" };
 	}
 
-	const line = position.lineNumber;
+	/*
+	 * A caret at the very start of a script nobody has clicked into is not a
+	 * decision, it is Monaco's default - and dropping a template above code the
+	 * author has already written is the least likely thing they meant. The
+	 * GraphQL explorer answers the same question the same way: a cursor outside
+	 * every selection set does not become a splice point at offset 0, the
+	 * insertion is appended to the end of the document as a new operation
+	 * (`insert-skeleton.ts`, placement `new-operation`). This is that rule in
+	 * a language with no selection sets: no caret of the author's own, so the
+	 * template goes after what is already there.
+	 */
+	const untouched = position.lineNumber === 1 && position.column === 1;
+	const line =
+		untouched && model.getValueLength() > 0 ? model.getLineCount() : position.lineNumber;
+
 	const landing = snippetLanding(model.getLineContent(line));
 	editor.setPosition({ lineNumber: line, column: model.getLineMaxColumn(line) });
 	controller.insert(`${landing.before}${snippet}`);
-	return true;
+	return { placement: line === position.lineNumber ? "cursor" : "end-of-script" };
 }

--- a/app/src/lib/editor-snippet.ts
+++ b/app/src/lib/editor-snippet.ts
@@ -14,32 +14,56 @@
  * string would put `${1:200}` in the script, and re-implementing tab stops here
  * would be a hand-rolled copy of a primitive Monaco already ships and fixes.
  *
+ * **The controller is reached by contribution, never by action id.** This first
+ * shipped as `editor.trigger(source, "editor.action.insertSnippet", { snippet })`
+ * and did nothing at all: that command belongs to VS Code's *workbench*, not to
+ * the standalone editor this app embeds - `monaco-editor` registers
+ * `SnippetController2` as the `snippetController2` *contribution* and no action
+ * of that name. `trigger` looks its argument up in the editor's action map and
+ * returns silently when there is no match, so a wrong id is not an error
+ * anywhere: the click simply did nothing. `getContribution` is the door that
+ * reports its own absence (`null`), which is why it is the one used here.
+ *
  * It is the one place in the renderer that drives the controller, which is why
  * it takes the editor instance rather than living in a component: the two hosts
  * (the request Script panel and the collection Script tab) both hold one, and
- * neither should learn the action id.
+ * neither should learn how a snippet is inserted.
  */
 
 import type * as Monaco from "monaco-editor";
 
-/** Names this app as the source of the edit in Monaco's undo stack. */
-const SNIPPET_SOURCE = "vayu-script-snippets";
+/**
+ * The contribution id `monaco-editor` registers `SnippetController2` under
+ * (`SnippetController2.ID`). Lazily instantiated, which `getContribution`
+ * handles: it builds the contribution on first ask.
+ */
+const SNIPPET_CONTROLLER = "snippetController2";
+
+/** The half of `SnippetController2` this module uses. */
+interface SnippetInserter extends Monaco.editor.IEditorContribution {
+	insert(template: string): void;
+}
 
 /**
- * Whether the snippet reached an editor. `false` means there was none to insert
- * into - the caller decides whether that is worth saying out loud.
+ * Whether the snippet reached the editor's snippet controller. `false` means it
+ * did not - there was no editor, no template, or no controller on it - and the
+ * caller decides whether that is worth saying out loud.
  */
 export function insertSnippetAtCursor(
 	editor: Monaco.editor.IStandaloneCodeEditor | null | undefined,
 	snippet: string
 ): boolean {
 	if (!editor || !snippet) return false;
+
+	const controller = editor.getContribution<SnippetInserter>(SNIPPET_CONTROLLER);
+	if (!controller || typeof controller.insert !== "function") return false;
+
 	/*
 	 * Focus first. The click that asked for this landed on the snippets list, so
 	 * the editor does not have focus, and a snippet expanded into an unfocused
 	 * editor leaves the tab stops with nothing driving them.
 	 */
 	editor.focus();
-	editor.trigger(SNIPPET_SOURCE, "editor.action.insertSnippet", { snippet });
+	controller.insert(snippet);
 	return true;
 }

--- a/app/src/lib/editor-snippet.ts
+++ b/app/src/lib/editor-snippet.ts
@@ -45,6 +45,28 @@ interface SnippetInserter extends Monaco.editor.IEditorContribution {
 }
 
 /**
+ * What a template needs in front of it to land as its own statement on the line
+ * the caret is on.
+ *
+ * Every template in the table is one or more whole statements, and the caret is
+ * wherever the author last left it - which this click cannot move, since it
+ * landed on a list below the editor. Two things follow, both measured against
+ * the real editor rather than reasoned about:
+ *
+ * - **The column is not a landing site.** A caret parked inside
+ *   `const t = Date.now();` cuts it wherever it happens to sit, and inserting
+ *   there - with or without a newline around it - leaves `const t = D` above
+ *   the template and `ate.now();` below it. So the template goes to the *end of
+ *   that line*, never into it, and a statement is never split.
+ * - **A blank line is where it belongs already**, indentation included: landing
+ *   at the end of `\t\t` puts the template after the tabs, which is what the
+ *   author was lining up. Only a line with code on it needs a break in front.
+ */
+export function snippetLanding(lineText: string): { before: string } {
+	return { before: lineText.trim() === "" ? "" : "\n" };
+}
+
+/**
  * Whether the snippet reached the editor's snippet controller. `false` means it
  * did not - there was no editor, no template, or no controller on it - and the
  * caller decides whether that is worth saying out loud.
@@ -64,6 +86,29 @@ export function insertSnippetAtCursor(
 	 * editor leaves the tab stops with nothing driving them.
 	 */
 	editor.focus();
-	controller.insert(snippet);
+
+	/*
+	 * Where it lands, decided here rather than left to the controller.
+	 *
+	 * `SnippetSession` builds its edit from `editor.getSelections()`, so a
+	 * selection is the range the template *replaces*. That is right when the
+	 * snippet was accepted from the completion popup - the selection is the
+	 * prefix being completed - and wrong from a list: clicking a row would
+	 * delete whatever the author had highlighted, with no way to see it coming.
+	 * So a selection is collapsed to its end first: the click adds code, never
+	 * removes any.
+	 */
+	const model = editor.getModel();
+	const selection = editor.getSelection();
+	const position = selection ? selection.getEndPosition() : editor.getPosition();
+	if (!model || !position) {
+		controller.insert(snippet);
+		return true;
+	}
+
+	const line = position.lineNumber;
+	const landing = snippetLanding(model.getLineContent(line));
+	editor.setPosition({ lineNumber: line, column: model.getLineMaxColumn(line) });
+	controller.insert(`${landing.before}${snippet}`);
 	return true;
 }


### PR DESCRIPTION
## Description

Owner-reported against #1324: clicking a snippet did nothing. Fixing that turned up two more defects in the same three lines - where the template lands, and whether anyone is told it landed. Three commits, each with its own root cause.

### 1. The insertion never reached Monaco

`editor.action.insertSnippet` is a VS Code **workbench** command. The standalone editor this app embeds registers no action of that name - it registers `SnippetController2` as the `snippetController2` *contribution* - and `trigger` resolves its argument against the editor's action map and returns silently when nothing matches. The call was well-formed, threw nothing, logged nothing, and inserted nothing.

Measured in headless Chromium against the shipped `monaco-editor@0.55.1`, driving one editor both ways:

```json
{ "viaAction": "", "hasController": true,
  "viaController": "pm.test(\"name\", function () {\n    \n});" }
```

**The test was the other half of that defect.** It mocked the editor as a bare object with a `trigger` spy and asserted the call the app makes - never that Monaco answers it - so it stayed green over a feature that did nothing. The fake is now shaped like the editor: `trigger` resolves nothing, as Monaco's does, and the only working door is the contribution. Reverting the fix reddens three of its cases. `editor-snippet.contract.test.ts` covers what a fake cannot, reading the installed package for the id we ask for, so a Monaco upgrade that renames it fails in a case that says why.

### 2. Where it landed was wrong twice

- **The caret's column is not a landing site.** A caret parked inside `const t = Date.now();` - where it is whenever the author typed there and then reached for the list - cut the statement: `const t = D` above the template, `ate.now();` below. Padding with newlines is what *produced* that split. The template now goes to the end of the caret's line, taking a leading newline only when that line has code on it; a blank line is where it belongs already, indentation included.
- **A selection was being replaced.** `SnippetSession` builds its edit from `getSelections()`, which is right when the completion popup accepts a snippet over the prefix being completed and wrong from a list: with `keep` selected, a click produced `const pm.test("name", …); = 1;`. The selection is collapsed to its end first. The click adds code; it never removes any.

### 3. It now behaves like the schema explorer, which solved this first

The GraphQL explorer inserts into an editor from a list beside it - the same problem - and `lib/graphql/insert-skeleton.ts` treats the cursor as **context rather than a splice point**: the selection set the cursor is in, failing that an enclosing one, failing both a new operation **appended to the end of the document**. A caret at offset 0 of a non-empty document gets that last case, because it is Monaco's default rather than the author's choice.

A script has no selection sets, but it has that case, and now gives the same answer: 1:1 in a script with code in it appends after that code; an empty script still takes it at 1:1. Two more conventions came from the same place - the explorer **announces** every insertion into a keyed live region (keyed because a live region only speaks when its text changes, so the same template twice would otherwise be silent), and shows a **refusal on screen**, since an `sr-only` refusal is a click that to a sighted user did nothing - which is this PR's own bug in miniature. `ScriptSnippets` does both, in the same words, which is why `insertSnippetAtCursor` returns *where it landed* rather than a boolean, as `insertionForNode` returns a `placement`.

**One difference kept deliberately**: the explorer's already-present handling (select the existing field rather than insert a duplicate) needs a parsed document to know a field is already in a selection set. Arbitrary JS has no equivalent, and a repeated statement is often what the author wants.

## Type of Change
- [x] Bug fix

## Testing

- `cd app && pnpm test` - full suite green on the branch.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean. Engine untouched.
- Real-editor probe (headless Chromium, the `monaco-editor` in `node_modules`), covering: the action id inserting nothing, the contribution inserting with tab stops, a caret mid-statement leaving it whole, a selection surviving, an indented blank line keeping its indentation, and an untouched editor appending after existing code. A scratch script rather than a committed test - Monaco does not run under jsdom, and standing a browser up for one insertion is a suite this repo does not have; the contract test is the committed guard that stands in for it.

`App on windows-latest (shard 1/2)` went red once on two 5-second timeouts in unrelated suites (`LoadTestConfigDialog`, `UrlBar/send-with-row`) - diagnosed in a comment below, then **green on the one permitted re-run of the same commit**, which settles it as the shard-load case `app/CLAUDE.md` documents (#846, #1280).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - not needed: no documented behaviour changes, the feature now does what #1223's docs already describe

## Related Issues

Follow-up to #1223 / #1324.