### PR TITLE
fix(app): keep the create-variable popover's focus in the value field

### DIFF
--- a/app/src/components/ui/variable-popover.test.tsx
+++ b/app/src/components/ui/variable-popover.test.tsx
@@ -257,7 +257,7 @@ describe("an undefined variable can define itself", () => {
 			writableScopes: ["global", "environment"],
 		});
 		const panel = open();
-		fireEvent.click(within(panel).getByRole("button", { name: "Global" }));
+		fireEvent.click(within(panel).getByRole("radio", { name: "Global" }));
 		fireEvent.change(within(panel).getByLabelText(/value for new variable/i), {
 			target: { value: "abc" },
 		});
@@ -271,11 +271,9 @@ describe("an undefined variable can define itself", () => {
 		// that appears to work and does not.
 		renderPopover({ varInfo: null, resolved: false, writableScopes: ["global"] });
 		const panel = open();
-		expect(within(panel).getByRole("button", { name: "Global" })).toBeInTheDocument();
-		expect(
-			within(panel).queryByRole("button", { name: "Environment" })
-		).not.toBeInTheDocument();
-		expect(within(panel).queryByRole("button", { name: "Collection" })).not.toBeInTheDocument();
+		expect(within(panel).getByRole("radio", { name: "Global" })).toBeInTheDocument();
+		expect(within(panel).queryByRole("radio", { name: "Environment" })).not.toBeInTheDocument();
+		expect(within(panel).queryByRole("radio", { name: "Collection" })).not.toBeInTheDocument();
 	});
 
 	it("falls back to explaining, when nothing at all is writable", () => {
@@ -283,6 +281,171 @@ describe("an undefined variable can define itself", () => {
 		const panel = open();
 		expect(within(panel).getByText(/Variable not defined/)).toBeInTheDocument();
 		expect(within(panel).queryByRole("button", { name: "Create" })).not.toBeInTheDocument();
+	});
+});
+
+/**
+ * Picking a scope used to end the interaction (issue #1380).
+ *
+ * The chips are `<button>`s, so clicking one took focus the way any button does,
+ * and the value field's `autoFocus` had run once at mount and had nothing left
+ * to give. Choosing "Collection" first and then typing put the keystrokes
+ * nowhere, and Enter re-pressed the chip instead of creating - the field sat
+ * empty beside a Create button that would have written an empty variable.
+ *
+ * jsdom does not move focus on a click the way a browser does, so each case here
+ * focuses the chip first: that is the browser behaviour under test, and asserting
+ * where focus lands afterwards is the only thing that distinguishes the fix.
+ */
+describe("the create row's keyboard model", () => {
+	/** The create branch, with all three scopes writable. */
+	function openCreate(
+		writableScopes: ("global" | "collection" | "environment")[] = [
+			"global",
+			"collection",
+			"environment",
+		]
+	) {
+		const { onValueChange } = renderPopover({ varInfo: null, resolved: false, writableScopes });
+		const panel = open();
+		const field = within(panel).getByLabelText(/value for new variable/i);
+		const chip = (label: string) => within(panel).getByRole("radio", { name: label });
+		return { onValueChange, panel, field, chip };
+	}
+
+	it("hands focus back to the value field when a chip is clicked", () => {
+		const { field, chip } = openCreate();
+		const collection = chip("Collection");
+		collection.focus();
+		fireEvent.click(collection);
+		// Drop the `.focus()` from the click handler and focus stays on the chip.
+		expect(document.activeElement).toBe(field);
+		expect(collection).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("creates with the picked scope from a value typed after the pick", () => {
+		const { onValueChange, field, chip } = openCreate();
+		fireEvent.click(chip("Collection"));
+		fireEvent.change(field, { target: { value: "abc" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledTimes(1);
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "abc", "collection");
+	});
+
+	it("is one Tab stop, with the selected chip carrying it", () => {
+		// Three chips, three tab stops in a two-control form, was the other half
+		// of the defect. Roving tabindex is what makes the group one stop.
+		const { chip } = openCreate();
+		expect(chip("Environment")).toHaveAttribute("tabindex", "0");
+		expect(chip("Collection")).toHaveAttribute("tabindex", "-1");
+		expect(chip("Global")).toHaveAttribute("tabindex", "-1");
+	});
+
+	it("moves selection and focus together on the arrow keys, wrapping at the ends", () => {
+		const { chip } = openCreate();
+		// Preference order is environment, collection, global.
+		const environment = chip("Environment");
+		environment.focus();
+
+		fireEvent.keyDown(environment, { key: "ArrowRight" });
+		expect(chip("Collection")).toHaveAttribute("aria-checked", "true");
+		expect(document.activeElement).toBe(chip("Collection"));
+
+		fireEvent.keyDown(chip("Collection"), { key: "ArrowLeft" });
+		expect(chip("Environment")).toHaveAttribute("aria-checked", "true");
+
+		// Wrapping: left from the first lands on the last.
+		fireEvent.keyDown(chip("Environment"), { key: "ArrowLeft" });
+		expect(chip("Global")).toHaveAttribute("aria-checked", "true");
+		expect(document.activeElement).toBe(chip("Global"));
+	});
+
+	it("reads as one choice out of three, not three independent toggles", () => {
+		const { panel, chip } = openCreate();
+		const group = within(panel).getByRole("radiogroup");
+		expect(group).toHaveAccessibleName("create in");
+		expect(chip("Environment")).toHaveAttribute("aria-checked", "true");
+		expect(chip("Global")).toHaveAttribute("aria-checked", "false");
+		expect(chip("Global")).not.toHaveAttribute("aria-pressed");
+	});
+
+	it("creates from a chip that has focus, since Enter has nothing else to mean", () => {
+		const { onValueChange, field, chip } = openCreate();
+		fireEvent.click(chip("Global"));
+		fireEvent.change(field, { target: { value: "abc" } });
+		// Tab from the field lands on the selected chip - the only one in the tab
+		// order - so that is the chip Enter can arrive on.
+		const global = chip("Global");
+		expect(global).toHaveAttribute("tabindex", "0");
+		global.focus();
+		fireEvent.keyDown(global, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "abc", "global");
+	});
+
+	it("ignores an Enter that only commits an IME buffer", () => {
+		// The same guard the edit field carries (#939): the composition commit
+		// arrives as an ordinary Enter keydown, so an unguarded field creates a
+		// variable out of a half-composed value.
+		const { onValueChange, field } = openCreate();
+		fireEvent.change(field, { target: { value: "ab" } });
+		fireEvent.keyDown(field, { key: "Enter", isComposing: true });
+		expect(onValueChange).not.toHaveBeenCalled();
+		fireEvent.keyDown(field, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "ab", "environment");
+	});
+});
+
+/**
+ * An empty field is not a variable worth writing (issue #1380).
+ *
+ * `mergeVariable` stores what it is handed, so Create on an empty field defined
+ * the name as `""` - which *resolves*, so the token stops reading as undefined
+ * and answers with nothing. The popover would then close over a silent write the
+ * user never typed.
+ */
+describe("creating with nothing typed", () => {
+	it("refuses the write and says so by disabling Create", () => {
+		const { onValueChange } = renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global", "environment"],
+		});
+		const panel = open();
+		const create = within(panel).getByRole("button", { name: "Create" });
+		expect(create).toBeDisabled();
+		fireEvent.click(create);
+		expect(onValueChange).not.toHaveBeenCalled();
+	});
+
+	it("refuses it on Enter too, so the keyboard path is not the way in", () => {
+		const { onValueChange } = renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global", "environment"],
+		});
+		const panel = open();
+		fireEvent.keyDown(within(panel).getByLabelText(/value for new variable/i), {
+			key: "Enter",
+		});
+		expect(onValueChange).not.toHaveBeenCalled();
+		// And the popover is still open to type into.
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("enables Create as soon as something is typed", () => {
+		const { onValueChange } = renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global", "environment"],
+		});
+		const panel = open();
+		fireEvent.change(within(panel).getByLabelText(/value for new variable/i), {
+			target: { value: "x" },
+		});
+		const create = within(panel).getByRole("button", { name: "Create" });
+		expect(create).toBeEnabled();
+		fireEvent.click(create);
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "x", "environment");
 	});
 });
 

