### PR TITLE
fix(app): keep the run id a load run's close forgets to its own run

### DIFF
--- a/app/src/services/load-test-service.progress.test.ts
+++ b/app/src/services/load-test-service.progress.test.ts
@@ -53,6 +53,7 @@ vi.mock("./run-progress", () => ({
 
 import { loadTestService } from "./load-test-service";
 import { sseClient } from "./sse-client";
+import { apiService } from "./api";
 import { RUN_PROGRESS_KEYS } from "./run-progress";
 
 const LOAD_RUN = RUN_PROGRESS_KEYS.loadRun;
@@ -133,6 +134,37 @@ describe("LoadTestService - the OS progress indicator", () => {
 		loadTestService.startMonitoring("run_1");
 		failStream("engine went away");
 		expect(mockFail).toHaveBeenCalledWith(LOAD_RUN, "run_1");
+	});
+
+	/*
+	 * The terminal fetch in `handleClose` is awaited, and a run started inside
+	 * that window has already put its own id on the service. Forgetting it there
+	 * would leave the service unable to name the run it is watching, and since
+	 * #1405 that is what every call to the indicator turns on: the live run's
+	 * fraction would be dropped from then on and its bar never cleared.
+	 *
+	 * Mutation check: drop the `this.activeRunId === runId` guard on the
+	 * assignment and the report below arrives naming `null`.
+	 */
+	it("keeps naming the run that started while the last one's report was in flight", async () => {
+		type RunReport = Awaited<ReturnType<typeof apiService.getRunReport>>;
+		let deliverReport: (report: RunReport) => void = () => {};
+		vi.mocked(apiService.getRunReport).mockReturnValueOnce(
+			new Promise<RunReport>((resolve) => {
+				deliverReport = resolve;
+			})
+		);
+
+		loadTestService.startMonitoring("run_1");
+		const closing = closeStream();
+		// The user starts the next run before the first one's report lands.
+		loadTestService.startMonitoring("run_2");
+		deliverReport({ summary: {}, latency: {} } as unknown as RunReport);
+		await closing;
+
+		mockReport.mockClear();
+		tickHandler()(tick(10));
+		expect(mockReport).toHaveBeenCalledWith(LOAD_RUN, "run_2", 0.5);
 	});
 
 	/*

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -328,7 +328,15 @@ class LoadTestService {
 			// status are stale until the next 5s poll - and once the user has
 			// paged History, that poll is off.
 			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
-			this.activeRunId = null;
+			// Only if it is still this run's. Same window as the store read above,
+			// and the same fix: a run started while this fetch was in flight has
+			// already put its own id here, and forgetting it would leave the
+			// service unable to name the run it is watching - so the live run's
+			// reports would be dropped and its bar never cleared, both of which
+			// now turn on naming the run (#1405).
+			if (this.activeRunId === runId) {
+				this.activeRunId = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description

Follow-up to #1406 (closed #1405), which merged while this commit was still in verification - so it is a separate PR rather than another commit on that branch. **It fixes a defect #1406 put on `master`**, found by review of its own first commit.

`LoadTestService.handleClose` nulls `this.activeRunId` *after* an awaited report fetch, unconditionally (`app/src/services/load-test-service.ts:331`). The store read eight lines above it already guards that exact window - `if (useDashboardStore.getState().currentRunId === runId)` - for the same reason: a run started inside the window has already put its own id on the service, and the continuation belongs to the run that ended.

Under the old claim keyed by `RunProgressKey` that clobber cost nothing: nothing asked which run was reporting, so a service holding `null` still painted. #1406 made every call to the indicator name its run, which turns the same clobber into a stranded bar:

1. Load run A ends; `handleClose` clears the indicator correctly and awaits A's report.
2. The user starts load run B inside that window. B claims the indicator and its ticks paint.
3. A's fetch resolves and the continuation sets `activeRunId = null`, wiping **B's** id.
4. Every later `commitBatch` reports as `(loadRun, null, fraction)`, which no longer owns the claim - B's bar freezes where it stood.
5. B's own close then reads `runId = null`, so its `clear` is a no-op and **the bar is never cleared**. (The same `if (runId)` also costs B its final report fetch, its finished notification and its run-list invalidation - all pre-existing, all reached by the same wipe.)

The assignment now carries the guard the store read carries. `ScenarioRunService` needs nothing: it nulls `activeRunId` synchronously at the top of its `handleClose`, before any await, and keeps the id in a local for the terminal calls.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- New case in `load-test-service.progress.test.ts`: `keeps naming the run that started while the last one's report was in flight`. It holds the report promise open, starts the next run inside that window, resolves, and then asserts the next tick reports under `run_2`. **Mutation check, run rather than asserted**: dropping the `this.activeRunId === runId` guard reddens it (the report arrives naming `null`); restored and re-run green.
- `pnpm test run-progress load-test-service scenario-run-service` - 6 files, 76 tests, passing on this base.
- `pnpm test` (full suite) - 675 files, 7659 tests, passing (run on the pre-merge base with the identical diff; the merge that landed between them changed nothing this touches).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.

Nothing the mocked suites could have caught on their own: `load-test-service.progress.test.ts` mocks `runProgress` wholesale, so it holds no claim state, and every existing case drives one run to completion with nothing starting during the await. The interleaving had to be written.

**No user-visible change** beyond the indicator itself, and no doc is stale: `docs/app/architecture.md` and `docs/architecture.md` describe the claim rule, which is unchanged - this is the service keeping its side of it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Refs #1405, follows #1406.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNgeniqvPPF44WBsdRTS5r)_