### PR TITLE
fix(engine): stop the skeleton export from writing two Parameter Objects for a duplicated Params/Headers key

### DIFF
--- a/app/src/modules/collections/ExportSpecDialog.test.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.test.tsx
@@ -67,6 +67,7 @@ function notes(overrides: Partial<ExportNotes> = {}): ExportNotes {
 		formValuesDropped: 0,
 		settingsDropped: 0,
 		exampleHeadersDropped: 0,
+		duplicateParameterRowsDropped: 0,
 		...overrides,
 	};
 }
@@ -262,6 +263,7 @@ describe("ExportSpecDialog", () => {
 					formValuesDropped: 1,
 					settingsDropped: 1,
 					exampleHeadersDropped: 2,
+					duplicateParameterRowsDropped: 1,
 				}),
 			})
 		);
@@ -269,6 +271,9 @@ describe("ExportSpecDialog", () => {
 
 		expect(await screen.findByText(/A skeleton document/)).toBeTruthy();
 		const lines = screen.getAllByRole("listitem").map((li) => li.textContent);
+		expect(lines).toContain(
+			"1 row sharing a key and location with an earlier row - only the first is declared"
+		);
 		expect(lines).toContain(
 			"1 request whose auth OpenAPI has no securityScheme for - not written"
 		);
@@ -350,10 +355,12 @@ describe("ExportSpecDialog", () => {
 		const placeholder = screen.getByRole("status", { name: "Assembling the document" });
 		expect(placeholder.className).toContain("surface-sunken");
 		// A heading bar, two for the paragraph that wraps under it, and a row per
-		// count: fourteen, the same for both directions since issue #1441. jsdom
-		// measures no heights, so the row counts those heights come from are what
-		// a test can hold.
-		expect(placeholder.querySelectorAll('[data-slot="skeleton"]').length).toBe(17);
+		// count. The skeleton direction lists one more row than the bound
+		// direction since issue #1465 (fifteen vs fourteen), and the placeholder
+		// holds the larger of the two so neither answer grows the dialog when it
+		// lands. jsdom measures no heights, so the row counts those heights come
+		// from are what a test can hold.
+		expect(placeholder.querySelectorAll('[data-slot="skeleton"]').length).toBe(18);
 
 		first.settle(answer());
 		expect(await screen.findByText(/own document, updated/)).toBeTruthy();

--- a/app/src/modules/collections/ExportSpecDialog.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.tsx
@@ -208,14 +208,16 @@ function errorText(error: unknown): string {
  * moves the top edge as well as the bottom, and the whole window reads as
  * flickering.
  *
- * Which direction ran is not known until the answer lands, but the two shapes
- * agree on their length since issue #1441 gave the free-form direction its own
- * eight counts: both list fourteen rows, so the card that arrives moves the
- * dialog's edge by nothing regardless of which one ran. The paragraph above
- * them is two bars because the sentence it stands for wraps at this width in
- * both directions.
+ * Which direction ran is not known until the answer lands. Issue #1441 gave
+ * the free-form direction its own eight counts, matching the bound
+ * direction's fourteen rows; issue #1465 added a ninth skeleton-only count
+ * (a duplicated Params/Headers row), so the skeleton direction now lists
+ * fifteen. The placeholder holds the larger of the two, so a bound answer
+ * settling in never grows the dialog and a skeleton answer never does either.
+ * The paragraph above them is two bars because the sentence it stands for
+ * wraps at this width in both directions.
  */
-const PLACEHOLDER_ROWS = 14;
+const PLACEHOLDER_ROWS = 15;
 
 function SummarySkeleton() {
 	return (
@@ -319,6 +321,11 @@ function ExportSummary({ notes }: { notes: ExportNotes }) {
 							count={notes.duplicateOperations}
 							label="request"
 							suffix="on a method and path another request already claimed - left out"
+						/>
+						<Line
+							count={notes.duplicateParameterRowsDropped}
+							label="row"
+							suffix="sharing a key and location with an earlier row - only the first is declared"
 						/>
 						<Line
 							count={notes.authDropped}

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -1890,6 +1890,8 @@ export interface ExportNotes {
 	settingsDropped: number;
 	/** Stored examples carrying a header besides `Content-Type`. */
 	exampleHeadersDropped: number;
+	/** Params or Headers rows sharing a key and location with an earlier row - only the first is written. */
+	duplicateParameterRowsDropped: number;
 }
 
 export interface SpecExportResponse {

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -522,7 +522,9 @@ Everything in it is something the collection actually holds:
   toggle itself is stated explicitly as `x-vayu-enabled`, since neither a value
   nor its absence says so on its own: a disabled row can carry a value and an
   enabled one can carry none. `Authorization` and `Content-Type` are left out,
-  the two an import also drops.
+  the two an import also drops. OpenAPI allows only one Parameter Object per
+  name and location, so two rows sharing both write only the first - the rest
+  are counted, never a second entry the specification forbids.
 - **No schema Vayu did not see.** A request or response body is described only
   where there is a body to read a shape off, and what is written is the shape of
   that one example - types, nothing more - carrying a `description` that says so.
@@ -547,7 +549,7 @@ sampled off a schema when the document was imported), the `$ref` responses and
 to express - a request body, a row the operation declares no parameter for, and
 a request whose method or path is no longer the operation it is stamped as.
 
-A free-form export states eight things of its own, because a collection holds
+A free-form export states nine things of its own, because a collection holds
 more than OpenAPI has names for: the auth it could not turn into a
 `securityScheme`, a request carrying a pre- or post-request script (OpenAPI has
 no operation-scoped hook for one), a collection variable besides `baseUrl` (a
@@ -555,8 +557,9 @@ document has nowhere else to declare one), a folder nested more than one level
 (flattened to a single tag), a body in a mode this direction has no media type
 for (GraphQL today), a form body's field values (only the names are declared),
 a request holding a non-default execution setting (redirects, TLS verification,
-HTTP version, streaming - OpenAPI describes an API, not how to send to it), and
-an example's header besides `Content-Type`.
+HTTP version, streaming - OpenAPI describes an API, not how to send to it), an
+example's header besides `Content-Type`, and a Params or Headers row sharing a
+key and location with one already declared (only the first is written).
 
 A large document takes a moment to put together, and the dialog says so without
 moving anything: on the first read it holds the summary's shape until the

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2251,7 +2251,8 @@ of the export, because its requests describe the very operations being patched.
     "bodiesDropped": 0,
     "formValuesDropped": 0,
     "settingsDropped": 0,
-    "exampleHeadersDropped": 0
+    "exampleHeadersDropped": 0,
+    "duplicateParameterRowsDropped": 0
   }
 }
 ```
@@ -2339,6 +2340,10 @@ this direction has no media type for - GraphQL today), `formValuesDropped` (a
 form body's field values, its names still declared), `settingsDropped` (a
 non-default redirect, TLS, HTTP-version or streaming setting), and
 `exampleHeadersDropped` (a stored example's header besides `Content-Type`).
+A Params or Headers row sharing a key and location with an earlier row would
+produce two Parameter Objects for the same name+location, which OpenAPI
+forbids - only the first is written and the rest are counted as
+`duplicateParameterRowsDropped`.
 
 **Errors:** `400` for a missing or empty `collectionId`, or a `format` other
 than `json`/`yaml`. `404` when the collection does not exist. `409` when the

--- a/engine/include/vayu/core/openapi_export.hpp
+++ b/engine/include/vayu/core/openapi_export.hpp
@@ -338,6 +338,11 @@ struct ExportNotes {
     int settings_dropped = 0;
     /// Stored examples carrying a header besides `Content-Type` - not written.
     int example_headers_dropped = 0;
+    /// Params or Headers rows sharing a key and location with an earlier row -
+    /// OpenAPI allows only one Parameter Object per name+location, so only the
+    /// first is written and the rest are dropped rather than producing an
+    /// invalid document with two entries for the same name.
+    int duplicate_parameter_rows_dropped = 0;
 };
 
 /**

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -1447,16 +1447,31 @@ SecuritySchemeRegistry& schemes) {
 
     Json parameters = Json::array ();
     append_path_parameters (templated, parameters);
+    // OpenAPI defines a unique parameter by name+location, so two rows sharing
+    // both would produce an invalid document; only the first is written, the
+    // same row `patch_parameters` matches on the bound direction.
+    std::unordered_set<std::string> declared_parameters;
     for (const ExportKeyValue& row : entry.params) {
-        if (!row.key.empty ()) {
-            parameters.push_back (parameter_object (row, "query"));
+        if (row.key.empty ()) {
+            continue;
         }
+        if (!declared_parameters
+            .insert ("query:" + vayu::utils::ascii_lower (row.key))
+            .second) {
+            notes.duplicate_parameter_rows_dropped += 1;
+            continue;
+        }
+        parameters.push_back (parameter_object (row, "query"));
     }
     for (const ExportKeyValue& row : entry.headers) {
         const std::string key = vayu::utils::ascii_lower (row.key);
         if (row.key.empty () ||
         std::find (NON_PARAMETER_HEADERS.begin (), NON_PARAMETER_HEADERS.end (),
         key) != NON_PARAMETER_HEADERS.end ()) {
+            continue;
+        }
+        if (!declared_parameters.insert ("header:" + key).second) {
+            notes.duplicate_parameter_rows_dropped += 1;
             continue;
         }
         parameters.push_back (parameter_object (row, "header"));
@@ -1721,7 +1736,8 @@ nlohmann::json export_notes_json (const ExportNotes& notes) {
         { "bodiesDropped", notes.bodies_dropped },
         { "formValuesDropped", notes.form_values_dropped },
         { "settingsDropped", notes.settings_dropped },
-        { "exampleHeadersDropped", notes.example_headers_dropped } };
+        { "exampleHeadersDropped", notes.example_headers_dropped },
+        { "duplicateParameterRowsDropped", notes.duplicate_parameter_rows_dropped } };
 }
 
 } // namespace vayu::core

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -599,6 +599,25 @@ TEST (SkeletonExport, DeclaresTheRowsTheRequestHoldsWithoutClaimingAnyAreRequire
     ])"));
 }
 
+TEST (SkeletonExport, StripsADuplicateParamsOrHeadersRowRatherThanWritingTwoParameterObjects) {
+    // OpenAPI defines a unique parameter by name+location; two rows sharing
+    // both would produce an invalid document. Case differs on purpose - the
+    // bound direction's own row match (`patch_parameters`) is case-insensitive
+    // for both locations, and the skeleton direction keeps that the same.
+    ExportRequest entry = request ("GET", "{{baseUrl}}/pets");
+    entry.params        = { row ("verbose", "1"), row ("Verbose", "2") };
+    entry.headers = { row ("X-Tenant", "acme"), row ("x-tenant", "acme2") };
+
+    const Exported exported = export_json ({ entry });
+    const json& parameters = operation_of (exported.document, "/pets", "get")["parameters"];
+    ASSERT_EQ (parameters.size (), 2);
+    EXPECT_EQ (parameters[0]["name"], "verbose");
+    EXPECT_EQ (parameters[0]["example"], "1");
+    EXPECT_EQ (parameters[1]["name"], "X-Tenant");
+    EXPECT_EQ (parameters[1]["example"], "acme");
+    EXPECT_EQ (exported.notes.duplicate_parameter_rows_dropped, 2);
+}
+
 TEST (SkeletonExport, WritesADisabledRowsToggleRatherThanGuessingItFromItsValue) {
     ExportRequest entry = request ("GET", "{{baseUrl}}/pets");
     // A disabled row with a value, and an enabled row with none - the two


### PR DESCRIPTION
## Description

`operation_object` (`engine/src/core/openapi_export.cpp`) pushed one Parameter
Object per Params/Headers row unconditionally, so two rows sharing a key and
location (two `verbose` query rows, say) produced two Parameter Objects with
the same `name`+`in` in the skeleton export - which the OpenAPI specification
forbids ("A unique parameter is defined by a combination of a name and
location"). A validator rejects the resulting document.

**Plan (root cause, approach, rejected alternative).** The row-to-parameter
loops in `operation_object` now track `(location, key)` pairs already
declared - keyed case-insensitively via `vayu::utils::ascii_lower`, matching
the bound direction's own row match (`patch_parameters`, which is also
case-insensitive for both locations) so the two directions agree on what
counts as "the same" row. Only the first row per pair is written; the rest
are counted in a new `ExportNotes::duplicate_parameter_rows_dropped`. I took
fix pathway (a) from the issue (keep the first row, count the rest) over (b)
(merge duplicate values into one `example`): a merged example implies a
resolution the request itself never states, and (a) matches the bound
direction's existing "first row wins" behavior exactly, so the two directions
stay consistent with each other rather than diverging on a defect this issue
does not ask them to reconcile.

**Deliberate scope note.** The bound direction's own silent-drop of a
duplicate row's value (`patch_parameters` matches only the first declared row
by name) is a related but distinct, uncounted loss the issue explicitly
calls out as not this issue's to fix, and this PR leaves it alone.

## App changes

None required by the fix itself, but `ExportNotes` is a whole-struct contract
with the export dialog: every field is rendered as a `<Line>` in
`ExportSpecDialog.tsx`, so the new counter needed a reader there too (the
repo's "written but never read" rule) rather than being engine-only. Added:
- `app/src/types/api.ts`: `duplicateParameterRowsDropped` on `ExportNotes`.
- `ExportSpecDialog.tsx`: a new line in the skeleton-only section reusing the
  same `<Line>` primitive as every other count.
- The skeleton direction now lists one more row than the bound direction
  (fifteen vs fourteen) for the first time since issue #1441 introduced the
  free-form counts, so `PLACEHOLDER_ROWS` (the loading-skeleton row count)
  moved from 14 to 15 - the larger of the two - so neither direction's real
  answer grows the dialog when it lands, and the doc comment above it was
  rewritten to state the asymmetry honestly instead of claiming parity that
  no longer holds.

## Type of Change
- [x] Bug fix

## Testing

- Added `SkeletonExport.StripsADuplicateParamsOrHeadersRowRatherThanWritingTwoParameterObjects`
  (`engine/tests/openapi_export_test.cpp`): two query rows and two header rows
  sharing a key differing only in case, asserting the exported `parameters`
  array keeps exactly one entry per name (the first row's value) and
  `duplicate_parameter_rows_dropped` counts the two dropped rows.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`:
  full suite green, including all `SkeletonExport`/`SpecExportRouteTest` cases.
- `clang-format-19 --dry-run -Werror` and the repo's clang-tidy pre-commit
  hook both pass on every changed engine file.
- `cd app && pnpm test ExportSpecDialog` - 10/10 passed, including the updated
  placeholder-row-count and skeleton-notes assertions.
- `pnpm type-check`, `pnpm lint`, and `pnpm exec prettier --check` on the
  touched app files - all clean.

## No user-visible design change

The new line in the export dialog's skeleton summary is the same `<Line>`
primitive and visual treatment as the fourteen counts already there, shown
only when a collection actually has a duplicated Params/Headers row (a rare
input the issue itself calls out) - there is nothing new to screenshot beyond
a list item identical in shape to its neighbors, already covered by
`ExportSpecDialog.test.tsx`.

## Docs, same commit

`docs/engine/api-reference.md` (`POST /specs/export`'s response example and
its "It carries what OpenAPI can name" paragraph), `docs/app/openapi.md`
("Rows are declared, not interpreted" bullet and "What the counts mean",
now "nine things" instead of eight).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1465