### PR TITLE
fix: report large captured bodies in GB, drop date-fns, measure run durations on a monotonic clock

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -60,7 +60,6 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.1.1",
-		"date-fns": "^4.4.0",
 		"electron-store": "^11.0.2",
 		"electron-updater": "^6.8.9",
 		"graphql": "^16.14.2",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      date-fns:
-        specifier: ^4.4.0
-        version: 4.4.0
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
@@ -2063,9 +2060,6 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
-
-  date-fns@4.4.0:
-    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   debounce-fn@6.0.0:
     resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
@@ -6365,8 +6359,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  date-fns@4.4.0: {}
 
   debounce-fn@6.0.0:
     dependencies:

--- a/app/src/components/shared/response-viewer/CapturedResponseNotice.test.tsx
+++ b/app/src/components/shared/response-viewer/CapturedResponseNotice.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The notice reports `bodyBytes`, which is documented as the size *before* any
+ * truncation - so the largest numbers in the app arrive here, on exactly the
+ * paths that exist because a body was too big to keep.
+ *
+ * This component used to format them with a private copy of `formatBytes` that
+ * stopped at MB, so a 2 GB response read "2048.0 MB". The copy was the defect;
+ * these assert the shared formatter's GB branch is the one in use.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { CapturedResponseNotice } from "./CapturedResponseNotice";
+import type { RunSample } from "@/types/domain";
+
+const GB = 1024 * 1024 * 1024;
+
+/** Render the notice for one captured response and hand back its text. */
+function noticeFor(response: RunSample["response"]): string {
+	const { container } = render(<CapturedResponseNotice response={response} />);
+	return container.textContent ?? "";
+}
+
+describe("sizes past a gigabyte", () => {
+	it("scales a dropped body to GB rather than reporting thousands of MB", () => {
+		const text = noticeFor({ headers: {}, bodyBytes: 2 * GB, bodyDropped: true });
+		expect(text).toContain("2.0 GB");
+		expect(text).not.toContain("MB");
+	});
+
+	it("scales a binary body to GB too", () => {
+		const text = noticeFor({
+			headers: {},
+			bodyBytes: 3 * GB,
+			binary: true,
+			contentType: "application/octet-stream",
+		});
+		expect(text).toContain("3.0 GB");
+	});
+});
+
+describe("the smaller units the private copy did get right", () => {
+	it("still reads bytes and MB as before", () => {
+		expect(noticeFor({ headers: {}, bodyBytes: 34, bodyDropped: true })).toContain("34 B");
+		expect(noticeFor({ headers: {}, bodyBytes: 5 * 1024 * 1024, bodyDropped: true })).toContain(
+			"5.0 MB"
+		);
+	});
+});

--- a/app/src/components/shared/response-viewer/CapturedResponseNotice.tsx
+++ b/app/src/components/shared/response-viewer/CapturedResponseNotice.tsx
@@ -24,18 +24,12 @@
  */
 
 import { Callout } from "../Callout";
