### PR TITLE
fix(app): give the inbox reply-headers table header-name suggestions

### DIFF
--- a/app/src/modules/inbox/CannedResponseControls.test.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.test.tsx
@@ -234,6 +234,24 @@ describe("the key/value table it borrows", () => {
 		expect(headerName(0)).toHaveValue("X-Trace");
 	});
 
+	it("completes header names, the same list the request builder offers", () => {
+		// #1449: this table is the one `KeyValueEditor` header mount without
+		// `keySuggestions` - a hand-rolled copy of the primitive that missed the
+		// fix `HeadersPanel` already carries.
+		render(
+			<CannedResponseControls
+				response={response({ body: "hi" })}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn()}
+			/>
+		);
+
+		fireEvent.focus(headerName(0));
+		fireEvent.change(headerName(0), { target: { value: "Cont" } });
+		expect(screen.getByText("Content-Type")).toBeInTheDocument();
+	});
+
 	it("offers no variable affordances, because a canned reply has no scope", () => {
 		// `{{trace}}` is sent verbatim by the engine. A token here would colour
 		// it "not defined" and open an editor with nowhere to write.

--- a/app/src/modules/inbox/CannedResponseControls.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.tsx
@@ -35,6 +35,7 @@ import { toKeyValueItems } from "@/components/shared/KeyValueEditor/key-value";
 import type { InboxCannedResponse, KeyValueItem } from "@/types";
 import { useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
+import { STANDARD_HEADERS } from "@/constants/http";
 
 /**
  * The engine's cap on the artificial delay (`MAX_RESPONSE_DELAY_MS`).
@@ -243,6 +244,7 @@ export function CannedResponseControls({
 							valuePlaceholder="Value"
 							allowDisable={false}
 							readOnly={disabled}
+							keySuggestions={STANDARD_HEADERS}
 						/>
 					</div>
 				</div>

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -675,7 +675,9 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   [`KeyValueEditor`](#shared-keyvalue-editor-componentssharedkeyvalueeditor) rows, with no `variables` scope
   passed - a canned reply is echoed verbatim, so there is nothing to resolve. They were local
   `Input` pairs until #564 made the primitive mountable outside `RequestBuilderProvider`; the
-  table's trailing blank row replaced the panel's own "Add header" button.
+  table's trailing blank row replaced the panel's own "Add header" button. Header names complete
+  from the same `STANDARD_HEADERS` list as the request builder's Headers tab (#1449) - the mount
+  had reused the primitive without its header-specific suggestion prop.
 - `capture-notifier.ts` - the OS notification a capture raises while Vayu is in the background
   (issue #1388), and the two gates it passes first: the global opt-in, read by `services/notify.ts`
   for every kind, and this inbox's own `Notify` toggle in the header, read here and off by default.


### PR DESCRIPTION
## Description

**Root cause and approach.** `KeyValueEditor` (`components/shared/KeyValueEditor`) takes an optional `keySuggestions` prop that feeds `VariableInput`'s plain-text completion list. The request builder's Headers tab passes it (`HeadersPanel.tsx:160`, `keySuggestions={STANDARD_HEADERS}`), but the webhook inbox's canned-reply headers table mounts the same primitive without it (`CannedResponseControls.tsx`) - the "hand-rolled copy of a primitive misses the primitive's fixes" shape in its mildest form, since both are the exact same component. Verified there are exactly four `<KeyValueEditor` mounts in `app/src` (params, headers, form-data, and this one), and this was the only header-name editor of the four without the list.

Fix is the one line the issue names: import `STANDARD_HEADERS` from `@/constants/http` and pass `keySuggestions={STANDARD_HEADERS}` on the inbox's mount, matching `HeadersPanel` exactly.

**Rejected:** splitting `STANDARD_HEADERS` into request/response-oriented lists (the issue's optional item 3, e.g. adding `Set-Cookie`/`Retry-After`/`Location` for a reply editor). That is a product decision about which headers belong on which surface, not something this defect's acceptance criteria asks for - the criteria only requires the *same* suggestions the request builder already offers. Left out to keep the fix to what was asked.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test CannedResponseControls HeadersPanel inbox` - 15 files, 125 tests, all passing, including the new case.
- `cd app && pnpm test` - full suite, 698 files / 7987 tests, all passing (no pre-existing failures).
- `pnpm type-check` and `pnpm lint` clean.
- `npx prettier --check` clean on both touched app files.
- New case: `CannedResponseControls.test.tsx`, "completes header names, the same list the request builder offers" - opens the panel, focuses the trailing blank header-name row, types `Cont`, asserts `Content-Type` appears in the suggestion list.
- Mutation-checked by hand: reverted the `keySuggestions` prop, reran `pnpm test CannedResponseControls` - the new case reds (`getByText("Content-Type")` finds nothing) while the other 9 cases stay green; restored, all 10 green again.

No engine or MCP change: this is a renderer-only prop addition to an existing shared component.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**No user-visible design change** - this adds an existing affordance (header-name autocomplete) to a surface that already has every other `KeyValueEditor` feature; there is nothing new to screenshot beyond a dropdown the request builder's Headers tab already shows identically.

## Docs, same commit

`docs/app/COMPONENTS.md`'s `CannedResponseControls.tsx` bullet gains a sentence noting header names complete from the same `STANDARD_HEADERS` list as the request builder's Headers tab.

## Related Issues
Closes #1449


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdMn4df2DEAEr33DzvwEwe)_