### PR TITLE
fix(engine): write an edited imported example back into the map entry it came from

### DIFF
--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -127,7 +127,7 @@ Both lists go through the walk's `parameters` guard (`openapi_drafts.cpp`) first
 | the JSON media type's `example` → first `examples[*].value` → `sampleSchema(schema)` | `body` | the same precedence `buildBody` uses for a request body; a string is stored as-is, anything else is `JSON.stringify(value, null, 2)` |
 | the JSON media type key | `contentType`, and a single `Content-Type` header | `application/json`, an `application/json;…` variant or a `+json` suffix, by the same rule request bodies use |
 
-A response `$ref` is resolved (single hop, like the parser's other refs). An `examples` entry is unwrapped from its Example Object - the payload is in `value`, and storing the wrapper would put a body on disk no server would send; an `externalValue` names a URL rather than carrying a payload, so it yields nothing (an import must not fetch).
+A response `$ref` is resolved (single hop, like the parser's other refs). An `examples` entry is unwrapped from its Example Object - the payload is in `value`, and storing the wrapper would put a body on disk no server would send; an `externalValue` names a URL rather than carrying a payload, so it yields nothing (an import must not fetch). The map key the entry was taken from is remembered too (`spec_example_key`, issue #1457, engine-side only - no surface here displays it): the bound export needs it to write an edited example back into that same entry rather than adding a new one beside it.
 
 A response that documents **no body** still imports: `204 No Content` is a real answer and a mock server has to be able to give it.
 

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -424,12 +424,17 @@ Vayu has something to say, and otherwise left exactly as it was:
   or from a response you kept. One example for a status and media type is written
   as `example`; where the response already answers with a named `examples` map,
   the kept response is added to it as another entry and every entry the document
-  had stays. This is where work done in Vayu flows back into the contract. An
-  example Vayu only kept **part** of - the Examples panel marks those, and a big
-  response is capped as it is saved - is the one kind that does not: the status
-  is documented, the body is not, and the dialog counts it. Half a payload
-  written as the payload would be indistinguishable from a complete one to
-  everyone downstream, including the mock server.
+  had stays - unless it is an *edited* import, in which case it is written into
+  the entry it was imported from instead: Vayu remembers which one that was
+  (issue #1457), so the map keeps the same entries it had and only that one's
+  value changes. If the document has since dropped or renamed that entry, it is
+  added beside the rest, same as an example with no such history. This is where
+  work done in Vayu flows back into the contract. An example Vayu only kept
+  **part** of - the Examples panel marks those, and a big response is capped as
+  it is saved - is the one kind that does not: the status is documented, the
+  body is not, and the dialog counts it. Half a payload written as the payload
+  would be indistinguishable from a complete one to everyone downstream,
+  including the mock server.
 - **An example the document already documents is written nowhere**, and neither
   is one the *import* produced for a response that declares no example: the
   import sampled that value off the response's schema, and writing it back would

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -401,6 +401,7 @@ found next to it (Postman's `item.response[]`, an OpenAPI operation's
 | `origin`       | TEXT    | `import` \| `user`; NOT NULL, default `import`     |
 | `body_truncated` | INTEGER | `body` stops short of the captured response; NOT NULL, default `0` |
 | `suppressed`   | INTEGER | A tombstone: an imported example the user deleted; NOT NULL, default `0` |
+| `spec_example_key` | TEXT | The `examples` map key this was imported from; NULL when there is none |
 | `created_at`   | INTEGER | Unix ms                                           |
 | `updated_at`   | INTEGER | Unix ms                                           |
 
@@ -460,6 +461,19 @@ mock server and an export behave exactly as though the delete had removed it -
 and `get_suppressed_request_examples` is the one read that sees them, for the
 one caller that must. A `user` row is still deleted outright: nothing re-creates
 a saved response, so there is no intent to keep.
+
+**spec_example_key** (issue #1457) records which entry of a 3.x response's
+named `examples` map the import took this example's payload from - the *first*
+one, unwrapped, since `firstNamedExample` never read past it. Nullable rather
+than NOT NULL with a default, on the `requests.spec_operation` precedent: a row
+that predates the column, or one taken from a single `example` or sampled off a
+schema, names no entry, and NULL is the only spelling of that - there is
+nothing to backfill it from. It exists because a value comparison alone cannot
+tell an edited example from a new one: once its body has changed, it no longer
+equals the entry it came from, so exporting it back would add it beside that
+entry rather than replace it. The bound export reads the key to find its way
+back to the same entry when the document still declares it, and falls back to
+adding a new one when it does not. Not a display field: no app surface reads it.
 
 **Cascade.** Examples are owned by their request: `DELETE /requests/:id` removes
 them in the same transaction, and the `delete_collection` cascade removes each

--- a/engine/include/vayu/core/openapi_document.hpp
+++ b/engine/include/vayu/core/openapi_document.hpp
@@ -65,6 +65,7 @@
 
 #include <cstddef>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -308,6 +309,16 @@ struct DraftExample {
     /// The payload as text - a documented string verbatim, anything else as
     /// `JSON.stringify(value, null, 2)` writes it.
     std::string body;
+    /**
+     * The key this payload was taken from a 3.x response's `examples` map
+     * (issue #1457), absent when it came from a single `example` or was
+     * sampled off a schema.
+     *
+     * Carried so the bound export can write an edited example back into the
+     * entry it came from rather than adding a new one beside it - the export
+     * cannot ask a value comparison which entry an edited body used to be.
+     */
+    std::optional<std::string> spec_example_key;
 };
 
 /// A draft request's body, in the shape `requests.body` stores.

--- a/engine/include/vayu/core/openapi_export.hpp
+++ b/engine/include/vayu/core/openapi_export.hpp
@@ -98,6 +98,17 @@ struct ExportExample {
      * which is what this export has always written.
      */
     bool from_import = false;
+    /**
+     * The map key the import took this example from, if any
+     * (`request_examples.spec_example_key`, issue #1457).
+     *
+     * A value comparison alone cannot tell an edited example from a new one:
+     * once the body has changed it no longer equals the entry it came from,
+     * so it read as news to the document and was added beside that entry
+     * rather than replacing it. This key, when the document still names it,
+     * says which entry to write into instead of adding a new one.
+     */
+    std::optional<std::string> spec_example_key = std::nullopt;
 };
 
 /** The identity a request carries, when it carries one (`spec_operation`). */

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -442,6 +442,12 @@ inline const char* to_string (ErrorCode code) {
 /**
  * @brief HTTP Response
  */
+// `optin.performance.Padding` is right that size-ordering these fields would
+// save 32 bytes, and the trade is refused deliberately, on the `ReportExtras`
+// precedent (`http/routes/runs.cpp`): the layout groups each field beside the
+// paragraph documenting what it means, and size order would interleave every
+// one of those groups for a saving smaller than one cache line.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct Response {
     int status_code = 0;
     std::string status_text;
@@ -1170,7 +1176,20 @@ struct RequestExample {
      * `false` for every row that predates the column, which is what they all
      * are - a row a delete had reached was gone.
      */
-    bool suppressed    = false;
+    bool suppressed = false;
+    /**
+     * The key this example was taken from a 3.x response's named `examples`
+     * map, if it was (issue #1457). NULL for every row that predates the
+     * column and for one taken from a single `example` or sampled off a
+     * schema - nullable rather than NOT NULL with a default, on the
+     * `Request::spec_operation` precedent: nothing to backfill it from, and
+     * NULL is the only spelling of "records no key".
+     *
+     * Not a display field, the same as `origin`: it exists so the bound
+     * export can write an edited example back into the document entry it
+     * came from instead of adding a new one beside it.
+     */
+    std::optional<std::string> spec_example_key;
     int64_t created_at = 0;
     int64_t updated_at = 0;
 };

--- a/engine/src/core/import_document.cpp
+++ b/engine/src/core/import_document.cpp
@@ -2260,9 +2260,16 @@ json draft_request (const SpecRequestDraft& entry) {
             rows.push_back ({ { "key", "Content-Type" },
             { "value", example.content_type }, { "enabled", true } });
         }
-        examples.push_back ({ { "name", example.name },
-        { "status", example.status }, { "headers", std::move (rows) },
-        { "body", example.body }, { "contentType", example.content_type } });
+        json row = { { "name", example.name }, { "status", example.status },
+            { "headers", std::move (rows) }, { "body", example.body },
+            { "contentType", example.content_type } };
+        // Engine-side provenance only (issue #1457): the renderer never reads
+        // it, but `POST /import/apply` must carry it through to the stored
+        // row so the bound export can find its way back to this entry.
+        if (example.spec_example_key) {
+            row["specExampleKey"] = *example.spec_example_key;
+        }
+        examples.push_back (std::move (row));
     }
 
     json request;

--- a/engine/src/core/openapi_drafts.cpp
+++ b/engine/src/core/openapi_drafts.cpp
@@ -544,17 +544,61 @@ const json* find_json_media (const json& content) {
     return nullptr;
 }
 
-/// `firstNamedExample(examples)`: the first entry of a 3.x `examples` map,
-/// unwrapped from its Example Object. `{"user": {"value": {...}}}` documents
-/// `{...}`, not the wrapper. `externalValue` names a URL rather than carrying a
-/// payload, and an import must not fetch one.
-const json* first_named_example (const json* examples) {
+/// One 3.x `examples` map entry, unwrapped from its Example Object, with the
+/// key it was found at (issue #1457) - what the bound export needs to write
+/// an edited example back into that same entry rather than beside it.
+struct NamedExample {
+    std::string key;
+    const json* value = nullptr;
+};
+
+/// `firstNamedExampleEntry(examples)`: the first entry of a 3.x `examples`
+/// map, unwrapped from its Example Object. `{"user": {"value": {...}}}`
+/// documents `{...}`, not the wrapper. `externalValue` names a URL rather than
+/// carrying a payload, and an import must not fetch one.
+std::optional<NamedExample> first_named_example_entry (const json* examples) {
     const json* map = as_record (examples);
     if (map == nullptr || map->empty ()) {
-        return nullptr;
+        return std::nullopt;
     }
-    const json* entry = as_record (&map->begin ().value ());
-    return entry == nullptr ? nullptr : prop (entry, "value");
+    auto begin        = map->begin ();
+    const json* entry = as_record (&begin.value ());
+    const json* value = entry == nullptr ? nullptr : prop (entry, "value");
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    return NamedExample{ begin.key (), value };
+}
+
+/// `firstNamedExample(examples)`: the value half of `first_named_example_entry`,
+/// for the callers that have no use for which entry it came from.
+const json* first_named_example (const json* examples) {
+    const std::optional<NamedExample> found = first_named_example_entry (examples);
+    return found ? found->value : nullptr;
+}
+
+/// A value found under a media object's `example` or `examples`, and, when it
+/// came from the map, the key it came from (issue #1457).
+struct DeclaredExampleValue {
+    const json* value = nullptr;
+    std::optional<std::string> key;
+};
+
+/// `media.example ?? firstNamedExample(media.examples)`: `??` falls through
+/// `null` as well as absence, so a documented `example: null` is not the
+/// answer - the named example, then nothing, still is. Pulled out of
+/// `examples_v3`'s payload lambda to keep that lambda's own branching within
+/// the cognitive-complexity budget.
+DeclaredExampleValue declared_example_value (const json* media) {
+    if (const json* example = prop (media, "example");
+    example != nullptr && !example->is_null ()) {
+        return { example, std::nullopt };
+    }
+    if (const std::optional<NamedExample> named =
+        first_named_example_entry (prop (media, "examples"))) {
+        return { named->value, named->key };
+    }
+    return { nullptr, std::nullopt };
 }
 
 /**
@@ -673,6 +717,9 @@ std::string example_body_text (const json& value) {
 struct ExamplePayload {
     std::string body;
     std::string content_type;
+    /// The `examples` map key this payload was read from (issue #1457),
+    /// absent when it came from a single `example` or a sampled schema.
+    std::optional<std::string> example_key;
 };
 
 /**
@@ -719,10 +766,11 @@ response_example (const std::string& code, const json* response, ImportTally* ta
     // examples for.
     const std::string* description = as_str (prop (node, "description"));
     example.name = description == nullptr ? code : code + " - " + *description;
-    example.status       = status;
-    example.documented   = found.has_value ();
-    example.content_type = found ? found->content_type : std::string ();
-    example.body         = found ? found->body : std::string ();
+    example.status           = status;
+    example.documented       = found.has_value ();
+    example.content_type     = found ? found->content_type : std::string ();
+    example.body             = found ? found->body : std::string ();
+    example.spec_example_key = found ? found->example_key : std::nullopt;
     return example;
 }
 
@@ -753,18 +801,16 @@ examples_v3 (const Sampler& sampler, const json* responses, ImportTally* tally) 
             if (media == nullptr) {
                 return std::nullopt;
             }
-            // `media.example ?? firstNamedExample(...) ?? sample`: `??` falls
-            // through `null` as well as absence, so a documented `example: null`
-            // is not the answer - the named example, then the schema, still is.
-            const json* value = prop (media, "example");
-            if (value == nullptr || value->is_null ()) {
-                value = first_named_example (prop (media, "examples"));
-            }
-            if (value != nullptr && !value->is_null ()) {
-                return ExamplePayload{ example_body_text (*value), *type };
+            // `declared ?? sample`: see `declared_example_value` for the `??`
+            // this stands in for.
+            const DeclaredExampleValue declared = declared_example_value (media);
+            if (declared.value != nullptr && !declared.value->is_null ()) {
+                return ExamplePayload{ example_body_text (*declared.value),
+                    *type, declared.key };
             }
             if (const json* schema = prop (media, "schema"); truthy (schema)) {
-                return ExamplePayload{ example_body_text (sampler.sample (schema)), *type };
+                return ExamplePayload{ example_body_text (sampler.sample (schema)),
+                    *type, {} };
             }
             return std::nullopt;
         });
@@ -837,14 +883,14 @@ const std::string& content_type) {
             value             = plain != nullptr ? plain : value;
         }
         if (value != nullptr) {
-            return ExamplePayload{ example_body_text (*value), content_type };
+            return ExamplePayload{ example_body_text (*value), content_type, {} };
         }
     }
     const json* schema = prop (&node, "schema");
     if (!truthy (schema)) {
         return std::nullopt;
     }
-    return ExamplePayload{ example_body_text (sampler.sample (schema)), content_type };
+    return ExamplePayload{ example_body_text (sampler.sample (schema)), content_type, {} };
 }
 
 std::vector<DraftExample> examples_v2 (const json& document,

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -252,6 +252,37 @@ const std::vector<Json>& values) {
 }
 
 /**
+ * Several examples of one status and media type, written into an `examples`
+ * map by the entry each was imported from (issue #1457), falling back to
+ * `add_named_examples` for the rest.
+ *
+ * A value comparison alone cannot tell an edited example from a new one, so
+ * an example that named a key when it was imported and whose value has since
+ * changed is written into that map entry - keeping its `summary` and
+ * `description` - rather than beside it. An example naming no key, or one the
+ * document no longer declares (the spec was re-fetched and the entry
+ * renamed), takes today's answer: added under a free key of its own.
+ */
+void write_named_examples (Json& map,
+const std::vector<const ExportExample*>& examples,
+const std::vector<Json>& values) {
+    std::vector<const ExportExample*> unmatched_examples;
+    std::vector<Json> unmatched_values;
+    for (size_t index = 0; index < examples.size (); ++index) {
+        const ExportExample& example = *examples[index];
+        const auto entry =
+        example.spec_example_key ? map.find (*example.spec_example_key) : map.end ();
+        if (entry != map.end () && entry->is_object ()) {
+            (*entry)["value"] = values[index];
+            continue;
+        }
+        unmatched_examples.push_back (examples[index]);
+        unmatched_values.push_back (values[index]);
+    }
+    add_named_examples (map, unmatched_examples, unmatched_values);
+}
+
+/**
  * Stored examples as an operation's `responses`, for both export directions.
  *
  * One implementation, because it is one decision made twice: a bound document
@@ -482,7 +513,7 @@ void write_media_examples (Json& media, const MediaWrite& write, ExportNotes& no
         media["example"] = values.front ();
     } else {
         Json map = examples_map_of (media);
-        add_named_examples (map, writing, values);
+        write_named_examples (map, writing, values);
         media["examples"] = std::move (map);
     }
     notes.examples_written += static_cast<int> (writing.size ());

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -301,6 +301,12 @@ inline auto make_storage (const std::string& path) {
     // precedent as the two columns above, and `false` is right for every
     // pre-existing row: before this column a delete removed the row outright.
     make_column ("suppressed", &RequestExample::suppressed, default_value (false)),
+    // The key of the 3.x response `examples` map entry this example was
+    // imported from (issue #1457). Nullable rather than NOT NULL with a
+    // default, on the `requests.spec_operation` precedent above: nothing to
+    // backfill a pre-existing row from, and NULL is the only spelling of "no
+    // key".
+    make_column ("spec_example_key", &RequestExample::spec_example_key),
     make_column ("created_at", &RequestExample::created_at),
     make_column ("updated_at", &RequestExample::updated_at)),
 

--- a/engine/src/http/routes/examples.cpp
+++ b/engine/src/http/routes/examples.cpp
@@ -125,6 +125,31 @@ RouteResult apply_origin_field (const nlohmann::json& json, std::string& out, bo
     "' or '" + example_bounds::ORIGIN_USER + "'");
 }
 
+/**
+ * The null-vs-absent rule for `specExampleKey` (issue #1457): the `examples`
+ * map key an OpenAPI import took this example from.
+ *
+ * Engine-side provenance, not a field the renderer ever sends - only the two
+ * import writers (`POST /import/apply`, `POST /specs/sync`) name it, through
+ * the same applier every other example write goes through. Nothing here
+ * validates the value beyond the shape: a stale key the document no longer
+ * declares is not this applier's to catch, since it can only be judged
+ * against the document at export time.
+ */
+void apply_spec_example_key_field (const nlohmann::json& json,
+std::optional<std::string>& out,
+bool is_create) {
+    if (!json.contains ("specExampleKey")) {
+        if (is_create) {
+            out = std::nullopt;
+        }
+        return;
+    }
+    out = json["specExampleKey"].is_string () ?
+    std::make_optional (json["specExampleKey"].get<std::string> ()) :
+    std::nullopt;
+}
+
 } // namespace
 
 /**
@@ -177,6 +202,7 @@ bool is_create) {
     // not claim otherwise: only the client that captured the response knows it
     // was cut, and no later read of the row can tell (issue #659).
     apply_bool_field (json, "bodyTruncated", x.body_truncated, false, is_create);
+    apply_spec_example_key_field (json, x.spec_example_key, is_create);
     return apply_origin_field (json, x.origin, is_create);
 }
 

--- a/engine/src/http/routes/spec_export.cpp
+++ b/engine/src/http/routes/spec_export.cpp
@@ -224,7 +224,8 @@ export_spec_response (vayu::db::Database& db, const nlohmann::json& json) {
             for (const auto& example : db.get_request_examples (row.id)) {
                 entry.examples.push_back ({ example.name, example.status,
                 example.body, example.content_type, example.body_truncated,
-                example.origin == vayu::core::constants::request_example::ORIGIN_IMPORT });
+                example.origin == vayu::core::constants::request_example::ORIGIN_IMPORT,
+                example.spec_example_key });
             }
             requests.push_back (std::move (entry));
         }

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -144,9 +144,16 @@ nlohmann::json draft_example_rows (const std::vector<vayu::core::DraftExample>& 
             headers.push_back ({ { "key", "Content-Type" },
             { "value", example.content_type }, { "enabled", true } });
         }
-        rows.push_back ({ { "name", example.name },
-        { "status", example.status }, { "headers", std::move (headers) },
-        { "body", example.body }, { "contentType", example.content_type } });
+        nlohmann::json row = { { "name", example.name },
+            { "status", example.status }, { "headers", std::move (headers) },
+            { "body", example.body }, { "contentType", example.content_type } };
+        // Engine-side provenance only (issue #1457): carried through
+        // `POST /specs/sync` to the stored row so the bound export can write
+        // an edited example back into the entry it came from.
+        if (example.spec_example_key) {
+            row["specExampleKey"] = *example.spec_example_key;
+        }
+        rows.push_back (std::move (row));
     }
     return rows;
 }

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -850,6 +850,85 @@ TEST_F (DatabaseTest, MigratesHttpVersionColumnOntoAPreExistingRequestsTable) {
     sqlite3_close (handle);
 }
 
+// request_examples.spec_example_key (issue #1457) is nullable rather than NOT
+// NULL + default, so there is nothing to backfill: a row from before the
+// column existed simply has no key on it. Simulates the pre-existing table
+// the same way MigratesHttpVersionColumnOntoAPreExistingRequestsTable does.
+TEST_F (DatabaseTest, MigratesSpecExampleKeyColumnOntoAPreExistingExamplesTable) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+
+        Collection col;
+        col.id    = "col_pre_migration";
+        col.name  = "Pre-migration collection";
+        col.order = 0;
+        db.create_collection (col);
+
+        Request r;
+        r.id            = "req_pre_migration";
+        r.collection_id = "col_pre_migration";
+        r.name          = "Pre-migration request";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test/pre-migration";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db.save_request (r);
+
+        RequestExample x;
+        x.id         = "exa_pre_migration";
+        x.request_id = "req_pre_migration";
+        x.name       = "200";
+        x.created_at = 1;
+        x.updated_at = 1;
+        db.save_request_example (x);
+    }
+
+    {
+        sqlite3* handle = nullptr;
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
+        char* err = nullptr;
+        ASSERT_EQ (sqlite3_exec (handle, "ALTER TABLE request_examples DROP COLUMN spec_example_key",
+                   nullptr, nullptr, &err),
+        SQLITE_OK)
+        << (err != nullptr ? err : "(no message)");
+        sqlite3_free (err);
+        sqlite3_close (handle);
+    }
+
+    // Guard the guard: if the drop silently did nothing, the assertion below
+    // would pass without proving anything.
+    {
+        sqlite3* handle = nullptr;
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
+        sqlite3_stmt* stmt = nullptr;
+        ASSERT_EQ (sqlite3_prepare_v2 (handle,
+                   "PRAGMA table_info(request_examples)", -1, &stmt, nullptr),
+        SQLITE_OK);
+        bool has_column = false;
+        while (sqlite3_step (stmt) == SQLITE_ROW) {
+            const auto* col_name = vayu::db::column_text (stmt, 1);
+            if (col_name != nullptr && std::string (col_name) == "spec_example_key") {
+                has_column = true;
+            }
+        }
+        sqlite3_finalize (stmt);
+        sqlite3_close (handle);
+        ASSERT_FALSE (has_column) << "drop did not remove spec_example_key";
+    }
+
+    // The column is back, and the pre-existing row survived with its data
+    // intact and no key to have recorded - not silently dropped and
+    // recreated empty.
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    auto after = reopened.get_request_example ("exa_pre_migration");
+    ASSERT_HAS_VALUE (after);
+    EXPECT_EQ (after->name, "200");
+    EXPECT_FALSE (after->spec_example_key.has_value ());
+}
+
 // A database written by an engine before issue #177 still carries the legacy
 // EAV `metrics` table and its index. sync_schema() only syncs the tables the
 // storage still declares - it never drops the ones removed from it - so

--- a/engine/tests/openapi_drafts_test.cpp
+++ b/engine/tests/openapi_drafts_test.cpp
@@ -21,11 +21,13 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include "optional_assert.hpp"
 #include "vayu/core/openapi_document.hpp"
 
 namespace {
@@ -395,6 +397,57 @@ TEST (SpecRequestDrafts, FilesAnOperationWhereAnImportWouldHavePutIt) {
     // folders is two requests to edit.
     EXPECT_EQ (find_draft (drafts, "GET /pets").folder, "Pets");
     EXPECT_EQ (find_draft (drafts, "GET /v1").folder, "");
+}
+
+TEST (SpecRequestDrafts, RemembersWhichNamedExampleKeyAResponseWasTakenFrom) {
+    // The bound export must write an edited example back into the entry it
+    // came from rather than beside it (issue #1457), which needs the map key
+    // `first_named_example` used to discard.
+    const auto drafts = drafts_of (R"({
+      "openapi": "3.0.0",
+      "paths": { "/pets": { "get": { "operationId": "list", "responses": {
+        "200": { "description": "ok", "content": { "application/json": {
+          "examples": {
+            "two": { "summary": "Two pets", "value": [1, 2] },
+            "none": { "summary": "No pets", "value": [] }
+          }
+        } } } }
+      } } }
+    })");
+    ASSERT_EQ (drafts.size (), 1u);
+    ASSERT_EQ (drafts[0].draft.examples.size (), 1u);
+    // The *first* entry of the map, same as `first_named_example` always took.
+    const std::optional<std::string>& key = drafts[0].draft.examples[0].spec_example_key;
+    ASSERT_HAS_VALUE (key);
+    EXPECT_EQ (*key, "two");
+}
+
+TEST (SpecRequestDrafts, RecordsNoKeyForAnExampleFromASingleExampleOrASampledSchema) {
+    // A single `example` and a schema-sampled value name no map entry - the
+    // key stays absent, which is what makes a row that predates issue #1457
+    // read exactly like one of these.
+    const auto drafts = drafts_of (R"({
+      "openapi": "3.0.0",
+      "paths": {
+        "/pets": { "get": { "operationId": "list", "responses": {
+          "200": { "description": "ok", "content": { "application/json": {
+            "example": [1, 2]
+          } } }
+        } } },
+        "/owners": { "get": { "operationId": "owners", "responses": {
+          "200": { "description": "ok", "content": { "application/json": {
+            "schema": { "type": "object", "example": { "id": "o1" } }
+          } } }
+        } } }
+      }
+    })");
+    ASSERT_EQ (drafts.size (), 2u);
+    ASSERT_EQ (find_draft (drafts, "GET /pets").draft.examples.size (), 1u);
+    EXPECT_FALSE (
+    find_draft (drafts, "GET /pets").draft.examples[0].spec_example_key.has_value ());
+    ASSERT_EQ (find_draft (drafts, "GET /owners").draft.examples.size (), 1u);
+    EXPECT_FALSE (
+    find_draft (drafts, "GET /owners").draft.examples[0].spec_example_key.has_value ());
 }
 
 } // namespace

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -122,6 +122,13 @@ ExportExample imported (ExportExample stored) {
     return stored;
 }
 
+/** The same example, with the `examples` map key the import took it from
+ * recorded (`request_examples.spec_example_key`, issue #1457). */
+ExportExample with_key (ExportExample stored, std::string key) {
+    stored.spec_example_key = std::move (key);
+    return stored;
+}
+
 ExportKeyValue row (std::string key, std::string value) {
     return { std::move (key), std::move (value), {} };
 }
@@ -289,6 +296,43 @@ TEST (BoundExport, AddsAKeptResponseBesideTheDocumentsExamplesRatherThanOverThem
     EXPECT_EQ (media["examples"]["none"]["summary"], "No pets");
     EXPECT_EQ (media["examples"]["Rex alone"]["value"], json::parse (R"([{"id":"p9"}])"));
     EXPECT_FALSE (media.contains ("example"));
+    EXPECT_EQ (exported.notes.examples_written, 1);
+}
+
+TEST (BoundExport, RewritesAnEditedImportedExampleIntoTheKeyItCameFromRatherThanBesideIt) {
+    std::vector<ExportRequest> requests = refs_requests ();
+    // Imported from `examples.two`, then edited: the value no longer equals
+    // what the document declares there, so a value comparison alone would
+    // read this as news and add it as a third entry (issue #1457).
+    requests[0].examples = { with_key (
+    imported (example ("200 - A list of pets", 200, R"([{"id":"p9","name":"Rex"}])")), "two") };
+
+    const Exported exported = export_json (requests, refs_fixture ());
+    const json& media       = operation_of (exported.document, "/pets",
+          "get")["responses"]["200"]["content"]["application/json"];
+    // The entry it was imported from, not a new one beside it: both original
+    // keys survive, `two`'s summary is untouched, and only its value changed.
+    EXPECT_EQ (keys_of (media["examples"]), (std::vector<std::string>{ "two", "none" }));
+    EXPECT_EQ (media["examples"]["two"]["summary"], "Two pets");
+    EXPECT_EQ (media["examples"]["two"]["value"],
+    json::parse (R"([{"id":"p9","name":"Rex"}])"));
+    EXPECT_EQ (media["examples"]["none"]["summary"], "No pets");
+    EXPECT_EQ (exported.notes.examples_written, 1);
+}
+
+TEST (BoundExport, AddsANewEntryWhenItsRecordedKeyIsNoLongerInTheDocument) {
+    std::vector<ExportRequest> requests = refs_requests ();
+    // The spec was re-fetched and the entry renamed since this was imported:
+    // the recorded key is gone, so this falls back to today's add-beside
+    // behaviour rather than being dropped.
+    requests[0].examples = { with_key (
+    imported (example ("Rex alone", 200, R"([{"id":"p9"}])")), "renamed") };
+
+    const Exported exported = export_json (requests, refs_fixture ());
+    const json& media       = operation_of (exported.document, "/pets",
+          "get")["responses"]["200"]["content"]["application/json"];
+    EXPECT_EQ (keys_of (media["examples"]),
+    (std::vector<std::string>{ "two", "none", "Rex alone" }));
     EXPECT_EQ (exported.notes.examples_written, 1);
 }
 


### PR DESCRIPTION
## Description

**Root cause.** The OpenAPI import unwraps the first entry of a response's named `examples` map (`first_named_example`, `openapi_drafts.cpp`) but discards the map key it read the payload from - only the value survives into the stored example. The bound export (#1442/#1456) tells an unedited imported example apart from the document by comparing values: an example equal to something the media object already declares is already in the contract and is counted rather than written. That comparison is exact for an example nobody touched, but once a user edits an imported example's body in the Examples panel, its value no longer equals the entry it came from - so it reads as *news* to the document and is added as a new named entry beside the original, rather than replacing it. The document ends up documenting the same response twice, with only the user knowing which is current.

**Approach.** Record the key the import took (`RequestExample.spec_example_key`, a nullable column with nothing to backfill - the same shape as `Request.spec_operation`), thread it through the draft (`DraftExample`) and both import-apply payloads (`POST /import/apply`, `POST /specs/sync`) via the existing `apply_request_example_fields` applier, and carry it into `ExportExample` at export time. `write_media_examples` now looks the key up in the response's *current* `examples` map before falling back to today's add-a-new-entry behavior: a match overwrites just that entry's `value` (keeping its `summary`/`description`), and no match - no key recorded, or the document has since dropped/renamed the entry - takes the existing path unchanged.

**Rejected alternative:** re-deriving the key at export time by matching the stored body against the map (what #1442/#1456 already does for the "is this already in the contract" question). That is exactly the comparison this issue exists to say is not enough once the body has changed - it can tell "already declared" from "new", but not "which entry this used to be."

While in `openapi_drafts.cpp`, the named-example lookup used by both the parameter-example path and the response-example path was pulled into one `first_named_example_entry` helper (returning key + value) so `first_named_example` (still value-only, for the parameter path) and the response path share one implementation rather than duplicating the map-walk. The response path's payload lambda was also extracted from a growing `??`-chain into `declared_example_value` to keep it under the engine's cognitive-complexity gate once the key had to travel through it too.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **2933 engine tests, all passing** (fresh full-suite run, no pre-existing failures on this base).
- `ctest --preset linux-dev -R "BoundExport|SpecRequestDrafts|SkeletonExport|SpecExportRouteTest|MigratesSpecExampleKey"` - 96/96 pass, including the 5 new cases this PR adds:
  - `BoundExport.RewritesAnEditedImportedExampleIntoTheKeyItCameFromRatherThanBesideIt` / `BoundExport.AddsANewEntryWhenItsRecordedKeyIsNoLongerInTheDocument` (`openapi_export_test.cpp`, on the existing `petstore-refs-bound.json` fixture's `examples: {two, none}` response).
  - `SpecRequestDrafts.RemembersWhichNamedExampleKeyAResponseWasTakenFrom` / `SpecRequestDrafts.RecordsNoKeyForAnExampleFromASingleExampleOrASampledSchema` (`openapi_drafts_test.cpp`).
  - `DatabaseTest.MigratesSpecExampleKeyColumnOntoAPreExistingExamplesTable` (`db_test.cpp`), following the `MigratesHttpVersionColumnOntoAPreExistingRequestsTable` precedent: drops the column externally, reopens, and asserts a pre-existing row reads back with no key.
- Mutation-checked by hand: reverted `write_media_examples`'s key lookup back to the old `add_named_examples`-only call, rebuilt, and confirmed `RewritesAnEditedImportedExampleIntoTheKeyItCameFromRatherThanBesideIt` reds with a third entry added (`AddsANewEntryWhenItsRecordedKeyIsNoLongerInTheDocument` still passes, as expected since that case has no matching key to find either way); restored, both green again.
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (via the repo's pre-commit hook) clean on every touched file.

**No user-visible change** - the fix pathway's own "App changes: None required" holds: the key is engine-side provenance (`RequestExample.spec_example_key`) that no HTTP response serializes (`vayu::json::serialize`) and no renderer type or MCP tool reads, the same way `suppressed`/`order`/timestamps are already omitted from that serializer. `POST /requests/:id/examples` and `PUT /requests/:id/examples/:exampleId` accept the field through the same applier the two import writers use, but nothing in the app or MCP server ever sends it.

## Also fixed in this PR

- `struct vayu::Response` in `engine/include/vayu/types.hpp` picked up a pre-existing `clang-analyzer-optin.performance.Padding` finding once this change touched the file (CI lints whole files a change touches). Suppressed with a one-line `NOLINTNEXTLINE`, on the exact precedent `http/routes/runs.cpp`'s `ReportExtras` already sets for this same check: the fields are grouped by meaning beside their explanatory comments, and reordering by size would interleave every one of those groups for well under a cache line's saving. Unrelated to this issue's own change (the struct's layout is untouched); noted here per the "adjacent one-line fix that needs no design decision" rule rather than filed separately.

## Docs, same commit

`docs/engine/db-schema.md` (new column + prose paragraph), `docs/app/import-collections/openapi-v3.md` (the "first named example" sentence gains that the key is remembered), `docs/app/openapi.md` (the bound export's "saved examples become response examples" bullet states the key-based overwrite and its fallback).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1457

---
_Generated by [Claude Code](https://claude.ai/code/session_016wALCCbcamsA1k62b9BCb9)_