### PR TITLE
build(engine): vcpkg baseline to 04a9d8e - cpp-httplib 0.54.1, curl 8.22.0

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -17,8 +17,11 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
    with curl, openssl and sqlite3 each missing point releases, purely because
    the pin had gone unexamined since June. A bump is `builtin-baseline` in
    `engine/vcpkg.json` **and** `VCPKG_COMMIT` in `release.yml`, `pr-tests.yml`,
-   `codeql.yml` and `cache-warm.yml` - one SHA in five places, and the `guard`
-   job in `cache-warm.yml` fails the build if any of them drift. Land a bump as
+   `codeql.yml`, `cache-warm.yml`, `sanitizers.yml`, `engine-tidy-scan.yml`
+   and `perf-measure.yml` - one SHA in eight places, and the `guard` job in
+   `cache-warm.yml` fails the build if any of them drift. Read that job's
+   `files=(...)` list rather than this sentence: it is the authority, and it
+   has grown twice. Land a bump as
    **its own PR before the release commit**, never inside it: a dependency
    change and a version bump that break one platform together cannot be told
    apart. Before merging a bump, run it against a **deliberately stale clone**
@@ -33,6 +36,17 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
    /tmp/stale-vcpkg/bootstrap-vcpkg.sh -disableMetrics
    VCPKG_ROOT=/tmp/stale-vcpkg python build.py -e     # must self-heal, then build
    ```
+
+   Expect the bump to be **work, not a rubber stamp**. `inbox.cpp` mirrors
+   cpp-httplib's private `Server::process_and_close_socket` behind a
+   `static_assert` on `CPPHTTPLIB_VERSION`, so any cpp-httplib move fails the
+   build until the mirror is re-read against the new source and the assert
+   updated (#1283 tracks retiring it; check first whether the release finally
+   carries a public hook that can rewrite `Request::path` before routing). And
+   `sanitizers/tsan.supp`'s `race:std::ctype<char>::narrow` entry is re-measured
+   on every cpp-httplib move, not carried forward - 10 runs of
+   `TransportPolicyPaths.LoadRunTraversesManualProxy` with the line and 10
+   without, recorded in that file and in `docs/engine/building.md`.
 3. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
    Changelog format, see below).
 4. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -313,7 +313,7 @@ jobs:
       # job above fails the build if they drift. `SCCACHE_GHA_ENABLED` selects
       # the ref-scoped GHA backend, so the entries this compile produces land in
       # the master scope a tag build reads - the whole point of warming here.
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ jobs:
       contents: read
       actions: read
     env:
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/engine-tidy-scan.yml
+++ b/.github/workflows/engine-tidy-scan.yml
@@ -122,7 +122,7 @@ jobs:
     # ceiling for a hosted runner is 360.
     timeout-minutes: 240
     env:
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
 

--- a/.github/workflows/perf-measure.yml
+++ b/.github/workflows/perf-measure.yml
@@ -88,7 +88,7 @@ jobs:
             mock: ./mock-server
             pack: --mac dir
     env:
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -654,7 +654,7 @@ jobs:
     # headroom is for that shape of change; nothing routine goes near it.
     timeout-minutes: 90
     env:
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             preset: macos-prod-arm64
     timeout-minutes: 120
     env:
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
       # v0.17.1's Windows leg reported 18 sccache "Cache errors" where v0.17.0

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -113,7 +113,7 @@ jobs:
       # library), so their archives are the same artifacts those workflows
       # build and this reads them out of the master scope rather than
       # recompiling OpenSSL weekly.
-      VCPKG_COMMIT: '114d9fe62faf35856b45cf55cb93b57028a45d63'
+      VCPKG_COMMIT: '04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       # No sccache, on purpose. The engine's own objects compile with sanitizer
       # flags, so they hash differently from every other workflow's - sharing

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -389,7 +389,11 @@ tracking issue.
   reproduces it 10 times out of 10, which is the cheap way to re-measure this
   one, and the way it was re-measured at `dc25029` after the baseline moved to
   cpp-httplib 0.53.1: 8 of 10 runs raced without the entry, 10 of 10 passed
-  with it. What is left is upstream in libstdc++.
+  with it. Re-measured the same way on the move to cpp-httplib 0.54.1
+  (2026-09-05): 10 of 10 raced without the entry, 10 of 10 passed with it, the
+  report frame for frame the same - that release rewrote
+  `process_and_close_socket` around a `serve_guarded` wrapper and left
+  `parse_status_line` alone. What is left is upstream in libstdc++.
 
 The matrix has therefore paid for itself twice over: two engine-side defects
 found and fixed, one of them a race the ordinary suite is structurally unable

--- a/engine/sanitizers/tsan.supp
+++ b/engine/sanitizers/tsan.supp
@@ -105,4 +105,12 @@ race:crypto/hashtable/hashtable.c
 # runs of that test raced without the line, 10 of 10 passed with it, and the
 # report was the stack above with the same libstdc++ and httplib frames. The
 # entry still earns its place on the version the engine now pins.
+#
+# Re-measured again on the move to cpp-httplib 0.54.1 (2026-09-05), the same
+# way and for the same reason: 10 of 10 runs raced without the line, 10 of 10
+# passed with it, and the report was again the stack above, frame for frame -
+# 0.54.1 rewrote `process_and_close_socket` around a `serve_guarded` wrapper
+# but left `parse_status_line` alone. This is the reading to repeat on the
+# next baseline move; it is not a standing pass, and the entry goes the day a
+# run without it comes back clean.
 race:std::ctype<char>::narrow

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -148,11 +148,21 @@ class AnyPathServer final : public httplib::Server {
         // is the `setup_request` callback below, which that one passes as null -
         // and `process_request` is its only caller, so there is no narrower
         // override that reaches the callback.
-        static_assert (std::string_view (CPPHTTPLIB_VERSION) == "0.53.1",
+        //
+        // `serve_guarded` is 0.54.0's addition and is copied rather than
+        // dropped: `process_request` wraps only `routing()` in a try/catch, so
+        // an exception from a content provider, a post-routing, error, logging
+        // or expect-100 handler runs outside it, and the task queue calls the
+        // job with no catch of its own. Omitting the guard here would terminate
+        // the process on a throw from any of those - on the one listener that
+        // may bind past loopback.
+        static_assert (std::string_view (CPPHTTPLIB_VERSION) == "0.54.1",
         "cpp-httplib moved: re-read Server::process_and_close_socket, "
         "confirm this override still mirrors it, then update this assert - "
         "or retire the mirror entirely if the release carries a public "
-        "request-setup hook (issue #1283).");
+        "request-setup hook (issue #1283). As of 0.54.1 it does not: "
+        "`set_pre_request_handler` is a `HandlerWithResponse`, which takes a "
+        "`const Request&` and so cannot rewrite the path either.");
 
         std::string remote_addr;
         int remote_port = 0;
@@ -163,14 +173,16 @@ class AnyPathServer final : public httplib::Server {
         httplib::detail::get_local_ip_and_port (sock, local_addr, local_port);
 
         bool websocket_upgraded = false;
-        const auto ret = httplib::detail::process_server_socket (svr_sock_,
-        sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_,
-        read_timeout_usec_, write_timeout_sec_, write_timeout_usec_,
-        [&] (httplib::Stream& strm, bool close_connection, bool& connection_closed) {
-            return process_request (
-            strm, remote_addr, remote_port, local_addr, local_port,
-            close_connection, connection_closed,
-            [] (httplib::Request& req) { req.path = ROUTE; }, &websocket_upgraded);
+        const auto ret          = serve_guarded ([&] () {
+            return httplib::detail::process_server_socket (svr_sock_, sock,
+                     keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_,
+                     read_timeout_usec_, write_timeout_sec_, write_timeout_usec_,
+                     [&] (httplib::Stream& strm, bool close_connection, bool& connection_closed) {
+                return process_request (
+                strm, remote_addr, remote_port, local_addr, local_port,
+                close_connection, connection_closed,
+                [] (httplib::Request& req) { req.path = ROUTE; }, &websocket_upgraded);
+            });
         });
 
         httplib::detail::drain_and_close_socket (sock);

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -32,5 +32,5 @@
     },
     "sqlite-orm"
   ],
-  "builtin-baseline": "114d9fe62faf35856b45cf55cb93b57028a45d63"
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4"
 }


### PR DESCRIPTION
## Description

The vcpkg baseline moves `114d9fe` -> `04a9d8e`. This is the pre-release baseline check the `releasing` skill calls for, landed as its own PR ahead of the 0.26.0 release commit so a dependency change and a version bump cannot break a platform together and be indistinguishable.

Two ports move:

- **cpp-httplib 0.53.1 -> 0.54.1**
- **curl 8.21.0#1 -> 8.22.0**

### cpp-httplib's move is not free

`AnyPathServer` in `engine/src/http/routes/inbox.cpp` mirrors the private `Server::process_and_close_socket` to reach the one `setup_request` hook that can rewrite `Request::path` ahead of routing. Its `static_assert` on `CPPHTTPLIB_VERSION` failed the build, which is exactly what it exists to do.

0.54.0 wrapped the serving loop in `serve_guarded`, a try/catch that stops an exception thrown by a user callback escaping the worker thread: `process_request` wraps only `routing()`, so a content provider, post-routing, error, logging or expect-100 handler throws outside it, and the task queue calls the job with no catch of its own. Omitting it from the mirror would have terminated the process on such a throw - on the one listener that may bind past loopback. The mirror copies it, and the assert moves to 0.54.1.

**#1283's exit is still not available.** `set_pre_request_handler`, new in this line, looked like it might retire the mirror entirely, but it is a `HandlerWithResponse` and so takes a `const Request &` - it cannot rewrite the path either. That finding is written into the assert's own message, because the next reader will ask the same question.

### The tsan suppression is re-measured, not carried

`sanitizers/tsan.supp`'s `race:std::ctype<char>::narrow` entry is re-measured on every cpp-httplib move, as it was at `dc25029`:

| | passed | raced |
|---|---|---|
| without the line | 0/10 | 10/10 |
| with the line | 10/10 | 0/10 |

The report is the recorded stack frame for frame - 0.54.1 rewrote `process_and_close_socket` but left `parse_status_line` alone. Recorded in that file and in `docs/engine/building.md`.

### The SHA is in eight places, not five

`sanitizers.yml`, `engine-tidy-scan.yml` and `perf-measure.yml` joined `cache-warm.yml`'s guard list after the `releasing` skill's "five places" sentence was written. Corrected, and pointed at the guard's own `files=(...)` as the authority rather than restating a list that has now drifted twice.

## Type of Change

- [x] Bug fix (the uninherited `serve_guarded` would have been one)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` - engine builds and the full C++ suite passes on the new baseline (34/34 inbox tests among them, including the two that pin the any-path routing this mirror exists for).
- **Stale-clone validation per #692**: a `--depth=1` vcpkg clone reset to the *previous* baseline (`114d9fe`), bootstrapped, then `VCPKG_ROOT=<stale> python build.py -e`. `build.py` self-healed the clone to `04a9d8e` before configuring - no `versions/baseline.json` error, no manual `git pull` needed. Every environment that has not updated since v0.25.0 is about to be this one.
- **tsan**: `ctest --preset linux-tsan` build, then 10 runs of `TransportPolicyPaths.LoadRunTraversesManualProxy` with and without the suppression line, table above.
- `scripts/pre-commit` - clang-format 19 and clang-tidy 19 clean on the changed source.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no new tests: the existing `static_assert` *is* the guard for this class of change, and it fired
- [x] I have updated documentation

## Related Issues

Refs #692, #1283


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdzN6CbBVwkWViZer9Lmde)_