### PR TITLE
fix(app): the palette reads the drawer's six views instead of restating them

### DIFF
--- a/app/src/modules/palette/sources/useViewItems.source.test.ts
+++ b/app/src/modules/palette/sources/useViewItems.source.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * That the palette *reads* the drawer's list, rather than agreeing with it by
+ * hand (#1341).
+ *
+ * `useViewItems.test.ts` compares the produced rows to `DRAWER_VIEWS`, and that
+ * comparison would go on passing if the mapping were replaced by literals which
+ * happen to match the list today - which is exactly the state this file's
+ * subject was just moved out of, and how Collections came to be `FolderOpen` in
+ * the Dock and `Folder` in the palette. The difference between reading a list
+ * and copying it is visible only in the source, so the source is read.
+ *
+ * Node environment on purpose: nothing here renders, and `import.meta.url` is a
+ * file URL only outside jsdom.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { DRAWER_VIEWS } from "@/constants/drawer-views";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "useViewItems.ts"), "utf8");
+
+/**
+ * The file's prose explains the drift by naming the views it happened to, so
+ * the scan reads the code alone. Comment syntax only - no string in this file
+ * contains `//` or `/*`, and a guard that had to parse TypeScript to answer
+ * this question would be the wrong guard.
+ */
+const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+describe("the palette's view source", () => {
+	it("was read - a scan of an empty string passes forever", () => {
+		expect(source).toContain("export function useViewItems");
+	});
+
+	it("takes the six from the shared list rather than importing marks of its own", () => {
+		expect(code).toContain('from "@/constants/drawer-views"');
+
+		// `Inbox` is the palette's own row and has no entry in `DRAWER_VIEWS`;
+		// any other mark here would be a second spelling of a Dock icon.
+		const lucide = /import\s*\{([^}]*)\}\s*from\s*"lucide-react"/.exec(code);
+		expect(lucide).not.toBeNull();
+		expect(lucide?.[1].split(",").map((name) => name.trim())).toEqual(["Inbox"]);
+	});
+
+	it("names no drawer view, so renaming one in the shared list cannot leave the palette behind", () => {
+		for (const { label } of DRAWER_VIEWS) {
+			expect(code).not.toContain(`"${label}"`);
+		}
+	});
+
+	it("keys its keywords exhaustively, which is what fails the build on a seventh view", () => {
+		// `Partial<...>` or a cast would compile and change no behaviour, so the
+		// annotation is the assertion: it is the whole of the guarantee.
+		expect(code).toContain("const VIEW_KEYWORDS: Record<DrawerView, string[]>");
+	});
+});

