### PR TITLE
fix(mcp): tell an agent why a write tool is missing

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -222,6 +222,10 @@ jobs:
               - 'docs/app/api-integration.md'
               - 'docs/app/data-driven-runs.md'
               - 'docs/app/COMPONENTS.md'
+              - 'docs/index.md'
+              - 'docs/engine/mcp.md'
+              - 'docs/compare/vayu-vs-bruno.md'
+              - 'docs/compare/vayu-vs-postman.md'
             # The files under `engine/` that a suite in `app/` reads: engine
             # headers and sources a parity guard pins a value against, and the
             # fixtures a conformance guard replays. Same defect as the pages

--- a/app/electron/mcp/protocol.integration.test.ts
+++ b/app/electron/mcp/protocol.integration.test.ts
@@ -155,6 +155,69 @@ describe("MCP protocol handshake (in-memory)", () => {
 	});
 
 	/*
+	 * Withholding a write tool took its handler's refusal off the wire with it:
+	 * the SDK rejects a name it never registered before any Vayu code runs, so
+	 * an agent that guessed the name - from its own memory, or from a list it
+	 * fetched while writes were on - got "not found" and nothing to ask the user
+	 * for (#1431). The refusal is the one the handlers return, so the two
+	 * cannot say different things about the same gate.
+	 */
+	it("answers a call to a withheld write tool with the refusal that names the setting", async () => {
+		const { client, server } = await connectClient();
+		const res = (await client.callTool({
+			name: "create_collection",
+			arguments: { name: "API" },
+		})) as { content: Array<{ text: string }>; isError?: boolean };
+
+		expect(res.isError).toBe(true);
+		expect(res.content[0].text).toMatch(/write access in Vayu Settings/i);
+		expect(res.content[0].text).not.toMatch(/not found/i);
+		await server.close();
+	});
+
+	/*
+	 * The wrapper stands in front of the SDK's dispatch, so the other three
+	 * categories must reach it unchanged - including a name that genuinely does
+	 * not exist, which still gets the SDK's answer.
+	 */
+	it("leaves every other name to the SDK's dispatch while writes are off", async () => {
+		const { client, server } = await connectClient();
+		const ok = (await client.callTool({ name: "get_engine_health", arguments: {} })) as {
+			content: Array<{ text: string }>;
+			isError?: boolean;
+		};
+		expect(ok.isError).toBeFalsy();
+		expect(ok.content[0].text).toContain("9.9.9");
+
+		const unknown = (await client.callTool({ name: "no_such_tool", arguments: {} })) as {
+			content: Array<{ text: string }>;
+			isError?: boolean;
+		};
+		expect(unknown.isError).toBe(true);
+		expect(unknown.content[0].text).toMatch(/not found/i);
+		await server.close();
+	});
+
+	/*
+	 * A write tool the *user* switched off is unregistered for the other reason,
+	 * and answering it with the write gate would send a user who enabled writes
+	 * back to a tool that is still off. It keeps the disabled-tool answer.
+	 */
+	it("does not claim the write gate for a write tool switched off in Settings", async () => {
+		const { client, server } = await connectClient({
+			safety: { disabledTools: ["create_collection"] },
+		});
+		const res = (await client.callTool({
+			name: "create_collection",
+			arguments: { name: "API" },
+		})) as { content: Array<{ text: string }>; isError?: boolean };
+
+		expect(res.isError).toBe(true);
+		expect(res.content[0].text).not.toMatch(/write access in Vayu Settings/i);
+		await server.close();
+	});
+
+	/*
 	 * Settings lists every tool with a per-tool switch, so the catalog behind it
 	 * must stay whole however the write toggle is set - otherwise turning writes
 	 * off would silently empty the half of that list a user turns them back on
@@ -201,6 +264,27 @@ describe("MCP protocol handshake (in-memory)", () => {
 
 		expect(named).toEqual([]);
 		await server.close();
+	});
+
+	/*
+	 * The one cross-cutting fact a withheld tool's own description can no longer
+	 * carry, because the description ships with the tool. It names the setting
+	 * and no tool, and it ships only in the sessions it is true of - the server
+	 * is rebuilt per request, so it cannot go stale against `tools/list`.
+	 */
+	it("states the write gate in the instructions only while writes are off", async () => {
+		const off = await connectClient();
+		expect(off.client.getInstructions() ?? "").toMatch(
+			/write access is off in this session[\s\S]*Vayu Settings → MCP/i
+		);
+		await off.server.close();
+
+		const on = await connectClient({ safety: { allowWrites: true } });
+		const onInstructions = on.client.getInstructions() ?? "";
+		expect(onInstructions).not.toMatch(/write access is off/i);
+		// The rest of the text is one string either way.
+		expect(onInstructions).toMatch(/grouped by capability/i);
+		await on.server.close();
 	});
 
 	it("exposes tool annotations (read-only / destructive hints + title)", async () => {

--- a/app/electron/mcp/server.ts
+++ b/app/electron/mcp/server.ts
@@ -16,7 +16,14 @@
  */
 
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { TOOLS, dispatchTool, type ElicitFn, type ToolContext } from "./tools.js";
+import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+	TOOLS,
+	dispatchTool,
+	withheldWriteRefusal,
+	type ElicitFn,
+	type ToolContext,
+} from "./tools.js";
 import { STATIC_RESOURCES, RUN_REPORT_RESOURCE, extractRunIds } from "./resources.js";
 import { PROMPTS } from "./prompts.js";
 
@@ -47,7 +54,7 @@ const VAYU_WEBSITE = "https://github.com/athrvk/vayu";
  * trust `tools/list` over it. Each tool's own description is the one copy of
  * its contract, and it ships only when the tool does.
  */
-const INSTRUCTIONS =
+const INSTRUCTIONS_HEAD =
 	"Vayu is a local API testing and load-testing platform (Postman-style requests " +
 	"plus k6-level load tests in one app, backed by a native C++ engine); these " +
 	"tools drive that engine. Start by checking engine health, so a later failure " +
@@ -58,12 +65,27 @@ const INSTRUCTIONS =
 	"load (start and stop load tests). " +
 	"Every tool that puts traffic on the network is restricted to an allowlist, " +
 	"and load runs additionally enforce hard RPS/concurrency/duration caps. Write " +
-	"tools require the user to enable write access - until it is on they are not " +
-	"listed at all, so a task that needs one is blocked on the user enabling it " +
-	"rather than on finding the right call - and the destructive ones ask " +
+	"tools require write access, and the destructive ones ask " +
 	"for confirmation - via elicitation where the client supports it, otherwise by " +
 	"returning what the call would destroy and waiting for a `confirmed: true` " +
-	"retry. A tool that is subject to either gate says so in its own description. " +
+	"retry. A tool that is subject to either gate says so in its own description. ";
+
+/**
+ * The write gate, stated where an agent reads it before its first call - and
+ * only in the sessions it applies to, since the server is rebuilt per request
+ * and this text is therefore as current as `tools/list` itself.
+ *
+ * Withholding the write tools (#1429) took the handlers' "turn on write access"
+ * refusal off the wire with them: the SDK rejects an unregistered name before
+ * dispatch, so an agent on a default install saw no write tool and no reason
+ * for its absence (#1431). It names the setting, and no tool.
+ */
+const WRITE_GATE_SENTENCE =
+	"Write access is off in this session, so no write tool is listed: a task that " +
+	"needs one is blocked on the user turning on Write access in Vayu Settings → " +
+	"MCP, after which they appear in `tools/list`. ";
+
+const INSTRUCTIONS_TAIL =
 	"`tools/list` is authoritative for what this session actually has. " +
 	"Vayu data is also available as resources (vayu://runs, vayu://collections, " +
 	"vayu://environments, vayu://config, and vayu://run/{runId}/report) to attach as " +
@@ -72,6 +94,11 @@ const INSTRUCTIONS =
 	"preRequestScript or postRequestScript, read vayu://scripting/completions - it is " +
 	"the engine's own list of every pm.* name the script sandbox provides, including " +
 	"synchronous pm.crypto hashing and btoa/atob for signing a request.";
+
+/** The server instructions for one session, gated on that session's config. */
+function instructionsFor(allowWrites: boolean): string {
+	return INSTRUCTIONS_HEAD + (allowWrites ? "" : WRITE_GATE_SENTENCE) + INSTRUCTIONS_TAIL;
+}
 
 /**
  * Create an MCP server exposing the Vayu tools. `contextProvider` is invoked
@@ -83,6 +110,8 @@ export function createMcpServer(
 	info: McpServerInfo,
 	contextProvider: ToolContextProvider
 ): McpServer {
+	const baseCtx = contextProvider();
+
 	const mcp = new McpServer(
 		{
 			name: info.name,
@@ -91,10 +120,11 @@ export function createMcpServer(
 			description: VAYU_DESCRIPTION,
 			websiteUrl: VAYU_WEBSITE,
 		},
-		{ capabilities: { tools: {} }, instructions: INSTRUCTIONS }
+		{
+			capabilities: { tools: {} },
+			instructions: instructionsFor(baseCtx.config.allowWrites),
+		}
 	);
-
-	const baseCtx = contextProvider();
 
 	// Bridge a tool's elicitation request to the client - but only if the client
 	// negotiated the elicitation capability; otherwise throw so the tool falls
@@ -109,6 +139,8 @@ export function createMcpServer(
 	};
 
 	const ctx: ToolContext = { ...baseCtx, elicit };
+
+	const sdkCallTool = captureCallToolHandler(mcp);
 
 	for (const tool of TOOLS) {
 		if (baseCtx.config.disabledTools.includes(tool.name)) continue;
@@ -153,10 +185,89 @@ export function createMcpServer(
 		);
 	}
 
+	answerWithheldWriteCalls(mcp, ctx, sdkCallTool());
+
 	registerResources(mcp, ctx);
 	registerPrompts(mcp, ctx);
 
 	return mcp;
+}
+
+/**
+ * A `tools/call` handler as the SDK's `Server` holds it.
+ *
+ * Deliberately loose in its request type: the wrapper below reads one field and
+ * forwards the rest untouched, and restating the SDK's request shape here is a
+ * second copy of it to drift.
+ */
+type CallToolHandler = (
+	request: { params: { name: string } },
+	extra: unknown
+) => unknown | Promise<unknown>;
+
+/**
+ * Watch for the `tools/call` handler `registerTool` installs, and return a
+ * getter for it.
+ *
+ * The SDK offers no pre-dispatch hook (1.30.0): its handler looks the name up in
+ * its own registry and throws before anything of Vayu's runs, and it refuses to
+ * be installed twice (`assertCanSetRequestHandler`), so a wrapper can only be
+ * put in front of it by replacing it - which needs the original to delegate to.
+ * `setRequestHandler` is public on both sides of this, and the interception is
+ * removed again as soon as the registration loop is done.
+ *
+ * A capture that came back empty would leave the refusal unshipped exactly as
+ * it is unshipped today, so what holds this to the SDK across an upgrade is the
+ * protocol test that calls a withheld name and reads the answer.
+ */
+function captureCallToolHandler(mcp: McpServer): () => CallToolHandler | undefined {
+	const server = mcp.server as unknown as {
+		setRequestHandler: (schema: unknown, handler: CallToolHandler) => void;
+	};
+	const install = server.setRequestHandler.bind(server);
+	let captured: CallToolHandler | undefined;
+
+	server.setRequestHandler = (schema: unknown, handler: CallToolHandler) => {
+		if (methodOf(schema) === "tools/call") captured = handler;
+		install(schema, handler);
+	};
+
+	return () => {
+		delete (server as Partial<typeof server>).setRequestHandler;
+		return captured;
+	};
+}
+
+/** The JSON-RPC method a request schema pins, or undefined for any other shape. */
+function methodOf(schema: unknown): string | undefined {
+	const method = (schema as { shape?: { method?: { value?: unknown } } })?.shape?.method?.value;
+	return typeof method === "string" ? method : undefined;
+}
+
+/**
+ * Answer a call to a write tool this session withheld with the refusal that
+ * names the setting, in place of the SDK's "Tool <name> not found".
+ *
+ * The withholding (#1429) is what makes this necessary: it took the handlers'
+ * refusal off the wire along with the schemas, leaving an agent that guessed a
+ * write tool's name - from its own memory, or from a list it fetched while
+ * writes were on - with an unknown-tool error and nothing to ask the user for
+ * (#1431). Every other name reaches the SDK's handler unchanged, so schema
+ * validation, structured output and task support are untouched.
+ */
+function answerWithheldWriteCalls(
+	mcp: McpServer,
+	ctx: ToolContext,
+	sdkCallTool: CallToolHandler | undefined
+): void {
+	if (ctx.config.allowWrites || !sdkCallTool) return;
+	const server = mcp.server as unknown as {
+		setRequestHandler: (schema: unknown, handler: CallToolHandler) => void;
+	};
+	server.setRequestHandler(CallToolRequestSchema, (request, extra) => {
+		const refusal = withheldWriteRefusal(request.params.name, ctx);
+		return refusal ?? sdkCallTool(request, extra);
+	});
 }
 
 /** Register the read-only Vayu data resources (static lists + run-report template). */

--- a/app/electron/mcp/tool-count-docs.test.ts
+++ b/app/electron/mcp/tool-count-docs.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @file tool-count-docs.test.ts
+ * @brief Holds every published tool count to `TOOLS.length`.
+ *
+ * The registry has grown by tools, never by a page edit: `README.md` said "24
+ * typed tools" until it held 68, and `docs/index.md` and the Bruno comparison
+ * were still on 49 and 24 after that (#1431). Nothing re-checked the figure,
+ * because a number in prose is not code and no build reads it.
+ *
+ * The rule this enforces: a digit that immediately precedes "tools" names the
+ * whole registry. A count of some *part* of it is written in words - as
+ * "Eight tools carry it" already is in `docs/engine/mcp.md` - so a subset does
+ * not need an exception here and cannot be mistaken for the total.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { DOC_READING_GUARDS, ROOT_READING_GUARDS, fromRepoRoot } from "@/lib/routed-inputs.testkit";
+import { TOOLS } from "./tools.js";
+
+/** Every page that states how many tools the MCP server exposes. */
+const PAGES = [...DOC_READING_GUARDS.mcpToolCount.paths, ...ROOT_READING_GUARDS.mcpToolCount.paths];
+
+/** "68 tools", "68 typed tools" - the shape a page states the total in. */
+const COUNT = /(\d+)\s+(?:typed\s+)?tools\b/g;
+
+describe("published tool counts", () => {
+	/*
+	 * A scan that matched nothing passes forever, including the day a stale
+	 * count is written back in. Three is what the pages carry between them
+	 * today; a page that states no count is still listed, so that it is covered
+	 * from the moment it gains one.
+	 */
+	it("reads pages that actually state a count", () => {
+		const stated = PAGES.flatMap((page) => [
+			...readFileSync(fromRepoRoot(page), "utf8").matchAll(COUNT),
+		]);
+		expect(stated.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it.each(PAGES)("%s states no count the registry disagrees with", (page) => {
+		const text = readFileSync(fromRepoRoot(page), "utf8");
+		expect(text.length).toBeGreaterThan(0);
+
+		for (const [, count] of text.matchAll(COUNT)) {
+			expect(Number(count)).toBe(TOOLS.length);
+		}
+	});
+});

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -842,6 +842,28 @@ function writesDisabled(ctx: ToolContext): ToolResult | null {
 }
 
 /**
+ * The answer for a write tool the toggle withheld from registration, or null
+ * when @p name is not one - a read/execute/load tool, a name no registry entry
+ * carries, or a write tool in a session where writes are on.
+ *
+ * The same refusal the handlers return, because it is the same fact: the tool
+ * exists, the user has not enabled writes, and enabling them is what unblocks
+ * it. Without this the SDK answers an unregistered name with "Tool <name> not
+ * found", which tells an agent nothing it can act on (issue #1431).
+ *
+ * A tool the *user* switched off is deliberately not covered: it is unregistered
+ * for a different reason, and answering it here would tell a user who then
+ * enabled writes to expect a tool that is still off.
+ */
+export function withheldWriteRefusal(name: string, ctx: ToolContext): ToolResult | null {
+	if (ctx.config.allowWrites) return null;
+	if (ctx.config.disabledTools.includes(name)) return null;
+	const tool = findTool(name);
+	if (!tool || tool.category !== "write") return null;
+	return writesDisabled(ctx);
+}
+
+/**
  * The run pinned as baseline for whatever saved request @p targetRunId ran -
  * `compare_runs`'s answer when the caller named no base, tool and prompt alike:
  * the prompt asked for both ids while the tool resolved one, so the same
@@ -3885,7 +3907,7 @@ export const TOOLS: McpTool[] = [
 		category: "read",
 		invalidates: [],
 		description:
-			"List the saved requests directly inside one collection. Each row is the *whole* stored request - method, url, headers, body, auth and both scripts - not a summary, so a large collection returns a correspondingly large result and there is no separate call needed to read one request. A sub-collection's requests are not included; list them by calling this again with the sub-collection id that list_collections returns. A stored request that cannot be serialized is omitted from the array rather than failing the call, so a short list is not proof the collection is small.",
+			"List the saved requests directly inside one collection. Each row is the *whole* stored request - method, url, headers, body, auth and both scripts - not a summary, so a large collection returns a correspondingly large result and there is no separate call needed to read one request. The one exception is a stored column the engine cannot hand back: one that will not parse, or one past its 10 MB field cap, comes back as an empty value rather than failing the row. A sub-collection's requests are not included; list them by calling this again with the sub-collection id that list_collections returns. A stored request that cannot be serialized is omitted from the array rather than failing the call, so a short list is not proof the collection is small.",
 		annotations: {
 			title: "List requests",
 			readOnlyHint: true,
@@ -6828,7 +6850,7 @@ export const TOOLS: McpTool[] = [
 		category: "load",
 		invalidates: ["run"],
 		description:
-			"Stop a run that is still in progress: a load test, or a streaming Design-mode send that is holding its connection open. The run ends where it is and keeps what it already recorded - it is marked `stopped` rather than discarded, so get_run_report and get_run_samples still answer for it afterwards. Calling it on a run that has already finished is not an error: the result reports the status it was already in. A run id the engine does not know is an error.",
+			"Stop a run that is still in progress: a load test, or a streaming Design-mode send that is holding its connection open. The run ends where it is and keeps what it already recorded rather than being discarded, so get_run_report and get_run_samples still answer for it afterwards. Read the status in the result: a stream that closes within the engine's 5 s settle budget comes back `stopped`, and one that has not settled yet comes back `running` with a message saying the stop was signalled - it is not a failure, and re-reading the run reports the end state. Calling it on a run that has already finished is not an error: the result reports the status it was already in. A run id the engine does not know is an error.",
 		annotations: {
 			title: "Stop run",
 			readOnlyHint: false,

--- a/app/src/lib/routed-inputs.testkit.ts
+++ b/app/src/lib/routed-inputs.testkit.ts
@@ -136,6 +136,22 @@ export const DOC_READING_GUARDS = {
 		reader: "app/src/modules/collections/row-persistence-claims.test.ts",
 		paths: ["docs/app/data-driven-runs.md", "docs/app/COMPONENTS.md"],
 	},
+	/*
+	 * The one guard whose input is a *number* in prose (#1431): the MCP tool
+	 * registry grows by a tool, and every page that says how many there are
+	 * stays on the figure that was true when it was written - 24 on two pages,
+	 * 49 on two more, against 68 in `TOOLS`. The pages that name no count are
+	 * listed too, so the guard covers them from the day one is added.
+	 */
+	mcpToolCount: {
+		reader: "app/electron/mcp/tool-count-docs.test.ts",
+		paths: [
+			"docs/index.md",
+			"docs/engine/mcp.md",
+			"docs/compare/vayu-vs-bruno.md",
+			"docs/compare/vayu-vs-postman.md",
+		],
+	},
 } as const satisfies Record<string, ReadingGuard>;
 
 /**
@@ -272,6 +288,14 @@ export const ROOT_READING_GUARDS = {
 	startupMarker: {
 		reader: "app/electron/startup-probe.test.ts",
 		paths: ["scripts/perf/measure-app.mjs"],
+	},
+	/*
+	 * The README states the MCP tool count twice, so the doc guard above reads
+	 * it as well - the same number, drifting for the same reason (#1431).
+	 */
+	mcpToolCount: {
+		reader: "app/electron/mcp/tool-count-docs.test.ts",
+		paths: ["README.md"],
 	},
 } as const satisfies Record<string, ReadingGuard>;
 

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
@@ -328,6 +328,21 @@ describe("McpSettingsPanel write-switch cross-references", () => {
 		expect(screen.getByText(/write access, below/i)).toBeInTheDocument();
 	});
 
+	/*
+	 * What the card says the toggle *does*, not just how it interacts with the
+	 * Tools card: with writes off a write tool is not offered to the agent at
+	 * all (#1429). The panel said so from the day that shipped and nothing held
+	 * it there, so it could have drifted back to the older "they refuse" while
+	 * every assertion here stayed green (#1431).
+	 */
+	it("tells the Write access card that a write tool is not offered at all", async () => {
+		await renderPanel();
+
+		expect(
+			screen.getByText(/no tool in the write group above is offered to the agent at all/i)
+		).toBeInTheDocument();
+	});
+
 	it("tells the Write access card that a tool switched off in Tools stays off", async () => {
 		await renderPanel();
 

--- a/docs/compare/vayu-vs-bruno.md
+++ b/docs/compare/vayu-vs-bruno.md
@@ -67,7 +67,7 @@ limit.
 
 Bruno ships an official MCP server that wraps its `bru` CLI, so an agent can run
 your collections. Vayu's MCP server runs inside the app on `127.0.0.1:9877` and
-exposes **24 typed tools** covering inspection, execution, **load runs**, and
+exposes **68 typed tools** covering inspection, execution, **load runs**, and
 writes over collections, requests and environments. The distinction worth caring
 about is the load engine: an agent can start a capped load run and read the
 report back. It is gated accordingly - an allowlist that starts empty, caps on

--- a/docs/compare/vayu-vs-postman.md
+++ b/docs/compare/vayu-vs-postman.md
@@ -76,7 +76,9 @@ two runs. Postman also exposes MCP, but against its cloud workspace; Vayu's runs
 locally and hands the agent the load engine itself. Because that is a real
 capability, it is gated: network tools refuse any host outside an allowlist that
 **starts empty**, load runs are capped on RPS, concurrency and duration, and the
-tools that write to saved data sit behind a toggle that ships off.
+tools that write to saved data sit behind a toggle that ships off - while it is
+off those tools are not offered to the agent at all, and calling one by name
+answers with the setting to turn on rather than an unknown-tool error.
 
 ## When to choose Postman
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -1367,10 +1367,14 @@ configurable in **Settings → MCP** and persisted.
   rather than destroying it, so the write toggle alone is its gate (below).
 - **Write toggle** (`allowWrites`, default off) - gates every tool in the
   **write** category, and while it is off they are **not registered at all**:
-  they are absent from `tools/list`, not merely refused by `tools/call`. The
-  refusal remains in every write handler, for a client still holding a list it
-  fetched while the toggle was on. Withholding the schema rather than only the
-  call is what makes the toggle free: those tools are ~40% of the tool payload
+  they are absent from `tools/list`, not merely refused by `tools/call`. A call
+  on one of their names anyway - guessed, or held over from a list fetched while
+  the toggle was on - is answered with the handlers' own refusal, which names the
+  setting to turn on; the SDK would otherwise reject the unregistered name with
+  `Tool <name> not found`, which tells an agent nothing it can act on. The
+  server instructions say the same thing up front, in the sessions where the
+  toggle is off. Withholding the schema rather than only the call is what makes
+  the toggle free: those tools are ~40% of the tool payload
   an agent is sent, and on a default install none of them could have succeeded.
   Because the tool set is recomputed per built server (a fresh one per HTTP
   request), flipping the toggle takes effect on the client's next `tools/list` -
@@ -1410,8 +1414,13 @@ configurable in **Settings → MCP** and persisted.
   endpoint needs no auth token. The bounds that do apply are the engine's own -
   at most 8 issuers at once - and the per-tool switch below.
 - **Per-tool control** - any tool or whole read/execute/write/load category can be
-  switched off; a disabled tool is omitted from `tools/list` **and** rejected by
-  `tools/call`. Settings lists every tool whatever the write toggle says, so the
+  switched off; a disabled tool is omitted from `tools/list`, and calling its
+  name is answered with `Tool <name> not found` - it is unregistered, so the SDK
+  rejects the name before any Vayu code runs. (The write toggle's refusal above
+  is the deliberate exception, and it does not claim a tool the user switched
+  off: that tool would still be off after enabling writes. The rejection in
+  `dispatchTool` is what any other caller of it gets.) Settings lists every tool
+  whatever the write toggle says, so the
   switches for write tools stay visible and settable while writes are off - the
   toggle governs what the *agent* is offered, not what the user can configure.
   This and the write toggle are **independent**, and a write tool

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,7 @@ second process to manage, and nothing leaves the machine.
     url = "http://127.0.0.1:9877/mcp"
     ```
 
-**49 tools, 5 resources, 4 prompts.** Inspection (`list_collections`,
+**68 tools, 5 resources, 4 prompts.** Inspection (`list_collections`,
 `get_run_report`, `compare_runs`), execution (`run_request`,
 `run_collection_smoke`), load (`start_load_run`, `stop_run`), and writes
 (full CRUD over collections, saved requests and environments, plus globals and
@@ -361,9 +361,10 @@ persists.
 ??? question "Can my coding agent use it?"
 
     Yes - Vayu hosts an MCP server on `127.0.0.1:9877` and one command registers
-    it with Claude Code, Cursor, VS Code, Codex or Zed. The agent gets 49 tools
+    it with Claude Code, Cursor, VS Code, Codex or Zed. The agent gets 68 tools
     across inspection, execution, load runs and writes, behind a host allowlist,
-    load caps, and a write toggle that ships off. See the
+    load caps, and a write toggle that ships off - and while it is off the write
+    tools are not listed at all. See the
     [MCP reference](engine/mcp.md).
 
 ??? question "Does it work offline, and does it need an account?"


### PR DESCRIPTION
## Description

**Plan.** Root cause: #1429 stopped registering the 28 `write` tools while `allowWrites` is off, which is right, but the SDK rejects an unregistered name before any Vayu code runs (`@modelcontextprotocol/sdk` 1.30.0, `server/mcp.js`) - so `writesDisabled()` became unreachable in production and the one message that told an agent to ask for write access stopped shipping, while the docs still claimed it did. Approach: put the explanation in the two places an agent reads - the server instructions (conditional on `!allowWrites`, since the HTTP host rebuilds the server per request, so the sentence cannot go stale against `tools/list`) and the answer to a `tools/call` on a withheld name, which now returns the handlers' own refusal instead of `Tool <name> not found`. The alternative the issue offered first - registering one always-present `request_write_access` tool - was rejected because it cannot satisfy the second acceptance criterion: an agent that guesses `create_collection` still gets the SDK's unknown-tool error, and the guess is the case the refusal exists for. Registering the write tools as name-only stubs was rejected too: it puts ~1.7 KB of listing back and re-introduces exactly the present-and-refusing surface #1429 removed. The SDK exposes no pre-dispatch hook, so the wrapper captures its `tools/call` handler as `registerTool` installs it (via the public `setRequestHandler`, restored the moment registration ends) and delegates every other name to it untouched - schema validation, structured output and task support all unchanged.

Anchors had drifted: `INSTRUCTIONS` already carried a write-gate clause at `90c2fff`/`5fe44e5` (added by #1429 after the issue's read), so part 1 is a rewrite rather than an addition - the clause is now split out, stated only in the sessions it is true of, and it names the setting (`Vayu Settings → MCP`) rather than only the fact. `docs/index.md` states the count twice, not once; both are fixed.

What changed:

- `app/electron/mcp/server.ts` - `instructionsFor(allowWrites)`; `captureCallToolHandler` + `answerWithheldWriteCalls`.
- `app/electron/mcp/tools.ts` - `withheldWriteRefusal(name, ctx)`, sharing the one refusal wording with the handlers. A write tool the *user* switched off keeps the disabled-tool answer, deliberately: it would still be off after enabling writes. Plus the two description nits from the same review - `stop_run` said a run "is marked `stopped`" when a stream that has not settled inside the engine's 5 s budget comes back `running` (`engine/src/http/routes/runs.cpp`), and `list_requests` promised "the whole stored request" when a column past the 10 MB field cap comes back as its fallback (`write_json_column`).
- `app/electron/mcp/tool-count-docs.test.ts` (new) - holds every published tool count to `TOOLS.length`, registered in `routed-inputs.testkit.ts` (doc + root guards) and routed in `pr-tests.yml`. The rule it enforces: a digit immediately before "tools" names the whole registry; a subset is written in words, as `docs/engine/mcp.md` already does ("Eight tools carry it").
- Docs, same commit - `docs/engine/mcp.md` write-toggle and per-tool bullets now say what a withheld or disabled call actually answers; `docs/index.md` 49 → 68 (both places); `docs/compare/vayu-vs-bruno.md` 24 → 68; `docs/compare/vayu-vs-postman.md` gains the withholding.

`tools/list` with writes off is byte-identical to master - nothing new is registered.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Full local run, all green:

- `cd app && pnpm test` - **7917 tests, 694 files, all passing** (`pnpm test electron/mcp` alone: 824 in 16 files)
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean
- `python build.py -t` - exit 0; `ctest --preset linux-dev` - **2908 tests, 100% passed** (no engine code in this diff; run for completeness)
- `mkdocs build --strict` - passes
- No pre-existing failures encountered.

Five new cases, each mutation-checked:

- A withheld write tool call returns the refusal naming the setting, not `not found` - reds with the SDK's message when `answerWithheldWriteCalls` is disabled.
- Every other name still reaches the SDK's dispatch (a read tool answers, an unknown name still gets `not found`) - this is the delegation proof.
- A write tool switched off in Settings does *not* get the write-gate answer - reds when the `disabledTools` check is removed from `withheldWriteRefusal`.
- The instructions carry the gate sentence only while writes are off - reds when `instructionsFor` stops branching. The existing `does not name individual tools` guard stays green.
- The count guard was red on the stale literals before the pages were fixed (24 and 49 against 68), which is its own mutation check.
- `McpSettingsPanel.test.tsx` pins the Write access card's "not offered to the agent at all" copy, which #1429 wrote and nothing held.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1431

Not filed as follow-ups, per the repo rule that only user-visible or measurable work is tracked: the `disabledTools` rejection in `dispatchTool` remains unreachable through the SDK for the same structural reason, and is now documented as such rather than papered over - answering a disabled tool with a Vayu message would be a behaviour change this issue did not ask for.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hnd1oG2sGDEdCuQyrpBVJ)_