### PR TITLE
docs(engine): re-measure the narrow-cache race on cpp-httplib 0.53.1

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -387,7 +387,9 @@ tracking issue.
   two runs, both sides of the report being pool threads parsing their first
   response - against 2796/2796 with the entry in place. That test alone
   reproduces it 10 times out of 10, which is the cheap way to re-measure this
-  one. What is left is upstream in libstdc++.
+  one, and the way it was re-measured at `dc25029` after the baseline moved to
+  cpp-httplib 0.53.1: 8 of 10 runs raced without the entry, 10 of 10 passed
+  with it. What is left is upstream in libstdc++.
 
 The matrix has therefore paid for itself twice over: two engine-side defects
 found and fixed, one of them a race the ordinary suite is structurally unable

--- a/engine/sanitizers/tsan.supp
+++ b/engine/sanitizers/tsan.supp
@@ -98,4 +98,11 @@ race:crypto/hashtable/hashtable.c
 # `./vayu_tests --gtest_filter=TransportPolicyPaths.LoadRunTraversesManualProxy`
 # raced without the line, 10 of 10 passed with it. That is the cheap way to
 # re-measure it; the suite run is only needed to confirm nothing else moved.
+#
+# Re-measured that way at dc25029 (2026-09-03), because the vcpkg baseline has
+# since moved to cpp-httplib 0.53.1, which the inbox pins by `static_assert`.
+# `parse_status_line` is byte-identical on it and so is the outcome: 8 of 10
+# runs of that test raced without the line, 10 of 10 passed with it, and the
+# report was the stack above with the same libstdc++ and httplib frames. The
+# entry still earns its place on the version the engine now pins.
 race:std::ctype<char>::narrow


### PR DESCRIPTION
## Description

`tsan.supp`'s `race:std::ctype<char>::narrow` entry is the one suppression in this repo that is justified by a repeatable before/after rather than by a captured trace, and the numbers on record were taken under **cpp-httplib 0.53.0** (`3d2a6a7`, 2026-08-29). The vcpkg baseline has since moved to **0.53.1** - the release `engine/src/http/routes/inbox.cpp` pins by `static_assert` - so the entry's justification, and the same account in `docs/engine/building.md`, named a version the engine no longer builds against. That matters here specifically: what narrowed this race in the first place was httplib hoisting its status-line `std::regex` to `thread_local`, so an httplib bump is exactly the event that could change the answer.

Root cause and approach: the answer is a measurement, not an argument, and the issue's own record says so, so this run re-took it on 0.53.1 rather than reasoning from the unchanged source. It still fires, so nothing about the entry, the tracking issue or the remaining remedy (libstdc++ synchronising or eagerly filling the narrow cache) changes - only the record of which version the numbers were taken on. The alternative considered and rejected was leaving the record alone on the grounds that `parse_status_line` is byte-identical between the two releases: true, and checked, but the entry exists precisely because a reader should not have to re-derive that from the vendored header - the header block already tells the next reader how to re-measure in 30 seconds, and a version-stamped result is what makes that instruction trustworthy after a bump.

**This does not close #967.** Its remaining scope is upstream-only; it stays open as the tracking record `tsan.supp`'s header requires.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (a comment block and a docs paragraph; no code, no behaviour change)

## Testing

Measured on this Linux host - gcc 13.3.0, libtsan 2, `cmake --preset linux-tsan`, `TSAN_OPTIONS` byte-identical to the string `sanitizers.yml` exports (`halt_on_error=1:second_deadlock_stack=1:suppressions=.../tsan.supp`), cpp-httplib 0.53.1 from `engine/vcpkg_installed`:

| Suppressions | Runs of `--gtest_filter=TransportPolicyPaths.LoadRunTraversesManualProxy` | Result |
|---|---|---|
| `tsan.supp` **minus** `race:std::ctype<char>::narrow` | 10 | **2 passed, 8 raced** - every report `SUMMARY: ThreadSanitizer: data race locale_facets.h:941 in std::ctype<char>::narrow`, read under `basic_regex`'s constructor under `httplib::detail::parse_status_line` (`httplib.h:13893`) |
| the checked-in `tsan.supp` | 10 | **10 passed**, zero ThreadSanitizer reports |

That pair is also the mutation check in both directions: remove the line and the test reddens on this race, restore it and it does not. The 8-of-10 figure is a little under the 10-of-10 measured at 0.53.0, which is the ordinary variance of a race that needs two pool threads to parse their first response concurrently; the qualitative answer (fires readily, suppressed cleanly) is unchanged.

`python3 -m mkdocs build --strict -f .github/mkdocs.yml` - clean, 3.90s.

No test suite was run beyond the above: the diff is a comment block in a suppression file and one sentence in a docs bullet, so nothing could go from green to red. The suppression file is machine-read, so it was exercised as the file the passing control runs above loaded.

## Checklist
- [x] My code follows the style guidelines (no em-dashes; the comment block keeps the file's wrap and its three-part entry discipline)
- [x] I have performed a self-review
- [ ] I have added tests (not applicable - no code change; the measurement above is the evidence)
- [x] I have updated documentation (`docs/engine/building.md`, same commit)

## Related Issues

Refs #967 - deliberately not `Closes`: the suppression still earns its place, and the issue remains the tracking record for the one live remedy, which is upstream in libstdc++.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAFcLkqyo7FH5n4zLKygfQ)_