+import { formatBytes } from "@/modules/settings/utils/format-size";
 import type { RunSample } from "@/types/domain";
 
 export interface CapturedResponseNoticeProps {
 	response: RunSample["response"];
 	className?: string;
-}
-
-/** Human-readable byte count - "1.2 KB", "34 B". */
-function formatBytes(bytes: number): string {
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export function CapturedResponseNotice({ response, className }: CapturedResponseNoticeProps) {

--- a/app/src/modules/welcome/components/RecentRuns.tsx
+++ b/app/src/modules/welcome/components/RecentRuns.tsx
@@ -26,10 +26,10 @@
  */
 
 import { ChevronRight } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
 import { useTabsStore } from "@/stores";
 import { MethodBadge, TruncatedText } from "@/components/shared";
 import { Eyebrow } from "@/components/ui";
+import { formatRelativeTime } from "@/utils";
 import type { Run } from "@/types";
 
 const RECENT_RUN_LIMIT = 5;
@@ -118,7 +118,7 @@ export function RecentRuns({ runs }: { runs: Run[] }) {
 								)}
 								{run.startTime > 0 && (
 									<span className="text-xs font-mono tabular-nums text-muted-foreground">
-										{formatDistanceToNow(run.startTime, { addSuffix: true })}
+										{formatRelativeTime(run.startTime)}
 									</span>
 								)}
 								<ChevronRight className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5750,6 +5750,15 @@ offset - because a tick's `elapsed_seconds` is measured from the run's first
 onto one timeline is what the wall clock is for. A series the target did not
 report in that scrape is **absent** from its `series` object rather than zero.
 
+The two fields are read off different clocks, which is why they can disagree.
+`timestamp` is wall time, so it moves when the host's clock is adjusted, while
+every elapsed figure the engine reports (`elapsed_seconds` here, and a run's
+duration and rates) is measured on a monotonic clock that an NTP step or a
+manual clock change cannot move. Over a run that spans an adjustment, the
+difference between two `timestamp` values is therefore not exactly the
+difference between their `elapsed_seconds`; the elapsed pair is the one that
+measures how long the run actually took.
+
 A run that configured no monitor returns `200` with an empty `data` array; only
 a run that does not exist is a `404`. Samples are deleted with the run, like
 every other child row.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -291,7 +291,15 @@ struct RunContext {
     std::atomic<bool> should_stop{ false };
     std::atomic<bool> is_running{ false };
     nlohmann::json config;
+    // Wall-clock stamp of the run's start. Its remaining job is the sentinel
+    // for "this run has started" - every duration is measured on the monotonic
+    // base below, because wall time can step under a running load test.
     int64_t start_time_ms = 0;
+    // Monotonic base for every elapsed figure the run reports: the final
+    // report's duration and rates, each persisted tick's elapsed_seconds, the
+    // live SSE tick, and when a mid-run auth refresh landed. Meaningful only
+    // against another reading of the same clock.
+    int64_t start_steady_ms = 0;
 
     // Test script for deferred validation
     std::string test_script;

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -28,6 +28,16 @@ int64_t now_ms () {
     .count ();
 }
 
+/// Monotonic companion to `now_ms()`, for the one thing here that is a length
+/// rather than a point in time: how far into the run a refresh landed. Wall
+/// time can step mid-run and would report an offset that never happened.
+/// Pairs with `RunContext::start_steady_ms`.
+int64_t steady_now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now ().time_since_epoch ())
+    .count ();
+}
+
 /// Sleep in slices of `poll_ms` so a stop is honoured promptly: the worker
 /// joins this thread on the way out, and a watchdog asleep until the next
 /// expiry would hold a finished run open for the rest of the token's life.
