### PR TITLE
fix(app): turn off the renderer's spellchecker

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -273,6 +273,12 @@ function createWindow() {
 			nodeIntegration: false,
 			contextIsolation: true,
 			preload: path.join(__dirname, "preload.js"),
+			// Off for the whole renderer (#1355). Nothing here is prose - URLs,
+			// header values, {{tokens}} and JSON keys all draw squiggles - and on
+			// Windows and Linux the checker fetches Hunspell dictionaries from a
+			// Google CDN the first time it runs, which a tool pointed at internal
+			// APIs should not do for a feature it does not want.
+			spellcheck: false,
 		},
 		title: "Vayu",
 		backgroundColor: nativeTheme.shouldUseDarkColors ? WINDOW_BG_DARK : WINDOW_BG_LIGHT,

--- a/app/electron/oauth.ts
+++ b/app/electron/oauth.ts
@@ -48,6 +48,12 @@ function openAuthWindow(params: OpenAuthWindowParams): Promise<OpenAuthWindowRes
 			contextIsolation: true,
 			sandbox: true,
 			partition: params.partition ?? "oauth:default",
+			// Off here for the same reason as the main window (#1355), and with
+			// more cause: this one loads the IdP's own login form, so a first
+			// keystroke in it would fetch Hunspell dictionaries from a Google CDN
+			// on Windows and Linux - during a sign-in, from a window the user did
+			// not know was a browser.
+			spellcheck: false,
 		},
 	});
 

