### PR TITLE
feat(app): ask about keeping the machine awake at ten minutes, not five

### DIFF
--- a/app/src/components/shared/KeepAwakePrompt.test.tsx
+++ b/app/src/components/shared/KeepAwakePrompt.test.tsx
@@ -21,7 +21,7 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import KeepAwakePrompt from "./KeepAwakePrompt";
 import { useClientSettingsStore, useDashboardStore } from "@/stores";
-import { LONG_RUN_SECONDS } from "@/modules/dashboard/utils/keepAwake";
+import { LONG_RUN_SECONDS, formatRunLength } from "@/modules/dashboard/utils/keepAwake";
 
 const { mockHold } = vi.hoisted(() => ({ mockHold: vi.fn() }));
 vi.mock("@/services/wake-lock", () => ({
@@ -57,7 +57,10 @@ describe("KeepAwakePrompt", () => {
 		streamRun("run_1", LONG_RUN_SECONDS);
 
 		expect(dialog()).not.toBeNull();
-		expect(screen.getByText(/5 minutes/)).toBeTruthy();
+		// From the constant, not a literal: the threshold is a judgement that will
+		// move, and a case that hardcodes today's number fails on the move rather
+		// than on the behaviour it is here to pin.
+		expect(screen.getByText(new RegExp(formatRunLength(LONG_RUN_SECONDS)))).toBeTruthy();
 	});
 
 	it("stays out of the way for a short run", () => {

--- a/app/src/components/shared/KeepAwakePrompt.tsx
+++ b/app/src/components/shared/KeepAwakePrompt.tsx
@@ -13,7 +13,7 @@
  * the case the lock exists for - a long run the user starts and walks away from
  * - is also the case where nobody thinks to visit a settings screen first. So
  * the app asks when the situation arises, and only then: a run that declares
- * five minutes or more, with the standing preference off.
+ * ten minutes or more, with the standing preference off.
  *
  * Mounted once, at the app root, rather than at any of the three places a load
  * run can start: the question is about the run that is streaming, and the

--- a/app/src/modules/dashboard/utils/keepAwake.ts
+++ b/app/src/modules/dashboard/utils/keepAwake.ts
@@ -21,13 +21,23 @@ import type { LoadTestRunConfig } from "@/stores/dashboard-store";
 /**
  * A run at least this long is worth an ask.
  *
- * Five minutes because that is under the shortest sleep timer a laptop ships
- * with (macOS idles the display at 2 minutes on battery and suspends a few
- * minutes later; Windows' balanced plan sleeps at 15). A run that cannot
- * outlast any of them is not worth interrupting the user over, and a run that
- * can is exactly the one that comes back with a hole in it.
+ * Ten minutes, and the number is a judgement rather than a measurement: the
+ * app cannot read the machine's sleep timer. No Electron API reports it, the
+ * value differs per power source, and even the true number would not answer
+ * the question - the timer counts from the user's last input, not from the
+ * run's start, so the same run suspends or does not depending on when its
+ * owner walked away.
+ *
+ * So this is a proxy for "a run the user is likely to leave", placed among the
+ * timers it wants to sit under: Windows' balanced plan sleeps at 15 minutes on
+ * battery, GNOME at 20, and a MacBook on battery goes within a few minutes of
+ * idle. Ten covers the first two and gives up on the third, which nothing short
+ * of asking about almost every run could catch.
+ *
+ * The costs either side are not symmetric - a needless ask costs one click, a
+ * missing one costs the run - so when this moves, it should move down.
  */
-export const LONG_RUN_SECONDS = 300;
+export const LONG_RUN_SECONDS = 600;
 
 /** Parse the `"600s"` form the run config carries; plain digits too. */
 function seconds(value: string | undefined): number | null {

--- a/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
+++ b/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
@@ -186,7 +186,7 @@ function KeepAwakeCard() {
 				<ToggleRow
 					anchor={setting.anchor}
 					label={setting.label}
-					description="Asks the system not to suspend until the run ends. The display still dims and locks as usual, and the request is dropped the moment no run is streaming. Read when a run starts, so it applies from the next one. With this off, a run of five minutes or more asks once."
+					description="Asks the system not to suspend until the run ends. The display still dims and locks as usual, and the request is dropped the moment no run is streaming. Read when a run starts, so it applies from the next one. With this off, a run of ten minutes or more asks once."
 					checked={keepAwake}
 					onChange={setKeepAwake}
 				/>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -410,7 +410,7 @@ The dashboard is **mode-adaptive**: a `useMode()` discriminator maps the run con
 While a run streams the app can hold a system wake lock, so the OS does not
 suspend the machine under a test the user walked away from (issue #1357). It is
 off by default and turned on either standing (Settings > Load testing) or per
-run: a load run of five minutes or more asks once as it starts, through
+run: a load run of ten minutes or more asks once as it starts, through
 `components/shared/KeepAwakePrompt.tsx`, which is mounted at the app root
 because the question is about whichever run is streaming rather than about the
 surface that started it. The

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -752,7 +752,7 @@ OS to stay awake (issue #1357). It is **read when a run starts** rather than
 watched, by `LoadTestService` and `ScenarioRunService`, so the answer that
 governs a run is the one that was true when it began - flipping the row mid-run
 does not reach a stream already going. Off is the shipped default: with it off a
-load run of five minutes or more asks once (`KeepAwakePrompt`), and that grant
+load run of ten minutes or more asks once (`KeepAwakePrompt`), and that grant
 takes the same wake-lock key the service releases, so it ends with the run.
 
 `loadTestCeilings` is the one slice with a bound outside the app: each value is clamped to `LOAD_TEST_CEILING_BOUNDS` (`constants/load-test.ts`) on write **and** on rehydrate, because the bounds are the engine's crash guards and a build that tightens one must not keep offering a stored ceiling above it. The load dialog turns them into its field ranges via `resolveLoadTestLimits`; nothing else reads them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ screen may still dim and lock; only suspension is refused.
 Two things turn it on. The standing preference (Settings > Load testing > Keep
 the machine awake during runs, `keepAwakeDuringRuns` in `client-settings-store`)
 is read when a run starts, and with it on every run holds. With it off, a load
-run that declares five minutes or more asks once when it starts
+run that declares ten minutes or more asks once when it starts
 (`KeepAwakePrompt`), and an answer of "keep awake" takes the lock for that run
 only. A collection run is never asked about: it declares no duration, so nothing
 in the app can tell a two-second sequence from a two-hour one.


### PR DESCRIPTION
## Description

Follow-up to #1367, which merged with the prompt's threshold at five minutes.
This moves it to ten.

The number is a judgement, not a measurement, and the code now says why. The app
cannot read the machine's sleep timer: no Electron API reports it
(`powerMonitor` offers idle time, idle state and battery state, and nothing
else), the value differs per power source, and reading it per platform would
mean `pmset` on macOS, `powercfg` on Windows and a different answer per desktop
environment on Linux - three parsers whose failure mode is silent, since a
broken one just stops the prompt appearing.

More to the point, the true number would not answer the question anyway: the
sleep timer counts from the user's last input, not from the run's start, so the
same run suspends or does not depending on when its owner walked away. The
threshold is therefore a proxy for "a run the user is likely to leave", and ten
places it under Windows' 15-minute balanced plan and GNOME's 20, above the
handful of minutes a MacBook on battery takes - which nothing short of asking
about almost every run could catch.

The costs either side are not symmetric: a needless ask costs one click, a
missing one costs the run. The comment on the constant records that, so whoever
moves it next knows which direction is the safe one.

## Type of Change
- [x] New feature

## Testing

- `pnpm test` - **644 files, 7306 tests passed** (0 failed) on the rebased tree,
  which includes the other work that merged into `master` alongside #1367.
- `pnpm type-check` (renderer, electron, electron tests) - clean
- `pnpm lint` - clean, 0 warnings
- `pnpm format:check` - clean

`KeepAwakePrompt.test.tsx` now takes the expected wording from
`formatRunLength(LONG_RUN_SECONDS)` rather than repeating today's number, so the
next move to the threshold changes one line instead of two. The boundary cases
either side of it were already written against the constant.

Prose naming the old number is updated in the same commit: the Settings row's
description, the prompt component's header, `docs/architecture.md`,
`docs/app/COMPONENTS.md` and `docs/app/state-management.md`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Follows #1367 (closed #1357).


---
_Generated by [Claude Code](https://claude.ai/code/session_011zePgDDeRiQHafuH14uknB)_