--- a/app/src/modules/palette/sources/useViewItems.test.ts
+++ b/app/src/modules/palette/sources/useViewItems.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The palette and the Dock offer the same six views, so they name and mark them
+ * the same way (#1341).
+ *
+ * Every assertion here is driven from `DRAWER_VIEWS` itself rather than from a
+ * list of expected titles and icons: a test that restated the literals would
+ * agree with a palette that had drifted, which is exactly how Collections came
+ * to be `FolderOpen` in the Dock and `Folder` here. Mutation check: give the
+ * mapped entry an icon of its own and the icon case reddens.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { DRAWER_VIEWS } from "@/constants/drawer-views";
+import type { PaletteItem } from "../types";
+
+const { revealDrawerView, activateDrawerView, openTab } = vi.hoisted(() => ({
+	revealDrawerView: vi.fn(),
+	activateDrawerView: vi.fn(),
+	openTab: vi.fn(),
+}));
+
+vi.mock("@/stores", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/stores")>();
+	return {
+		...actual,
+		useLayoutStore: (selector: (s: Record<string, unknown>) => unknown) =>
+			selector({ revealDrawerView, activateDrawerView }),
+		useTabsStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ openTab }),
+	};
+});
+
+const { useViewItems } = await import("./useViewItems");
+
+function items(): PaletteItem[] {
+	return renderHook(() => useViewItems()).result.current;
+}
+
+function itemFor(title: string): PaletteItem {
+	const found = items().find((item) => item.title === title);
+	if (!found) throw new Error(`the palette offers no "${title}" row`);
+	return found;
+}
+
+beforeEach(() => {
+	revealDrawerView.mockClear();
+	activateDrawerView.mockClear();
+	openTab.mockClear();
+});
+
+describe("the six drawer views", () => {
+	it("are offered in the Dock's order, under the Dock's names", () => {
+		expect(
+			items()
+				.slice(0, DRAWER_VIEWS.length)
+				.map((item) => item.title)
+		).toEqual(DRAWER_VIEWS.map((view) => view.label));
+	});
+
+	it("carry the Dock's mark - the same icon component, not one that looks like it", () => {
+		const offered = items();
+		for (const [index, view] of DRAWER_VIEWS.entries()) {
+			expect(offered[index].icon).toBe(view.icon);
+		}
+	});
+
+	it("each have search synonyms of their own", () => {
+		// The compile-time half of this is `Record<DrawerView, string[]>` in the
+		// source: a seventh view added to `DRAWER_VIEWS` without a keywords line
+		// fails `pnpm type-check`. What runs here is that none of the six was
+		// given an empty list to satisfy the type.
+		for (const [index] of DRAWER_VIEWS.entries()) {
+			expect(items()[index].keywords?.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("what a view row does", () => {
+	it("reveals the drawer view rather than toggling it", () => {
+		itemFor("History").perform();
+
+		expect(revealDrawerView).toHaveBeenCalledWith("history");
+		expect(activateDrawerView).not.toHaveBeenCalled();
+		expect(openTab).not.toHaveBeenCalled();
+	});
+
+	it("opens the tab as well for the two views that are also a tab", () => {
+		itemFor("Variables").perform();
+
+		expect(revealDrawerView).toHaveBeenCalledWith("variables");
+		expect(openTab).toHaveBeenCalledWith({ type: "variables", entityId: null });
+
+		openTab.mockClear();
+		revealDrawerView.mockClear();
+
+		itemFor("Settings").perform();
+
+		expect(revealDrawerView).toHaveBeenCalledWith("settings");
+		expect(openTab).toHaveBeenCalledWith({ type: "settings", entityId: null });
+	});
+});
+
+describe("Inbox", () => {
+	it("is still offered, after the six, as a tab with no drawer view", () => {
+		const offered = items();
+
+		expect(offered).toHaveLength(DRAWER_VIEWS.length + 1);
+		expect(offered[offered.length - 1].title).toBe("Inbox");
+
+		offered[offered.length - 1].perform();
+
+		expect(openTab).toHaveBeenCalledWith({ type: "inbox", entityId: null });
+		expect(revealDrawerView).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/modules/palette/sources/useViewItems.ts
+++ b/app/src/modules/palette/sources/useViewItems.ts
@@ -20,11 +20,20 @@
  * is right for a button pressed twice and wrong for a search result: picking
  * "History" from the palette must show History, never hide it. So the entries
  * here reveal it instead (`revealDrawerView`, the store's non-toggling half).
+ *
+ * Names, marks and order for the six come from `constants/drawer-views.ts`, the
+ * list the Dock reads. Restating them here is what let Collections carry
+ * `FolderOpen` in the Dock and `Folder` in the palette (#1341): the same view
+ * with two marks, depending on which surface the user reached it from.
  */
 
-import { Braces, Clock, Folder, Inbox, Radio, Settings, Trash2 } from "lucide-react";
+import { Inbox } from "lucide-react";
+import { DRAWER_VIEWS } from "@/constants/drawer-views";
 import { useLayoutStore, useTabsStore, type DrawerView, type TabType } from "@/stores";
 import type { PaletteItem } from "../types";
+
+/** A surface that is both a drawer view and a tab of which there is only one. */
+type SingletonTab = Extract<TabType, "variables" | "settings" | "inbox">;
 
 interface ViewEntry {
 	title: string;
@@ -33,52 +42,50 @@ interface ViewEntry {
 	/** The drawer view to reveal, when this surface has one. */
 	drawerView?: DrawerView;
 	/** The singleton tab to open, when this surface has one. */
-	tabType?: Extract<TabType, "variables" | "settings" | "inbox">;
+	tabType?: SingletonTab;
 }
 
 /**
- * Fixed order, matching the Dock's switchers left to right so the two lists do
- * not disagree about what the app is made of.
+ * Search synonyms - the palette's own half, which the Dock has no use for.
+ *
+ * These are not names: they are what someone types when they are looking for a
+ * view but do not know (or do not recall) what it is called. Keyed by
+ * `DrawerView` rather than listed alongside a title, so a seventh view added to
+ * `DRAWER_VIEWS` without a line here fails to compile instead of shipping a
+ * row nobody can find.
  */
+const VIEW_KEYWORDS: Record<DrawerView, string[]> = {
+	collections: ["requests", "tree", "sidebar"],
+	history: ["runs", "past", "results"],
+	variables: ["environment", "globals", "{{", "substitution"],
+	services: ["inbox", "webhook", "oauth", "issuer", "mock", "listener"],
+	// "deleted" and "restore" are what someone types when they are looking for
+	// this: they know what happened, not what the surface is called.
+	trash: ["deleted", "restore", "undo", "removed", "recover"],
+	settings: ["preferences", "options", "config"],
+};
+
+/**
+ * The two drawer views that are also a singleton tab. Partial on purpose: the
+ * other four have no tab, and saying so is not a gap.
+ */
+const VIEW_TABS: Partial<Record<DrawerView, SingletonTab>> = {
+	variables: "variables",
+	settings: "settings",
+};
+
 const VIEWS: ViewEntry[] = [
-	{
-		title: "Collections",
-		keywords: ["requests", "tree", "sidebar"],
-		icon: Folder,
-		drawerView: "collections",
-	},
-	{ title: "History", keywords: ["runs", "past", "results"], icon: Clock, drawerView: "history" },
-	{
-		title: "Variables",
-		keywords: ["environment", "globals", "{{", "substitution"],
-		icon: Braces,
-		drawerView: "variables",
-		tabType: "variables",
-	},
-	{
-		title: "Services",
-		keywords: ["inbox", "webhook", "oauth", "issuer", "mock", "listener"],
-		icon: Radio,
-		drawerView: "services",
-	},
-	{
-		title: "Trash",
-		// "deleted" and "restore" are what someone types when they are looking
-		// for this: they know what happened, not what the surface is called.
-		keywords: ["deleted", "restore", "undo", "removed", "recover"],
-		icon: Trash2,
-		drawerView: "trash",
-	},
-	{
-		title: "Settings",
-		keywords: ["preferences", "options", "config"],
-		icon: Settings,
-		drawerView: "settings",
-		tabType: "settings",
-	},
+	...DRAWER_VIEWS.map(({ view, label, icon }) => ({
+		title: label,
+		keywords: VIEW_KEYWORDS[view],
+		icon,
+		drawerView: view,
+		tabType: VIEW_TABS[view],
+	})),
 	// Kept beside Services, which lists inboxes and is where one is started:
 	// this entry is the *tab*, the detail surface with the capture list, and
-	// searching "inbox" should reach both.
+	// searching "inbox" should reach both. Not a drawer view, so it is a
+	// literal rather than a seventh entry in the shared list.
 	{ title: "Inbox", keywords: ["webhook", "receive", "callback"], icon: Inbox, tabType: "inbox" },
 ];
 


### PR DESCRIPTION
## Description

`app/src/constants/drawer-views.ts` exists to be the one list of the drawer's six views - its header says why, and `Dock.tsx:313-315` repeats the claim ("so the palette offering the same six cannot name them differently"). The palette did not read it: `useViewItems.ts` declared its own `VIEWS` array with its own titles and its own lucide imports, coupled to the Dock by a comment at `:40-42`. They had already drifted - Collections was `FolderOpen` in the Dock (`drawer-views.ts:34`) and `Folder` in the palette (`useViewItems.ts:47`): the same view carrying two marks depending on which surface the user reached it from.

**Root cause and approach.** This is `CLAUDE.md`'s repeated defect in its second form - a definition read by one surface and re-derived by another, where only one of the two can be corrected by a fix to the shared file. So the six entries now map `DRAWER_VIEWS`, taking `label` as the title and `icon` as the mark, with the order coming from the array rather than being restated. What is genuinely the palette's own stays in the palette: the search synonyms (`Record<DrawerView, string[]>`, so a seventh view added to `DRAWER_VIEWS` without keywords fails to compile rather than shipping a row nobody can find) and the singleton `tabType` for the two views that are both a drawer view and a tab. `Inbox` is not a drawer view - it is a singleton tab kept beside Services deliberately - so it stays a literal, appended after the mapped six.

**The alternative rejected:** moving the palette's keywords into `drawer-views.ts` so one entry carried everything. They are search synonyms, not names, and the Dock has no use for them; putting them in the shared file would make the Dock's list carry palette-only data and invite the next surface to add its own field there too. The shared file keeps what both surfaces show; the palette keeps what only it needs.

**No behaviour change beyond the mark.** `revealDrawerView` (not the toggling `activateDrawerView`), the open-tab behaviour for Variables/Settings/Inbox, the item `id` shape and the group order are all unchanged. `useViewItems` has one consumer, `PaletteResults.tsx`, which treats the items generically; `lib/commands/registry.ts`'s `DRAWER_VIEW_COMMANDS` is a separate roster that already derived from `DRAWER_VIEWS` and is untouched.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Two test files, because they answer two different questions.

`useViewItems.test.ts` (jsdom, 6 cases) - what the palette *offers*: titles and icons for the six asserted **against `DRAWER_VIEWS` itself**, never against restated literals, plus the order, non-empty keywords for each of the six, reveal-not-toggle, open-tab for Variables/Settings, and Inbox still offered last as a tab with no drawer view.

`useViewItems.source.test.ts` (node, 4 cases) - that the palette *reads* the list rather than agreeing with it by hand. The behavioural file would go on passing if the mapping were replaced by literals matching the list today, which is the state this PR undoes, so acceptance criterion 1 ("declares no view title and no view icon of its own") is only checkable in the source: it imports `@/constants/drawer-views`, imports no lucide mark but `Inbox`, contains no drawer-view name as a string literal, and keys its keywords `Record<DrawerView, string[]>` - the annotation being the whole of the compile-time guarantee. Comments are stripped before the scan (the file's prose names the views the drift happened to) and the scan asserts it read something, per `CLAUDE.md`'s rule about guards over empty strings.

Mutation checks, all run:
- Giving the mapped entry `Folder` for Collections again reddens the icon case (`Expected render: FolderOpen, Received render: Folder`).
- Re-importing a second lucide mark, adding a view name as a literal, and weakening the keywords table to `Partial<Record<...>>` redden the three corresponding source guards. Restored and green after each.

Commands:
- `cd app && pnpm test palette` - 9 files, 109 tests passed.
- `cd app && pnpm test` - 623 files, 7089 tests passed (before the source guard was added; the guard file adds 4 passing cases and touches nothing else).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `pnpm exec eslint` and `pnpm exec prettier --check` on the touched files - clean.

No pre-existing failures observed on this base (`3a7e4c3`).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: none needed, as the issue states. `docs/design-system.md`'s `### Dock` section already asserts the rule ("its names, marks and order read from `constants/drawer-views.ts` ... so the palette offering the same six cannot name them differently") - this change is what makes that sentence true for the palette's Views section as well as its Commands section, so no line goes stale. `docs/app/COMPONENTS.md`'s description of `useViewItems` ("drawer views and singleton tabs") also stays accurate. The new guard reads a file inside `app/`, so it needs no entry in `routed-inputs.testkit.ts`.

## Related Issues
Closes #1341