### PR TITLE
fix(engine): hold POST /client-certificates' uniqueness check and write under one lock

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3281,6 +3281,12 @@ id](#the-engine-owns-every-id)).
 | `keyPath` | for `pem` | Path to the private key file. Must be readable now, and must be **absent** for `p12`. |
 | `passphrase` | no | The key's passphrase, or a PKCS#12 bundle's import password. Write-only. |
 
+**The uniqueness check and the write are one lock scope.** Proving no other
+row already claims this `host` + `port` and writing the new row happen under
+one acquisition of the database lock, so two creates for the same target
+racing each other cannot both pass the check before either writes - the second
+is answered with the `409` below rather than landing beside the first.
+
 **Errors:**
 
 | Status | When |

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -114,6 +114,12 @@ Two shapes need it, and both are in the code today:
   first - whole fields, with neither request failing. Each of those cores is a
   thin wrapper over an `update_*_locked` function holding the read, the merge
   and the write, in the shape `reorder_response` established.
+- **The uniqueness-checked create** - `POST /client-certificates` (issue
+  #1455), the one create with a cross-row invariant to protect. Proving no
+  other row already claims a candidate's host and port is only as good as the
+  window between that proof and the write, so the create holds the lock across
+  both, in a `create_*_locked` core of the same shape as the merge-patch
+  update's.
 
 Both wrappers take an optional `before_write` seam, invoked inside the scope
 immediately before the commit. It is what lets a test drive a genuinely
@@ -123,12 +129,13 @@ timing (`tests/competing_writer.hpp`).
 Hold the lock only for a bounded composite: `/health`, the runs poll and SSE
 serialize on it too, so everything waits for the whole of it. A merge is
 microseconds, and anything unbounded - a transfer, a wait on another thread -
-never belongs inside. The one file read in a lock scope is
-`PUT /client-certificates/:id`, whose usability check reads the first page of
-the file the merged row names: the check runs on the merged row, so hoisting it
-out would either give up the atomicity or re-open the window between the check
-and the write it exists to guard. It is called out at the site, and it is the
-shape of exception to argue for - bounded, local, and load-bearing - not a
+never belongs inside. The file reads in a lock scope are
+`PUT /client-certificates/:id` and `POST /client-certificates` (#1455), whose
+usability check reads the first page of the file the merged (or, for the
+create, the staged) row names: the check runs on that row, so hoisting it out
+would either give up the atomicity or re-open the window between the check and
+the write it exists to guard. Both are called out at their site, and they are
+the shape of exception to argue for - bounded, local, and load-bearing - not a
 precedent for reaching further.
 
 ### Listeners

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -236,12 +236,13 @@ bool is_create) {
 } // namespace
 
 /**
- * Testable core of POST /client-certificates - **create only**, returning
- * {http_status, json_body}. The engine owns the id (#97), so a body carrying
- * one is a 400.
+ * The check-decide-write of POST /client-certificates, run under the caller's
+ * lock: stages a fresh row, proves no other row claims its host and port, and
+ * writes it.
  */
-std::pair<int, nlohmann::json>
-create_client_certificate_response (vayu::db::Database& db, const nlohmann::json& json) {
+static std::pair<int, nlohmann::json> create_client_certificate_locked (vayu::db::Database& db,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
     if (auto outcome = reject_client_supplied_id (json); !outcome) {
         return as_response (outcome.error ());
     }
@@ -258,8 +259,45 @@ create_client_certificate_response (vayu::db::Database& db, const nlohmann::json
         return as_response (outcome.error ());
     }
 
+    if (before_write) {
+        before_write ();
+    }
     db.save_client_certificate (c);
     return { 200, vayu::json::serialize (c) };
+}
+
+/**
+ * Testable core of POST /client-certificates - **create only**, returning
+ * {http_status, json_body}. The engine owns the id (#97), so a body carrying
+ * one is a 400.
+ *
+ * **The check and the write are one lock scope** (#1455, the create-side
+ * sibling of #1440): two creates for the same host and port racing each other
+ * must not both pass `reject_duplicate_target` before either writes, or two
+ * rows end up claiming one target and the certificate presented depends on
+ * row order - exactly what the 409 exists to prevent.
+ * `update_client_certificate_response`'s doc comment states the identical
+ * reasoning for the update side of this invariant; this is the second (not
+ * the only) lock scope in the engine that reads the filesystem, for the same
+ * reason - `apply_client_certificate_fields`'s usability check reads the
+ * first page of the file this create is about to register.
+ *
+ * @param before_write Test seam, invoked inside the lock scope with the new
+ *        row staged and immediately before it is written; see
+ *        `update_request_response` for why it is an overload.
+ */
+std::pair<int, nlohmann::json> create_client_certificate_response (vayu::db::Database& db,
+const nlohmann::json& json,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock (
+    [&] { result = create_client_certificate_locked (db, json, before_write); });
+    return result;
+}
+
+std::pair<int, nlohmann::json>
+create_client_certificate_response (vayu::db::Database& db, const nlohmann::json& json) {
+    return create_client_certificate_response (db, json, nullptr);
 }
 
 /**
@@ -308,13 +346,14 @@ const std::function<void ()>& before_write) {
  * leave the presented certificate decided by row order, the state the 409
  * exists to prevent.
  *
- * It is also the one lock scope in the engine that touches the filesystem:
+ * It is also one of the two lock scopes in the engine that touch the
+ * filesystem (the other being this file's own create, #1455):
  * `client_cert_rejection` stats the paths and reads the first page of the
  * certificate to catch a `.p12` registered as a PEM pair. That check reads the
  * *merged* row, which is why it cannot be hoisted out - and moving it out
  * anyway would only trade this bounded read for a window between the check and
  * the write it exists to guard. Bounded, local, and one page per path; see
- * `docs/engine/architecture.md`, which names it as the exception to the rule
+ * `docs/engine/architecture.md`, which names both as the exception to the rule
  * that a file read stays outside.
  *
  * @param before_write Test seam, invoked inside the lock scope with the merged

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -47,6 +47,11 @@ namespace vayu::http::routes {
 // Defined in client_certificates.cpp; each returns {http_status, json_body}.
 std::pair<int, nlohmann::json>
 create_client_certificate_response (vayu::db::Database& db, const nlohmann::json& json);
+// The create core with its `before_write` seam - invoked inside the lock scope
+// with the new row staged and immediately before it is written (#1455).
+std::pair<int, nlohmann::json> create_client_certificate_response (vayu::db::Database& db,
+const nlohmann::json& json,
+const std::function<void ()>& before_write);
 std::pair<int, nlohmann::json> update_client_certificate_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json);
@@ -809,6 +814,37 @@ TEST_F (ClientCertificateDbTest, RefusesASecondEntryForTheSameTarget) {
     // As is the catch-all beside them.
     EXPECT_EQ (
     routes::create_client_certificate_response (*db_, body ("api.example.com")).first, 200);
+}
+
+/**
+ * The create core's check and write are one lock scope (#1455), so a second
+ * create for the same host and port started during the first's window cannot
+ * pass `reject_duplicate_target` before the first's row lands. Without the
+ * lock, both checks run before either write, both pass, and two rows end up
+ * claiming one target - the state the 409 exists to prevent.
+ *
+ * The second writer runs from inside the first one's scope through the
+ * `before_write` seam and is given a window to finish (`competing_writer.hpp`).
+ * Mutation check: drop the `with_lock` and this reds with two rows stored and
+ * a 200 for both creates.
+ */
+TEST_F (ClientCertificateDbTest, AConcurrentCreateForOneTargetWaitsAndTheSecondGetsThe409) {
+    int other_status = 0;
+    json other_body;
+    vayu::tests::CompetingWriter other ([&] {
+        auto result = routes::create_client_certificate_response (
+        *db_, body ("api.example.com", 8443));
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    const auto [status, created] = routes::create_client_certificate_response (
+    *db_, body ("api.example.com", 8443), other.probe ());
+    ASSERT_EQ (status, 200) << created.dump ();
+    other.join ();
+
+    EXPECT_EQ (other_status, 409) << other_body.dump ();
+    EXPECT_EQ (db_->get_client_certificates ().size (), 1u);
 }
 
 TEST_F (ClientCertificateDbTest, AWildcardIsATargetLikeAnyOther) {


### PR DESCRIPTION
## Description

Found by an adversarial review of #1440's PR and deliberately left out of it: #1440 fixed the read-modify-write race on `PUT /client-certificates/:id` (holding the read, merge and write in one `Database::with_lock` scope), but the create side of the same file's own uniqueness invariant was left open.

**Root cause.** `create_client_certificate_response` called `reject_duplicate_target` (the host+port uniqueness check, 409 on a match) and `db.save_client_certificate` as two separate acquisitions of the database mutex. Two `POST /client-certificates` for the same host+port - a retried request the client believed failed is the realistic path - could both pass the check before either wrote, landing two rows for one target. The file's own header comment states the rule this breaks: "One entry per host+port... the second one is a 409 naming the first rather than a silent shadowing." With two rows stored, `match_client_certificate`'s ranking falls through to row order for the tie, the exact state the 409 exists to prevent, reached without either request seeing one.

**Approach.** Extracted `create_client_certificate_locked`, mirroring `update_client_certificate_locked`'s already-established shape (#1440): a static core taking a `before_write` test seam, wrapped by the public `create_client_certificate_response` in `db.with_lock`, with a second overload forwarding `nullptr` for production callers. The check and the write are now one lock scope, so a second create for the same target either lands entirely before or entirely after the first - never in the window between its check and its write.

Confirmed (per #1455's own fix pathway) that no other resource's create path needs the same treatment: `collections`, `requests` and `environments` only check an engine-generated id against a ~122-bit collision, not a cross-row content invariant, and that check is already treated as unreachable in practice.

### Rejected alternative

None considered beyond the one #1455 named - this mirrors the exact pattern #1440 already established and reviewed for the update side of this same file, rather than inventing a different mechanism for the create side.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - all engine tests pass; `ctest --preset linux-dev -R ClientCert --output-on-failure` - 57/57 pass, including the new `AConcurrentCreateForOneTargetWaitsAndTheSecondGetsThe409`.
- Mutation-checked: temporarily removed the `with_lock` wrap and reran the new test - it reds deterministically (both concurrent creates return 200, two rows stored). Restored, the suite is green again.
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19 -p build` clean on both touched engine files (the pre-commit hook ran both on the actual commit).
- No app changes (engine-only route fix), so no `pnpm test` run - the app sends the same payload and reads the same responses/status codes as before.

**No user-visible change** - same status codes and response bodies; what changes is that a duplicate-target create now *reliably* gets the documented 409 instead of only usually getting it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1455