### PR TITLE
fix(app): the loading skeleton's bars, not its box, take the row inset (#1372)

### DIFF
--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.group-inset.test.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.group-inset.test.tsx
@@ -73,6 +73,23 @@ function insetClass(element: HTMLElement): string | undefined {
 }
 
 /**
+ * The left padding an element contributes, in Tailwind spacing steps, from a
+ * `pl-*` or - when it has none - the `px-*` that sets both sides.
+ *
+ * Needed only for the skeleton, whose left edge is two elements' padding added
+ * together. Everywhere else a single class is the whole answer and the cases
+ * compare classes directly.
+ */
+function leftPaddingSteps(element: HTMLElement): number {
+	const classes = element.className.split(/\s+/);
+	const left = classes.find((name) => name.startsWith("pl-"));
+	const both = classes.find((name) => name.startsWith("px-"));
+	const value = Number((left ?? both ?? "").replace(/^p[lx]-/, ""));
+	if (!Number.isFinite(value)) throw new Error(`no left padding on: ${element.className}`);
+	return value;
+}
+
+/**
  * What an environment row indents to, read off a rendered row. Renders its own
  * tree and puts the query state back, so a case can take the reference and then
  * set up the state it is actually about.
@@ -118,12 +135,19 @@ describe("everything inside a section's group takes the row's left edge", () => 
 		expect(insetClass(field.parentElement as HTMLElement)).toBe(expected);
 	});
 
-	it("indents the loading skeleton", () => {
-		const expected = rowInsetClass();
+	it("indents the loading skeleton's bars, not just the box around them", () => {
+		// `ListSkeleton` pads every bar it draws with its own `px-2`, inside
+		// whatever the caller sets on the wrapper, so the wrapper carrying the
+		// row's inset put the bars 8px right of the rows they stand in for. The
+		// two paddings are what the eye adds up, so the test adds them too.
+		const expectedSteps = Number(rowInsetClass()?.replace("pl-", ""));
 		queryState.environments = { ...settled, data: [], isLoading: true };
 		renderTree();
 
-		expect(insetClass(screen.getByRole("status", { name: "Loading" }))).toBe(expected);
+		const wrapper = screen.getByRole("status", { name: "Loading" });
+		const bar = wrapper.querySelector(".flex") as HTMLElement;
+		expect(bar).toBeTruthy();
+		expect(leftPaddingSteps(wrapper) + leftPaddingSteps(bar)).toBe(expectedSteps);
 	});
 
 	it("indents the failure line", () => {

--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
@@ -102,6 +102,17 @@ const SCOPE_SECTIONS = 3;
  */
 const GROUP_CHILD_INSET = "pl-12.5";
 
+/**
+ * The same left edge for `ListSkeleton`, which cannot take it directly.
+ *
+ * The primitive pads each bar it draws with its own `px-2`, inside whatever the
+ * caller puts on the wrapper, so the two stack: the inset above put the bars 8px
+ * right of the rows they stand in for. 42 + 8 = the 50px above. The arithmetic
+ * is held by a test rather than by this comment - it reads both classes off the
+ * rendered skeleton and a rendered row, so changing either side fails.
+ */
+const GROUP_CHILD_SKELETON_INSET = "pl-10.5";
+
 export default function VariablesCategoryTree() {
 	// Fetches its own data, like the other three drawer views. It used to
 	// receive both lists as props from the Drawer, which read them with `= []`
@@ -459,7 +470,7 @@ export default function VariablesCategoryTree() {
 								{isLoadingEnvironments ? (
 									<ListSkeleton
 										rows={2}
-										className={cn("pr-3", GROUP_CHILD_INSET)}
+										className={cn("pr-3", GROUP_CHILD_SKELETON_INSET)}
 									/>
 								) : showEnvironmentsError ? (
 									<ErrorState
@@ -734,7 +745,7 @@ export default function VariablesCategoryTree() {
 								{isLoadingCollections ? (
 									<ListSkeleton
 										rows={2}
-										className={cn("pr-3", GROUP_CHILD_INSET)}
+										className={cn("pr-3", GROUP_CHILD_SKELETON_INSET)}
 									/>
 								) : showCollectionsError ? (
 									<ErrorState


### PR DESCRIPTION
## Description

Follow-up to #1374, which is merged. It gave the variables tree's group contents one left edge and got three of the four states right; the loading skeleton it got half right, and my own review phase caught it after the merge rather than before.

`ListSkeleton` pads every bar it draws with its own `px-2`, on a row div **inside** the wrapper the caller styles (`ListSkeleton.tsx:46`). #1374 put the 50px row inset on that wrapper, so the two paddings stacked: the bars rendered at 58px while the environment rows they stand in for sit at 50px. An 8px jog, in the state a user sees first - the same defect #1372 is about, just smaller than the 38px version it replaced (`px-1` + `px-2` = 12px against rows at 50px).

The wrapper now carries the remainder, 42px, as a named constant with the reason on it rather than a number that looks arbitrary next to the 50px above. The alternative was dropping the `px-2` inside `ListSkeleton`: rejected, because the three other callers (History, Trash, CollectionTree) pass no inset at all and their bars would move to the panel edge. A caller compensating for one primitive beats changing the primitive for one caller.

Not changed: `leading` stays on, so the skeleton's leftmost element is its 16px square, and that square is what now starts at the rows' 50px.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

The existing skeleton case in `VariablesCategoryTree.group-inset.test.tsx` asserted the wrapper's class only, which is exactly why it passed over this - a class-level guard cannot see a second element's padding underneath it. It now does the arithmetic the eye does: reads the left padding off the wrapper **and** off a bar, adds them, and compares to the inset a rendered environment row carries.

- Mutation check: against #1374's version the guard fails with `expected 14.5 to be 12.5` - the 8px this fixes, in Tailwind spacing steps.
- `pnpm test` (full suite): 647 files, 7322 tests passed.
- `pnpm test VariablesCategoryTree CollectionItem drawer-row-hit-area`: 6 files, 54 tests passed.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check`: clean.

One note for anyone reproducing locally: `pnpm install` is needed on top of the #1373 merge before type-checking. A stale `node_modules` still holding Electron 42 reports `electron/main.ts(410,28): Type 'string' is not assignable to type 'Promise<string>'`, because the promise-based `clipboard.readText` that #1373 targets only exists in 44's types. It is an artifact of the stale install, not a fault on master - the error is gone after installing, and it reproduced identically on the base commit before that.

No doc change: `docs/design-system.md`'s rule from #1374 ("non-row content inside a level takes a child row's left edge", the loading skeleton named among them) is what this makes true, not something it changes.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Refs #1372 (closed by #1374; this corrects one state that PR got wrong).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhriNY8mpazKYaV7NuRLos)_