### PR TITLE
fix(engine): stop a skeleton export/import cycle from accreting a status prefix

### DIFF
--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -511,6 +511,30 @@ ExportNotes& notes) {
     }
 }
 
+/**
+ * The description an undeclared response's Response Object is written with.
+ *
+ * The example's own name is what the user (or the import) called it, which
+ * beats a generated line - and `response_example` always names a described
+ * response "<status> - <description>", so a single leading copy of that
+ * prefix is the normal, first-generation shape and stays. Only a *doubled*
+ * prefix is rewritten: reimporting a prior export's own generated
+ * description prepends the prefix again on top of the one it already carries,
+ * and writing that back verbatim would accrete another copy every further
+ * export/reimport cycle. One copy of the doubled pair is stripped so the text
+ * a fresh export produces stays the same across repeated cycles.
+ */
+std::string undeclared_response_description (const std::string& status,
+const std::string& example_name) {
+    const std::string self_prefix    = status + " - ";
+    const std::string doubled_prefix = self_prefix + self_prefix;
+    const std::string description =
+    example_name.compare (0, doubled_prefix.size (), doubled_prefix) == 0 ?
+    example_name.substr (self_prefix.size ()) :
+    example_name;
+    return description.empty () ? status + " response" : description;
+}
+
 void write_response_examples (Json& responses,
 const std::vector<ExportExample>& examples,
 ExportNotes& notes,
@@ -563,13 +587,10 @@ ExportDirection direction) {
         }
         if (!declared_here) {
             // A Response Object's `description` is required, so one has to be
-            // written for a status the document does not already document. The
-            // example's own name is what the user (or the import) called it,
-            // which beats a generated line - and an existing description is
-            // never replaced.
+            // written for a status the document does not already document, and
+            // an existing description is never replaced.
             responses[status] = Json{ { "description",
-            group.front ()->name.empty () ? status + " response" :
-                                            group.front ()->name } };
+            undeclared_response_description (status, group.front ()->name) } };
         }
         Json& response = responses[status];
         for (const auto& [content_type, write] : planned) {

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -792,6 +792,20 @@ TEST (SkeletonExport, WritesResponsesFromStoredExamplesAndNothingElse) {
     EXPECT_EQ (exported.notes.examples_written, 2);
 }
 
+TEST (SkeletonExport, StripsARepeatedStatusPrefixInsteadOfAccretingOneOnEveryReimport) {
+    // "200 - 200 - A user" is what `response_example` derives on import from a
+    // prior export's own generated description "200 - A user" - the reimported
+    // example carries the status prefix twice. Exporting it again must land
+    // back on the single-prefix form, not "200 - 200 - 200 - A user".
+    ExportRequest entry = request ("GET", "{{baseUrl}}/pets");
+    entry.examples      = { example ("200 - 200 - A user") };
+
+    const Exported exported = export_json ({ entry });
+    const json& responses =
+    operation_of (exported.document, "/pets", "get")["responses"];
+    EXPECT_EQ (responses["200"]["description"], "200 - A user");
+}
+
 TEST (SkeletonExport, DerivesNoSchemaFromABodyItOnlyHasPartOf) {
     ExportExample partial  = example ();
     partial.body           = R"({"id":"p1","na")";


### PR DESCRIPTION
## Description

`write_response_examples` (`engine/src/core/openapi_export.cpp`) wrote an undeclared response's `description` straight from the stored example's `name`. `response_example` (`engine/src/core/openapi_drafts.cpp`) always names a described response `"<status> - <description>"` on import. Reimporting a skeleton export's own generated description therefore doubled that prefix, and every further export/reimport cycle added another copy - a free-form collection round-tripped through OpenAPI a few times grew `"200 - 200 - 200 - ..."` onto its response descriptions forever.

**Plan (root cause, approach, rejected alternative):** the fix intercepts the one write site (`write_response_examples`'s undeclared-response branch) and extracts `undeclared_response_description`, which distinguishes a normal *first-generation* name (a single leading `"<status> - "`, which is how every described response is named on import, real or previously exported - left untouched) from a *doubled* prefix (the mark of reimporting Vayu's own already-generated description - one copy is stripped). I considered the issue's alternative fix pathway (b): dropping the example name entirely for undeclared responses and always writing a fixed placeholder like `"<status> response"`. That trivially satisfies round-trip stability from any starting text, but throws away the informative description for every skeleton export, not just reimported ones, and the issue's own text prefers keeping it informative when a reviewer doesn't object - so I kept (a).

**Deliberate scope note:** the fix guarantees a stable, non-growing description from the second export onward - reimporting an already-doubled name always collapses back to the same single-prefixed text, which is the "accretes ... on every round trip" defect the issue names and what the new test pins. It does not make the *very first* export/reimport/export triple byte-identical when the original example name never carried the status prefix at all (e.g. a live-saved example whose name isn't of the `"<status> - X"` shape) - `response_example` unconditionally adds one prefix layer on that first reimport regardless of the fix, and this one-time shift exists identically in the pre-fix code too, so it isn't a regression. Flagging this rather than silently taking the narrower reading of the acceptance criteria.

## Type of Change
- [x] Bug fix

## Testing

- Added `SkeletonExport.StripsARepeatedStatusPrefixInsteadOfAccretingOneOnEveryReimport` (`engine/tests/openapi_export_test.cpp`), a mutation-check case: starting from `"200 - 200 - A user"` (what `response_example` derives on reimport of a prior export's `"200 - A user"`), asserts the second export's description is `"200 - A user"`, not a third accreted prefix. Reverting the fix reds this case.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2942/2942 passed** (0 failures), including all `SkeletonExport`/`BoundExport` cases.
- `clang-format-19 --style=file` and the repo's clang-tidy pre-commit hook both pass on the changed files.

## No user-visible change

Engine-only fix to OpenAPI export text generation; no app or MCP surface is touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (none needed - confirmed no doc in `docs/` describes this generated-description text; only the code comment does, which is updated)

## Related Issues
Closes #1464
