### PR TITLE
fix(app): show the window even when the first frame never arrives

### DIFF
--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -305,12 +305,17 @@ jobs:
       # once (743 ms) and timed out every other time, each time having come up
       # whole - engine listening, MCP up, the renderer fetching config,
       # collections and globals from it, all inside a second - and then produced
-      # no frame at all, so `ready-to-show` never fired. The harness's plain window becomes showable in the
-      # same session every time; the app's is frameless. Running a window
-      # manager (openbox, waited for with `_NET_SUPPORTING_WM_CHECK`) changed
-      # nothing, so none is carried here. #1347 holds the evidence and is where
-      # a fix belongs. Until then the note in the summary carries the app's own
-      # output, and the Windows and macOS figures are the ones to read.
+      # no frame at all, so `ready-to-show` never fired. The harness's plain
+      # window becomes showable in the same session every time; the app's comes
+      # up hidden. Running a window manager (openbox, waited for with
+      # `_NET_SUPPORTING_WM_CHECK`) changed nothing, so none is carried here.
+      #
+      # #1347 bounded that wait rather than leaving it open: the app shows the
+      # window anyway after 8 s and says so, which makes this leg fail in
+      # seconds with the cause in `note` instead of burning three 90-second
+      # timeouts. It is still not a figure - a window revealed by that fallback
+      # never painted - so the Windows and macOS numbers remain the ones to
+      # read here.
       - name: Measure the app
         shell: bash
         env:

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -60,6 +60,7 @@ import { createRendererRecovery } from "./renderer-recovery.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
 import { stampInstalledVersion } from "./appimage-stamp.js";
 import { reportStartupIfRequested } from "./startup-probe.js";
