### PR TITLE
build(app): electron 42 to 44 - part 1 of the September dependency sweep (#1335)

### DIFF
--- a/.github/release-notes/v0.26.0.md
+++ b/.github/release-notes/v0.26.0.md
@@ -6,7 +6,7 @@
 
 ## [0.26.0] - 2026-09-04
 
-The **platform floor release** for macOS. Vayu moves to Electron 44 (Chromium 152, Node 24.19), which raises the minimum macOS version and brings a Chromium and Node jump to the renderer and the main process.
+The **platform floor release** for macOS. Vayu moves to Electron 44 (Chromium 152, Node 24.18), which raises the minimum macOS version and brings a Chromium and Node jump to the renderer and the main process.
 
 ### Changed
 

--- a/.github/release-notes/v0.26.0.md
+++ b/.github/release-notes/v0.26.0.md
@@ -11,6 +11,6 @@ The **platform floor release** for macOS. Vayu moves to Electron 44 (Chromium 15
 ### Changed
 
 - **macOS 13 (Ventura) or later is now required.** Electron 44 dropped support for macOS 12, so the universal DMG and zip this release publishes will not launch on it. Windows and Linux are unaffected; the Linux AppImage stays x86_64 and the Windows installer stays x64, as before - Electron's removal of 32-bit Windows and Linux ARMv7 builds costs Vayu nothing, because it never shipped either.
-- **The shell window pins its own corner shape.** Electron 43 made frameless windows rounded by default on Linux; Vayu draws its titlebar and window edge itself, so the native shape is now set explicitly rather than inherited - macOS keeps its rounded frame and Linux the square one it shipped with.
+- **The window has rounded corners on Linux.** Electron 43 made frameless windows rounded by default there, which is the shape Vayu's own titlebar already implies and the one macOS has always drawn. The app now states the shape explicitly rather than inheriting it, so a future Electron default cannot move it.
 
 [0.26.0]: https://github.com/athrvk/vayu/compare/v0.25.0...v0.26.0

--- a/.github/release-notes/v0.26.0.md
+++ b/.github/release-notes/v0.26.0.md
@@ -1,0 +1,16 @@
+<!-- Started by the Electron 44 pull request (#1335), which had to state the new
+     macOS floor somewhere a user reads before updating. The release commit owns
+     this file: update the date, extend the sections from `git log`, and keep
+     the platform-requirement bullet - it is the one entry a macOS 12 user needs
+     to see. -->
+
+## [0.26.0] - 2026-09-04
+
+The **platform floor release** for macOS. Vayu moves to Electron 44 (Chromium 152, Node 24.19), which raises the minimum macOS version and brings a Chromium and Node jump to the renderer and the main process.
+
+### Changed
+
+- **macOS 13 (Ventura) or later is now required.** Electron 44 dropped support for macOS 12, so the universal DMG and zip this release publishes will not launch on it. Windows and Linux are unaffected; the Linux AppImage stays x86_64 and the Windows installer stays x64, as before - Electron's removal of 32-bit Windows and Linux ARMv7 builds costs Vayu nothing, because it never shipped either.
+- **The shell window pins its own corner shape.** Electron 43 made frameless windows rounded by default on Linux; Vayu draws its titlebar and window edge itself, so the native shape is now set explicitly rather than inherited - macOS keeps its rounded frame and Linux the square one it shipped with.
+
+[0.26.0]: https://github.com/athrvk/vayu/compare/v0.25.0...v0.26.0

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Migrating takes seconds. Drop an existing export onto Vayu and the workspace is 
 
 ## Install
 
-Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
+Windows (x64), macOS 13+ (universal), and Linux (AppImage). No account, no sign-in.
 
 **Windows** - [winget](https://learn.microsoft.com/windows/package-manager/winget/), or the [installer](https://github.com/athrvk/vayu/releases/latest/download/Vayu-x64.exe):
 
@@ -222,7 +222,8 @@ Yes. Drop in an OpenAPI 3.1, OpenAPI 3.0 or Swagger 2.0 file (JSON or YAML) and 
 QuickJS implementing the `pm.*` API (`pm.test()`, `pm.expect()`, `pm.environment.get/set()`, `pm.response.*`), so most Postman test scripts run without modification.
 
 **Which platforms does Vayu support?**
-Windows (x64), macOS (Apple Silicon + Intel universal), and Linux (x86_64 AppImage).
+Windows (x64), macOS 13 (Ventura) or later (Apple Silicon + Intel universal), and Linux
+(x86_64 AppImage).
 
 ---
 

--- a/app/electron/context-menu.test.ts
+++ b/app/electron/context-menu.test.ts
@@ -43,7 +43,7 @@ function target(overrides: Partial<ContextTarget> = {}): ContextTarget {
 	return { ...NO_CONTEXT_TARGET, ...overrides };
 }
 
-const noClipboard = () => "";
+const noClipboard = async () => "";
 
 /** The roles a template offers, in order, with whether each is enabled. */
 function roles(items: ContextMenuItem[]): Array<[string, boolean]> {
@@ -62,8 +62,8 @@ afterEach(() => {
 });
 
 describe("menuTemplateFor - editable fields", () => {
-	it("offers the four edit roles, Select All behind a separator", () => {
-		const items = menuTemplateFor(params({ isEditable: true }), target(), noClipboard);
+	it("offers the four edit roles, Select All behind a separator", async () => {
+		const items = await menuTemplateFor(params({ isEditable: true }), target(), noClipboard);
 
 		expect(roles(items)).toEqual([
 			["cut", true],
@@ -74,8 +74,8 @@ describe("menuTemplateFor - editable fields", () => {
 		expect(items[3]).toEqual({ kind: "separator" });
 	});
 
-	it("disables the items the edit flags say cannot act", () => {
-		const items = menuTemplateFor(
+	it("disables the items the edit flags say cannot act", async () => {
+		const items = await menuTemplateFor(
 			params({
 				isEditable: true,
 				editFlags: { ...ALL_FLAGS, canPaste: false, canCut: false },
@@ -94,11 +94,11 @@ describe("menuTemplateFor - editable fields", () => {
 });
 
 describe("menuTemplateFor - the URL bar's Paste as offer", () => {
-	it("offers the import when the clipboard holds a curl command", () => {
-		const items = menuTemplateFor(
+	it("offers the import when the clipboard holds a curl command", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true }),
 			target({ kind: "url-bar" }),
-			() => "curl https://api.example.com -H 'X-Key: 1'"
+			async () => "curl https://api.example.com -H 'X-Key: 1'"
 		);
 
 		expect(labels(items)).toEqual(["Paste as curl"]);
@@ -108,30 +108,34 @@ describe("menuTemplateFor - the URL bar's Paste as offer", () => {
 		});
 	});
 
-	it("names wget when that is what the clipboard holds", () => {
-		const items = menuTemplateFor(
+	it("names wget when that is what the clipboard holds", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true }),
 			target({ kind: "url-bar" }),
-			() => "wget https://api.example.com"
+			async () => "wget https://api.example.com"
 		);
 
 		expect(labels(items)).toEqual(["Paste as wget"]);
 	});
 
-	it("offers nothing extra for ordinary clipboard text", () => {
-		const items = menuTemplateFor(
+	it("offers nothing extra for ordinary clipboard text", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true }),
 			target({ kind: "url-bar" }),
-			() => "https://api.example.com"
+			async () => "https://api.example.com"
 		);
 
 		expect(labels(items)).toEqual([]);
 	});
 
-	it("does not read the clipboard at all outside the URL bar", () => {
-		const readClipboardText = vi.fn(() => "curl https://api.example.com");
+	it("does not read the clipboard at all outside the URL bar", async () => {
+		const readClipboardText = vi.fn(async () => "curl https://api.example.com");
 
-		const items = menuTemplateFor(params({ isEditable: true }), target(), readClipboardText);
+		const items = await menuTemplateFor(
+			params({ isEditable: true }),
+			target(),
+			readClipboardText
+		);
 
 		expect(readClipboardText).not.toHaveBeenCalled();
 		expect(labels(items)).toEqual([]);
@@ -139,8 +143,8 @@ describe("menuTemplateFor - the URL bar's Paste as offer", () => {
 });
 
 describe("menuTemplateFor - variable tokens", () => {
-	it("offers Edit variable for the token under the pointer", () => {
-		const items = menuTemplateFor(
+	it("offers Edit variable for the token under the pointer", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true }),
 			target({ kind: "url-bar", variable: "baseUrl" }),
 			noClipboard
@@ -152,8 +156,8 @@ describe("menuTemplateFor - variable tokens", () => {
 		});
 	});
 
-	it("offers it in any editable field, not only the URL bar", () => {
-		const items = menuTemplateFor(
+	it("offers it in any editable field, not only the URL bar", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true }),
 			target({ variable: "token" }),
 			noClipboard
@@ -164,18 +168,22 @@ describe("menuTemplateFor - variable tokens", () => {
 });
 
 describe("menuTemplateFor - read-only surfaces", () => {
-	it("offers Copy for selected text", () => {
-		const items = menuTemplateFor(params({ selectionText: "200 OK" }), target(), noClipboard);
+	it("offers Copy for selected text", async () => {
+		const items = await menuTemplateFor(
+			params({ selectionText: "200 OK" }),
+			target(),
+			noClipboard
+		);
 
 		expect(roles(items)).toEqual([["copy", true]]);
 	});
 
-	it("shows nothing on empty chrome", () => {
-		expect(menuTemplateFor(params(), target(), noClipboard)).toEqual([]);
+	it("shows nothing on empty chrome", async () => {
+		expect(await menuTemplateFor(params(), target(), noClipboard)).toEqual([]);
 	});
 
-	it("shows nothing inside a Monaco editor, which draws its own", () => {
-		const items = menuTemplateFor(
+	it("shows nothing inside a Monaco editor, which draws its own", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true, selectionText: "{}", linkURL: "https://example.com" }),
 			target({ kind: "monaco" }),
 			noClipboard
@@ -186,8 +194,8 @@ describe("menuTemplateFor - read-only surfaces", () => {
 });
 
 describe("menuTemplateFor - links", () => {
-	it("offers both link actions, separated from the edit items", () => {
-		const items = menuTemplateFor(
+	it("offers both link actions, separated from the edit items", async () => {
+		const items = await menuTemplateFor(
 			params({ isEditable: true, linkURL: "https://vayu.sh/docs" }),
 			target(),
 			noClipboard
@@ -204,8 +212,8 @@ describe("menuTemplateFor - links", () => {
 		expect(items[last - 2]).toEqual({ kind: "separator" });
 	});
 
-	it("offers a link on a read-only surface with no selection", () => {
-		const items = menuTemplateFor(
+	it("offers a link on a read-only surface with no selection", async () => {
+		const items = await menuTemplateFor(
 			params({ linkURL: "http://localhost:9876" }),
 			target(),
 			noClipboard
@@ -215,8 +223,8 @@ describe("menuTemplateFor - links", () => {
 		expect(items[0]).not.toEqual({ kind: "separator" });
 	});
 
-	it("does not offer to open a scheme a browser does not answer for", () => {
-		const items = menuTemplateFor(
+	it("does not offer to open a scheme a browser does not answer for", async () => {
+		const items = await menuTemplateFor(
 			params({ linkURL: "file:///etc/passwd", selectionText: "x" }),
 			target(),
 			noClipboard
@@ -233,22 +241,22 @@ describe("menuTemplateFor - platform", () => {
 	 * platform branch to get wrong. Driving both platforms is what proves that:
 	 * an app-drawn accelerator would show up here as a difference.
 	 */
-	function templateOn(platform: NodeJS.Platform): ContextMenuItem[] {
+	async function templateOn(platform: NodeJS.Platform): Promise<ContextMenuItem[]> {
 		Object.defineProperty(process, "platform", { value: platform, configurable: true });
 		return menuTemplateFor(
 			params({ isEditable: true, linkURL: "https://vayu.sh" }),
 			target({ kind: "url-bar", variable: "host" }),
-			() => "curl https://vayu.sh"
+			async () => "curl https://vayu.sh"
 		);
 	}
 
-	it("builds the same menu on macOS and on Windows", () => {
-		expect(templateOn("darwin")).toEqual(templateOn("win32"));
+	it("builds the same menu on macOS and on Windows", async () => {
+		expect(await templateOn("darwin")).toEqual(await templateOn("win32"));
 	});
 
-	it("leaves every edit item a role rather than a hand-drawn accelerator", () => {
+	it("leaves every edit item a role rather than a hand-drawn accelerator", async () => {
 		for (const platform of ["darwin", "win32", "linux"] as const) {
-			const editItems = templateOn(platform).filter((item) => item.kind === "role");
+			const editItems = (await templateOn(platform)).filter((item) => item.kind === "role");
 			expect(editItems.map((item) => (item.kind === "role" ? item.role : ""))).toEqual([
 				"cut",
 				"copy",
@@ -409,33 +417,83 @@ describe("installContextMenu", () => {
 		};
 	}
 
-	it("pops the menu the pointer's context earns", () => {
+	/**
+	 * The clipboard read is a promise (Electron 44), so the menu is popped a
+	 * turn after the native event. `setImmediate` runs behind every microtask
+	 * the handler queues, which a fixed number of `await`s would only guess at.
+	 */
+	const settled = () => new Promise((resolve) => setImmediate(resolve));
+
+	it("pops the menu the pointer's context earns", async () => {
 		const contents = fakeContents();
 		const showMenu = vi.fn();
 		installContextMenu(contents, {
 			takeTarget: () => target({ kind: "url-bar" }),
-			readClipboardText: () => "curl https://vayu.sh",
+			readClipboardText: async () => "curl https://vayu.sh",
 			showMenu,
 		});
 
 		contents.rightClick(params({ isEditable: true }));
+		await settled();
 
 		expect(showMenu).toHaveBeenCalledTimes(1);
 		expect(labels(showMenu.mock.calls[0][0])).toEqual(["Paste as curl"]);
 	});
 
-	it("pops nothing where the template is empty", () => {
+	it("pops nothing where the template is empty", async () => {
 		const contents = fakeContents();
 		const showMenu = vi.fn();
 		installContextMenu(contents, {
 			takeTarget: () => target({ kind: "monaco" }),
-			readClipboardText: () => "",
+			readClipboardText: async () => "",
+			showMenu,
+		});
+
+		contents.rightClick(params({ isEditable: true }));
+		await settled();
+
+		expect(showMenu).not.toHaveBeenCalled();
+	});
+
+	it("takes the announcement for the click before awaiting the clipboard", async () => {
+		const contents = fakeContents();
+		const showMenu = vi.fn();
+		const takeTarget = vi.fn(() => target({ kind: "url-bar" }));
+		installContextMenu(contents, {
+			takeTarget,
+			readClipboardText: async () => "curl https://vayu.sh",
 			showMenu,
 		});
 
 		contents.rightClick(params({ isEditable: true }));
 
-		expect(showMenu).not.toHaveBeenCalled();
+		// Consume-once has to pair with the click that raised the event: a take
+		// deferred past the await would answer a right-click with the target of
+		// whichever one announced last.
+		expect(takeTarget).toHaveBeenCalledTimes(1);
+		await settled();
+	});
+
+	it("still pops the plain menu when the clipboard refuses to be read", async () => {
+		const contents = fakeContents();
+		const showMenu = vi.fn();
+		installContextMenu(contents, {
+			takeTarget: () => target({ kind: "url-bar" }),
+			readClipboardText: () => Promise.reject(new Error("clipboard unavailable")),
+			showMenu,
+		});
+
+		contents.rightClick(params({ isEditable: true }));
+		await settled();
+
+		expect(showMenu).toHaveBeenCalledTimes(1);
+		expect(roles(showMenu.mock.calls[0][0]).map(([role]) => role)).toEqual([
+			"cut",
+			"copy",
+			"paste",
+			"selectAll",
+		]);
+		expect(labels(showMenu.mock.calls[0][0])).toEqual([]);
 	});
 });
 

--- a/app/electron/context-menu.ts
+++ b/app/electron/context-menu.ts
@@ -140,11 +140,11 @@ function joinGroups(groups: ContextMenuItem[][]): ContextMenuItem[] {
 }
 
 /** The edit items and the Vayu offers that only an editable field can carry. */
-function editableGroups(
+async function editableGroups(
 	params: ContextMenuParams,
 	target: ContextTarget,
-	readClipboardText: () => string
-): ContextMenuItem[][] {
+	readClipboardText: () => Promise<string>
+): Promise<ContextMenuItem[][]> {
 	const { canCut, canCopy, canPaste, canSelectAll } = params.editFlags;
 	const extras: ContextMenuItem[] = [];
 
@@ -153,7 +153,7 @@ function editableGroups(
 	// a second one, and it is offered nowhere else: a header value holding a
 	// command is text, not a request. Read behind that test rather than before
 	// it, so an ordinary right-click does not touch the clipboard at all.
-	const clipboardText = target.kind === "url-bar" ? readClipboardText() : "";
+	const clipboardText = target.kind === "url-bar" ? await readClipboardText() : "";
 	const command = clipboardText ? commandOnClipboard(clipboardText) : null;
 	if (command) {
 		extras.push({
@@ -184,11 +184,11 @@ function editableGroups(
  * the editor's own menu is the answer, and on empty chrome with nothing
  * selected there is nothing to offer, which is what a native app does.
  */
-export function menuTemplateFor(
+export async function menuTemplateFor(
 	params: ContextMenuParams,
 	target: ContextTarget,
-	readClipboardText: () => string
-): ContextMenuItem[] {
+	readClipboardText: () => Promise<string>
+): Promise<ContextMenuItem[]> {
 	if (target.kind === "monaco") return [];
 
 	const linkGroup: ContextMenuItem[] =
@@ -208,7 +208,10 @@ export function menuTemplateFor(
 			: [];
 
 	if (params.isEditable) {
-		return joinGroups([...editableGroups(params, target, readClipboardText), linkGroup]);
+		return joinGroups([
+			...(await editableGroups(params, target, readClipboardText)),
+			linkGroup,
+		]);
 	}
 
 	// Read-only text: Copy, and only when there is something to copy. No marker
@@ -289,7 +292,7 @@ export interface ContextMenuDeps {
 	/** The announcement for this click, cleared as it is read. */
 	takeTarget(): ContextTarget;
 	/** The system clipboard's text, read only where an offer depends on it. */
-	readClipboardText(): string;
+	readClipboardText(): Promise<string>;
 	/** Build and pop the menu. Never called with an empty template. */
 	showMenu(items: ContextMenuItem[]): void;
 }
@@ -322,11 +325,24 @@ export function toElectronTemplate(
 	});
 }
 
-/** Answer this window's right-clicks with the menu the pointer's context earns. */
+/**
+ * Answer this window's right-clicks with the menu the pointer's context earns.
+ *
+ * The announcement is taken synchronously, before the clipboard read the URL
+ * bar's offer may need: consume-once has to pair with the click that raised the
+ * event, and Electron 44's `clipboard.readText` is a promise, so anything after
+ * the await belongs to a later turn. A clipboard that refuses to be read costs
+ * the offer and not the menu, for the reason `readContextTarget` gives - a
+ * decoration is not worth a right-click that opens nothing.
+ */
 export function installContextMenu(contents: ContextMenuContents, deps: ContextMenuDeps): void {
 	contents.on("context-menu", (_event, params) => {
-		const items = menuTemplateFor(params, deps.takeTarget(), () => deps.readClipboardText());
-		if (items.length === 0) return;
-		deps.showMenu(items);
+		const target = deps.takeTarget();
+		void menuTemplateFor(params, target, () => deps.readClipboardText().catch(() => "")).then(
+			(items) => {
+				if (items.length === 0) return;
+				deps.showMenu(items);
+			}
+		);
 	});
 }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -278,13 +278,12 @@ function createWindow() {
 		// Custom titlebar settings
 		frame: false,
 		titleBarStyle: "hidden",
-		// Electron 43 made frameless windows rounded by default on Linux. The
-		// renderer paints its own chrome square to the window edge, so the
-		// native shape is pinned here rather than inherited from whichever
-		// default the current Electron ships: macOS keeps the rounded frame it
-		// has always drawn, Linux keeps the square one Vayu shipped with, and
-		// Windows ignores the option.
-		roundedCorners: process.platform !== "linux",
+		// Electron 43 made frameless windows rounded by default on Linux, which
+		// is the shape Vayu wants there - it matches the frame macOS has always
+		// drawn. Stated rather than inherited, so the window's shape does not
+		// move with whichever default the current Electron ships. Windows
+		// ignores the option.
+		roundedCorners: true,
 		// Centre the macOS traffic lights in the bar. The frame height is a named
 		// constant because it has been wrong twice: 16 originally, then 12 (the
 		// visible circle) - Electron positions the button frame, which is 14.

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -136,7 +136,10 @@ const contextTargets = createContextTargetStore();
 /** Do what a context-menu item promised, in whichever process owns the action. */
 function runMenuCommand(command: ContextCommand): void {
 	runContextCommand(command, {
-		writeClipboard: (text) => clipboard.writeText(text),
+		// Electron 44 made the clipboard writes promises. Nothing waits on the
+		// copy - the menu item is done when the text is queued - so the promise
+		// is discarded deliberately rather than left floating.
+		writeClipboard: (text) => void clipboard.writeText(text),
 		openExternal: (url) => {
 			void shell.openExternal(url);
 		},
@@ -275,6 +278,13 @@ function createWindow() {
 		// Custom titlebar settings
 		frame: false,
 		titleBarStyle: "hidden",
+		// Electron 43 made frameless windows rounded by default on Linux. The
+		// renderer paints its own chrome square to the window edge, so the
+		// native shape is pinned here rather than inherited from whichever
+		// default the current Electron ships: macOS keeps the rounded frame it
+		// has always drawn, Linux keeps the square one Vayu shipped with, and
+		// Windows ignores the option.
+		roundedCorners: process.platform !== "linux",
 		// Centre the macOS traffic lights in the bar. The frame height is a named
 		// constant because it has been wrong twice: 16 originally, then 12 (the
 		// visible circle) - Electron positions the button frame, which is 14.

--- a/app/electron/window-chrome.test.ts
+++ b/app/electron/window-chrome.test.ts
@@ -8,12 +8,12 @@
 /**
  * The shell window's native shape is decided here, not inherited (#1335).
  *
- * Electron 43 made frameless windows rounded by default on Linux. Vayu's shell
- * is frameless - the titlebar, its buttons and the window's edge are drawn by
- * the renderer, square to the boundary - so the platform default is the one
- * thing that can change what the window looks like without a line of this app
- * changing. Pinning `roundedCorners` costs one property and makes the next
- * Electron's default a non-event; leaving it out is how the corners moved.
+ * Electron 43 made frameless windows rounded by default on Linux, and Vayu's
+ * shell is frameless - the titlebar, its buttons and the window's edge are
+ * drawn by the renderer. Rounded is the shape wanted there, matching macOS, so
+ * this is not a change being resisted; what the guard holds is that the app
+ * *states* it. Otherwise the platform default is the one thing that can change
+ * what the window looks like without a line of this app changing.
  *
  * main.ts creates the window at import time, so the option can only be read -
  * the characterization approach `startup-order.test.ts` and
@@ -37,10 +37,10 @@ describe("the shell window's chrome", () => {
 		expect(main).toContain("frame: false,");
 	});
 
-	it("pins the native corners rather than taking the platform default", () => {
-		// macOS has always rounded its windows and keeps doing so; Linux keeps
-		// the square shape Vayu shipped with, because nothing in the renderer
-		// paints around a rounded native edge. Windows ignores the option.
-		expect(main).toContain('roundedCorners: process.platform !== "linux",');
+	it("states the native corners rather than taking the platform default", () => {
+		// One value on every platform: macOS has always rounded its windows,
+		// Linux rounds a frameless one since Electron 43, and Windows ignores
+		// the option.
+		expect(main).toContain("roundedCorners: true,");
 	});
 });

--- a/app/electron/window-chrome.test.ts
+++ b/app/electron/window-chrome.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The shell window's native shape is decided here, not inherited (#1335).
+ *
+ * Electron 43 made frameless windows rounded by default on Linux. Vayu's shell
+ * is frameless - the titlebar, its buttons and the window's edge are drawn by
+ * the renderer, square to the boundary - so the platform default is the one
+ * thing that can change what the window looks like without a line of this app
+ * changing. Pinning `roundedCorners` costs one property and makes the next
+ * Electron's default a non-event; leaving it out is how the corners moved.
+ *
+ * main.ts creates the window at import time, so the option can only be read -
+ * the characterization approach `startup-order.test.ts` and
+ * `context-menu.test.ts` take to the same file.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts"), "utf8");
+
+describe("the shell window's chrome", () => {
+	it("read the file it is guarding", () => {
+		// A guard over an empty string passes forever.
+		expect(main).toContain("new BrowserWindow({");
+	});
+
+	it("draws its own frame", () => {
+		expect(main).toContain("frame: false,");
+	});
+
+	it("pins the native corners rather than taking the platform default", () => {
+		// macOS has always rounded its windows and keeps doing so; Linux keeps
+		// the square shape Vayu shipped with, because nothing in the renderer
+		// paints around a rounded native edge. Windows ignores the option.
+		expect(main).toContain('roundedCorners: process.platform !== "linux",');
+	});
+});

--- a/app/package.json
+++ b/app/package.json
@@ -93,7 +93,7 @@
 		"@vitejs/plugin-react": "^6.1.1",
 		"concurrently": "^9.2.1",
 		"cross-env": "^10.1.0",
-		"electron": "^42.3.3",
+		"electron": "^44.0.0",
 		"electron-builder": "^26.15.3",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^9.1.2",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       electron:
-        specifier: ^42.3.3
-        version: 42.3.3
+        specifier: ^44.0.0
+        version: 44.0.0
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -374,6 +374,10 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@electron-internal/extract-zip@1.0.5':
+    resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -1618,9 +1622,6 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@typescript-eslint/eslint-plugin@8.69.0':
     resolution: {integrity: sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2046,9 +2047,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2398,8 +2396,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.3.3:
-    resolution: {integrity: sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==}
+  electron@44.0.0:
+    resolution: {integrity: sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -2618,11 +2616,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2637,9 +2630,6 @@ packages:
 
   fast-uri@3.1.7:
     resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3777,9 +3767,6 @@ packages:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4716,9 +4703,6 @@ packages:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4912,6 +4896,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@electron-internal/extract-zip@1.0.5': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -4944,7 +4930,7 @@ snapshots:
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 7.8.3
+      semver: 7.8.5
       sumchecker: 3.0.1
     optionalDependencies:
       undici: 7.27.2
@@ -6073,11 +6059,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 25.9.2
-    optional: true
-
   '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -6529,8 +6510,6 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
-  buffer-crc32@0.2.13: {}
-
   buffer-from@1.1.2: {}
 
   builder-util-runtime@9.7.0:
@@ -6935,11 +6914,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.3.3:
+  electron@44.0.0:
     dependencies:
+      '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.0.0
       '@types/node': 24.13.1
-      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7281,16 +7260,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -7300,10 +7269,6 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.7: {}
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -8666,8 +8631,6 @@ snapshots:
 
   pe-library@0.4.1: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -9714,11 +9677,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Coming from another tool? Read the honest comparison:
 
 ## Install
 
-Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
+Windows (x64), macOS 13+ (universal), and Linux (AppImage). No account, no sign-in.
 
 <!-- This section is the canonical install copy (flipped from README.md in #631).
      The README carries the three one-liners only and links back here for the
@@ -45,6 +45,9 @@ Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
     ```sh
     bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"
     ```
+
+    **macOS 13 (Ventura) or later.** The app is built on Electron, which sets
+    that floor; on macOS 12 the installed app will not launch.
 
     Installs the latest release to `/Applications`, and asks for your password
     once. Vayu ships unsigned, so the script ad-hoc signs the app and clears the
@@ -380,8 +383,8 @@ persists.
 
 ??? question "Which platforms are supported?"
 
-    Windows (x64), macOS (Apple Silicon and Intel, universal), and Linux
-    (x86_64 AppImage).
+    Windows (x64), macOS 13 (Ventura) or later (Apple Silicon and Intel,
+    universal), and Linux (x86_64 AppImage).
 
 ## Contribute
 


### PR DESCRIPTION
## Description

**Part 1 of #1335: Electron 42.3.3 to 44.0.0.** Chromium 148 to 152.0.7977.54, Node 24.15 to 24.18.1, and a macOS floor that moves up to 13 (Ventura).

**Plan (root cause, approach, the alternative rejected).** The upgrade itself is one line in `package.json`; the work is the two breaking changes that actually reach this app, and the issue's audit is stale on one of them. Electron 44 makes the main-process `clipboard` API promise-based, and `grep -rn clipboard electron/` no longer "finds nothing": the context menu shipped since (#1359) reads the clipboard to decide the URL bar's **Paste as curl** offer, and `main.ts` writes it for **Copy Link** - so `pnpm type-check` fails on `readClipboardText` the moment 44 is installed. The approach keeps the module's shape: the reader stays lazy (an ordinary right-click still never touches the clipboard) and becomes `() => Promise<string>`, `menuTemplateFor` becomes async, and the announcement is still taken **synchronously**, before the await, because consume-once has to pair with the click that raised the event. The alternative was to hoist the read into `installContextMenu` and keep `menuTemplateFor` synchronous by passing it a string; rejected because the rule "only the URL bar reads the clipboard" would then be stated in two places - the site that decides whether to read and the site that decides what to offer - which is exactly the drift the module's comments exist to prevent. Second change: Electron 43 made frameless windows rounded by default on Linux, and Vayu's shell is frameless, so `roundedCorners: true` is now set explicitly - one value on every platform, matching the frame macOS has always drawn and Linux's new default. It is stated rather than inherited so the window's shape cannot move with the next Electron's default; the rejected alternative was keeping Linux square, which would have preserved the old look at the cost of two different window shapes across platforms.

The issue's other three items cost nothing and were verified rather than worked around: `release.yml` publishes no ia32 or ARMv7 artefact, the renderer reaches the clipboard through `navigator.clipboard` / `clipboardData` (`UrlInput.tsx`), and nothing here handles `select-client-certificate`.

### Deliberate deviations from the issue

- **44.0.0, not 44.1.1.** `.npmrc`'s `minimum-release-age=10080` - the seven-day floor part 2 fixed (#1343) - admits only 44.0.0 today; 44.1.0 (Aug 31), 44.1.1 (Sep 1) and 44.2.0 (Sep 4) are inside the window. Taking a newer one would mean overriding the floor for one package. **The lockfile pins what it resolved, so the later patches are a deliberate bump, not something a future install picks up on its own** - 44.1.1 matures Sep 8 and 44.2.0 Sep 11, and the patch worth taking before this ships is 44.1.1's fix for an intermittent Linux startup crash (a Pango / fontconfig race that needs no app code to hit). No CVE is named in 44.1.0, 44.1.1 or 44.2.0; the Chromium bumps they carry (152.0.7977.54 to .65 to .76) are upstream backports.
- **The clipboard change is real work, not a grep.** The issue said "no change needed; the grep is the acceptance check". The anchor drifted - see the plan above.
- **The release-notes file is `v0.26.0.md` and is a stub.** Notes are normally authored in the release commit (`releasing` skill), but the acceptance criteria ask this PR to state the macOS floor in `.github/release-notes/`. The file carries the two user-visible bullets and an HTML comment telling the release commit to own it - extend the sections, fix the date, keep the platform bullet.
- **Not verified here, and this is the gap:** a packaged build per OS and a look at the Linux window's corners on a real desktop. This container is headless (Electron 44.0.0 launches under `--no-sandbox` and prints its version; no display), so the corner decision is stated and guarded in a test rather than photographed. The issue asks for `pnpm electron:dev` on each OS and one packaged build per OS from `release.yml` on a branch - that still needs doing before release.

## Type of Change

- [x] Bug fix - a right-click on the URL bar would have shown no menu at all under Electron 44 (`readClipboardText` returned a promise where a string was read)
- [ ] New feature
- [x] Breaking change - macOS 12 is no longer supported
- [x] Documentation update

## Testing

All green on this branch:

- `cd app && pnpm test` - **645 files, 7311 tests passed**, 0 failed (5 of them new: 3 in `electron/window-chrome.test.ts` and 2 in `electron/context-menu.test.ts`, where 6 existing cases were rewritten to async)
- `cd app && pnpm type-check` - clean across the three projects (renderer, electron, electron tests); it is what caught the clipboard change
- `cd app && pnpm lint` - 0 errors, 0 warnings
- `cd app && pnpm format:check` - clean (only files this PR touched were formatted)
- `python build.py -t` - exit 0
- `cd engine && ctest --preset linux-dev --output-on-failure` - **2904 tests passed, 0 failed**
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, for the `docs/index.md` edit
- `./node_modules/.bin/electron --no-sandbox --version` - `v44.0.0`

The second commit (rounded corners on every platform) re-ran the electron tests, type-check, lint and format:check; the full suite and engine numbers above are from the first. The third is a one-line correction to the release-notes stub.

No pre-existing failures were seen on the base commit.

The two new behavioural tests were mutation-checked: dropping the `.catch(() => "")` in `installContextMenu` leaves the menu unshown when the clipboard rejects, and moving `deps.takeTarget()` after the await drops the "takes the announcement before awaiting" assertion to zero calls. Both fail without the fix.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation - install page and README carry the macOS 13 floor; the release-notes stub states it for the release that ships this

## Related Issues

Refs #1335 - this is part 1 of three. Part 2 landed in #1343 and #1351; **part 3 (the majors) stays open**, in the order the issue's Sequencing gives. Deliberately does not close #1335.