### PR TITLE
feat(app): hold a system wake lock for the length of a run, and mark a sleep it could not prevent

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -13,6 +13,7 @@ import {
 	nativeTheme,
 	Menu,
 	powerMonitor,
+	powerSaveBlocker,
 	session,
 	shell,
 } from "electron";
@@ -31,6 +32,7 @@ import { setupOAuthIpcHandlers } from "./oauth.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } from "./updater.js";
 import { installQuitOnSignal } from "./quit-signals.js";
+import { createWakeLock, registerPowerIpc } from "./power-save.js";
 import { installWindowNavigationGuard } from "./window-navigation.js";
 import { watchNavigationGestures, type NavDirection } from "./nav-history.js";
 import { createSaveFlusher } from "./save-flush.js";
@@ -715,6 +717,19 @@ async function restartEngine(): Promise<{ success: boolean; error?: string }> {
 function setupIpcHandlers() {
 	// OAuth 2.0 interactive flow (system browser / embedded window)
 	setupOAuthIpcHandlers();
+
+	// The wake lock a streaming run holds, so the OS does not suspend the machine
+	// under a test the user walked away from (#1357). Built here rather than at
+	// module scope because `powerMonitor` is only usable once the app is ready,
+	// and nothing outside these two channels holds it.
+	registerPowerIpc(
+		ipcMain,
+		createWakeLock({
+			blocker: powerSaveBlocker,
+			monitor: powerMonitor,
+			send: (channel, payload) => liveWindow()?.webContents.send(channel, payload),
+		})
+	);
 
 	// Open one of the app's own documentation links in the system browser.
 	// Keyed rather than URL-taking on purpose: the renderer cannot ask for an

--- a/app/electron/power-save.test.ts
+++ b/app/electron/power-save.test.ts
@@ -12,7 +12,7 @@
  * the machine sleep mid-run, which is the bug #1357 exists to fix.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createWakeLock,
 	registerPowerIpc,
@@ -68,9 +68,17 @@ function harness(clock?: () => number) {
 	const blocker = fakeBlocker();
 	const monitor = fakeMonitor();
 	const send = vi.fn();
+	// Held rather than let through: these lines are the app's log in production
+	// (see the eslint override for `electron/`), and a test suite that prints
+	// them is a test suite nobody reads the output of.
+	const log = vi.spyOn(console, "log").mockImplementation(() => {});
 	const lock = createWakeLock({ blocker, monitor, send, now: clock });
-	return { blocker, monitor, send, lock };
+	return { blocker, monitor, send, lock, log };
 }
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("createWakeLock - reference counting", () => {
 	it("starts the blocker on the first hold, and only once", () => {
@@ -81,6 +89,20 @@ describe("createWakeLock - reference counting", () => {
 
 		expect(blocker.startCalls).toEqual([WAKE_LOCK_BLOCKER_TYPE]);
 		expect(lock.activeHolds()).toBe(2);
+	});
+
+	it("says what is holding the machine awake, and when it lets go", () => {
+		// The reason a holder gives has exactly one reader, and this is it: the
+		// OS tools name Vayu but not what it is doing, so a reason that reached
+		// nothing would be a string threaded through three layers for nobody.
+		const { lock, log } = harness();
+		const token = lock.hold("Load test run streaming");
+
+		expect(log.mock.calls[0]?.[0]).toContain("Load test run streaming");
+
+		log.mockClear();
+		lock.release(token);
+		expect(log).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps the blocker while another holder remains", () => {

--- a/app/electron/power-save.test.ts
+++ b/app/electron/power-save.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The wake lock's contract, in the terms a run depends on: one blocker however
+ * many runs hold it, and none the moment the last one lets go. A ref count that
+ * leaks pins the user's laptop awake for the session; one that drops early lets
+ * the machine sleep mid-run, which is the bug #1357 exists to fix.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	createWakeLock,
+	registerPowerIpc,
+	POWER_HOLD_CHANNEL,
+	POWER_RELEASE_CHANNEL,
+	POWER_RESUMED_CHANNEL,
+	POWER_SUSPENDED_CHANNEL,
+	WAKE_LOCK_BLOCKER_TYPE,
+	type IpcEventLike,
+	type WakeLock,
+} from "./power-save.js";
+
+function fakeBlocker() {
+	const started = new Set<number>();
+	let nextId = 1;
+	return {
+		started,
+		startCalls: [] as string[],
+		stopCalls: [] as number[],
+		start(type: string) {
+			this.startCalls.push(type);
+			const id = nextId++;
+			started.add(id);
+			return id;
+		},
+		stop(id: number) {
+			this.stopCalls.push(id);
+			started.delete(id);
+		},
+		isStarted(id: number) {
+			return started.has(id);
+		},
+	};
+}
+
+function fakeMonitor() {
+	const listeners = new Map<string, () => void>();
+	return {
+		listeners,
+		on(event: "suspend" | "resume", listener: () => void) {
+			listeners.set(event, listener);
+			return this;
+		},
+		fire(event: "suspend" | "resume") {
+			const listener = listeners.get(event);
+			if (!listener) throw new Error(`nothing subscribed to ${event}`);
+			listener();
+		},
+	};
+}
+
+function harness(clock?: () => number) {
+	const blocker = fakeBlocker();
+	const monitor = fakeMonitor();
+	const send = vi.fn();
+	const lock = createWakeLock({ blocker, monitor, send, now: clock });
+	return { blocker, monitor, send, lock };
+}
+
+describe("createWakeLock - reference counting", () => {
+	it("starts the blocker on the first hold, and only once", () => {
+		const { blocker, lock } = harness();
+
+		lock.hold("load run");
+		lock.hold("collection run");
+
+		expect(blocker.startCalls).toEqual([WAKE_LOCK_BLOCKER_TYPE]);
+		expect(lock.activeHolds()).toBe(2);
+	});
+
+	it("keeps the blocker while another holder remains", () => {
+		const { blocker, lock } = harness();
+		const first = lock.hold("load run");
+		lock.hold("collection run");
+
+		expect(lock.release(first)).toBe(true);
+
+		expect(blocker.stopCalls).toEqual([]);
+		expect(blocker.started.size).toBe(1);
+	});
+
+	it("stops the blocker when the last holder lets go", () => {
+		const { blocker, lock } = harness();
+		const first = lock.hold("load run");
+		const second = lock.hold("collection run");
+
+		lock.release(first);
+		lock.release(second);
+
+		expect(blocker.stopCalls).toHaveLength(1);
+		expect(blocker.started.size).toBe(0);
+		expect(lock.activeHolds()).toBe(0);
+	});
+
+	it("ignores a token it never issued, and a second release of one it did", () => {
+		const { blocker, lock } = harness();
+		const token = lock.hold("load run");
+
+		expect(lock.release("not-a-token")).toBe(false);
+		expect(blocker.started.size).toBe(1);
+
+		expect(lock.release(token)).toBe(true);
+		expect(lock.release(token)).toBe(false);
+		// The double release must not stop a blocker a later run started.
+		expect(blocker.stopCalls).toHaveLength(1);
+	});
+
+	it("takes a fresh blocker for a run that starts after the last one ended", () => {
+		const { blocker, lock } = harness();
+		lock.release(lock.hold("load run"));
+
+		lock.hold("second run");
+
+		expect(blocker.startCalls).toEqual([WAKE_LOCK_BLOCKER_TYPE, WAKE_LOCK_BLOCKER_TYPE]);
+		expect(blocker.started.size).toBe(1);
+	});
+
+	it("drops every hold a gone renderer took, and nobody else's", () => {
+		const { blocker, lock } = harness();
+		lock.hold("load run", 7);
+		lock.hold("collection run", 7);
+		lock.hold("run from another window", 9);
+
+		expect(lock.releaseAllFrom(7)).toBe(2);
+
+		expect(lock.activeHolds()).toBe(1);
+		expect(blocker.stopCalls).toEqual([]);
+
+		expect(lock.releaseAllFrom(9)).toBe(1);
+		expect(blocker.stopCalls).toHaveLength(1);
+	});
+
+	it("does not stop a blocker for a renderer that held nothing", () => {
+		const { blocker, lock } = harness();
+		lock.hold("load run", 7);
+
+		expect(lock.releaseAllFrom(9)).toBe(0);
+
+		expect(blocker.stopCalls).toEqual([]);
+	});
+});
+
+describe("createWakeLock - reporting a sleep it could not prevent", () => {
+	it("says nothing about a suspend with no run under way", () => {
+		const { monitor, send } = harness();
+
+		monitor.fire("suspend");
+		monitor.fire("resume");
+
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("reports the interval when the host slept during a run", () => {
+		let now = 1_000;
+		const { monitor, send, lock } = harness(() => now);
+		lock.hold("load run");
+
+		monitor.fire("suspend");
+		now = 46_000;
+		monitor.fire("resume");
+
+		expect(send).toHaveBeenNthCalledWith(1, POWER_SUSPENDED_CHANNEL, { at: 1_000 });
+		expect(send).toHaveBeenNthCalledWith(2, POWER_RESUMED_CHANNEL, {
+			at: 46_000,
+			durationMs: 45_000,
+		});
+	});
+
+	it("closes an announced interval even though the run ended while the host was down", () => {
+		let now = 1_000;
+		const { monitor, send, lock } = harness(() => now);
+		const token = lock.hold("load run");
+
+		monitor.fire("suspend");
+		lock.release(token);
+		now = 5_000;
+		monitor.fire("resume");
+
+		expect(send).toHaveBeenLastCalledWith(POWER_RESUMED_CHANNEL, {
+			at: 5_000,
+			durationMs: 4_000,
+		});
+	});
+
+	it("does not close an interval it never opened", () => {
+		const { monitor, send, lock } = harness();
+		// The host slept before the run; the run started after the resume.
+		monitor.fire("suspend");
+		lock.hold("load run");
+
+		monitor.fire("resume");
+
+		expect(send).not.toHaveBeenCalled();
+	});
+});
+
+function fakeRenderer(id: number) {
+	const once = new Map<string, () => void>();
+	const on = new Map<string, () => void>();
+	return {
+		id,
+		once(event: "destroyed", listener: () => void) {
+			once.set(event, listener);
+			return this;
+		},
+		on(event: "did-start-loading", listener: () => void) {
+			on.set(event, listener);
+			return this;
+		},
+		destroy() {
+			once.get("destroyed")?.();
+		},
+		reload() {
+			on.get("did-start-loading")?.();
+		},
+	};
+}
+
+function fakeIpc() {
+	const handlers = new Map<string, (event: IpcEventLike, ...args: unknown[]) => unknown>();
+	return {
+		handlers,
+		handle(channel: string, listener: (event: IpcEventLike, ...args: unknown[]) => unknown) {
+			handlers.set(channel, listener);
+			return this;
+		},
+		call(channel: string, sender: IpcEventLike["sender"], ...args: unknown[]) {
+			const handler = handlers.get(channel);
+			if (!handler) throw new Error(`no handler for ${channel}`);
+			return handler({ sender }, ...args);
+		},
+	};
+}
+
+function wired(): {
+	ipc: ReturnType<typeof fakeIpc>;
+	lock: WakeLock;
+	blocker: ReturnType<typeof fakeBlocker>;
+} {
+	const { blocker, lock } = harness();
+	const ipc = fakeIpc();
+	registerPowerIpc(ipc, lock);
+	return { ipc, lock, blocker };
+}
+
+describe("registerPowerIpc", () => {
+	it("hands the renderer a token that releases its hold", () => {
+		const { ipc, lock, blocker } = wired();
+		const sender = fakeRenderer(1);
+
+		const token = ipc.call(POWER_HOLD_CHANNEL, sender, "load run");
+		expect(typeof token).toBe("string");
+		expect(lock.activeHolds()).toBe(1);
+
+		expect(ipc.call(POWER_RELEASE_CHANNEL, sender, token)).toBe(true);
+		expect(blocker.started.size).toBe(0);
+	});
+
+	it("refuses a release that is not a token, without touching the lock", () => {
+		const { ipc, lock } = wired();
+		const sender = fakeRenderer(1);
+		ipc.call(POWER_HOLD_CHANNEL, sender, "load run");
+
+		expect(ipc.call(POWER_RELEASE_CHANNEL, sender, 42)).toBe(false);
+
+		expect(lock.activeHolds()).toBe(1);
+	});
+
+	it("releases a destroyed renderer's holds", () => {
+		const { ipc, lock, blocker } = wired();
+		const sender = fakeRenderer(1);
+		ipc.call(POWER_HOLD_CHANNEL, sender, "load run");
+
+		sender.destroy();
+
+		expect(lock.activeHolds()).toBe(0);
+		expect(blocker.started.size).toBe(0);
+	});
+
+	it("releases holds a reloading renderer can no longer name", () => {
+		const { ipc, lock, blocker } = wired();
+		const sender = fakeRenderer(1);
+		ipc.call(POWER_HOLD_CHANNEL, sender, "load run");
+
+		sender.reload();
+
+		expect(lock.activeHolds()).toBe(0);
+		expect(blocker.started.size).toBe(0);
+	});
+
+	it("watches a renderer once however many holds it takes", () => {
+		const { ipc, lock } = wired();
+		const sender = fakeRenderer(1);
+		const onSpy = vi.spyOn(sender, "on");
+
+		ipc.call(POWER_HOLD_CHANNEL, sender, "load run");
+		ipc.call(POWER_HOLD_CHANNEL, sender, "collection run");
+
+		expect(onSpy).toHaveBeenCalledTimes(1);
+		expect(lock.activeHolds()).toBe(2);
+	});
+});

--- a/app/electron/power-save.ts
+++ b/app/electron/power-save.ts
@@ -88,14 +88,19 @@ export interface WakeLock {
 
 export function createWakeLock(deps: WakeLockDeps): WakeLock {
 	const now = deps.now ?? Date.now;
-	const holds = new Map<string, { reason: string; ownerId: number | null }>();
+	const holds = new Map<string, { ownerId: number | null }>();
 	let blockerId: number | null = null;
 	/** Set only between an announced suspend and its resume. */
 	let suspendedAt: number | null = null;
 
-	function startBlocker(): void {
+	function startBlocker(reason: string): void {
 		if (blockerId !== null) return;
 		blockerId = deps.blocker.start(WAKE_LOCK_BLOCKER_TYPE);
+		// The main process's console is the app's log, and "why is this machine
+		// refusing to sleep" is a question a user does ask - `pmset -g assertions`
+		// and `powercfg /requests` name Vayu but not what it is doing. This is the
+		// only place that can answer, so the reason a holder gives is stated here.
+		console.log(`[power] holding the system wake lock: ${reason}`);
 	}
 
 	function stopBlockerIfIdle(): void {
@@ -104,6 +109,7 @@ export function createWakeLock(deps: WakeLockDeps): WakeLock {
 		// it no longer knows throws on some platforms.
 		if (deps.blocker.isStarted(blockerId)) deps.blocker.stop(blockerId);
 		blockerId = null;
+		console.log("[power] system wake lock released");
 	}
 
 	/*
@@ -137,8 +143,8 @@ export function createWakeLock(deps: WakeLockDeps): WakeLock {
 	return {
 		hold(reason: string, ownerId?: number): string {
 			const token = randomUUID();
-			holds.set(token, { reason, ownerId: ownerId ?? null });
-			startBlocker();
+			holds.set(token, { ownerId: ownerId ?? null });
+			startBlocker(reason);
 			return token;
 		},
 

--- a/app/electron/power-save.ts
+++ b/app/electron/power-save.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The system wake lock a run holds, and the report of a sleep it could not
+ * prevent (issue #1357).
+ *
+ * A load test is a long-running foreground task the user stops watching: they
+ * start a thirty-minute run and switch to something else. The OS then suspends
+ * the machine on its own timer, the engine stops with it, and the report comes
+ * back with a flat stretch or a cluster of timeouts that reads as the server's
+ * fault. So while a run streams, the app asks the OS not to sleep.
+ *
+ * `prevent-app-suspension`, never `prevent-display-sleep`: the screen may dim
+ * and lock, the machine may not suspend. A run is not a reason to keep a laptop
+ * lit on someone's desk.
+ *
+ * The lock is ref-counted because two runs can overlap in the renderer's model
+ * (a load run and a collection run each hold), and because a hold that outlived
+ * its holder would pin the machine awake for the rest of the session. Every
+ * holder gets a token back and hands it in; the blocker starts on the first and
+ * stops on the last.
+ *
+ * Kept out of main.ts so it can be tested - main.ts creates windows and starts
+ * the engine at import time, which no unit test can do. The Electron surfaces it
+ * needs arrive as arguments for the same reason.
+ */
+
+import { randomUUID } from "node:crypto";
+
+/** What a run asks the OS for. See the header: never `prevent-display-sleep`. */
+export const WAKE_LOCK_BLOCKER_TYPE = "prevent-app-suspension";
+
+export const POWER_HOLD_CHANNEL = "power:hold";
+export const POWER_RELEASE_CHANNEL = "power:release";
+export const POWER_SUSPENDED_CHANNEL = "power:suspended";
+export const POWER_RESUMED_CHANNEL = "power:resumed";
+
+/** The host went to sleep while a run held the lock. `at` is a wall clock ms. */
+export interface HostSuspendedEvent {
+	at: number;
+}
+
+/** The host came back. `durationMs` is the gap the run's series cannot explain. */
+export interface HostResumedEvent {
+	at: number;
+	durationMs: number;
+}
+
+/** The slice of Electron's `powerSaveBlocker` this needs, so a test can pass a fake. */
+export interface PowerSaveBlockerLike {
+	start(type: string): number;
+	stop(id: number): void;
+	isStarted(id: number): boolean;
+}
+
+/** The slice of Electron's `powerMonitor` this needs. */
+export interface PowerMonitorLike {
+	on(event: "suspend" | "resume", listener: () => void): unknown;
+}
+
+export interface WakeLockDeps {
+	blocker: PowerSaveBlockerLike;
+	monitor: PowerMonitorLike;
+	/** Push an event to the renderer. A destroyed window is the caller's problem. */
+	send: (channel: string, payload: unknown) => void;
+	/** Wall clock, injected so a test can move it. */
+	now?: () => number;
+}
+
+export interface WakeLock {
+	/**
+	 * Ask the OS to stay awake. Returns the token that releases this hold - the
+	 * caller keeps it, and nothing else can drop a hold it did not take.
+	 */
+	hold(reason: string, ownerId?: number): string;
+	/** Hand a token back. `false` for a token that was never live, or is already home. */
+	release(token: string): boolean;
+	/** Drop every hold taken by one renderer - it is gone or reloading. */
+	releaseAllFrom(ownerId: number): number;
+	/** How many holds are live. The blocker is running when this is above zero. */
+	activeHolds(): number;
+}
+
+export function createWakeLock(deps: WakeLockDeps): WakeLock {
+	const now = deps.now ?? Date.now;
+	const holds = new Map<string, { reason: string; ownerId: number | null }>();
+	let blockerId: number | null = null;
+	/** Set only between an announced suspend and its resume. */
+	let suspendedAt: number | null = null;
+
+	function startBlocker(): void {
+		if (blockerId !== null) return;
+		blockerId = deps.blocker.start(WAKE_LOCK_BLOCKER_TYPE);
+	}
+
+	function stopBlockerIfIdle(): void {
+		if (holds.size > 0 || blockerId === null) return;
+		// `isStarted` because the OS can refuse or drop a blocker - stopping an id
+		// it no longer knows throws on some platforms.
+		if (deps.blocker.isStarted(blockerId)) deps.blocker.stop(blockerId);
+		blockerId = null;
+	}
+
+	/*
+	 * Subscribed once, for the life of the process, rather than while a hold is
+	 * live: `powerMonitor` exposes no removal that survives a listener taken and
+	 * given back repeatedly, and the guard below is what "while any token is
+	 * held" actually means to a reader - no hold, nothing to report.
+	 */
+	deps.monitor.on("suspend", () => {
+		if (holds.size === 0) return;
+		suspendedAt = now();
+		deps.send(POWER_SUSPENDED_CHANNEL, { at: suspendedAt } satisfies HostSuspendedEvent);
+	});
+
+	deps.monitor.on("resume", () => {
+		const startedAt = suspendedAt;
+		suspendedAt = null;
+		// Nothing announced the suspend, so there is no interval to close - a
+		// resume the app slept through without a run is not an event.
+		if (startedAt === null) return;
+		const at = now();
+		// Announced suspends are always closed, even if the run ended while the
+		// host was down: the renderer is holding an open marker on the strength of
+		// the suspend event, and only this closes it.
+		deps.send(POWER_RESUMED_CHANNEL, {
+			at,
+			durationMs: Math.max(0, at - startedAt),
+		} satisfies HostResumedEvent);
+	});
+
+	return {
+		hold(reason: string, ownerId?: number): string {
+			const token = randomUUID();
+			holds.set(token, { reason, ownerId: ownerId ?? null });
+			startBlocker();
+			return token;
+		},
+
+		release(token: string): boolean {
+			if (!holds.delete(token)) return false;
+			stopBlockerIfIdle();
+			return true;
+		},
+
+		releaseAllFrom(ownerId: number): number {
+			let dropped = 0;
+			for (const [token, held] of holds) {
+				if (held.ownerId !== ownerId) continue;
+				holds.delete(token);
+				dropped++;
+			}
+			if (dropped > 0) stopBlockerIfIdle();
+			return dropped;
+		},
+
+		activeHolds(): number {
+			return holds.size;
+		},
+	};
+}
+
+/** The slice of `ipcMain` the channels need. */
+export interface IpcLike {
+	handle(
+		channel: string,
+		listener: (event: IpcEventLike, ...args: unknown[]) => unknown
+	): unknown;
+}
+
+/**
+ * The renderer behind a call, and the two lifecycle events that mean its holds
+ * are gone: `destroyed` (window closed, process gone) and `did-start-loading`
+ * (a reload - the new page cannot release the old page's tokens).
+ */
+export interface RendererLike {
+	id: number;
+	once(event: "destroyed", listener: () => void): unknown;
+	on(event: "did-start-loading", listener: () => void): unknown;
+}
+
+export interface IpcEventLike {
+	sender: RendererLike;
+}
+
+/**
+ * Wire the two channels, and make a renderer's holds die with it.
+ *
+ * The owner cleanup is not a nicety: a renderer that crashes or reloads mid-run
+ * never gets to release, and without this the machine stays pinned awake until
+ * the app quits.
+ */
+export function registerPowerIpc(ipc: IpcLike, lock: WakeLock): void {
+	const watched = new Set<number>();
+
+	function watchOwner(sender: RendererLike): void {
+		if (watched.has(sender.id)) return;
+		watched.add(sender.id);
+		const drop = () => {
+			lock.releaseAllFrom(sender.id);
+		};
+		sender.once("destroyed", () => {
+			watched.delete(sender.id);
+			drop();
+		});
+		sender.on("did-start-loading", drop);
+	}
+
+	ipc.handle(POWER_HOLD_CHANNEL, (event: IpcEventLike, ...args: unknown[]) => {
+		// A reason the renderer did not send is not a reason to refuse the hold:
+		// the lock is what the run needs, the string only says who asked.
+		const reason = typeof args[0] === "string" ? args[0] : "run";
+		watchOwner(event.sender);
+		return lock.hold(reason, event.sender.id);
+	});
+
+	ipc.handle(POWER_RELEASE_CHANNEL, (_event: IpcEventLike, ...args: unknown[]) => {
+		const token = args[0];
+		if (typeof token !== "string") return false;
+		return lock.release(token);
+	});
+}

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -233,6 +233,29 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	// force, "" for a direct configuration, or null when it could not be asked.
 	refreshSystemProxy: (): Promise<string | null> => ipcRenderer.invoke("proxy:refreshSystem"),
 
+	// System wake lock, held while a run streams (#1357). Token-based: the main
+	// process ref-counts the holds and only the token taken here releases one, so
+	// two overlapping runs cannot drop each other's lock. Main also drops a
+	// renderer's holds when it goes away or reloads, which is the case a token
+	// cannot cover.
+	holdWakeLock: (reason: string): Promise<string> => ipcRenderer.invoke("power:hold", reason),
+	releaseWakeLock: (token: string): Promise<boolean> =>
+		ipcRenderer.invoke("power:release", token),
+	// The host slept anyway - lid closed, battery critical, a user who forced it.
+	// The lock is a request to the OS, not a guarantee, so the run's series can
+	// still have a gap; these two say where it is. Sent only while a run holds.
+	onHostSuspended: (callback: (event: { at: number }) => void) => {
+		const handler = (_event: unknown, payload: { at: number }) => callback(payload);
+		ipcRenderer.on("power:suspended", handler);
+		return () => ipcRenderer.removeListener("power:suspended", handler);
+	},
+	onHostResumed: (callback: (event: { at: number; durationMs: number }) => void) => {
+		const handler = (_event: unknown, payload: { at: number; durationMs: number }) =>
+			callback(payload);
+		ipcRenderer.on("power:resumed", handler);
+		return () => ipcRenderer.removeListener("power:resumed", handler);
+	},
+
 	// Before quit flush handler. ACKs main once the callback settles so quit
 	// can resume immediately instead of waiting out the fallback timeout.
 	onBeforeQuit: (callback: () => void | Promise<void>) => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,7 @@ import TitleBar from "./components/layout/TitleBar";
 import UpdateBanner from "./components/shared/UpdateBanner";
 import RecoveryBanner from "./components/shared/RecoveryBanner";
 import Toaster from "./components/shared/Toaster";
+import KeepAwakePrompt from "./components/shared/KeepAwakePrompt";
 import {
 	useConfigQuery,
 	useHealthQuery,
@@ -112,6 +113,9 @@ function App() {
 				<Shell />
 			</div>
 			<Toaster />
+			{/* Asks, once, about a run long enough for the machine to sleep under
+			    it - and only while the standing preference is off (#1357). */}
+			<KeepAwakePrompt />
 		</div>
 	);
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,7 @@ import { useScriptVariableCompletionProvider } from "./hooks/useScriptVariableCo
 import { useScriptTypeDefinitions } from "./hooks/useScriptTypeDefinitions";
 import { useMenuActions } from "./hooks/useMenuActions";
 import { useMcpDataInvalidation } from "./hooks/useMcpDataInvalidation";
+import { useHostSleepRecorder } from "./hooks/useHostSleepRecorder";
 import { useSaveStore } from "./stores/save-store";
 
 function App() {
@@ -85,6 +86,12 @@ function App() {
 	// An agent writing over MCP mutates the engine from the main process, which
 	// no query can see. This is the channel that tells the cache to refetch.
 	useMcpDataInvalidation();
+
+	// The app asks the OS not to sleep under a run, but a closed lid overrides
+	// that. Mounted here rather than on the dashboard: the suspend arrives with
+	// no warning and the dashboard may not be the open tab, while the run it
+	// interrupts streams from a service that outlives every view (#1357).
+	useHostSleepRecorder();
 
 	// Register Electron before-quit handler to flush pending saves
 	useEffect(() => {

--- a/app/src/components/shared/KeepAwakePrompt.test.tsx
+++ b/app/src/components/shared/KeepAwakePrompt.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * When the app interrupts the user, and what the answer does (issue #1357).
+ *
+ * The failure modes here are both user-visible and opposite: a prompt that
+ * appears for every short run trains people to dismiss it, and one that never
+ * appears leaves the feature unreachable for anyone who does not go looking
+ * through Settings. Each case below pins one edge of that.
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import KeepAwakePrompt from "./KeepAwakePrompt";
+import { useClientSettingsStore, useDashboardStore } from "@/stores";
+import { LONG_RUN_SECONDS } from "@/modules/dashboard/utils/keepAwake";
+
+const { mockHold } = vi.hoisted(() => ({ mockHold: vi.fn() }));
+vi.mock("@/services/wake-lock", () => ({
+	wakeLock: { hold: mockHold, release: vi.fn() },
+	WAKE_LOCK_KEYS: { loadRun: "load-run", collectionRun: "collection-run" },
+}));
+
+/** Put the dashboard store in the state a streaming run of `seconds` leaves it. */
+function streamRun(runId: string, seconds: number | null) {
+	// Inside `act`: the store write is what the dialog's open state is derived
+	// from, and React must be allowed to flush it before the case reads.
+	act(() => {
+		useDashboardStore.setState({
+			currentRunId: runId,
+			isStreaming: true,
+			loadTestConfig: seconds === null ? { mode: "iterations" } : { duration: `${seconds}s` },
+		});
+	});
+}
+
+beforeEach(() => {
+	cleanup();
+	mockHold.mockClear();
+	useClientSettingsStore.setState({ keepAwakeDuringRuns: false });
+	useDashboardStore.setState({ currentRunId: null, isStreaming: false, loadTestConfig: null });
+});
+
+const dialog = () => screen.queryByRole("dialog");
+
+describe("KeepAwakePrompt", () => {
+	it("asks about a run long enough to be walked away from", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_1", LONG_RUN_SECONDS);
+
+		expect(dialog()).not.toBeNull();
+		expect(screen.getByText(/5 minutes/)).toBeTruthy();
+	});
+
+	it("stays out of the way for a short run", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_2", LONG_RUN_SECONDS - 1);
+
+		expect(dialog()).toBeNull();
+	});
+
+	it("stays out of the way for a run that declares no length", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_3", null);
+
+		expect(dialog()).toBeNull();
+	});
+
+	it("does not ask when the user has already said yes to every run", () => {
+		// The service took the lock at start; asking again would be asking a
+		// question that is already answered.
+		useClientSettingsStore.setState({ keepAwakeDuringRuns: true });
+		render(<KeepAwakePrompt />);
+		streamRun("run_4", LONG_RUN_SECONDS * 4);
+
+		expect(dialog()).toBeNull();
+	});
+
+	it("takes the lock for this run when the user says yes", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_5", LONG_RUN_SECONDS * 6);
+
+		fireEvent.click(screen.getByRole("button", { name: "Keep awake" }));
+
+		// The load-run key, which is the one the service releases on every
+		// terminal path - so this grant ends with the run rather than outliving it.
+		expect(mockHold).toHaveBeenCalledWith("load-run", expect.any(String));
+		expect(dialog()).toBeNull();
+	});
+
+	it("takes no lock when the user would rather the machine slept", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_6", LONG_RUN_SECONDS * 6);
+
+		fireEvent.click(screen.getByRole("button", { name: "Allow sleep" }));
+
+		expect(mockHold).not.toHaveBeenCalled();
+		expect(dialog()).toBeNull();
+	});
+
+	it("does not ask twice about the same run", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_7", LONG_RUN_SECONDS * 6);
+		fireEvent.click(screen.getByRole("button", { name: "Allow sleep" }));
+
+		// A run's stream can stop and start again under the same id - a dropped
+		// SSE connection reconnecting, or the dashboard re-attaching when the
+		// user navigates back to it. Without the record of what has been asked,
+		// every one of those re-opens a question the user already answered.
+		act(() => useDashboardStore.setState({ isStreaming: false }));
+		act(() => useDashboardStore.setState({ isStreaming: true }));
+
+		expect(dialog()).toBeNull();
+	});
+
+	it("asks again for the next long run", () => {
+		render(<KeepAwakePrompt />);
+		streamRun("run_8", LONG_RUN_SECONDS * 6);
+		expect(dialog()).not.toBeNull();
+
+		streamRun("run_9", LONG_RUN_SECONDS * 6);
+
+		// A decision about one run is not a decision about the next: the answer
+		// is per run until the user makes it standing in Settings.
+		expect(dialog()).not.toBeNull();
+	});
+});

--- a/app/src/components/shared/KeepAwakePrompt.tsx
+++ b/app/src/components/shared/KeepAwakePrompt.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * KeepAwakePrompt - the one ask, for the one run that needs it (issue #1357).
+ *
+ * The wake lock is off by default, because an app that quietly overrides the
+ * machine's power settings has decided something that is not its to decide. But
+ * the case the lock exists for - a long run the user starts and walks away from
+ * - is also the case where nobody thinks to visit a settings screen first. So
+ * the app asks when the situation arises, and only then: a run that declares
+ * five minutes or more, with the standing preference off.
+ *
+ * Mounted once, at the app root, rather than at any of the three places a load
+ * run can start: the question is about the run that is streaming, and the
+ * dashboard store is where that fact lives. One mount also means one dialog -
+ * a prompt per start site could stack.
+ *
+ * A collection run is never asked about. It declares no duration, so nothing
+ * here can tell a two-second sequence from a two-hour one, and a prompt on
+ * every one of them would train the user to dismiss it.
+ */
+
+import { useState } from "react";
+import { DeleteConfirmDialog } from "@/components/ui";
+import { useClientSettingsStore, useDashboardStore } from "@/stores";
+import { wakeLock, WAKE_LOCK_KEYS } from "@/services/wake-lock";
+import { formatRunLength, isLongRun, runLengthSeconds } from "@/modules/dashboard/utils/keepAwake";
+
+export default function KeepAwakePrompt() {
+	const runId = useDashboardStore((s) => s.currentRunId);
+	const isStreaming = useDashboardStore((s) => s.isStreaming);
+	const config = useDashboardStore((s) => s.loadTestConfig);
+	const keepAwakeAlways = useClientSettingsStore((s) => s.keepAwakeDuringRuns);
+
+	/**
+	 * The run the user has already answered about - by either button, or by
+	 * dismissing. Held so a stream that stops and starts again under the same id
+	 * (a reconnect, or the dashboard re-attaching) does not re-open a question
+	 * that was answered.
+	 *
+	 * State rather than an effect: whether to ask is a function of what is
+	 * streaming and what the user has said, so it is derived during render. An
+	 * effect that opened the dialog would be a second copy of that answer, one
+	 * render behind.
+	 */
+	const [decided, setDecided] = useState<string | null>(null);
+
+	const asking =
+		runId !== null && isStreaming && !keepAwakeAlways && decided !== runId && isLongRun(config);
+
+	const length = runLengthSeconds(config);
+
+	const keepAwake = () => {
+		// Held under the same key the service releases on every terminal path, so
+		// this grant ends with the run rather than outliving it.
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "Load test run streaming (allowed for this run)");
+		setDecided(runId);
+	};
+
+	return (
+		<DeleteConfirmDialog
+			open={asking}
+			onOpenChange={() => setDecided(runId)}
+			title="Keep this machine awake?"
+			description={
+				<>
+					This run is set to last{" "}
+					{length === null ? "several minutes" : formatRunLength(length)}. If the machine
+					suspends before it ends, the run stops with it and its charts come back with a
+					gap.
+					<br />
+					<br />
+					Vayu can ask the system not to sleep until the run finishes. The display still
+					dims and locks as usual. To answer this once for every run, use Settings &gt;
+					Load testing &gt; Keep the machine awake during runs.
+				</>
+			}
+			confirmLabel="Keep awake"
+			cancelLabel="Allow sleep"
+			confirmVariant="default"
+			onConfirm={keepAwake}
+		/>
+	);
+}

--- a/app/src/components/ui/delete-confirm-dialog.tsx
+++ b/app/src/components/ui/delete-confirm-dialog.tsx
@@ -48,6 +48,16 @@ export interface DeleteConfirmDialogProps {
 	 */
 	confirmLabel?: string;
 	/**
+	 * Word on the declining button. Defaults to "Cancel".
+	 *
+	 * "Cancel" is right when the dialog interrupts something the user started,
+	 * and ambiguous when it asks a question the user did not - declining an
+	 * offer to keep the machine awake is not cancelling anything, so that caller
+	 * names the outcome ("Allow sleep") instead. The button keeps its role
+	 * either way: it is the one focus opens on.
+	 */
+	cancelLabel?: string;
+	/**
 	 * `destructive` (default) for anything that removes data. `primary` for an
 	 * irreversible-but-not-destructive action, where a red button overstates it.
 	 */
@@ -72,6 +82,7 @@ export function DeleteConfirmDialog({
 	onConfirm,
 	isDeleting = false,
 	confirmLabel = "Delete",
+	cancelLabel = "Cancel",
 	confirmVariant = "destructive",
 	onCloseAutoFocus,
 }: DeleteConfirmDialogProps) {
@@ -120,7 +131,7 @@ export function DeleteConfirmDialog({
 						onClick={() => onOpenChange(false)}
 						disabled={isDeleting}
 					>
-						Cancel
+						{cancelLabel}
 					</Button>
 					<Button variant={confirmVariant} onClick={onConfirm} disabled={isDeleting}>
 						{isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : confirmLabel}

--- a/app/src/constants/storage-keys.ts
+++ b/app/src/constants/storage-keys.ts
@@ -52,4 +52,10 @@ export const STORAGE_KEYS = {
 	 * seen (issue #922). One timestamp - the engine keeps the record itself.
 	 */
 	RECOVERY_NOTICE_STORE: "vayu.recovery-notice",
+	/**
+	 * Zustand persist name for the intervals the host spent asleep under a run
+	 * (issue #1357). Keyed by run id; the engine's report cannot carry them,
+	 * because the engine was suspended too.
+	 */
+	HOST_SLEEP_STORE: "vayu.host-sleeps",
 } as const;

--- a/app/src/hooks/useHostSleepRecorder.test.tsx
+++ b/app/src/hooks/useHostSleepRecorder.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The suspend/resume pair turning into one sleep record (issue #1357). The
+ * whole design is that the anchor is taken on the way down, at suspend time -
+ * so the case that matters most here proves that, by moving the dashboard's
+ * elapsed time between the two events and checking the recorded sleep still
+ * carries the suspend-time value.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHostSleepRecorder } from "./useHostSleepRecorder";
+import { useDashboardStore } from "@/stores";
+import { useHostSleepStore } from "@/stores/host-sleep-store";
+import type { LoadTestMetrics } from "@/types";
+
+type SuspendCb = (event: { at: number }) => void;
+type ResumeCb = (event: { at: number; durationMs: number }) => void;
+
+function tick(elapsed: number): LoadTestMetrics {
+	return {
+		timestamp: elapsed * 1000,
+		elapsed_seconds: elapsed,
+		requests_completed: 0,
+		requests_failed: 0,
+		current_rps: 0,
+		current_concurrency: 0,
+		latency_p50_ms: 0,
+		latency_p95_ms: 0,
+		latency_p99_ms: 0,
+		avg_latency_ms: 0,
+		bytes_sent: 0,
+		bytes_received: 0,
+	};
+}
+
+let suspendCb: SuspendCb | null;
+let resumeCb: ResumeCb | null;
+let unsubSuspend: ReturnType<typeof vi.fn>;
+let unsubResume: ReturnType<typeof vi.fn>;
+
+function stubElectronAPI() {
+	unsubSuspend = vi.fn();
+	unsubResume = vi.fn();
+	(window as unknown as { electronAPI: unknown }).electronAPI = {
+		onHostSuspended: (cb: SuspendCb) => {
+			suspendCb = cb;
+			return unsubSuspend;
+		},
+		onHostResumed: (cb: ResumeCb) => {
+			resumeCb = cb;
+			return unsubResume;
+		},
+	};
+}
+
+beforeEach(() => {
+	suspendCb = null;
+	resumeCb = null;
+	stubElectronAPI();
+	useHostSleepStore.setState({ byRun: {}, runOrder: [] });
+	useDashboardStore.setState({ currentRunId: null, isStreaming: false, currentMetrics: null });
+});
+
+afterEach(() => {
+	delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+	vi.restoreAllMocks();
+});
+
+describe("useHostSleepRecorder", () => {
+	it("records one sleep against the streaming run, anchored at the suspend", () => {
+		useDashboardStore.setState({
+			currentRunId: "run_1",
+			isStreaming: true,
+			currentMetrics: tick(42),
+		});
+		renderHook(() => useHostSleepRecorder());
+		expect(suspendCb).not.toBeNull();
+
+		act(() => suspendCb!({ at: 1000 }));
+
+		// The clock keeps moving on the renderer's side of the suspend (the
+		// frozen stretch is only real for the OS, not for this state) - if the
+		// anchor were read again at resume instead of carried from the suspend,
+		// startSeconds would come out 999 here, not 42.
+		useDashboardStore.setState({ currentMetrics: tick(999) });
+
+		act(() => resumeCb!({ at: 5000, durationMs: 4000 }));
+
+		const sleeps = useHostSleepStore.getState().byRun.run_1;
+		expect(sleeps).toEqual([{ at: 5000 - 4000, durationMs: 4000, startSeconds: 42 }]);
+	});
+
+	it("records nothing on a resume when no run has an id", () => {
+		useDashboardStore.setState({
+			currentRunId: null,
+			isStreaming: true,
+			currentMetrics: tick(5),
+		});
+		renderHook(() => useHostSleepRecorder());
+
+		act(() => suspendCb!({ at: 1000 }));
+		act(() => resumeCb!({ at: 5000, durationMs: 4000 }));
+
+		expect(useHostSleepStore.getState().runOrder).toEqual([]);
+	});
+
+	it("records nothing on a resume when the run is not streaming", () => {
+		useDashboardStore.setState({
+			currentRunId: "run_1",
+			isStreaming: false,
+			currentMetrics: tick(5),
+		});
+		renderHook(() => useHostSleepRecorder());
+
+		act(() => suspendCb!({ at: 1000 }));
+		act(() => resumeCb!({ at: 5000, durationMs: 4000 }));
+
+		expect(useHostSleepStore.getState().runOrder).toEqual([]);
+	});
+
+	it("records nothing on a resume with no preceding suspend", () => {
+		useDashboardStore.setState({
+			currentRunId: "run_1",
+			isStreaming: true,
+			currentMetrics: tick(5),
+		});
+		renderHook(() => useHostSleepRecorder());
+
+		act(() => resumeCb!({ at: 5000, durationMs: 4000 }));
+
+		expect(useHostSleepStore.getState().runOrder).toEqual([]);
+	});
+
+	it("unsubscribes both listeners on unmount", () => {
+		const { unmount } = renderHook(() => useHostSleepRecorder());
+		unmount();
+
+		expect(unsubSuspend).toHaveBeenCalledTimes(1);
+		expect(unsubResume).toHaveBeenCalledTimes(1);
+	});
+
+	it("is inert without window.electronAPI", () => {
+		delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+		expect(() => {
+			const { unmount } = renderHook(() => useHostSleepRecorder());
+			unmount();
+		}).not.toThrow();
+	});
+});

--- a/app/src/hooks/useHostSleepRecorder.ts
+++ b/app/src/hooks/useHostSleepRecorder.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Turn the main process's suspend / resume pair into one annotation on the run
+ * that was streaming when the host went down (issue #1357).
+ *
+ * Two events rather than one because each carries half the answer: the suspend
+ * is the last moment the renderer can read where the run had got to, and the
+ * resume is the only thing that knows how long the machine was gone. Between
+ * them the renderer is frozen, so the anchor has to be taken on the way down.
+ *
+ * A collection run holds the wake lock too, but records nothing: its tab is a
+ * list of steps with no time axis and no Events surface, so there is nowhere to
+ * put a marker that a reader would find. The lock is the part that matters
+ * there.
+ */
+
+import { useEffect, useRef } from "react";
+import { useDashboardStore } from "@/stores";
+import { useHostSleepStore } from "@/stores/host-sleep-store";
+
+/** Where a run had got to when the host went down. */
+interface SuspendAnchor {
+	runId: string;
+	startSeconds: number;
+}
+
+/** The run streaming right now, and its elapsed position - or null if none is. */
+function streamingAnchor(): SuspendAnchor | null {
+	const { currentRunId, isStreaming, currentMetrics } = useDashboardStore.getState();
+	if (!currentRunId || !isStreaming) return null;
+	return { runId: currentRunId, startSeconds: currentMetrics?.elapsed_seconds ?? 0 };
+}
+
+export function useHostSleepRecorder(): void {
+	const anchor = useRef<SuspendAnchor | null>(null);
+
+	useEffect(() => {
+		const api = window.electronAPI;
+		if (!api?.onHostSuspended || !api.onHostResumed) return;
+
+		const stopSuspend = api.onHostSuspended(() => {
+			anchor.current = streamingAnchor();
+		});
+
+		const stopResume = api.onHostResumed(({ at, durationMs }) => {
+			const pending = anchor.current;
+			anchor.current = null;
+			// No run was streaming when the host went down, so there is no series
+			// with a hole in it to explain.
+			if (!pending) return;
+			useHostSleepStore.getState().recordSleep(pending.runId, {
+				at: at - durationMs,
+				durationMs,
+				startSeconds: pending.startSeconds,
+			});
+		});
+
+		return () => {
+			stopSuspend();
+			stopResume();
+		};
+	}, []);
+}

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -25,6 +25,7 @@ import { memo, useMemo, useState } from "react";
 import { Activity } from "lucide-react";
 import { formatNumber } from "@/utils";
 import { useDashboardStore } from "@/stores";
+import { useHostSleeps } from "@/stores/host-sleep-store";
 import type { MetricsViewProps, DashboardDerived } from "../types";
 import { InfoChip } from "./shared";
 import { fmt } from "./format";
@@ -127,6 +128,11 @@ function MetricsView({
 	// Empty for a run that configured no monitor - the row below reads that
 	// rather than the config, so it is right for a replayed run too.
 	const monitorSamples = useDashboardStore((s) => s.monitorSamples);
+	// Marked on the same layer as the anomaly windows: a stretch where the host
+	// was asleep is a hole in the series no detector can account for, because the
+	// engine was suspended with it (#1357).
+	const currentRunId = useDashboardStore((s) => s.currentRunId);
+	const hostSleeps = useHostSleeps(currentRunId);
 
 	// Only the latest tick's elapsed_seconds is consumed below - depending on the
 	// whole historicalMetrics array would rebuild `derived` every tick (10 Hz) and
@@ -274,6 +280,7 @@ function MetricsView({
 						syncKey={CHART_SYNC.live}
 						breakpoint={breakpoint}
 						anomalies={anomalies}
+						sleeps={hostSleeps}
 					/>
 					{rampOverlay && (
 						<div className="flex justify-between gap-3 mt-2.5 pt-2.5 border-t border-dashed border-border text-[11px] font-mono text-muted-foreground">
@@ -339,6 +346,7 @@ function MetricsView({
 						isCompleted={isCompleted}
 						syncKey={CHART_SYNC.live}
 						anomalies={anomalies}
+						sleeps={hostSleeps}
 					/>
 				</div>
 			)}
@@ -415,6 +423,7 @@ function MetricsView({
 								syncKey={CHART_SYNC.live}
 								breakpoint={breakpoint}
 								anomalies={anomalies}
+								sleeps={hostSleeps}
 							/>
 						</div>
 					)}
@@ -481,6 +490,7 @@ function MetricsView({
 						isCompleted={isCompleted}
 						syncKey={CHART_SYNC.live}
 						anomalies={anomalies}
+						sleeps={hostSleeps}
 					/>
 				</div>
 			)}

--- a/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
@@ -23,12 +23,11 @@ import {
 	type RampOverlay,
 } from "../../../utils/metricsTransforms";
 import type { Breakpoint } from "../../../utils/computeBreakpoint";
-import type { Anomaly, AnomalyKind } from "../../../utils/detectAnomalies";
-import { hostSleepLabel } from "../../../utils/hostSleep";
+import type { Anomaly } from "../../../utils/detectAnomalies";
 import type { HostSleep } from "@/stores/host-sleep-store";
+import { runAnnotations } from "./annotations";
 import { joinMonitorToTimeline } from "../../../utils/monitorSeries";
-import type { ColorRole } from "./uplotTheme";
-import { UPlotChart, type UPlotSeriesSpec, type Marker, type Annotation } from "./UPlotChart";
+import { UPlotChart, type UPlotSeriesSpec, type Marker } from "./UPlotChart";
 import {
 	bucketColumns,
 	rebucket,
@@ -82,52 +81,6 @@ function breakpointMarker(breakpoint?: Breakpoint | null): Marker[] {
 			label: breakpoint.p99Ms != null ? `SLO · ${Math.round(breakpoint.p99Ms)}ms` : "SLO",
 		},
 	];
-}
-
-/**
- * Anomaly colour by what went wrong - errors read as errors, slowness as a
- * warning. The breakpoint marker is `warning` too and they can coincide, which
- * is correct: both are saying the run degraded there, one against the SLO and
- * one against the run's own baseline.
- */
-const ANOMALY_ROLE: Record<AnomalyKind, ColorRole> = {
-	latency_spike: "warning",
-	error_burst: "destructive",
-	throughput_drop: "warning",
-	first_5xx: "destructive",
-};
-
-/**
- * Everything shaded on the time axis: the detected anomaly windows, plus the
- * host sleeps the run could not prevent.
- *
- * A sleep is drawn as an instant, not a band. Whether the engine's elapsed
- * clock advanced through a suspend is a per-platform answer, so a band drawn
- * `durationMs` wide would be a claim about the series that may be fiction; the
- * mark says where the machine went down and the label says for how long.
- *
- * Exported for its own test: every chart below calls it and none of them can be
- * read for what it produced, since uPlot draws to a canvas.
- */
-export function runAnnotations(
-	anomalies?: Anomaly[] | null,
-	sleeps?: readonly HostSleep[] | null
-): Annotation[] {
-	const windows: Annotation[] = (anomalies ?? []).map((a) => ({
-		startSeconds: a.startSeconds,
-		endSeconds: a.endSeconds,
-		label: a.label,
-		role: ANOMALY_ROLE[a.kind],
-	}));
-	for (const sleep of sleeps ?? []) {
-		windows.push({
-			startSeconds: sleep.startSeconds,
-			endSeconds: sleep.startSeconds,
-			label: hostSleepLabel(sleep),
-			role: "warning",
-		});
-	}
-	return windows;
 }
 
 /** Response-time percentiles over time - the canonical "latency vs time" chart. */

--- a/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
@@ -24,6 +24,8 @@ import {
 } from "../../../utils/metricsTransforms";
 import type { Breakpoint } from "../../../utils/computeBreakpoint";
 import type { Anomaly, AnomalyKind } from "../../../utils/detectAnomalies";
+import { hostSleepLabel } from "../../../utils/hostSleep";
+import type { HostSleep } from "@/stores/host-sleep-store";
 import { joinMonitorToTimeline } from "../../../utils/monitorSeries";
 import type { ColorRole } from "./uplotTheme";
 import { UPlotChart, type UPlotSeriesSpec, type Marker, type Annotation } from "./UPlotChart";
@@ -60,6 +62,13 @@ interface BaseProps {
 	 * so every chart in a synced stack shades the same windows.
 	 */
 	anomalies?: Anomaly[] | null;
+	/**
+	 * Intervals the host spent asleep under the run (#1357), marked on the same
+	 * layer as the anomaly windows. Not derived from the series - the series is
+	 * exactly what a suspend interrupts - so they arrive from the app's own
+	 * record of the run rather than from a detector.
+	 */
+	sleeps?: readonly HostSleep[] | null;
 }
 
 /** Vertical breakpoint marker (p99 crossed SLO), shared by the time-series charts. */
@@ -88,14 +97,37 @@ const ANOMALY_ROLE: Record<AnomalyKind, ColorRole> = {
 	first_5xx: "destructive",
 };
 
-/** Anomaly windows as chart-layer bands, shared by the time-series charts. */
-function anomalyAnnotations(anomalies?: Anomaly[] | null): Annotation[] {
-	return (anomalies ?? []).map((a) => ({
+/**
+ * Everything shaded on the time axis: the detected anomaly windows, plus the
+ * host sleeps the run could not prevent.
+ *
+ * A sleep is drawn as an instant, not a band. Whether the engine's elapsed
+ * clock advanced through a suspend is a per-platform answer, so a band drawn
+ * `durationMs` wide would be a claim about the series that may be fiction; the
+ * mark says where the machine went down and the label says for how long.
+ *
+ * Exported for its own test: every chart below calls it and none of them can be
+ * read for what it produced, since uPlot draws to a canvas.
+ */
+export function runAnnotations(
+	anomalies?: Anomaly[] | null,
+	sleeps?: readonly HostSleep[] | null
+): Annotation[] {
+	const windows: Annotation[] = (anomalies ?? []).map((a) => ({
 		startSeconds: a.startSeconds,
 		endSeconds: a.endSeconds,
 		label: a.label,
 		role: ANOMALY_ROLE[a.kind],
 	}));
+	for (const sleep of sleeps ?? []) {
+		windows.push({
+			startSeconds: sleep.startSeconds,
+			endSeconds: sleep.startSeconds,
+			label: hostSleepLabel(sleep),
+			role: "warning",
+		});
+	}
+	return windows;
 }
 
 /** Response-time percentiles over time - the canonical "latency vs time" chart. */
@@ -106,9 +138,10 @@ export function LatencyPercentilesChart({
 	height,
 	breakpoint,
 	anomalies,
+	sleeps,
 }: BaseProps) {
 	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const { data, series } = useMemo(() => {
 		const d = buildPercentileChartData(history);
 		const { times, cols } = rebucket(
@@ -148,9 +181,10 @@ export function LatencyBreakdownChart({
 	syncKey,
 	height,
 	anomalies,
+	sleeps,
 }: BaseProps) {
 	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const { data, series } = useMemo(() => {
 		const d = buildLatencyChartData(history);
 		const { times, cols } = rebucket(
@@ -203,9 +237,10 @@ export function RequestRateChart({
 	rampOverlay,
 	breakpoint,
 	anomalies,
+	sleeps,
 }: BaseProps & { targetRps?: number; rampOverlay?: RampOverlay | null }) {
 	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const { data, series, hasRamp } = useMemo(() => {
 		const { times, cols } = bucketColumns(
 			history,
@@ -286,9 +321,10 @@ export function ConnectionsChart({
 	height,
 	breakpoint,
 	anomalies,
+	sleeps,
 }: BaseProps) {
 	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const data = useMemo<uPlot.AlignedData>(() => {
 		const { times, cols } = bucketColumns(history, [pickConcurrency], bucketSeconds);
 		return [times, cols[0]];
@@ -320,9 +356,10 @@ export function ErrorRateChart({
 	height,
 	breakpoint,
 	anomalies,
+	sleeps,
 }: BaseProps) {
 	const bucketSeconds = useClientSettingsStore((s) => s.chartBucketSeconds);
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const data = useMemo<uPlot.AlignedData>(() => {
 		const { times, cols } = bucketColumns(history, [pickErrorRate], bucketSeconds);
 		return [times, cols[0]];
@@ -380,10 +417,11 @@ export function ServerVitalsChart({
 	syncKey,
 	height,
 	anomalies,
+	sleeps,
 }: BaseProps & { samples: MonitorSample[] }) {
 	// The most useful place a degradation window can be shaded: this row is where
 	// "the p99 spike at t=41" gets answered with what the server was doing then.
-	const annotations = useMemo(() => anomalyAnnotations(anomalies), [anomalies]);
+	const annotations = useMemo(() => runAnnotations(anomalies, sleeps), [anomalies, sleeps]);
 	const { data, series } = useMemo(() => {
 		const joined = joinMonitorToTimeline(history, samples);
 		const aligned: uPlot.AlignedData = [

--- a/app/src/modules/dashboard/components/charts/uplot/annotations.test.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/annotations.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Everything `runAnnotations` puts on the shaded layer: the detected anomaly
+ * windows, coloured by what went wrong, and the host sleeps the run could not
+ * prevent, drawn as instants rather than bands (issue #1357). uPlot draws to a
+ * canvas, so this drives the pure function directly rather than a rendered
+ * chart.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runAnnotations } from "./annotations";
+import type { Anomaly, AnomalyKind } from "../../../utils/detectAnomalies";
+import { hostSleepLabel } from "../../../utils/hostSleep";
+import type { HostSleep } from "@/stores/host-sleep-store";
+
+function anomaly(kind: AnomalyKind, startSeconds: number, endSeconds: number): Anomaly {
+	return { kind, startSeconds, endSeconds, magnitude: 4.2, label: `${kind} finding` };
+}
+
+function sleep(startSeconds: number, durationMs = 90_000): HostSleep {
+	return { at: startSeconds * 1000, durationMs, startSeconds };
+}
+
+describe("runAnnotations", () => {
+	it("colours a latency spike or throughput drop as warning, keeping its own window", () => {
+		const spike = anomaly("latency_spike", 5, 12);
+		const drop = anomaly("throughput_drop", 30, 40);
+
+		const windows = runAnnotations([spike, drop], null);
+
+		expect(windows).toEqual([
+			{ startSeconds: 5, endSeconds: 12, label: spike.label, role: "warning" },
+			{ startSeconds: 30, endSeconds: 40, label: drop.label, role: "warning" },
+		]);
+	});
+
+	it("colours an error burst or the first 5xx as destructive, keeping its own window", () => {
+		const burst = anomaly("error_burst", 8, 9);
+		const first5xx = anomaly("first_5xx", 20, 20);
+
+		const windows = runAnnotations([burst, first5xx], null);
+
+		expect(windows).toEqual([
+			{ startSeconds: 8, endSeconds: 9, label: burst.label, role: "destructive" },
+			{ startSeconds: 20, endSeconds: 20, label: first5xx.label, role: "destructive" },
+		]);
+	});
+
+	it("draws a host sleep as an instant at its start, never a band durationMs wide", () => {
+		// Whether the engine's elapsed clock advanced through a suspend is a
+		// per-platform answer, so a band drawn `durationMs` wide would be a claim
+		// about the series that may be fiction (see hostSleep.ts / host-sleep-store
+		// doc comments). The mark says only where the machine went down; the label
+		// carries how long. That is the property this case pins: startSeconds ===
+		// endSeconds, not startSeconds + durationMs / 1000.
+		const s = sleep(50, 90_000);
+
+		const [window] = runAnnotations(null, [s]);
+
+		expect(window.startSeconds).toBe(50);
+		expect(window.endSeconds).toBe(50);
+		expect(window.startSeconds).toBe(window.endSeconds);
+		expect(window.label).toBe(hostSleepLabel(s));
+		expect(window.role).toBe("warning");
+	});
+
+	it("lists anomalies and sleeps together when both are present", () => {
+		const spike = anomaly("latency_spike", 5, 12);
+		const s = sleep(50);
+
+		const windows = runAnnotations([spike], [s]);
+
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({ startSeconds: 5, endSeconds: 12, role: "warning" });
+		expect(windows[1]).toMatchObject({ startSeconds: 50, endSeconds: 50, role: "warning" });
+	});
+
+	it("returns only the sleeps when anomalies is undefined or null", () => {
+		const s = sleep(50);
+		expect(runAnnotations(undefined, [s])).toHaveLength(1);
+		expect(runAnnotations(null, [s])).toHaveLength(1);
+	});
+
+	it("returns only the anomalies when sleeps is undefined or null", () => {
+		const spike = anomaly("latency_spike", 5, 12);
+		expect(runAnnotations([spike], undefined)).toHaveLength(1);
+		expect(runAnnotations([spike], null)).toHaveLength(1);
+	});
+
+	it("returns an empty list when both arguments are absent", () => {
+		expect(runAnnotations(null, null)).toEqual([]);
+		expect(runAnnotations(undefined, undefined)).toEqual([]);
+	});
+});

--- a/app/src/modules/dashboard/components/charts/uplot/annotations.test.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/annotations.test.ts
@@ -61,13 +61,13 @@ describe("runAnnotations", () => {
 		// endSeconds, not startSeconds + durationMs / 1000.
 		const s = sleep(50, 90_000);
 
-		const [window] = runAnnotations(null, [s]);
+		const [mark] = runAnnotations(null, [s]);
 
-		expect(window.startSeconds).toBe(50);
-		expect(window.endSeconds).toBe(50);
-		expect(window.startSeconds).toBe(window.endSeconds);
-		expect(window.label).toBe(hostSleepLabel(s));
-		expect(window.role).toBe("warning");
+		expect(mark.startSeconds).toBe(50);
+		expect(mark.endSeconds).toBe(50);
+		expect(mark.startSeconds).toBe(mark.endSeconds);
+		expect(mark.label).toBe(hostSleepLabel(s));
+		expect(mark.role).toBe("warning");
 	});
 
 	it("lists anomalies and sleeps together when both are present", () => {

--- a/app/src/modules/dashboard/components/charts/uplot/annotations.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/annotations.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the time-series charts shade, as chart-layer bands.
+ *
+ * Beside `buildData.ts` rather than inside `TimeSeriesCharts.tsx`, for the same
+ * reason that file exists: a module that exports components exports only
+ * components, or fast refresh stops working for the whole file.
+ */
+
+import type { Anomaly, AnomalyKind } from "../../../utils/detectAnomalies";
+import { hostSleepLabel } from "../../../utils/hostSleep";
+import type { HostSleep } from "@/stores/host-sleep-store";
+import type { ColorRole } from "./uplotTheme";
+import type { Annotation } from "./UPlotChart";
+
+/**
+ * Anomaly colour by what went wrong - errors read as errors, slowness as a
+ * warning. The breakpoint marker is `warning` too and they can coincide, which
+ * is correct: both are saying the run degraded there, one against the SLO and
+ * one against the run's own baseline.
+ */
+export const ANOMALY_ROLE: Record<AnomalyKind, ColorRole> = {
+	latency_spike: "warning",
+	error_burst: "destructive",
+	throughput_drop: "warning",
+	first_5xx: "destructive",
+};
+
+/**
+ * Everything shaded on the time axis: the detected anomaly windows, plus the
+ * host sleeps the run could not prevent.
+ *
+ * A sleep is drawn as an instant, not a band. Whether the engine's elapsed
+ * clock advanced through a suspend is a per-platform answer, so a band drawn
+ * `durationMs` wide would be a claim about the series that may be fiction; the
+ * mark says where the machine went down and the label says for how long.
+ *
+ * Its own module is also what makes it testable: every chart calls it and none
+ * of them can be read for what it produced, since uPlot draws to a canvas.
+ */
+export function runAnnotations(
+	anomalies?: Anomaly[] | null,
+	sleeps?: readonly HostSleep[] | null
+): Annotation[] {
+	const windows: Annotation[] = (anomalies ?? []).map((a) => ({
+		startSeconds: a.startSeconds,
+		endSeconds: a.endSeconds,
+		label: a.label,
+		role: ANOMALY_ROLE[a.kind],
+	}));
+	for (const sleep of sleeps ?? []) {
+		windows.push({
+			startSeconds: sleep.startSeconds,
+			endSeconds: sleep.startSeconds,
+			label: hostSleepLabel(sleep),
+			role: "warning",
+		});
+	}
+	return windows;
+}

--- a/app/src/modules/dashboard/utils/hostSleep.test.ts
+++ b/app/src/modules/dashboard/utils/hostSleep.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `formatSleepDuration` at its boundaries, and the one-line sentence built on
+ * top of it. Both readers - the chart mark and the Events row - go through
+ * these, so a wrong boundary here is wrong on both surfaces at once.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatSleepDuration, hostSleepLabel } from "./hostSleep";
+import type { HostSleep } from "@/stores/host-sleep-store";
+
+function sleep(durationMs: number): HostSleep {
+	return { at: 0, durationMs, startSeconds: 0 };
+}
+
+describe("formatSleepDuration", () => {
+	it("reads under a minute as seconds", () => {
+		expect(formatSleepDuration(45_000)).toBe("45s");
+	});
+
+	it("reads exactly a minute as '1m', with no dangling '0s'", () => {
+		// Pins `seconds > 0 ? "...s" : "..."`: a naive concatenation would print
+		// "1m 0s" here.
+		expect(formatSleepDuration(60_000)).toBe("1m");
+	});
+
+	it("reads minutes with a seconds remainder", () => {
+		expect(formatSleepDuration(72_000)).toBe("1m 12s");
+	});
+
+	it("reads minutes with no remainder, and no hours branch below an hour", () => {
+		expect(formatSleepDuration(180_000)).toBe("3m");
+	});
+
+	it("reads the hours branch with remaining minutes", () => {
+		expect(formatSleepDuration(5_400_000)).toBe("1h 30m"); // 1h 30m
+	});
+
+	it("reads the hours branch with no remaining minutes, and no dangling '0m'", () => {
+		expect(formatSleepDuration(7_200_000)).toBe("2h");
+	});
+
+	it("clamps a negative duration to '0s' rather than printing a negative number", () => {
+		expect(formatSleepDuration(-5_000)).toBe("0s");
+	});
+
+	it("reads a zero duration as '0s'", () => {
+		expect(formatSleepDuration(0)).toBe("0s");
+	});
+});
+
+describe("hostSleepLabel", () => {
+	it("is 'Host asleep <duration>', the same sentence on the chart and the Events row", () => {
+		expect(hostSleepLabel(sleep(72_000))).toBe("Host asleep 1m 12s");
+	});
+});

--- a/app/src/modules/dashboard/utils/hostSleep.ts
+++ b/app/src/modules/dashboard/utils/hostSleep.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * How a host sleep reads, in one place (issue #1357).
+ *
+ * The charts mark it and History's Events tab states it, the same way one
+ * `detectAnomalies` call feeds both the bands and the prose - so the mark on
+ * the chart and the row under it can never disagree about how long the machine
+ * was gone.
+ */
+
+import type { HostSleep } from "@/stores/host-sleep-store";
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+
+/**
+ * "45s", "6m 12s", "1h 4m" - the coarsest pair that still says something.
+ *
+ * A run interrupted overnight is the case the hours branch exists for, and a
+ * reader counting 31,000 seconds is a reader the marker failed.
+ */
+export function formatSleepDuration(durationMs: number): string {
+	const ms = Math.max(0, durationMs);
+	if (ms < MINUTE_MS) return `${Math.round(ms / SECOND_MS)}s`;
+	if (ms < HOUR_MS) {
+		const minutes = Math.floor(ms / MINUTE_MS);
+		const seconds = Math.round((ms % MINUTE_MS) / SECOND_MS);
+		return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+	}
+	const hours = Math.floor(ms / HOUR_MS);
+	const minutes = Math.round((ms % HOUR_MS) / MINUTE_MS);
+	return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+/** The chart mark's label, and the Events row's sentence. */
+export function hostSleepLabel(sleep: HostSleep): string {
+	return `Host asleep ${formatSleepDuration(sleep.durationMs)}`;
+}

--- a/app/src/modules/dashboard/utils/keepAwake.test.ts
+++ b/app/src/modules/dashboard/utils/keepAwake.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which runs are worth asking about, and how the ask says their length.
+ *
+ * The threshold is a product decision, so what is pinned here is the boundary
+ * behaviour around it rather than the number: a run at the threshold asks, one
+ * under it does not, and a run that never declared a length is never guessed at.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LONG_RUN_SECONDS, formatRunLength, isLongRun, runLengthSeconds } from "./keepAwake";
+
+describe("runLengthSeconds", () => {
+	it("reads the seconds form the run config carries", () => {
+		expect(runLengthSeconds({ duration: "600s" })).toBe(600);
+	});
+
+	it("reads a bare number too", () => {
+		expect(runLengthSeconds({ duration: "600" })).toBe(600);
+	});
+
+	it("falls back to the ramp when that is all the config named", () => {
+		expect(runLengthSeconds({ rampUpDuration: "900s" })).toBe(900);
+	});
+
+	it("prefers the total over the ramp, which is a part of it", () => {
+		expect(runLengthSeconds({ duration: "1200s", rampUpDuration: "300s" })).toBe(1200);
+	});
+
+	it("answers null for a run that declares no length", () => {
+		// An iterations run ends when the work does. Guessing a length for it
+		// would put a duration in a sentence the config never supported.
+		expect(runLengthSeconds({ mode: "iterations", iterations: 100_000 })).toBeNull();
+		expect(runLengthSeconds(null)).toBeNull();
+		expect(runLengthSeconds(undefined)).toBeNull();
+	});
+
+	it("answers null for a value it cannot read rather than a wrong number", () => {
+		expect(runLengthSeconds({ duration: "" })).toBeNull();
+		expect(runLengthSeconds({ duration: "forever" })).toBeNull();
+		// "10m" is not a form the dialog produces, and reading it as 10 *seconds*
+		// would silently stop asking about a ten-minute run.
+		expect(runLengthSeconds({ duration: "10m" })).toBeNull();
+	});
+});
+
+describe("isLongRun", () => {
+	it("asks about a run at the threshold", () => {
+		expect(isLongRun({ duration: `${LONG_RUN_SECONDS}s` })).toBe(true);
+	});
+
+	it("says nothing about a run one second under it", () => {
+		expect(isLongRun({ duration: `${LONG_RUN_SECONDS - 1}s` })).toBe(false);
+	});
+
+	it("says nothing about a run with no declared length", () => {
+		expect(isLongRun({ mode: "iterations" })).toBe(false);
+	});
+});
+
+describe("formatRunLength", () => {
+	it("keeps a short run in seconds", () => {
+		expect(formatRunLength(90)).toBe("90 seconds");
+	});
+
+	it("rounds to minutes for the runs that get asked about", () => {
+		expect(formatRunLength(300)).toBe("5 minutes");
+		expect(formatRunLength(1800)).toBe("30 minutes");
+	});
+
+	it("moves to hours once minutes stop reading as a length", () => {
+		expect(formatRunLength(7200)).toBe("2 hours");
+		expect(formatRunLength(9000)).toBe("2.5 hours");
+	});
+});

--- a/app/src/modules/dashboard/utils/keepAwake.ts
+++ b/app/src/modules/dashboard/utils/keepAwake.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which runs are long enough to be worth asking about (issue #1357).
+ *
+ * The wake lock is off by default: an app that silently overrides the user's
+ * power settings is a worse citizen than one that lets a short run finish
+ * before the machine idles out. What is left is the case the setting exists
+ * for - a run the user starts and walks away from - and that case announces
+ * itself in the config, so the app asks then rather than making the user find
+ * a preference first.
+ */
+
+import type { LoadTestRunConfig } from "@/stores/dashboard-store";
+
+/**
+ * A run at least this long is worth an ask.
+ *
+ * Five minutes because that is under the shortest sleep timer a laptop ships
+ * with (macOS idles the display at 2 minutes on battery and suspends a few
+ * minutes later; Windows' balanced plan sleeps at 15). A run that cannot
+ * outlast any of them is not worth interrupting the user over, and a run that
+ * can is exactly the one that comes back with a hole in it.
+ */
+export const LONG_RUN_SECONDS = 300;
+
+/** Parse the `"600s"` form the run config carries; plain digits too. */
+function seconds(value: string | undefined): number | null {
+	if (!value) return null;
+	const match = /^\s*(\d+)\s*s?\s*$/.exec(value);
+	if (!match) return null;
+	const parsed = Number.parseInt(match[1], 10);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * How long the run says it will take, or `null` when it does not say.
+ *
+ * An iterations run has no duration at all - it ends when the work does - so
+ * there is no number here to compare, and nothing to ask about. A ramp run
+ * carries its total in `duration`; `rampUpDuration` is the fallback for a
+ * config that named only the ramp.
+ */
+export function runLengthSeconds(config: LoadTestRunConfig | null | undefined): number | null {
+	if (!config) return null;
+	return seconds(config.duration) ?? seconds(config.rampUpDuration);
+}
+
+/** Is this a run the user is likely to walk away from? */
+export function isLongRun(config: LoadTestRunConfig | null | undefined): boolean {
+	const length = runLengthSeconds(config);
+	return length !== null && length >= LONG_RUN_SECONDS;
+}
+
+/** "30 minutes" / "8 minutes" - the length, for the sentence that asks. */
+export function formatRunLength(totalSeconds: number): string {
+	if (totalSeconds < 120) return `${totalSeconds} seconds`;
+	const minutes = Math.round(totalSeconds / 60);
+	if (minutes < 120) return `${minutes} minutes`;
+	const hours = Math.round(minutes / 6) / 10;
+	return `${hours} hours`;
+}

--- a/app/src/modules/history/main/LoadTestDetail.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.tsx
@@ -382,7 +382,12 @@ export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 				<ScrollArea className="flex-1">
 					<div className="p-6">
 						<TabsContent value="overview" className="mt-0 space-y-4">
-							<OverviewTab report={report} derived={derived} anomalies={anomalies} />
+							<OverviewTab
+								report={report}
+								runId={runId}
+								derived={derived}
+								anomalies={anomalies}
+							/>
 						</TabsContent>
 
 						<TabsContent value="performance" className="mt-0 space-y-4">

--- a/app/src/modules/history/main/components/HistoricalChartsSection.tsx
+++ b/app/src/modules/history/main/components/HistoricalChartsSection.tsx
@@ -18,6 +18,7 @@ import { Loader2 } from "lucide-react";
 import type { LoadTestMetrics, MonitorSample } from "@/types";
 import type { Breakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
 import type { Anomaly } from "@/modules/dashboard/utils/detectAnomalies";
+import type { HostSleep } from "@/stores/host-sleep-store";
 import {
 	RequestRateChart,
 	ConnectionsChart,
@@ -35,6 +36,8 @@ interface HistoricalChartsSectionProps {
 	progress?: { loaded: number; total: number };
 	breakpoint?: Breakpoint | null;
 	anomalies?: Anomaly[] | null;
+	/** Intervals the host slept under the run, marked beside the anomaly windows. */
+	sleeps?: readonly HostSleep[] | null;
 }
 
 const SYNC_KEY = CHART_SYNC.history;
@@ -47,6 +50,7 @@ export default function HistoricalChartsSection({
 	progress,
 	breakpoint,
 	anomalies,
+	sleeps,
 }: HistoricalChartsSectionProps) {
 	if (isLoading && data.length === 0) {
 		return (
@@ -98,6 +102,7 @@ export default function HistoricalChartsSection({
 						syncKey={SYNC_KEY}
 						breakpoint={breakpoint}
 						anomalies={anomalies}
+						sleeps={sleeps}
 					/>
 				</CardContent>
 			</Card>
@@ -113,6 +118,7 @@ export default function HistoricalChartsSection({
 						syncKey={SYNC_KEY}
 						breakpoint={breakpoint}
 						anomalies={anomalies}
+						sleeps={sleeps}
 					/>
 				</CardContent>
 			</Card>
@@ -140,6 +146,7 @@ export default function HistoricalChartsSection({
 							isCompleted
 							syncKey={SYNC_KEY}
 							anomalies={anomalies}
+							sleeps={sleeps}
 						/>
 					</CardContent>
 				</Card>

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -26,10 +26,15 @@ import { HeroRow } from "@/modules/dashboard/components/hero/HeroRow";
 import { ModeStatsRow } from "@/modules/dashboard/components/stats/ModeStatsRow";
 import { RunEvents } from "./RunEvents";
 import { extractTestFailures } from "../test-validation";
+import { useHostSleeps } from "@/stores/host-sleep-store";
 import type { TabProps } from "../../types";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
 
-export default function OverviewTab({ report, derived, anomalies }: TabProps) {
+export default function OverviewTab({ report, runId, derived, anomalies }: TabProps) {
+	// Read by run id rather than passed down: `PerformanceTab` reads the same
+	// list for the chart marks, and one prop drilled through `LoadTestDetail`
+	// for two independent readers is a copy waiting to disagree (#1357).
+	const hostSleeps = useHostSleeps(runId);
 	// The named failures live on a synthetic result row, not on `testValidation`;
 	// lifted here so the Overview says which assertions failed while the Samples
 	// tab drops the row rather than drawing it as a request that never ran.
@@ -84,7 +89,7 @@ export default function OverviewTab({ report, derived, anomalies }: TabProps) {
 			    because those are cumulative and this is the thing they hide: a
 			    3-second collapse and a steady 0.4% failure rate can produce the
 			    same summary row. */}
-			<RunEvents anomalies={anomalies} />
+			<RunEvents anomalies={anomalies} sleeps={hostSleeps} />
 
 			{/* Status Codes */}
 			{report.statusCodes && Object.keys(report.statusCodes).length > 0 && (

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -25,6 +25,7 @@ import { PhasePercentiles } from "@/modules/dashboard/components/charts/PhasePer
 import LatencyMetric from "./LatencyMetric";
 import MonitorSummary from "./MonitorSummary";
 import HistoricalChartsSection from "./HistoricalChartsSection";
+import { useHostSleeps } from "@/stores/host-sleep-store";
 import type { PerformanceTabProps } from "../../types";
 
 export default function PerformanceTab({
@@ -38,6 +39,10 @@ export default function PerformanceTab({
 	isFetchingMore,
 	progress,
 }: PerformanceTabProps) {
+	// The run's own record of the host sleeping under it (#1357), read here by
+	// run id rather than drilled from `LoadTestDetail`: Overview states them and
+	// this tab marks them, and neither derives anything the other must match.
+	const hostSleeps = useHostSleeps(runId);
 	// Windowed per-tick percentiles now persist for completed runs (W1), so the
 	// history percentile chart / scatter can render the same views as the live
 	// dashboard. Mirror MetricsView's split: ramp_up → response-time-vs-concurrency
@@ -70,6 +75,7 @@ export default function PerformanceTab({
 					progress={progress}
 					breakpoint={derived.breakpoint}
 					anomalies={anomalies}
+					sleeps={hostSleeps}
 				/>
 			)}
 
@@ -107,6 +113,7 @@ export default function PerformanceTab({
 								syncKey={CHART_SYNC.history}
 								breakpoint={derived.breakpoint}
 								anomalies={anomalies}
+								sleeps={hostSleeps}
 							/>
 						</CardContent>
 					</Card>

--- a/app/src/modules/history/main/components/RunEvents.test.tsx
+++ b/app/src/modules/history/main/components/RunEvents.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Events card: silent for a clean run with no sleeps, and otherwise the
+ * one place a host sleep is stated in words (issue #1357's acceptance
+ * criterion - "an Events row stating how long the host slept").
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RunEvents } from "./RunEvents";
+import type { Anomaly } from "@/modules/dashboard/utils/detectAnomalies";
+import type { HostSleep } from "@/stores/host-sleep-store";
+
+function anomaly(over: Partial<Anomaly> = {}): Anomaly {
+	return {
+		kind: "latency_spike",
+		startSeconds: 5,
+		endSeconds: 9,
+		magnitude: 4.2,
+		label: "p99 4.2x baseline for 4s",
+		...over,
+	};
+}
+
+function sleep(over: Partial<HostSleep> = {}): HostSleep {
+	return { at: 30_000, durationMs: 90_000, startSeconds: 30, ...over };
+}
+
+describe("RunEvents", () => {
+	it("renders nothing when there are neither anomalies nor sleeps", () => {
+		const { container: empty } = render(<RunEvents />);
+		expect(empty).toBeEmptyDOMElement();
+
+		const { container: explicit } = render(<RunEvents anomalies={[]} sleeps={[]} />);
+		expect(explicit).toBeEmptyDOMElement();
+
+		const { container: nully } = render(<RunEvents anomalies={null} sleeps={null} />);
+		expect(nully).toBeEmptyDOMElement();
+	});
+
+	it("renders a row naming how long the host slept, for sleeps alone", () => {
+		render(<RunEvents sleeps={[sleep({ durationMs: 90_000 })]} />);
+
+		expect(screen.getByText("Events")).toBeInTheDocument();
+		// "90s" -> "1m 30s" through the same formatSleepDuration the chart mark uses.
+		expect(screen.getByText(/slept for 1m 30s/)).toBeInTheDocument();
+	});
+
+	it("renders both anomalies and sleeps together when both are present", () => {
+		render(<RunEvents anomalies={[anomaly()]} sleeps={[sleep()]} />);
+
+		expect(screen.getByText("Host asleep")).toBeInTheDocument();
+		expect(screen.getByText("Latency spike")).toBeInTheDocument();
+	});
+
+	it("gives the sleep row a -text tone token, never a bare fill", () => {
+		render(<RunEvents sleeps={[sleep()]} />);
+
+		const label = screen.getByText("Host asleep");
+		expect(label.className).toMatch(/\btext-warning-text\b/);
+		expect(label.className).not.toMatch(/\bbg-warning\b/);
+	});
+});

--- a/app/src/modules/history/main/components/RunEvents.tsx
+++ b/app/src/modules/history/main/components/RunEvents.tsx
@@ -20,6 +20,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { Anomaly, AnomalyKind } from "@/modules/dashboard/utils/detectAnomalies";
+import { formatSleepDuration } from "@/modules/dashboard/utils/hostSleep";
+import type { HostSleep } from "@/stores/host-sleep-store";
 
 /**
  * How each kind reads on screen. The tone follows the finding: an error burst
@@ -41,11 +43,19 @@ function at(seconds: number): string {
 
 export interface RunEventsProps {
 	anomalies?: Anomaly[] | null;
+	/**
+	 * Intervals the host spent asleep under the run (#1357). Listed beside the
+	 * detected windows because a reader looking at a flat stretch is asking the
+	 * same question of both - and this is the one answer the series cannot give,
+	 * since the engine was suspended too.
+	 */
+	sleeps?: readonly HostSleep[] | null;
 	className?: string;
 }
 
-export function RunEvents({ anomalies, className }: RunEventsProps) {
-	if (!anomalies || anomalies.length === 0) return null;
+export function RunEvents({ anomalies, sleeps, className }: RunEventsProps) {
+	const hostSleeps = sleeps ?? [];
+	if ((!anomalies || anomalies.length === 0) && hostSleeps.length === 0) return null;
 
 	return (
 		<Card className={className}>
@@ -54,11 +64,26 @@ export function RunEvents({ anomalies, className }: RunEventsProps) {
 			</CardHeader>
 			<CardContent>
 				<p className="mb-3 text-xs text-muted-foreground">
-					Windows where the run departed from its own baseline. Shaded on the charts in
-					the Performance tab.
+					Windows where the run departed from its own baseline, and any stretch the host
+					spent asleep under it. Both are marked on the charts in the Performance tab.
 				</p>
 				<ul className="space-y-1.5">
-					{anomalies.map((a) => (
+					{hostSleeps.map((sleep) => (
+						<li
+							key={`host-sleep-${sleep.at}`}
+							className="flex items-baseline justify-between gap-3 p-2 bg-muted rounded-md text-sm"
+						>
+							<span className="font-medium text-warning-text">Host asleep</span>
+							<span className="flex-1 text-muted-foreground">
+								The machine slept for {formatSleepDuration(sleep.durationMs)}; the
+								run could not send during it
+							</span>
+							<span className="font-mono text-xs text-muted-foreground">
+								{at(sleep.startSeconds)}
+							</span>
+						</li>
+					))}
+					{(anomalies ?? []).map((a) => (
 						<li
 							key={`${a.kind}-${a.startSeconds}`}
 							className="flex items-baseline justify-between gap-3 p-2 bg-muted rounded-md text-sm"

--- a/app/src/modules/settings/main/app-settings.ts
+++ b/app/src/modules/settings/main/app-settings.ts
@@ -242,6 +242,14 @@ export const APP_SETTINGS = [
 
 	// Load testing
 	{
+		anchor: "load-keep-awake",
+		panel: "load-testing",
+		label: "Keep the machine awake during runs",
+		searchText:
+			"Ask the operating system not to suspend the machine while a load or collection run is streaming.",
+		keywords: ["sleep", "suspend", "power", "wake lock", "idle", "battery"],
+	},
+	{
 		anchor: "load-max-connections",
 		panel: "load-testing",
 		label: "Max connections",

--- a/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
+++ b/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
@@ -21,7 +21,7 @@
  * `resolveLoadTestLimits`.
  */
 
-import { Gauge, RotateCcw } from "lucide-react";
+import { Coffee, Gauge, RotateCcw } from "lucide-react";
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { useClientSettingsStore } from "@/stores";
 import {
@@ -30,7 +30,7 @@ import {
 	type LoadTestCeilingKey,
 } from "@/constants/load-test";
 import { appSetting, type AppSettingDescriptor } from "../app-settings";
-import { NumberSettingRow } from "./SettingControls";
+import { NumberSettingRow, ToggleRow } from "./SettingControls";
 
 interface CeilingField {
 	key: LoadTestCeilingKey;
@@ -84,62 +84,112 @@ export default function LoadTestingPanel() {
 	const isDefault = FIELDS.every((f) => ceilings[f.key] === DEFAULT_LOAD_TEST_CEILINGS[f.key]);
 
 	return (
+		<>
+			<KeepAwakeCard />
+
+			<Card>
+				<CardHeader className="pb-3">
+					<div className="flex items-start justify-between gap-4">
+						<div>
+							<div className="flex items-center gap-2">
+								<Gauge className="w-5 h-5 text-muted-foreground" />
+								<CardTitle className="text-base">Load test ceilings</CardTitle>
+							</div>
+							<CardDescription className="mt-1">
+								The largest value each field in the Run a load test dialog will
+								offer. Raising one does not change any run you have already
+								configured - it only widens what you can ask for. The engine
+								enforces its own limits regardless, and no value here can exceed
+								them.
+							</CardDescription>
+						</div>
+						{!isDefault && (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="shrink-0 text-xs h-7 px-2"
+								onClick={() => setCeilings(DEFAULT_LOAD_TEST_CEILINGS)}
+							>
+								<RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+								{/* "all", because each row now carries its own Reset
+							    beside its Default line. */}
+								Reset all
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-5">
+					{FIELDS.map((field) => {
+						const bounds = LOAD_TEST_CEILING_BOUNDS[field.key];
+						return (
+							<NumberSettingRow
+								key={field.key}
+								anchor={field.setting.anchor}
+								label={field.setting.label}
+								description={field.description}
+								value={String(ceilings[field.key])}
+								// Applies live: the next load dialog reads the store, so
+								// there is nothing to save and nothing to wait for.
+								commit="change"
+								onCommit={(next) =>
+									setCeilings({ [field.key]: parseInt(next, 10) })
+								}
+								unit={field.unit}
+								min={String(bounds.MIN)}
+								max={String(bounds.MAX)}
+								rangeHint={`${bounds.MIN.toLocaleString()} - ${bounds.MAX.toLocaleString()}`}
+								defaultValue={String(DEFAULT_LOAD_TEST_CEILINGS[field.key])}
+								defaultDisplay={DEFAULT_LOAD_TEST_CEILINGS[
+									field.key
+								].toLocaleString()}
+								onResetToDefault={() =>
+									setCeilings({
+										[field.key]: DEFAULT_LOAD_TEST_CEILINGS[field.key],
+									})
+								}
+							/>
+						);
+					})}
+				</CardContent>
+			</Card>
+		</>
+	);
+}
+
+/**
+ * Whether a run may ask the operating system to stay awake (issue #1357).
+ *
+ * Off by default, and deliberately not a knob the app sets on the user's
+ * behalf: a machine that refuses to sleep is the user's battery and the user's
+ * decision. With it off, a run long enough to be walked away from asks once,
+ * when it starts - see `KeepAwakePrompt`. This row is the standing answer for
+ * people who would rather not be asked at all.
+ */
+function KeepAwakeCard() {
+	const keepAwake = useClientSettingsStore((s) => s.keepAwakeDuringRuns);
+	const setKeepAwake = useClientSettingsStore((s) => s.setKeepAwakeDuringRuns);
+	const setting = appSetting("load-keep-awake");
+
+	return (
 		<Card>
 			<CardHeader className="pb-3">
-				<div className="flex items-start justify-between gap-4">
-					<div>
-						<div className="flex items-center gap-2">
-							<Gauge className="w-5 h-5 text-muted-foreground" />
-							<CardTitle className="text-base">Load test ceilings</CardTitle>
-						</div>
-						<CardDescription className="mt-1">
-							The largest value each field in the Run a load test dialog will offer.
-							Raising one does not change any run you have already configured - it
-							only widens what you can ask for. The engine enforces its own limits
-							regardless, and no value here can exceed them.
-						</CardDescription>
-					</div>
-					{!isDefault && (
-						<Button
-							variant="ghost"
-							size="sm"
-							className="shrink-0 text-xs h-7 px-2"
-							onClick={() => setCeilings(DEFAULT_LOAD_TEST_CEILINGS)}
-						>
-							<RotateCcw className="w-3.5 h-3.5 mr-1.5" />
-							{/* "all", because each row now carries its own Reset
-							    beside its Default line. */}
-							Reset all
-						</Button>
-					)}
+				<div className="flex items-center gap-2">
+					<Coffee className="w-5 h-5 text-muted-foreground" />
+					<CardTitle className="text-base">While a run is streaming</CardTitle>
 				</div>
+				<CardDescription className="mt-1">
+					A load test the machine sleeps through stops with it, and its report comes back
+					with a flat stretch that reads as the server's fault.
+				</CardDescription>
 			</CardHeader>
-			<CardContent className="space-y-5">
-				{FIELDS.map((field) => {
-					const bounds = LOAD_TEST_CEILING_BOUNDS[field.key];
-					return (
-						<NumberSettingRow
-							key={field.key}
-							anchor={field.setting.anchor}
-							label={field.setting.label}
-							description={field.description}
-							value={String(ceilings[field.key])}
-							// Applies live: the next load dialog reads the store, so
-							// there is nothing to save and nothing to wait for.
-							commit="change"
-							onCommit={(next) => setCeilings({ [field.key]: parseInt(next, 10) })}
-							unit={field.unit}
-							min={String(bounds.MIN)}
-							max={String(bounds.MAX)}
-							rangeHint={`${bounds.MIN.toLocaleString()} - ${bounds.MAX.toLocaleString()}`}
-							defaultValue={String(DEFAULT_LOAD_TEST_CEILINGS[field.key])}
-							defaultDisplay={DEFAULT_LOAD_TEST_CEILINGS[field.key].toLocaleString()}
-							onResetToDefault={() =>
-								setCeilings({ [field.key]: DEFAULT_LOAD_TEST_CEILINGS[field.key] })
-							}
-						/>
-					);
-				})}
+			<CardContent>
+				<ToggleRow
+					anchor={setting.anchor}
+					label={setting.label}
+					description="Asks the system not to suspend until the run ends. The display still dims and locks as usual, and the request is dropped the moment no run is streaming. Read when a run starts, so it applies from the next one. With this off, a run of five minutes or more asks once."
+					checked={keepAwake}
+					onChange={setKeepAwake}
+				/>
 			</CardContent>
 		</Card>
 	);

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -14,6 +14,9 @@ const mockAddMetricsBatch = vi.fn();
 // Which run the dashboard is showing *right now* - re-read after every await,
 // which is the whole point of the guard under test.
 const dashboard = { currentRunId: null as string | null };
+// The user's standing answer to "keep this machine awake" (#1357), which the
+// service reads at start. Off is the shipped default, so it is the default here.
+const settings = { keepAwakeDuringRuns: false };
 vi.mock("@/stores", () => ({
 	useDashboardStore: {
 		getState: () => ({
@@ -24,7 +27,9 @@ vi.mock("@/stores", () => ({
 			addMetricsBatch: mockAddMetricsBatch,
 		}),
 	},
-	useClientSettingsStore: { getState: () => ({ liveRefreshMs: 0 }) },
+	useClientSettingsStore: {
+		getState: () => ({ liveRefreshMs: 0, keepAwakeDuringRuns: settings.keepAwakeDuringRuns }),
+	},
 }));
 vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn(), disconnect: vi.fn() } }));
 vi.mock("./api", () => ({
@@ -123,9 +128,24 @@ describe("LoadTestService", () => {
 	});
 
 	describe("wake lock (issue #1357)", () => {
-		it("holds the load-run key on start", () => {
+		afterEach(() => {
+			settings.keepAwakeDuringRuns = false;
+		});
+
+		it("holds nothing on start while the preference is off", () => {
+			// The shipped default. Overriding the machine's power settings is the
+			// user's decision, so a run takes no lock until they have made it -
+			// `KeepAwakePrompt` is what asks, for a run long enough to matter.
+			loadTestService.startMonitoring("run_4a");
+			expect(mockWakeLockHold).not.toHaveBeenCalled();
+		});
+
+		it("holds the load-run key on start once the preference is on", () => {
+			settings.keepAwakeDuringRuns = true;
 			loadTestService.startMonitoring("run_4");
-			// Pins the `wakeLock.hold(...)` call in `startMonitoring`.
+			// Pins the `wakeLock.hold(...)` call in `startMonitoring`, and the
+			// condition around it: drop the condition and the case above fails,
+			// drop the call and this one does.
 			expect(mockWakeLockHold).toHaveBeenCalledWith(
 				WAKE_LOCK_KEYS.loadRun,
 				expect.any(String)

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -30,10 +30,19 @@ vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn(), disconnect: vi.f
 vi.mock("./api", () => ({
 	apiService: { getRunReport: vi.fn().mockResolvedValue({ summary: {}, latency: {} }) },
 }));
+const { mockWakeLockHold, mockWakeLockRelease } = vi.hoisted(() => ({
+	mockWakeLockHold: vi.fn(),
+	mockWakeLockRelease: vi.fn(),
+}));
+vi.mock("./wake-lock", () => ({
+	wakeLock: { hold: mockWakeLockHold, release: mockWakeLockRelease },
+	WAKE_LOCK_KEYS: { loadRun: "load-run", collectionRun: "collection-run" },
+}));
 
 import { loadTestService } from "./load-test-service";
 import { sseClient } from "./sse-client";
 import { apiService } from "./api";
+import { WAKE_LOCK_KEYS } from "./wake-lock";
 
 /** `handleClose` is private; the SSE client is what calls it in production. */
 function closeStream(): Promise<void> {
@@ -111,5 +120,54 @@ describe("LoadTestService", () => {
 		expect(mockSetError).toHaveBeenCalledWith(null);
 		expect(mockSetFinalReport).not.toHaveBeenCalled();
 		expect(mockAddMetricsBatch).not.toHaveBeenCalled();
+	});
+
+	describe("wake lock (issue #1357)", () => {
+		it("holds the load-run key on start", () => {
+			loadTestService.startMonitoring("run_4");
+			// Pins the `wakeLock.hold(...)` call in `startMonitoring`.
+			expect(mockWakeLockHold).toHaveBeenCalledWith(
+				WAKE_LOCK_KEYS.loadRun,
+				expect.any(String)
+			);
+		});
+
+		it("releases the load-run key on stop", () => {
+			loadTestService.startMonitoring("run_5");
+			mockWakeLockRelease.mockClear();
+			loadTestService.stopMonitoring();
+			// Pins the `wakeLock.release(...)` call in `stopMonitoring`.
+			expect(mockWakeLockRelease).toHaveBeenCalledWith(WAKE_LOCK_KEYS.loadRun);
+		});
+
+		it("releases the load-run key when the stream closes, before the report fetch resolves", async () => {
+			dashboard.currentRunId = "run_6";
+			loadTestService.startMonitoring("run_6");
+			mockWakeLockRelease.mockClear();
+
+			let releaseCalledBeforeFetch = false;
+			vi.mocked(apiService.getRunReport).mockImplementationOnce(() => {
+				// The lock must already be gone by the time the report fetch is
+				// even asked for - reverting the release's position in `handleClose`
+				// (moving it after the `await`) leaves this false.
+				releaseCalledBeforeFetch = mockWakeLockRelease.mock.calls.length > 0;
+				return Promise.resolve({ summary: {}, latency: {} } as never);
+			});
+
+			await closeStream();
+
+			expect(releaseCalledBeforeFetch).toBe(true);
+			expect(mockWakeLockRelease).toHaveBeenCalledWith(WAKE_LOCK_KEYS.loadRun);
+		});
+
+		it("releases the load-run key on a stream error", () => {
+			loadTestService.startMonitoring("run_7");
+			mockWakeLockRelease.mockClear();
+			(loadTestService as unknown as { handleError: (e: Error) => void }).handleError(
+				new Error("transport gone")
+			);
+			// Pins the `wakeLock.release(...)` call in `handleError`.
+			expect(mockWakeLockRelease).toHaveBeenCalledWith(WAKE_LOCK_KEYS.loadRun);
+		});
 	});
 });

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -18,7 +18,7 @@ import { apiService } from "./api";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { QUERY_CACHE } from "@/config/cache";
-import { useDashboardStore } from "@/stores";
+import { useDashboardStore, useClientSettingsStore } from "@/stores";
 import { wakeLock, WAKE_LOCK_KEYS } from "./wake-lock";
 import type { LoadTestMetrics, MonitorSample } from "@/types";
 // Engine emits at 10 Hz (100ms cadence - see engine/src/http/routes/metrics.cpp).
@@ -55,9 +55,15 @@ class LoadTestService {
 			this.stopMonitoring();
 		}
 
-		// Fire-and-forget: the stream below connects the same tick regardless of
-		// whether the main process has answered yet.
-		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "Load test run streaming");
+		// Only on the user's standing say-so (#1357). With the setting off, a run
+		// long enough to be walked away from is asked about instead, and that ask
+		// takes the lock itself - see `KeepAwakePrompt`. Read here rather than
+		// watched, so the answer for a run is the one that was true when it
+		// started. Fire-and-forget either way: the stream below connects the same
+		// tick regardless of whether the main process has answered yet.
+		if (useClientSettingsStore.getState().keepAwakeDuringRuns) {
+			wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "Load test run streaming");
+		}
 
 		this.activeRunId = runId;
 		this.isConnected = true;

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -19,6 +19,7 @@ import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { useDashboardStore } from "@/stores";
+import { wakeLock, WAKE_LOCK_KEYS } from "./wake-lock";
 import type { LoadTestMetrics, MonitorSample } from "@/types";
 // Engine emits at 10 Hz (100ms cadence - see engine/src/http/routes/metrics.cpp).
 // The batcher throttles UI commits to keep render cost bounded, but every tick
@@ -53,6 +54,10 @@ class LoadTestService {
 		if (this.activeRunId && this.activeRunId !== runId) {
 			this.stopMonitoring();
 		}
+
+		// Fire-and-forget: the stream below connects the same tick regardless of
+		// whether the main process has answered yet.
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "Load test run streaming");
 
 		this.activeRunId = runId;
 		this.isConnected = true;
@@ -89,6 +94,7 @@ class LoadTestService {
 			return;
 		}
 
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
 		this.metricsBatcher.discard();
 		this.pendingMonitor = [];
 		this.activeRunId = null;
@@ -151,6 +157,7 @@ class LoadTestService {
 
 	private handleError(error: Error): void {
 		console.error("[LoadTestService] SSE error:", error);
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
 		const store = useDashboardStore.getState();
 		store.setError(error.message);
 	}
@@ -159,6 +166,10 @@ class LoadTestService {
 		const runId = this.activeRunId;
 		this.flushPending();
 		this.isConnected = false;
+		// Before the awaited report fetch below: the run is over the moment the
+		// stream closed, and the machine must not stay pinned awake through a
+		// slow fetch.
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
 		const store = useDashboardStore.getState();
 		store.setStreaming(false);
 

--- a/app/src/services/scenario-run-service.test.ts
+++ b/app/src/services/scenario-run-service.test.ts
@@ -45,12 +45,21 @@ vi.mock("@/stores", () => ({
 }));
 vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn() } }));
 vi.mock("./api", () => ({ apiService: { getRunReport: vi.fn() } }));
+const { mockWakeLockHold, mockWakeLockRelease } = vi.hoisted(() => ({
+	mockWakeLockHold: vi.fn(),
+	mockWakeLockRelease: vi.fn(),
+}));
+vi.mock("./wake-lock", () => ({
+	wakeLock: { hold: mockWakeLockHold, release: mockWakeLockRelease },
+	WAKE_LOCK_KEYS: { loadRun: "load-run", collectionRun: "collection-run" },
+}));
 
 import { scenarioRunService } from "./scenario-run-service";
 import { sseClient } from "./sse-client";
 import { apiService } from "./api";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
+import { WAKE_LOCK_KEYS } from "./wake-lock";
 import type { ScenarioStepEvent } from "@/types";
 
 /** The live-refresh cadence these cases run at. */
@@ -257,5 +266,44 @@ describe("ScenarioRunService", () => {
 		// awaits it, and the stream's own teardown is not the report's business.
 		await expect(closeStream()).resolves.toBeUndefined();
 		expect(mockSetStreaming).toHaveBeenCalledWith(false);
+	});
+
+	describe("wake lock (issue #1357)", () => {
+		it("holds the collection-run key on start", () => {
+			scenarioRunService.startMonitoring("run_10");
+			// Pins the `wakeLock.hold(...)` call in `startMonitoring`.
+			expect(mockWakeLockHold).toHaveBeenCalledWith(
+				WAKE_LOCK_KEYS.collectionRun,
+				expect.any(String)
+			);
+		});
+
+		it("releases the collection-run key when the stream closes, before the awaited fetches resolve", async () => {
+			scenarioRunService.startMonitoring("run_11");
+			mockWakeLockRelease.mockClear();
+
+			let releaseCalledBeforeFetch = false;
+			vi.mocked(apiService.getRunReport).mockImplementationOnce(() => {
+				// Reverting the release's position in `handleClose` (moving it after
+				// the `await Promise.all(...)`) leaves this false.
+				releaseCalledBeforeFetch = mockWakeLockRelease.mock.calls.length > 0;
+				return Promise.resolve(
+					storedReport as unknown as Awaited<ReturnType<typeof apiService.getRunReport>>
+				);
+			});
+
+			await closeStream();
+
+			expect(releaseCalledBeforeFetch).toBe(true);
+			expect(mockWakeLockRelease).toHaveBeenCalledWith(WAKE_LOCK_KEYS.collectionRun);
+		});
+
+		it("releases the collection-run key on a stream error", () => {
+			scenarioRunService.startMonitoring("run_12");
+			mockWakeLockRelease.mockClear();
+			failStream("engine gone");
+			// Pins the `wakeLock.release(...)` call in `handleError`.
+			expect(mockWakeLockRelease).toHaveBeenCalledWith(WAKE_LOCK_KEYS.collectionRun);
+		});
 	});
 });

--- a/app/src/services/scenario-run-service.test.ts
+++ b/app/src/services/scenario-run-service.test.ts
@@ -39,9 +39,16 @@ vi.mock("@/stores/scenario-run-store", () => ({
 		}),
 	},
 }));
-// The one thing the service reads from the settings store is the cadence.
+// The service reads the cadence from the settings store, and the user's
+// standing answer on keeping the machine awake (#1357). Off is the default.
+const settings = { keepAwakeDuringRuns: false };
 vi.mock("@/stores", () => ({
-	useClientSettingsStore: { getState: () => ({ liveRefreshMs: FLUSH_MS }) },
+	useClientSettingsStore: {
+		getState: () => ({
+			liveRefreshMs: FLUSH_MS,
+			keepAwakeDuringRuns: settings.keepAwakeDuringRuns,
+		}),
+	},
 }));
 vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn() } }));
 vi.mock("./api", () => ({ apiService: { getRunReport: vi.fn() } }));
@@ -269,9 +276,23 @@ describe("ScenarioRunService", () => {
 	});
 
 	describe("wake lock (issue #1357)", () => {
-		it("holds the collection-run key on start", () => {
+		afterEach(() => {
+			settings.keepAwakeDuringRuns = false;
+		});
+
+		it("holds nothing on start while the preference is off", () => {
+			// A collection run is never prompted about either - it declares no
+			// duration, so nothing can tell a two-second sequence from a long one.
+			// The standing preference is its only route to a lock.
+			scenarioRunService.startMonitoring("run_10a");
+			expect(mockWakeLockHold).not.toHaveBeenCalled();
+		});
+
+		it("holds the collection-run key on start once the preference is on", () => {
+			settings.keepAwakeDuringRuns = true;
 			scenarioRunService.startMonitoring("run_10");
-			// Pins the `wakeLock.hold(...)` call in `startMonitoring`.
+			// Pins the `wakeLock.hold(...)` call in `startMonitoring` and the
+			// condition around it.
 			expect(mockWakeLockHold).toHaveBeenCalledWith(
 				WAKE_LOCK_KEYS.collectionRun,
 				expect.any(String)

--- a/app/src/services/scenario-run-service.ts
+++ b/app/src/services/scenario-run-service.ts
@@ -31,6 +31,7 @@ import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { useScenarioRunStore } from "@/stores/scenario-run-store";
 import { createThrottledBatcher } from "./throttled-batcher";
+import { wakeLock, WAKE_LOCK_KEYS } from "./wake-lock";
 import type { ScenarioStepEvent } from "@/types";
 
 class ScenarioRunService {
@@ -42,6 +43,10 @@ class ScenarioRunService {
 	/** Attach to a scenario run's stream and push its steps into the store. */
 	startMonitoring(runId: string): void {
 		if (this.activeRunId === runId) return;
+
+		// Fire-and-forget: the stream below connects the same tick regardless of
+		// whether the main process has answered yet.
+		wakeLock.hold(WAKE_LOCK_KEYS.collectionRun, "Collection run streaming");
 
 		// Whatever the previous run left buffered belongs to a list the store is
 		// about to clear, so it is dropped rather than flushed into this run's.
@@ -92,6 +97,7 @@ class ScenarioRunService {
 
 	private handleError(error: Error): void {
 		console.error("[ScenarioRunService] SSE error:", error);
+		wakeLock.release(WAKE_LOCK_KEYS.collectionRun);
 		// Before the error, so the steps that did arrive are on screen under the
 		// notice explaining why no more will be. A buffered batch stranded here
 		// would be the run's last steps, silently missing from a list the reader
@@ -115,6 +121,9 @@ class ScenarioRunService {
 		this.stepBatcher.flush();
 		this.discardPending();
 		useScenarioRunStore.getState().setStreaming(false);
+		// Before the awaited fetches below: the run is over the moment the
+		// stream closed, and the machine must not stay pinned awake through them.
+		wakeLock.release(WAKE_LOCK_KEYS.collectionRun);
 		if (!runId) return;
 
 		// Through the cache, not a bare fetch: the run tab reads these exact

--- a/app/src/services/scenario-run-service.ts
+++ b/app/src/services/scenario-run-service.ts
@@ -30,6 +30,7 @@ import { apiService } from "./api";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { useScenarioRunStore } from "@/stores/scenario-run-store";
+import { useClientSettingsStore } from "@/stores";
 import { createThrottledBatcher } from "./throttled-batcher";
 import { wakeLock, WAKE_LOCK_KEYS } from "./wake-lock";
 import type { ScenarioStepEvent } from "@/types";
@@ -44,9 +45,15 @@ class ScenarioRunService {
 	startMonitoring(runId: string): void {
 		if (this.activeRunId === runId) return;
 
+		// Only on the user's standing say-so (#1357), the same read
+		// `LoadTestService` makes. A collection run is never asked about: it
+		// declares no duration, so nothing here can tell a two-second sequence
+		// from a two-hour one, and a prompt on every run would be noise.
 		// Fire-and-forget: the stream below connects the same tick regardless of
 		// whether the main process has answered yet.
-		wakeLock.hold(WAKE_LOCK_KEYS.collectionRun, "Collection run streaming");
+		if (useClientSettingsStore.getState().keepAwakeDuringRuns) {
+			wakeLock.hold(WAKE_LOCK_KEYS.collectionRun, "Collection run streaming");
+		}
 
 		// Whatever the previous run left buffered belongs to a list the store is
 		// about to clear, so it is dropped rather than flushed into this run's.

--- a/app/src/services/wake-lock.test.ts
+++ b/app/src/services/wake-lock.test.ts
@@ -80,10 +80,36 @@ describe("wakeLock", () => {
 		pending.resolve("token-late");
 		await flushMicrotasks();
 
-		// Pins the `state.releasePending` branch in the `.then` handler: without
-		// it the token that arrives after `release()` is stored and never handed
-		// back, leaking the lock for the rest of the session.
+		// Pins the `state.released` branch in the `.then` handler: without it the
+		// token that arrives after `release()` is stored and never handed back,
+		// leaking the lock for the rest of the session.
 		expect(releaseWakeLock).toHaveBeenCalledWith("token-late");
+	});
+
+	it("takes a fresh lock for a run that replaces one still waiting on its token", async () => {
+		const { holdWakeLock, releaseWakeLock } = stubElectron();
+		const first = deferred<string>();
+		holdWakeLock.mockReturnValueOnce(first.promise).mockResolvedValueOnce("token-b");
+
+		// What `LoadTestService.startMonitoring` does when one run replaces
+		// another: `stopMonitoring()` releases and the new run holds, in the same
+		// tick, while the first hold's round trip is still out.
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "run A");
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "run B");
+
+		// Pins `release()` freeing the key before the token arrives. Leave the
+		// released hold under its key and this is 1: run B's hold is swallowed as
+		// a duplicate, run A's token is handed back, and the machine is free to
+		// sleep under a run that believes it is protected.
+		expect(holdWakeLock).toHaveBeenCalledTimes(2);
+
+		first.resolve("token-a");
+		await flushMicrotasks();
+
+		// Run A's late token goes back; run B's stays live.
+		expect(releaseWakeLock).toHaveBeenCalledTimes(1);
+		expect(releaseWakeLock).toHaveBeenCalledWith("token-a");
 	});
 
 	it("swallows a rejected hold, logs it, and leaves the key re-holdable", async () => {

--- a/app/src/services/wake-lock.test.ts
+++ b/app/src/services/wake-lock.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { wakeLock, WAKE_LOCK_KEYS } from "./wake-lock";
+
+/** A deferred promise, so a case can control exactly when `holdWakeLock` answers. */
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (v: T) => void;
+} {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+/** Let every microtask queued so far (the module's own `.then`/`.catch`) run. */
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 5; i += 1) await Promise.resolve();
+}
+
+/** Stub `window.electronAPI` with controllable `holdWakeLock` / `releaseWakeLock` mocks. */
+function stubElectron(): {
+	holdWakeLock: ReturnType<typeof vi.fn>;
+	releaseWakeLock: ReturnType<typeof vi.fn>;
+} {
+	const holdWakeLock = vi.fn();
+	const releaseWakeLock = vi.fn().mockResolvedValue(true);
+	vi.stubGlobal("window", { electronAPI: { holdWakeLock, releaseWakeLock } });
+	return { holdWakeLock, releaseWakeLock };
+}
+
+describe("wakeLock", () => {
+	afterEach(async () => {
+		// Each key is module-level state shared across cases - drain any
+		// in-flight hold and hand it back so the next case starts on a clean key,
+		// regardless of which branch the case under test exercised.
+		await flushMicrotasks();
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
+		await flushMicrotasks();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("takes one lock for two holds on the same key", () => {
+		const { holdWakeLock } = stubElectron();
+		holdWakeLock.mockResolvedValue("token-1");
+
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+		// A second call for the same run (startMonitoring called again) must not
+		// take a second lock while the first is still live. Reverting the
+		// `holds.has(key)` guard in `hold()` makes this 2.
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+
+		expect(holdWakeLock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does nothing and never throws when releasing a key that is not held", () => {
+		stubElectron();
+		// Pins the `if (!state) return;` guard in `release()`.
+		expect(() => wakeLock.release(WAKE_LOCK_KEYS.loadRun)).not.toThrow();
+	});
+
+	it("releases the token once it arrives when release() ran while the hold was still in flight", async () => {
+		const { holdWakeLock, releaseWakeLock } = stubElectron();
+		const pending = deferred<string>();
+		holdWakeLock.mockReturnValue(pending.promise);
+
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+		// The run ended before the main process ever answered.
+		wakeLock.release(WAKE_LOCK_KEYS.loadRun);
+		expect(releaseWakeLock).not.toHaveBeenCalled();
+
+		pending.resolve("token-late");
+		await flushMicrotasks();
+
+		// Pins the `state.releasePending` branch in the `.then` handler: without
+		// it the token that arrives after `release()` is stored and never handed
+		// back, leaking the lock for the rest of the session.
+		expect(releaseWakeLock).toHaveBeenCalledWith("token-late");
+	});
+
+	it("swallows a rejected hold, logs it, and leaves the key re-holdable", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { holdWakeLock } = stubElectron();
+		holdWakeLock.mockRejectedValueOnce(new Error("main refused"));
+
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+		await flushMicrotasks();
+
+		// Pins the `console.warn` call in the `.catch` handler.
+		expect(warn).toHaveBeenCalledTimes(1);
+
+		// Pins `holds.delete(key)` in the `.catch` handler: without it the key
+		// stays in the map forever and this second `hold()` is swallowed as a
+		// duplicate of the failed one.
+		holdWakeLock.mockResolvedValueOnce("token-2");
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+		expect(holdWakeLock).toHaveBeenCalledTimes(2);
+	});
+
+	it("releasing after a rejected hold is still a safe no-op, never wedged", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { holdWakeLock } = stubElectron();
+		holdWakeLock.mockRejectedValueOnce(new Error("main refused"));
+
+		wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason");
+		await flushMicrotasks();
+
+		expect(() => wakeLock.release(WAKE_LOCK_KEYS.loadRun)).not.toThrow();
+	});
+
+	it("is a no-op outside Electron - no window.electronAPI", () => {
+		vi.stubGlobal("window", {});
+		// Pins the `canHold()` guard: without it `hold()` calls into an
+		// `electronAPI` that does not exist and throws.
+		expect(() => wakeLock.hold(WAKE_LOCK_KEYS.loadRun, "reason")).not.toThrow();
+		expect(() => wakeLock.release(WAKE_LOCK_KEYS.loadRun)).not.toThrow();
+	});
+});

--- a/app/src/services/wake-lock.ts
+++ b/app/src/services/wake-lock.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One keyed wake-lock holder, shared by every run service (issue #1357).
+ *
+ * `electron/power-save.ts` (main process) ref-counts holds by token; this is
+ * the renderer side of that contract, kept in one place so a load run and a
+ * collection run each hold under their own key instead of two services
+ * copying the same token bookkeeping - the repo rule against a hand-rolled
+ * copy of a primitive: it never receives the primitive's fixes.
+ *
+ * `hold`/`release` are fire-and-forget by design - neither returns a promise,
+ * because a run's start and stop paths must not await IPC to do work of their
+ * own. The round trip to the main process happens in the background and is
+ * reconciled here, including the case where `release` runs before the
+ * matching `hold` has even heard back.
+ */
+
+/** The two runs that ever hold a lock at once. */
+export const WAKE_LOCK_KEYS = {
+	loadRun: "load-run",
+	collectionRun: "collection-run",
+} as const;
+
+export type WakeLockKey = (typeof WAKE_LOCK_KEYS)[keyof typeof WAKE_LOCK_KEYS];
+
+interface HoldState {
+	/** What `holdWakeLock` resolved with, or `null` while that call is in flight. */
+	token: string | null;
+	/**
+	 * `release()` ran before `token` arrived. Honored the moment the promise
+	 * settles, so a run shorter than the IPC round trip does not leak a lock it
+	 * already asked to drop.
+	 */
+	releasePending: boolean;
+}
+
+const holds = new Map<WakeLockKey, HoldState>();
+
+type Bridge = NonNullable<Window["electronAPI"]>;
+
+/**
+ * The preload bridge, or nothing outside Electron - the same guard the rest of
+ * the renderer uses for an Electron-only method. Resolved once per call and
+ * used from there on, so a key can never be recorded as held against a bridge
+ * that turned out not to exist.
+ */
+function bridge(): Bridge | undefined {
+	if (typeof window === "undefined") return undefined;
+	const api = window.electronAPI;
+	return api?.holdWakeLock ? api : undefined;
+}
+
+function warnFailure(key: WakeLockKey, what: string, error: unknown): void {
+	console.warn(`[wake-lock] ${what} for "${key}" failed`, error);
+}
+
+export const wakeLock = {
+	/**
+	 * Ask the OS to stay awake under `key`. A key that is already held (or
+	 * being acquired) is a no-op - `startMonitoring` can be called again for
+	 * the same run without taking a second lock.
+	 */
+	hold(key: WakeLockKey, reason: string): void {
+		const api = bridge();
+		if (!api) return;
+		if (holds.has(key)) return;
+
+		const state: HoldState = { token: null, releasePending: false };
+		// Recorded before the round trip: a second `hold()` on this key, called
+		// before this one answers, must see it as already in flight.
+		holds.set(key, state);
+
+		api.holdWakeLock(reason)
+			.then((token) => {
+				if (!state.releasePending) {
+					state.token = token;
+					return;
+				}
+				// Released while still in flight - the token is only good for
+				// handing straight back, never for staying live.
+				holds.delete(key);
+				void api
+					.releaseWakeLock(token)
+					.catch((error: unknown) => warnFailure(key, "late release", error));
+			})
+			.catch((error: unknown) => {
+				warnFailure(key, "hold", error);
+				// No token ever arrived, so there is nothing to release later - drop
+				// the entry rather than leaving the key wedged against a lock that
+				// will never come.
+				holds.delete(key);
+			});
+	},
+
+	/** Hand the lock under `key` back. A key that is not held is a no-op. */
+	release(key: WakeLockKey): void {
+		const state = holds.get(key);
+		if (!state) return;
+
+		if (state.token === null) {
+			// Still waiting on `holdWakeLock` - mark it and let the `.then` above
+			// release the token the moment it arrives.
+			state.releasePending = true;
+			return;
+		}
+
+		holds.delete(key);
+		const api = bridge();
+		if (!api) return;
+		void api
+			.releaseWakeLock(state.token)
+			.catch((error: unknown) => warnFailure(key, "release", error));
+	},
+};

--- a/app/src/services/wake-lock.ts
+++ b/app/src/services/wake-lock.ts
@@ -29,15 +29,21 @@ export const WAKE_LOCK_KEYS = {
 
 export type WakeLockKey = (typeof WAKE_LOCK_KEYS)[keyof typeof WAKE_LOCK_KEYS];
 
+/**
+ * One hold, tracked by the object rather than by its key.
+ *
+ * The distinction is load-bearing: `release()` frees the key immediately, so a
+ * hold that is still in flight when its run ends is reconciled through the
+ * object its own round trip closed over. Keeping the released hold under the
+ * key instead would swallow the next `hold()` on that key as a duplicate - and
+ * `LoadTestService.startMonitoring` releases and re-holds in the same tick when
+ * one run replaces another, which is exactly that case.
+ */
 interface HoldState {
 	/** What `holdWakeLock` resolved with, or `null` while that call is in flight. */
 	token: string | null;
-	/**
-	 * `release()` ran before `token` arrived. Honored the moment the promise
-	 * settles, so a run shorter than the IPC round trip does not leak a lock it
-	 * already asked to drop.
-	 */
-	releasePending: boolean;
+	/** The run let go. The token is handed back on arrival if it is not here yet. */
+	released: boolean;
 }
 
 const holds = new Map<WakeLockKey, HoldState>();
@@ -60,6 +66,11 @@ function warnFailure(key: WakeLockKey, what: string, error: unknown): void {
 	console.warn(`[wake-lock] ${what} for "${key}" failed`, error);
 }
 
+/** Hand one token back. A failure here is logged, never thrown at a run. */
+function releaseToken(api: Bridge, key: WakeLockKey, token: string): void {
+	void api.releaseWakeLock(token).catch((error: unknown) => warnFailure(key, "release", error));
+}
+
 export const wakeLock = {
 	/**
 	 * Ask the OS to stay awake under `key`. A key that is already held (or
@@ -71,30 +82,25 @@ export const wakeLock = {
 		if (!api) return;
 		if (holds.has(key)) return;
 
-		const state: HoldState = { token: null, releasePending: false };
+		const state: HoldState = { token: null, released: false };
 		// Recorded before the round trip: a second `hold()` on this key, called
 		// before this one answers, must see it as already in flight.
 		holds.set(key, state);
 
 		api.holdWakeLock(reason)
 			.then((token) => {
-				if (!state.releasePending) {
-					state.token = token;
-					return;
-				}
+				state.token = token;
 				// Released while still in flight - the token is only good for
 				// handing straight back, never for staying live.
-				holds.delete(key);
-				void api
-					.releaseWakeLock(token)
-					.catch((error: unknown) => warnFailure(key, "late release", error));
+				if (state.released) releaseToken(api, key, token);
 			})
 			.catch((error: unknown) => {
 				warnFailure(key, "hold", error);
 				// No token ever arrived, so there is nothing to release later - drop
 				// the entry rather than leaving the key wedged against a lock that
-				// will never come.
-				holds.delete(key);
+				// will never come. Only if it is still this hold's: a `release` and a
+				// fresh `hold` may already have replaced it.
+				if (holds.get(key) === state) holds.delete(key);
 			});
 	},
 
@@ -103,18 +109,13 @@ export const wakeLock = {
 		const state = holds.get(key);
 		if (!state) return;
 
-		if (state.token === null) {
-			// Still waiting on `holdWakeLock` - mark it and let the `.then` above
-			// release the token the moment it arrives.
-			state.releasePending = true;
-			return;
-		}
-
+		// Free the key first, whatever stage the hold is at, so the next run can
+		// take a lock of its own in this same tick.
 		holds.delete(key);
+		state.released = true;
+		if (state.token === null) return;
+
 		const api = bridge();
-		if (!api) return;
-		void api
-			.releaseWakeLock(state.token)
-			.catch((error: unknown) => warnFailure(key, "release", error));
+		if (api) releaseToken(api, key, state.token);
 	},
 };

--- a/app/src/stores/client-settings-store.ts
+++ b/app/src/stores/client-settings-store.ts
@@ -70,6 +70,16 @@ interface ClientSettingsState {
 	liveRefreshMs: number;
 	autoSave: AutoSavePrefs;
 	reducedMotion: boolean;
+	/**
+	 * Standing answer to "should a run keep this machine awake" (issue #1357).
+	 *
+	 * Off by default: overriding the user's power settings is theirs to opt into,
+	 * and a run shorter than any sleep timer never needed it. With it off, a run
+	 * long enough to be walked away from asks once - see `KeepAwakePrompt`, which
+	 * is also what turns this on when the user answers "always". Read when a run
+	 * starts, so flipping it does not reach a run already streaming.
+	 */
+	keepAwakeDuringRuns: boolean;
 	/** Toast position, duration scale, stack cap and severity floor. */
 	notifications: NotificationPrefs;
 	/** Upper bounds the load-test dialog offers. Read via `resolveLoadTestLimits`. */
@@ -84,6 +94,7 @@ interface ClientSettingsState {
 	setAutoSave: (patch: Partial<AutoSavePrefs>) => void;
 	setNotifications: (patch: Partial<NotificationPrefs>) => void;
 	setReducedMotion: (on: boolean) => void;
+	setKeepAwakeDuringRuns: (on: boolean) => void;
 	/** Patch one or more ceilings; each is clamped to what the engine accepts. */
 	setLoadTestCeilings: (patch: Partial<LoadTestCeilings>) => void;
 	/** Clear every renderer preference and reload so defaults re-apply cleanly. */
@@ -179,6 +190,7 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 			liveRefreshMs: DEFAULT_LIVE_REFRESH_MS,
 			autoSave: { ...DEFAULT_AUTO_SAVE_PREFS },
 			reducedMotion: false,
+			keepAwakeDuringRuns: false,
 			notifications: { ...DEFAULT_NOTIFICATION_PREFS },
 			loadTestCeilings: { ...DEFAULT_LOAD_TEST_CEILINGS },
 
@@ -201,6 +213,7 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 				applyReducedMotion(on);
 				set({ reducedMotion: on });
 			},
+			setKeepAwakeDuringRuns: (on) => set({ keepAwakeDuringRuns: on }),
 			// Clamped on the way in, not only on the way out: the dialog reads
 			// this to build its own ranges, so an out-of-range ceiling stored
 			// here would present the user a value the engine rejects.
@@ -230,6 +243,7 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 				liveRefreshMs: s.liveRefreshMs,
 				autoSave: s.autoSave,
 				reducedMotion: s.reducedMotion,
+				keepAwakeDuringRuns: s.keepAwakeDuringRuns,
 				notifications: s.notifications,
 				loadTestCeilings: s.loadTestCeilings,
 			}),

--- a/app/src/stores/host-sleep-store.test.ts
+++ b/app/src/stores/host-sleep-store.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The per-run sleep record (issue #1357): ordering and the two eviction
+ * bounds, the selector's stable identity (what keeps the dashboard from
+ * re-rendering on every tick), and rehydration - including the version bump
+ * and the malformed-payload cases a hand-edited or half-written localStorage
+ * entry can produce.
+ *
+ * Follows `persist-migrations.test.ts`'s idiom: rehydrate through
+ * `persist.rehydrate()`, never by calling `migrate` directly, so these cases
+ * cover the seam zustand actually exercises.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+	useHostSleepStore,
+	useHostSleeps,
+	MAX_RUNS,
+	MAX_SLEEPS_PER_RUN,
+	type HostSleep,
+} from "./host-sleep-store";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
+
+function mkSleep(startSeconds: number, durationMs = 60_000, at = startSeconds * 1000): HostSleep {
+	return { at, durationMs, startSeconds };
+}
+
+const seed = (payload: unknown) =>
+	localStorage.setItem(STORAGE_KEYS.HOST_SLEEP_STORE, JSON.stringify(payload));
+
+beforeEach(() => {
+	localStorage.clear();
+	useHostSleepStore.setState({ byRun: {}, runOrder: [] });
+});
+
+afterEach(() => {
+	localStorage.clear();
+	useHostSleepStore.setState({ byRun: {}, runOrder: [] });
+});
+
+describe("recordSleep", () => {
+	it("appends in order for one run and keeps runs apart", () => {
+		const s1 = mkSleep(10);
+		const s2 = mkSleep(40);
+		useHostSleepStore.getState().recordSleep("run1", s1);
+		useHostSleepStore.getState().recordSleep("run1", s2);
+		useHostSleepStore.getState().recordSleep("run2", mkSleep(5));
+
+		const state = useHostSleepStore.getState();
+		expect(state.byRun.run1).toEqual([s1, s2]);
+		expect(state.byRun.run2).toHaveLength(1);
+	});
+
+	it("caps a run's intervals at MAX_SLEEPS_PER_RUN, keeping the newest", () => {
+		// Mutation check: drop the `.slice(-MAX_SLEEPS_PER_RUN)` in recordSleep and
+		// this fails - the array grows past the cap instead of staying at it.
+		for (let i = 0; i < MAX_SLEEPS_PER_RUN + 5; i++) {
+			useHostSleepStore.getState().recordSleep("run1", mkSleep(i));
+		}
+
+		const sleeps = useHostSleepStore.getState().byRun.run1;
+		expect(sleeps).toHaveLength(MAX_SLEEPS_PER_RUN);
+		// The oldest 5 (startSeconds 0..4) were dropped; the newest MAX_SLEEPS_PER_RUN survive.
+		expect(sleeps[0].startSeconds).toBe(5);
+		expect(sleeps[sleeps.length - 1].startSeconds).toBe(MAX_SLEEPS_PER_RUN + 4);
+	});
+
+	it("evicts the oldest run past MAX_RUNS, keeping the newest runs", () => {
+		for (let i = 0; i < MAX_RUNS + 2; i++) {
+			useHostSleepStore.getState().recordSleep(`run_${i}`, mkSleep(i));
+		}
+
+		const state = useHostSleepStore.getState();
+		expect(state.runOrder).toHaveLength(MAX_RUNS);
+		// run_0 and run_1 were the oldest two, first-annotated - evicted first.
+		expect(state.byRun.run_0).toBeUndefined();
+		expect(state.byRun.run_1).toBeUndefined();
+		expect(state.runOrder[0]).toBe("run_2");
+		expect(state.byRun.run_2).toBeDefined();
+		expect(state.byRun[`run_${MAX_RUNS + 1}`]).toBeDefined();
+	});
+});
+
+describe("useHostSleeps identity", () => {
+	it("returns the same array reference across renders when the run is unchanged", () => {
+		useHostSleepStore.getState().recordSleep("run_a", mkSleep(1));
+		const { result, rerender } = renderHook(
+			({ runId }: { runId: string }) => useHostSleeps(runId),
+			{
+				initialProps: { runId: "run_a" },
+			}
+		);
+		const first = result.current;
+
+		// An unrelated run changes; run_a's own array must not be replaced.
+		useHostSleepStore.getState().recordSleep("run_b", mkSleep(2));
+		rerender({ runId: "run_a" });
+
+		expect(result.current).toBe(first);
+	});
+
+	it("returns a new reference once the run itself gains a sleep", () => {
+		const { result, rerender } = renderHook(
+			({ runId }: { runId: string }) => useHostSleeps(runId),
+			{
+				initialProps: { runId: "run_c" },
+			}
+		);
+		const before = result.current;
+
+		useHostSleepStore.getState().recordSleep("run_c", mkSleep(3));
+		rerender({ runId: "run_c" });
+
+		expect(result.current).not.toBe(before);
+	});
+
+	it("returns the same stable empty array for an unknown run id, and for null/undefined", () => {
+		// This is what keeps a component with no sleeps yet from re-rendering the
+		// dashboard on every tick - assert identity, not just equal contents.
+		const unknown = renderHook(() => useHostSleeps("no-such-run"));
+		const nullId = renderHook(() => useHostSleeps(null));
+		const undefinedId = renderHook(() => useHostSleeps(undefined));
+
+		expect(unknown.result.current).toEqual([]);
+		expect(unknown.result.current).toBe(nullId.result.current);
+		expect(nullId.result.current).toBe(undefinedId.result.current);
+	});
+});
+
+describe("rehydration", () => {
+	it("carries a well-formed payload across the version bump", async () => {
+		seed({
+			version: 0,
+			state: {
+				byRun: { run1: [{ at: 1000, durationMs: 5000, startSeconds: 10 }] },
+				runOrder: ["run1"],
+			},
+		});
+
+		await useHostSleepStore.persist.rehydrate();
+
+		const state = useHostSleepStore.getState();
+		expect(state.byRun.run1).toEqual([{ at: 1000, durationMs: 5000, startSeconds: 10 }]);
+		expect(state.runOrder).toEqual(["run1"]);
+	});
+
+	it("degrades to no annotations when byRun is not an object", async () => {
+		seed({ version: 0, state: { byRun: "nope", runOrder: ["run1"] } });
+
+		await useHostSleepStore.persist.rehydrate();
+
+		const state = useHostSleepStore.getState();
+		expect(state.byRun).toEqual({});
+		expect(state.runOrder).toEqual([]);
+	});
+
+	it("drops a run whose entries are not an array, rather than handing one to a reader", async () => {
+		seed({ version: 0, state: { byRun: { run1: "nope" }, runOrder: ["run1"] } });
+
+		await useHostSleepStore.persist.rehydrate();
+
+		const state = useHostSleepStore.getState();
+		expect(state.byRun.run1).toBeUndefined();
+		expect(state.runOrder).toEqual([]);
+	});
+
+	it("drops sleeps with non-finite numbers, rather than handing one to a reader", async () => {
+		seed({
+			version: 0,
+			state: {
+				byRun: {
+					run1: [
+						{ at: Number.NaN, durationMs: 5000, startSeconds: 10 },
+						{ at: 1000, durationMs: Number.POSITIVE_INFINITY, startSeconds: 10 },
+						{ at: 1000, durationMs: 5000, startSeconds: "ten" },
+					],
+				},
+				runOrder: ["run1"],
+			},
+		});
+
+		await useHostSleepStore.persist.rehydrate();
+
+		const state = useHostSleepStore.getState();
+		// Every entry was malformed, so the run has nothing worth keeping.
+		expect(state.byRun.run1).toBeUndefined();
+		expect(state.runOrder).toEqual([]);
+	});
+
+	it("repairs a payload missing runOrder from byRun, keeping the runs", async () => {
+		seed({
+			version: 0,
+			state: {
+				byRun: { run1: [{ at: 1, durationMs: 2, startSeconds: 3 }] },
+				// runOrder omitted entirely.
+			},
+		});
+
+		await useHostSleepStore.persist.rehydrate();
+
+		const state = useHostSleepStore.getState();
+		expect(state.runOrder).toEqual(["run1"]);
+		expect(state.byRun.run1).toHaveLength(1);
+	});
+});

--- a/app/src/stores/host-sleep-store.ts
+++ b/app/src/stores/host-sleep-store.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Host Sleep Store - when the machine slept under a run, per run (issue #1357).
+ *
+ * The wake lock the app holds during a run is a request to the OS, not a
+ * guarantee: a closed lid, a critical battery or a user who forces sleep
+ * overrides it. The run's series then has a stretch it cannot explain, and a
+ * reader with no marker reads it as the server's fault.
+ *
+ * The engine's run report has no field for a client-side annotation - the
+ * engine was suspended too and knows nothing about it - so the record lives
+ * here, beside the report rather than inside it, keyed by run id. Two readers:
+ * the live dashboard marks it on the charts, and History's Events tab states it
+ * in words for the same run later.
+ *
+ * Persisted, because the gap outlives the session that produced it: a user who
+ * finds the hole tomorrow needs the same answer. Bounded on both axes - the
+ * newest {@link MAX_RUNS} runs, {@link MAX_SLEEPS_PER_RUN} intervals each -
+ * because localStorage is a fixed budget shared with the workspace, and a run
+ * nobody has open is not worth a byte of it.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
+
+/** One interval the host spent asleep while a run was streaming. */
+export interface HostSleep {
+	/** Wall clock ms at the suspend - the only clock that ran through it. */
+	at: number;
+	/** How long the host was down. This is the number a reader needs. */
+	durationMs: number;
+	/**
+	 * Elapsed seconds into the run at the last tick before the suspend, which is
+	 * where the marker sits on the charts.
+	 *
+	 * Deliberately not paired with an end: whether the engine's elapsed clock
+	 * advanced through the suspend is a per-platform answer (a monotonic clock
+	 * stops on Linux and macOS; a boot-time clock does not), so a band drawn
+	 * `durationMs` wide would be a claim about the series that may be fiction.
+	 * The marker says where, the duration says how long.
+	 */
+	startSeconds: number;
+}
+
+/** Runs kept. Older runs' annotations are evicted oldest-first. */
+export const MAX_RUNS = 20;
+
+/** Intervals kept per run - a laptop lid opened and closed all afternoon. */
+export const MAX_SLEEPS_PER_RUN = 20;
+
+interface HostSleepState {
+	/** Sleeps by run id, oldest interval first within a run. */
+	byRun: Record<string, HostSleep[]>;
+	/** Run ids in the order they were first annotated, oldest first. */
+	runOrder: string[];
+	recordSleep: (runId: string, sleep: HostSleep) => void;
+}
+
+/** One frozen empty array, so a run with no sleeps is a stable selector result. */
+const NONE: readonly HostSleep[] = Object.freeze([]);
+
+interface PersistedHostSleeps {
+	byRun: Record<string, HostSleep[]>;
+	runOrder: string[];
+}
+
+function isSleep(value: unknown): value is HostSleep {
+	const sleep = value as Partial<HostSleep> | null;
+	if (!sleep || typeof sleep !== "object") return false;
+	return (
+		Number.isFinite(sleep.at) &&
+		Number.isFinite(sleep.durationMs) &&
+		Number.isFinite(sleep.startSeconds)
+	);
+}
+
+/**
+ * Normalize a persisted payload.
+ *
+ * Wired as both `migrate` and `merge`, as `recovery-notice-store` is and for
+ * the same reason: `migrate` only runs on a version change, `merge` runs on
+ * every rehydrate. A hand-edited or half-written entry must not put a
+ * non-array where a reader maps over one.
+ */
+function normalizeHostSleeps(persisted: unknown): PersistedHostSleeps {
+	const stored = (persisted ?? {}) as Partial<PersistedHostSleeps>;
+	const rawRuns = stored.byRun;
+	if (!rawRuns || typeof rawRuns !== "object") return { byRun: {}, runOrder: [] };
+
+	const byRun: Record<string, HostSleep[]> = {};
+	for (const [runId, sleeps] of Object.entries(rawRuns)) {
+		if (!Array.isArray(sleeps)) continue;
+		const kept = sleeps.filter(isSleep).slice(-MAX_SLEEPS_PER_RUN);
+		if (kept.length > 0) byRun[runId] = kept;
+	}
+
+	// Order is a cache-eviction detail, so a payload that lost it is repaired
+	// from the runs themselves rather than thrown away with them.
+	const stampedOrder = Array.isArray(stored.runOrder) ? stored.runOrder : [];
+	const runOrder = stampedOrder.filter((id) => typeof id === "string" && id in byRun);
+	for (const runId of Object.keys(byRun)) {
+		if (!runOrder.includes(runId)) runOrder.push(runId);
+	}
+	return { byRun, runOrder };
+}
+
+export const useHostSleepStore = create<HostSleepState>()(
+	persist(
+		(set) => ({
+			byRun: {},
+			runOrder: [],
+
+			recordSleep: (runId, sleep) =>
+				set((state) => {
+					const existing = state.byRun[runId] ?? [];
+					const byRun = {
+						...state.byRun,
+						[runId]: [...existing, sleep].slice(-MAX_SLEEPS_PER_RUN),
+					};
+					const runOrder = state.runOrder.includes(runId)
+						? state.runOrder
+						: [...state.runOrder, runId];
+					if (runOrder.length <= MAX_RUNS) return { byRun, runOrder };
+
+					const evicted = runOrder.slice(0, runOrder.length - MAX_RUNS);
+					for (const old of evicted) delete byRun[old];
+					return { byRun, runOrder: runOrder.slice(evicted.length) };
+				}),
+		}),
+		{
+			name: STORAGE_KEYS.HOST_SLEEP_STORE,
+			version: 1,
+			partialize: (state) => ({ byRun: state.byRun, runOrder: state.runOrder }),
+			migrate: normalizeHostSleeps,
+			merge: (persisted, current) => ({ ...current, ...normalizeHostSleeps(persisted) }),
+		}
+	)
+);
+
+/**
+ * The sleeps recorded against one run, for a component that has its id.
+ *
+ * A selector rather than a prop drilled from the view that owns the run: both
+ * readers (the live dashboard, History's detail) already hold the run id, and
+ * neither derives anything from the list that the other would have to match.
+ */
+export function useHostSleeps(runId: string | null | undefined): readonly HostSleep[] {
+	return useHostSleepStore((state) => (runId ? (state.byRun[runId] ?? NONE) : NONE));
+}

--- a/app/src/types/electron.d.ts
+++ b/app/src/types/electron.d.ts
@@ -24,6 +24,22 @@ interface ThemeInfo {
 	themeSource: ThemeSource;
 }
 
+/**
+ * The host went to sleep under a running test, and came back. Mirrors
+ * `HostSuspendedEvent` / `HostResumedEvent` in `electron/power-save.ts`; the two
+ * are separated only by the process boundary. Wall-clock milliseconds, because
+ * the gap is the thing being reported and the engine's own clock is exactly
+ * what the suspend stopped.
+ */
+interface HostSuspendedEvent {
+	at: number;
+}
+
+interface HostResumedEvent {
+	at: number;
+	durationMs: number;
+}
+
 type UpdateStrategy = "silent" | "notify" | "disabled";
 
 interface UpdateAvailableInfo {
@@ -173,6 +189,28 @@ interface ElectronAPI {
 	 * caller may be as eager as it likes.
 	 */
 	refreshSystemProxy: () => Promise<string | null>;
+
+	/**
+	 * System wake lock, held while a run streams (issue #1357). Resolves to the
+	 * token that releases this hold; `releaseWakeLock` answers `false` for a
+	 * token that was never live or has already been handed back, which is what
+	 * makes a double release safe. Mirrors `power-save.ts` in the main process,
+	 * which ref-counts the holds and drops a renderer's own when it goes away.
+	 *
+	 * Renderer callers go through `@/services/wake-lock` rather than these
+	 * directly: one holder per run, and the token bookkeeping in one place.
+	 */
+	holdWakeLock: (reason: string) => Promise<string>;
+	releaseWakeLock: (token: string) => Promise<boolean>;
+
+	/**
+	 * The host suspended and resumed anyway, while a run held the lock. The lock
+	 * is a request to the OS, not a guarantee - a closed lid or a critical
+	 * battery overrides it - so a run's series can still have a gap, and these
+	 * are what let the app say how long it was instead of leaving a hole.
+	 */
+	onHostSuspended: (callback: (event: HostSuspendedEvent) => void) => () => void;
+	onHostResumed: (callback: (event: HostResumedEvent) => void) => () => void;
 
 	// Before quit flush handler
 	onBeforeQuit: (callback: () => void | Promise<void>) => () => void;

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -24,6 +24,7 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
 │   └── EnvPill + WindowControls (Linux only; Windows native overlay; macOS traffic lights)
 ├── <RecoveryBanner />                   // components/shared/RecoveryBanner.tsx - only when the engine restored or deleted the database
 ├── <UpdateBanner />
+├── <KeepAwakePrompt />                  // components/shared/KeepAwakePrompt.tsx - asks once about a run long enough for the machine to sleep under it (#1357)
 └── <Shell />                            // components/layout/Shell.tsx - tab-centric layout with drawer + context bar
     ├── <ImportModal />                  // modules/collections/ImportModal.tsx - global overlay, open-state in a store
     ├── <CommandPalette />               // modules/palette/ - ⌘K overlay; open-state in layout-store
@@ -390,8 +391,13 @@ Connects to the engine SSE metrics stream (`/runs/:runId/live`, via the load-tes
 
 The dashboard is **mode-adaptive**: a `useMode()` discriminator maps the run config to one of `constant_rps` / `constant_concurrency` / `iterations` / `ramp_up`, and the hero row + stat row + charts render the surfaces appropriate to that mode. `MetricsView` is a thin orchestrator over a modular tree:
 
-While a run streams the app holds a system wake lock, so the OS does not
-suspend the machine under a test the user walked away from (issue #1357). The
+While a run streams the app can hold a system wake lock, so the OS does not
+suspend the machine under a test the user walked away from (issue #1357). It is
+off by default and turned on either standing (Settings > Load testing) or per
+run: a load run of five minutes or more asks once as it starts, through
+`components/shared/KeepAwakePrompt.tsx`, which is mounted at the app root
+because the question is about whichever run is streaming rather than about the
+surface that started it. The
 lock is a request, not a guarantee - a closed lid overrides it - so a suspend
 that happens anyway is marked on the time-series charts at the point the run
 reached, labelled with how long the machine was gone. The record is the app's

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -390,6 +390,14 @@ Connects to the engine SSE metrics stream (`/runs/:runId/live`, via the load-tes
 
 The dashboard is **mode-adaptive**: a `useMode()` discriminator maps the run config to one of `constant_rps` / `constant_concurrency` / `iterations` / `ramp_up`, and the hero row + stat row + charts render the surfaces appropriate to that mode. `MetricsView` is a thin orchestrator over a modular tree:
 
+While a run streams the app holds a system wake lock, so the OS does not
+suspend the machine under a test the user walked away from (issue #1357). The
+lock is a request, not a guarantee - a closed lid overrides it - so a suspend
+that happens anyway is marked on the time-series charts at the point the run
+reached, labelled with how long the machine was gone. The record is the app's
+own (`stores/host-sleep-store.ts`, keyed by run id): the engine was suspended
+too and its report has no field for it.
+
 **Top-level (`components/`)**
 
 | Component | Role |
@@ -511,7 +519,7 @@ The picker is told **which run it is for** (`loadTest`), because a row means som
 | Component | Role |
 |---|---|
 | `OverviewTab.tsx` | Summary - renders the dashboard's mode-adaptive `HeroRow` + `ModeStatsRow`; the Rate-Control card is gated to `constant_rps`; also the shared `ThresholdVerdict`, `ContractCoverage`, `SampledSchemaValidation` and `TestValidationSummary` (the last carrying the run's named `pm.test` failures) |
-| `RunEvents.tsx` | The run's detected anomaly windows in words (`detectAnomalies`); silent for a clean run |
+| `RunEvents.tsx` | The run's detected anomaly windows in words (`detectAnomalies`), plus any stretch the host spent asleep under the run (`stores/host-sleep-store.ts`, issue #1357); silent for a clean run that the machine stayed awake for |
 | `PerformanceTab.tsx` | Latency/throughput detail |
 | `SamplesTab.tsx`, `SampleRequestCard.tsx` | Sampled request/response pairs; the synthetic test-validation row (`test-validation.ts`) is dropped here so it is never drawn as a request with no response |
 | `ScenarioStepsTab.tsx` | Per-step latency and counts for a **scenario load run** - see below |

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -320,6 +320,7 @@ The preload script (`electron/preload.ts`) exposes a minimal, context-isolated A
 - **Navigation History**: `onNavigateHistory()` delivers a `menu:navigate` step, sent by the View menu's Back/Forward items, the mouse's back/forward buttons where the OS reports them as `app-command`, and the macOS three-finger swipe (issue #1245)
 - **Platform & Paths**: `platform` constant and `getAppPaths()` for OS and directory detection
 - **Graceful Shutdown**: `onBeforeQuit()` to allow the renderer to flush state (saves, pending requests) before app termination
+- **Wake Lock**: `holdWakeLock(reason)` / `releaseWakeLock(token)` keep the machine from suspending under a streaming run (issue #1357). Ref-counted in `electron/power-save.ts`; the renderer side is `services/wake-lock.ts`, one keyed holder both run services call. `onHostSuspended()` / `onHostResumed()` report a sleep the lock could not prevent, which `useHostSleepRecorder` records against the run
 
 ## Security Considerations
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -732,6 +732,7 @@ Central home for renderer-only preferences that aren't part of the pre-paint app
   liveRefreshMs: number          // how often live metrics commit into the store
   autoSave: AutoSavePrefs        // { enabled, delayMs }
   reducedMotion: boolean         // mirrored onto <html data-reduced-motion>
+  keepAwakeDuringRuns: boolean   // standing answer on the run wake lock; default off
   notifications: NotificationPrefs  // position, durationScale, maxVisible, minSeverity
   loadTestCeilings: LoadTestCeilings
 }
@@ -745,6 +746,14 @@ import { SETTINGS_STORAGE_KEYS } from "@/stores";  // localStorage keys reset by
 `data-reduced-motion`), so their setters and `onRehydrateStorage` both apply
 them - a preference that only lands on the next reload reads as a broken
 setting.
+
+`keepAwakeDuringRuns` is the user's standing answer to whether a run may ask the
+OS to stay awake (issue #1357). It is **read when a run starts** rather than
+watched, by `LoadTestService` and `ScenarioRunService`, so the answer that
+governs a run is the one that was true when it began - flipping the row mid-run
+does not reach a stream already going. Off is the shipped default: with it off a
+load run of five minutes or more asks once (`KeepAwakePrompt`), and that grant
+takes the same wake-lock key the service releases, so it ends with the run.
 
 `loadTestCeilings` is the one slice with a bound outside the app: each value is clamped to `LOAD_TEST_CEILING_BOUNDS` (`constants/load-test.ts`) on write **and** on rehydrate, because the bounds are the engine's crash guards and a build that tightens one must not keep offering a stored ceiling above it. The load dialog turns them into its field ranges via `resolveLoadTestLimits`; nothing else reads them.
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -827,6 +827,40 @@ the dashboard then shows no active test while one streams.
 
 **Non-persisted** (fresh per session).
 
+#### `host-sleep-store.ts` - When The Machine Slept Under A Run
+
+The intervals the host spent asleep while a run was streaming (issue #1357),
+keyed by run id. The app holds a system wake lock for the length of a run, but
+that lock is a request to the OS: a closed lid or a critical battery overrides
+it, and the run's series is then missing a stretch that nothing in it explains.
+
+The record lives here rather than in the run report because the engine was
+suspended too and knows nothing about it. `useHostSleepRecorder` writes it -
+the main process's `power:suspended` carries the anchor (where the run had got
+to, read off `dashboard-store` on the way down, since the renderer is frozen in
+between) and `power:resumed` carries the duration.
+
+**State:**
+
+```typescript
+{
+  byRun: Record<string, HostSleep[]>  // { at, durationMs, startSeconds }, oldest first
+  runOrder: string[]                  // first-annotated order, for eviction
+}
+```
+
+Two readers, both by run id through the `useHostSleeps(runId)` selector rather
+than one prop drilled to both: `MetricsView` and `PerformanceTab` mark the
+sleeps on the charts, `OverviewTab` states them in `RunEvents`. The selector
+returns one frozen empty array for a run with no sleeps, so a dashboard
+rendering at 10 Hz is not re-rendered by a stable absence.
+
+**Persisted**, bounded to the newest `MAX_RUNS` (20) runs and
+`MAX_SLEEPS_PER_RUN` (20) intervals each: the gap outlives the session that
+produced it, and a user who finds the hole tomorrow needs the same answer, but
+localStorage is a fixed budget shared with the workspace. `migrate` and `merge`
+both normalize, as `recovery-notice-store` does and for the same reason.
+
 #### `scenario-run-store.ts` - Live Collection-Run Steps
 
 The live half of a scenario (collection) run's tab. `ScenarioRunService` pushes the `step` SSE events in here and `ScenarioRunView` reads them, so the stream survives navigating away from the tab and back - the same split, for the same reason, as `LoadTestService` and `dashboard-store`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,14 +148,23 @@ Manager                              Engine
    │◄───────────────────────────────────┤
 ```
 
-For the length of that stream - a load run or a collection run - the Manager
-holds a system wake lock (`electron/power-save.ts`, `prevent-app-suspension`),
-so an OS sleep timer cannot suspend the machine under a test the user walked
-away from and leave the report with a gap it cannot explain. The lock is
-ref-counted and token-based: the renderer's run services take one each over
-`power:hold` and hand it back on every terminal path, the main process drops a
-renderer's holds when it goes away or reloads, and the blocker stops with the
-last holder. The screen may still dim and lock; only suspension is refused.
+For the length of that stream - a load run or a collection run - the Manager can
+hold a system wake lock (`electron/power-save.ts`, `prevent-app-suspension`), so
+an OS sleep timer cannot suspend the machine under a test the user walked away
+from and leave the report with a gap it cannot explain. The lock is ref-counted
+and token-based: the renderer's run services take one each over `power:hold` and
+hand it back on every terminal path, the main process drops a renderer's holds
+when it goes away or reloads, and the blocker stops with the last holder. The
+screen may still dim and lock; only suspension is refused.
+
+**It is off by default, because the machine's power settings are the user's.**
+Two things turn it on. The standing preference (Settings > Load testing > Keep
+the machine awake during runs, `keepAwakeDuringRuns` in `client-settings-store`)
+is read when a run starts, and with it on every run holds. With it off, a load
+run that declares five minutes or more asks once when it starts
+(`KeepAwakePrompt`), and an answer of "keep awake" takes the lock for that run
+only. A collection run is never asked about: it declares no duration, so nothing
+in the app can tell a two-second sequence from a two-hour one.
 
 The lock is a request to the OS, not a guarantee. When the host suspends anyway
 (a closed lid, a critical battery), main reports the interval to the renderer as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,21 @@ Manager                              Engine
    │◄───────────────────────────────────┤
 ```
 
+For the length of that stream - a load run or a collection run - the Manager
+holds a system wake lock (`electron/power-save.ts`, `prevent-app-suspension`),
+so an OS sleep timer cannot suspend the machine under a test the user walked
+away from and leave the report with a gap it cannot explain. The lock is
+ref-counted and token-based: the renderer's run services take one each over
+`power:hold` and hand it back on every terminal path, the main process drops a
+renderer's holds when it goes away or reloads, and the blocker stops with the
+last holder. The screen may still dim and lock; only suspension is refused.
+
+The lock is a request to the OS, not a guarantee. When the host suspends anyway
+(a closed lid, a critical battery), main reports the interval to the renderer as
+`power:suspended` / `power:resumed`, and the app records it against the run and
+marks it on the charts and in the run's Events tab. The engine cannot carry that
+record: it was suspended too.
+
 See [Engine API Reference](engine/api-reference.md) for complete endpoint documentation.
 
 ## Sidecar Pattern


### PR DESCRIPTION
## Description

Nothing in the app asked the OS to stay awake, so a thirty-minute load run on a
laptop with a ten-minute sleep timer suspends mid-run: the engine stops with the
host, and the report comes back with a flat stretch or a cluster of timeouts
that reads as the server's fault.

**Root cause and approach.** The missing piece is a signal, not a setting: the
run lifecycle lives entirely in the renderer, which never told the main process
a run was under way, and the main process owns the only `powerSaveBlocker`
there is. So this adds an IPC pair - `power:hold(reason)` returning a token,
`power:release(token)` - ref-counted in `electron/power-save.ts`, held by the
two services that own a stream and released on every terminal path. Because the
lock is a request to the OS rather than a guarantee, main also reports a
suspend that happened anyway (`power:suspended` / `power:resumed`), and the app
records it against the run and marks it. The alternative - one blocker started
at the first run and never released - was rejected: it pins the machine awake
for the rest of the session, which is worse than the bug.

**The lock is off by default and the user turns it on.** A machine that refuses
to sleep is the user's battery, so the app does not decide that for them:

- **Standing:** Settings > Load testing > "Keep the machine awake during runs"
  (`keepAwakeDuringRuns`, default off). Both run services read it when a run
  starts, so the answer that governs a run is the one that was true when it
  began - a preference flipped mid-run does not reach a stream already going,
  and the row says so.
- **Per run:** with the setting off, a load run that declares **five minutes or
  more** asks once as it starts (`KeepAwakePrompt`, mounted at the app root
  because the question is about whichever run is streaming, not about which of
  the three surfaces started it). "Keep awake" takes the lock for that run alone,
  under the same key the service releases, so the grant ends with the run.
  Five minutes because it is under the shortest sleep timer a laptop ships with.

A run that declares no length (an iterations run) is never asked about rather
than guessed at, and neither is a collection run: it carries no duration, so
nothing in the app can tell a two-second sequence from a two-hour one, and
asking every time would train the user to dismiss the question. Its only route
to a lock is the standing preference.

**Deliberate deviations from the issue text**, each for a reason:

- The issue specifies an unconditional hold. It is opt-in instead, per the
  discussion on this PR: same mechanism, the user's decision.
- The chart mark for a sleep is an **instant, not a `durationMs`-wide band**.
  Whether the engine's elapsed clock advanced through a suspend is a
  per-platform answer (a monotonic clock stops on Linux and macOS, a boot-time
  clock does not), so a band drawn that wide would be a claim about the series
  that may be fiction. The mark says where the machine went down; the label and
  the Events row say for how long. Pinned by a test.
- Preload grows **two events, not one**: a suspend and a resume carry different
  payloads, and both are read - the suspend is the last moment the renderer can
  read where the run had got to (it is frozen in between), the resume is the
  only thing that knows the duration.
- The app-side record is a small persisted store (`stores/host-sleep-store.ts`,
  the issue's own "store it in the app's run metadata beside the report"),
  bounded to the newest 20 runs and 20 intervals each. The engine cannot carry
  it: it was suspended too.

## Type of Change
- [x] New feature

## Testing

All green locally on the branch head:

- `pnpm test` - **636 files, 7233 tests passed** (0 failed), including 9 new
  files: `electron/power-save.test.ts` (17), `src/services/wake-lock.test.ts`
  (7), `src/components/shared/KeepAwakePrompt.test.tsx` (8),
  `src/modules/dashboard/utils/keepAwake.test.ts` (12),
  `src/stores/host-sleep-store.test.ts`, `src/hooks/useHostSleepRecorder.test.tsx`,
  `src/modules/dashboard/utils/hostSleep.test.ts`,
  `src/modules/dashboard/components/charts/uplot/annotations.test.ts`,
  `src/modules/history/main/components/RunEvents.test.tsx`, plus new cases in
  `load-test-service.test.ts` and `scenario-run-service.test.ts` that pin both
  branches of the preference. The existing `monitor-flush` tests still pass.
- `pnpm type-check` (all three projects: renderer, electron, electron tests) - clean
- `pnpm lint` - clean, 0 warnings
- `pnpm format:check` - clean
- No pre-existing failures were observed on the base commit.

Three behaviours were mutation-checked by actually reverting the code and
watching the case fail: the wake-lock key being freed on `release()` rather than
on the token's arrival, the sleep anchor being taken at suspend rather than at
resume, and the prompt's record of what it has already asked (without it, a
stream that reconnects re-opens a question the user answered).

Not verified here, because it needs real hardware and an OS suspend: the
acceptance criteria that a five-minute run on battery survives a two-minute
sleep timer on each platform, and that `pmset -g assertions` / `powercfg /requests`
shows no Vayu assertion once no run is active. The mechanism is Electron's own
`powerSaveBlocker` with no platform-specific code, and the release paths are
unit-tested; the on-device check is worth doing before closing the issue.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Two findings from that self-review are already fixed in this branch rather than
left for a reviewer: a released-then-immediately-re-held key dropped the lock
for the run that replaced it (`fix(app): free the wake-lock key on release`),
and `OverviewTab` was never given the `runId` it needed, so its Events tab would
have read an empty annotation list for every run.

Noted, not filed as issues (they change nothing a user experiences): the docs
hunks land in the branch's later commits rather than each beside the behaviour
it describes; `runAnnotations` moved out of `TimeSeriesCharts.tsx` into
`annotations.ts` because a module that exports components may export only
components, and the function needed to be callable from a test - uPlot draws to
a canvas, so nothing can be read back off a chart. One thing deliberately left
out of the prompt: an "always" button that flips the standing preference from
the dialog. It is a checkbox away if you want it, but every extra control in an
interruption is a decision the user did not ask to make - the Settings row is
named in the dialog's own text instead.

## Related Issues
Closes #1357
