### PR TITLE
fix(app): one left edge per level in both trees (#1372)

### DIFF
--- a/app/src/constants/layout.ts
+++ b/app/src/constants/layout.ts
@@ -61,6 +61,26 @@ export const RETIRED_CONTEXT_BAR_SECTIONS: readonly string[] = ["environment"];
  */
 export const INDENT_STEP = 12;
 
+/** Left edge of a tree row at `depth` (px), the root row's padding included. */
+export function rowInsetPx(depth: number): number {
+	return 8 + depth * INDENT_STEP;
+}
+
+/**
+ * Left edge for anything rendered *inside* a row's `role="group"` at `depth` -
+ * a placeholder, an inline form, a skeleton, an inline error.
+ *
+ * It is the inset a child row of that group takes, not a padding of its own:
+ * the group's contents belong to one level, so they line up whether the level
+ * currently holds rows, one message, or a half-typed name. Derived from
+ * `rowInsetPx` rather than restated, because the two drifting apart is the
+ * defect (#1372) - a nested folder's "Empty folder" sat at the tree's left
+ * edge, left of its own parent's label.
+ */
+export function childInsetPx(depth: number): number {
+	return rowInsetPx(depth + 1);
+}
+
 /* ── Document tab strip (over the content column) ────────────────────────── */
 
 /**

--- a/app/src/modules/collections/CollectionItem.child-inset.test.tsx
+++ b/app/src/modules/collections/CollectionItem.child-inset.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One level shows one left edge.
+ *
+ * Rows derive their indent from their depth; everything else inside a folder's
+ * `role="group"` used to carry a fixed `px-*`, so a nested folder's "Empty
+ * folder" line sat at the tree's left edge - left of its own parent's label and
+ * left of the sibling request rows below it (#1372). The new-subfolder form had
+ * the same defect one step further left.
+ *
+ * The guard is an equality rather than a number: the placeholder and the form
+ * are compared against the `paddingLeft` a `RequestItem` actually renders at
+ * `depth + 1`, which is the row they stand in for. A fix that moved only one of
+ * the two, or that moved both to some other constant, fails here. The formula
+ * is asserted as well, from `INDENT_STEP`, so the pair cannot drift together.
+ *
+ * jsdom has no layout, so this reads the inline `style` the component sets, not
+ * a computed box.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CollectionItem from "./CollectionItem";
+import RequestItem from "./RequestItem";
+import { withCollectionTreeContext } from "@/test/collection-tree-context";
+import { INDENT_STEP } from "@/constants/layout";
+import type { Collection, Request } from "@/types";
+
+vi.mock("@/queries", () => ({
+	useReorderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+const COLLECTION: Collection = {
+	id: "col_1",
+	name: "Acme API",
+	description: "",
+	order: 0,
+	variables: {},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const REQUEST: Request = {
+	id: "req_1",
+	collectionId: "col_1",
+	name: "Get user",
+	description: "",
+	method: "GET",
+	url: "https://api.test/user",
+	params: [],
+	headers: [],
+	body: { mode: "none" },
+	bodyType: "none",
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	followRedirects: true,
+	maxRedirects: 10,
+	verifySSL: true,
+	httpVersion: "auto",
+	stream: false,
+	order: 0,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+/** The expanded, empty folder at `depth`, with nothing being created. */
+function renderEmptyFolder(depth: number) {
+	return render(
+		withCollectionTreeContext(
+			<CollectionItem collection={COLLECTION} depth={depth} posInSet={1} setSize={1} />,
+			{
+				allCollections: [COLLECTION],
+				expandedCollectionIds: new Set([COLLECTION.id]),
+			}
+		)
+	);
+}
+
+/** What a child row of that folder actually indents to. */
+function childRowPaddingLeft(depth: number): string {
+	const { container, unmount } = render(
+		withCollectionTreeContext(
+			<RequestItem
+				request={REQUEST}
+				collectionId={COLLECTION.id}
+				depth={depth + 1}
+				posInSet={1}
+				setSize={1}
+			/>
+		)
+	);
+	const row = container.querySelector('[role="treeitem"]') as HTMLElement;
+	const padding = row.style.paddingLeft;
+	unmount();
+	return padding;
+}
+
+describe.each([0, 2])("a folder at depth %i", (depth) => {
+	const expected = `${8 + (depth + 1) * INDENT_STEP}px`;
+
+	it("starts its 'Empty folder' line where a request row starts", () => {
+		renderEmptyFolder(depth);
+
+		const placeholder = screen.getByText("Empty folder");
+		expect(placeholder.style.paddingLeft).toBe(expected);
+		expect(placeholder.style.paddingLeft).toBe(childRowPaddingLeft(depth));
+	});
+
+	it("starts the new-subfolder form at that same edge", () => {
+		render(
+			withCollectionTreeContext(
+				<CollectionItem collection={COLLECTION} depth={depth} posInSet={1} setSize={1} />,
+				{
+					allCollections: [COLLECTION],
+					expandedCollectionIds: new Set([COLLECTION.id]),
+					creatingSubfolder: COLLECTION.id,
+				}
+			)
+		);
+
+		const form = screen.getByPlaceholderText("Folder name").closest("div") as HTMLElement;
+		expect(form.style.paddingLeft).toBe(expected);
+		expect(form.style.paddingLeft).toBe(childRowPaddingLeft(depth));
+	});
+});
+
+describe("an empty folder's row", () => {
+	it("describes itself as empty, since its group holds no treeitem to find", () => {
+		const { container } = renderEmptyFolder(1);
+
+		const row = container.querySelector('[role="treeitem"]') as HTMLElement;
+		const describedBy = row.getAttribute("aria-describedby");
+		expect(describedBy).toBeTruthy();
+		expect(document.getElementById(describedBy as string)?.textContent).toBe("Empty folder");
+	});
+
+	it("drops the description once the folder has a row to announce", () => {
+		const { container } = render(
+			withCollectionTreeContext(
+				<CollectionItem collection={COLLECTION} depth={1} posInSet={1} setSize={1} />,
+				{
+					allCollections: [COLLECTION],
+					expandedCollectionIds: new Set([COLLECTION.id]),
+					getRequestsByCollection: () => [REQUEST],
+				}
+			)
+		);
+
+		const row = container.querySelector('[role="treeitem"]') as HTMLElement;
+		expect(row.getAttribute("aria-describedby")).toBeNull();
+		expect(screen.queryByText("Empty folder")).not.toBeInTheDocument();
+	});
+});

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -17,7 +17,7 @@ import { compareTreeOrder } from "@/types";
 import { Button, Input } from "@/components/ui";
 import { RowActionsMenu, TruncatedText } from "@/components/shared";
 import { cn } from "@/lib/utils";
-import { INDENT_STEP } from "@/constants/layout";
+import { childInsetPx, rowInsetPx } from "@/constants/layout";
 
 /**
  * What differs per row. Everything shared - the expanded set, the selection,
@@ -96,6 +96,20 @@ export default function CollectionItem({
 	// Ties the children's group back to this row for assistive tech - see the
 	// `aria-owns` note on the row itself.
 	const childrenId = `tree-group-${collection.id}`;
+	/**
+	 * An empty folder announces itself through the row, not the placeholder.
+	 * The group holds no treeitem in this state, so a screen reader walking the
+	 * tree reaches nothing and the emptiness is silent; `aria-describedby` on
+	 * the row says it at the moment the row is focused. The placeholder is not
+	 * given a role of its own - a `role="group"` inside a tree owns treeitems,
+	 * and a second role in there would be an invalid child rather than an extra
+	 * stop.
+	 */
+	const emptyId = `tree-empty-${collection.id}`;
+	const showsEmptyPlaceholder =
+		requests.length === 0 &&
+		childCollections.length === 0 &&
+		creatingSubfolder !== collection.id;
 
 	const rowRef = useRef<HTMLDivElement>(null);
 	/**
@@ -155,7 +169,14 @@ export default function CollectionItem({
 	 * reached it. Depth is shown by where the content sits, not where the row
 	 * starts.
 	 */
-	const indentPx = 8 + depth * INDENT_STEP;
+	const indentPx = rowInsetPx(depth);
+
+	/**
+	 * Everything inside this row's group - the "Empty folder" placeholder, the
+	 * new-subfolder form - takes the left edge a child row takes, so one level
+	 * shows one left edge whether it holds rows, a message, or a half-typed name.
+	 */
+	const childIndentPx = childInsetPx(depth);
 
 	return (
 		<div className={cn("select-none", isDeleting && "opacity-50")}>
@@ -189,6 +210,7 @@ export default function CollectionItem({
 				// way to say "that group belongs to me" without restructuring the
 				// DOM the roving-focus walk and the hit-area rules depend on.
 				aria-owns={isExpanded ? childrenId : undefined}
+				aria-describedby={isExpanded && showsEmptyPlaceholder ? emptyId : undefined}
 				onClick={(e) => isRowSurface(e) && handleClick(e)}
 				onDoubleClick={(e) => isRowSurface(e) && handleDoubleClick(e)}
 				// Whole-row drag handle: the gesture is captured here and only
@@ -361,7 +383,10 @@ export default function CollectionItem({
 				<div id={childrenId} role="group" className="mt-1 space-y-0.5">
 					{/* Subfolder Creation Form */}
 					{creatingSubfolder === collection.id && (
-						<div className="flex gap-2 py-1 px-2">
+						<div
+							className="flex gap-2 py-1 pr-2"
+							style={{ paddingLeft: childIndentPx }}
+						>
 							<Input
 								type="text"
 								value={newSubCollectionName}
@@ -412,13 +437,15 @@ export default function CollectionItem({
 					))}
 
 					{/* Requests */}
-					{requests.length === 0 &&
-						childCollections.length === 0 &&
-						creatingSubfolder !== collection.id && (
-							<div className="py-2 px-3 text-xs text-muted-foreground">
-								Empty folder
-							</div>
-						)}
+					{showsEmptyPlaceholder && (
+						<div
+							id={emptyId}
+							className="py-2 pr-3 text-xs text-muted-foreground"
+							style={{ paddingLeft: childIndentPx }}
+						>
+							Empty folder
+						</div>
+					)}
 					{requests.map((request, index) => (
 						<RequestItem
 							key={request.id}

--- a/app/src/modules/collections/MoveToDialog.tsx
+++ b/app/src/modules/collections/MoveToDialog.tsx
@@ -32,7 +32,7 @@ import { isDescendant } from "./tree-utils";
 import type { TreeEntity } from "./drop-position";
 import type { Collection } from "@/types";
 import { compareTreeOrder } from "@/types";
-import { INDENT_STEP } from "@/constants/layout";
+import { rowInsetPx } from "@/constants/layout";
 
 export interface MoveToDialogProps {
 	/** The row being moved; `null` closes the dialog. */
@@ -110,7 +110,7 @@ export function MoveToDialog({ entity, collections, onClose, onMove }: MoveToDia
 							key={collection.id}
 							variant="ghost"
 							className="w-full justify-start gap-2 h-8"
-							style={{ paddingLeft: 8 + depth * INDENT_STEP }}
+							style={{ paddingLeft: rowInsetPx(depth) }}
 							onClick={() => onMove(entity, collection.id)}
 						>
 							<Folder className="w-4 h-4 shrink-0 text-primary/70" />

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -15,7 +15,7 @@ import type { Request } from "@/types";
 import { Input } from "@/components/ui";
 import { RowActionsMenu, MethodBadge, TruncatedText } from "@/components/shared";
 import { cn } from "@/lib/utils";
-import { INDENT_STEP } from "@/constants/layout";
+import { rowInsetPx } from "@/constants/layout";
 
 /**
  * What differs per row. The selection, the rename and delete state and every
@@ -153,7 +153,7 @@ export default function RequestItem({
 			data-drop-blocked={dnd.isBlocked || undefined}
 			// Indent inside the row (see CollectionItem) so the fill still
 			// reaches both panel edges.
-			style={{ paddingLeft: 8 + depth * INDENT_STEP }}
+			style={{ paddingLeft: rowInsetPx(depth) }}
 			className={cn(
 				// focus-row: this row is the perceived target, not the narrower
 				// label button inside it - it paints the keyboard focus ring.
@@ -170,7 +170,7 @@ export default function RequestItem({
 				rowDndClasses(dnd)
 			)}
 		>
-			<RowDropIndicator edge={dnd.dropEdge} indentPx={8 + depth * INDENT_STEP} />
+			<RowDropIndicator edge={dnd.dropEdge} indentPx={rowInsetPx(depth)} />
 			<button
 				onClick={handleClick}
 				onDoubleClick={handleDoubleClick}

--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.group-inset.test.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.group-inset.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One level shows one left edge, in the variables sidebar too.
+ *
+ * A section's rows are indented 50px, past the header's chevron and icon. What
+ * stands in for those rows was not: the empty line and the failure line at
+ * 12px, the new-environment field at 24px, the loading skeleton at 4px (#1372).
+ * Under one expanded header the eye saw up to four left edges, and the section
+ * appeared to shift sideways as its query settled.
+ *
+ * Each case asserts the state's left-edge class *equals the one a real
+ * environment row renders*, rather than naming `pl-12.5` again: the value can
+ * move, but a placeholder standing where no row would stand is the defect.
+ * Reverting any one of the four to its old padding fails its case here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import VariablesCategoryTree from "./VariablesCategoryTree";
+import type { Environment } from "@/types";
+
+const ENVIRONMENT: Environment = {
+	id: "env_1",
+	name: "Staging",
+	description: "",
+	variables: {},
+	isActive: false,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const settled = { isLoading: false, isError: false, refetch: vi.fn() };
+const queryState = {
+	collections: { ...settled, data: [] as unknown[] },
+	environments: { ...settled, data: [] as unknown[] },
+};
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => queryState.collections,
+	useEnvironmentsQuery: () => queryState.environments,
+	useCreateEnvironmentMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteEnvironmentMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateEnvironmentMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	// TooltipProvider mirrors main.tsx: the tree contains a TooltipIconButton
+	// (Add environment), and Radix Tooltip throws without a provider ancestor.
+	return render(
+		<QueryClientProvider client={qc}>
+			<TooltipProvider>
+				<VariablesCategoryTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+/** The one left-edge class an element carries, or `undefined` if it has none. */
+function insetClass(element: HTMLElement): string | undefined {
+	return element.className.split(/\s+/).find((name) => name.startsWith("pl-"));
+}
+
+/**
+ * What an environment row indents to, read off a rendered row. Renders its own
+ * tree and puts the query state back, so a case can take the reference and then
+ * set up the state it is actually about.
+ */
+function rowInsetClass(): string | undefined {
+	const restore = queryState.environments;
+	queryState.environments = { ...settled, data: [ENVIRONMENT] };
+	const { unmount } = renderTree();
+	const row = screen.getByText(ENVIRONMENT.name).closest('[role="treeitem"]');
+	const inset = insetClass(row as HTMLElement);
+	unmount();
+	queryState.environments = restore;
+	return inset;
+}
+
+describe("everything inside a section's group takes the row's left edge", () => {
+	beforeEach(() => {
+		queryState.collections = { ...settled, data: [] };
+		queryState.environments = { ...settled, data: [] };
+	});
+
+	it("indents an environment row past the header, which is the edge the rest follow", () => {
+		// The reference the cases below compare against has to be a real class,
+		// or every one of them would pass on two `undefined`s.
+		expect(rowInsetClass()).toBeTruthy();
+	});
+
+	it("indents the empty line", () => {
+		const expected = rowInsetClass();
+		renderTree();
+
+		expect(insetClass(screen.getByText("No environments"))).toBe(expected);
+		expect(insetClass(screen.getByText("No collections"))).toBe(expected);
+	});
+
+	it("indents the new-environment field", () => {
+		const expected = rowInsetClass();
+		renderTree();
+
+		fireEvent.click(screen.getByRole("button", { name: "Add environment" }));
+		const field = screen.getByPlaceholderText("Environment name");
+
+		expect(insetClass(field.parentElement as HTMLElement)).toBe(expected);
+	});
+
+	it("indents the loading skeleton", () => {
+		const expected = rowInsetClass();
+		queryState.environments = { ...settled, data: [], isLoading: true };
+		renderTree();
+
+		expect(insetClass(screen.getByRole("status", { name: "Loading" }))).toBe(expected);
+	});
+
+	it("indents the failure line", () => {
+		const expected = rowInsetClass();
+		queryState.environments = { ...settled, data: [], isError: true };
+		renderTree();
+
+		const error = screen.getByText("Couldn't load environments").parentElement;
+		expect(insetClass(error as HTMLElement)).toBe(expected);
+	});
+});

--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
@@ -83,6 +83,25 @@ import { DEFAULT_ENVIRONMENT_NAME } from "@/constants/environment";
  */
 const SCOPE_SECTIONS = 3;
 
+/**
+ * The left edge of everything inside a section's `role="group"`: the level-2
+ * rows, and equally the empty line, the new-environment field, the loading
+ * skeleton and a load error.
+ *
+ * 50px, past the header's chevron and icon, so a level-2 row reads as a child
+ * of the header rather than a sibling of it. Named because it was four
+ * different paddings before (#1372) - `px-3`, `pl-6`, `px-1`, and the rows'
+ * own `pl-12.5` - which put up to four left edges under one expanded header.
+ * The collection tree derives the same rule from its depth (`childInsetPx`);
+ * this tree is exactly two levels deep, so the value is a constant rather than
+ * a function of one.
+ *
+ * Always written *after* a `px-*` in the same class list, the order the rows
+ * already use: `cn` is tailwind-merge, which drops an earlier `pl-*` when a
+ * later `px-*` overrides it, and the row would silently lose its indent.
+ */
+const GROUP_CHILD_INSET = "pl-12.5";
+
 export default function VariablesCategoryTree() {
 	// Fetches its own data, like the other three drawer views. It used to
 	// receive both lists as props from the Drawer, which read them with `= []`
@@ -119,11 +138,11 @@ export default function VariablesCategoryTree() {
 
 	/*
 	 * The pane variant centres inside `p-8`, which would break the rhythm of a
-	 * tree of 32px rows. `px-3 py-2` is the padding the italic empty rows above
-	 * already use, so the failure line sits on the tree's left edge like every
-	 * other row; `justify-start` undoes the variant's centring.
+	 * tree of 32px rows. `justify-start` undoes that centring, and the inset
+	 * puts the failure line where the rows it replaces would have started -
+	 * inside a group, one level shows one left edge.
 	 */
-	const inlineErrorClass = "justify-start px-3 py-2 text-xs";
+	const inlineErrorClass = cn("justify-start px-3 py-2 text-xs", GROUP_CHILD_INSET);
 
 	const { selectedCategory, setSelectedCategory } = useVariablesStore();
 	const { openTab } = useTabsStore();
@@ -411,7 +430,7 @@ export default function VariablesCategoryTree() {
 							<div id={environmentsGroupId} role="group" className="mt-1">
 								{/* New Environment Input */}
 								{creatingEnvironment && (
-									<div className="px-3 py-1 pl-6">
+									<div className={cn("px-3 py-1", GROUP_CHILD_INSET)}>
 										<Input
 											value={newEnvName}
 											onChange={(e) => setNewEnvName(e.target.value)}
@@ -438,7 +457,10 @@ export default function VariablesCategoryTree() {
 								)}
 
 								{isLoadingEnvironments ? (
-									<ListSkeleton rows={2} className="px-1" />
+									<ListSkeleton
+										rows={2}
+										className={cn("pr-3", GROUP_CHILD_INSET)}
+									/>
 								) : showEnvironmentsError ? (
 									<ErrorState
 										variant="inline"
@@ -447,7 +469,12 @@ export default function VariablesCategoryTree() {
 										onRetry={() => void refetchEnvironments()}
 									/>
 								) : environments.length === 0 && !creatingEnvironment ? (
-									<div className="px-3 py-2 text-xs text-muted-foreground italic">
+									<div
+										className={cn(
+											"px-3 py-2 text-xs text-muted-foreground italic",
+											GROUP_CHILD_INSET
+										)}
+									>
 										No environments
 									</div>
 								) : (
@@ -470,7 +497,7 @@ export default function VariablesCategoryTree() {
 											 * The button therefore stays and owns the
 											 * action. The row *additionally* delegates
 											 * clicks landing on its own box - the 50px
-											 * `pl-12.5` indent, the gap, `px-3` - which
+											 * group inset, the gap, `px-3` - which
 											 * belong to no child and so had nowhere to
 											 * go. RequestItem carries the rule and why
 											 * the target check is what it is.
@@ -501,7 +528,8 @@ export default function VariablesCategoryTree() {
 													});
 												}}
 												className={cn(
-													"focus-row group flex h-8 cursor-pointer items-center gap-2 px-3 pl-12.5 text-sm hover:bg-accent transition-colors",
+													"focus-row group flex h-8 cursor-pointer items-center gap-2 px-3 text-sm hover:bg-accent transition-colors",
+													GROUP_CHILD_INSET,
 													isSelected({
 														type: "environment",
 														environmentId: environment.id,
@@ -704,7 +732,10 @@ export default function VariablesCategoryTree() {
 						{collectionsExpanded && (
 							<div id={collectionsGroupId} role="group" className="mt-1">
 								{isLoadingCollections ? (
-									<ListSkeleton rows={2} className="px-1" />
+									<ListSkeleton
+										rows={2}
+										className={cn("pr-3", GROUP_CHILD_INSET)}
+									/>
 								) : showCollectionsError ? (
 									<ErrorState
 										variant="inline"
@@ -713,7 +744,12 @@ export default function VariablesCategoryTree() {
 										onRetry={() => void refetchCollections()}
 									/>
 								) : collections.length === 0 ? (
-									<div className="px-3 py-2 text-xs text-muted-foreground italic">
+									<div
+										className={cn(
+											"px-3 py-2 text-xs text-muted-foreground italic",
+											GROUP_CHILD_INSET
+										)}
+									>
 										No collections
 									</div>
 								) : (
@@ -757,7 +793,10 @@ export default function VariablesCategoryTree() {
 													// covers all of it: the indent stays here
 													// rather than on the row, and no part of the
 													// 32px is dead to a click.
-													className="flex min-w-0 flex-1 self-stretch items-center gap-2 px-3 pl-12.5 text-left text-sm"
+													className={cn(
+														"flex min-w-0 flex-1 self-stretch items-center gap-2 px-3 text-left text-sm",
+														GROUP_CHILD_INSET
+													)}
 												>
 													{/* <Folder className="w-4 h-4 text-orange-400" /> */}
 													<TruncatedText className="flex-1">

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1559,7 +1559,17 @@ header band, body below it.
   the row's _background_ in too, so a nested row's hover and selection fill stops
   short of the panel edge while a top-level row's reaches it. Depth is shown by
   where the content sits, not where the row starts:
-  `paddingLeft: 8 + depth * INDENT_STEP` (`constants/layout`).
+  `paddingLeft: rowInsetPx(depth)` (`constants/layout`, `8 + depth * INDENT_STEP`).
+- **Non-row content inside a level takes a child row's left edge.** A
+  placeholder, an inline form, a loading skeleton and an inline error all stand
+  in for the rows that are not there, so they start where those rows would:
+  `childInsetPx(depth)` in the collections tree, the named `GROUP_CHILD_INSET`
+  in the two-level variables tree. Each carrying its own `px-*` is how one
+  expanded folder came to show up to five different left edges, with "Empty
+  folder" left of its own parent's label (#1372). An empty level also has to
+  _say_ so: its group holds no `treeitem`, so the folder row carries
+  `aria-describedby` pointing at the placeholder rather than the placeholder
+  taking a role inside a group that owns rows.
 - **A control with an outward focus ring needs clearance from the body's top
   edge.** The body scrolls, so it clips at its own bounds, and a ring drawn
   outside the border box gets its top cut off when the control sits flush. Rows


### PR DESCRIPTION
## Description

A nested folder's "Empty folder" line sat at the tree's left edge, left of its own parent's label and left of the sibling request rows below it. Root cause: rows in both trees derive their left edge from their level, while everything that is **not** a row - placeholders, inline forms, skeletons, inline errors - carried a fixed `px-*`, so one expanded node showed up to five different left edges and a variables section appeared to shift sideways as its query settled. The fix states one rule where the rows already state theirs - anything inside a level's `role="group"` takes the left edge a child row at that level would take - and derives it from the row's own computation rather than introducing a token. The alternative considered and rejected was a per-placeholder padding tuned to look right at each site: it is what produced the five edges, and it leaves the next placeholder to guess.

- `rowInsetPx(depth)` / `childInsetPx(depth)` in `constants/layout`, the second derived from the first. The formula had three copies (`CollectionItem`, `RequestItem` twice, `MoveToDialog`); all now call the helper, so a placeholder and the row it stands in for cannot drift apart.
- The variables tree is exactly two levels deep, so its inset is a named class rather than a function of depth. `GROUP_CHILD_INSET` replaces the four paddings the groups' contents used (`px-3`, `pl-6`, `px-1`, and the rows' own `pl-12.5`), and the rows read it too, so there is one definition.
- An empty folder now announces itself: its group holds no `treeitem`, so a screen reader walking the tree reached nothing. The folder row carries `aria-describedby` pointing at the placeholder. The placeholder takes no role of its own - a `role="group"` inside a tree owns treeitems, and a second role in there would be an invalid child rather than an extra stop.

Deliberate deviations from the issue:

- **Schema explorer left alone.** The issue lists it as "verify, not asserted, in the running app". Its group headings are eyebrow labels (`role="presentation"`) for a flat group rather than placeholders standing in for a level's rows, and judging whether they read as the same defect needs the app on screen. Not changed, and no scope added here.
- **`MoveToDialog` moved onto the helper** though the issue names only the two tree files. It held a third copy of the same formula; leaving it would make the helper one definition out of two.
- **`docs/app/COMPONENTS.md` not touched.** Its `CollectionItem` and `VariablesCategoryTree` entries describe role and props only and say nothing about padding, so there is nothing stale in them. The rule went to `docs/design-system.md`, which does state the indent.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Two new guards, both mutation-checked (reverted the fix, confirmed failure, restored - 9 of 11 cases failed on the revert, the two survivors being the reference-sanity case and the absence case):

- `CollectionItem.child-inset.test.tsx` (6 cases): the placeholder and the new-subfolder form at depth 0 and depth 2, each asserted both against `8 + (depth + 1) * INDENT_STEP` and against the `paddingLeft` a `RequestItem` actually renders at `depth + 1`; plus the row's `aria-describedby` when the folder is empty and its absence when it is not.
- `VariablesCategoryTree.group-inset.test.tsx` (5 cases): the empty line, the new-environment field, the loading skeleton and the failure line, each compared to the inset class a rendered environment row carries rather than to a literal.

Commands run, all green:

- `pnpm test CollectionItem VariablesCategoryTree RequestItem drawer-row-hit-area CollectionTree MoveToDialog` - 22 files, 172 tests passed
- `pnpm test` (full suite) - see the check run
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean (prettier run on the touched `app/` files only)

Not verifiable here: the visual check in the running app. This is a headless container, and #1347 records that the frameless window does not paint under a bare X server.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1372

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhriNY8mpazKYaV7NuRLos)_