### PR TITLE
feat(app): watch a run an MCP agent started

### DIFF
--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -550,7 +550,141 @@ describe("dispatch emits mcp:data-changed", () => {
 		expect(res.isError).toBeFalsy();
 		expect(onDataChanged).not.toHaveBeenCalled();
 	});
+});
 
+/*
+ * The one field on the event that is not a scope hint (#1419). Every other hint
+ * is read off the call's arguments; this one is read off the engine's answer,
+ * because a run has no id until the engine has given it one - and it is what
+ * tells the renderer to watch a run no surface of its own started.
+ */
+describe("a run that started says so", () => {
+	/** A client whose collection `c1` holds one allowlisted request. */
+	function runClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
+		return fakeClient({
+			startRun: vi.fn().mockResolvedValue({ runId: "run_5", status: "running" }),
+			listRequests: vi.fn().mockResolvedValue([{ id: "r1", name: "login" }]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "https://api.example.com/r1" }),
+			...overrides,
+		});
+	}
+
+	const ALLOWED: Partial<McpSafetyConfig> = { allowlist: ["api.example.com"] };
+
+	test("a confirmed load run names the run and the service that watches it", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(runClient(), ALLOWED);
+		const res = await dispatchTool(
+			"start_load_run",
+			{
+				url: "https://api.example.com/x",
+				mode: "constant_rps",
+				targetRps: 10,
+				confirmed: true,
+			},
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledWith({
+			entity: "run",
+			startedRun: { runId: "run_5", kind: "load" },
+		});
+	});
+
+	test("a scenario load run is a load run - the metrics stream watches it", async () => {
+		// Which service, not which surface the user would call it from: a
+		// scenario *load* run publishes metric ticks like any other load run,
+		// while `run_collection` publishes steps. Mutation check: hand this one
+		// "collection" and the dashboard attaches a step listener to a tick
+		// stream and stays empty for the whole run.
+		const { ctx, onDataChanged } = ctxWithNotifier(runClient(), ALLOWED);
+		const res = await dispatchTool(
+			"start_load_run",
+			{
+				scenario: { collectionId: "c1" },
+				mode: "constant_concurrency",
+				concurrency: 2,
+				duration: "10s",
+				confirmed: true,
+			},
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledWith({
+			entity: "run",
+			startedRun: { runId: "run_5", kind: "load" },
+		});
+	});
+
+	test("a collection run says so on its run event and not on the cookie jar", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(runClient(), ALLOWED);
+		const res = await dispatchTool("run_collection", { collectionId: "c1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledWith({
+			entity: "run",
+			collectionId: "c1",
+			startedRun: { runId: "run_5", kind: "collection" },
+		});
+		// The jar went stale too, but a cookie invalidation has no use for a run
+		// to watch - and a second copy of the bit would be a second thing to
+		// keep in step.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "cookie", collectionId: "c1" });
+	});
+
+	test("a smoke run starts no run to watch", async () => {
+		// It sends its requests one at a time through `POST /execute`: there is
+		// no run id and no stream, so there is nothing to attach to.
+		const client = runClient({
+			executeRequest: vi.fn().mockResolvedValue({ statusCode: 200 }),
+		});
+		const { ctx, onDataChanged } = ctxWithNotifier(client, ALLOWED);
+		const res = await dispatchTool("run_collection_smoke", { collectionId: "c1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		expect(client.startRun).not.toHaveBeenCalled();
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run", collectionId: "c1" });
+	});
+
+	test("the run tools that name an existing run start nothing", async () => {
+		for (const [tool, args] of [
+			["stop_run", { runId: "run_1" }],
+			["set_run_baseline", { runId: "run_1", baseline: true }],
+			["delete_run", { runId: "run_1", confirmed: true }],
+		] as const) {
+			const { ctx, onDataChanged } = ctxWithNotifier(runClient(), WRITES_ENABLED);
+			const res = await dispatchTool(tool, args, ctx);
+			expect(res.isError, `${tool} dispatched`).toBeFalsy();
+			expect(onDataChanged, `${tool} emitted`).toHaveBeenCalledWith({
+				entity: "run",
+				runId: "run_1",
+			});
+		}
+	});
+
+	test("an engine answer with no run id announces no run", async () => {
+		// The 202 body is what says a run exists. Anything else is handed to the
+		// agent as it came rather than turned into a run the renderer would open
+		// a stream on - and the history lists are still stale either way.
+		const { ctx, onDataChanged } = ctxWithNotifier(
+			runClient({ startRun: vi.fn().mockResolvedValue({ message: "accepted" }) }),
+			ALLOWED
+		);
+		const res = await dispatchTool(
+			"start_load_run",
+			{
+				url: "https://api.example.com/x",
+				mode: "constant_rps",
+				targetRps: 10,
+				confirmed: true,
+			},
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run" });
+	});
+});
+
+describe("dispatch emits mcp:data-changed, continued", () => {
 	test("a context without a notifier dispatches normally", async () => {
 		const client = fakeClient();
 		const ctx: ToolContext = { client, config: resolveSafetyConfig(WRITES_ENABLED) };

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -160,6 +160,38 @@ export interface McpDataChangedEvent {
 	 * no longer exists. `useStopMockServerMutation` already drops it app-side.
 	 */
 	mockId?: string;
+	/**
+	 * The run this call just started, and which run service watches it (#1419).
+	 *
+	 * The one field on this event that is not a scope hint: it says the run is
+	 * *live*, which is what lets the renderer attach its stream to a run no
+	 * surface of its own started - and with it the OS progress indicator (#1362),
+	 * the keep-awake hold (#1357) and the finished notification (#1358), all of
+	 * which live inside the run services and used to begin only once a dashboard
+	 * was opened.
+	 *
+	 * Present on the `run` event of the two tools that create a run
+	 * (`start_load_run`, `run_collection`) and on no other: `run_collection_smoke`
+	 * sends its requests one at a time and has no run to watch, and the tools that
+	 * stop, re-baseline or delete a run are naming one that already exists. Read
+	 * from the engine's answer rather than from the call's arguments, because a
+	 * run has no id until the engine has given it one - which is also why it
+	 * cannot be spelled the way the hints above are.
+	 */
+	startedRun?: StartedRun;
+}
+
+/**
+ * A run an agent's call put in flight, named for the renderer that watches it.
+ *
+ * `kind` is which service owns the stream rather than what the user would call
+ * the run: a load run and a collection run publish different frames, so
+ * attaching the wrong service is a permanently empty view and not a degraded
+ * one - the fork `RunCollectionDialog` already records for the app's own runs.
+ */
+export interface StartedRun {
+	runId: string;
+	kind: "load" | "collection";
 }
 
 export interface ToolContext {
@@ -883,6 +915,32 @@ const NOTHING_CHANGED = new WeakSet<ToolResult>();
 /** Mark a successful result as having changed nothing (see {@link NOTHING_CHANGED}). */
 function unchanged(result: ToolResult): ToolResult {
 	NOTHING_CHANGED.add(result);
+	return result;
+}
+
+/**
+ * Results that started a run the app should watch (#1419), keyed by the run.
+ *
+ * A WeakMap for the reason {@link NOTHING_CHANGED} is a WeakSet: the result
+ * object is handed to the SDK verbatim (`server.ts`), so a field here would be
+ * serialized to the client as though it were part of the MCP result shape.
+ */
+const STARTED_RUNS = new WeakMap<ToolResult, StartedRun>();
+
+/**
+ * Mark a result as having started `kind`'s run, taking the id from the engine's
+ * own answer (see {@link STARTED_RUNS}).
+ *
+ * An answer without a `runId` marks nothing: the engine's 202 body is what says
+ * a run exists, and a body shaped some other way is handed back to the agent as
+ * it came rather than announced to the renderer as a run to attach to.
+ */
+function watchedRun(result: ToolResult, kind: StartedRun["kind"], started: unknown): ToolResult {
+	const runId =
+		started && typeof started === "object" && !Array.isArray(started)
+			? (started as Record<string, unknown>).runId
+			: undefined;
+	if (typeof runId === "string" && runId !== "") STARTED_RUNS.set(result, { runId, kind });
 	return result;
 }
 
@@ -2846,12 +2904,24 @@ async function startScenarioLoadRun(
 	});
 	if (unconfirmed) return unconfirmed;
 
-	return withCaveat(
-		await callEngine(() => ctx.client.startRun(payload, signal)),
-		`\n\nThe plan is ${plannedSteps} step(s) per iteration. Follow the run with ` +
-			`get_run_report: its \`scenario\` section carries the virtual-user, iteration and ` +
-			`per-step breakdown. Pre-request scripts DO run on a scenario load run - each virtual ` +
-			`user walks the plan the way the design runner does.`
+	// Read here rather than through `callEngine` for the reason the single-target
+	// path states: the run id in the answer is what the renderer watches (#1419).
+	let started: unknown;
+	try {
+		started = await ctx.client.startRun(payload, signal);
+	} catch (err) {
+		return engineErrorResult(err);
+	}
+	return watchedRun(
+		withCaveat(
+			jsonResult(started),
+			`\n\nThe plan is ${plannedSteps} step(s) per iteration. Follow the run with ` +
+				`get_run_report: its \`scenario\` section carries the virtual-user, iteration and ` +
+				`per-step breakdown. Pre-request scripts DO run on a scenario load run - each virtual ` +
+				`user walks the plan the way the design runner does.`
+		),
+		"load",
+		started
 	);
 }
 
@@ -6278,18 +6348,22 @@ export const TOOLS: McpTool[] = [
 			if (!started || typeof started !== "object" || Array.isArray(started)) {
 				return jsonResult(started);
 			}
-			return structuredResult({
-				...(started as Record<string, unknown>),
-				plannedSteps,
-				nextStep:
-					`The run executes engine-side. Read it with get_run_report(runId): the ` +
-					`\`scenario\` section carries the iteration and pass/fail/skip totals plus ` +
-					`\`stepsStored\`/\`stepsDropped\`, and \`results\` returns at most 100 step rows ` +
-					`(non-passing steps are kept first). Each row's \`trace\` carries that step's ` +
-					`request and response bodies inline, so a long plan against large responses ` +
-					`makes for a large report - read the totals first and the rows when you need ` +
-					`them. stop_run ends the run early.`,
-			});
+			return watchedRun(
+				structuredResult({
+					...(started as Record<string, unknown>),
+					plannedSteps,
+					nextStep:
+						`The run executes engine-side. Read it with get_run_report(runId): the ` +
+						`\`scenario\` section carries the iteration and pass/fail/skip totals plus ` +
+						`\`stepsStored\`/\`stepsDropped\`, and \`results\` returns at most 100 step rows ` +
+						`(non-passing steps are kept first). Each row's \`trace\` carries that step's ` +
+						`request and response bodies inline, so a long plan against large responses ` +
+						`makes for a large report - read the totals first and the rows when you need ` +
+						`them. stop_run ends the run early.`,
+				}),
+				"collection",
+				started
+			);
 		},
 	},
 	{
@@ -6737,7 +6811,16 @@ export const TOOLS: McpTool[] = [
 			});
 			if (unconfirmed) return unconfirmed;
 
-			return withCaveat(await callEngine(() => ctx.client.startRun(payload, signal)), caveat);
+			// The engine's answer is read here rather than left to `callEngine`,
+			// because the run id it carries is what the renderer attaches its stream
+			// to (#1419) - a run has no id until this call returns.
+			let started: unknown;
+			try {
+				started = await ctx.client.startRun(payload, signal);
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			return watchedRun(withCaveat(jsonResult(started), caveat), "load", started);
 		},
 	},
 	{
@@ -7609,7 +7692,7 @@ export async function dispatchTool(
 	// an invalidation storm on every rejected call would be worse than the one
 	// stale list a genuinely-partial failure leaves behind. A confirmation
 	// preview is the third case: successful, and deliberately without effect.
-	if (!result.isError && !NOTHING_CHANGED.has(result)) notifyDataChanged(tool, args, ctx);
+	if (!result.isError && !NOTHING_CHANGED.has(result)) notifyDataChanged(tool, args, ctx, result);
 	return result;
 }
 
@@ -7624,13 +7707,22 @@ export async function dispatchTool(
  * throwing listener is logged and swallowed rather than turned into a tool
  * error the agent would read as "the write did not happen".
  */
-function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: ToolContext): void {
+function notifyDataChanged(
+	tool: McpTool,
+	args: Record<string, unknown>,
+	ctx: ToolContext,
+	result: ToolResult
+): void {
 	if (!ctx.onDataChanged || tool.invalidates.length === 0) return;
 	const collectionId = str(args, "collectionId");
 	const requestId = str(args, "requestId");
 	const runId = str(args, "runId");
 	const inboxId = str(args, "inboxId");
 	const mockId = str(args, "mockId");
+	// Rides the `run` event alone: that a run started is a fact about the run
+	// family, and `run_collection`'s other entity is the cookie jar, which has no
+	// use for it.
+	const startedRun = STARTED_RUNS.get(result);
 	for (const entity of tool.invalidates) {
 		try {
 			ctx.onDataChanged({
@@ -7640,6 +7732,7 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 				...(runId !== undefined ? { runId } : {}),
 				...(inboxId !== undefined ? { inboxId } : {}),
 				...(mockId !== undefined ? { mockId } : {}),
+				...(entity === "run" && startedRun !== undefined ? { startedRun } : {}),
 			});
 		} catch (err) {
 			console.error(`[MCP] Failed to notify "${entity}" change from ${tool.name}:`, err);

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -36,12 +36,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	onMcpDataChanged: (
 		callback: (event: {
 			entity:
-				"collection" | "request" | "environment" | "run" | "cookie" | "config" | "service";
+				| "collection"
+				| "request"
+				| "environment"
+				| "run"
+				| "cookie"
+				| "config"
+				| "service"
+				| "oauth";
 			collectionId?: string;
 			requestId?: string;
 			runId?: string;
 			inboxId?: string;
 			mockId?: string;
+			startedRun?: { runId: string; kind: "load" | "collection" };
 		}) => void
 	) => {
 		const handler = (_event: unknown, change: unknown) =>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -31,6 +31,7 @@ import { useNotificationActivation } from "./hooks/useNotificationActivation";
 import { useOsIcon } from "./hooks/useOsIcon";
 import { useOpenIntent } from "./hooks/useOpenIntent";
 import { useMcpDataInvalidation } from "./hooks/useMcpDataInvalidation";
+import { useRunWatchers } from "./hooks/useRunWatchers";
 import { useHostSleepRecorder } from "./hooks/useHostSleepRecorder";
 import { useInboxWatchers } from "./hooks/useInboxWatchers";
 import { useRunningServicesPublisher } from "@/modules/services";
@@ -109,6 +110,12 @@ function App() {
 	// An agent writing over MCP mutates the engine from the main process, which
 	// no query can see. This is the channel that tells the cache to refetch.
 	useMcpDataInvalidation();
+
+	// A run an agent started reaches no surface of this app, so nothing used to
+	// watch it: no taskbar bar, no wake lock and no notification when it ended,
+	// until its dashboard tab was opened. Mounted here beside the line above
+	// because the two read the same channel and a run is not a screen (#1419).
+	useRunWatchers();
 
 	// The app asks the OS not to sleep under a run, but a closed lid overrides
 	// that. Mounted here rather than on the dashboard: the suspend arrives with

--- a/app/src/hooks/useRunWatchers.test.tsx
+++ b/app/src/hooks/useRunWatchers.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A run an MCP agent started is watched by the app from the moment it starts
+ * (#1419).
+ *
+ * What is under test is the routing: which service is entered for which kind of
+ * run, and that a `run` event which is not a start enters neither. What each
+ * service then does - the wake lock, the progress claim, the terminal
+ * notification - is its own file's tests.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRunWatchers } from "./useRunWatchers";
+import { loadTestService } from "@/services/load-test-service";
+import { scenarioRunService } from "@/services/scenario-run-service";
+import { useDashboardStore } from "@/stores/dashboard-store";
+import type { McpDataChangedEvent } from "@/types/domain";
+
+type Bridge = NonNullable<Window["electronAPI"]>;
+
+/**
+ * Put a partial preload bridge on the window, or take it away with `null`.
+ *
+ * Assigned onto the real `window` rather than stubbed over it, and through
+ * `unknown` because `Window.electronAPI` is declared as the whole `ElectronAPI`
+ * while this case needs one method of it.
+ */
+function bridged(api: Partial<Bridge> | null): void {
+	const host = window as unknown as { electronAPI?: Partial<Bridge> };
+	if (api === null) delete host.electronAPI;
+	else host.electronAPI = api;
+}
+
+/** Mount the hook and hand back the emitter main would call. */
+function mounted(): {
+	emit: (event: McpDataChangedEvent) => void;
+	unsubscribe: ReturnType<typeof vi.fn>;
+	unmount: () => void;
+} {
+	let emit: ((event: McpDataChangedEvent) => void) | null = null;
+	const unsubscribe = vi.fn();
+	bridged({
+		onMcpDataChanged: (callback: (event: McpDataChangedEvent) => void) => {
+			emit = callback;
+			return unsubscribe;
+		},
+	});
+	const { unmount } = renderHook(() => useRunWatchers());
+	if (!emit) throw new Error("the hook subscribed to nothing");
+	return { emit, unsubscribe, unmount };
+}
+
+afterEach(() => {
+	useDashboardStore.setState({ currentRunId: null, mode: "running" });
+	bridged(null);
+	vi.restoreAllMocks();
+});
+
+describe("useRunWatchers", () => {
+	it("watches a load run an agent started, with the store pointed at it first", () => {
+		const load = vi.spyOn(loadTestService, "startMonitoring").mockImplementation(() => {});
+		const scenario = vi
+			.spyOn(scenarioRunService, "startMonitoring")
+			.mockImplementation(() => {});
+		const { emit } = mounted();
+
+		emit({ entity: "run", startedRun: { runId: "run_7", kind: "load" } });
+
+		expect(load).toHaveBeenCalledTimes(1);
+		expect(load).toHaveBeenCalledWith("run_7");
+		expect(scenario).not.toHaveBeenCalled();
+		// The service states that its caller registers the run: without this the
+		// dashboard opened later finds no current run and the ticks that arrived
+		// while it was closed belong to nothing.
+		expect(useDashboardStore.getState().currentRunId).toBe("run_7");
+		expect(useDashboardStore.getState().mode).toBe("running");
+	});
+
+	it("watches a collection run through the scenario service", () => {
+		// Mutation check: drop the kind branch and this case attaches the load
+		// service to a stream that publishes steps and no metric ticks - a
+		// permanently empty view rather than a degraded one.
+		const load = vi.spyOn(loadTestService, "startMonitoring").mockImplementation(() => {});
+		const scenario = vi
+			.spyOn(scenarioRunService, "startMonitoring")
+			.mockImplementation(() => {});
+		const { emit } = mounted();
+
+		emit({ entity: "run", startedRun: { runId: "run_8", kind: "collection" } });
+
+		expect(scenario).toHaveBeenCalledTimes(1);
+		expect(scenario).toHaveBeenCalledWith("run_8");
+		expect(load).not.toHaveBeenCalled();
+	});
+
+	it("watches nothing for a run event that is not a start", () => {
+		const load = vi.spyOn(loadTestService, "startMonitoring").mockImplementation(() => {});
+		const scenario = vi
+			.spyOn(scenarioRunService, "startMonitoring")
+			.mockImplementation(() => {});
+		const { emit } = mounted();
+
+		// A delete, a stop, a baseline change: the run is named, and it is not
+		// live. Attaching here would open a stream on a finished run and hold a
+		// wake lock for it.
+		emit({ entity: "run", runId: "run_9" });
+		// And a family that is not runs at all.
+		emit({ entity: "collection", collectionId: "col_1" });
+
+		expect(load).not.toHaveBeenCalled();
+		expect(scenario).not.toHaveBeenCalled();
+	});
+
+	it("drops its listener when the app unmounts", () => {
+		const { unsubscribe, unmount } = mounted();
+		expect(unsubscribe).not.toHaveBeenCalled();
+		unmount();
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it("does nothing outside Electron, where there is no bridge", () => {
+		bridged(null);
+		expect(() => renderHook(() => useRunWatchers())).not.toThrow();
+	});
+});

--- a/app/src/hooks/useRunWatchers.ts
+++ b/app/src/hooks/useRunWatchers.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Watch a run an MCP agent started, as if the app had started it (issue #1419).
+ *
+ * Everything a run does in the background - the OS progress indicator (#1362),
+ * the keep-awake hold (#1357) and the finished/failed notification (#1358) -
+ * lives inside `LoadTestService` and `ScenarioRunService`, and both begin at
+ * `startMonitoring`. Until this hook existed only a renderer surface called it:
+ * the dashboard and the Run Collection dialog. A run handed to an agent
+ * therefore painted no taskbar bar, held no wake lock and said nothing when it
+ * ended, until its dashboard tab was opened - and the user who hands a long run
+ * to an agent is exactly the user who is not looking at the window.
+ *
+ * The fix is deliberately not a second copy of the run lifecycle in the main
+ * process: main says only *that* a run started and which service owns it
+ * (`startedRun` on the `mcp:data-changed` event), and the renderer enters the
+ * one path that already means "watch this run".
+ *
+ * Mounted once in `App.tsx`, beside `useMcpDataInvalidation`, for the same
+ * reason: the event names a run, not a screen, and a listener that came and went
+ * with a view would miss the runs this exists for. Absent outside Electron,
+ * where there is no MCP server to hear from.
+ */
+
+import { useEffect } from "react";
+import { loadTestService } from "@/services/load-test-service";
+import { scenarioRunService } from "@/services/scenario-run-service";
+import { useDashboardStore } from "@/stores/dashboard-store";
+
+export function useRunWatchers(): void {
+	useEffect(() => {
+		if (!window.electronAPI?.onMcpDataChanged) return;
+		return window.electronAPI.onMcpDataChanged((event) => {
+			const started = event.startedRun;
+			// Every other `run` event names a run that already exists - a stop, a
+			// baseline change, a delete - and none of them is something to attach
+			// a stream to.
+			if (!started) return;
+			if (started.kind === "load") {
+				// Registered before the stream, exactly as the app's own callers do:
+				// `startMonitoring` writes metrics into this store and states that
+				// its caller has already pointed the store at the run. No config
+				// rides along - the agent's arguments are the engine's business,
+				// and the dashboard reads a run with no declared duration as one
+				// whose bar has no denominator yet, which is what it is.
+				useDashboardStore.getState().startRun(started.runId);
+				loadTestService.startMonitoring(started.runId);
+			} else {
+				scenarioRunService.startMonitoring(started.runId);
+			}
+		});
+	}, []);
+}

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2500,6 +2500,31 @@ export interface McpDataChangedEvent {
 	 * no id until the engine answers.
 	 */
 	mockId?: string;
+	/**
+	 * The run this call just started, and which run service watches it (#1419).
+	 *
+	 * The one field here that is not a scope hint: it says the run is *live*, and
+	 * `useRunWatchers` reads it to attach the matching service's stream to a run
+	 * no surface of this app started - which is what gives an agent's run the OS
+	 * progress indicator, the keep-awake hold and the finished notification it
+	 * would otherwise only get once its dashboard tab was opened.
+	 *
+	 * Present on the `run` event of `start_load_run` and `run_collection` and on
+	 * no other: the remaining `run` tools name a run that already exists.
+	 */
+	startedRun?: StartedRun;
+}
+
+/**
+ * A run an MCP call put in flight, named for the renderer that watches it.
+ *
+ * `kind` is which service owns the stream: a load run and a collection run
+ * publish different frames, so attaching the wrong one is a permanently empty
+ * view rather than a degraded one.
+ */
+export interface StartedRun {
+	runId: string;
+	kind: "load" | "collection";
 }
 
 export interface ScriptCompletion {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -744,6 +744,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   toggles change, plus the pruning of notify preferences whose inbox the engine no longer lists. It
   observes the inbox list only while at least one inbox may notify: that list polls every
   `SERVICES_POLL_INTERVAL_MS`, and a root observer nobody reads is what #1150 removed.
+- `hooks/useRunWatchers.ts` (mounted once in `App.tsx`, beside
+  `useMcpDataInvalidation`) - the app's answer to a run an MCP agent started (issue #1419). Main
+  names the run and which service owns its stream on the `mcp:data-changed` event; this enters the
+  same `startMonitoring` path the dashboard does, so the taskbar bar, the wake lock and the finished
+  notification are the same for an agent's run as for the user's. A `run` event that is not a start
+  attaches nothing.
 - `useInboxDeletion.ts` / `DeleteInboxDialog.tsx` - deleting an inbox (issue #553), shared with the
   Services drawer so the two surfaces cannot disagree about when the confirmation appears or what it
   says is at stake. An inbox holding captures confirms and names their count; one holding none is

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1773,6 +1773,24 @@ from, since a mock's record dies with its listener. Both are what
 All three lists are invalidated on every `service` event rather than one per
 kind, because the entity is deliberately one family: the drawer and the Dock's
 count ask "what is listening", not "which kind".
+**One field on that event is not about the cache at all.** `startedRun` rides
+the `run` event of `start_load_run` and `run_collection` and names the run those
+tools just created, plus which of the two run services owns its stream
+(`{runId, kind}`, issue #1419). `useRunWatchers()` - registered once in
+`App.tsx`, beside `useMcpDataInvalidation()` - reads it and calls
+`loadTestService.startMonitoring` or `scenarioRunService.startMonitoring`, which
+is the same path the dashboard and the Run Collection dialog take, so the wake
+lock, the OS progress bar and the finished notification all begin when an
+agent's run does rather than when someone opens its tab. For a load run it
+points `dashboard-store` at the run first, exactly as those surfaces do:
+`startMonitoring` states that its caller has registered the run, and a store
+left unpointed would collect the ticks of a run it does not name. It carries no
+config - the agent's arguments are the engine's business, and a run with no
+declared duration is one whose bar has no denominator yet. Every other `run`
+event names a run that already exists (a stop, a baseline change, a delete) and
+starts no watcher; `run_collection_smoke` sends its requests one at a time and
+has no run to watch at all.
+
 The entity list is duplicated across the process boundary
 (`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
 `types/domain.ts`) because production code under `electron/` cannot import from

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,9 @@ services share one SSE client, so starting a collection run takes the socket
 from a streaming load run, and the client tells the displaced service rather
 than closing on it in silence, which used to leave that key held for the rest of
 the session (issue #1417). The screen may still dim and lock; only suspension is
-refused.
+refused. A run an MCP agent started holds the lock on the same terms: main
+does not watch runs, it names the run its `mcp:data-changed` event just started
+and the renderer enters the same watch path a dashboard would (issue #1419).
 
 **It is off by default, because the machine's power settings are the user's.**
 Two things turn it on. The standing preference (Settings > Load testing > Keep
@@ -184,10 +186,14 @@ lives in a localStorage-backed store main cannot see - over `notify:show`
 (`services/notify.ts`); `electron/notify.ts` decides *whether and how*, from the
 window's focus and the platform's support, and answers `notify:availability`
 for the settings row. Nothing is posted while the window is focused - the toast
-already said it. Windows shows nothing at all unless `app.setAppUserModelId`
-matches the shortcut's id; macOS authorizes per bundle and refuses one whose
-code signature does not bind its own `Info.plist`. Ad-hoc signing satisfies it,
-and `install.sh` re-signs what it installs, so an installed build notifies - but
+already said it. A run an agent started over MCP notifies like any other: the
+renderer is told the run began and watches it from that moment, so its end
+reaches the user who handed it over and walked away - which is the case the
+setting exists for (issue #1419). Windows shows nothing at all unless
+`app.setAppUserModelId` matches the shortcut's id; macOS authorizes per bundle
+and refuses one whose code signature does not bind its own `Info.plist`. Ad-hoc
+signing satisfies it, and `install.sh` re-signs what it installs, so an
+installed build notifies - but
 the dev `Electron.app` and a bundle dragged straight out of the DMG do not, so
 system notifications cannot be exercised by `pnpm electron:dev` on macOS. That
 refusal is caught, latched, and reported in Settings, with the toast standing in
@@ -225,11 +231,16 @@ test, or a collection run whose plan frame - the size the engine publishes on
 its stream as the run opens, issue #1398 - never reached the client) shows
 indeterminate on Windows and nothing on macOS; a failed run flashes the Windows
 error state; the bar clears on every terminal path, and main clears it itself
-when the renderer that asked for it is destroyed or reloads. One indicator is
-all the OS gives an application, and one run is all the renderer watches: the
-SSE client is a singleton, so starting a second run closes the first one's
-stream - and tells its service so, which is what gives up the displaced run's
-bar and its wake lock rather than leaving both standing (issue #1417). The
+when the renderer that asked for it is destroyed or reloads. The bar is not the
+app's own runs only: a run started by an MCP agent is watched from the moment
+the main process reports it (`startedRun` on `mcp:data-changed`, issue #1419),
+so it paints the same fill, and opening its dashboard tab later attaches nothing
+new - `startMonitoring` is idempotent for a run already being watched. One
+indicator is all the OS gives an application, and one run is all the renderer
+watches: the SSE client is a singleton, so starting a second run closes the
+first one's stream - and tells its service so, which is what gives up the
+displaced run's bar and its wake lock rather than leaving both standing (issue
+#1417). The
 superseded run is not stopped and says nothing to the user: it is still running
 in the engine, and its row reaches a terminal status on the next list read
 rather than through a notification for a run nobody is watching. The indicator

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -1554,8 +1554,26 @@ exists: an agent names the key it clears, but the key a `fetch_oauth2_token`
 writes under is derived engine-side and appears only in the answer, so a hint
 would be present for one tool and absent for the other - the shape that leaves
 a stale row exactly when it matters. The family is invalidated at its prefix
-instead. The renderer side, including
-which query keys each family maps to, is in
+instead.
+
+**One field on the event is not a hint at all.** `startedRun` rides the `run`
+event of the two tools that *create* a run - `start_load_run` and
+`run_collection` - and says that the run is live, naming it and which of the
+renderer's two run services owns its stream (`{runId, kind: "load" |
+"collection"}`, issue #1419). It is read from the engine's 202 answer rather
+than from the call's arguments, because a run has no id until the engine has
+given it one, and an answer carrying no `runId` announces no run. Everything a
+run does in the background - the taskbar/Dock progress bar, the keep-awake hold
+and the finished notification - lives in those services and begins when one is
+told to watch a run, and before this field existed only a renderer surface ever
+told them: a run an agent started painted nothing and said nothing until its
+dashboard tab was opened. `useRunWatchers` reads the field and enters the same
+`startMonitoring` path the dashboard does, so the main process still tracks no
+runs of its own. `run_collection_smoke` sends its requests one at a time through
+`POST /execute` and has no run to watch, so its `run` event carries nothing
+extra.
+
+The renderer side, including which query keys each family maps to, is in
 [`docs/app/state-management.md`](../app/state-management.md).
 
 Declaring the families per tool rather than deriving them from `category` is


### PR DESCRIPTION
## Description

**Plan.** Root cause: the OS progress bar (#1362), the keep-awake hold (#1357) and the terminal notification (#1358) all live inside `LoadTestService` / `ScenarioRunService` and all begin at `startMonitoring`, which until now only a renderer surface ever called - the dashboard (`modules/dashboard/index.tsx:90`, `:98`, `:386`) and `RunCollectionDialog.tsx:327`, `:330`. A run started over MCP reaches the engine from the main process, so nothing in the renderer knew it existed and the run painted nothing, held nothing and said nothing until its dashboard tab was opened. Approach: main says only *that* a run began - `start_load_run` and `run_collection` mark their result with the run id from the engine's 202 answer, and the dispatch chokepoint puts it on the `run` data-changed event as `startedRun: {runId, kind}` - and a new `useRunWatchers` hook mounted once in `App.tsx` enters the one path that already means "watch this run". The alternative I rejected is the one PR #1397 rejected: having main track runs of its own (its own stream, its own wake lock, its own notification), which is a second copy of the run lifecycle in a process that has no run state and no access to the opt-ins that gate all three features. The smaller seam - one bit on an event that already exists - keeps every rule in the one place that holds it today.

Anchors held: all the line references in the issue still describe the code at `90c2fff`, and `rg -n "runProgress|wakeLock|systemNotify" app/electron/mcp` is still empty.

**Main process** (`electron/mcp/tools.ts`)
- `McpDataChangedEvent` gains `startedRun?: StartedRun` (`{runId, kind: "load" | "collection"}`), mirrored in `src/types/domain.ts` and in `preload.ts`'s inlined shape, and pinned by the existing `Exact<>` conformance check.
- A `STARTED_RUNS` WeakMap keyed on the result object, for the reason `NOTHING_CHANGED` is a WeakSet: the result is handed to the SDK verbatim, so a field on it would be serialized to the client as part of the MCP result shape.
- The two load paths in `start_load_run` now read the engine's answer themselves instead of going through `callEngine`, because the run id only exists in that answer. Error handling is unchanged (`engineErrorResult`); the returned text is byte-identical.
- `kind` is which service owns the stream, not what a user would call the run: a **scenario load run** (`start_load_run` with `scenario`) is `"load"`, because it publishes metric ticks; `run_collection` is `"collection"`, because it publishes steps.

**Renderer**
- `src/hooks/useRunWatchers.ts`, mounted once in `App.tsx` beside `useMcpDataInvalidation`. For a load run it points `dashboard-store` at the run first (as `RunCollectionDialog` and the request builder do - `startMonitoring` states that its caller registers the run) and then calls `loadTestService.startMonitoring`; for a collection run, `scenarioRunService.startMonitoring`. No config rides along: the agent's arguments are the engine's business, and a run with no declared duration is one whose bar has no denominator yet.
- The #1417 supersession rules apply unchanged - the hook enters `startMonitoring`, which is exactly where the cross-service hand-off lives - and no stale `currentRunId` is left behind, because the store is pointed at the run being watched rather than left pointing at nothing while ticks arrive.

**Deliberate deviation from the issue spec.** The issue names `run_collection_smoke` alongside the other two run-start tools ("the three run-start tools carry the live bit"). It starts no run: it composes and sends each saved request one at a time through `POST /execute` and returns a matrix, so there is no run id and no stream to attach to. It therefore does **not** carry the bit, and a test pins that its `run` event stays bare. Everything else is as specified.

Noted, not filed (no user-visible effect, per CLAUDE.md): `preload.ts`'s inlined copy of the event union was missing `"oauth"`; since I was editing that shape anyway I added it. It was a type-only drift - the renderer-side type is the checked one.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on this branch:

- `cd app && pnpm test` - **693 files, 7906 tests passed**, 0 failed (includes the 5 new `useRunWatchers` tests and the 6 new `data-changed` tests).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-tests).
- `cd app && pnpm lint` - clean; `pnpm format:check` - clean.
- `python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **2908 tests passed, 0 failed**. The engine is untouched by this diff; run because the checklist asked. (The vcpkg GitHub-archive 403 documented in CLAUDE.md hit `cpp-httplib` and `curl` in this environment; `vcpkg-fix-port` cured both. No repo file changed.)
- `mkdocs build --strict -f .github/mkdocs.yml` - built clean.

No pre-existing failures encountered.

New tests, each mutation-checked:
- `src/hooks/useRunWatchers.test.tsx` - a live load run calls `loadTestService.startMonitoring` once with that id and points the dashboard store at it; a collection run calls `scenarioRunService.startMonitoring` (drop the kind branch and this fails); a `run` event with no `startedRun`, and a non-run family, start neither watcher; the listener is dropped on unmount; no bridge is not a throw.
- `electron/mcp/data-changed.test.ts` - a confirmed `start_load_run` emits `{entity: "run", startedRun: {runId, kind: "load"}}`; a scenario load run is `"load"` too; `run_collection` carries it on the `run` event and **not** on the `cookie` event; `run_collection_smoke` starts no run; `stop_run` / `set_run_baseline` / `delete_run` carry nothing extra; an engine answer with no `runId` announces no run.

Not covered by automated tests, by nature: that Windows paints the taskbar fill and macOS the Dock bar for the run (the platform half is `electron/run-progress.ts`, unchanged here and already tested at its own seam).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the doc table: `docs/architecture.md` (the wake-lock, notifications and `runs:progress` paragraphs), `docs/engine/mcp.md` (the `mcp:data-changed` section - what `startedRun` is and why it is read from the answer), `docs/app/state-management.md` (the renderer side and the hook), `docs/app/COMPONENTS.md` (the hook's entry beside `useInboxWatchers`).

## Related Issues
Closes #1419

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyUtLwPcxrgzYrQmSt8Hqi)_