--- a/app/electron/spellcheck.test.ts
+++ b/app/electron/spellcheck.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The renderer's spellchecker is off, in one place (issue #1355).
+ *
+ * Electron enables Chromium's spellchecker by default, so every editable field
+ * in the request builder - URL bar, header keys and values, query parameters,
+ * variable values - drew red underlines under things that are not prose, while
+ * Monaco (which owns its own text area) did not. On Windows and Linux the
+ * checker also fetches Hunspell dictionaries from a Google CDN the first time
+ * it runs, which is a network request the app never disclosed.
+ *
+ * `main.ts` creates the window at import time, so the option can only be read -
+ * the characterization approach `startup-order.test.ts` and
+ * `renderer-recovery.test.ts` take to main.ts's own wiring. The second case is
+ * the other half of "one place": with the window option set, a per-field
+ * `spellCheck={false}` is a dead attribute that suggests the default is still
+ * on, so none may come back.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, globSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const main = readFileSync(join(here, "main.ts"), "utf8");
+
+/** The `webPreferences` object literal in `createWindow`, braces included. */
+function webPreferencesBlock(): string {
+	const start = main.indexOf("\t\twebPreferences: {");
+	expect(start).toBeGreaterThan(-1);
+
+	// The literal holds no nested braces today; `\n\t\t},` is its own closer at
+	// the option's indent, which a nested one could not match.
+	const end = main.indexOf("\n\t\t},", start);
+	expect(end).toBeGreaterThan(start);
+
+	return main.slice(start, end);
+}
+
+describe("the renderer window", () => {
+	it("disables the spellchecker in webPreferences", () => {
+		expect(webPreferencesBlock()).toContain("spellcheck: false");
+	});
+
+	it("keeps the setting on the window rather than a session override", () => {
+		// `setSpellCheckerDictionaryDownloadURL` would keep the checker on and
+		// only move the download; the app has no field where a spellchecked word
+		// helps, so there is nothing to redirect.
+		expect(main).not.toContain("setSpellCheckerDictionaryDownloadURL");
+		expect(main).not.toContain("setSpellCheckerLanguages");
+	});
+});
+
+const RENDERER_SOURCES = join(here, "..", "src");
+
+function rendererFiles(): string[] {
+	return globSync("**/*.{ts,tsx}", { cwd: RENDERER_SOURCES }).map((f) =>
+		join(RENDERER_SOURCES, f)
+	);
+}
+
+describe("the renderer's own fields", () => {
+	it("found the files to scan", () => {
+		// A glob that stopped matching would make the next case vacuous.
+		expect(rendererFiles().length).toBeGreaterThan(500);
+	});
+
+	it("carries no per-field spellCheck attribute", () => {
+		const offenders = rendererFiles()
+			.filter((file) => /spellCheck\s*=/.test(readFileSync(file, "utf8")))
+			.map((file) => file.slice(RENDERER_SOURCES.length + 1));
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/app/electron/spellcheck.test.ts
+++ b/app/electron/spellcheck.test.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * The renderer's spellchecker is off, in one place (issue #1355).
+ * Every window Vayu opens has the spellchecker off (issue #1355).
  *
  * Electron enables Chromium's spellchecker by default, so every editable field
  * in the request builder - URL bar, header keys and values, query parameters,
@@ -15,12 +15,17 @@
  * checker also fetches Hunspell dictionaries from a Google CDN the first time
  * it runs, which is a network request the app never disclosed.
  *
- * `main.ts` creates the window at import time, so the option can only be read -
- * the characterization approach `startup-order.test.ts` and
- * `renderer-recovery.test.ts` take to main.ts's own wiring. The second case is
- * the other half of "one place": with the window option set, a per-field
- * `spellCheck={false}` is a dead attribute that suggests the default is still
- * on, so none may come back.
+ * The guard is written over *every* `new BrowserWindow` in `app/electron`
+ * rather than over the main window's options alone, because the app has two -
+ * the shell and the OAuth sign-in window - and the second one was missed on the
+ * first pass. A third would be missed the same way; this way it fails instead.
+ * The windows are constructed at import time, so their options can only be read
+ * - the characterization approach `startup-order.test.ts` and
+ * `renderer-recovery.test.ts` take to main.ts's own wiring.
+ *
+ * The other half of "off in one place" is the renderer: with the window option
+ * set, a per-field `spellCheck={false}` is a dead attribute that suggests the
+ * default is still on, so none may come back.
  */
 
 import { describe, it, expect } from "vitest";
@@ -29,30 +34,62 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const main = readFileSync(join(here, "main.ts"), "utf8");
 
-/** The `webPreferences` object literal in `createWindow`, braces included. */
-function webPreferencesBlock(): string {
-	const start = main.indexOf("\t\twebPreferences: {");
-	expect(start).toBeGreaterThan(-1);
+/**
+ * The option object of every `new BrowserWindow({...})` in the main process,
+ * sliced by counting braces so the guard survives a reindent - it reads what
+ * the constructor is passed, not how the file happens to be formatted.
+ */
+function browserWindowOptions(): { file: string; source: string }[] {
+	const blocks: { file: string; source: string }[] = [];
 
-	// The literal holds no nested braces today; `\n\t\t},` is its own closer at
-	// the option's indent, which a nested one could not match.
-	const end = main.indexOf("\n\t\t},", start);
-	expect(end).toBeGreaterThan(start);
+	for (const name of globSync("*.ts", { cwd: here }).filter((f) => !f.endsWith(".test.ts"))) {
+		const source = readFileSync(join(here, name), "utf8");
+		const opener = "new BrowserWindow({";
 
-	return main.slice(start, end);
+		for (let at = source.indexOf(opener); at !== -1; at = source.indexOf(opener, at + 1)) {
+			let depth = 0;
+			let cursor = at + opener.length - 1;
+
+			do {
+				if (source[cursor] === "{") depth++;
+				if (source[cursor] === "}") depth--;
+				cursor++;
+			} while (depth > 0 && cursor < source.length);
+
+			expect(depth, `unbalanced BrowserWindow options in ${name}`).toBe(0);
+			blocks.push({ file: name, source: source.slice(at, cursor) });
+		}
+	}
+
+	return blocks;
 }
 
-describe("the renderer window", () => {
-	it("disables the spellchecker in webPreferences", () => {
-		expect(webPreferencesBlock()).toContain("spellcheck: false");
+describe("every window the app opens", () => {
+	it("found the windows to scan", () => {
+		// Two today: the shell in main.ts and the OAuth window in oauth.ts. A
+		// scan that stopped matching would make the next case vacuous.
+		expect(
+			browserWindowOptions()
+				.map((b) => b.file)
+				.sort()
+		).toEqual(["main.ts", "oauth.ts"]);
+	});
+
+	it("disables the spellchecker in its webPreferences", () => {
+		const offenders = browserWindowOptions()
+			.filter((b) => !b.source.includes("spellcheck: false"))
+			.map((b) => b.file);
+
+		expect(offenders).toEqual([]);
 	});
 
 	it("keeps the setting on the window rather than a session override", () => {
 		// `setSpellCheckerDictionaryDownloadURL` would keep the checker on and
 		// only move the download; the app has no field where a spellchecked word
 		// helps, so there is nothing to redirect.
+		const main = readFileSync(join(here, "main.ts"), "utf8");
+
 		expect(main).not.toContain("setSpellCheckerDictionaryDownloadURL");
 		expect(main).not.toContain("setSpellCheckerLanguages");
 	});

--- a/app/src/modules/services/NewIssuerDialog.tsx
+++ b/app/src/modules/services/NewIssuerDialog.tsx
@@ -263,7 +263,6 @@ export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProp
 						<Textarea
 							id="new-issuer-claims"
 							rows={4}
-							spellCheck={false}
 							placeholder={'{ "sub": "alice", "roles": ["admin"] }'}
 							value={claimsText}
 							onChange={(e) => setClaimsText(e.target.value)}

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -741,7 +741,6 @@ export default function SettingsMain() {
 							value={currentValue}
 							onChange={(e) => handleValueChange(entry, e.target.value)}
 							rows={8}
-							spellCheck={false}
 							className="font-mono text-xs"
 							// Same as the Switch above: the name is in the
 							// CardTitle, which nothing links to this control.

--- a/app/src/modules/settings/main/panels/FontPicker.tsx
+++ b/app/src/modules/settings/main/panels/FontPicker.tsx
@@ -111,7 +111,6 @@ export function FontPicker({
 						onChange={(e) => onCustomChange(e.target.value)}
 						placeholder={placeholder}
 						className="max-w-sm"
-						spellCheck={false}
 						autoComplete="off"
 					/>
 					<p className="mt-1.5 text-xs text-muted-foreground">

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -74,7 +74,10 @@ The Vayu Manager is an Electron-based desktop application built with React and T
 
 The main process is responsible for:
 
-- **Window Management**: Creates and manages the Electron `BrowserWindow`
+- **Window Management**: Creates and manages the Electron `BrowserWindow`. Its
+  `webPreferences` hold the renderer's security posture - no Node integration,
+  context isolation on, and Chromium's spellchecker off, so no field in the
+  request builder draws underlines and no dictionary is fetched over the network
 - **Engine Lifecycle**: Starts and stops the C++ engine via `EngineSidecar`
 - **App Lifecycle**: Handles app ready, window close, and quit events
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,11 +343,11 @@ Variables are resolved with priority: **Environment > Collection > Global**
 - **Local-Only Communication**: Control API only binds to `127.0.0.1:9876`
 - **Context Isolation**: Electron renderer runs in isolated context (no Node.js access)
 - **No Cloud Sync**: All data stored locally in SQLite database
-- **No spellchecker**: the window is created with `spellcheck: false`, so
-  Chromium checks nothing the user types and never fetches Hunspell
-  dictionaries, which it otherwise downloads from a Google CDN at first use on
-  Windows and Linux. Monaco's editors are unaffected either way; they own their
-  own text area.
+- **No spellchecker**: every window the app opens - the shell and the OAuth
+  sign-in window - is created with `spellcheck: false`, so Chromium checks
+  nothing the user types and never fetches Hunspell dictionaries, which it
+  otherwise downloads from a Google CDN at first use on Windows and Linux.
+  Monaco's editors are unaffected either way; they own their own text area.
 - **Proxy credentials**: stored in the `proxyUrl` setting as plaintext in
   SQLite, the same way every other stored credential is. libcurl derives the
   `Proxy-Authorization` header from the URL, and that header is on the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,6 +343,11 @@ Variables are resolved with priority: **Environment > Collection > Global**
 - **Local-Only Communication**: Control API only binds to `127.0.0.1:9876`
 - **Context Isolation**: Electron renderer runs in isolated context (no Node.js access)
 - **No Cloud Sync**: All data stored locally in SQLite database
+- **No spellchecker**: the window is created with `spellcheck: false`, so
+  Chromium checks nothing the user types and never fetches Hunspell
+  dictionaries, which it otherwise downloads from a Google CDN at first use on
+  Windows and Linux. Monaco's editors are unaffected either way; they own their
+  own text area.
 - **Proxy credentials**: stored in the `proxyUrl` setting as plaintext in
   SQLite, the same way every other stored credential is. libcurl derives the
   `Proxy-Authorization` header from the URL, and that header is on the


### PR DESCRIPTION
## Description

Electron enables Chromium's spellchecker by default, so every editable field outside Monaco - the URL bar, header keys and values, query parameters, variable values, JSON in single-line inputs - drew red underlines under things that are not prose, while the Monaco body pane directly above them did not. On Windows and Linux the checker also fetches Hunspell dictionaries from a Google CDN the first time it runs, a network request the app never disclosed.

**Root cause and approach.** `createWindow` set only `nodeIntegration`, `contextIsolation` and `preload` in `webPreferences`; `spellcheck` defaults to `true`, and the three renderer fields carrying `spellCheck={false}` were opting out one at a time from a default nobody had chosen. The fix puts the decision on the window, which covers the whole renderer on all three platforms and stops the dictionary download as a side effect, and removes the three per-field opt-outs, which become dead attributes implying the default is still on. **The alternative rejected:** `session.setSpellCheckerDictionaryDownloadURL`, which keeps the checker running and only redirects where dictionaries come from. The app has no field where spellchecking a word helps, so there is nothing to keep and nowhere useful to point it.

**One extension beyond the issue's text, deliberate.** The issue names the `BrowserWindow` in `main.ts`. The app opens **two** windows: the shell, and the OAuth sign-in window in `oauth.ts:41`, whose `webPreferences` had no `spellcheck` key either. That second one loads the identity provider's own login form - the one page in Vayu a user types real prose into - so it was in fact the likelier of the two to trigger the CDN fetch, during a sign-in, from a window that does not look like a browser. Fixing only the shell would have left the issue's actual goal ("should not phone a third party for a feature it does not want") half-delivered while passing every acceptance check, since those only require silence *at startup*. Both windows are set, and the guard is written over both.

**One deliberate deviation on docs placement.** The issue pointed the doc sentence at `docs/architecture.md` "around line 285". That line sits inside `### Outbound Transport`, which is scoped to the *engine's* libcurl requests and its proxy/TLS policy; a Chromium-level statement there would read as part of the engine's transport contract. The sentence went into the same document's `## Security` list instead, which already enumerates context isolation and local-only storage and is where a reader looks for what the app talks to. `docs/app/architecture.md` (the doc that actually enumerates `BrowserWindow` responsibilities) gets the matching line.

Recon confirmed every anchor in the issue before any edit: the `webPreferences` literal at `main.ts:272-276` with no `spellcheck` key, exactly three `spellCheck={false}` sites (`NewIssuerDialog.tsx:266`, `SettingsMain.tsx:744`, `FontPicker.tsx:114`), all on `Input`/`Textarea` wrappers that forward unknown props to the real DOM element, and no pre-existing `setSpellCheckerLanguages` / `misspelledWord` wiring anywhere.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

New `app/electron/spellcheck.test.ts`, 5 cases, in the source-characterisation style `startup-order.test.ts` uses on `main.ts`:

- The options of **every** `new BrowserWindow` under `app/electron` carry `spellcheck: false`; an offender is reported by filename. The blocks are sliced by counting braces rather than by matching a literal indent, so a reformat of `main.ts` cannot break the guard for an unrelated reason.
- A preceding case asserts the scan found exactly `["main.ts", "oauth.ts"]`, so the guard cannot pass by matching nothing - and a third window added later fails here until it is considered.
- No `setSpellCheckerDictionaryDownloadURL` / `setSpellCheckerLanguages` in `main.ts`, pinning the rejected alternative.
- A source scan over `app/src/**/*.{ts,tsx}` finds no `spellCheck=` attribute, again preceded by a non-empty-scan assertion (>500 files; 635 today).

Mutation-checked all three halves: deleting `spellcheck: false` from `main.ts` fails the window guard, deleting it from `oauth.ts` fails it naming `oauth.ts`, and restoring a `spellCheck={false}` on `FontPicker` fails the renderer scan. All were restored and the file re-run green.

- `pnpm test spellcheck` - 5 passed
- `pnpm test` (full suite, final state) - **628 files / 7141 tests passed**, against a baseline of 627 / 7136 measured on `711f359f` before any edit. The delta is exactly this PR's 5 new cases; no pre-existing failures to report
- `pnpm type-check` - clean (renderer, electron, electron-tests)
- `pnpm lint` - clean; `pnpm format:check` - clean (prettier run on the new file only, per the repo's format-scope rule)

Not verifiable from this Linux host: the acceptance criterion asking for a Windows/Linux fresh install watched with a network monitor for the absence of a CDN dictionary fetch. `spellcheck: false` is Chromium's documented switch for exactly that request and the tests pin the option on both windows, but the packet-level confirmation is left unclaimed rather than asserted.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1355