### PR TITLE
docs(design-system): describe the shell this app has, and guard the paths the doc names

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -162,9 +162,11 @@ conclusion about a combination the app never renders is not a finding.
   variant pairs `bg-x` with `hover:bg-x/80`, and `cn()` (tailwind-merge)
   replaces `bg-*` but not `hover:bg-*`, so the caller's fill wins at rest and
   the variant's hover wins on hover. → `badge-hover.test.tsx`
-- **`docs/design-system.md` values are checked against `index.css`**
+- **`docs/design-system.md` values are checked against `index.css`**, and the
+  paths its Source Files table names are checked to exist
   → `design-system-doc.test.ts`. Prose is not: if you change a value, read the
-  sentence around it.
+  sentence around it, and if you rename a component the doc describes, the table
+  row fails but the section around it will not.
 - **Accessibility has a section of its own** in `docs/design-system.md`
   ("Accessibility", after Focus & Interaction States): which check holds which
   rule, why a tooltip is not a name, why `outline-none` needs a replacement in

--- a/app/src/design-system-doc.test.ts
+++ b/app/src/design-system-doc.test.ts
@@ -15,12 +15,13 @@
  * `24 90% 46%`, named a default that had since changed, and quoted
  * `--muted-foreground` at 44% two points after the CSS moved to 42%.
  *
