### PR TITLE
fix(app): a sidebar rename no longer reports "Saved" over an unrelated unsaved edit - #1385

### DIFF
--- a/app/src/components/layout/context-bar/variable-commit.ts
+++ b/app/src/components/layout/context-bar/variable-commit.ts
@@ -129,7 +129,7 @@ function usePendingCommits(): () => () => void {
 			// it lands. This path armed no reset at all before #369, which left
 			// "Saved" in the Dock until something else changed it.
 			if (useSaveStore.getState().status !== "error") {
-				useSaveStore.getState().completeSaveThenIdle();
+				useSaveStore.getState().completeSaveThenIdle(SAVE_CONTEXT_ID);
 			}
 		};
 	}, [updateContext]);

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -19,6 +19,14 @@ import { useEffect, useRef, useCallback } from "react";
 import { useSaveStore } from "@/stores/save-store";
 import { useClientSettingsStore } from "@/stores";
 
+/**
+ * The registry id this hook saves under. Three places in this file need it -
+ * the registration, the `hasPendingChanges` update, and the success this hook
+ * reports for itself - and a fourth spelling of the same template string is how
+ * the three drift apart.
+ */
+const saveContextId = (entityId: string) => `request-${entityId}`;
+
 interface UseSaveManagerOptions {
 	/** Unique identifier for this save context (e.g., request ID) */
 	entityId: string | null;
@@ -155,7 +163,7 @@ export function useSaveManager({
 				// edit nobody had persisted. The caller re-arms the save; this
 				// only refuses to mislabel it.
 				if (changeTokenRef.current === savedGeneration) {
-					completeSaveThenIdle();
+					completeSaveThenIdle(saveContextId(entityId));
 				} else {
 					markPendingSave();
 				}
@@ -172,7 +180,7 @@ export function useSaveManager({
 	useEffect(() => {
 		if (!entityId || !enabled) return;
 
-		const contextId = `request-${entityId}`;
+		const contextId = saveContextId(entityId);
 
 		registerContext({
 			id: contextId,
@@ -199,7 +207,7 @@ export function useSaveManager({
 	// Update context when hasChanges changes
 	useEffect(() => {
 		if (!entityId || !enabled) return;
-		const contextId = `request-${entityId}`;
+		const contextId = saveContextId(entityId);
 		updateContext(contextId, { hasPendingChanges: hasChanges, save: performSave });
 	}, [entityId, enabled, hasChanges, performSave, updateContext]);
 

--- a/app/src/modules/collections/useTreeCrud.rename-status.test.tsx
+++ b/app/src/modules/collections/useTreeCrud.rename-status.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A sidebar rename writes the shared save status by hand - it registers no save
+ * context, so `runSave`'s rule never covered it - and the Dock renders that one
+ * status for the whole app. Renaming a folder while the open request holds an
+ * unsaved edit therefore said "Saved": true of the rename, false of the editor
+ * (#1385).
+ *
+ * The rename itself is unchanged, and these cases say so: the status it
+ * publishes is the only thing that moved, and the failure it reports is not.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useSaveStore } from "@/stores/save-store";
+import { useToastStore } from "@/stores/toast-store";
+import { useTreeCrud } from "./useTreeCrud";
+import type { Collection, Request } from "@/types";
+
+const updateCollection = vi.fn();
+const updateRequest = vi.fn();
+
+vi.mock("@/queries", () => ({
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: updateCollection, isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: updateRequest, isPending: false }),
+	useRestoreTrashMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+const collections = [{ id: "c-1", name: "Acme", order: 0 }] as Collection[];
+const requests = [
+	{ id: "r-1", collectionId: "c-1", name: "List users", method: "GET", order: 0 },
+] as Request[];
+const requestsByCollection = new Map([["c-1", requests]]);
+
+function renderCrud() {
+	return renderHook(() =>
+		useTreeCrud({
+			collections,
+			rootCollections: collections,
+			selectedCollectionId: null,
+			requestsByCollection,
+			getRequestsByCollection: (id: string) => requestsByCollection.get(id) ?? [],
+		})
+	);
+}
+
+/** The open request tab, mid-edit: registered, dirty, and nothing to do with the tree. */
+function registerDirtyRequestContext() {
+	useSaveStore.getState().registerContext({
+		id: "request-r-open",
+		name: "Request",
+		save: () => Promise.resolve(),
+		hasPendingChanges: true,
+	});
+}
+
+describe("collection tree rename and the shared save status", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+		updateCollection.mockResolvedValue(undefined);
+		updateRequest.mockResolvedValue(undefined);
+	});
+
+	it("does not report 'Saved' for a collection rename while an editor is dirty", async () => {
+		registerDirtyRequestContext();
+		const { result } = renderCrud();
+
+		act(() => result.current.rows.onRenameChange("Acme Corp"));
+		await act(async () => {
+			await result.current.rows.onRenameSubmit("c-1");
+		});
+
+		expect(updateCollection).toHaveBeenCalledWith({ id: "c-1", name: "Acme Corp" });
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("does not report 'Saved' for a request rename while an editor is dirty", async () => {
+		registerDirtyRequestContext();
+		const { result } = renderCrud();
+
+		act(() => result.current.rows.onRequestRenameChange("List accounts"));
+		await act(async () => {
+			await result.current.rows.onRequestRenameSubmit("r-1");
+		});
+
+		expect(updateRequest).toHaveBeenCalledWith({ id: "r-1", name: "List accounts" });
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("still reports 'Saved' for a rename with nothing else unsaved", async () => {
+		const { result } = renderCrud();
+
+		act(() => result.current.rows.onRenameChange("Acme Corp"));
+		await act(async () => {
+			await result.current.rows.onRenameSubmit("c-1");
+		});
+
+		expect(useSaveStore.getState().status).toBe("saved");
+	});
+
+	it("still reports a failed rename through failSave, dirty editor or not", async () => {
+		registerDirtyRequestContext();
+		updateRequest.mockRejectedValue(new Error("Request name already taken"));
+		const { result } = renderCrud();
+
+		act(() => result.current.rows.onRequestRenameChange("List accounts"));
+		await act(async () => {
+			await result.current.rows.onRequestRenameSubmit("r-1");
+		});
+
+		expect(useSaveStore.getState().status).toBe("error");
+		expect(useToastStore.getState().toasts).toHaveLength(1);
+		expect(useToastStore.getState().toasts[0]).toMatchObject({
+			message: "Request name already taken",
+			variant: "error",
+		});
+	});
+});

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -58,6 +58,12 @@ import { useEngineRestart } from "@/hooks/useEngineRestart";
 const ENGINE_SAVE_NOTE = "Changes are staged here and written when you save.";
 
 /**
+ * The save registry id this panel holds. At module scope because the write
+ * reports its success under it, and that call sits above the registration.
+ */
+const SAVE_CONTEXT_ID = "settings";
+
+/**
  * Check if a config entry requires a restart when changed
  *
  * `requiresRestart` is a typed field the engine serializes on every entry
@@ -282,7 +288,7 @@ export default function SettingsMain() {
 					}
 					return next;
 				});
-				completeSaveThenIdle();
+				completeSaveThenIdle(SAVE_CONTEXT_ID);
 
 				// Track restart-required configs
 				for (const key of restartKeys) {
@@ -364,7 +370,6 @@ export default function SettingsMain() {
 	}, [handleSave]);
 
 	// Register save context when settings are ready (not loading, no error, category selected)
-	const contextId = "settings";
 	useEffect(() => {
 		// Only register when we have a valid settings view (not loading, no error, category selected, not a client-side category)
 		if (isLoading || error || !selectedCategory || isClientCategory(selectedCategory)) {
@@ -372,15 +377,15 @@ export default function SettingsMain() {
 		}
 
 		registerContext({
-			id: contextId,
+			id: SAVE_CONTEXT_ID,
 			name: "Settings",
 			save: () => handleSaveRef.current?.() ?? Promise.resolve(),
 			hasPendingChanges: hasChanges && !hasInvalidValues,
 		});
-		setActiveContext(contextId);
+		setActiveContext(SAVE_CONTEXT_ID);
 
 		return () => {
-			unregisterContext(contextId);
+			unregisterContext(SAVE_CONTEXT_ID);
 		};
 	}, [
 		isLoading,
@@ -398,7 +403,7 @@ export default function SettingsMain() {
 		if (isLoading || error || !selectedCategory || isClientCategory(selectedCategory)) {
 			return;
 		}
-		updateContext(contextId, {
+		updateContext(SAVE_CONTEXT_ID, {
 			hasPendingChanges: hasChanges && !hasInvalidValues,
 			save: () => handleSaveRef.current?.() ?? Promise.resolve(),
 		});

--- a/app/src/modules/variables/main/VariableTableEditor.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.tsx
@@ -331,9 +331,9 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 				hasPendingChangesRef.current = false;
 				setHasPendingChanges(false);
 			}
-			completeSaveThenIdle();
+			completeSaveThenIdle(contextId);
 		},
-		[completeSaveThenIdle]
+		[completeSaveThenIdle, contextId]
 	);
 
 	// Auto-save function (payload order by createdAt so round-trip preserves order)

--- a/app/src/stores/save-store.test.ts
+++ b/app/src/stores/save-store.test.ts
@@ -24,6 +24,16 @@ import { TIMING } from "@/config/timing";
 import { useSaveStore } from "./save-store";
 import { useToastStore } from "./toast-store";
 
+/** A registered context, dirty or clean, with a `save` nothing in here calls. */
+function registerContext(id: string, hasPendingChanges: boolean) {
+	useSaveStore.getState().registerContext({
+		id,
+		name: id,
+		save: () => Promise.resolve(),
+		hasPendingChanges,
+	});
+}
+
 describe("completeSaveThenIdle", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -78,5 +88,71 @@ describe("completeSaveThenIdle", () => {
 
 		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS / 2);
 		expect(useSaveStore.getState().status).toBe("idle");
+	});
+});
+
+/**
+ * The Dock shows one status for the whole app, so "Saved" is a claim about the
+ * editor and not about the round trip that just returned. `runSave` has held
+ * that rule since #1381 for the contexts that go through it; the collection
+ * tree's renames go through nothing, and published their success straight onto
+ * the shared status - "Saved", over a Tests script the user had not saved.
+ */
+describe("completeSaveThenIdle with other unsaved work on screen", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports 'pending', not 'saved', for a direct writer while a context is dirty", () => {
+		registerContext("request-1", true);
+
+		// The shape of a sidebar rename: no registered context of its own.
+		useSaveStore.getState().startSaving();
+		useSaveStore.getState().completeSaveThenIdle();
+
+		expect(useSaveStore.getState().status).toBe("pending");
+
+		// And it stays that way - the dirty context clears it when it writes.
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("still reports 'saved' for a direct writer when nothing else is dirty", () => {
+		// The control: a guard that never completes would pass the case above.
+		registerContext("request-1", false);
+
+		useSaveStore.getState().startSaving();
+		useSaveStore.getState().completeSaveThenIdle();
+
+		expect(useSaveStore.getState().status).toBe("saved");
+
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("does not hold a context's own success against it", () => {
+		// A registered context's entry is refreshed by an effect, so it still
+		// reads dirty at the moment it reports the write that cleaned it. Naming
+		// itself is what keeps that from reading as "somebody else is dirty".
+		registerContext("request-1", true);
+
+		useSaveStore.getState().completeSaveThenIdle("request-1");
+
+		expect(useSaveStore.getState().status).toBe("saved");
+	});
+
+	it("holds another context's unsaved work against a context's own success", () => {
+		registerContext("request-1", true);
+		registerContext("settings", true);
+
+		useSaveStore.getState().completeSaveThenIdle("settings");
+
+		expect(useSaveStore.getState().status).toBe("pending");
 	});
 });

--- a/app/src/stores/save-store.test.ts
+++ b/app/src/stores/save-store.test.ts
@@ -147,6 +147,21 @@ describe("completeSaveThenIdle with other unsaved work on screen", () => {
 		expect(useSaveStore.getState().status).toBe("saved");
 	});
 
+	it("clears a 'pending' it invented once the lagging registry catches up", () => {
+		// Two surfaces finishing within a render of each other: each reads the
+		// other's not-yet-refreshed entry as dirty, so both report `pending` over
+		// an editor that holds nothing. Left alone that would describe nothing
+		// until the next save.
+		registerContext("request-1", true);
+		useSaveStore.getState().completeSaveThenIdle("settings");
+		expect(useSaveStore.getState().status).toBe("pending");
+
+		registerContext("request-1", false);
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
 	it("holds another context's unsaved work against a context's own success", () => {
 		registerContext("request-1", true);
 		registerContext("settings", true);

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -119,6 +119,15 @@ export const useSaveStore = create<SaveState>((set, get) => {
 	// history is made of.
 	let idleResetGeneration = 0;
 
+	// Is any registered context holding an unsaved edit? `exceptId` leaves out
+	// the context asking, which is the one entry that cannot be trusted at the
+	// moment it asks: a context's `hasPendingChanges` is refreshed by an effect,
+	// so its own still reads the pre-save `true` as its write lands.
+	const dirtyContextExists = (exceptId?: string) =>
+		[...get().contexts.values()].some(
+			(context) => context.id !== exceptId && context.hasPendingChanges
+		);
+
 	// Internal helper - runs a save for the given context and updates store state.
 	// Caller must own the in-progress guard if needed.
 	const runSave = async (context: SaveContext) => {
@@ -172,11 +181,25 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			// changes" - the context still holding the edit clears it when it
 			// writes. Guarding here rather than at the call sites covers the ones
 			// added later, which is the half a per-caller fix cannot do.
-			const othersDirty = [...get().contexts.values()].some(
-				(context) => context.id !== reportingContextId && context.hasPendingChanges
-			);
-			if (othersDirty) {
+			if (dirtyContextExists(reportingContextId)) {
 				set({ status: "pending" });
+				// A registry entry is refreshed by an effect, so a *sibling* that
+				// finished its own write moments ago can still read dirty above -
+				// two surfaces saving within a render of each other each see the
+				// other as unsaved, and this `pending` would then sit on the Dock
+				// until the next save, describing nothing. So re-derive it once the
+				// effects have flushed. The two guards are the ones below: a later
+				// save re-arms the generation and owns the status from then on, and
+				// a `pending` a context published for its own unsaved edit is not
+				// this timer's to clear - that context is still in the registry,
+				// still dirty.
+				const armed = ++idleResetGeneration;
+				setTimeout(() => {
+					if (armed !== idleResetGeneration) return;
+					if (get().status !== "pending") return;
+					if (dirtyContextExists()) return;
+					get().setStatus("idle");
+				}, TIMING.SAVED_STATUS_DURATION_MS);
 				return;
 			}
 

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -85,8 +85,16 @@ interface SaveState {
 	 * surface published to the Dock, or wipes a `pending` from an edit made since.
 	 * `triggerSave` has always guarded its own reset this way; the five callers
 	 * that hand-rolled the timer did not.
+	 *
+	 * `reportingContextId` names the registered context whose save this is, when
+	 * there is one. A context's own `hasPendingChanges` is not consulted: the
+	 * registry entry is refreshed by a React effect, so a context that has just
+	 * written still reads dirty at the moment it reports. Every *other*
+	 * registered context is consulted (see the implementation), and a direct
+	 * writer - the collection tree's two renames, which register nothing - names
+	 * nobody and is therefore measured against all of them.
 	 */
-	completeSaveThenIdle: () => void;
+	completeSaveThenIdle: (reportingContextId?: string) => void;
 	failSave: (error: string) => void;
 	reset: () => void;
 
@@ -134,7 +142,7 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			// silence.
 			const published = get().status;
 			if (published === "error" || published === "pending") return;
-			get().completeSaveThenIdle();
+			get().completeSaveThenIdle(context.id);
 		} catch (error) {
 			get().failSave(error instanceof Error ? error.message : "Save failed");
 		}
@@ -151,7 +159,27 @@ export const useSaveStore = create<SaveState>((set, get) => {
 
 		startSaving: () => set({ status: "saving" }),
 
-		completeSaveThenIdle: () => {
+		completeSaveThenIdle: (reportingContextId) => {
+			// "Saved" is a claim about the editor, not about one round trip. That
+			// is the rule #1381 wrote for `runSave`, and `runSave` only covers the
+			// contexts that go through it: a direct writer publishes its success
+			// straight onto the one status the Dock renders, so renaming a folder
+			// while the open request holds an unsaved edit said "Saved" - true of
+			// the rename, false of everything else on screen.
+			//
+			// So a success is only `saved` when nothing else is dirty. `pending`
+			// is the honest answer otherwise, and it is the Dock's "Unsaved
+			// changes" - the context still holding the edit clears it when it
+			// writes. Guarding here rather than at the call sites covers the ones
+			// added later, which is the half a per-caller fix cannot do.
+			const othersDirty = [...get().contexts.values()].some(
+				(context) => context.id !== reportingContextId && context.hasPendingChanges
+			);
+			if (othersDirty) {
+				set({ status: "pending" });
+				return;
+			}
+
 			set({ status: "saved" });
 			const armed = ++idleResetGeneration;
 			setTimeout(() => {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -610,6 +610,20 @@ quit flush take, so overwriting it put "Saved" on the Dock over an edit nobody
 had persisted. One rule covers both: a status the context published for itself
 is the truthful one, and `runSave` only fills in the silence.
 
+**A writer that registers no context inherits that rule from
+`completeSaveThenIdle`.** The collection tree's two renames call `startSaving`
+and `completeSaveThenIdle` by hand, so `runSave` never saw them: a rename
+published "Saved" onto the one status the Dock renders while the open request
+held an unsaved script - true of the rename, false of everything else on screen
+(#1385). The success reporter now asks the registry, and publishes `pending`
+instead while any *other* registered context still has `hasPendingChanges`; the
+context holding that edit clears it when it writes. A registered context names
+itself as it reports - `completeSaveThenIdle(contextId)` - because its own entry
+is refreshed by an effect and so still reads dirty at the moment its write
+lands. A direct writer names nobody and is measured against all of them, which
+is the point of guarding in the store rather than at the call sites: the writer
+added next inherits it without knowing the rule exists.
+
 **SaveContext:**
 ```typescript
 {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -624,6 +624,14 @@ lands. A direct writer names nobody and is measured against all of them, which
 is the point of guarding in the store rather than at the call sites: the writer
 added next inherits it without knowing the rule exists.
 
+That same effect lag is why the `pending` this guard publishes is re-derived
+once, after `TIMING.SAVED_STATUS_DURATION_MS`. Two surfaces finishing within a
+render of each other each read the other's not-yet-refreshed entry as dirty, so
+both report `pending` over an editor holding nothing - and nothing would revisit
+it until the next save. The re-check clears it only while no context is dirty
+and no later save has re-armed the reset, so a `pending` a context published for
+its own unsaved edit is untouched.
+
 **SaveContext:**
 ```typescript
 {


### PR DESCRIPTION
## Description

Root cause: the Dock renders one global `useSaveStore().status`, and `completeSaveThenIdle` published `saved` unconditionally, so any caller could make a claim about the whole editor out of a single round trip. The collection tree's two renames (`useTreeCrud.ts`) register no save context at all, so the rule #1381 wrote for `runSave` - "a status the context published for itself is the truthful one" - never covered them: a rename while the open request held an unsaved edit put "Saved" on the Dock. Approach: the store's own success reporter carries the rule instead. `completeSaveThenIdle` consults the context registry and publishes `pending` ("Unsaved changes") while any *other* registered context still has `hasPendingChanges`; the context holding that edit clears the status when it writes. A registered context names itself as it reports (`completeSaveThenIdle(contextId)`), because its registry entry is refreshed by a React effect and therefore still reads dirty at the instant its own write lands - without that, every request auto-save would have reported `pending` over its own success. Rejected alternative (the issue's option 1): give the rename a short-lived registered context so it inherits `runSave`'s guard. It fixes the two call sites in this diff and nothing else, and it would put a save-less mutation into the registry that `flushAll`, `tabs-store`'s dirty-tab indicator and `useTreeDnd`'s drag guard all read. The store-level rule covers every direct writer, including the ones added later.

The same effect lag cuts the other way, and the second commit handles it: two surfaces finishing within a render of each other each read the other's not-yet-refreshed entry as dirty, so both publish `pending` over an editor holding nothing, and `runSave`'s "do not stomp what the context published" return keeps the second from correcting it. That `pending` would then sit on the Dock until the next save. So the guard re-derives its own `pending` once the effects have flushed, under the two conditions the `saved` reset already uses - a later save owns the status from then on, and a `pending` a context published for its own unsaved edit is left alone, because that context is still in the registry and still dirty.

Call sites that report their own context's success now name it: `runSave`, `useSaveManager` (which also loses its third copy of the `request-${entityId}` id spelling), `VariableTableEditor`, `SettingsMain`, `variable-commit`. `useTreeCrud`'s renames are unchanged - naming nobody is what makes them measured against every context.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test` - **653 files, 7403 tests, all passing** (9 of them new here).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- No engine change, so no `ctest` run: the diff is renderer TypeScript only.
- No pre-existing failures on this base (`f5ad0ed`).

New tests, each mutation-checked by reverting the guard and confirming the failure:

`save-store.test.ts` (+5, node env, drives the store directly)
- a direct writer reports `pending`, not `saved`, while a registered context is dirty - and stays `pending` past `SAVED_STATUS_DURATION_MS`. Removing the guard: fails.
- the control - a direct writer with a registered *clean* context still reports `saved` and returns to `idle`, so a guard that never completes is caught.
- a context reporting its own success is not blocked by its own stale flag. Dropping `context.id !== reportingContextId`: fails.
- another context's unsaved work does block a context's own success.
- a `pending` the guard invented is cleared once the lagging registry catches up. Removing the re-derivation: fails.

`useTreeCrud.rename-status.test.tsx` (+4, new file, jsdom, drives the real hook with mocked mutations) - collection rename and request rename each leave the status `pending` while a dirty `request-*` context is registered; a rename with nothing else unsaved still reports `saved`; a failed rename still reports through `failSave` with its error toast, unchanged.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs, same commit as each change: `docs/app/state-management.md`, the save-store section, gains the paragraph after the `runSave` / #1381 prose - which rule a direct status writer inherits, why a registered context names itself when it reports, and why the guard's `pending` is re-derived once.

## Screenshots

Verified in the running app, not only in tests: engine daemon on 127.0.0.1:9876, the renderer served by `pnpm dev`, driven with the preinstalled Chromium. The flow is the acceptance criterion - create a collection, add a request, type a URL (leaving it unsaved inside the 5s auto-save delay), then rename the collection in the sidebar - run once against this branch and once with `save-store.ts` reverted to `f5ad0ed`:

| | Dock after the edit | Dock after the rename |
|---|---|---|
| `f5ad0ed` (before) | Unsaved changes | **Saved** - over an edit nobody had persisted |
| this branch (after) | Unsaved changes | **Unsaved changes** |

The images could not be attached here: the `gh` CLI is not installed in this environment and the GitHub MCP tools have no media upload, so the four captures (both full windows and both cropped Dock strips) were delivered directly to @athrvk instead of being dropped silently.

## Related Issues

Closes #1385

Noted, not filed (no user-visible effect, per the repo's rule for what earns an issue): `request-${entityId}` is still spelled by hand in `tabs-store.ts:307` and `useTreeDnd.ts:493`. This PR consolidates the three copies inside `useSaveManager.ts`, where a drifted spelling would have defeated the new self-exclusion; a shared exported helper for the other two readers would be a tidy follow-up.