--- a/app/src/components/ui/variable-popover.test.tsx
+++ b/app/src/components/ui/variable-popover.test.tsx
@@ -382,6 +382,18 @@ describe("the create row's keyboard model", () => {
 		expect(onValueChange).toHaveBeenCalledWith("merchantId", "abc", "global");
 	});
 
+	it("creates from the default chip too, with no pick of its own", () => {
+		// The path a user who accepts the preselected scope takes: type, Tab once
+		// to the chip already holding the tab stop, Enter. No click anywhere.
+		const { onValueChange, field, chip } = openCreate();
+		fireEvent.change(field, { target: { value: "abc" } });
+		const environment = chip("Environment");
+		expect(environment).toHaveAttribute("tabindex", "0");
+		environment.focus();
+		fireEvent.keyDown(environment, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", "abc", "environment");
+	});
+
 	it("ignores an Enter that only commits an IME buffer", () => {
 		// The same guard the edit field carries (#939): the composition commit
 		// arrives as an ordinary Enter keydown, so an unguarded field creates a
@@ -430,6 +442,28 @@ describe("creating with nothing typed", () => {
 		expect(onValueChange).not.toHaveBeenCalled();
 		// And the popover is still open to type into.
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("takes a value of spaces, which is a value the user typed", () => {
+		/*
+		 * The line the refusal is drawn on, asserted rather than left to be
+		 * rediscovered: empty means empty. Trimming would be this popover having
+		 * an opinion about a value that a header, a path segment or a delimiter
+		 * may legitimately want, and the variables editor - which stores the same
+		 * string without trimming it - would then disagree with the popover about
+		 * what the user typed.
+		 */
+		const { onValueChange } = renderPopover({
+			varInfo: null,
+			resolved: false,
+			writableScopes: ["global", "environment"],
+		});
+		const panel = open();
+		fireEvent.change(within(panel).getByLabelText(/value for new variable/i), {
+			target: { value: " " },
+		});
+		fireEvent.click(within(panel).getByRole("button", { name: "Create" }));
+		expect(onValueChange).toHaveBeenCalledWith("merchantId", " ", "environment");
 	});
 
 	it("enables Create as soon as something is typed", () => {

--- a/app/src/components/ui/variable-popover.tsx
+++ b/app/src/components/ui/variable-popover.tsx
@@ -48,7 +48,7 @@
  * a scope that cannot be written is a Create button that does nothing.
  */
 
-import { useState, useRef, useMemo } from "react";
+import { useState, useRef, useMemo, useId } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { Button } from "./button";
 import { TooltipIconButton } from "./tooltip-icon-button";
@@ -301,6 +301,43 @@ export function VariablePopover({
 	// pointing at a no-op.
 	const activeCreateScope =
 		createScope && creatableScopes.includes(createScope) ? createScope : creatableScopes[0];
+	const createValueRef = useRef<HTMLInputElement>(null);
+	const createScopeGroupRef = useRef<HTMLDivElement>(null);
+	const createScopeLabelId = useId();
+
+	/**
+	 * Picking a scope is a modifier on the value, not a destination (issue #1380).
+	 *
+	 * A chip is a `<button>`, so clicking one takes focus the way any button does,
+	 * and the field's `autoFocus` only ever ran at mount - so choosing the scope
+	 * first and then typing put the keystrokes nowhere and left Enter re-pressing
+	 * the chip. The click hands focus back to the value the chip qualifies.
+	 */
+	const selectCreateScope = (scope: VariableScope) => {
+		setCreateScope(scope);
+		createValueRef.current?.focus();
+	};
+
+	/**
+	 * Arrow movement inside the group, where focus follows selection.
+	 *
+	 * The WAI-ARIA radio group pattern, as `ProfilePicker.tsx` spells it out: the
+	 * group is one Tab stop (roving `tabIndex`), and arrows move *and* select,
+	 * wrapping at the ends - the user is choosing as they arrow, not navigating
+	 * and then committing. Focus stays on the chips here rather than returning to
+	 * the field, because otherwise the second arrow press would have nothing to
+	 * move from.
+	 */
+	const moveCreateScope = (delta: number) => {
+		const index = creatableScopes.findIndex((s) => s === activeCreateScope);
+		const next =
+			creatableScopes[(index + delta + creatableScopes.length) % creatableScopes.length];
+		if (!next) return;
+		setCreateScope(next);
+		createScopeGroupRef.current
+			?.querySelector<HTMLElement>(`[data-create-scope="${next}"]`)
+			?.focus();
+	};
 
 	const handleOpenChange = (open: boolean) => {
 		if (open) {
@@ -331,8 +368,21 @@ export function VariablePopover({
 		closePopover();
 	};
 
+	/**
+	 * An empty field is not a variable worth writing (issue #1380).
+	 *
+	 * `mergeVariable` stores what it is handed, so an empty value defines the name
+	 * as `""` - a definition that resolves, so the token stops reading as
+	 * undefined and answers with nothing. That is worse than the state it
+	 * replaced, and it is one stray click away while the field is still empty, so
+	 * the write is refused here and the Create button is disabled for the same
+	 * reason. Refused rather than trimmed: a value of spaces is a value the user
+	 * typed, and this popover is not the place to have an opinion about it.
+	 */
+	const canSubmitCreate = editValue.length > 0;
+
 	const handleCreate = () => {
-		if (!onValueChange || !activeCreateScope) return;
+		if (!onValueChange || !activeCreateScope || !canSubmitCreate) return;
 		onValueChange(name, editValue, activeCreateScope);
 		closePopover();
 	};
@@ -646,10 +696,14 @@ export function VariablePopover({
 					) : canCreate ? (
 						<>
 							<Input
+								ref={createValueRef}
 								value={editValue}
 								onChange={(e) => setEditValue(e.target.value)}
 								onKeyDown={(e) => {
-									if (e.key === "Enter") {
+									// `isCommitEnter`, not a bare Enter (#939): an IME
+									// commits its composition with the same keydown, and
+									// the app's Send chord is Ctrl/Cmd+Enter.
+									if (isCommitEnter(e)) {
 										e.preventDefault();
 										handleCreate();
 									}
@@ -660,36 +714,88 @@ export function VariablePopover({
 								autoFocus
 							/>
 							<div className="flex items-center gap-1.5">
-								<span className="shrink-0 text-[10px] text-muted-foreground">
+								<span
+									id={createScopeLabelId}
+									className="shrink-0 text-[10px] text-muted-foreground"
+								>
 									create in
 								</span>
 								{/*
-								 * Only writable scopes appear. A picker offering
-								 * "Environment" with none selected would produce a
-								 * Create button that silently does nothing.
+								 * Three mutually exclusive choices, so a radio group -
+								 * `aria-pressed` chips said "three independent toggles,
+								 * two of them off" to a screen reader, and each was its
+								 * own Tab stop in the middle of a two-control form.
+								 *
+								 * The arrow handler sits on the chips rather than on the
+								 * group: keydown from the focused chip bubbles either
+								 * way, and a handler on the group would make it an
+								 * unfocusable interactive element that `jsx-a11y` can
+								 * only be silenced about at the line.
 								 */}
-								{creatableScopes.map((scope) => (
-									<button
-										key={scope}
-										type="button"
-										onClick={() => setCreateScope(scope)}
-										aria-pressed={scope === activeCreateScope}
-										className={cn(
-											"rounded-md border px-1.5 py-0.5 text-[10px] transition-colors",
-											scope === activeCreateScope
-												? cn(
-														VARIABLE_SCOPE_CONFIG[scope].tint,
-														VARIABLE_SCOPE_CONFIG[scope].border
-													)
-												: "border-transparent text-muted-foreground hover:bg-accent"
-										)}
-									>
-										{VARIABLE_SCOPE_CONFIG[scope].full}
-									</button>
-								))}
+								<div
+									ref={createScopeGroupRef}
+									role="radiogroup"
+									aria-labelledby={createScopeLabelId}
+									className="flex items-center gap-1.5"
+								>
+									{/*
+									 * Only writable scopes appear. A picker offering
+									 * "Environment" with none selected would produce a
+									 * Create button that silently does nothing.
+									 */}
+									{creatableScopes.map((scope) => {
+										const selected = scope === activeCreateScope;
+										return (
+											<button
+												key={scope}
+												type="button"
+												role="radio"
+												aria-checked={selected}
+												data-create-scope={scope}
+												// Roving tabindex: the group is one Tab stop.
+												tabIndex={selected ? 0 : -1}
+												onClick={() => selectCreateScope(scope)}
+												onKeyDown={(e) => {
+													// A chip that has focus and a value
+													// already typed leaves Enter nothing
+													// else to mean.
+													if (isCommitEnter(e)) {
+														e.preventDefault();
+														handleCreate();
+														return;
+													}
+													const delta =
+														e.key === "ArrowRight" ||
+														e.key === "ArrowDown"
+															? 1
+															: e.key === "ArrowLeft" ||
+																  e.key === "ArrowUp"
+																? -1
+																: 0;
+													if (delta === 0) return;
+													// Arrows would otherwise scroll the panel.
+													e.preventDefault();
+													moveCreateScope(delta);
+												}}
+												className={cn(
+													"rounded-md border px-1.5 py-0.5 text-[10px] transition-colors",
+													selected
+														? cn(
+																VARIABLE_SCOPE_CONFIG[scope].tint,
+																VARIABLE_SCOPE_CONFIG[scope].border
+															)
+														: "border-transparent text-muted-foreground hover:bg-accent"
+												)}
+											>
+												{VARIABLE_SCOPE_CONFIG[scope].full}
+											</button>
+										);
+									})}
+								</div>
 								<Button
 									size="sm"
 									className="ml-auto h-6 px-2 text-[11px]"
+									disabled={!canSubmitCreate}
 									onClick={handleCreate}
 								>
 									Create

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1847,6 +1847,18 @@ instead of telling the reader to go and define it. The red itself stays - the
 token genuinely does not resolve. `data.*` is the one state with no list, for
 the same disjointness reason it has no create offer.
 
+**The create offer's scope chips are a radio group, and picking one keeps you in
+the value field** (issue #1380). They are one Tab stop on a roving `tabIndex`,
+arrows move the selection and the focus together wrapping at the ends, and Enter
+on the focused chip creates - a chip that has focus beside a value already typed
+leaves Enter nothing else to mean. A mouse click hands focus back to the field,
+because picking a scope qualifies the value rather than replacing it as the
+destination; as plain buttons the chips kept the focus a click gave them, and
+the next keystroke went nowhere. Create is refused while the field is empty:
+`mergeVariable` stores what it is handed, so an empty value defines the name as
+`""`, which resolves - the token stops reading as undefined and answers with
+nothing.
+
 Reaching the list into those states also reached the bound-row note into them,
 and it could not be carried over as written: "the definition above still
 resolves on a send that carries no row" is exactly what a switched-off

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1401,6 +1401,18 @@ unfocusable, so those sites carry a one-line disable naming the hook - the same
 for a row whose Enter and Space arrive through the tree rather than through its
 own handler.
 
+**A radio group whose options are already buttons needs no disable.** The
+variable popover's "create in" row (issue #1380) is the same pattern with
+focusable children: the arrow handler sits on each `role="radio"` button, where
+the keydown starts, rather than on the container it would bubble to, so the
+group is a plain `role="radiogroup"` with no handler and nothing for
+`interactive-supports-focus` to report. Reach for the container handler only
+where the options are not focusable in their own right, and take the disable
+with it. Selection there is a modifier, not a destination: the arrows move
+selection and focus together between the chips, and a mouse click on one returns
+focus to the value field it qualifies, because a chip that keeps focus after a
+click leaves the next keystroke going nowhere.
+
 **The lint's allowlist.** Three rules are configured rather than obeyed as
 written, in `app/eslint.config.mjs`, each because the pattern it flags is the
 correct one here:


### PR DESCRIPTION
## Description

Picking a scope in the create-variable popover moved focus to the chip, so typing afterwards went nowhere and Enter re-pressed the chip instead of creating (#1380).

**Root cause.** The "create in" chips are plain `<button>`s carrying only `onClick={() => setCreateScope(scope)}` (`variable-popover.tsx:672-688`), so a click takes focus the way any button does, and the value field's `autoFocus` had run once at mount with nothing left to give. Nothing in the component put focus back - the file has no DOM refs and no `useEffect` at all. Two defects travelled with it: Create on an empty field called `onValueChange(name, "", scope)`, and `mergeVariable` stores what it is handed, so the name got defined as `""` - a definition that *resolves*, so the token stops reading as undefined and answers with nothing; and the create field's Enter was a bare `e.key === "Enter"`, which #939 exists to prevent (an IME's composition commit arrives as an ordinary Enter keydown).

**Approach.** The chips become the WAI-ARIA radio group they always were - three mutually exclusive choices were announcing as three independent toggles and standing as three Tab stops in a two-control form. Roving tabindex makes the group one stop, `role="radio"` + `aria-checked` replaces `aria-pressed`, arrows move selection and focus together wrapping at the ends, and Enter on a focused chip creates with that chip's scope. A mouse click hands focus back to the value field: picking a scope is a modifier on the value, not a destination.

**The alternative rejected.** `ToggleGroup` (`components/ui/toggle-group.tsx`, Radix-backed) is the repo's segmented-control primitive and would have brought roving focus for free, but its single-select arm lets the active item be *deselected* to no value, and its arrows move focus without selecting - neither is what "exactly one scope, chosen as you arrow" needs - and adopting it would have restyled the 10px scope-tinted chips into a segmented control the issue never asked for. The hand-rolled group follows `ProfilePicker.tsx`, which the design system names as the canonical radiogroup.

**One deliberate deviation from that pattern:** the arrow handler sits on each `role="radio"` button rather than on the container. Keydown from the focused chip bubbles either way, but a handler on the container makes it an unfocusable interactive element that `jsx-a11y` can only be silenced about at the line - and the repo's suppression ceiling is at 15/15. Options that are already focusable do not need that trade, which is the sentence added to the design system.

**One deliberate deviation from the issue spec:** the empty-value refusal is `length > 0`, not a trim. A value of spaces is a value the user typed, and the variables editor stores the same string without trimming it, so trimming here would make the two disagree about what the user wrote. The behaviour is asserted rather than left to be rediscovered.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`pnpm test` - **647 files, 7332 tests, all passing** on the first commit; the popover's own file then goes 39 → 51 with the second. `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean. Engine untouched, so no C++ build or ctest run: no engine test could go from green to red.

Twelve new cases in `variable-popover.test.tsx`, mutation-checked by reverting the fix and confirming the failure:

| Mutation reverted | Test that goes red |
|---|---|
| drop `createValueRef.current?.focus()` from the chip click | hands focus back to the value field when a chip is clicked |
| drop the `canSubmitCreate` guard and `disabled` | refuses the write and says so by disabling Create; refuses it on Enter too |
| `isCommitEnter` → bare `e.key === "Enter"` | ignores an Enter that only commits an IME buffer |

jsdom does not move focus on a click the way a browser does, so the focus cases focus the chip first - that is the browser behaviour under test, and where focus lands afterwards is the only thing that distinguishes the fix.

The two existing create tests move from `getByRole("button", …)` to `getByRole("radio", …)` for the chips; no other test in the repo asserts on this row.

### Driven in the running app, not only in jsdom

Both states were exercised in the real Electron app (engine connected, a request in a collection with `https://{{base_url}}/v1/orders` in the URL bar, the red token clicked), driving the same interaction the issue reports: click the **Global** chip, then type `api.staging.internal`. The pre-fix component was checked out into the same running app to capture the left column.

| What was read off the live popover | Before (master `3a83608`) | After (this PR) |
|---|---|---|
| Chip group role | no radiogroup; two `aria-pressed` toggles | one `role="radiogroup"`, chips `role="radio"` |
| Tab stops in the group | 2 (`tabindex=0`, `tabindex=0`) | 1 (`tabindex=0` on the selected chip, `-1` on the rest) |
| `document.activeElement` after clicking a chip | `BUTTON[Global]` - focus stuck on the chip | `INPUT[Value for new variable base_url]` |
| What the field holds after typing 20 characters | `""` - the keystrokes went nowhere | `api.staging.internal` |
| Create with an empty field | enabled, ready to write `base_url=""` | disabled |
| ArrowRight on the last chip | no handler | wraps to the first, selection and focus together |

The screenshots show it plainly: before, the focus ring sits on the **Global** chip with the value field still showing its `value…` placeholder after typing and Create solid blue; after, the ring is back on the field holding `api.staging.internal`, with Global selected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/COMPONENTS.md`, beside the prose that already describes when the create offer appears and when it is withheld: the create row's keyboard model and the empty-value refusal. `docs/design-system.md`, Accessibility section: the radio-group-of-buttons case beside the existing composite-widget rule, since this group deliberately places its handler where that rule does not.

## Related Issues

Closes #1380