### PR TITLE
fix(app): the suggestion list scrolls to the highlight the field moves

### DIFF
--- a/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
+++ b/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
@@ -153,6 +153,23 @@ describe("the suggestion list the arrows steer", () => {
 		expect(input.value).toBe("{{");
 	});
 
+	/*
+	 * Closing is this component's state rather than the list's, so Escape is
+	 * answered even where there is nothing to navigate - and nothing mounted
+	 * inside the list, the scroll probe included, has a say in it. Untested
+	 * until issue #1333 went looking for it.
+	 */
+	it("closes the list on Escape", () => {
+		const { container, input } = renderHarness();
+
+		type(input, "{{");
+		expect(container.querySelectorAll("[cmdk-list]")).toHaveLength(1);
+
+		fireEvent.keyDown(input, { key: "Escape" });
+
+		expect(container.querySelectorAll("[cmdk-list]")).toHaveLength(0);
+	});
+
 	it("navigates the plain suggestion list the same way", () => {
 		const { input } = renderHarness({
 			scoped: false,

--- a/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
+++ b/app/src/components/shared/VariableInput/keyboard-navigation.test.tsx
@@ -25,7 +25,7 @@
  * list" reds; drop the aria wiring and the semantics block does.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useState } from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { Command, CommandList, CommandGroup, CommandItem, TooltipProvider } from "@/components/ui";
@@ -166,6 +166,123 @@ describe("the suggestion list the arrows steer", () => {
 		expect(input.value).toBe("Accept-Encoding");
 	});
 });
+
+/**
+ * The other half of steering a list from outside it (issue #1333).
+ *
+ * `cmdk` schedules its scroll inside `setState("value", …)`, the path its own
+ * `Command.Input` arrow handling takes. A highlight arriving through the
+ * controlled `value` *prop* lands in a layout effect that assigns and emits
+ * instead, so `[data-selected]` moved to the right row and the scroll container
+ * never followed - past the eighth entry the highlight was below the fold of
+ * `CommandList`'s `max-h-[300px]`, and the only way to see what Enter would
+ * insert was the mouse.
+ *
+ * jsdom has no layout and so no scrolling: the observable fact is *which*
+ * element `scrollIntoView` was called on, which is exactly the thing that was
+ * wrong. Drop `CommandScrollIntoView` from either list and every case below
+ * reds; the decoy keeps a document-wide query from passing them.
+ */
+describe("the list scrolls to the highlight the field moves", () => {
+	/** In call order, the elements `scrollIntoView` was invoked on. */
+	const scrolled: Element[] = [];
+
+	beforeEach(() => {
+		scrolled.length = 0;
+		Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
+			scrolled.push(this);
+		});
+	});
+
+	it("scrolls every row the arrows reach, past the fold and back", () => {
+		const { container, input } = renderHarness({ decoy: true });
+
+		type(input, "{{");
+		const list = ownList(container);
+		// The stored variables, the iteration identities and the generators: more
+		// rows than the list can show, which is what the report needed.
+		const rows = list.querySelectorAll<HTMLElement>("[cmdk-item]");
+		expect(rows.length).toBeGreaterThan(8);
+
+		for (const key of ["ArrowDown", "ArrowUp"]) {
+			for (let step = 0; step < 10; step++) {
+				scrolled.length = 0;
+				fireEvent.keyDown(input, { key });
+				expect(scrolled).toContain(highlighted(list));
+			}
+		}
+
+		// And never a row of the list that merely happens to be first in the
+		// document - the defect this whole file exists for.
+		expect(scrolled.every((el) => list.contains(el))).toBe(true);
+	});
+
+	it("scrolls a row the pointer highlighted the same way", () => {
+		/*
+		 * cmdk opts its own pointer handler out of scrolling - it passes the flag
+		 * that skips the scheduled scroll - so this is the probe's doing, not
+		 * cmdk's. Reading the highlight from cmdk's store rather than from the
+		 * props coming down is what makes the two one code path, and
+		 * `block: "nearest"` is why it costs nothing: a row under the pointer is
+		 * on screen already and does not move.
+		 */
+		const { container, input } = renderHarness();
+
+		type(input, "{{");
+		const list = ownList(container);
+		const rows = list.querySelectorAll<HTMLElement>("[cmdk-item]");
+		scrolled.length = 0;
+		fireEvent.pointerMove(rows[2]);
+
+		expect(highlighted(list)).toBe(rows[2]);
+		expect(scrolled).toContain(rows[2]);
+	});
+
+	it("scrolls the plain suggestion list too, which is the same defect twice", () => {
+		// Both lists are steered through the controlled `value`, so both need the
+		// probe; mounting it in one only leaves the header list exactly as it was.
+		const { container, input } = renderHarness({
+			scoped: false,
+			suggestions: ["Accept", "Accept-Encoding", "Accept-Language"],
+		});
+
+		fireEvent.focus(input);
+		const list = ownList(container);
+		scrolled.length = 0;
+		fireEvent.keyDown(input, { key: "ArrowDown" });
+
+		expect(highlighted(list)).toHaveTextContent("Accept-Encoding");
+		expect(scrolled).toContain(highlighted(list));
+	});
+
+	it("brings a group's heading in with the first row of that group", () => {
+		const { container, input } = renderHarness();
+
+		type(input, "{{");
+		const list = ownList(container);
+		const groups = list.querySelectorAll<HTMLElement>("[cmdk-group]");
+		// The headings are what tells a generator from a stored variable, so the
+		// first row of a group arriving without its heading says less than it
+		// should. Needs a second group to be a test at all.
+		expect(groups.length).toBeGreaterThan(1);
+
+		const firstOfSecond = groups[1].querySelector<HTMLElement>("[cmdk-item]")!;
+		const heading = groups[1].querySelector<HTMLElement>("[cmdk-group-heading]")!;
+		for (let step = 0; step < rowsBefore(list, firstOfSecond); step++) {
+			scrolled.length = 0;
+			fireEvent.keyDown(input, { key: "ArrowDown" });
+		}
+
+		expect(highlighted(list)).toBe(firstOfSecond);
+		expect(scrolled.indexOf(heading)).toBeGreaterThanOrEqual(0);
+		expect(scrolled.indexOf(heading)).toBeLessThan(scrolled.indexOf(firstOfSecond));
+	});
+});
+
+/** How many ArrowDowns from the top of the list it takes to reach `row`. */
+function rowsBefore(list: HTMLElement, row: HTMLElement): number {
+	return Array.from(list.querySelectorAll<HTMLElement>("[cmdk-item]")).indexOf(row);
+}
 
 describe("the field's combobox semantics", () => {
 	it("names the open list and the row the arrows are on", () => {

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -122,8 +122,17 @@ export function CommandScrollIntoView() {
 
 	React.useEffect(() => {
 		const list = ref.current?.closest<HTMLElement>("[cmdk-list]");
-		// Scoped to this list, never across the document: the app mounts several
-		// of these and the highlight being scrolled to is this one's.
+		/*
+		 * Scoped to this list, never across the document: the app mounts several
+		 * of these and the highlight being scrolled to is this one's.
+		 *
+		 * On `aria-selected`, where `CommandListboxProbe` above deliberately reads
+		 * `data-value` instead: that probe has to name a row on the list's first
+		 * paint, when the rendered `aria-selected` still lags a layout effect.
+		 * This one has nothing to say about a paint that has not scrolled yet, so
+		 * it can use the selector `cmdk` uses for this job itself - which is the
+		 * point, since the scroll it is standing in for is `cmdk`'s.
+		 */
 		const row = list?.querySelector<HTMLElement>('[cmdk-item][aria-selected="true"]');
 		if (!row) return;
 		if (row.parentElement?.firstChild === row) {

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -91,6 +91,52 @@ export function CommandListboxProbe({ onChange }: { onChange: (s: CommandListbox
 	return <span ref={ref} hidden />;
 }
 
+/**
+ * Scrolls the highlighted row into view, for a list steered from outside.
+ *
+ * `cmdk` scrolls on its own state path only. Its `setState("value", …)`
+ * schedules the scroll before it emits, which is the path its `Command.Input`
+ * arrow handling takes; a highlight arriving through the controlled `value`
+ * *prop* lands somewhere else entirely - a layout effect that assigns the value
+ * and emits, with no scroll and no `selectedItemId`. So a list driven the way
+ * `CommandListboxProbe` exists to serve moves `[data-selected]` onto a row it
+ * never brings into view, and past the eighth entry the highlight is below the
+ * fold of `CommandList`'s own `max-h-[300px] overflow-y-auto` (issue #1333).
+ *
+ * Read from `cmdk`'s store rather than from a prop, so a highlight the pointer
+ * moved and one the arrows moved are one code path - `cmdk` opts its own
+ * pointer handler out of scrolling, and `block: "nearest"` is why that costs
+ * nothing: a row already on screen, which every row the pointer can reach is,
+ * does not move.
+ *
+ * The group heading rides along, matching what `cmdk` does for the first row of
+ * a group: here the headings are what tells a generator from a stored variable.
+ *
+ * Render it inside a `CommandList`; anything driving a `Command` from a
+ * controlled `value` wants it, which is why it lives beside the primitive
+ * rather than in either caller.
+ */
+export function CommandScrollIntoView() {
+	const highlight = useCommandState((state) => state.value);
+	const ref = React.useRef<HTMLSpanElement>(null);
+
+	React.useEffect(() => {
+		const list = ref.current?.closest<HTMLElement>("[cmdk-list]");
+		// Scoped to this list, never across the document: the app mounts several
+		// of these and the highlight being scrolled to is this one's.
+		const row = list?.querySelector<HTMLElement>('[cmdk-item][aria-selected="true"]');
+		if (!row) return;
+		if (row.parentElement?.firstChild === row) {
+			row.closest("[cmdk-group]")
+				?.querySelector<HTMLElement>("[cmdk-group-heading]")
+				?.scrollIntoView({ block: "nearest" });
+		}
+		row.scrollIntoView({ block: "nearest" });
+	}, [highlight]);
+
+	return <span ref={ref} hidden />;
+}
+
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
 	return (
 		<CommandPrimitive

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -119,6 +119,7 @@ export {
 	CommandItem,
 	CommandSeparator,
 	CommandListboxProbe,
+	CommandScrollIntoView,
 } from "./command";
 export type { CommandListboxState } from "./command";
 

--- a/app/src/components/ui/suggestion-list.tsx
+++ b/app/src/components/ui/suggestion-list.tsx
@@ -40,6 +40,7 @@ import {
 	CommandGroup,
 	CommandItem,
 	CommandListboxProbe,
+	CommandScrollIntoView,
 	type CommandListboxState,
 } from "./command";
 import { cn } from "@/lib/utils";
@@ -89,6 +90,7 @@ export function SuggestionList({
 			<Command shouldFilter={false} value={value} onValueChange={onValueChange}>
 				<CommandList>
 					{onListboxState && <CommandListboxProbe onChange={onListboxState} />}
+					<CommandScrollIntoView />
 					<CommandGroup>
 						{items.slice(0, limit).map((item) => (
 							<CommandItem

--- a/app/src/components/ui/variable-autocomplete.tsx
+++ b/app/src/components/ui/variable-autocomplete.tsx
@@ -28,6 +28,7 @@ import {
 	CommandGroup,
 	CommandItem,
 	CommandListboxProbe,
+	CommandScrollIntoView,
 	type CommandListboxState,
 } from "./command";
 import { VariableScopeBadge } from "./variable-scope-badge";
@@ -127,6 +128,7 @@ export function VariableAutocomplete({
 			<Command shouldFilter={false} value={value} onValueChange={onValueChange}>
 				<CommandList>
 					{onListboxState && <CommandListboxProbe onChange={onListboxState} />}
+					<CommandScrollIntoView />
 					<CommandEmpty>No variables found.</CommandEmpty>
 					{groups.map(({ group, heading, items }) => (
 						<CommandGroup key={group} heading={heading}>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1755,6 +1755,22 @@ ordering `lib/variable-suggestions.ts` builds and `VariableAutocomplete` draws.
 `CommandListboxProbe` reports them from inside the list for `aria-controls` and
 `aria-activedescendant`.
 
+**The field moves the highlight; the list scrolls it.** That split is not free:
+`cmdk` schedules its scroll inside `setState("value", …)`, the path its own
+`Command.Input` arrow handling takes, and a highlight arriving through the
+controlled `value` *prop* lands in a layout effect that assigns and emits with
+no scroll at all. So the highlight walked to the right row and the list stayed
+where it was - past the eighth entry, below the fold of `CommandList`'s
+`max-h-[300px]`, the only way to see what Enter would insert was the mouse
+(#1333). `CommandScrollIntoView` closes it the way `CommandListboxProbe` closes
+the ids: mounted inside the list, reading the highlight from `cmdk`'s store
+rather than from a prop, so a row the pointer highlighted and one the arrows
+reached take one code path - `cmdk` opts its own pointer handler out of
+scrolling, and `block: "nearest"` is why matching them costs nothing, since a
+row under the pointer is on screen already. A group's heading rides in with the
+first row of that group, matching `cmdk`, because the headings are what tells a
+generator from a stored variable.
+
 `EditableVariable` takes the scope as a **required** prop, because a token only
 renders where there is one. `RuntimeToken` serves all three run-time cases - a
 value produced when the request is sent rather than stored anywhere - and is one


### PR DESCRIPTION
## Description

**Root cause.** `VariableInput` owns the arrow keys - `cmdk` reads them off its own `Command.Input`, which neither `VariableAutocomplete` nor `SuggestionList` renders - and hands the new highlight down as `cmdk`'s controlled `value` prop. Inside cmdk 1.1.1 the scroll lives in `setState("value", …)`, which schedules `scrollSelectedIntoView` before it emits; that is the path cmdk's *own* arrow handling takes. A change to the `value` **prop** lands somewhere else entirely - a layout effect that assigns `state.value` and emits, with no scroll and no `selectedItemId`. So `[data-selected]` moved to the right row and the scroll container stayed put: past the eighth entry the highlight was below the fold of `CommandList`'s `max-h-[300px] overflow-y-auto`, and the only way to see what Enter would insert was the mouse.

**Approach.** `CommandScrollIntoView` in `command.tsx`, mounted inside the `CommandList` of both lists - the same shape as `CommandListboxProbe`, which exists for the same reason (a fact only readable from inside the `Command` tree). It reads the highlight from cmdk's store via `useCommandState` rather than from a prop, so a highlight the pointer moved and one the arrows moved are one code path, and it mirrors cmdk's own `scrollSelectedIntoView`: `[cmdk-item][aria-selected="true"]` scoped to *this* list, `block: "nearest"`, and the group heading brought in first when the row is the first of its group.

**The alternative rejected:** widening `CommandListboxProbe` with a `scroll` option instead of adding a second probe. The two have different mount conditions - the ids are wanted only where a combobox outside the list needs them (`{onListboxState && …}`), the scroll is wanted always - so one component would carry a conditional it does not need, and each probe is currently one decision's worth of work. A copy of the scroll logic inside each list was rejected for the reason the repo guide gives: a hand-rolled copy of a primitive does not receive the primitive's fixes, and anything else driving a `Command` from a controlled `value` now gets this by adding one line.

Verified against the installed cmdk 1.1.1 rather than from memory. One detail worth recording: cmdk's pointer handler calls `setState("value", v, true)`, and that third argument *skips* the scheduled scroll - so cmdk deliberately does not scroll on hover. Routing both paths through this probe therefore does change the pointer case, and `block: "nearest"` is what makes that harmless: a row the pointer can reach is on screen already, so it does not move.

## Type of Change
- [x] Bug fix

## Testing

- `pnpm test keyboard-navigation variable-autocomplete suggestion-list command` - **135 passed in 11 files** (`keyboard-navigation.test.tsx` goes 22 → 27).
- Full app suite, `pnpm test` - **7029 passed in 621 files**, no pre-existing failures on this base.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- Five new cases in `keyboard-navigation.test.tsx`, every one mutation-checked by actually breaking the code and re-running:
  - Removing `<CommandScrollIntoView />` from `variable-autocomplete.tsx` reddens 3 (`3 failed | 22 passed`).
  - Removing it from `suggestion-list.tsx` reddens the 4th (`1 failed | 25 passed`).
  - Breaking both Escape handlers reddens the 5th (`1 failed | 26 passed`).
  - All restored. The cases cover the arrow walk down past the fold and back up, the pointer path, the group heading, the plain header-suggestion list, and Escape.
- jsdom has no layout, so the assertion is *which element* `scrollIntoView` was called on - which is precisely what was wrong. The file's existing `DecoyList` (a second real `Command` mounted first) keeps a document-wide query from passing: the walk case asserts every scrolled element is inside the field's own list.
- Engine untouched. No new test file, so no `routed-inputs.testkit.ts` / `pr-tests.yml` entry is needed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1333

Acceptance criteria, line by line:
- Holding Down moves the highlight to the bottom and the list scrolls with it, at every step, and the same holds arrowing back up - the walk case asserts the scrolled element is the highlighted row on each of 10 downs and 10 ups.
- A row highlighted by the pointer scrolls the same way as one highlighted by the arrows - one code path, read from cmdk's store.
- Enter still inserts the highlighted row and Escape still closes the list. Enter had a case already. **Escape had none, anywhere in the tree** - the behaviour predates this change and is untouched by it, but nothing pinned it, so this adds the case rather than asserting the criterion on faith.
- The first row of a group scrolls its heading into view with it.

Docs updated in the same commit: `docs/app/COMPONENTS.md`, the Shared Variable Input section, directly under the paragraph that explains why `CommandListboxProbe` exists.

**Reviewer note.** The second commit also answers a contradiction a reader would hit: `CommandListboxProbe` argues in a comment for matching rows on `data-value` because the rendered `aria-selected` lags a layout effect, and the new probe two functions below matches on `aria-selected`. That is deliberate - only the first-paint case the id probe serves is affected by the lag, and this selector is the one cmdk uses for the very scroll being stood in for - and it is now said at the line rather than left to be re-derived from the cmdk source.

One review finding was deliberately not acted on: the issue's fix pathway spells the selector `[cmdk-item=""]`, and this uses the bare `[cmdk-item]`. They select the identical node set (cmdk never writes anything but `""`), and the bare form is what `CommandListboxProbe` and the file's own Tailwind selectors already use, so consistency inside the file won over the literal spelling in the issue.