+import { revealWhenReady } from "./window-reveal.js";
 /*
  * MCP is imported by weight, not through its barrel.
  *
@@ -449,13 +450,14 @@ function createWindow() {
 		mainWindow.maximize();
 	}
 
-	// Show window when ready to prevent visual flash
-	mainWindow.once("ready-to-show", () => {
-		mainWindow?.show();
+	// Show the window when it has a frame to show - and show it anyway if that
+	// frame never arrives, rather than leaving a started app invisible with
+	// nothing said about it (#1347). See window-reveal.ts.
+	revealWhenReady(mainWindow, (via) => {
 		// Nothing unless VAYU_MEASURE_STARTUP=1 asked - see startup-probe.ts. The
 		// packaged app is the only thing that can answer "how long until a window",
 		// which is why the perf workflow packages before it measures (#1165).
-		reportStartupIfRequested();
+		reportStartupIfRequested(via);
 	});
 
 	// The preload re-runs on whatever this window navigates to, so a navigation

--- a/app/electron/startup-probe.test.ts
+++ b/app/electron/startup-probe.test.ts
@@ -29,6 +29,7 @@ import {
 	sampleStartup,
 	type StartupClock,
 } from "./startup-probe.js";
+import { type RevealReason } from "./window-reveal.js";
 import { ENGINE_PORT } from "./constants.js";
 import { ROOT_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
 
@@ -44,9 +45,13 @@ function fixedClock(overrides: Partial<StartupClock> = {}): StartupClock {
 	};
 }
 
-function collect(env: Record<string, string | undefined>, clock = fixedClock()) {
+function collect(
+	env: Record<string, string | undefined>,
+	clock = fixedClock(),
+	via: RevealReason = "ready-to-show"
+) {
 	const lines: string[] = [];
-	const wrote = reportStartupIfRequested(env, clock, (line) => lines.push(line));
+	const wrote = reportStartupIfRequested(via, env, clock, (line) => lines.push(line));
 	return { lines, wrote };
 }
 
@@ -75,7 +80,21 @@ describe("the startup probe's guard", () => {
 		expect(lines[0].startsWith(`${STARTUP_MARKER} `)).toBe(true);
 
 		const payload = JSON.parse(lines[0].slice(STARTUP_MARKER.length));
-		expect(payload).toEqual({ readyToShowMs: 500, basis: "process-creation" });
+		expect(payload).toEqual({
+			readyToShowMs: 500,
+			basis: "process-creation",
+			via: "ready-to-show",
+		});
+	});
+
+	it("says when the window was shown without ever painting", () => {
+		// Same number, a different thing measured: the reveal fallback's timer
+		// rather than a first frame (#1347). Without this the reader would take
+		// an 8-second timeout for a cold start.
+		const { lines } = collect({ [STARTUP_MEASURE_ENV]: "1" }, fixedClock(), "reveal-fallback");
+
+		const payload = JSON.parse(lines[0].slice(STARTUP_MARKER.length));
+		expect(payload.via).toBe("reveal-fallback");
 	});
 
 	it("writes no newline of its own - the sink adds it", () => {
@@ -88,16 +107,20 @@ describe("the startup probe's guard", () => {
 
 describe("what the number is measured from", () => {
 	it("measures from process creation when the platform can say", () => {
-		const sample = sampleStartup(fixedClock());
-		expect(sample).toEqual({ readyToShowMs: 500, basis: "process-creation" });
+		const sample = sampleStartup("ready-to-show", fixedClock());
+		expect(sample).toEqual({
+			readyToShowMs: 500,
+			basis: "process-creation",
+			via: "ready-to-show",
+		});
 	});
 
 	it("falls back to the time origin, and says so", () => {
 		// Electron's getCreationTime() answers null where the platform cannot
 		// tell. Reporting the fallback as if it were a cold start would compare
 		// numbers that start counting at different moments.
-		const sample = sampleStartup(fixedClock({ processCreatedAt: () => null }));
-		expect(sample).toEqual({ readyToShowMs: 320, basis: "time-origin" });
+		const sample = sampleStartup("ready-to-show", fixedClock({ processCreatedAt: () => null }));
+		expect(sample).toEqual({ readyToShowMs: 320, basis: "time-origin", via: "ready-to-show" });
 	});
 });
 
@@ -106,16 +129,17 @@ describe("the probe's two ends", () => {
 	const main = readFileSync(join(electronDir, "main.ts"), "utf8");
 	const measurer = readFileSync(measurerPath, "utf8");
 
-	it("is called from the window's ready-to-show handler", () => {
+	it("is called from the reveal that puts the window on screen", () => {
 		// main.ts creates windows and starts the engine at import time, so the
 		// wiring can only be read - the approach startup-order.test.ts takes to
-		// the same file. Without this the probe is a function nobody calls.
-		const handlerAt = main.indexOf('mainWindow.once("ready-to-show"');
-		expect(handlerAt).toBeGreaterThan(-1);
+		// the same file. Without this the probe is a function nobody calls, and
+		// with the `via` dropped it would report a fallback reveal as a paint.
+		const revealAt = main.indexOf("revealWhenReady(mainWindow, (via) => {");
+		expect(revealAt).toBeGreaterThan(-1);
 
-		const handlerEnd = main.indexOf("});", handlerAt);
-		expect(handlerEnd).toBeGreaterThan(handlerAt);
-		expect(main.slice(handlerAt, handlerEnd)).toContain("reportStartupIfRequested()");
+		const revealEnd = main.indexOf("\n\t});", revealAt);
+		expect(revealEnd).toBeGreaterThan(revealAt);
+		expect(main.slice(revealAt, revealEnd)).toContain("reportStartupIfRequested(via)");
 	});
 
 	it("prints the marker the perf script waits for", () => {
@@ -130,6 +154,14 @@ describe("the probe's two ends", () => {
 
 		expect(declared, "measure-app.mjs no longer declares PACKAGED_MEASURE_ENV").not.toBeNull();
 		expect(declared?.[1]).toBe(STARTUP_MEASURE_ENV);
+	});
+
+	it("makes the reader reject a launch the fallback revealed", () => {
+		// The app prints `via`; only this script reads it. A rename on one side
+		// alone would silently turn an 8-second fallback timer back into a
+		// reported cold start (#1347).
+		const fallback: RevealReason = "reveal-fallback";
+		expect(measurer).toContain(`payload.via === "${fallback}"`);
 	});
 
 	it("waits on the port the sidecar would adopt an engine from", () => {

--- a/app/electron/startup-probe.ts
+++ b/app/electron/startup-probe.ts
@@ -34,6 +34,8 @@
  * `window-navigation.ts` and `quit-shutdown.ts` sit beside it.
  */
 
