### PR TITLE
fix(app): a click on a `{{token}}` in an editor opens it

### DIFF
--- a/app/src/components/shared/EditorVariableTokens/EditorVariableTokensProvider.test.tsx
+++ b/app/src/components/shared/EditorVariableTokens/EditorVariableTokensProvider.test.tsx
@@ -166,6 +166,21 @@ describe("EditorVariableTokensProvider", () => {
 			expect(cardText()).toContain("Staging");
 		});
 
+		it("says the token can be opened, since nothing else does now", () => {
+			const tokens = mountProvider();
+			act(() => tokens.setHoveredToken({ name: "baseUrl", rect }));
+			// The Monaco hover this card replaced spelled the affordance out
+			// ("⌘-click or ⇧⌘D to edit"); painted text on a canvas has no other
+			// way to say it is pressable.
+			expect(cardText()).toContain("Click to edit");
+		});
+
+		it("offers no edit line for a generator, which has nothing to open", () => {
+			const tokens = mountProvider();
+			act(() => tokens.setHoveredToken({ name: "$guid", rect }));
+			expect(cardText()).not.toContain("Click to edit");
+		});
+
 		it("says a secret is one, and never prints it", () => {
 			const tokens = mountProvider();
 			act(() => tokens.setHoveredToken({ name: "token", rect }));

--- a/app/src/components/shared/EditorVariableTokens/TokenHoverCard.tsx
+++ b/app/src/components/shared/EditorVariableTokens/TokenHoverCard.tsx
@@ -17,13 +17,20 @@
  * editor measured, which is exactly how `VariablePopover` already reaches a
  * token that has no DOM node of its own.
  *
- * **What it says is the field tooltip's three lines and no more** (`Editable-
- * Variable`): what the send will use, and where that came from. The list of
- * definitions that lost stays in the popover, one ⌘-click away, where it was
- * already drawn and where there is room to strike them through.
+ * **What it says is the field tooltip's answer** (`EditableVariable`): what the
+ * send will use, and where that came from - plus the one line a field does not
+ * need, saying the token opens on a click. The list of definitions that lost
+ * stays in the popover that click opens, where it was already drawn and where
+ * there is room to strike them through.
  */
 
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipValue } from "@/components/ui";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipHint,
+	TooltipTrigger,
+	TooltipValue,
+} from "@/components/ui";
 import type { VariableTokenKind } from "@/lib/variable-token-kind";
 import type { VariableOrigin } from "@/types";
 import type { TokenHoverRequest } from "./context";
@@ -79,7 +86,7 @@ export function TokenHoverCard({
 			// Fixed and inert, for the same reason the popover's anchor is: the
 			// rectangle came from `getBoundingClientRect` on the editor, and a box
 			// over Monaco's canvas that took the pointer would end the hover it was
-			// drawn for - and swallow the ⌘-click that opens the popover.
+			// drawn for - and swallow the click that opens the popover.
 			style={{
 				position: "fixed",
 				left: request.rect.left,
@@ -107,7 +114,18 @@ export function TokenHoverCard({
 					</span>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" className="max-w-xs">
-					<HoverAnswer kind={kind} origins={origins} />
+					<span className="flex flex-col gap-1">
+						<HoverAnswer kind={kind} origins={origins} />
+						{/*
+						 * What to do about it, for the one class of token that has
+						 * something to do. A field's token is a real element and
+						 * looks pressable; this one is painted text on a canvas, and
+						 * the affordance used to be spelled out by the Monaco hover
+						 * ("⌘-click or ⇧⌘D to edit") this card replaced. A generator
+						 * has no stored variable behind it, so it says nothing.
+						 */}
+						{kind.state !== "runtime" && <TooltipHint>Click to edit</TooltipHint>}
+					</span>
 				</TooltipContent>
 			</Tooltip>
 		</div>

--- a/app/src/components/shared/EditorVariableTokens/useEditorVariableTokens.test.tsx
+++ b/app/src/components/shared/EditorVariableTokens/useEditorVariableTokens.test.tsx
@@ -10,7 +10,7 @@
 
 /**
  * What one editor does with the tokens in its text: paints them, shows the one
- * under the pointer, opens one on ⌘-click, and binds the chord that opens the
+ * under the pointer, opens one on a click, and binds the chord that opens the
  * one under the caret.
  *
  * Driven against a Monaco stub rather than a real editor - the API surface used
@@ -337,13 +337,32 @@ describe("useEditorVariableTokens", () => {
 		expect(request.rect).toMatchObject({ left: 10 + 5 * 8, top: 24, height: 18 });
 	});
 
-	it("keeps a plain click for placing the caret", () => {
+	it("opens on a plain click too, without taking the caret from it", () => {
+		// The chord was the only way in while the Monaco hover spelled it out.
+		// Nothing spells it out now, and a painted token looks pressable.
+		variables.baseUrl = { value: "https://x", scope: "environment" };
+		const stub = stubEditor(["GET {{baseUrl}}"]);
+		mount(stub);
+
+		const preventDefault = vi.fn();
+		stub.handlers.mouse?.({
+			event: { metaKey: false, ctrlKey: false, preventDefault },
+			target: { position: { lineNumber: 1, column: 8 } },
+		} as unknown as Monaco.editor.IEditorMouseEvent);
+		expect(openTokenEditor).toHaveBeenCalledTimes(1);
+		expect(openTokenEditor.mock.calls[0][0].name).toBe("baseUrl");
+		// Monaco still places the caret: only the modified click is prevented,
+		// so Escape hands focus back to where the click landed.
+		expect(preventDefault).not.toHaveBeenCalled();
+	});
+
+	it("leaves a click outside any token to the editor", () => {
 		variables.baseUrl = { value: "https://x", scope: "environment" };
 		const stub = stubEditor(["GET {{baseUrl}}"]);
 		mount(stub);
 		stub.handlers.mouse?.({
 			event: { metaKey: false, ctrlKey: false, preventDefault: vi.fn() },
-			target: { position: { lineNumber: 1, column: 8 } },
+			target: { position: { lineNumber: 1, column: 2 } },
 		} as unknown as Monaco.editor.IEditorMouseEvent);
 		expect(openTokenEditor).not.toHaveBeenCalled();
 	});

--- a/app/src/components/shared/EditorVariableTokens/useEditorVariableTokens.ts
+++ b/app/src/components/shared/EditorVariableTokens/useEditorVariableTokens.ts
@@ -283,7 +283,7 @@ export function useEditorVariableTokens({
 	);
 
 	/**
-	 * Install the decorations, the ⌘-click and the chord on the mounted editor -
+	 * Install the decorations, the click-to-edit and the chord on the mounted editor -
 	 * once, and only where the tokens are painted at all.
 	 *
 	 * Called from the mount callback and again from the effect below, because
@@ -323,16 +323,26 @@ export function useEditorVariableTokens({
 			editor.onMouseLeave(() => hideHover()),
 			editor.onDidScrollChange(() => hideHover()),
 			editor.onMouseDown((event) => {
-				// ⌘/Ctrl-click edits, plain click keeps placing the caret - taking
-				// the plain one would steal the click that puts the cursor in the
-				// middle of a body.
-				if (!event.event.ctrlKey && !event.event.metaKey) return;
+				/*
+				 * A plain click on a token opens it, which is what everyone tries
+				 * first - the token is painted like something you can click.
+				 *
+				 * It used to take ⌘/Ctrl, on the reasoning that a plain click
+				 * belongs to the caret. What made that liveable was the hover
+				 * saying "⌘-click or ⇧⌘D to edit"; without that line the chord is
+				 * unguessable, and a token that looks clickable and answers
+				 * nothing is worse than a caret that lands one character late.
+				 * The caret is not actually lost either: `preventDefault` is only
+				 * called for the modified click, so a plain one still places it
+				 * before the popover takes focus, and Escape hands focus back to
+				 * exactly there.
+				 */
 				if (!event.target.position) return;
 				const model = editor.getModel();
 				if (!model) return;
 				const range = tokenAtPosition(variableTokenRanges(model), event.target.position);
 				if (!range) return;
-				event.event.preventDefault();
+				if (event.event.ctrlKey || event.event.metaKey) event.event.preventDefault();
 				open(editor, range);
 			})
 		);

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1550,7 +1550,7 @@ makes it, for every surface (see below):
 |-------|-----------|------------|
 | `{{data.email}}` - the reserved `data.*` namespace (issue #402) | `RuntimeToken`, or a decoration in an editor | muted or amber, depending on the declared contract - see below |
 | `{{$vu}}`, `{{$iteration}}` - the reserved identity namespace (issues #994, #1101) | `RuntimeToken`, or a decoration in an editor | muted, "not generated here", no popover |
-| `{{merchantId}}` - a stored variable, or a name nothing defines | `EditableVariable`, or a decoration in an editor | accent when it resolves, **red** when it does not; hover reads, and click or Enter - ⌘-click or ⇧⌘D in an editor - edits or creates |
+| `{{merchantId}}` - a stored variable, or a name nothing defines | `EditableVariable`, or a decoration in an editor | accent when it resolves, **red** when it does not; hover reads, and click or Enter - or ⇧⌘D in an editor - edits or creates |
 | `{{$guid}}` - a generator | `RuntimeToken`, or a decoration in an editor | muted, "generated per use", no popover |
 
 The two reserved rows sit above the scopes for the same reason and the generator
@@ -1565,7 +1565,7 @@ too** (issue #1220), as decorations rather than DOM tokens - there is no
 `<input>` behind that text to overlay. Hovering opens the app's own tooltip
 card over the token's screen rectangle, saying what the overlay's tooltip
 says - not Monaco's own hover widget, which is what answered until issue
-#1320 - and ⌘/Ctrl-click or the `EDIT_VARIABLE_CHORD` opens the same
+#1320 - and a click or the `EDIT_VARIABLE_CHORD` opens the same
 `VariablePopover`, positioned over that same rectangle. The decision of *what
 a token is* is shared: `classifyVariableToken` (`lib/variable-token-kind.ts`)
 lifts the same ladder this section describes out of the paint, so the editors


### PR DESCRIPTION
## Description

Follow-up to #1328, which merged while this fix was still on the branch. Reported from the app: **clicking a variable token in a body editor does nothing** - only ⌘/Ctrl-click opens the popover.

That was the behaviour before #1328 too, and it was liveable then for one reason: Monaco's hover card ended with "⌘-click or ⇧⌘D to edit". #1328 replaced that card with the app's own tooltip and did not carry the line over, so the chord became unguessable - leaving a token painted to look pressable that answers nothing on the gesture everyone tries first.

**The fix.** A plain click on a token opens the popover. `preventDefault` stays on the modified click alone, so Monaco still places the caret where the click landed and Escape hands focus back to exactly there - the caret is not lost, which was the original reason for requiring the modifier. A click outside any token is the editor's, untouched. The card also carries the affordance now: one muted `TooltipHint` line, "Click to edit", and nothing at all for a generator (`{{$guid}}`), which has no stored variable behind it to open.

**The alternative rejected:** restoring the hint line only, and keeping the modifier. It fixes discoverability and leaves the gesture wrong - a click on something that looks like a control should act, and a hint that has to teach a chord is a hint standing in for the thing it describes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test` - **621 files, 7028 tests, all passing** (full suite, on top of the merged `master`).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- `useEditorVariableTokens.test.tsx`: the plain-click case replaces the one that pinned the old behaviour - it asserts the popover opens for the token under the click **and** that `preventDefault` was *not* called, which is what keeps the caret. A second case pins that a click outside a token still opens nothing. The ⌘-click case is unchanged and still passes.
- `EditorVariableTokensProvider.test.tsx`: the card carries "Click to edit", and a generator's card does not.
- Mutation checks: restore the `if (!ctrlKey && !metaKey) return` guard and the plain-click case fails; call `preventDefault` unconditionally and its caret assertion fails; drop the hint line and the card case fails.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Follows up #1320 / #1328. `docs/app/COMPONENTS.md` no longer says the modifier is required, in the token-states table and in the editor-decorations passage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PF6NKkFrDj9RYYpJFSaPqb)_