### PR TITLE
docs: the Electron major the app actually ships, and a header that could only drift

### DIFF
--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -425,7 +425,7 @@ Key settings in `vite.config.ts`:
 ### Production Dependencies
 
 - **React 19**: UI framework
-- **Electron 28**: Desktop app framework
+- **Electron 44**: Desktop app framework
 - **Zustand**: State management
 - **TanStack Query**: Server state
 - **Radix UI**: Component primitives

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ The Manager is the "face" of Vayu-a standard Electron application that provides 
 - Run history viewing
 
 **Technology Stack:**
-- **Electron 28**: Desktop app framework
+- **Electron 44**: Desktop app framework
 - **React 19**: UI framework
 - **TypeScript**: Type safety - 5.9 compiles and lints, 7 runs the `pnpm type-check` gate (see [app building](app/building.md#two-compilers-one-on-purpose))
 - **Zustand**: UI state management

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -5,9 +5,6 @@ description: >-
 
 # Vayu Engine Architecture
 
-**Version:** 0.3.0  
-**Last Updated:** June 2026
-
 ## Overview
 
 The Vayu Engine is a high-performance C++ daemon that executes HTTP requests and load tests. It uses a sidecar architecture pattern, running as a separate process from the Electron UI and communicating via HTTP on `localhost:9876` (configurable).


### PR DESCRIPTION
## Description

Issue #1418's three stale lines, checked against live master `d84bbab` rather than the issue's snapshot - which changed what the diff is.

**Plan.** Root cause is the same in all three: a fact copied into prose that the code then moved past, with no mechanism to keep it true. Item 1 (Electron 28) had a second occurrence the issue did not name - `docs/architecture.md:73` as well as `docs/app/building.md:428` - and the acceptance grep (`rg -n "Electron 28" docs/`) covers both, so both are fixed. For the version they are bumped rather than dropped, because `docs/app/architecture.md:307` already reads `**Electron 44**: Desktop app framework` and the surrounding entries in both lists are versioned (React 19, ESLint 10, TypeScript 5.9); making these two lists match the sibling that is already correct beats leaving three lists in two different styles. Item 2 goes the other way, as the issue reasoned: a `**Version:**` stamp on a document rewritten every time the engine changes has no keeper, so it is removed, not bumped. Item 3 needed no change - it shipped in `48d84a1` (2026-09-04), after the `75c7277b` the issue was verified at.

**Deliberate deviation.** The issue names one line in `docs/engine/architecture.md`; this removes two. `**Last Updated:** June 2026` is the next line of the same metadata block, is stale by the identical mechanism (the file was last touched 2026-09-03), and would be the same issue re-filed. Removing the version stamp while leaving its neighbour asserting a false date is not a smaller change, only a less finished one.

**Item 3, closed as already shipped.** `capture-notifier.ts`'s `dispose()` comment now reads: *"A stream ends because the user switched inbox, closed the tab or quit ... or because the toggle went off, the engine stopped the inbox, or the stream cap evicted it, and none of those three is an inbox to announce a capture for either."* That is the issue's acceptance criterion, met by #1401's follow-up. The file is untouched here.

No user-visible change - published prose and one already-correct source comment.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

No test can go red or green on prose, so per CLAUDE.md's scale-the-verification rule the checks are the two the issue names:

- `mkdocs build --strict -f .github/mkdocs.yml` - clean, built in 5.37 s, no warning promoted (the removed lines carry no heading anchor, so nothing linked to them).
- `pnpm format:check` - not run and not applicable: prettier's domain is `app/`, and no file under `app/` is touched.

Acceptance criteria:

- `rg -n "Electron 28" docs/` - no matches (was 2).
- `rg -n "^\*\*Version" docs/engine/` - no matches; the repo-wide sweep `rg -n "^\*\*Version|^\*\*Last Updated" docs/` is also empty, so there is no sibling header left to drift.
- The `dispose()` comment names the reasons a stream ends today - already true at `48d84a1`, quoted above.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, see Testing
- [x] I have updated documentation

## Related Issues
Closes #1418


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxHnzqG7vRJqsHRxtxA5Wv)_