+import type { RevealReason } from "./window-reveal.js";
+
 /**
  * Must match `PACKAGED_MARKER` in `scripts/perf/measure-app.mjs`, which is the
  * only reader. A rename that missed one end reports every launch as an
@@ -60,6 +62,13 @@ export type StartupBasis = "process-creation" | "time-origin";
 export interface StartupSample {
 	readyToShowMs: number;
 	basis: StartupBasis;
+	/**
+	 * Which path put the window on screen. A launch revealed by
+	 * `window-reveal.ts`'s fallback waited out a timer instead of painting, so
+	 * the number it carries is that timer and not a cold start; the reader
+	 * rejects the leg rather than reporting it (#1347).
+	 */
+	via: RevealReason;
 }
 
 /** The clock readings this needs, so a test can hand it fixed ones. */
@@ -89,12 +98,15 @@ export const defaultStartupClock: StartupClock = {
 };
 
 /** Time from process start to this call, on the best basis the platform offers. */
-export function sampleStartup(clock: StartupClock = defaultStartupClock): StartupSample {
+export function sampleStartup(
+	via: RevealReason,
+	clock: StartupClock = defaultStartupClock
+): StartupSample {
 	const createdAt = clock.processCreatedAt();
 	if (createdAt === null) {
-		return { readyToShowMs: clock.elapsedMs(), basis: "time-origin" };
+		return { readyToShowMs: clock.elapsedMs(), basis: "time-origin", via };
 	}
-	return { readyToShowMs: clock.now() - createdAt, basis: "process-creation" };
+	return { readyToShowMs: clock.now() - createdAt, basis: "process-creation", via };
 }
 
 /**
@@ -104,13 +116,14 @@ export function sampleStartup(clock: StartupClock = defaultStartupClock): Startu
  * caller ignores it.
  */
 export function reportStartupIfRequested(
+	via: RevealReason,
 	env: Record<string, string | undefined> = process.env,
 	clock: StartupClock = defaultStartupClock,
 	write: (line: string) => void = (line) => void process.stdout.write(`${line}\n`)
 ): boolean {
 	if (env[STARTUP_MEASURE_ENV] !== "1") return false;
 
-	const sample = sampleStartup(clock);
+	const sample = sampleStartup(via, clock);
 	write(`${STARTUP_MARKER} ${JSON.stringify(sample)}`);
 	return true;
 }

--- a/app/electron/window-reveal.test.ts
+++ b/app/electron/window-reveal.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The window reaches the screen either way (#1347).
+ *
+ * The failure this covers has no visible symptom to assert against in the app:
+ * a first frame that never arrives leaves `ready-to-show` unfired, so the
+ * window is never shown and nothing at all is logged - the app looks started
+ * and is invisible. So the two paths are driven here directly, and `main.ts`'s
+ * end of the wiring is read the way `startup-order.test.ts` reads the rest of
+ * its startup, because main.ts creates windows at import time and cannot be
+ * imported.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { REVEAL_FALLBACK_MS, revealWhenReady, type RevealReason } from "./window-reveal.js";
+
+/** A BrowserWindow double that records the show and can be destroyed. */
+function fakeWindow(options: { destroyed?: boolean } = {}) {
+	let destroyed = options.destroyed ?? false;
+	const listeners: Array<() => void> = [];
+	const shows = vi.fn();
+
+	return {
+		once: (_event: "ready-to-show", listener: () => void) => void listeners.push(listener),
+		isDestroyed: () => destroyed,
+		show: shows,
+		/** Fire `ready-to-show`, as Chromium would on a first frame. */
+		paint: () => listeners.forEach((listener) => listener()),
+		destroy: () => void (destroyed = true),
+		shows,
+	};
+}
+
+/** Collect the fallback timer instead of running it, so a test can fire it. */
+function heldTimer() {
+	const armed: Array<{ ms: number; fire: () => void }> = [];
+	return {
+		after: (ms: number, fn: () => void) => void armed.push({ ms, fire: fn }),
+		armed,
+		fireAll: () => armed.forEach((timer) => timer.fire()),
+	};
+}
+
+function reveal(window: ReturnType<typeof fakeWindow>, timer = heldTimer()) {
+	const revealed: RevealReason[] = [];
+	const warnings: string[] = [];
+	revealWhenReady(window, (reason) => revealed.push(reason), {
+		after: timer.after,
+		warn: (message) => warnings.push(message),
+	});
+	return { revealed, warnings, timer };
+}
+
+describe("revealing the window", () => {
+	it("shows it on the first frame, and says nothing", () => {
+		const window = fakeWindow();
+		const { revealed, warnings } = reveal(window);
+
+		expect(window.shows).not.toHaveBeenCalled();
+		window.paint();
+
+		expect(window.shows).toHaveBeenCalledTimes(1);
+		expect(revealed).toEqual(["ready-to-show"]);
+		// The ordinary launch is every launch on a desktop. A warning here would
+		// be in every user's log.
+		expect(warnings).toEqual([]);
+	});
+
+	it("shows it anyway when no frame ever arrives, and says why", () => {
+		// The whole point: without this the app is up, the renderer is running,
+		// and the screen stays empty with nothing written about it.
+		const window = fakeWindow();
+		const { revealed, warnings, timer } = reveal(window);
+
+		timer.fireAll();
+
+		expect(window.shows).toHaveBeenCalledTimes(1);
+		expect(revealed).toEqual(["reveal-fallback"]);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain(String(REVEAL_FALLBACK_MS));
+		expect(warnings[0]).toContain("#1347");
+	});
+
+	it("waits the stated budget before it gives up on a frame", () => {
+		const timer = heldTimer();
+		reveal(fakeWindow(), timer);
+
+		expect(timer.armed.map((armed) => armed.ms)).toEqual([REVEAL_FALLBACK_MS]);
+	});
+
+	it("shows it once when the frame arrives late", () => {
+		// Both paths stay armed - the timer cannot be cleared through the window
+		// - so a frame landing after the fallback must not re-show the window or
+		// print a second startup line over the first.
+		const window = fakeWindow();
+		const { revealed, timer } = reveal(window);
+
+		timer.fireAll();
+		window.paint();
+
+		expect(window.shows).toHaveBeenCalledTimes(1);
+		expect(revealed).toEqual(["reveal-fallback"]);
+	});
+
+	it("shows it once when the frame arrives on time", () => {
+		const window = fakeWindow();
+		const { revealed, timer } = reveal(window);
+
+		window.paint();
+		timer.fireAll();
+
+		expect(window.shows).toHaveBeenCalledTimes(1);
+		expect(revealed).toEqual(["ready-to-show"]);
+	});
+
+	it("does not show a window that is already gone", () => {
+		// A launch closed inside the fallback budget leaves the timer holding a
+		// destroyed window; `show()` on one throws, and a throw from a timer
+		// callback in the main process takes the app down.
+		const window = fakeWindow();
+		const { revealed, timer } = reveal(window);
+
+		window.destroy();
+		timer.fireAll();
+
+		expect(window.shows).not.toHaveBeenCalled();
+		expect(revealed).toEqual([]);
+	});
+});
+
+describe("main.ts's end of it", () => {
+	const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts"), "utf8");
+
+	it("reveals the window through this module", () => {
+		expect(main).toContain("revealWhenReady(mainWindow,");
+	});
+
+	it("has no unbounded wait of its own left behind", () => {
+		// A second `ready-to-show` handler that shows the window would restore the
+		// silent hang for whichever of the two the paint never reaches.
+		expect(main).not.toContain('mainWindow.once("ready-to-show"');
+	});
+});

--- a/app/electron/window-reveal.ts
+++ b/app/electron/window-reveal.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Put the window on screen, even when the first frame never arrives (#1347).
+ *
+ * The window is created with `show: false` and revealed from `ready-to-show`,
+ * which is what keeps a user from watching an unpainted rectangle fill in.
+ * Chromium emits that event once the renderer has produced a first frame for
+ * this window, so it is a promise about compositing, not about loading - and
+ * where compositing never gets going, nothing else in the app notices. The
+ * main process finishes `whenReady`, the engine listens, MCP listens, the
+ * renderer mounts and issues its prefetches, and the app then sits there
+ * looking healthy with nothing on screen and nothing in the log.
+ *
+ * Measured on this repository's own `ubuntu-latest` runner under `xvfb-run`
+ * with no window manager: one launch in five reached `ready-to-show` (743 ms)
+ * and four produced no frame for the remaining 89 seconds of the launch
+ * budget. Intermittent on identical code, so it is a race in getting the first
+ * frame out of a hidden window, not a capability the environment lacks - a
+ * window manager, started and waited for, changed nothing. The plain
+ * `BrowserWindow` in `scripts/perf/startup-harness.cjs` has never failed in
+ * the same session, and the one thing it does not do is come up hidden.
+ *
+ * So the wait is bounded. A window that is visible and briefly unpainted is a
+ * worse first second than `ready-to-show` buys, and a better app than one that
+ * never appears; the warning is what turns a silent hang into something a log
+ * can be read for. `ready-to-show` still reveals the window on every ordinary
+ * launch - the fallback is dead code on a desktop.
+ *
+ * Kept out of `main.ts` so it can be tested: main.ts creates windows and
+ * starts the engine at import time, which no unit test can do - the same
+ * reason `startup-probe.ts` and `window-navigation.ts` sit beside it.
+ */
+
+/**
+ * How long a first frame gets before the window is shown regardless.
+ *
+ * Long enough that no ordinary launch reaches it - the runners that do paint
+ * report 743 ms (Linux), 773 ms (Windows) and 2281 ms (macOS) from process
+ * creation, and this timer starts after the window exists - and short enough
+ * that a user meets it as a slow start rather than as a dead app.
+ */
+export const REVEAL_FALLBACK_MS = 8_000;
+
+/**
+ * Which of the two paths put the window on screen.
+ *
+ * It travels with the startup measurement (`startup-probe.ts`), because a
+ * launch revealed by the fallback waited out this timer instead of painting
+ * and is not a cold-start figure.
+ */
+export type RevealReason = "ready-to-show" | "reveal-fallback";
+
+/** The slice of `BrowserWindow` this needs, so a test can hand it a double. */
+export interface RevealableWindow {
+	once(event: "ready-to-show", listener: () => void): void;
+	isDestroyed(): boolean;
+	show(): void;
+}
+
+export interface RevealDeps {
+	/** Defaults to `REVEAL_FALLBACK_MS`. */
+	fallbackMs?: number;
+	/** Timer for the fallback, injected so a test need not wait it out. */
+	after?: (ms: number, fn: () => void) => void;
+	/** Defaults to `console.warn`. */
+	warn?: (message: string) => void;
+}
+
+/**
+ * Show `window` as soon as it has a frame, or once `fallbackMs` has passed
+ * without one, whichever comes first. `onRevealed` runs after the show, once,
+ * with the path that got there.
+ */
+export function revealWhenReady(
+	window: RevealableWindow,
+	onRevealed: (reason: RevealReason) => void,
+	deps: RevealDeps = {}
+): void {
+	const fallbackMs = deps.fallbackMs ?? REVEAL_FALLBACK_MS;
+	const after = deps.after ?? ((ms: number, fn: () => void) => void setTimeout(fn, ms));
+	const warn = deps.warn ?? ((message: string) => console.warn(message));
+
+	// Both paths stay armed - the event can still fire after the fallback, and
+	// the timer cannot be cleared through the slice of BrowserWindow this takes
+	// - so the second one to arrive has to find the window already revealed.
+	let revealed = false;
+
+	function reveal(reason: RevealReason): void {
+		if (revealed) return;
+		revealed = true;
+
+		// The window can be gone before either path lands: on macOS the app
+		// outlives its window, and a launch closed inside the fallback window
+		// leaves this timer holding a destroyed one. Showing it would throw
+		// inside a timer callback, which in the main process is a crash.
+		if (window.isDestroyed()) return;
+
+		if (reason === "reveal-fallback") {
+			warn(
+				`[Main] No first frame after ${fallbackMs}ms - showing the window anyway. ` +
+					"Its renderer is running; something in this display environment is not " +
+					"compositing it (seen under a bare X server with no window manager). " +
+					"The window may be blank until it paints. See issue #1347."
+			);
+		}
+
+		window.show();
+		onRevealed(reason);
+	}
+
+	window.once("ready-to-show", () => reveal("ready-to-show"));
+	after(fallbackMs, () => reveal("reveal-fallback"));
+}

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -325,12 +325,19 @@ is one.** Under `xvfb-run` the app produced a figure once across the runs that
 landed this leg and timed out every other time, each time having come up whole
 - engine listening, MCP up, the renderer fetching config, collections and
 globals from it, inside a second - and then produced no frame, so
-`ready-to-show` never fired and the leg reported `"unavailable"` with that
-output in `note`. The harness's plain window becomes
-showable in the same session every time, and the app's window is frameless.
-Running a window manager in the session changed nothing. #1347 tracks it; the
-Windows and macOS figures are unaffected, as is a Linux desktop, where this has
-not been seen.
+`ready-to-show` never fired. The harness's plain window becomes showable in the
+same session every time, and the app's window comes up hidden. Running a window
+manager in the session changed nothing.
+
+The app no longer hangs on that (#1347): `app/electron/window-reveal.ts` shows
+the window anyway once a first frame has not arrived within 8 seconds, and
+warns why. What that does for this measurement is make the failure fast and
+legible rather than fixable - a launch revealed that way waited out a timer
+instead of painting, so it is not a cold start. The app says which path it took
+(`via` in the startup line) and `measure-app.mjs` reports the leg
+`"unavailable"` naming the count, in seconds rather than after three 90-second
+timeouts. The Windows and macOS figures are unaffected, as is a Linux desktop,
+where this has not been seen.
 
 **The packaged figure is the real cold start.** The workflow builds the
 renderer, compiles the Electron main process, stages the engine binary into

--- a/scripts/perf/measure-app.mjs
+++ b/scripts/perf/measure-app.mjs
@@ -604,6 +604,20 @@ async function measurePackagedStartup(repoRoot, packagedDir) {
 	const result = await timeLaunches(spec, repoRoot, "packaged", waitForEngineToExit);
 	if (!result.ok) return unavailable(result.reason);
 
+	// A launch the app's reveal fallback put on screen never produced a first
+	// frame: it waited that timer out and then showed the window anyway
+	// (#1347), so the figure it prints is the timer and not a cold start.
+	// Rejected rather than folded into the median - this is the case that used
+	// to be a 90-second timeout with no cause, and it is still not a
+	// measurement. Must match `RevealReason` in `app/electron/window-reveal.ts`;
+	// `app/electron/startup-probe.test.ts` holds the two ends together.
+	const fellBack = result.payloads.filter((payload) => payload.via === "reveal-fallback").length;
+	if (fellBack > 0) {
+		return unavailable(
+			`${fellBack} of ${result.payloads.length} launches never painted - the window was shown by the app's reveal fallback, so no cold start was measured (see issue #1347)`
+		);
+	}
+
 	const launches = result.payloads.map((payload) => payload.readyToShowMs);
 	// Every launch on one machine reports the same basis; a mixture would mean
 	// the app measured two different things across three launches.


### PR DESCRIPTION
## Description

Under a bare X server the app came up whole - engine listening, MCP listening, the renderer mounted and issuing its prefetches - and then showed nothing at all, with no error, no dialog and no log line.

**Root cause, approach, and the alternative I rejected.** `ready-to-show` is Chromium promising a *first frame* for a window created with `show: false`; it is a statement about compositing, not about loading. `createWindow` revealed the window from that event and from nothing else, so where compositing never gets going the window is never shown and no other part of the app notices - the process sits there looking healthy. The issue offered two remedies and its own comment settles which: the failure is intermittent on identical code (one launch in five painted, 743 ms; four produced no frame for the remaining 89 s of the launch budget), so this is a race in getting a first frame out of a hidden window, not a capability the environment lacks - which is why remedy 2, a frameless-configuration fix, does not fit the evidence, and why a window manager, started and then properly waited for on `_NET_SUPPORTING_WM_CHECK`, changed nothing in #1345. So remedy 1: `app/electron/window-reveal.ts` shows the window on the first frame as before, or after 8 seconds without one, warning why. A visible window that is briefly unpainted is a worse first second than `ready-to-show` buys and a far better app than one that never appears; on a desktop the fallback is dead code. **The alternative I rejected inside remedy 1** was letting the fallback quietly rescue the perf measurement too: a launch revealed by a timer never painted, so reporting its number as a cold start would replace a visible gap in the Linux figure with a wrong one. The reveal path therefore travels with the measurement (`via` in the startup line) and `measure-app.mjs` rejects the leg, naming the count - in seconds now, rather than after three 90-second timeouts.

**Anchors.** They held: `createWindow` is at `main.ts:329` as the issue says, and the `ready-to-show` handler had moved from `:406-412` to `:453-460` (notifications, progress and the close prompt all landed in between, as the Sequencing section predicted). The problem reproduces as described - nothing but that event could reveal the window.

**Blast radius.** `reportStartupIfRequested` gained a required first argument; `main.ts` is its only caller, and `scripts/perf/measure-app.mjs` is the only reader of the line it prints (`summarize.py`'s `app_rows()` contract - `method` / `launches` / `medianMs` / `basis` / `note` - is unchanged, so the JSON shape and the step summary are untouched). No renderer, MCP, CLI or import path reads any of it.

**On acceptance criterion 1, plainly:** the cause is named as far as the evidence supports - a first frame that is sometimes not produced for a hidden window - but I did not reproduce it deliberately on a runner before writing the fix. I cannot dispatch a workflow from this session, and the issue records that it does not reproduce in a container. What I did instead: this PR touches `scripts/perf/**`, which is one of the two paths `perf-measure.yml`'s `pull_request` trigger watches, so opening it runs the packaged Linux leg under `xvfb-run` on `ubuntu-latest` - the exact environment the failure was measured in. That run is the deliberate reproduction, and its outcome is legible either way now: a painted launch reports `packaged-cold-start`, and a stalled one reports `unavailable` naming the reveal fallback instead of timing out with no cause. I will report what it says.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Everything below was run on this branch; all green, and no pre-existing failures were seen on the base commit.

| check | result |
|---|---|
| `python build.py -t` | exit 0 |
| `ctest --preset linux-dev` | **2908 passed**, 0 failed |
| `pnpm test` | **690 files / 7870 tests** passed |
| `pnpm type-check` | clean (renderer, electron, electron-tests) |
| `pnpm lint` | clean, 0 warnings |
| `pnpm format:check` | clean |
| repo-JS ESLint (files outside `app/`) | clean |
| `mkdocs build --strict` | built |

No engine code is touched; the engine build and `ctest` ran because they were asked for, not because the diff could move them.

**New tests.** `app/electron/window-reveal.test.ts`, 8 cases: the first frame shows the window and logs nothing (a warning here would be in every user's log), no frame shows it anyway and says why, the budget armed is the stated one, a frame arriving late does not re-show or print a second startup line, a frame arriving on time does not let the timer re-show, and a window destroyed inside the budget is not shown - `show()` on a destroyed window throws, and a throw from a timer callback in the main process takes the app down. `startup-probe.test.ts` gains the fallback's `via` in the payload and a guard that `measure-app.mjs` still reads the same string, routed through `ROOT_READING_GUARDS` like its siblings; its main.ts wiring guard now reads the reveal callback.

**Mutation checks, run rather than reasoned:** dropping the fallback timer reddens 3 cases, dropping the already-revealed guard reddens 2, dropping the `isDestroyed()` check reddens 1.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1347


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tct8qFTcUpyGbAj8WazCgg)_