### PR TITLE
feat(app): an agent can refuse a header the engine adds

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -3347,6 +3347,11 @@ describe("start_load_run scenario runs", () => {
 			// per request sent, so a payload carrying both would have one of the
 			// two silently dropped.
 			["data", [{ id: "1" }]],
+			// The send's default-header refusals (issue #1337): the engine reads
+			// them off one request's payload, and a scenario's steps are each
+			// composed from their own saved request, so a run-level list would be
+			// an argument written and never read.
+			["disabledDefaultHeaders", ["User-Agent"]],
 		] as Array<[string, unknown]>) {
 			const res = await dispatchTool(
 				"start_load_run",
@@ -5578,6 +5583,91 @@ describe("dispatchTool", () => {
 		expect(
 			parsed.reliability.find((m) => m.metric === "summary.totalRequests")?.direction
 		).toBe("neutral");
+	});
+});
+
+/**
+ * An agent can refuse a header the engine adds (issue #1337).
+ *
+ * The engine has taken `disabledDefaultHeaders` on `POST /execute` and
+ * `POST /runs` since #1229; what an agent could not do was name it, because the
+ * MCP SDK parses arguments through each tool's zod `inputSchema` and a zod
+ * object strips what it does not declare. So every case here parses through the
+ * tool's own schema first, exactly as the SDK does: handing `dispatchTool` the
+ * field directly would pass with the schema entry removed and prove nothing.
+ */
+describe("default-header opt-outs reach the engine", () => {
+	const parseArgs = (name: string, args: Record<string, unknown>) =>
+		z
+			.object(TOOLS.find((t) => t.name === name)!.inputSchema as Record<string, z.ZodTypeAny>)
+			.parse(args);
+
+	test("run_request forwards the refused names to /execute", async () => {
+		const client = fakeClient();
+		const args = parseArgs("run_request", {
+			url: "https://api.example.com/users",
+			disabledDefaultHeaders: ["User-Agent", "Accept-Encoding"],
+		});
+		expect(args.disabledDefaultHeaders).toEqual(["User-Agent", "Accept-Encoding"]);
+
+		const res = await dispatchTool(
+			"run_request",
+			args,
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		// The whole point of the argument: this send carries no User-Agent at
+		// all, which writing one yourself cannot express.
+		expect(payload.disabledDefaultHeaders).toEqual(["User-Agent", "Accept-Encoding"]);
+	});
+
+	test("run_request sends no such key when the agent names none", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"run_request",
+			parseArgs("run_request", { url: "https://api.example.com/users" }),
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		// An empty list and no list say the same thing to the engine, so saying
+		// it here would be this layer making a claim the agent did not.
+		expect(payload).not.toHaveProperty("disabledDefaultHeaders");
+	});
+
+	test("start_load_run forwards the refused names to /runs", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				confirmed: true,
+				disabledDefaultHeaders: ["Accept-Encoding"],
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload.disabledDefaultHeaders).toEqual(["Accept-Encoding"]);
+	});
+
+	test("the shared sentence names the two tools that take the argument", () => {
+		const description = (name: string) => TOOLS.find((t) => t.name === name)!.description;
+		// One sentence carried by the three tools that send traffic, so it has to
+		// tell them apart: a paraphrase per tool is what it exists to prevent.
+		for (const name of ["run_request", "start_load_run"]) {
+			expect(description(name), name).toContain("disabledDefaultHeaders");
+			expect(description(name), name).toMatch(
+				/run_request and start_load_run take it as an argument/
+			);
+		}
+		expect(description("run_collection_smoke")).toMatch(
+			/run_collection_smoke does not: it replays each saved request exactly as stored/
+		);
 	});
 });
 

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -5638,6 +5638,34 @@ describe("default-header opt-outs reach the engine", () => {
 		expect(payload).not.toHaveProperty("disabledDefaultHeaders");
 	});
 
