### PR TITLE
docs: add "platform before a dependency" to repo conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,11 @@ and assert **both** branches.
 - **A hand-rolled copy of a primitive does not receive the primitive's fixes.**
   Before styling or reimplementing something that already exists as a
   primitive, `rg` for the primitive.
+- **The platform before a dependency, a dependency before new code.** Before
+  adding a package or hand-building a control, check whether the platform
+  already covers it: an HTML input type, CSS, `Intl`, a DB constraint, the
+  STL. A dependency taken on for what a native feature already does is a
+  permanent maintenance cost bought for a one-time convenience.
 - **Mutation-check behavioural tests** (revert the fix, confirm failure,
   restore). Source-scanning guards must assert they scanned something
   non-empty; vitest stubs CSS imports to `""`, so a guard over a stylesheet can


### PR DESCRIPTION
## Description

One bullet added to the repo-wide conventions in `CLAUDE.md`, directly under the existing "a hand-rolled copy of a primitive does not receive the primitive's fixes" rule.

That rule covers reimplementing something that already lives in this repo. It says nothing about the rung below it: a package or a hand-built control standing in for something the platform already ships - an HTML input type, CSS, `Intl`, a DB constraint, the STL. That is the gap where a dependency gets taken on permanently to save a one-time afternoon, so the new bullet states it where the related rule already is.

The wording came out of an evaluation of the [ponytail](https://github.com/DietrichGebert/ponytail) plugin. The plugin itself was not adopted: its ladder largely restates rules `CLAUDE.md` already has, and three of its conventions conflict with ours (it defers work into `ponytail:` code comments and a `PONYTAIL-DEBT.md` backlog file, where this repo files a tracker issue in the same commit; it prescribes framework-free `assert` self-checks, where this repo uses GTest under ctest and vitest; and its "stopgap now, upgrade later" posture is the opposite of the core principle). The native-platform rung was the one idea it had that this repo had not already written down.

The first thing the new rule catches, found while auditing for it: `app/` carries `date-fns` as a runtime dependency for a single `formatDistanceToNow` call in `RecentRuns.tsx`, while `formatRelativeTime` in `src/utils/helpers.ts` already serves five other call sites. Not fixed here, to keep this diff to the convention itself.

## Type of Change

- [x] Documentation update

## Testing

No code changed. `CLAUDE.md` is not published by MkDocs and is outside prettier's `app/`-only domain, so no check applies beyond reading the diff. The bullet is hand-wrapped to match its neighbours and contains no em-dashes. CI is green: the `CI gate`, `Conventional title` and CodeQL JS/TS jobs passed, and every path-gated build job correctly skipped on a docs-only diff.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - n/a, docs only
- [x] I have updated documentation - this change is the documentation

## Related Issues

None.
