### PR TITLE
fix(app): auto-write Content-Type on switching the Body panel to json

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.test.tsx
@@ -66,10 +66,14 @@ describe("when a mode needs a Content-Type", () => {
 		expect(contentTypeToAdd("xml", [])).toBe("application/xml");
 	});
 
-	it.each(["none", "json", "text", "form-data", "x-www-form-urlencoded"] as const)(
+	it("asks for one on JSON, the panel's most common mode", () => {
+		expect(contentTypeToAdd("json", [])).toBe("application/json");
+	});
+
+	it.each(["none", "text", "form-data", "x-www-form-urlencoded"] as const)(
 		"asks for nothing on %s",
 		(mode) => {
-			// Only the three modes above write a header the user did not type. The
+			// Only the four modes above write a header the user did not type. The
 			// others declare a content type, but the engine sets it from the mode.
 			expect(contentTypeToAdd(mode, [])).toBeNull();
 		}
@@ -184,10 +188,10 @@ describe("what a mode change does to the header", () => {
 		expect(off.added).toBeNull();
 	});
 
-	it.each(["json", "text", "form-data", "x-www-form-urlencoded"] as const)(
+	it.each(["text", "form-data", "x-www-form-urlencoded"] as const)(
 		"removes it on the way to %s too",
 		(mode) => {
-			// JSON declares the same content type, but the engine sets it from the
+			// These modes declare a content type, but the engine sets it from the
 			// mode - the row we wrote is still ours to clear.
 			const on = intoGraphql();
 			expect(switchContentType(mode, on.headers, REQUEST, on.auto).headers).toEqual(base);
@@ -227,7 +231,7 @@ describe("what a mode change does to the header", () => {
 	it("returns the same array when there is nothing to do", () => {
 		// The panel skips `updateField` on identity, so an unrelated mode change
 		// must not mark the request dirty.
-		const result = switchContentType("json", base, REQUEST, null);
+		const result = switchContentType("text", base, REQUEST, null);
 		expect(result.headers).toBe(base);
 	});
 
@@ -254,6 +258,16 @@ describe("what a mode change does to the header", () => {
 		// And leaving JSON-RPC still takes back the row GraphQL added.
 		expect(switchContentType("none", rpc.headers, REQUEST, rpc.auto).headers).toEqual(base);
 	});
+
+	it("keeps it across GraphQL and JSON, which need the same one", () => {
+		// json now auto-writes the same header, so switching into it from GraphQL
+		// must not churn the row any more than switching to JSON-RPC does.
+		const on = intoGraphql();
+		const json = switchContentType("json", on.headers, REQUEST, on.auto);
+		expect(json.headers).toBe(on.headers);
+		expect(json.auto).toBe(on.auto);
+		expect(json.added).toBeNull();
+	});
 });
 
 describe("what a mode requires", () => {
@@ -262,7 +276,7 @@ describe("what a mode requires", () => {
 		// there; the switch needs "does this mode still want that value?", which
 		// must stay true for a request that already carries it.
 		expect(requiredContentType("graphql")).toBe("application/json");
-		expect(requiredContentType("json")).toBeNull();
+		expect(requiredContentType("text")).toBeNull();
 	});
 });
 

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.ts
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.ts
@@ -52,9 +52,10 @@ export const CONTENT_TYPE = "Content-Type";
  * when the request says it is, and without this the document goes out under
  * libcurl's default `application/x-www-form-urlencoded`.
  *
- * `json` and `text` are deliberately absent. They are the modes a user reaches
- * for when they are writing the header themselves, and adding one on their
- * behalf would take a choice away rather than complete one.
+ * `json` is the Body panel's most common mode, so it earns the same auto-write
+ * rather than staying silent about what the engine already implies for it.
+ * `text` is deliberately absent: it is the mode a user reaches for precisely
+ * to write the header themselves, and it implies nothing on the engine side.
  *
  * This table is the app-side half of the engine's `implied_content_type`
  * (`engine/src/http/form_body.cpp`); the two must name the same type per mode.
@@ -62,6 +63,7 @@ export const CONTENT_TYPE = "Content-Type";
  * row the panel writes, so the user can see and edit what will be sent.
  */
 const REQUIRED_CONTENT_TYPE: Partial<Record<BodyMode, string>> = {
+	json: "application/json",
 	graphql: "application/json",
 	jsonrpc: "application/json",
 	xml: "application/xml",


### PR DESCRIPTION
## Description

`content-type.ts`'s `REQUIRED_CONTENT_TYPE` auto-writes/removes a Content-Type
header row when the Body panel's mode switches, but only listed
`graphql`/`jsonrpc` → `application/json` and `xml` → `application/xml`. The
engine's mirror of the same rule, `implied_content_type`
(`engine/src/http/form_body.cpp`), has a fourth case - `BodyMode::Json` →
`application/json` - that this table did not carry, so switching the panel to
json (its most common mode) left the Headers tab undersell what the request
actually sends. The wire itself was unaffected (the engine already implies the
header at send time); this is purely a UI-consistency gap.

Plan: add `json: "application/json"` to `REQUIRED_CONTENT_TYPE`, mirroring the
engine's table exactly. The auto-add/auto-remove/never-override-a-declaration
machinery already lives in the shared `switchAutoHeader` primitive
(`utils/auto-header.ts`), so the table entry is the whole fix - no change to
`BodyPanel.tsx` or the codegen mirror in `services/codegen/prepare.ts` (which
already had `json` in its own independently-maintained table, fixed in #1445).
Rejected alternative: none considered - the fix pathway in the issue was
exact, and `prepare.ts`, `content-type.ts` and the engine's table are three
deliberately separate mirrors of one rule, so this issue's scope is this one
file.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `pnpm test content-type` - 34/34 passed. Updated the existing suite: the
  "asks for nothing on json" and "removes it on the way to json" cases moved
  out of their `it.each` lists (json now behaves like graphql/jsonrpc, not
  like text/form-data), `requiredContentType("json")` no longer asserts
  `null`, and a new "keeps it across GraphQL and JSON" case pins the
  same-header-no-churn behavior for the new pair, mirroring the existing
  GraphQL/JSON-RPC case.
- `pnpm test auto-records-per-request` - 18/18 passed (uses `switchContentType`
  but only ever with `graphql`/`none`, unaffected).
- `pnpm test BodyPanel` - 24/24 passed.
- Full app suite (`pnpm test`) - 7986/7986 passed.
- `pnpm type-check` - clean.
- `pnpm lint` - clean.
- `pnpm format:check` - clean.

## Docs, same commit

Checked `docs/app/COMPONENTS.md`'s Body panel description and
`docs/app/api-integration.md` per the issue's note: neither enumerates a count
of auto-implied modes that would need bumping from three to four (they
describe jsonrpc's and xml's auto-header individually, not a table size), so
no doc change was needed.

No user-visible change beyond the Headers tab now showing the row json mode
already implies on the wire - no screenshot needed for a single auto-written
header row; the behavior is proven by the tests above, and the existing test
suite for graphql/jsonrpc/xml (unchanged) covers what json now matches.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #1462
