### PR TITLE
fix(engine): hold every resource PUT's read to its write (#1440)

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -92,6 +92,16 @@ omitted field keeps its stored value. We deliberately did not add a separate
 client call site expects it. The `:id` in the path is the record's identity; the
 body carries the changed fields only.
 
+**An update is atomic against a concurrent one.** The read the merge is computed
+from, the merge itself and the write are one acquisition of the database lock, so
+two clients patching one record at the same moment - the app's autosave and an
+MCP agent, say - each merge onto what the other committed rather than onto the
+row as both of them found it. The alternative is not a conflict but a silent
+loss: the merge carries every field the body did not name, so the loser's fields
+come back written with the values the winner read a moment earlier, and neither
+request fails. There is no precondition header; a client that needs to *detect*
+that the row moved under it has nothing to read yet.
+
 ### The engine owns every id
 
 A create must **not** carry an `id`. The engine generates one via `generate_id`,
@@ -2450,8 +2460,10 @@ every named row and owner, and the acyclicity of the **post-move** collection
 graph are all checked first; a failure is a `400` naming the offending row with
 nothing written. The cycle check reading the post-move shape is what makes two
 reparents that each look legal alone (`A` under `B` and `B` under `A`) a
-deterministic rejection rather than a race - unlike `PUT /collections/:id`, which
-validates and writes under different locks.
+deterministic rejection rather than a race. The same pair sent as two
+`PUT /collections/:id` calls is caught as well - each update holds its read to
+its write - but one at a time, so the first reparent is already committed when
+the second is refused; the batch refuses both and writes nothing.
 
 That rejection is deterministic **because the check and the commit share one lock
 scope**: two such batches arriving concurrently are serialized whole, and the

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -223,13 +223,17 @@ under a fast enough writer, and it would make row identity depend on clock
 resolution across the three platforms Vayu builds on.
 
 **Repositioning several rows at once** is [`POST /reorder`](#post-reorder), not a
-run of `PUT`s. Each `PUT` is its own write under its own lock, so a reorder
-expressed as N sibling `PUT`s is last-write-wins between concurrent clients, can
-be interrupted halfway (leaving two rows at one `order` and a gap where the
-moved one was), and its collection cycle guard is read-then-write across two lock
-scopes. The batch endpoint validates and writes under one lock scope, which
-closes all three. The per-row `PUT`s remain correct for a single row - a rename,
-a move that appends - and still carry those caveats when used in a loop.
+run of `PUT`s. Each `PUT` is one row under its own lock, so a reorder expressed
+as N sibling `PUT`s can be interrupted halfway, leaving two rows at one `order`
+and a gap where the moved one was, and a concurrent client's move lands between
+any two of them. The batch endpoint validates and writes the whole set under one
+lock scope, which closes both. What is *not* a difference any more is the cycle
+guard: since a `PUT` holds its own read to its own write, its guard and its write
+are one scope too, so two conflicting reparents sent as single `PUT`s are
+serialized and the second is refused against the first's committed graph - it is
+refused after that first move is already stored, which is the part only a batch
+avoids. The per-row `PUT`s remain correct for a single row - a rename, a move
+that appends - and still carry those caveats when used in a loop.
 
 ### Accepted field shapes
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -59,7 +59,8 @@ The HTTP server handles all API requests from the Electron UI. It runs on `127.0
 **Key Features:**
 - RESTful API endpoints for collections, requests, environments, and runs
 - Server-Sent Events (SSE) for real-time metrics streaming
-- Single-threaded request handling (non-blocking I/O)
+- Requests served on cpp-httplib's default thread pool, so two clients - the
+  app and an MCP agent - are genuinely concurrent inside the daemon
 
 #### How a route says no
 
@@ -92,6 +93,36 @@ propagates, and the response is reachable only through `.error ()`.
 
 All error bodies, either way, come from `error_body` - one shape,
 `{"error": {"code", "message"}}`, which the app's http-client reads.
+
+#### A core that reads, decides and writes holds one lock
+
+`Database` takes its mutex per call, which is enough while a write depends only
+on its own arguments. It is not enough for a core that reads a row, decides
+something from it and then writes: between the read and the write another
+client's write can move the ground. `Database::with_lock` (issue #386) scopes
+the mutex around the whole composite, and because the mutex is recursive the
+lambda calls the same public `get_*` / `save_*` methods everything else does.
+
+Two shapes need it, and both are in the code today:
+
+- **The validate-then-commit batch** - `POST /reorder`, `POST /import/apply`,
+  `POST /specs/sync`, `POST /specs/bind`. The validation the write is based on
+  has to still be true when the write lands.
+- **The merge-patch update** - every `PUT /<resource>/:id` (issue #1440). The
+  write carries each field the body did not name, read a moment earlier, so a
+  read not held to its write loses whichever of two concurrent updates read
+  first - whole fields, with neither request failing. Each of those cores is a
+  thin wrapper over an `update_*_locked` function holding the read, the merge
+  and the write, in the shape `reorder_response` established.
+
+Both wrappers take an optional `before_write` seam, invoked inside the scope
+immediately before the commit. It is what lets a test drive a genuinely
+concurrent writer into the window rather than asserting the absence of a race by
+timing (`tests/competing_writer.hpp`).
+
+Hold the lock only for a bounded composite: `/health`, the runs poll and SSE
+serialize on it too, so everything waits for the whole of it. A merge is
+microseconds; a network call or a file read is not, and does not belong inside.
 
 ### Listeners
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -122,7 +122,14 @@ timing (`tests/competing_writer.hpp`).
 
 Hold the lock only for a bounded composite: `/health`, the runs poll and SSE
 serialize on it too, so everything waits for the whole of it. A merge is
-microseconds; a network call or a file read is not, and does not belong inside.
+microseconds, and anything unbounded - a transfer, a wait on another thread -
+never belongs inside. The one file read in a lock scope is
+`PUT /client-certificates/:id`, whose usability check reads the first page of
+the file the merged row names: the check runs on the merged row, so hoisting it
+out would either give up the atomicity or re-open the window between the check
+and the write it exists to guard. It is called out at the site, and it is the
+shape of exception to argue for - bounded, local, and load-bearing - not a
+precedent for reaching further.
 
 ### Listeners
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -474,8 +474,9 @@ Notes:
   its denormalized column move together or the two disagree about what the
   request sends). `update_collection` carries a collection's own state - name,
   description, variables, auth, both scripts - and never its position:
-  re-parenting is `move_item`'s job (below), because `POST /reorder` is the only
-  write path that is atomic against a concurrent one.
+  re-parenting is `move_item`'s job (below), because a move is a batch. The
+  destination's siblings renumber with it, and `POST /reorder` is the write path
+  that commits the whole batch or none of it; a `PUT` writes one row.
 - **`delete_collection` cascades**, so it reads the subtree first: `GET
   /collections` gives it every descendant through `parentId`, one `GET
   /requests?collectionId=` per collection in that subtree gives the request
@@ -562,8 +563,12 @@ Notes:
 - **`move_item` is a bounded move, not a reorder** (issue #759). It maps to
   `POST /reorder`, whose batch validates and commits under one acquisition of the
   engine's DB mutex (#386) - which is why re-parenting goes here rather than
-  through `PUT /collections/:id`'s own `parentId`, where two concurrent moves can
-  each pass an acyclicity check neither one's commit was visible to. What the
+  through `PUT /collections/:id`'s own `parentId`. That `PUT` holds its own read
+  to its write since #1440, so two concurrent moves no longer each pass an
+  acyclicity check neither one's commit was visible to; what one row at a time
+  still cannot do is refuse the pair together - the first move is committed by
+  the time the second is rejected - or renumber the destination's siblings in the
+  same write. What the
   tool offers is the row menu's "Move to...": a destination, and `first` or
   `last` among its new siblings. Positions in between stay a UI gesture on
   purpose - naming one means reproducing the app's ordering arithmetic

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -308,6 +308,15 @@ const std::function<void ()>& before_write) {
  * leave the presented certificate decided by row order, the state the 409
  * exists to prevent.
  *
+ * It is also the one lock scope in the engine that touches the filesystem:
+ * `client_cert_rejection` stats the paths and reads the first page of the
+ * certificate to catch a `.p12` registered as a PEM pair. That check reads the
+ * *merged* row, which is why it cannot be hoisted out - and moving it out
+ * anyway would only trade this bounded read for a window between the check and
+ * the write it exists to guard. Bounded, local, and one page per path; see
+ * `docs/engine/architecture.md`, which names it as the exception to the rule
+ * that a file read stays outside.
+ *
  * @param before_write Test seam, invoked inside the lock scope with the merged
  *        row staged and immediately before it is written; see
  *        `update_request_response` for why it is an overload.

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -263,13 +263,13 @@ create_client_certificate_response (vayu::db::Database& db, const nlohmann::json
 }
 
 /**
- * Testable core of PUT /client-certificates/:id - **update only**
- * (merge-patch), returning {http_status, json_body}. A missing id is a 404
- * rather than a silent create, like every other resource.
+ * The read-merge-write of PUT /client-certificates/:id, run under the caller's
+ * lock.
  */
-std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
+static std::pair<int, nlohmann::json> update_client_certificate_locked (vayu::db::Database& db,
 const std::string& id,
-const nlohmann::json& json) {
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
         return as_response (outcome.error ());
     }
@@ -288,8 +288,45 @@ const nlohmann::json& json) {
     }
     c.updated_at = now_ms ();
 
+    if (before_write) {
+        before_write ();
+    }
     db.save_client_certificate (c);
     return { 200, vayu::json::serialize (c) };
+}
+
+/**
+ * Testable core of PUT /client-certificates/:id - **update only**
+ * (merge-patch), returning {http_status, json_body}. A missing id is a 404
+ * rather than a silent create, like every other resource.
+ *
+ * **The read, the merge and the write are one lock scope** (#1440), for the
+ * reason `update_request_response` states. This resource has a second stake in
+ * it: `reject_duplicate_target` proves no other row claims this host and port,
+ * and that proof is only worth as much as the window between it and the write -
+ * two PUTs converging on one target from either side of it would both pass and
+ * leave the presented certificate decided by row order, the state the 409
+ * exists to prevent.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the merged
+ *        row staged and immediately before it is written; see
+ *        `update_request_response` for why it is an overload.
+ */
+std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock ([&] {
+        result = update_client_certificate_locked (db, id, json, before_write);
+    });
+    return result;
+}
+
+std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json) {
+    return update_client_certificate_response (db, id, json, nullptr);
 }
 
 void register_client_certificate_routes (RouteContext& ctx) {

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -16,6 +16,7 @@
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -349,19 +350,11 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
     return result;
 }
 
-/**
- * Testable core of PUT /collections/:id - **update only**, returning
- * {http_status, json_body}. A missing id is a 404 rather than a silent create.
- *
- * Semantics are merge-patch: absent fields keep their stored value. We use PUT
- * loosely rather than adding a separate PATCH verb (documented in
- * api-reference.md) because that is what the update branch has always done and
- * what every renderer call site expects. A body `id` that disagrees with the
- * path is a 400 (#97); the path is the identity.
- */
-std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+/** The read-merge-write of PUT /collections/:id, run under the caller's lock. */
+static std::pair<int, nlohmann::json> update_collection_locked (vayu::db::Database& db,
 const std::string& id,
-const nlohmann::json& json) {
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
         return as_response (outcome.error ());
     }
@@ -376,25 +369,61 @@ const nlohmann::json& json) {
     }
     c.updated_at = now_ms ();
 
-    // One lock scope over check-then-write, exactly as the create core does -
-    // see there for why the two cannot be separate acquisitions. The check runs
-    // only when the write states a binding: a collection bound to a spec that
-    // has since been deleted out of band must stay editable by a PUT that says
-    // nothing about `openapi`, rather than becoming unwritable - the same
-    // reading `reject_missing_collection` gets on a request move.
-    std::pair<int, nlohmann::json> result;
-    db.with_lock ([&] {
-        if (json.contains ("openapi")) {
-            if (auto outcome = reject_unbindable_spec (db, c.openapi, {}); !outcome) {
-                result = as_response (outcome.error ());
-                return;
-            }
-            stamp_binding_from_store (db, c.openapi);
+    // The spec check runs only when the write states a binding: a collection
+    // bound to a spec that has since been deleted out of band must stay
+    // editable by a PUT that says nothing about `openapi`, rather than becoming
+    // unwritable - the same reading `reject_missing_collection` gets on a
+    // request move.
+    if (json.contains ("openapi")) {
+        if (auto outcome = reject_unbindable_spec (db, c.openapi, {}); !outcome) {
+            return as_response (outcome.error ());
         }
-        db.create_collection (c);
-        result = { 200, vayu::json::serialize (c) };
-    });
+        stamp_binding_from_store (db, c.openapi);
+    }
+    if (before_write) {
+        before_write ();
+    }
+    db.create_collection (c);
+    return { 200, vayu::json::serialize (c) };
+}
+
+/**
+ * Testable core of PUT /collections/:id - **update only**, returning
+ * {http_status, json_body}. A missing id is a 404 rather than a silent create.
+ *
+ * Semantics are merge-patch: absent fields keep their stored value. We use PUT
+ * loosely rather than adding a separate PATCH verb (documented in
+ * api-reference.md) because that is what the update branch has always done and
+ * what every renderer call site expects. A body `id` that disagrees with the
+ * path is a 400 (#97); the path is the identity.
+ *
+ * **The read, the merge and the write are one lock scope** (#1440). The create
+ * core states why the spec check and the write cannot be separate acquisitions;
+ * merge-patch extends the same argument to the read the merge is computed from.
+ * The write carries every field the body did not name, read a moment earlier,
+ * so two PUTs interleaved as read, read, write, write leave the second writer's
+ * stale copy of the untouched fields on top of the first writer's changes -
+ * silently, on both sides. That window used to sit between `get_collection`
+ * here and `create_collection` inside the lock.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the merged
+ *        row staged and immediately before it is written; see
+ *        `update_request_response` for why it is an overload.
+ */
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock (
+    [&] { result = update_collection_locked (db, id, json, before_write); });
     return result;
+}
+
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json) {
+    return update_collection_response (db, id, json, nullptr);
 }
 
 void register_collection_routes (RouteContext& ctx) {

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -15,6 +15,7 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <utility>
@@ -87,15 +88,11 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
     return { 200, vayu::json::serialize (e) };
 }
 
-/**
- * Testable core of PUT /environments/:id - **update only**, returning
- * {http_status, json_body}. A missing id is a 404 rather than a silent create.
- * Merge-patch semantics, same as collections and requests - including the 400
- * on a body `id` that disagrees with the path (#97).
- */
-std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
+/** The read-merge-write of PUT /environments/:id, run under the caller's lock. */
+static std::pair<int, nlohmann::json> update_environment_locked (vayu::db::Database& db,
 const std::string& id,
-const nlohmann::json& json) {
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
         return as_response (outcome.error ());
     }
@@ -110,8 +107,45 @@ const nlohmann::json& json) {
     }
     e.updated_at = now_ms ();
 
+    if (before_write) {
+        before_write ();
+    }
     db.save_environment (e);
     return { 200, vayu::json::serialize (e) };
+}
+
+/**
+ * Testable core of PUT /environments/:id - **update only**, returning
+ * {http_status, json_body}. A missing id is a 404 rather than a silent create.
+ * Merge-patch semantics, same as collections and requests - including the 400
+ * on a body `id` that disagrees with the path (#97).
+ *
+ * **The read, the merge and the write are one lock scope** (#1440), for the
+ * reason `update_request_response` states: a merge-patch write carries the
+ * fields the body did not name, so a read that is not held to the write loses
+ * whichever writer read first. This resource is the one with a second reader
+ * inside its own window - MCP's `update_environment` merges across two HTTP
+ * round trips (`app/electron/mcp/tools.ts`), which this lock cannot close;
+ * what it closes is the engine's own.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the merged
+ *        row staged and immediately before it is written; see
+ *        `update_request_response` for why it is an overload.
+ */
+std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock (
+    [&] { result = update_environment_locked (db, id, json, before_write); });
+    return result;
+}
+
+std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json) {
+    return update_environment_response (db, id, json, nullptr);
 }
 
 void register_environment_routes (RouteContext& ctx) {

--- a/engine/src/http/routes/examples.cpp
+++ b/engine/src/http/routes/examples.cpp
@@ -251,13 +251,14 @@ const nlohmann::json& json) {
 }
 
 /**
- * Testable core of PUT /requests/:id/examples/:exampleId - **update only**,
- * merge-patch, 404 on a missing example rather than a silent create.
+ * The read-merge-write of PUT /requests/:id/examples/:exampleId, run under the
+ * caller's lock.
  */
-std::pair<int, nlohmann::json> update_request_example_response (vayu::db::Database& db,
+static std::pair<int, nlohmann::json> update_request_example_locked (vayu::db::Database& db,
 const std::string& request_id,
 const std::string& example_id,
-const nlohmann::json& json) {
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_mismatched_body_id (json, example_id); !outcome) {
         return as_response (outcome.error ());
     }
@@ -274,8 +275,44 @@ const nlohmann::json& json) {
     }
     x.updated_at = now_ms ();
 
+    if (before_write) {
+        before_write ();
+    }
     db.save_request_example (x);
     return { 200, vayu::json::serialize (x) };
+}
+
+/**
+ * Testable core of PUT /requests/:id/examples/:exampleId - **update only**,
+ * merge-patch, 404 on a missing example rather than a silent create.
+ *
+ * **The read, the merge and the write are one lock scope** (#1440), for the
+ * reason `update_request_response` states. The ownership check is inside it
+ * too: an example reached through the wrong request is a 404, and a check that
+ * released the lock before the write would answer for a row a concurrent
+ * `delete_request` cascade could take in between.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the merged
+ *        row staged and immediately before it is written; see
+ *        `update_request_response` for why it is an overload.
+ */
+std::pair<int, nlohmann::json> update_request_example_response (vayu::db::Database& db,
+const std::string& request_id,
+const std::string& example_id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock ([&] {
+        result = update_request_example_locked (db, request_id, example_id, json, before_write);
+    });
+    return result;
+}
+
+std::pair<int, nlohmann::json> update_request_example_response (vayu::db::Database& db,
+const std::string& request_id,
+const std::string& example_id,
+const nlohmann::json& json) {
+    return update_request_example_response (db, request_id, example_id, json, nullptr);
 }
 
 /**

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -16,6 +16,7 @@
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -351,15 +352,11 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
     return { 200, vayu::json::serialize (r) };
 }
 
-/**
- * Testable core of PUT /requests/:id - **update only**, returning
- * {http_status, json_body}. A missing id is a 404 rather than a silent create.
- * Merge-patch semantics, same as collections - including the 400 on a body `id`
- * that disagrees with the path (#97).
- */
-std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+/** The read-merge-write of PUT /requests/:id, run under the caller's lock. */
+static std::pair<int, nlohmann::json> update_request_locked (vayu::db::Database& db,
 const std::string& id,
-const nlohmann::json& json) {
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_mismatched_body_id (json, id); !outcome) {
         return as_response (outcome.error ());
     }
@@ -389,8 +386,52 @@ const nlohmann::json& json) {
     }
     r.updated_at = now_ms ();
 
+    if (before_write) {
+        before_write ();
+    }
     db.save_request (r);
     return { 200, vayu::json::serialize (r) };
+}
+
+/**
+ * Testable core of PUT /requests/:id - **update only**, returning
+ * {http_status, json_body}. A missing id is a 404 rather than a silent create.
+ * Merge-patch semantics, same as collections - including the 400 on a body `id`
+ * that disagrees with the path (#97).
+ *
+ * **The read, the merge and the write are one lock scope** (#1440, the rule
+ * `POST /reorder` states at length under #386). Merge-patch means the write
+ * carries every field the body did not name, read a moment earlier - so two
+ * PUTs to one row interleaved as read, read, write, write leave the second
+ * writer's stale copy of the fields it never mentioned on top of the first
+ * writer's changes, and the first client's edit is gone with no error on either
+ * side. cpp-httplib serves on a thread pool and the renderer's autosave and an
+ * MCP agent are genuinely concurrent clients, so the interleaving is reachable
+ * today. Holding the lock across the composite makes the row the merge was
+ * computed from still the stored row when the merge lands; the merge itself is
+ * microseconds, which is the whole cost to everything else serializing here.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the merged
+ *        row staged and immediately before it is written - the only way to
+ *        drive a competing writer into the window this closes. It is a separate
+ *        overload rather than the defaulted parameter `reorder_response` uses
+ *        because ten test files already declare the three-argument form, and a
+ *        defaulted parameter would move the symbol they link against.
+ */
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock (
+    [&] { result = update_request_locked (db, id, json, before_write); });
+    return result;
+}
+
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json) {
+    return update_request_response (db, id, json, nullptr);
 }
 
 void register_request_routes (RouteContext& ctx) {

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -22,6 +22,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,6 +32,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
@@ -48,6 +50,12 @@ create_client_certificate_response (vayu::db::Database& db, const nlohmann::json
 std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json);
+// The update core with its `before_write` seam - invoked inside the lock scope
+// with the merged row staged and immediately before it is written (#1440).
+std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
 } // namespace vayu::http::routes
 
 namespace vayu::http {
@@ -873,6 +881,46 @@ TEST_F (ClientCertificateDbTest, UpdateChecksTheMergedRowNotTheBody) {
     *db_, id, json{ { "keyPath", "/nope/client.key" } });
     EXPECT_EQ (status, 400);
     EXPECT_EQ (db_->get_client_certificates ().front ().key_path, key_.path ());
+}
+
+/**
+ * The update core's read, merge and write are one lock scope (#1440), so two
+ * PUTs to one entry naming different fields both land. Merge-patch is what
+ * makes an unheld read destructive: the write carries the fields the body never
+ * named, so the loser's change is overwritten with a value nobody sent - here
+ * either a passphrase that stops matching the key, or a port the entry was
+ * narrowed to and silently widens back out of.
+ *
+ * The second writer runs from inside the first one's scope through the
+ * `before_write` seam and is given a window to finish (`competing_writer.hpp`).
+ * Mutation check: drop the `with_lock` and the `port` assertion reds.
+ */
+TEST_F (ClientCertificateDbTest, AConcurrentUpdateWaitsAndKeepsBothFieldsWritten) {
+    const auto [created_status, created] =
+    routes::create_client_certificate_response (*db_, body ("api.example.com"));
+    ASSERT_EQ (created_status, 200) << created.dump ();
+    const std::string id = created["id"];
+
+    int other_status = 0;
+    json other_body;
+    vayu::tests::CompetingWriter other ([&] {
+        auto result = routes::update_client_certificate_response (
+        *db_, id, json{ { "port", 8443 } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    const auto [status, updated] = routes::update_client_certificate_response (
+    *db_, id, json{ { "passphrase", "s3cret" } }, other.probe ());
+    ASSERT_EQ (status, 200) << updated.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto stored = db_->get_client_certificate (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->passphrase, "s3cret");
+    EXPECT_EQ (stored->port, std::optional<int> (8443))
+    << "the port write merged against the row this write had already staged";
 }
 
 TEST_F (ClientCertificateDbTest, UpdatingAMissingEntryIs404) {

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -895,7 +895,7 @@ TEST_F (ClientCertificateDbTest, UpdateChecksTheMergedRowNotTheBody) {
  * `before_write` seam and is given a window to finish (`competing_writer.hpp`).
  * Mutation check: drop the `with_lock` and the `port` assertion reds.
  */
-TEST_F (ClientCertificateDbTest, AConcurrentUpdateWaitsAndKeepsBothFieldsWritten) {
+TEST_F (ClientCertificateDbTest, AConcurrentCertificateUpdateWaitsAndKeepsBothFieldsWritten) {
     const auto [created_status, created] =
     routes::create_client_certificate_response (*db_, body ("api.example.com"));
     ASSERT_EQ (created_status, 200) << created.dump ();

--- a/engine/tests/competing_writer.hpp
+++ b/engine/tests/competing_writer.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/competing_writer.hpp
+ * @brief A second client driven into the window a route holds the DB lock over.
+ *
+ * Every route that reads, decides and then writes claims that the three are one
+ * lock scope (`Database::with_lock`, issue #386). The claim is about an
+ * interleaving, so a test for it has to produce one: this starts a genuinely
+ * concurrent writer from inside the scope, through the route's `before_write`
+ * seam, and gives it a bounded window to finish before the route commits.
+ *
+ * With the lock scope in place the writer blocks on the DB mutex, the wait runs
+ * its full timeout every time, and the route commits first deterministically -
+ * there is no ordering in which it does not. Remove the lock scope and the
+ * writer proceeds immediately against the pre-write state, the wait returns as
+ * soon as it is done, and the test sees the interleaving it forbids. That is
+ * what makes each of these tests decide in both directions.
+ */
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace vayu::tests {
+
+class CompetingWriter {
+    public:
+    explicit CompetingWriter (std::function<void ()> work)
+    : work_ (std::move (work)) {
+    }
+    ~CompetingWriter () {
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+    CompetingWriter (const CompetingWriter&)            = delete;
+    CompetingWriter& operator= (const CompetingWriter&) = delete;
+    CompetingWriter (CompetingWriter&&)                 = delete;
+    CompetingWriter& operator= (CompetingWriter&&)      = delete;
+
+    /** The `before_write` probe: starts the writer, then waits out the window. */
+    std::function<void ()> probe () {
+        return [this] {
+            thread_ = std::thread ([this] {
+                work_ ();
+                {
+                    std::lock_guard<std::mutex> guard (mutex_);
+                    done_ = true;
+                }
+                cv_.notify_all ();
+            });
+            std::unique_lock<std::mutex> guard (mutex_);
+            cv_.wait_for (
+            guard, std::chrono::milliseconds (300), [this] { return done_; });
+        };
+    }
+
+    void join () {
+        thread_.join ();
+    }
+
+    private:
+    std::function<void ()> work_;
+    std::thread thread_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool done_ = false;
+};
+
+} // namespace vayu::tests

--- a/engine/tests/examples_route_test.cpp
+++ b/engine/tests/examples_route_test.cpp
@@ -17,12 +17,14 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
@@ -44,6 +46,13 @@ const nlohmann::json& json);
 std::pair<int, nlohmann::json> delete_request_example_response (vayu::db::Database& db,
 const std::string& request_id,
 const std::string& example_id);
+// The update core with its `before_write` seam - invoked inside the lock scope
+// with the merged row staged and immediately before it is written (#1440).
+std::pair<int, nlohmann::json> update_request_example_response (vayu::db::Database& db,
+const std::string& request_id,
+const std::string& example_id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
 // Defined in import.cpp - the bulk path that also writes examples.
 std::pair<int, nlohmann::json>
 import_apply_response (vayu::db::Database& db, const nlohmann::json& body);
@@ -593,6 +602,41 @@ TEST_F (ExamplesRouteTest, ImportApplyRejectsABadExampleAndWritesNothing) {
     const auto collections = db_->get_collections ();
     ASSERT_EQ (collections.size (), 1u);
     EXPECT_EQ (collections[0].id, "col_1");
+}
+
+/**
+ * The update core's read, merge and write are one lock scope (#1440), so two
+ * PUTs to one example naming different fields both land. Merge-patch is what
+ * makes an unheld read destructive: the write carries the fields the body never
+ * named, so the loser's change is overwritten with a value nobody sent.
+ *
+ * The second writer runs from inside the first one's scope through the
+ * `before_write` seam and is given a window to finish (`competing_writer.hpp`).
+ * Mutation check: drop the `with_lock` and the `status` assertion reds.
+ */
+TEST_F (ExamplesRouteTest, AConcurrentExampleUpdateWaitsAndKeepsBothFieldsWritten) {
+    const std::string id = create_example ("req_1", json{ { "name", "Saved" } });
+
+    int other_status = 0;
+    json other_body;
+    vayu::tests::CompetingWriter other ([&] {
+        auto result = routes::update_request_example_response (
+        *db_, "req_1", id, json{ { "status", 404 } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = routes::update_request_example_response (
+    *db_, "req_1", id, json{ { "name", "Renamed" } }, other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto stored = db_->get_request_example (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->name, "Renamed");
+    EXPECT_EQ (stored->status, 404)
+    << "the status write merged against the row this write had already staged";
 }
 
 } // namespace

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -38,19 +38,16 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
-#include <condition_variable>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
@@ -573,62 +570,12 @@ TEST_F (ReorderRouteTest, TheResponseCarriesTheRowsAsWritten) {
 // ---------------------------------------------------------------------------
 
 /**
- * A writer started from inside a batch's `before_write` seam - that is, on
- * another thread, while the batch holds the DB lock - and given a window to
- * finish before the batch commits.
- *
- * The window is what makes these tests decide in both directions, and it cannot
- * be designed away: the defect *is* an interleaving, so a test for it has to
- * produce one. With the lock scope spanning the batch, the writer blocks on the
- * DB mutex, the wait runs its full timeout every time, and the batch commits
- * first deterministically - there is no ordering in which it does not. Remove
- * the lock scope and the writer proceeds immediately against the pre-write
- * state, the wait returns as soon as it is done, and each test below sees the
- * interleaving it forbids.
+ * The competing writer these three tests drive into the window is
+ * `vayu::tests::CompetingWriter` (`competing_writer.hpp`), shared with the
+ * resource PUTs' own lock-scope tests (#1440); its header carries why the
+ * window makes each case decide in both directions.
  */
-class CompetingWriter {
-    public:
-    explicit CompetingWriter (std::function<void ()> work)
-    : work_ (std::move (work)) {
-    }
-    ~CompetingWriter () {
-        if (thread_.joinable ()) {
-            thread_.join ();
-        }
-    }
-    CompetingWriter (const CompetingWriter&)            = delete;
-    CompetingWriter& operator= (const CompetingWriter&) = delete;
-    CompetingWriter (CompetingWriter&&)                 = delete;
-    CompetingWriter& operator= (CompetingWriter&&)      = delete;
-
-    /** The `before_write` probe: starts the writer, then waits out the window. */
-    std::function<void ()> probe () {
-        return [this] {
-            thread_ = std::thread ([this] {
-                work_ ();
-                {
-                    std::lock_guard<std::mutex> guard (mutex_);
-                    done_ = true;
-                }
-                cv_.notify_all ();
-            });
-            std::unique_lock<std::mutex> guard (mutex_);
-            cv_.wait_for (
-            guard, std::chrono::milliseconds (300), [this] { return done_; });
-        };
-    }
-
-    void join () {
-        thread_.join ();
-    }
-
-    private:
-    std::function<void ()> work_;
-    std::thread thread_;
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    bool done_ = false;
-};
+using vayu::tests::CompetingWriter;
 
 TEST_F (ReorderRouteTest, AConflictingBatchWaitsAndIsRejectedAgainstTheCommittedGraph) {
     const std::string a = make_collection ("A");

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -4,7 +4,7 @@
  *        null-vs-absent rule across collections, requests and environments
  *        (issues #95, #97).
  *
- * Four things are pinned here, for each of the three resources:
+ * What is pinned here, for each of the three resources:
  *
  *  - **POST creates and only creates.** Before the split, POSTing a stale or
  *    typo'd id merged two records into one - the same upsert that turned an id
@@ -35,12 +35,21 @@
  *    Those tests assert the **stored blob**, because a response-only
  *    assertion passes against the old code too.
  *
+ *  - **The read, the merge and the write are one lock scope** (issue #1440).
+ *    Merge-patch means the write carries every field the body did not name,
+ *    read a moment earlier, so a read that is not held to its write loses
+ *    whichever of two concurrent PUTs read first - whole fields, silently, on
+ *    both sides. The three tests at the bottom of this file drive a genuinely
+ *    concurrent second PUT into that window through each core's `before_write`
+ *    seam and assert both writers' fields survive.
+ *
  * Follows the suite's route-test convention (requests_route_test.cpp): the
  * routes' extracted cores are exercised directly, no in-process HTTP server.
  */
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -48,6 +57,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
@@ -73,6 +83,23 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
 std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json);
+// The same three cores with their `before_write` seam - invoked inside the lock
+// scope with the merged row staged and immediately before it is written, which
+// is the only way to drive a second writer into the window (#1440). A separate
+// overload rather than a defaulted parameter, so the three-argument
+// declarations every other test file carries keep naming the same symbol.
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
+std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
 // Defined in requests.cpp - the list serializer, which is separate code from
 // the single-request one and has been the half a new field missed before.
 std::string list_requests_body (vayu::db::Database& db, const std::string& collection_id);
@@ -1179,6 +1206,107 @@ TEST_F (ResourceWriteRouteTest, EnvironmentNullNameIsRejected) {
     const auto stored_environment = db_->get_environment (id);
     ASSERT_HAS_VALUE (stored_environment);
     EXPECT_EQ (stored_environment->name, "Keep me");
+}
+
+// ---------------------------------------------------------------------------
+// The lock scope: read + merge + write (issue #1440)
+// ---------------------------------------------------------------------------
+
+/**
+ * Each case below is the same experiment on a different resource, and it is the
+ * one the defect's own report describes: two clients PUT one row at the same
+ * moment, each naming a field the other does not, and *both* fields must be
+ * stored afterwards. Merge-patch is what makes that a real risk - the write
+ * carries the whole row, including the fields the body never mentioned - so the
+ * loser of an unheld read has its change overwritten with a value nobody sent.
+ *
+ * The second writer is started from inside the first one's lock scope, through
+ * the `before_write` seam, and given a window to finish (see
+ * `competing_writer.hpp`). Holding the read to the write makes it block, so it
+ * merges against the committed row and both fields survive; without the lock it
+ * merges against the row as it was before either write and the first writer's
+ * field is gone. Mutation check: drop either `with_lock` and its case reds on
+ * the second field.
+ */
+using vayu::tests::CompetingWriter;
+
+TEST_F (ResourceWriteRouteTest, AConcurrentRequestUpdateWaitsAndKeepsBothFieldsWritten) {
+    const std::string collection = make_collection ();
+    const std::string id         = make_request (collection);
+
+    int other_status = 0;
+    json other_body;
+    CompetingWriter other ([&] {
+        auto result = update_request_response (*db_, id, json{ { "name", "Renamed" } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = update_request_response (
+    *db_, id, json{ { "url", "https://example.com/v2" } }, other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto stored = db_->get_request (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->url, "https://example.com/v2");
+    EXPECT_EQ (stored->name, "Renamed")
+    << "the rename merged against the row this write had already staged";
+}
+
+TEST_F (ResourceWriteRouteTest, AConcurrentCollectionUpdateWaitsAndKeepsBothFieldsWritten) {
+    const std::string id = make_collection ("Billing");
+
+    int other_status = 0;
+    json other_body;
+    CompetingWriter other ([&] {
+        auto result =
+        update_collection_response (*db_, id, json{ { "description", "Invoices" } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = update_collection_response (
+    *db_, id, json{ { "name", "Renamed" } }, other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto stored = db_->get_collection (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->name, "Renamed");
+    EXPECT_EQ (stored->description, "Invoices")
+    << "the description merged against the row this write had already staged";
+}
+
+TEST_F (ResourceWriteRouteTest, AConcurrentEnvironmentUpdateWaitsAndKeepsBothFieldsWritten) {
+    auto [created_status, created] =
+    create_environment_response (*db_, json{ { "name", "Staging" } });
+    ASSERT_EQ (created_status, 200);
+    const std::string id = created["id"].get<std::string> ();
+
+    int other_status = 0;
+    json other_body;
+    CompetingWriter other ([&] {
+        auto result  = update_environment_response (*db_, id,
+         json{ { "variables", json{ { "host", "api.example.com" } } } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = update_environment_response (
+    *db_, id, json{ { "name", "Production" } }, other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto stored = db_->get_environment (id);
+    ASSERT_HAS_VALUE (stored);
+    EXPECT_EQ (stored->name, "Production");
+    EXPECT_EQ (json::parse (stored->variables)["host"], "api.example.com")
+    << "the variables write merged against the row this write had already "
+       "staged";
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A merge-patch update read its row, merged the body onto the copy and saved it back across **two** acquisitions of the database mutex. cpp-httplib serves on its default thread pool, so two PUTs to one row - the app's autosave and an MCP agent, or two agents - can interleave as read, read, write, write. The second write carries the first reader's copy of every field the body never named, so the first writer's edit is gone entirely, not just the fields both named. Neither request fails, and there is no precondition anywhere to notice it with.

**Root cause and approach.** The race is above the database, in the route: SQLite is fine (WAL, one mutex per `Database` call, a lock file against a second engine). `Database::with_lock` exists for exactly this composite (#386) and was used by `/reorder`, `/import/apply`, `spec_bind` and `spec_sync`, but not by the resource updates. Each update core is now a thin wrapper over an `update_*_locked` function holding the read, the merge and the write, in the shape `reorder_response` established - the mutex is recursive, so the locked function calls the same public `get_*`/`save_*` methods as before. **Rejected:** an `If-Match`/version precondition instead. It turns a silent loss into a loud 412 but still loses one side's work, and it needs a consumer on the app side that does not exist; the lock is what makes both writes land, and #1436 is the renderer-side sibling that removes the common cause. A precondition stays worth adding later as a second line of defence, not as this fix.

**Five handlers, not the three the issue names.** `rg` over `engine/src/http/routes/` finds `PUT /client-certificates/:id` and `PUT /requests/:id/examples/:exampleId` in the identical shape, and the issue's third acceptance criterion is about every plain resource PUT. Two of them gain more than lost-update safety, because a check can no longer be outrun by the write it guards: a client certificate's one-entry-per-host-and-port rule, and an example's ownership check against the request in the path.

**What was deliberately left out**, each filed rather than folded in:
- `POST /globals` replaces the singleton without reading it, so it has no window. Nothing to file.
- `POST /config` is a batch of validate-then-write over many rows - a concurrent reader can see half a batch. #1453.
- `PUT /inbox/:id` has exactly this defect against `InboxManager`'s mutex rather than the database's, so neither this fix nor its tests reach it. #1454.
- `POST /client-certificates` proves host+port uniqueness under one lock and writes under another, so two creates for one target both pass the 409 that exists to stop them. This fix closed the window on the PUT side and left the create side open, which is why it is filed rather than ignored. #1455.

**One deliberate exception, called out at the site.** `PUT /client-certificates/:id`'s usability check stats the named paths and reads their first page (catching a `.p12` registered as a PEM pair), and it now runs inside the lock scope. It reads the *merged* row, so hoisting it out would either give up the atomicity or reopen the window between the check and the write it guards. `docs/engine/architecture.md` names it as the one file read in a lock scope and states the rule that actually holds - nothing unbounded.

**The test seam is a separate overload** rather than the defaulted `before_write` parameter `reorder_response` uses: ten test files already declare the three-argument form, and a defaulted parameter would move the symbol they link against. `CompetingWriter` moves out of `reorder_route_test.cpp` into `tests/competing_writer.hpp` unchanged, so the new cases drive their window through the same helper rather than a copy of it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **2913 tests, 0 failures**, 42.8s. No app change, so no app suite run - the issue's own "App changes: None, verified" holds: the renderer and MCP send the same payloads and read the same responses.

Five new cases, one per fixed handler, each the experiment the issue describes - two PUTs to one row naming different fields, both fields expected afterwards:

| Case | Suite |
|---|---|
| `AConcurrentRequestUpdateWaitsAndKeepsBothFieldsWritten` | `ResourceWriteRouteTest` |
| `AConcurrentCollectionUpdateWaitsAndKeepsBothFieldsWritten` | `ResourceWriteRouteTest` |
| `AConcurrentEnvironmentUpdateWaitsAndKeepsBothFieldsWritten` | `ResourceWriteRouteTest` |
| `AConcurrentExampleUpdateWaitsAndKeepsBothFieldsWritten` | `ExamplesRouteTest` |
| `AConcurrentCertificateUpdateWaitsAndKeepsBothFieldsWritten` | `ClientCertificateDbTest` |

**Mutation-checked**, all five: with its own `with_lock` removed each case fails, and it fails *fast* - the competing writer never blocks, so the 300 ms window returns at once (~40 ms per case) instead of running out (~343 ms). Restored, all five pass. That is the same deterministic-in-both-directions property `reorder_route_test.cpp` documents for #386. Note what each case is really pinning: the *second* writer's field is the discriminating assertion, since the first writer's own field survives either interleaving. Both are asserted because "both fields land" is the criterion, and each case's comment says which half does the work.

No new file to register: `resource_write_route_test.cpp`, `examples_route_test.cpp` and `client_certificates_test.cpp` are already in `add_executable(vayu_tests ...)`. Note the TSan job does not run on this PR - `.github/workflows/sanitizers.yml` deliberately excludes `engine/tests/CMakeLists.txt` from its trigger paths (#970) - so these threaded cases are swept in by the next weekly run, not by this one.

Local gates run: `clang-format-19 --dry-run -Werror` clean on every touched file, `clang-tidy-19 -p build` clean on all five route sources (whole-file, as CI lints them), and the repo pre-commit hook passed on all three commits. No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**No user-visible change** - engine-only, same status codes and same response bodies, so there is nothing to screenshot. What changes is which of two concurrent writes survives.

Docs, same commits. Three doc lines the fix made false, all of them claims *about* the missing lock:
- `docs/engine/api-reference.md`'s `POST /reorder` note contrasted the batch with a `PUT /collections/:id` that "validates and writes under different locks", and its "Repositioning several rows" note called a per-row PUT's cycle guard "read-then-write across two lock scopes". Both are one scope now; the notes keep the two differences that survive - N PUTs can be interrupted halfway, and a conflicting reparent is refused only after the first one is already stored.
- `docs/engine/mcp.md` gave `move_item` the wrong reason for existing ("`POST /reorder` is the only write path that is atomic against a concurrent one") and repeated the acyclicity claim. Corrected to the reason that survives: a move is a batch, and a PUT writes one row.

Added: `docs/engine/architecture.md` gains "A core that reads, decides and writes holds one lock" beside the route-shape section, naming both shapes that need it, the `before_write` seam, and the one bounded file read inside a scope. Its **"Single-threaded request handling"** bullet is corrected - the daemon serves on cpp-httplib's default thread pool, which is the premise this whole fix rests on. `api-reference.md` states the atomicity beside the merge-patch contract.

## Related Issues
Closes #1440

Filed from this run: #1453, #1454, #1455.