### PR TITLE
fix(mcp): correct four tool descriptions and stop naming tools in the server instructions

### DIFF
--- a/app/electron/mcp/protocol.integration.test.ts
+++ b/app/electron/mcp/protocol.integration.test.ts
@@ -25,7 +25,8 @@ import { createMcpServer } from "./server.js";
 import { McpHttpServer } from "./http.js";
 import { MCP_ENDPOINT_URL, MCP_HOST, MCP_PORT } from "../constants.js";
 import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
-import type { ToolContext } from "./tools.js";
+import { TOOLS, type ToolContext } from "./tools.js";
+import { PROMPTS } from "./prompts.js";
 import type { EngineClient } from "./engine-client.js";
 
 const REPORT = {
@@ -137,6 +138,33 @@ describe("MCP protocol handshake (in-memory)", () => {
 		expect(String(info?.description)).toMatch(/load-testing platform/i);
 		expect(info?.websiteUrl).toContain("github.com/athrvk/vayu");
 		expect(client.getInstructions()).toMatch(/API testing and load-testing/i);
+		await server.close();
+	});
+
+	/*
+	 * The instructions carry the cross-cutting facts - the capability taxonomy,
+	 * the allowlist, the two gates - and deliberately name no tool. A roster
+	 * here is a list of things that may not exist: the user can disable any
+	 * tool individually, and this text used to end by telling the reader to
+	 * trust `tools/list` over itself, which is the shape of the bug rather than
+	 * a fix for it. Each tool's own description ships only when the tool does.
+	 *
+	 * `compare_runs` is exempt because it is also a prompt name, and the
+	 * instructions legitimately point at the prompts - which nothing disables.
+	 */
+	it("does not name individual tools in the server instructions", async () => {
+		const { client, server } = await connectClient();
+		const instructions = client.getInstructions() ?? "";
+		// The guard is only meaningful if it read both sides of the comparison.
+		expect(instructions.length).toBeGreaterThan(100);
+		expect(TOOLS.length).toBeGreaterThan(20);
+
+		const promptNames = new Set(PROMPTS.map((p) => p.name));
+		const named = TOOLS.map((t) => t.name)
+			.filter((name) => !promptNames.has(name))
+			.filter((name) => new RegExp(`\\b${name}\\b`).test(instructions));
+
+		expect(named).toEqual([]);
 		await server.close();
 	});
 

--- a/app/electron/mcp/server.ts
+++ b/app/electron/mcp/server.ts
@@ -37,26 +37,32 @@ const VAYU_DESCRIPTION =
 	"tests, and read or tune engine configuration on the user's machine.";
 const VAYU_WEBSITE = "https://github.com/athrvk/vayu";
 
+/*
+ * What belongs here: the cross-cutting facts no single tool description can
+ * carry - the capability taxonomy, the safety model, and the other surfaces.
+ *
+ * What does not: tool names. The user can disable any tool individually, so a
+ * roster written here is a list of things that may not exist in the session
+ * reading it - which is why this text used to end by telling the reader to
+ * trust `tools/list` over it. Each tool's own description is the one copy of
+ * its contract, and it ships only when the tool does.
+ */
 const INSTRUCTIONS =
 	"Vayu is a local API testing and load-testing platform (Postman-style requests " +
 	"plus k6-level load tests in one app, backed by a native C++ engine); these " +
-	"tools drive that engine. Call get_engine_health first. Tools are grouped by " +
-	"capability: read (inspect collections, requests, environments, runs, config, " +
-	"and live metrics - always safe), execute (run_request, run_collection_smoke - " +
-	"send real traffic to a target), write (create/update/delete collections and " +
-	"saved requests, update_environment, update_engine_config - mutate saved data " +
-	"or engine config), and load (start_load_run, stop_run - start/stop a load " +
-	"test). Traffic-touching tools " +
-	"(run_request, run_collection_smoke, start_load_run) are restricted to an " +
-	"allowlist, and load runs also enforce hard RPS/concurrency/duration caps. " +
-	"start_load_run, delete_collection and delete_request ask the user to confirm " +
-	"(via elicitation when supported, otherwise a confirmed:true flag); " +
-	"delete_collection cascades, so its prompt states how many sub-collections and " +
-	"saved requests it would destroy. The write tools require the user to enable " +
-	"write access. Some update_engine_config keys need an engine restart to take " +
-	"effect; the result flags those under restartRequired (saved, but the running " +
-	"engine keeps the old value until restarted). The user may disable individual " +
-	"tools, so treat tools/list as authoritative and expect some tools to be absent. " +
+	"tools drive that engine. Start by checking engine health, so a later failure " +
+	"is not mistaken for a bad request. Tools are grouped by capability, named in " +
+	"each tool's own description: read (inspect collections, requests, " +
+	"environments, runs, config and live metrics - always safe), execute (send " +
+	"real traffic to a target), write (mutate saved data or engine config), and " +
+	"load (start and stop load tests). " +
+	"Every tool that puts traffic on the network is restricted to an allowlist, " +
+	"and load runs additionally enforce hard RPS/concurrency/duration caps. Write " +
+	"tools require the user to enable write access, and the destructive ones ask " +
+	"for confirmation - via elicitation where the client supports it, otherwise by " +
+	"returning what the call would destroy and waiting for a `confirmed: true` " +
+	"retry. A tool that is subject to either gate says so in its own description. " +
+	"`tools/list` is authoritative for what this session actually has. " +
 	"Vayu data is also available as resources (vayu://runs, vayu://collections, " +
 	"vayu://environments, vayu://config, and vayu://run/{runId}/report) to attach as " +
 	"context, and prompts (summarize_run, compare_runs, diagnose_errors, " +

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -3759,7 +3759,7 @@ export const TOOLS: McpTool[] = [
 		category: "read",
 		invalidates: [],
 		description:
-			"Check the Vayu engine's status and version. Use this first to confirm Vayu is running.",
+			'Check the Vayu engine\'s status and version. Use this first to confirm Vayu is running. Returns `status`, plus `version` when the engine reports one. An engine answering mid-restart may not return that shape at all; rather than failing, this reports `status: "unknown"` with the engine\'s raw body under `raw`, so a restarting engine reads as unknown rather than as a broken tool. An engine that is not running at all - port closed, nothing listening - comes back as a tool error instead, which is the difference between "starting up" and "not there".',
 		annotations: {
 			title: "Check engine health",
 			readOnlyHint: true,
@@ -3809,7 +3809,8 @@ export const TOOLS: McpTool[] = [
 		name: "list_requests",
 		category: "read",
 		invalidates: [],
-		description: "List the saved requests inside a collection.",
+		description:
+			"List the saved requests directly inside one collection. Each row is the *whole* stored request - method, url, headers, body, auth and both scripts - not a summary, so a large collection returns a correspondingly large result and there is no separate call needed to read one request. A sub-collection's requests are not included; list them by calling this again with the sub-collection id that list_collections returns. A stored request that cannot be serialized is omitted from the array rather than failing the call, so a short list is not proof the collection is small.",
 		annotations: {
 			title: "List requests",
 			readOnlyHint: true,
@@ -4074,7 +4075,7 @@ export const TOOLS: McpTool[] = [
 		category: "read",
 		invalidates: [],
 		description:
-			"Get the engine's tunable configuration entries (workers, timeouts, connection limits, buffer sizes, etc.), each with its current value, default, type, and allowed range.",
+			"Get the engine's tunable configuration entries (workers, timeouts, connection limits, buffer sizes, etc.), each with its current value, default, type, and allowed range. Read this before update_engine_config rather than assuming a key exists or what it accepts - the ranges here are what that call validates against. The values are what the engine has saved, which is not always what it is running: a key changed since the last restart reads as its new value here while the running engine still uses the old one.",
 		annotations: {
 			title: "Get engine config",
 			readOnlyHint: true,
@@ -6726,7 +6727,8 @@ export const TOOLS: McpTool[] = [
 		name: "stop_run",
 		category: "load",
 		invalidates: ["run"],
-		description: "Stop an in-progress load test.",
+		description:
+			"Stop a run that is still in progress: a load test, or a streaming Design-mode send that is holding its connection open. The run ends where it is and keeps what it already recorded - it is marked `stopped` rather than discarded, so get_run_report and get_run_samples still answer for it afterwards. Calling it on a run that has already finished is not an error: the result reports the status it was already in. A run id the engine does not know is an error.",
 		annotations: {
 			title: "Stop run",
 			readOnlyHint: false,


### PR DESCRIPTION
## Description

Findings from a prompt audit of Vayu's MCP surface - the text that reaches a consuming agent: 65 tool descriptions, their parameter descriptions, the server `INSTRUCTIONS`, prompts and resources.

The surface came out clean on nearly every axis. No pressure language, no thinking scaffolds, no numeric output caps or update cadences, no retired model names, no anti-formatting rules, no grader vocabulary, no identity stubs. Median description length is 91 words, well above the "3-4 sentences" bar, so almost every fix here **adds** text rather than trimming it.

Five findings warranted an edit.

### Two descriptions were wrong, not just thin

**`stop_run`** said `"Stop an in-progress load test."` It also stops a **streaming Design-mode send** - the case an agent most needs it for, since that is the run holding a connection open. `engine/src/http/routes/runs.cpp:1498` has handled this since #573 and checks the design path *first*, with a comment explaining why. The description never said so, so an agent with a hung stream had no reason to reach for this tool. It now also states that stopping keeps what the run recorded, and that stopping an already-finished run reports its status rather than failing.

**`get_engine_health`** never documented the `status: "unknown"` shape its own handler deliberately produces. `tools.ts:3775-3785` carries a ten-line comment explaining that a mid-restart engine answering with a non-conforming body is wrapped rather than failed - the "starting up" versus "not there" distinction a caller most wants from a health check. The knowledge already existed one line below the text that should have carried it.

### Two stated contract a caller cannot otherwise know

**`list_requests`** returns *whole* stored requests - headers, body, auth, both scripts (`requests.cpp:65-89`) - not summaries, so a large collection returns a correspondingly large result. It also silently skips any row that fails to serialize, so a short list is not proof of a small collection. `docs/engine/mcp.md:507` already relied on the full-object behaviour; the description didn't mention it.

**`get_engine_config`** now says it is the ranges `update_engine_config` validates against, and that it reports saved values, which are not always the running ones.

### The server instructions named ten tools

`INSTRUCTIONS` listed ten tools by name across its capability, allowlist and confirmation sections, then ended with *"treat tools/list as authoritative and expect some tools to be absent."*

That closing sentence is the tell. A user can disable any tool individually and a disabled tool is never registered (`server.ts:105`), so the roster was a list of things that may not exist in the session reading it - and the fix on record was a disclaimer asking the reader to distrust the surrounding text.

The cross-cutting facts stay, because no single description can carry them: the capability taxonomy, the allowlist over every traffic-touching tool, the RPS/concurrency/duration caps, and the two gates. They are expressed by capability now rather than by roster. The `restartRequired` paragraph goes entirely - it was a near-verbatim duplicate of `update_engine_config`'s own description, which is where it ships only when that tool does. Resource and prompt pointers stay named: nothing disables those, so they carry no dangling reference.

## Type of Change

- [x] Bug fix

## Testing

- `pnpm test electron/mcp` - **806 tests, 15 files, all passing**
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` on the touched files
- New guard test is mutation-checked: reinstating two tool names in the instructions fails it with `expected [ 'get_engine_health', 'stop_run' ] to deeply equal []`. It asserts both the instructions and `TOOLS` are non-empty before comparing, so it cannot pass by reading nothing.
- The existing instructions assertion (`protocol.integration.test.ts:139`) still matches, and `docs/engine/mcp.md`'s tool table is unaffected - names, categories and engine endpoints are unchanged, only description prose.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - no doc describes the changed text; the `docs/engine/mcp.md` table maps names to endpoints and is unaffected

## Not addressed here

Two audit findings deliberately carry no code change:

- **65 always-loaded tools, roughly 14,400 tokens of schema on every request** (~10.6K of descriptions plus ~3.8K of parameter text). Past a few dozen tools the usual answer is deferred loading or tool search, but MCP exposes neither; today's only lever is the user-driven `disabledTools`. Narrowing the default set is a product decision about who the server is for, not a cleanup, so it is left for a separate discussion.
- **`BOUNDED, ALWAYS:` in the `streamInput` parameter description** (`tools.ts:1960`). Caps emphasis, but it labels a genuine contract invariant with its reason immediately adjacent, so it is reported rather than edited.

## Related Issues

None - these were found by audit rather than reported.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7y8LnmDYyn8x5eeX4FTyW)_