### PR TITLE
build: install the git pre-commit hook from --setup

### DIFF
--- a/build.py
+++ b/build.py
@@ -1053,6 +1053,40 @@ def setup_environment(project_root: Path):
     log(f'{Style.GREEN}{Style.CHECK}{Style.RESET} JS dependencies installed')
 
     print()
+
+    # ── Git pre-commit hook ───────────────────────────────────────────────────
+    # Installed here rather than left to the contributor: the hook is the only
+    # thing that runs clang-format 19 and clang-tidy over staged C++ before a
+    # commit exists, and every clone starts without it - `.git/hooks` is not
+    # tracked. A session that never ran `scripts/install-git-hooks.sh` by hand
+    # commits unformatted, and the first anyone hears of it is a red
+    # `Engine formatting` job. `--setup` is every entry point's front door
+    # (`.claude/hooks/session-start.sh` calls it too), so one call here covers
+    # a fresh contributor and a fresh cloud session alike.
+    #
+    # Non-fatal by design. A worktree, a tarball with no `.git`, or a hook the
+    # user deliberately replaced should not stop an environment from coming up.
+    log(f'{Style.CYAN}{Style.ARROW}{Style.RESET} Installing git pre-commit hook...')
+    hook_installer = project_root / "scripts" / "install-git-hooks.sh"
+    try:
+        result = subprocess.run(
+            ["bash", str(hook_installer)],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            log(f'{Style.GREEN}{Style.CHECK}{Style.RESET} Pre-commit hook installed')
+        else:
+            detail = (result.stderr or result.stdout or "").strip().splitlines()
+            reason = detail[-1] if detail else f"exit {result.returncode}"
+            log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} Pre-commit hook not installed ({reason})')
+            log('    Commits will not be format-checked; CI still is.')
+    except OSError as exc:
+        log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} Pre-commit hook not installed ({exc})')
+        log('    Commits will not be format-checked; CI still is.')
+
+    print()
     log(f'{Style.GREEN}{Style.CHECK} Environment ready.{Style.RESET} Build with:  python build.py --dev')
     print()
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -957,7 +957,7 @@ It runs in two places, and both of them can stop a change:
 
 | Where | What it checks | What a difference does |
 |-------|----------------|------------------------|
-| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **whole** of every staged `engine/{src,include,tests}` source | Refuses the commit |
+| `scripts/pre-commit` (installed by `python build.py --setup`) | The **whole** of every staged `engine/{src,include,tests}` source | Refuses the commit |
 | `Engine formatting`, a job of its own in `.github/workflows/pr-tests.yml` | The **whole tree** under those three roots | Fails CI |
 
 Unlike the two clang-tidy gates below, these two agree on scope, because
@@ -1014,7 +1014,7 @@ clang-tidy runs in two places, and both of them can stop a change:
 
 | Where | What it lints | What a finding does |
 |-------|---------------|---------------------|
-| `scripts/pre-commit` (install with `bash scripts/install-git-hooks.sh`) | The **whole** of every staged `.c/.cpp/.h/.hpp` file | Refuses the commit |
+| `scripts/pre-commit` (installed by `python build.py --setup`) | The **whole** of every staged `.c/.cpp/.h/.hpp` file | Refuses the commit |
 | `Lint changed engine sources`, in the engine job of `.github/workflows/pr-tests.yml` | The **whole** of every changed `engine/{src,include,tests}` **translation unit**, on Linux and Windows alike. Headers are never direct inputs | Fails CI |
 | `Engine tidy scan` (`.github/workflows/engine-tidy-scan.yml`), **weekly** plus `workflow_dispatch` | The **whole tree**, on Linux and Windows both. Not a pull-request gate - the denominator no per-change gate can give | Fails the run |
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -185,7 +185,12 @@ a change touches (#946), so nothing else holds an untouched file at zero.
   `ryml`) fetches three `vcpkg_download_distfile` sub-archives the fixer leaves
   alone; rewrite those to `vcpkg_from_git` in the overlay. Only this
   environment needs it; CI reaches the archives.
-- Install the git pre-commit hook: `bash scripts/install-git-hooks.sh`.
+- **The git pre-commit hook installs itself** with `python build.py --setup`,
+  which `.claude/hooks/session-start.sh` also runs - `.git/hooks` is not tracked,
+  so every clone and every cloud session would otherwise start without the one
+  thing that format-checks a commit before it exists. `bash
+  scripts/install-git-hooks.sh` still installs it directly, which is what a
+  Windows checkout needs: `--setup` refuses to run there.
 
 ## Formatting and linting
 


### PR DESCRIPTION
## Description

`.git/hooks` is not tracked, so **every clone starts without the pre-commit hook**, and the only thing that installs it is a command in a doc someone has to notice and run.

This session was the case in point. A fresh cloud checkout had no hook (`.git/hooks/pre-commit` absent, `core.hooksPath` unset), six commits were made without one, and a clang-format violation in `inbox.cpp` was caught only because the hook was invoked by hand. Uncaught, it reaches the `Engine formatting` job and costs a CI cycle to learn something clang-format knows locally in a second.

`python build.py --setup` is the front door every entry point already uses - `.claude/hooks/session-start.sh` calls it, and it is what `CONTRIBUTING.md` tells a new contributor to run - so installing from there covers a fresh clone and a fresh cloud session with one call. It shells out to the existing `scripts/install-git-hooks.sh` rather than growing a second copy of the symlink logic.

**Non-fatal on purpose.** A worktree, a tarball with no `.git`, or a moved installer warns and carries on; an environment that cannot come up because of a convenience hook would be the worse failure. The warning names what is lost and that CI still checks:

```
   ⚠ Pre-commit hook not installed (…)
       Commits will not be format-checked; CI still is.
```

**Windows is unchanged.** `--setup` refuses to run there, so a Windows checkout still installs the hook by hand. `engine/CLAUDE.md` now says that explicitly rather than presenting the manual command as the only path.

## Type of Change

- [x] Bug fix (a guard that was silently absent everywhere)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Four checks, all on this clone, which started without the hook:

| Check | Result |
|---|---|
| Install into a hookless clone | `.git/hooks/pre-commit -> scripts/pre-commit` |
| Re-run `--setup` (idempotency) | Installs again cleanly, no error |
| Installer removed (failure path) | Warns, names the reason, **setup still exits 0** |
| Staged a deliberately misformatted `health.cpp` | **Hook refused the commit**, clang-format message, exit 1 |

The last one is the behavioural check that matters - it proves the installed hook actually blocks, not just that a symlink appeared. Working tree restored afterwards.

`docs/engine/building.md` is touched, but only table-cell text (no links, no headings), so `mkdocs build --strict` has nothing new to fail on; `docs.yml` gates it regardless. mkdocs is not installed in this environment, so that was not run locally.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no automated test: this installs a *git* hook, which a test would have to install into a real `.git` to observe. Verified behaviourally as above.
- [x] I have updated documentation - `engine/CLAUDE.md` and both `docs/engine/building.md` lint-gate tables described this as a manual step

## Related Issues

None - found while cutting 0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdzN6CbBVwkWViZer9Lmde


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdzN6CbBVwkWViZer9Lmde)_