+	test("a streaming run_request carries them too", async () => {
+		// The streaming branch answers `202 {runId, eventsUrl}` and consumes the
+		// events itself, so it is the one send whose payload a reader has to
+		// follow into a second function - and a refusal dropped there would be a
+		// stream opened with a User-Agent the agent declined.
+		const client = fakeClient({
+			executeRequest: vi
+				.fn()
+				.mockResolvedValue({ runId: "run_s", eventsUrl: "/runs/run_s/events" }),
+			consumeStreamEvents: vi
+				.fn()
+				.mockResolvedValue({ events: [], completed: true, capReached: false }),
+		});
+		const res = await dispatchTool(
+			"run_request",
+			parseArgs("run_request", {
+				url: "https://api.example.com/events",
+				stream: true,
+				disabledDefaultHeaders: ["User-Agent"],
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload).toMatchObject({ stream: true, disabledDefaultHeaders: ["User-Agent"] });
+	});
+
 	test("start_load_run forwards the refused names to /runs", async () => {
 		const client = fakeClient();
 		const res = await dispatchTool(

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1696,6 +1696,27 @@ function applyRecordingKnobs(
 	if (comment !== undefined) payload.comment = comment;
 }
 
+/**
+ * Copy the default-header opt-outs onto an execute or run payload (issue #1337).
+ *
+ * Beside the composed payload rather than through composition, for the reason
+ * `data` is: composition resolves `{{variables}}` and the auth chain, and an
+ * opt-out is neither - it is a send-time fact about the engine's own defaults,
+ * never stored on a request and never interpolated. `POST /execute` and
+ * `POST /runs` read it off the payload they are given.
+ *
+ * Absent stays absent: an empty list and no list say the same thing to the
+ * engine, and sending one where the agent named none would be this layer
+ * making a claim on its behalf.
+ */
+function applyDefaultHeaderOptOuts(
+	args: Record<string, unknown>,
+	payload: Record<string, unknown>
+): void {
+	const names = args.disabledDefaultHeaders;
+	if (Array.isArray(names)) payload.disabledDefaultHeaders = names;
+}
+
 // --- Shared input schema fragments ------------------------------------------
 
 /** Optional resolution scope shared by the ad-hoc execute/load tools. */
@@ -1746,7 +1767,25 @@ const environmentIdInput = z
  * paraphrases of the same rule are three things to keep in step with the engine.
  */
 export const ENGINE_DEFAULT_HEADERS_SENTENCE =
-	"Headers the engine adds itself: every request sent through Vayu that does not already name them gets a `User-Agent` (`Vayu/<version>`), an `Accept-Encoding` negotiating the compression this build can decode, and - only when the user has switched it on - a fresh per-request correlation id (`X-Vayu-Request-Id` by default). They are added at send time and never stored on a request, and a header you write under one of those names always wins, so setting `User-Agent` yourself is how you control what the target sees. Refusing one outright - sending no `User-Agent` at all - is the engine's `disabledDefaultHeaders` field, which names the headers a send declines; the app's Headers tab offers it as a tick per header, and it is not an argument these tools take.";
+	"Headers the engine adds itself: every request sent through Vayu that does not already name them gets a `User-Agent` (`Vayu/<version>`), an `Accept-Encoding` negotiating the compression this build can decode, and - only when the user has switched it on - a fresh per-request correlation id (`X-Vayu-Request-Id` by default). They are added at send time and never stored on a request, and a header you write under one of those names always wins, so setting `User-Agent` yourself is how you control what the target sees. Refusing one outright - sending no `User-Agent` at all - is the engine's `disabledDefaultHeaders` field, which names the headers a send declines; the app's Headers tab offers it as a tick per header, and run_request and start_load_run take it as an argument. run_collection_smoke does not: it replays each saved request exactly as stored, so a refusal there would be a per-send decision applied to requests the agent did not write.";
+
+/**
+ * The default headers one send refuses (issue #1337), as `disabledDefaultHeaders`.
+ *
+ * One fragment for the two tools that build a request payload: the field means
+ * the same thing on `POST /execute` and `POST /runs`, and the engine reads it
+ * off both through the same `read_default_header_opt_outs` (`utils/json.cpp`).
+ *
+ * Shape only. The engine owns what a usable header name is and refuses a bad
+ * one by name, so a second copy of that rule here could only drift from it -
+ * the same posture `thresholds` and the stream caps take.
+ */
+const defaultHeaderOptOutsInput = z
+	.array(z.string())
+	.optional()
+	.describe(
+		'Default headers this send refuses, by name (e.g. ["User-Agent", "Accept-Encoding"]). This is the only way to send a request with **no** User-Agent at all - writing one yourself replaces the value but still sends the header. Only the engine\'s own defaults are refusable; a name it adds nothing under is accepted and does nothing, and a name that cannot be a header name is refused by the engine. Nothing is stored: the refusal applies to this send alone.'
+	);
 
 export const INSECURE_TLS_REFUSAL =
 	"verifySSL: false is not accepted on a one-off send - a skipped certificate check has to leave a record, and an argument on a single call leaves none. Two ways forward: ask the user to add the internal authority under Vayu Settings > Network & connectivity, which keeps verification on for every request; or save the request with create_request/update_request `verifySSL: false` and run it (run_collection_smoke composes a saved request exactly as stored). The app then shows that request as accepting any certificate, and the user can untick it.";
@@ -2634,6 +2673,10 @@ const SINGLE_TARGET_LOAD_FIELDS: ReadonlyArray<[string, string]> = [
 	[
 		"data",
 		"a collection run states its rows as `scenario.data`, where one row is bound per iteration and shared by every step",
+	],
+	[
+		"disabledDefaultHeaders",
+		"the engine reads a send's default-header refusals off one request's payload, and a scenario's steps are each composed from their own saved request",
 	],
 	["postRequestScript", "each step runs the scripts stored on it and its collection chain"],
 	["tests", "each step runs the scripts stored on it and its collection chain"],
@@ -4082,6 +4125,7 @@ export const TOOLS: McpTool[] = [
 			environmentId: environmentIdInput,
 			collectionId: collectionIdInput,
 			data: dataRowInput,
+			disabledDefaultHeaders: defaultHeaderOptOutsInput,
 			preRequestScript: z
 				.string()
 				.optional()
@@ -4148,6 +4192,11 @@ export const TOOLS: McpTool[] = [
 			// row (issue #601). Absent means today's send, unchanged.
 			const dataRow = args.data;
 			if (dataRow !== undefined && dataRow !== null) payload.data = dataRow;
+
+			// The same posture, and the same reason it is not composed: the names
+			// say which of the engine's own defaults this send declines, which
+			// composition neither reads nor rewrites (issue #1337).
+			applyDefaultHeaderOptOuts(args, payload);
 
 			// Stated on every call, never elided: the two answers have different
 			// *shapes* - `202 {runId, eventsUrl}` against the exchange - so a
@@ -6493,6 +6542,7 @@ export const TOOLS: McpTool[] = [
 			collectionId: collectionIdInput,
 			postRequestScript: validationScriptInput,
 			tests: validationScriptAliasInput,
+			disabledDefaultHeaders: defaultHeaderOptOutsInput,
 			// The single-target data set (issue #993). Bounded by the engine's
 			// own `maxScenarioDataRows` / `maxScenarioDataBytes`, whose 400 is
 			// surfaced verbatim rather than re-derived here - the same posture
@@ -6636,6 +6686,11 @@ export const TOOLS: McpTool[] = [
 				payload.monitor = monitor;
 			}
 			applyRecordingKnobs(args, payload);
+			// A single target's own send-time refusals (issue #1337). A scenario
+			// run never reaches here: it refuses the field by name, because its
+			// steps are composed one by one and nothing reads a run-level
+			// opt-out - see SINGLE_TARGET_LOAD_FIELDS.
+			applyDefaultHeaderOptOuts(args, payload);
 			// An omitted duration is 60s engine-side, not "unbounded" and not
 			// "capped" - so a cap under 60s has to be sent as an explicit field
 			// or it never reaches the run.

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -894,7 +894,16 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   where one is switched on - and
   the `Cookie` line the jar matched for the environment. A header the call
   wrote itself always wins over the default of that name, and
-  `disabledDefaultHeaders` on the payload refuses one outright. So the request an agent
+  `disabledDefaultHeaders` on the payload refuses one outright.
+  `run_request` and `start_load_run` take that list as an argument
+  (issue [#1337](https://github.com/athrvk/vayu/issues/1337)), which is how an
+  agent sends a request with no `User-Agent` at all rather than one carrying a
+  value it chose; it rides beside the composed payload, because the names say
+  which of the engine's own defaults this send declines and composition neither
+  reads nor rewrites them. `run_collection_smoke` does not take it - it replays
+  each saved request exactly as stored - and a scenario load run refuses it by
+  name, as it does every other single-target field, because its steps are each
+  composed from their own saved request. So the request an agent
   composed is not the request that was sent, and asserting on the composed one
   is how a correct request gets reported as wrong. `requestHeaders` in the
   result is the sent record - composed plus everything but the `Cookie` line,


### PR DESCRIPTION
## Description

The engine has accepted `disabledDefaultHeaders` on `POST /execute` and `POST /runs` since #1229 (`read_default_header_opt_outs`, `engine/src/utils/json.cpp`), and the app's Headers tab offers it as a tick per header. MCP could not reach it: the SDK parses each tool's arguments through its zod `inputSchema` before dispatch and a zod object strips what it does not declare, so a caller passing the field got no error and no effect. An agent could write its own `User-Agent` - which replaces the value - but could not send a request with **no** `User-Agent` or no `Accept-Encoding` at all, which is exactly the case "test what this endpoint does with no User-Agent" needs.

**Root cause and approach.** The capability exists everywhere except the one layer that declares its arguments, so the fix is a declaration plus a forward, not new behaviour: `run_request` and `start_load_run` gain `disabledDefaultHeaders: z.array(z.string()).optional()` through one shared schema fragment, and one shared helper lays the list onto the payload beside `data` and `requestId`. It is attached *beside* the composed payload rather than threaded into the inline request that goes to `POST /compose` - the rejected alternative. Compose does pass unknown keys through key by key, so that would have worked, but an opt-out is a send-time fact about the engine's own defaults: never stored, never interpolated, and nothing in composition reads or rewrites it. `data` sits beside the composed payload for the same reason. Going through compose would additionally push the field into per-step scenario composition, where nothing reads it. The engine keeps every rule: it refuses a name that cannot be a header name, so this layer states the shape and adds no rules of its own.

A scenario load run refuses the field by name (`SINGLE_TARGET_LOAD_FIELDS`), as it does every other single-target argument: its steps are each composed from their own saved request, so a run-level list would be an argument written and never read. `run_collection_smoke` still takes no per-request overlay, and `ENGINE_DEFAULT_HEADERS_SENTENCE` - the one sentence the three traffic-sending tools share - now names the argument and says which tool does not take it, instead of stating the refusal is unavailable.

Known engine behaviour, unchanged by this PR and worth stating because the issue assumed otherwise: a malformed list is a synchronous `400` on `POST /execute` and on a scenario `POST /runs`, but on a single-target load run `build_load_request` runs in the run's own worker after the `202`, so a bad header name there fails the run asynchronously rather than refusing the call. Zod already guarantees the array-of-strings shape before either path is reached.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test electron/mcp/tools` - 438 passed (5 new). The whole app suite is green locally too: `pnpm test` - 627 files, 7140 passed. `pnpm type-check`, `pnpm lint` and `pnpm exec prettier --check` on the touched files are clean. Engine untouched, so no C++ build or ctest run: the field, its validation and its behaviour already exist there. No pre-existing failures were observed on the base commit.

Each new assertion was mutation-checked:

- drop the schema entry from `run_request` -> "run_request forwards the refused names to /execute" fails (the tests parse through the tool's own `inputSchema` first, as the SDK does; asserting on `dispatchTool` alone would pass with the field removed and prove nothing).
- drop the payload attach -> both forwarding tests and the streaming case fail.
- drop the `SINGLE_TARGET_LOAD_FIELDS` row -> the scenario refusal test fails.

The streaming case exists because `run_request` with `stream: true` hands its payload to a second function: it is the same object today, and the test is what keeps a rebuild there from opening a stream carrying a `User-Agent` the agent declined.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1337