- * This checks the values only. Prose, ratios and rationale still need a human -
- * a number here being right does not make the sentence around it right.
+ * This checks the values, and the source files the doc's own table sends a
+ * reader to. Prose, ratios and rationale still need a human - a number here
+ * being right does not make the sentence around it right.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { DOC_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
 import { declaredValues, indexCss as css } from "@/lib/css-tokens.testkit";
 
@@ -98,6 +99,29 @@ describe("design-system.md token values", () => {
 				token(block(scheme, true), "primary"),
 				token(block(scheme, true), "primary-fill"),
 			]);
+		}
+	});
+
+	// The Source Files table is the doc telling a reader where to go and look.
+	// A row for `layout/Sidebar.tsx` sat there describing an "ActivityBar +
+	// SidebarPanel" the tree never held, which is how a doc sends the next
+	// session hunting for a component and then guessing (#1329). A path is
+	// checkable where the prose around it is not, and this cannot go stale
+	// itself: it reads whatever the table currently names.
+	it("names source files that exist on disk", () => {
+		const start = doc.indexOf("\n## Source Files\n");
+		expect(start, "the Source Files heading has moved").toBeGreaterThan(-1);
+
+		const section = doc.slice(start + 1);
+		const next = section.indexOf("\n## ", 1);
+		const table = next === -1 ? section : section.slice(0, next);
+
+		// First column only, backtick-quoted: `| \`app/src/index.css\` | … |`.
+		const paths = [...table.matchAll(/^\| `([^`]+)` \|/gm)].map((m) => m[1]);
+		expect(paths.length, "no source-file rows found - has the table moved?").toBeGreaterThan(5);
+
+		for (const path of paths) {
+			expect(existsSync(fromRepoRoot(path)), path).toBe(true);
 		}
 	});
 });

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2078,27 +2078,55 @@ because a drag there resized a box inside a pane the user had already sized, and
 held that size in component state that Radix threw away on the next tab switch
 (#1323). The pane's own splitter is the one control for how tall an editor is.
 
-### ActivityBar
+### Dock
 
-- **Width:** `w-11` (44px), full height, `bg-panel border-r border-border`
-- **Tab buttons:** `w-10 h-10 flex items-center justify-center rounded-md`
-- **Active state:** `bg-primary/10 text-primary` + 2px left accent bar
-  ```tsx
-  <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r-sm" />
-  ```
-- **Inactive hover:** `hover:bg-accent hover:text-foreground`
-- **Icon size:** `w-4 h-4`
-- **Tabs (top):** Collections (Folder), History (Clock), Variables (Code2)
-- **Tab (bottom, pinned):** Settings (Settings2) - pushed down with `flex-1` spacer
-- **Collapse:** clicking active tab while panel open → `setPanelOpen(false)`
-- **Tooltips:** `side="right"` via `TooltipContent`
+The view switcher runs along the bottom of the window, not down its left edge:
+`Dock` (`app/src/components/layout/Dock.tsx`) is one flex row,
+`h-[var(--dock-height)] px-2 gap-2 border-t border-border bg-panel shrink-0`. The
+height is that token rather than a bare `h-8` because the toast viewport is
+`fixed` and offsets itself above this strip by the same value - the token is what
+keeps the two from drifting apart.
 
-### SidebarPanel
+- **Left - the six view buttons.** A `<nav aria-label="Sidebar views">`, its
+  names, marks and order read from `constants/drawer-views.ts` and its chords
+  from `constants/shortcuts.ts`, so the palette offering the same six cannot name
+  them differently. Deliberately not `role="toolbar"`: that promises arrow-key
+  traversal between the buttons, which this does not implement.
+- **A button is `w-7 h-7 rounded-md text-xs` with a `w-4 h-4` icon** -
+  `bg-accent text-accent-foreground` while its view is the open one, and
+  `text-muted-foreground hover:bg-muted/50 hover:text-foreground` otherwise. It
+  is icon-only, so its `aria-label` is the accessible name and the chord stays
+  out of it: a tooltip supplies `aria-describedby` while open, never a name.
+- **Middle - ambient status.** The engine connection light (a `bg-current` dot
+  plus Starting… / Connected / Disconnected, on `status-success-text` when
+  connected and `--muted-foreground` otherwise), a running-services button and a
+  pending-restart button that render only when there is something to report, the
+  save status, and the version string. **This strip is where the connection
+  state lives** - no sidebar footer carries a second copy.
+- **Right - the context bar toggle**, the same button component again, pressed
+  on what is visible rather than on the stored open flag.
+- **Clicking the open view's button closes the drawer.** The buttons call
+  `activateDrawerView`, which switches the view and toggles `drawerOpen` only
+  when that view is already showing; an ambient chip pointing at a view calls
+  `revealDrawerView`, which opens and never closes.
 
-- **Width:** `w-60` (240px) internal - the outer resizable container starts at 320px
-- `bg-panel border-r border-border overflow-hidden`
-- **Content:** `ScrollArea` fills available space
-- **Footer:** `ConnectionStatus` pinned to bottom with `border-t border-border`
+### Drawer
+
+The sidebar is `Drawer` (`app/src/components/layout/Drawer.tsx`): an
+`<aside className="relative flex shrink-0 bg-panel">` whose width is `drawerWidth`
+from `layout-store` and whose right edge carries its own `PanelResizeHandle`. It
+renders nothing while `drawerOpen` is false, and it is labelled by the view
+showing ("Collections sidebar") because one landmark hosts six panels -
+collections, history, variables, services, trash and settings - and
+"Complementary" alone would not say which.
+
+**The Drawer wraps no view in a scroll region.** Each view supplies its own
+`DrawerPanel` (`app/src/components/shared/DrawerPanel.tsx`), which owns the
+header - `h-[var(--tabstrip-height)]`, so it lines up with the TabStrip across
+the resize handle - and the single `overflow-y-auto overflow-x-hidden` body
+below it. That frame, not the shell, is what a new view needs: switching views
+changes the content and nothing else. The body is flush, so rows run edge to
+edge and bring their own padding.
 
 ### Pane Toggles
 
@@ -2785,8 +2813,10 @@ opt-out.
 | `app/tailwind.config.js` | Color mapping, font families, keyframes, animation aliases |
 | `app/index.html` | Pre-paint appearance script; no font `<link>` (see `fonts.css`) |
 | `app/src/fonts.css` | Bundled `@fontsource` imports for all six font families |
-| `app/src/components/layout/Shell.tsx` | Root layout - resizable sidebar + drag handle + main |
-| `app/src/components/layout/Sidebar.tsx` | ActivityBar + SidebarPanel |
+| `app/src/components/layout/Shell.tsx` | Root layout - the drawer row, the content column (TabStrip, main, ContextBar), the Dock, and the window chords |
+| `app/src/components/layout/Dock.tsx` | The bottom strip - six view buttons, ambient status, context bar toggle |
+| `app/src/components/layout/Drawer.tsx` | The sidebar `<aside>` - one of six views, plus its resize handle |
+| `app/src/components/shared/DrawerPanel.tsx` | The frame every drawer view sits in - header plus the one scroll region |
 | `app/src/components/layout/PanelResizeHandle.tsx` | The drawer's and the context bar's one drag handle (a focusable window splitter) |
 | `app/src/utils/helpers.ts` | `getMethodColor(method)` → `var(--method-xxx)` |
 | `app/src/modules/dashboard/components/MetricsView.tsx` | Sparkline, SvgAreaChart, LatencyBar, HeroCard, StatCard |


### PR DESCRIPTION
## Description

`docs/design-system.md`'s Layout Structure section documented an `ActivityBar`, a `SidebarPanel` and an `app/src/components/layout/Sidebar.tsx` - a 44px vertical rail with four tabs, a 240px panel footed by a `ConnectionStatus`. None of the three is in the tree, and `git log --all --diff-filter=D` finds no deletion that left them behind, so the sections describe a shell this repository does not appear to have built. They sit one screen below the Layout Structure diagram that #1327 had just corrected, in a file `app/CLAUDE.md` tells every session to read before touching a UI file, so a reader following the accurate diagram downward landed directly in the fiction.

**Root cause and approach.** The doc's values are checked against `index.css` by `design-system-doc.test.ts`; its prose is not, which is what let two whole sections describe components that never existed. Deleting and rewriting them is the only option that survives contact with the tree - the widths, the borders, the accent bar, the `setPanelOpen` API and the `ScrollArea`/`ConnectionStatus` composition are all about something else - so `### Dock` and `### Drawer` are written from the components as they are: the bottom strip that switches the six views and carries the connection light, and the `<aside>` whose width is a stored preference and whose views each supply their own `DrawerPanel` instead of being wrapped in a shared scroll region. **The alternative I rejected** was a prose guard over the section (assert the doc's component names appear in `app/src`): it cannot distinguish a component name from an ordinary noun, it would fire on every mention of a class or a token, and it would need maintaining alongside the prose it checks. The guard added instead is a declaration check - the Source Files table's paths, asserted to exist - which would have failed the moment the `Sidebar.tsx` row was written, and which reads whatever the table currently names, so it cannot itself go stale.

Changes:

- **`docs/design-system.md`**: `### ActivityBar` and `### SidebarPanel` are gone. `### Dock` covers the `h-[var(--dock-height)] border-t border-border bg-panel` strip, why the height is that token, the `<nav aria-label="Sidebar views">` and why it is not a `role="toolbar"`, the button's classes and its icon-only naming rule, the ambient middle (connection light, running services, pending restart, save status, version) with the note that this strip is where connection state lives, the context bar toggle, and the `activateDrawerView` / `revealDrawerView` distinction. `### Drawer` covers the `<aside>`, the width from `layout-store`, the right-edge `PanelResizeHandle`, the six views and the per-view landmark label, plus a paragraph on `DrawerPanel` as the frame a new view actually needs.
- **Source Files table**: the `Sidebar.tsx` row is dropped, `Shell.tsx`'s purpose is restated as the drawer row plus the content column plus the Dock, and `Dock.tsx`, `Drawer.tsx` and `shared/DrawerPanel.tsx` - never listed - are added.
- **`app/src/design-system-doc.test.ts`**: a new case extracts the Source Files table's paths and asserts each exists on disk, via `existsSync(fromRepoRoot(path))` - the established idiom in `routed-inputs.test.ts`, not a hand-rolled copy. It scopes itself to the section, fails loudly if the heading moves, and asserts it scanned a non-empty set of rows.
- **`app/CLAUDE.md`**: the bullet describing what that guard checks, updated in the same commit.

No registry change was needed: `DOC_READING_GUARDS.designSystem` already routes `docs/design-system.md` to this reader, and the path is already in `pr-tests.yml`'s `app_doc_fixtures` filter.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test design-system-doc` - 5 passed (4 existing, 1 new).
- **Mutation check**: restoring the `| app/src/components/layout/Sidebar.tsx | ActivityBar + SidebarPanel |` row makes the new case fail (1 failed | 4 passed); the row was then removed again.
- `cd app && pnpm test routed-inputs` - covered in the full run below; no registry or workflow change was required.
- `cd app && pnpm test` - **622 files, 7054 tests, all passed**.
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `cd app && pnpm lint` - clean, zero warnings. `prettier --check` on the touched test file - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - built with no warnings. Nothing anywhere in the repo links to `#activitybar` or `#sidebarpanel`, and `### Dock` / `### Drawer` collide with no existing anchor (`## Drawer Panel Frame` and `## Drawer Row Metric` slugify differently).
- No engine change, so no engine build or `ctest` run: nothing in this diff could turn a C++ test red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1329

Acceptance criteria, line by line:

- `rg -n 'ActivityBar|SidebarPanel|setPanelOpen' docs/` returns nothing (exit 1). The only remaining mention in the repo is the historical rationale comment above the new guard.
- Every path the doc's file table names exists on disk, and the new test proves it.
- The Layout Structure section reads top to bottom - diagram, the panels that resize, then Dock and Drawer - without naming a component the tree does not have.
- Every thing the section names (`Dock`, `Drawer`, `DrawerPanel`, `PanelResizeHandle`, `layout-store`, `constants/drawer-views.ts`) is findable by that name in `app/src`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqKX9Te8irsicYnmpccrdF)_