@@ -173,7 +183,7 @@ const AuthRefreshTuning& tuning) {
         retry_ms                = tuning.retry_ms;
         const auto& token       = std::get<vayu::db::OAuthToken> (result);
         const double at_seconds = context->start_time_ms > 0 ?
-        static_cast<double> (now_ms () - context->start_time_ms) / 1000.0 :
+        static_cast<double> (steady_now_ms () - context->start_steady_ms) / 1000.0 :
         0.0;
         state->publish (
         vayu::http::oauth2_header_value (state->config (), token.access_token), at_seconds,

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -34,6 +34,24 @@ inline int64_t now_ms () {
 }
 
 /**
+ * The clock every *elapsed* figure is measured on.
+ *
+ * `now_ms()` is wall time: NTP steps it and the user can set it, so a run that
+ * spans an adjustment reports a duration that never happened, and a backward
+ * step reports a negative one. Durations therefore come from here and
+ * timestamps from `now_ms()` - a tick's `timestamp` is a point in time a reader
+ * compares against their own clock, while its `elapsedSeconds` is a length.
+ *
+ * The epoch is arbitrary, so a value is only ever meaningful against another
+ * value from this same function.
+ */
+inline int64_t steady_now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now ().time_since_epoch ())
+    .count ();
+}
+
+/**
  * @brief One deferred replay: a script, the samples it runs against, and the
  *        identity `pm.info` reports while it does.
  *
@@ -1009,8 +1027,9 @@ const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn) {
 
         // IMPORTANT: Set is_running BEFORE spawning threads to avoid race condition
         // where metrics_thread exits immediately because is_running is still false
-        context->is_running    = true;
-        context->start_time_ms = now_ms ();
+        context->is_running      = true;
+        context->start_time_ms   = now_ms ();
+        context->start_steady_ms = steady_now_ms ();
 
         // The handle is kept - not detached - so shutdown can join the worker
         // before `db` and this manager go out of scope from under the
@@ -1437,8 +1456,8 @@ void execute_load_test (const std::shared_ptr<RunContext>& context,
 vayu::db::Database* db_ptr,
 bool verbose,
 RunManager& manager) {
-    // Note: is_running and start_time_ms are set in start_run() before threads
-    // spawn to avoid race condition with metrics_thread
+    // Note: is_running and both start stamps are set in start_run() before
+    // threads spawn to avoid race condition with metrics_thread
 
     auto& db           = *db_ptr;
     const auto& config = context->config;
@@ -1568,7 +1587,7 @@ RunManager& manager) {
             auto& mc                       = *context->metrics_collector;
             inputs.total_requests          = mc.total_requests ();
             const double elapsed_s         = context->start_time_ms > 0 ?
-                    static_cast<double> (now_ms () - context->start_time_ms) / 1000.0 :
+                    static_cast<double> (steady_now_ms () - context->start_steady_ms) / 1000.0 :
                     0.0;
             inputs.rps                     = elapsed_s > 0 ?
                                 static_cast<double> (inputs.total_requests) / elapsed_s :
@@ -1820,11 +1839,12 @@ struct TickWindow {
 void persist_metric_tick (const std::shared_ptr<RunContext>& context,
 vayu::db::Database& db,
 int64_t tick_wall_ms,
+int64_t tick_steady_ms,
 double elapsed,
 const std::map<int, size_t>& status_snapshot,
 const TickWindow& window,
 size_t& last_total,
-int64_t& first_tick_wall_ms) {
+int64_t& first_tick_steady_ms) {
     size_t current_total  = context->total_requests ();
     size_t current_errors = context->total_errors ();
     size_t delta          = current_total - last_total;
@@ -1837,7 +1857,7 @@ int64_t& first_tick_wall_ms) {
     // Calculate send rate (requests dispatched per second) and throughput (responses per second)
     size_t requests_sent = context->requests_sent.load ();
     double run_elapsed_s =
-    (static_cast<double> (tick_wall_ms - context->start_time_ms)) / 1000.0;
+    (static_cast<double> (tick_steady_ms - context->start_steady_ms)) / 1000.0;
     double send_rate =
     run_elapsed_s > 0 ? static_cast<double> (requests_sent) / run_elapsed_s : 0.0;
     double throughput =
@@ -1879,15 +1899,15 @@ int64_t& first_tick_wall_ms) {
         // tick, not from the run's start: the 1 Hz gate means the
         // first stored tick lands ~1s in, and a series that starts
         // at 0 is what the charts have always drawn.
-        if (first_tick_wall_ms == 0) {
-            first_tick_wall_ms = tick_wall_ms;
+        if (first_tick_steady_ms == 0) {
+            first_tick_steady_ms = tick_steady_ms;
         }
 
         auto& mc = *context->metrics_collector;
         MetricTickSample sample;
         sample.timestamp = tick_wall_ms;
         sample.elapsed_seconds =
-        static_cast<double> (tick_wall_ms - first_tick_wall_ms) / 1000.0;
+        static_cast<double> (tick_steady_ms - first_tick_steady_ms) / 1000.0;
         sample.requests_completed  = current_total;
         sample.requests_failed     = current_errors;
         sample.current_rps         = current_rps;
@@ -1941,9 +1961,9 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     // Declared here so it is in scope inside the try block below.
     int tick_interval_ms = 0;
 
-    // Wall clock of the first persisted tick; the origin every stored tick's
-    // elapsed_seconds is relative to. 0 until the first DB-gated tick.
-    int64_t first_tick_wall_ms = 0;
+    // Monotonic reading at the first persisted tick; the origin every stored
+    // tick's elapsed_seconds is relative to. 0 until the first DB-gated tick.
+    int64_t first_tick_steady_ms = 0;
 
     // Windowed (rolling) percentiles sampled by emit_live_tick each tick. Captured
     // here so the 1 Hz DB-gated block below can persist the same window it just
@@ -1957,12 +1977,13 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     // persisted enrichment for the same logical tick share one timestamp -
     // re-sampling now_ms() inside drifts them into adjacent ms buckets and the
     // dashboard sees status-codes shift left vs throughput on the same x-axis.
-    auto emit_live_tick = [&] (const std::map<int, size_t>* status_snapshot, int64_t now_wall_ms) {
+    auto emit_live_tick = [&] (const std::map<int, size_t>* status_snapshot,
+                          int64_t now_wall_ms, int64_t now_steady_ms) {
         size_t active_count      = context->active_transfer_count ();
         size_t requests_sent     = context->requests_sent.load ();
         size_t requests_expected = context->requests_expected.load ();
         double elapsed_seconds   = context->start_time_ms > 0 ?
-          static_cast<double> (now_wall_ms - context->start_time_ms) / 1000.0 :
+          static_cast<double> (now_steady_ms - context->start_steady_ms) / 1000.0 :
           0.0;
 
         // Sample the rolling window exactly once per tick (it resets on read) and
@@ -2036,7 +2057,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         static_cast<int> (vayu::core::constants::server::DEFAULT_MAX_LIVE_TICKS)))));
 
         // Tick 0: emit immediately so consumers see data before the first sleep.
-        emit_live_tick (nullptr, now_ms ());
+        emit_live_tick (nullptr, now_ms (), steady_now_ms ());
 
         // Loop on is_running alone. should_stop is only the *request* to stop:
         // the worker acts on it, then blocks in event_loop->stop (cancelling on
@@ -2049,10 +2070,13 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         while (context->is_running) {
             std::this_thread::sleep_for (std::chrono::milliseconds (tick_interval_ms));
 
-            // Single wall-clock sample per tick - shared by the SSE payload
-            // timestamp, the run-elapsed calc, and (on DB-gated ticks) every
-            // persisted metric row below. See #27.
-            int64_t tick_wall_ms = now_ms ();
+            // Single sample of each clock per tick - the wall one is shared by
+            // the SSE payload timestamp and (on DB-gated ticks) every persisted
+            // metric row below (see #27); the monotonic one carries every
+            // elapsed figure derived from the same tick, so the two stay one
+            // logical instant without a duration riding on wall time.
+            int64_t tick_wall_ms   = now_ms ();
+            int64_t tick_steady_ms = steady_now_ms ();
 
             // Snapshot the status-code distribution once per tick and share it
             // with both the SSE builder and (on DB-gated ticks) the persisted
@@ -2060,22 +2084,23 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
             auto status_snapshot = context->metrics_collector->status_code_distribution ();
 
             // Emit a live tick every iteration regardless of the 1 Hz DB gate.
-            emit_live_tick (&status_snapshot, tick_wall_ms);
+            emit_live_tick (&status_snapshot, tick_wall_ms, tick_steady_ms);
 
             auto now = std::chrono::steady_clock::now ();
             auto elapsed = std::chrono::duration<double> (now - last_update).count ();
 
             if (elapsed >= 1.0) // Update every second
             {
-                persist_metric_tick (context, db, tick_wall_ms, elapsed, status_snapshot,
-                TickWindow{ win_p50, win_p95, win_p99 }, last_total, first_tick_wall_ms);
+                persist_metric_tick (context, db, tick_wall_ms, tick_steady_ms,
+                elapsed, status_snapshot, TickWindow{ win_p50, win_p95, win_p99 },
+                last_total, first_tick_steady_ms);
                 last_update = now;
             }
         }
 
         // Final settled tick before signalling closed - consumers use this ordering
         // as the termination contract (last data before closed==true).
-        emit_live_tick (nullptr, now_ms ());
+        emit_live_tick (nullptr, now_ms (), steady_now_ms ());
     } catch (const std::exception& e) {
         vayu::utils::log_error ("collect_metrics: " + std::string (e.what ()));
     } catch (...) {


### PR DESCRIPTION
Closes #1421.

## Description

The three findings from the over-engineering audit that met the "changes what the app does" bar, one commit each.

**1. `CapturedResponseNotice` formatted bytes with a private copy that stopped at MB** (`8e3b843`)

The copy had lost the GB branch that `modules/settings/utils/format-size.ts` has. It is worst exactly where it is used: `bodyBytes` is documented as the size *before* truncation, and this notice renders it on the two paths that exist because a body was too big to keep, so a 2 GB response read `2048.0 MB`. Deleted the copy, imported the shared formatter.

**2. `date-fns` was a runtime dependency for one call** (`ed0e696`)

`RecentRuns` was its only importer, for a single `formatDistanceToNow`, while `formatRelativeTime` already serves five other call sites. The welcome screen was therefore also the one surface saying "about 2 hours ago" where every other list says "2h ago"; that wording change is intended.

**3. Run durations and rates were measured by subtracting two wall-clock reads** (`2bb6c21`)

`test_duration_s`, `rps`, `send_rate`, `throughput`, each tick's `elapsed_seconds`, the live SSE tick, and a mid-run auth refresh's `at_seconds` were all `system_clock` differences from `RunContext::start_time_ms`. Wall time is stepped by NTP and settable by the user, so a run spanning an adjustment reported a duration that never happened. The app already ships host-sleep detection, so long runs are known to cross suspend boundaries - and the same metrics loop already gates its 1 Hz persistence on `steady_clock` while publishing durations off the wall clock, which is what makes this an oversight rather than a decision.

`RunContext` gains `start_steady_ms`; the five figures are measured against it. Timestamps stay wall-clock - a tick's `timestamp` is a point in time a reader compares against their own clock, its `elapsed_seconds` is a length - and both clocks are still sampled once per tick so the two remain one logical instant. `start_time_ms` keeps its remaining job as the "run has started" sentinel.

Deliberately unchanged: the retention cutoff at `run_manager.cpp:774`. Both sides of that comparison are wall stamps taken in the same process and nothing displays the result.

## Type of Change

- [x] Bug fix

## Testing

- Engine: full suite green - **2908 tests, 0 failures** (`ctest --preset linux-dev`), after a clean `python build.py -e -t`.
- App: `pnpm type-check`, `pnpm lint`, `pnpm format:check` on the touched files, plus the response-viewer (150 tests), welcome and utils suites.
- New `CapturedResponseNotice.test.tsx` is mutation-checked: restoring the old private `formatBytes` makes it fail with exactly the reported `2048.0 MB`, while its B/MB assertions still pass, so the guard is not over-broad.
- `clang-format-19` clean on all three engine files. Note the version matters - the plain `clang-format` here is 18 and reports violations on untouched lines, which is the split the workflow comment at `pr-tests.yml` warns about.

The clock change cannot be covered by a test that steps the clock without adding clock injection to the engine, which is a larger refactor; verification is the existing suite proving no regression on what is otherwise a clock-source substitution.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/api-reference.md` has a paragraph contrasting a tick's `timestamp` with its `elapsed_seconds`. The documented semantics are unchanged, but the two now come off different clocks and can disagree across an adjustment, so that paragraph says so.

## Related Issues

Closes #1421.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7y8LnmDYyn8x5eeX4FTyW)_