### PR TITLE
fix(app): a cleared script reaches the engine, and a save only clears the dirty flag for what it sent - #1381

### DIFF
--- a/app/src/hooks/useSaveManager.autosave-setting.test.tsx
+++ b/app/src/hooks/useSaveManager.autosave-setting.test.tsx
@@ -44,7 +44,15 @@ function chooseInSettings(patch: { enabled?: boolean; delayMs?: number }) {
 
 function mountManager(onSave: () => Promise<void>) {
 	return renderHook(() =>
-		useSaveManager({ entityId: "req_1", contextName: "Request", onSave, hasChanges: true })
+		useSaveManager({
+			entityId: "req_1",
+			contextName: "Request",
+			onSave,
+			hasChanges: true,
+			// One edit, never revised: these cases are about the save, not the
+			// debounce. `useSaveManager.debounce.test.tsx` varies the token.
+			changeToken: 1,
+		})
 	);
 }
 

--- a/app/src/hooks/useSaveManager.concurrent-save.test.tsx
+++ b/app/src/hooks/useSaveManager.concurrent-save.test.tsx
@@ -42,7 +42,15 @@ function deferred() {
 
 function mountManager(onSave: () => Promise<void>) {
 	return renderHook(() =>
-		useSaveManager({ entityId: "req_1", contextName: "Request", onSave, hasChanges: true })
+		useSaveManager({
+			entityId: "req_1",
+			contextName: "Request",
+			onSave,
+			hasChanges: true,
+			// One edit, never revised: these cases are about the save, not the
+			// debounce. `useSaveManager.debounce.test.tsx` varies the token.
+			changeToken: 1,
+		})
 	);
 }
 

--- a/app/src/hooks/useSaveManager.debounce.test.tsx
+++ b/app/src/hooks/useSaveManager.debounce.test.tsx
@@ -170,4 +170,65 @@ describe("what a returning save is allowed to call itself", () => {
 		expect(useSaveStore.getState().status).toBe("pending");
 		expect(useSaveStore.getState().status).not.toBe("saved");
 	});
+
+	/*
+	 * Cmd+S and the quit flush do not call `performSave` directly - they go
+	 * through the store's `runSave`, which publishes its own status around the
+	 * context's save. It knew to keep its hands off an `error` the context had
+	 * reported and nothing else, so it painted "Saved" straight over the
+	 * `pending` this fix publishes. Two paths, two cases: the guard is one line
+	 * and covers both, and only a test that drives the store catches it.
+	 */
+	it("stays unsaved when the edit landed during a Cmd+S", async () => {
+		const held = deferred();
+		const onSave = vi.fn().mockReturnValue(held.promise);
+		const { rerender } = mountManager(onSave);
+
+		let triggered!: Promise<void>;
+		act(() => {
+			triggered = useSaveStore.getState().triggerSave();
+		});
+		await settle();
+
+		rerender({ token: 2 });
+
+		held.resolve();
+		await act(async () => {
+			await triggered;
+		});
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("stays unsaved when the edit landed during the quit flush", async () => {
+		const held = deferred();
+		const onSave = vi.fn().mockReturnValue(held.promise);
+		const { rerender } = mountManager(onSave);
+
+		let flushed!: Promise<void>;
+		act(() => {
+			flushed = useSaveStore.getState().flushAll();
+		});
+		await settle();
+
+		rerender({ token: 2 });
+
+		held.resolve();
+		await act(async () => {
+			await flushed;
+		});
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("still reports Saved through Cmd+S when nothing raced it", async () => {
+		// The control. A guard that refused to ever complete would pass the two
+		// cases above and break every ordinary save.
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await useSaveStore.getState().triggerSave();
+		});
+
+		expect(useSaveStore.getState().status).toBe("saved");
+	});
 });

--- a/app/src/hooks/useSaveManager.debounce.test.tsx
+++ b/app/src/hooks/useSaveManager.debounce.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The delay is measured from the last edit, and "Saved" is a claim about the
+ * editor rather than about the round trip (issue #1381).
+ *
+ * Both properties hang on `changeToken`, and both were broken without it. The
+ * hook watched `hasChanges`, a boolean already `true` by the second keystroke:
+ * the auto-save effect did not re-run, the timer armed by the *first* keystroke
+ * ran to term, and a save went out five seconds into a burst carrying a
+ * half-typed script. Then that save resolved, reported "Saved" over the
+ * keystrokes it had not carried, and the provider cleared the dirty flag - so
+ * nothing re-armed and the edit was gone.
+ *
+ * These cases drive the token the way an editing provider does: one increment
+ * per edit, `hasChanges` staying `true` throughout, which is exactly the shape
+ * that used to slip through.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useClientSettingsStore } from "@/stores";
+import { useSaveStore } from "@/stores/save-store";
+import { useSaveManager } from "./useSaveManager";
+
+function mountManager(onSave: () => Promise<void>) {
+	return renderHook(
+		({ token }: { token: number }) =>
+			useSaveManager({
+				entityId: "req_1",
+				contextName: "Request",
+				onSave,
+				// Dirty from the first edit and never re-clean: the provider only
+				// clears this once a save carrying every edit comes back.
+				hasChanges: true,
+				changeToken: token,
+			}),
+		{ initialProps: { token: 1 } }
+	);
+}
+
+/** Let queued promises run without moving the clock. */
+async function settle() {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(0);
+	});
+}
+
+/** A promise the test resolves by hand, to hold a save in flight. */
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+describe("the auto-save delay as a debounce", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.getState().reset();
+		useClientSettingsStore.setState({ autoSave: { enabled: true, delayMs: 5000 } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("restarts on every edit, so the save follows the pause and not the first keystroke", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { rerender } = mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(2000);
+		});
+		// A second edit, 2s into the first one's window.
+		rerender({ token: 2 });
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(3000);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1999);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		// 5s after the *second* edit, not the first.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("saves a 15s typing burst once, at the end, not once per delay window", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { rerender } = mountManager(onSave);
+
+		for (let edit = 2; edit <= 9; edit++) {
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			rerender({ token: edit });
+		}
+		expect(onSave).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("what a returning save is allowed to call itself", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		// Auto-save off: the only save in these cases is the explicit one, so the
+		// status under test cannot be a later timer's.
+		useClientSettingsStore.setState({ autoSave: { enabled: false, delayMs: 5000 } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("reports Saved when nothing was typed while it was in flight", async () => {
+		const held = deferred();
+		const onSave = vi.fn().mockReturnValue(held.promise);
+		const { result } = mountManager(onSave);
+
+		act(() => {
+			void result.current.forceSave();
+		});
+		await settle();
+		expect(useSaveStore.getState().status).toBe("saving");
+
+		held.resolve();
+		await settle();
+		expect(useSaveStore.getState().status).toBe("saved");
+	});
+
+	it("stays unsaved when an edit landed while it was in flight", async () => {
+		const held = deferred();
+		const onSave = vi.fn().mockReturnValue(held.promise);
+		const { result, rerender } = mountManager(onSave);
+
+		act(() => {
+			void result.current.forceSave();
+		});
+		await settle();
+
+		// The keystroke the flying payload does not carry.
+		rerender({ token: 2 });
+
+		held.resolve();
+		await settle();
+		expect(useSaveStore.getState().status).toBe("pending");
+		expect(useSaveStore.getState().status).not.toBe("saved");
+	});
+});

--- a/app/src/hooks/useSaveManager.status-stomp.test.tsx
+++ b/app/src/hooks/useSaveManager.status-stomp.test.tsx
@@ -29,7 +29,15 @@ import { useSaveManager } from "./useSaveManager";
 
 function mountManager(onSave: () => Promise<void>) {
 	return renderHook(() =>
-		useSaveManager({ entityId: "req_1", contextName: "Request", onSave, hasChanges: true })
+		useSaveManager({
+			entityId: "req_1",
+			contextName: "Request",
+			onSave,
+			hasChanges: true,
+			// One edit, never revised: these cases are about the save, not the
+			// debounce. `useSaveManager.debounce.test.tsx` varies the token.
+			changeToken: 1,
+		})
 	);
 }
 

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -28,6 +28,17 @@ interface UseSaveManagerOptions {
 	onSave: () => Promise<void>;
 	/** Whether there are unsaved changes */
 	hasChanges: boolean;
+	/**
+	 * A counter the caller increments on every edit.
+	 *
+	 * `hasChanges` cannot carry this on its own: it is already `true` for the
+	 * second keystroke of a burst, so an effect watching it does not re-run and
+	 * the delay measures from the *first* edit rather than the last. The token
+	 * changes on every edit, which is what makes the delay a debounce and what
+	 * tells a returning save whether the payload it sent is still the whole
+	 * story.
+	 */
+	changeToken: number;
 	/** Whether auto-save is enabled (default: true) */
 	enabled?: boolean;
 }
@@ -46,6 +57,7 @@ export function useSaveManager({
 	contextName,
 	onSave,
 	hasChanges,
+	changeToken,
 	enabled = true,
 }: UseSaveManagerOptions): UseSaveManagerReturn {
 	const {
@@ -69,6 +81,7 @@ export function useSaveManager({
 	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
 	const onSaveRef = useRef(onSave);
 	const hasChangesRef = useRef(hasChanges);
+	const changeTokenRef = useRef(changeToken);
 	const enabledRef = useRef(enabled);
 
 	// Keep onSave ref updated to avoid stale closures
@@ -80,6 +93,11 @@ export function useSaveManager({
 	useEffect(() => {
 		hasChangesRef.current = hasChanges;
 	}, [hasChanges]);
+
+	// Keep the change token ref updated
+	useEffect(() => {
+		changeTokenRef.current = changeToken;
+	}, [changeToken]);
 
 	// Keep enabled ref updated
 	useEffect(() => {
@@ -121,12 +139,26 @@ export function useSaveManager({
 		// repoints `onSaveRef` - a queued save that read the ref late would write
 		// the entity the user just switched *to*.
 		const save = onSaveRef.current;
+		// The generation that saver carries. Bound here, beside it, for the same
+		// reason: both describe the state of the entity at this moment, and a
+		// read taken later would describe an edit this save is not carrying.
+		const savedGeneration = changeTokenRef.current;
 
 		const run = saveQueueRef.current.then(async () => {
 			startSaving();
 			try {
 				await save();
-				completeSaveThenIdle();
+				// "Saved" is a claim about the editor, not about the round trip.
+				// An edit that landed while this save was in flight is not in
+				// what went out, so the honest status is still "unsaved" - the
+				// Dock reads this store, and it used to flash "Saved" over an
+				// edit nobody had persisted. The caller re-arms the save; this
+				// only refuses to mislabel it.
+				if (changeTokenRef.current === savedGeneration) {
+					completeSaveThenIdle();
+				} else {
+					markPendingSave();
+				}
 			} catch (error) {
 				console.error("Save failed:", error);
 				failSave(error instanceof Error ? error.message : "Save failed");
@@ -134,7 +166,7 @@ export function useSaveManager({
 		});
 		saveQueueRef.current = run;
 		return run;
-	}, [entityId, startSaving, completeSaveThenIdle, failSave]);
+	}, [entityId, startSaving, completeSaveThenIdle, markPendingSave, failSave]);
 
 	// Register/unregister with centralized save context
 	useEffect(() => {
@@ -202,7 +234,15 @@ export function useSaveManager({
 		await performSave();
 	}, [performSave]);
 
-	// Auto-save on changes (debounced)
+	// Auto-save on changes, debounced from the *last* edit.
+	//
+	// `changeToken` is in the dependency list and `hasChanges` alone is not
+	// enough: the boolean is already `true` by the second keystroke, so this
+	// effect did not re-run and the timer armed by the first keystroke ran to
+	// term - a save fired five seconds into a burst carrying a half-typed
+	// script, every burst, which is what made the in-flight-edit race fire so
+	// often. With the token here, each edit clears the pending timer in the
+	// cleanup below and arms a fresh one, so one save follows the pause.
 	useEffect(() => {
 		if (!enabled || !hasChanges || !entityId) {
 			return;
@@ -236,6 +276,7 @@ export function useSaveManager({
 	}, [
 		enabled,
 		hasChanges,
+		changeToken,
 		entityId,
 		markPendingSave,
 		performSave,

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.save-generation.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.save-generation.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A save only gets to call the request clean if it carried every edit
+ * (issue #1381).
+ *
+ * `onSave(request)` serialises the state as it was when the save started, and
+ * the engine round trip is tens of milliseconds - a window a script editor
+ * lands keystrokes in constantly. Clearing `hasUnsavedChanges` when that
+ * promise resolved marked those keystrokes saved: the payload never held them,
+ * nothing was left dirty, so `useSaveManager` never re-armed, and the Dock said
+ * "Saved" over an edit that was gone on the next open.
+ *
+ * The provider therefore stamps every edit with a generation and clears the
+ * flag only for the generation it actually sent. The mocked save manager here
+ * is the seam: it hands back the options it was given, so a test can drive
+ * `onSave` by hand and read the `hasChanges` / `changeToken` the hook would
+ * have debounced on. That the hook then re-arms on those values is
+ * `useSaveManager.debounce.test.tsx`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import RequestBuilderProvider from "./RequestBuilderProvider";
+import { useRequestBuilderContext } from "./RequestBuilderContext";
+import type { RequestState } from "../types";
+
+/** The options the provider handed the save manager on the last render. */
+let managerOptions: { onSave: () => Promise<void>; hasChanges: boolean; changeToken: number };
+
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		resolveObject: (o: unknown) => o,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
+	useSaveManager: (options: {
+		onSave: () => Promise<void>;
+		hasChanges: boolean;
+		changeToken: number;
+	}) => {
+		managerOptions = options;
+		return { forceSave: vi.fn(), status: "idle", isSaving: false };
+	},
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	useConfigQuery: () => ({ data: { entries: [] } }),
+}));
+
+/** Reads the dirty flag and offers the one edit the cases make. */
+function ScriptProbe() {
+	const { request, updateField, hasUnsavedChanges } = useRequestBuilderContext();
+	return (
+		<>
+			<span data-testid="script">{request.testScript}</span>
+			<span data-testid="dirty">{String(hasUnsavedChanges)}</span>
+			<button onClick={() => updateField("testScript", "first")}>type first</button>
+			<button onClick={() => updateField("testScript", "second")}>type second</button>
+		</>
+	);
+}
+
+/** A save the test holds open, so an edit can land while it is in flight. */
+function heldSave() {
+	const sent: RequestState[] = [];
+	let release!: () => void;
+	let pending = new Promise<void>((r) => {
+		release = r;
+	});
+	const onSave = vi.fn((request: RequestState) => {
+		sent.push(request);
+		return pending;
+	});
+	return {
+		onSave,
+		sent,
+		/** Let the in-flight save land, and arm the next one. */
+		finish: async () => {
+			const done = release;
+			pending = new Promise<void>((r) => {
+				release = r;
+			});
+			await act(async () => {
+				done();
+			});
+		},
+	};
+}
+
+const dirty = () => screen.getByTestId("dirty").textContent;
+const click = (label: string) => act(() => screen.getByText(label).click());
+const save = () => act(() => void managerOptions.onSave());
+
+describe("a save that raced an edit", () => {
+	let saves: ReturnType<typeof heldSave>;
+	const harness = () => saves;
+
+	beforeEach(() => {
+		const initialRequest: Partial<RequestState> = { id: "req_1", name: "Req" };
+		saves = heldSave();
+		render(
+			<RequestBuilderProvider
+				initialRequest={initialRequest}
+				collectionId="col_1"
+				onSave={saves.onSave}
+			>
+				<ScriptProbe />
+			</RequestBuilderProvider>
+		);
+	});
+
+	it("leaves the request dirty, so the next save is still scheduled", async () => {
+		click("type first");
+		expect(dirty()).toBe("true");
+
+		save();
+		// The keystroke the flying payload does not carry.
+		click("type second");
+
+		await harness().finish();
+
+		expect(dirty()).toBe("true");
+		expect(managerOptions.hasChanges).toBe(true);
+	});
+
+	it("sends the newer state on the save that follows", async () => {
+		click("type first");
+		save();
+		click("type second");
+		await harness().finish();
+
+		// The save manager only issues this one because the request is still
+		// marked dirty; asserting the flag here is what ties the payload below
+		// to the generation check rather than to the test calling `onSave`.
+		expect(managerOptions.hasChanges).toBe(true);
+		save();
+		await harness().finish();
+
+		expect(harness().sent.map((r) => r.testScript)).toEqual(["first", "second"]);
+	});
+
+	it("still reports clean when nothing was typed during the flight", async () => {
+		click("type first");
+		expect(dirty()).toBe("true");
+
+		save();
+		await harness().finish();
+
+		expect(dirty()).toBe("false");
+	});
+
+	it("stamps each edit with a new generation for the debounce to restart on", () => {
+		click("type first");
+		const afterFirst = managerOptions.changeToken;
+
+		click("type second");
+
+		expect(managerOptions.changeToken).not.toBe(afterFirst);
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -272,6 +272,31 @@ export default function RequestBuilderProvider({
 	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
 	/*
+	 * How many edits this request has seen - the generation `handleSave` checks
+	 * before it reports the request clean.
+	 *
+	 * `onSave(request)` serialises the state as it was when the save started, so
+	 * a keystroke that lands during the round trip is not in the payload that
+	 * went out. Clearing `hasUnsavedChanges` unconditionally on the way back
+	 * therefore marked that keystroke saved and dropped it: nothing was left
+	 * dirty, so `useSaveManager` never re-armed and the Dock said "Saved".
+	 * Comparing generations across the await keeps a save from claiming an edit
+	 * it never carried - the same shape `save-store.ts` uses to keep an early
+	 * timer off a later save's indicator.
+	 *
+	 * Kept as a ref *and* as state on purpose: the ref is what survives the
+	 * await, and the state is what `useSaveManager` can watch to restart its
+	 * debounce on each edit.
+	 */
+	const changeTokenRef = useRef(0);
+	const [changeToken, setChangeToken] = useState(0);
+	const markDirty = useCallback(() => {
+		changeTokenRef.current += 1;
+		setChangeToken(changeTokenRef.current);
+		setHasUnsavedChanges(true);
+	}, []);
+
+	/*
 	 * What the body modes you are not looking at were holding. It lives here
 	 * rather than in `BodyPanel` because Radix unmounts an inactive
 	 * `TabsContent`: a panel-local ref is discarded the moment you glance at the
@@ -659,9 +684,18 @@ export default function RequestBuilderProvider({
 	// Centralized save manager - handles auto-save, keyboard shortcut, and status
 	const handleSave = useCallback(async () => {
 		if (!onSave) return;
+		// Read from state, not the ref: this closure's `request` is the snapshot
+		// `onSave` serialises, and `changeToken` is the generation that produced
+		// it. The ref holds whatever the newest edit made it, which is the thing
+		// we are comparing against.
+		const savedGeneration = changeToken;
 		await onSave(request);
+		// An edit landed while this save was in flight: it is not in the payload
+		// that went out, so the request is still dirty and `useSaveManager` has
+		// to keep its debounce running for it.
+		if (changeTokenRef.current !== savedGeneration) return;
 		setHasUnsavedChanges(false);
-	}, [request, onSave]);
+	}, [request, changeToken, onSave]);
 
 	const {
 		forceSave,
@@ -671,14 +705,18 @@ export default function RequestBuilderProvider({
 		entityId: request.id || null,
 		onSave: handleSave,
 		hasChanges: hasUnsavedChanges,
+		changeToken,
 		enabled: !!onSave,
 	});
 
 	// Set request with change tracking
-	const setRequest = useCallback((updates: Partial<RequestState>) => {
-		setRequestState((prev) => ({ ...prev, ...updates }));
-		setHasUnsavedChanges(true);
-	}, []);
+	const setRequest = useCallback(
+		(updates: Partial<RequestState>) => {
+			setRequestState((prev) => ({ ...prev, ...updates }));
+			markDirty();
+		},
+		[markDirty]
+	);
 
 	// saveRequest now uses the centralized forceSave
 	const saveRequest = useCallback(async () => {

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -171,8 +171,13 @@ export default function RequestBuilder() {
 			formData: toKeyValueItems(formFields),
 			urlEncoded: toKeyValueItems(urlEncodedFields),
 			auth: fetchedRequest.auth,
-			preRequestScript: fetchedRequest.preRequestScript,
-			testScript: fetchedRequest.postRequestScript,
+			// `?? ""` rather than the bare field: these are optional on the
+			// wire type, and spreading an explicit `undefined` over
+			// `createDefaultRequestState()` would replace the `""` default with
+			// it. The save payload below sends both verbatim, so a state that
+			// held `undefined` would drop the key and lose a clear.
+			preRequestScript: fetchedRequest.preRequestScript ?? "",
+			testScript: fetchedRequest.postRequestScript ?? "",
 			followRedirects: fetchedRequest.followRedirects,
 			maxRedirects: fetchedRequest.maxRedirects,
 			httpVersion: fetchedRequest.httpVersion,
@@ -524,8 +529,22 @@ export default function RequestBuilder() {
 				body: bodyPayload,
 				bodyType: bodyPayload.mode,
 				auth: authPayload,
-				preRequestScript: request.preRequestScript || undefined,
-				postRequestScript: request.testScript || undefined,
+				/*
+				 * Both scripts are sent as they are, empty string included.
+				 *
+				 * They used to be `|| undefined`, the only two fields in this
+				 * payload that were. `undefined` serialises the key out of the
+				 * body, and an absent key on a `PUT` means "leave the stored
+				 * value alone" (`apply_string_field` in the engine's routes) -
+				 * so deleting a whole script saved nothing while the Dock
+				 * reported "Saved", and the old script came back on the next
+				 * open. `""` is a value the engine stores, which is what
+				 * clearing a script means. Both fields are always strings here:
+				 * `createDefaultRequestState` seeds them `""` and the memo above
+				 * keeps them strings.
+				 */
+				preRequestScript: request.preRequestScript,
+				postRequestScript: request.testScript,
 				followRedirects: request.followRedirects,
 				maxRedirects: request.maxRedirects,
 				httpVersion: request.httpVersion,

--- a/app/src/modules/request-builder/request-builder.script-clearing.test.tsx
+++ b/app/src/modules/request-builder/request-builder.script-clearing.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Deleting a script has to reach the engine as a value (issue #1381).
+ *
+ * `PUT /requests/:id` is a merge patch: a key that is present is written, and a
+ * key that is *absent* leaves the stored value alone. `JSON.stringify` drops a
+ * key whose value is `undefined`, so the save payload's
+ * `request.preRequestScript || undefined` turned the one state that means
+ * "cleared" into the one wire shape that means "keep what you have". Emptying a
+ * Tests script saved nothing, the mutation succeeded, the Dock said "Saved",
+ * and the old script was back on the next open.
+ *
+ * The two script fields were the only ones in that payload written this way.
+ * `name` looks similar and is not: it is omitted deliberately when blank,
+ * because a nameless request is unusable everywhere it is listed - that
+ * distinction is `save-request-name.test.ts`, and the cases here must not
+ * disturb it.
+ *
+ * The save is driven through the real component rather than through the
+ * payload builder alone, so the load-side seeding is in the path too: an
+ * `undefined` arriving from the wire type and spreading over
+ * `createDefaultRequestState()` would put the same hole back from the other
+ * end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useTabsStore, useSessionStore, useDashboardStore } from "@/stores";
+import type { RequestState } from "./types";
+
+const updateRequest = vi.fn();
+
+const STORED_PRE = "pm.environment.set('t', Date.now());";
+const STORED_POST = "pm.test('ok', () => pm.response.to.have.status(200));";
+
+/** What the request query hands back - the two script keys are the variable. */
+let storedScripts: { preRequestScript?: string; postRequestScript?: string } = {
+	preRequestScript: STORED_PRE,
+	postRequestScript: STORED_POST,
+};
+
+const requestQuery = {
+	get data() {
+		return {
+			id: "req_1",
+			collectionId: "col_1",
+			name: "Get user",
+			method: "GET",
+			url: "https://api.test/u",
+			params: [],
+			headers: [],
+			body: { mode: "none" },
+			auth: { mode: "none" },
+			...storedScripts,
+			followRedirects: true,
+			maxRedirects: 10,
+			httpVersion: "auto",
+			verifySSL: true,
+			stream: false,
+		} as unknown;
+	},
+	isLoading: false,
+	isError: false,
+	error: null as unknown,
+	refetch: vi.fn(),
+};
+
+vi.mock("@/queries", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/queries")>();
+	return {
+		...actual,
+		useRequestQuery: () => requestQuery,
+		useUpdateRequestMutation: () => ({ mutateAsync: updateRequest, mutate: vi.fn() }),
+		useCollectionAncestors: () => [],
+	};
+});
+
+vi.mock("@/hooks", () => ({
+	useEngine: () => ({ composeRequest: vi.fn(), executeRequest: vi.fn() }),
+	useVariableResolver: () => ({ resolveObject: <T,>(value: T) => value }),
+}));
+
+vi.mock("@/services", () => ({
+	apiService: { startLoadTest: vi.fn(), executeStreamRequest: vi.fn() },
+	loadTestService: { startMonitoring: vi.fn() },
+}));
+
+let providerProps: Record<string, unknown> = {};
+
+vi.mock("./context", () => ({
+	RequestBuilderProvider: (props: Record<string, unknown>) => {
+		providerProps = props;
+		return null;
+	},
+}));
+vi.mock("./components/RequestBuilderLayout", () => ({ default: () => null }));
+vi.mock("./components/LoadTestCommandSurface", () => ({ default: () => null }));
+vi.mock("./components/SendRequestCommandSurface", () => ({ default: () => null }));
+vi.mock("./components/LoadTestConfigDialog", () => ({ default: () => null }));
+
+const { default: RequestBuilder } = await import("./index");
+
+function renderBuilder() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	render(<RequestBuilder />, { wrapper });
+}
+
+/** The editor state the builder seeded, which is what the user then edits. */
+function seededState(overrides: Partial<RequestState> = {}): RequestState {
+	const initial = providerProps.initialRequest as Partial<RequestState>;
+	return { ...(initial as RequestState), disabledDefaultHeaders: [], ...overrides };
+}
+
+async function save(state: RequestState) {
+	await act(async () => {
+		await (providerProps.onSave as (r: RequestState) => Promise<void>)(state);
+	});
+	return updateRequest.mock.calls[0][0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+	storedScripts = { preRequestScript: STORED_PRE, postRequestScript: STORED_POST };
+	updateRequest.mockReset().mockResolvedValue({});
+	providerProps = {};
+	useTabsStore.setState({
+		openTabs: [{ id: "t1", type: "request", entityId: "req_1", title: "Req" } as never],
+		activeTabId: "t1",
+	});
+	useSessionStore.setState({ activeEnvironmentId: "env_1" });
+	useDashboardStore.getState().setStreaming(false);
+});
+
+describe("clearing a script", () => {
+	it("sends the empty string rather than dropping the key", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ preRequestScript: "", testScript: "" }));
+
+		// `toHaveProperty` is the assertion that matters: an absent key is what
+		// the engine reads as "keep the stored script".
+		expect(patch).toHaveProperty("preRequestScript", "");
+		expect(patch).toHaveProperty("postRequestScript", "");
+	});
+
+	it("clears one script without touching the other", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ testScript: "" }));
+
+		expect(patch).toHaveProperty("postRequestScript", "");
+		expect(patch).toHaveProperty("preRequestScript", STORED_PRE);
+	});
+
+	it("still refuses to send a blank name, which is a different rule", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ name: "   ", testScript: "" }));
+
+		expect(patch).not.toHaveProperty("name");
+		expect(patch).toHaveProperty("postRequestScript", "");
+	});
+});
+
+describe("a stored request that never had a script", () => {
+	it("seeds the editor with strings, not undefined", async () => {
+		// The wire type marks both optional, and spreading an `undefined` over
+		// `createDefaultRequestState()` replaces the `""` default with it - which
+		// would drop the key again on the first save.
+		storedScripts = {};
+		renderBuilder();
+
+		const initial = providerProps.initialRequest as Partial<RequestState>;
+		expect(initial.preRequestScript).toBe("");
+		expect(initial.testScript).toBe("");
+	});
+
+	it("sends both keys anyway, so the first clear after one is written lands", async () => {
+		storedScripts = {};
+		renderBuilder();
+		const patch = await save(seededState());
+
+		expect(patch).toHaveProperty("preRequestScript", "");
+		expect(patch).toHaveProperty("postRequestScript", "");
+	});
+});
+
+describe("a script the user kept", () => {
+	it("rides the save unchanged", async () => {
+		renderBuilder();
+		const patch = await save(seededState());
+
+		expect(patch).toHaveProperty("preRequestScript", STORED_PRE);
+		expect(patch).toHaveProperty("postRequestScript", STORED_POST);
+	});
+});

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -122,7 +122,18 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			// rejecting (`useSaveManager`, `SettingsMain`, `VariableTableEditor`
 			// all do), so overwriting unconditionally turned a failed Cmd+S into
 			// "Saved" - with the failure toast still on screen next to it.
-			if (get().status === "error") return;
+			//
+			// Nor is it proof of completeness (#1381). A context that saw an edit
+			// land while its write was in flight publishes `pending`, because the
+			// payload that went out does not hold that edit; overwriting *that*
+			// put "Saved" on the Dock over an edit nobody had persisted, on the
+			// two paths that come through here - Cmd+S and the quit flush.
+			//
+			// Both cases are the same rule: a status the context published for
+			// itself is the truthful one, and this wrapper only fills in the
+			// silence.
+			const published = get().status;
+			if (published === "error" || published === "pending") return;
 			get().completeSaveThenIdle();
 		} catch (error) {
 			get().failSave(error instanceof Error ? error.message : "Save failed");

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -2070,6 +2070,7 @@ const {
   contextName?: string              // Display name (e.g., "Request: GET /api")
   onSave: () => Promise<void>       // Function to persist changes
   hasChanges: boolean               // Whether unsaved changes exist
+  changeToken: number               // Bumped by the caller on every edit
   enabled?: boolean                 // Disable auto-save (default: true)
 });
 ```
@@ -2091,6 +2092,18 @@ const {
   one, so the hook reads it from the store rather than taking it as an option.
   Turning auto-save off in Settings leaves the entity marked dirty - Ctrl/Cmd+S
   still saves it - but schedules nothing.
+- **The delay runs from the last edit, and `changeToken` is what makes it a
+  debounce** (#1381). `hasChanges` cannot carry that on its own: it is already
+  `true` by the second keystroke, so an effect keyed on it does not re-run and
+  the timer armed by the *first* keystroke runs to term. A save then went out
+  five seconds into every burst carrying a half-typed script. The token changes
+  on every edit, so each one tears the pending timer down and arms a fresh one
+- **A returning save reports "Saved" only for the edits it carried** (#1381).
+  The saver and the token are bound together when `performSave` is called;
+  if the token has moved by the time the write lands, an edit arrived that the
+  payload does not hold, and the status goes back to `pending` rather than
+  flashing "Saved" over it. The caller is what re-arms the save - this only
+  refuses to mislabel it
 
 `app/src/config/timing.ts` used to carry an `AUTO_SAVE_DELAY_MS: 3000` that
 nothing read and that this section documented as the source of truth. It is
@@ -2252,12 +2265,13 @@ restore) and `save-request-name.test.ts` (the payload).
 2. Component mounts `useSaveManager()` with the request ID and save callback
 3. Hook registers the context with `useSaveStore()` for Ctrl/Cmd+S integration
 4. User edits the request (URL, headers, body, etc.)
-5. `hasChanges` is marked true, triggering the debounce timer - `autoSave.delayMs` from `client-settings-store`, 5s by default (Settings → General offers 5s / 30s / 1m)
-6. A further change within that window resets the timer
+5. `hasChanges` is marked true and `changeToken` is bumped, arming the debounce timer - `autoSave.delayMs` from `client-settings-store`, 5s by default (Settings → General offers 5s / 30s / 1m)
+6. A further change within that window bumps the token again, which tears the pending timer down and arms a new one, so the delay measures from the last edit
 7. After the delay elapses with no edit, `performSave()` is called, which calls the `onSave` callback
 8. Save status updates in `useSaveStore()`, and the Dock shows "Saving..." then "Saved" for `TIMING.SAVED_STATUS_DURATION_MS`
-9. On **tab switch or unmount**, any pending save is flushed before the context is unregistered
-10. On **app quit** (Electron `before-quit`) *and* on **window close** (the X
+9. **A save is only allowed to call the entity clean for the generation it sent** (#1381). `onSave(request)` serialises the state as it was when the save started, so a keystroke landing during the round trip is not in that payload. The provider records the generation beside the snapshot and clears `hasUnsavedChanges` only if the token has not moved when the write lands; the hook applies the same check to the "Saved" indicator. Clearing unconditionally marked that keystroke saved, left nothing dirty for the next timer to fire on, and lost the edit
+10. On **tab switch or unmount**, any pending save is flushed before the context is unregistered
+11. On **app quit** (Electron `before-quit`) *and* on **window close** (the X
     button), `useSaveStore().flushAll()` saves all dirty contexts
 
 **Both window-destroying paths flush, through one coordinator.** `before-quit`

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -603,6 +603,13 @@ do - so `runSave` checks for `status === "error"` after awaiting instead of
 setting `"saved"` unconditionally. Without that check a failed Cmd/Ctrl+S showed
 "Saved" beside its own failure toast.
 
+It refuses `"pending"` on the same grounds (#1381). A context that saw an edit
+land while its write was in flight publishes `pending`, because the payload that
+went out does not hold that edit - and `runSave` is the path Cmd/Ctrl+S and the
+quit flush take, so overwriting it put "Saved" on the Dock over an edit nobody
+had persisted. One rule covers both: a status the context published for itself
+is the truthful one, and `runSave` only fills in the silence.
+
 **SaveContext:**
 ```typescript
 {

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1339,6 +1339,14 @@ coerced. Changing the global `defaultHttpVersion` afterward does not
 retroactively alter a request already saved; only an explicit `null` on this
 request re-seeds it.
 
+**`preRequestScript` and `postRequestScript`** take the same rule, and the empty
+string is where it bites: an absent key leaves the stored script untouched,
+while `""` is a value that stores and is therefore how a script is *cleared*.
+`null` clears it too, since the default for these fields is the empty string. A
+client that means "delete this script" has to send `""` rather than dropping the
+key - the app sent `script || undefined` until #1381, which serialises the key
+out of the body, so deleting a script saved nothing and reported success.
+
 **Response:** The updated request object.
 
 **Errors:** `404` if the request does not exist; `400` on a `null`

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -566,6 +566,34 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateAbsentKeepsNullResets) {
     EXPECT_EQ (reset["maxRedirects"], 10);
 }
 
+// The server-side witness for the client contract in issue #1381: an empty
+// script is a value a client sends to clear one, and it is a different thing
+// from omitting the key. The app used to collapse the two - it wrote
+// `script || undefined`, which serialises the key out of the body - so
+// deleting a whole script saved nothing and reported success. Both fields,
+// because only `postRequestScript` had a case here at all.
+TEST_F (ResourceWriteRouteTest, RequestUpdateEmptyScriptStringClears) {
+    const std::string collection = make_collection ();
+    const std::string id         = make_request (collection);
+    ASSERT_EQ (update_request_response (*db_, id,
+               json{ { "preRequestScript", "pm.environment.set('t', 1);" },
+               { "postRequestScript", "pm.test('x', () => {});" } })
+               .first,
+    200);
+
+    auto [status, cleared] = update_request_response (
+    *db_, id, json{ { "preRequestScript", "" }, { "postRequestScript", "" } });
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (cleared["preRequestScript"], "");
+    EXPECT_EQ (cleared["postRequestScript"], "");
+
+    // Stored, not merely echoed back.
+    const auto stored = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->pre_request_script, "");
+    EXPECT_EQ (stored->post_request_script, "");
+}
+
 // `requests.stream` (issue #574). It follows the redirect policy's contract
 // exactly - absent keeps, null resets, a non-boolean is ignored rather than
 // rejected - and it is the app's Event stream toggle that persists here, so a


### PR DESCRIPTION
## Description

Three defects on one path, all reachable from the reported symptom ("edited the Tests script, the Dock said Saved, the edit was not there").

**Root cause.** The save payload wrote `request.preRequestScript || undefined` for the two script fields, the only fields in that payload written that way. `JSON.stringify` drops an `undefined` value, and `PUT /requests/:id` is a merge patch where an absent key means "keep the stored value" (`apply_string_field`) - so the one state that means *cleared* became the one wire shape that means *keep*. On top of that, the provider cleared `hasUnsavedChanges` unconditionally when `onSave` resolved, although `onSave(request)` serialises the snapshot taken when the save started: a keystroke landing during the round trip was marked saved without being in the payload, and since nothing stayed dirty, nothing re-armed. That race fired on nearly every typing burst because the delay was not a debounce - `useSaveManager` keyed its timer on the `hasChanges` boolean, which is already `true` by the second keystroke, so the effect never re-ran and a save went out five seconds into typing with a half-written script.

**Approach.** Send both scripts verbatim, empty string included; stamp every edit with a generation and clear the dirty flag only for the generation the save actually carried; pass that same generation to `useSaveManager` as `changeToken` so the timer restarts on each edit and a returning save cannot report "Saved" over an edit it did not send. The generation is the shape `save-store.ts` already uses to keep an early timer off a later save's indicator.

**Alternative rejected.** Omitting the key when the script is empty and adding a separate "clear script" signal (the shape `name` uses, which is deliberately omitted when blank). Rejected because the engine already treats `""` as the value that clears a script, and the MCP `update_request` tool already relies on exactly that ("an empty string is a value here, not an omission"). A second convention would have left the app the only client of that endpoint that could not clear a script.

### Beyond the issue's fix pathway

Three things the issue did not name, each found by tracing rather than assumed:

- **`save-store.ts`'s `runSave` had to learn the same rule** (second commit). Cmd+S and the quit flush do not call `performSave` directly - they go through `runSave`, which publishes its own status around the context's save and knew to keep its hands off exactly one status the context had set for itself, `error`. It therefore painted "Saved" straight over the new `pending`, re-opening the acceptance criterion from the other direction on the two paths a user is most likely to hit deliberately. One guard covers both: a status the context published for itself is the truthful one, and `runSave` only fills in the silence.
- **The load side seeds the two scripts `?? ""`.** They are optional on the wire type, and spreading an `undefined` over `createDefaultRequestState()` replaces the `""` default with it, which would reopen the hole from the other end. The issue assumed this invariant already held; it did not.
- **`changeToken` is a required option, not an optional one.** There is exactly one production caller, and an optional token would silently degrade any future caller back to the non-debounce. It cost three one-line edits in existing hook test harnesses.

### Noted, deliberately not in this diff

- **#1385** (filed): `useTreeCrud`'s sidebar rename writes the shared save status by hand rather than through a registered context, so a rename can flash "Saved" while an unrelated edit is unsaved. Pre-existing, a different surface, and generalising the rule to every direct status writer is its own change.
- The generation-guard idiom now has four hand-rolled copies (`save-store.ts`'s `idleResetGeneration`, `ImportModal.tsx`, and the two here). None is an importable primitive, so this is not a copy of one - but a shared `useGenerationGuard()` would be worth having if a fifth appears. Ergonomics rather than behaviour, so noted here instead of filed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Locally green on the issue's own commands: `python build.py -t`; `ctest --preset linux-dev --output-on-failure` **2905 passed, 0 failed**; `pnpm test` **7339 passed across 650 files, 0 failed**; `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean; `mkdocs build --strict` clean for the two doc edits. No pre-existing failures observed on the base commit.

New and touched suites:

| Suite | Tests |
| --- | --- |
| `request-builder.script-clearing.test.tsx` (new) | 6 |
| `useSaveManager.debounce.test.tsx` (new) | 7 |
| `RequestBuilderProvider.save-generation.test.tsx` (new) | 4 |
| `engine/tests/resource_write_route_test.cpp` (new case `RequestUpdateEmptyScriptStringClears`) | 1 |
| `useSaveManager.*` + `save-store` (existing, `changeToken` threaded through the harnesses) | 19 |

Every new case is mutation-checked - the fix reverted, the failure confirmed, the fix restored:

- restore `|| undefined` in the payload: 4 of the 6 clearing cases fail.
- drop the `?? ""` seeding: 2 fail.
- drop the token from the debounce dependency list, and report "Saved" unconditionally: 3 of the 4 original hook cases fail, the no-edit control still passes.
- drop the provider's generation compare: 2 of the 4 provider cases fail.
- restore `runSave`'s error-only guard: the 2 store-driven cases fail, the "nothing raced it" control still passes.

Each acceptance criterion in the issue maps to a case above; criterion 3's "the Dock never shows Saved while an unsaved edit exists" is what the `runSave` commit exists for, since the Dock reads `save-store`'s status rather than the provider's flag.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1381
