### PR TITLE
fix(engine): hold PUT /inbox/:id's read, merge and write to one lock

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3519,6 +3519,13 @@ restart and no captures lost. Merge-patch: an absent field keeps what the inbox
 is serving. The body may be the response object itself or `{"response": {...}}`,
 so a client can send back what `start` handed it. `404` for an unknown id.
 
+**Atomic against a concurrent update**, the same guarantee the resource `PUT`s
+above give (issue #1454): the read, the merge and the write are one acquisition
+of the inbox's own lock, not the database's - the canned response lives in
+memory - so two clients patching one inbox at the same moment each merge onto
+what the other just committed rather than onto the response as both of them
+found it.
+
 ### POST /inbox/:inboxId/stop
 
 Stop the listener. Returns the inbox with `running: false`. Captures survive;

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -121,6 +121,15 @@ Two shapes need it, and both are in the code today:
   both, in a `create_*_locked` core of the same shape as the merge-patch
   update's.
 
+The same shape holds where the state being merged is not a `Database` row at
+all: **`PUT /inbox/:id`** (issue #1454) merge-patches an inbox's canned
+response, which lives in `InboxManager`'s own map, guarded by its own mutex.
+`InboxManager::update_response` takes a merge function and runs the read, the
+merge and the write under one acquisition of that lock - `Database::with_lock`
+has nothing to scope here, since no database call is involved - mirroring
+`MockIssuerManager::update`, which already held its equivalent composite this
+way.
+
 Both wrappers take an optional `before_write` seam, invoked inside the scope
 immediately before the commit. It is what lets a test drive a genuinely
 concurrent writer into the window rather than asserting the absence of a race by

--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <expected>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -236,10 +237,41 @@ class InboxManager {
     /// they belong to rather than whatever the config says at that moment.
     std::optional<InboxLimits> limits (const std::string& inbox_id);
 
-    /// nullopt when no such inbox exists. Applies to a stopped inbox too - it
-    /// is the configuration a restart would use, not the listener's state.
-    std::optional<InboxInfo> update_response (const std::string& inbox_id,
-    const InboxCannedResponse& response);
+    /// A merge step for `update_response`: given the currently-stored
+    /// response, returns the merged one, or refuses.
+    using ResponseMergeFn =
+    std::function<std::expected<InboxCannedResponse, InboxParseError> (const InboxCannedResponse&)>;
+
+    /**
+     * `found == false` when no such inbox exists, in which case @p merge is
+     * never called. Otherwise `error` carries a refusal from @p merge (the
+     * stored response is left untouched) or `info` carries the inbox after
+     * the merged response was written.
+     *
+     * Applies to a stopped inbox too - it is the configuration a restart
+     * would use, not the listener's state.
+     */
+    struct UpdateResponseResult {
+        bool found = false;
+        std::optional<InboxParseError> error;
+        std::optional<InboxInfo> info;
+    };
+
+    /**
+     * Read the current response, run @p merge against it, and write the
+     * result back, all under one acquisition of the manager's locks - the
+     * same read-merge-write-in-one-lock-scope `Database::with_lock` gives the
+     * database-backed resources (issue #1440), closed here for the one
+     * canned response that lives in memory rather than a row (issue #1454).
+     *
+     * @param before_write Test seam, invoked with the merged response staged
+     *        and immediately before it is written, still inside the lock
+     *        scope; see `update_collection_response` in collections.cpp for
+     *        why it exists.
+     */
+    UpdateResponseResult update_response (const std::string& inbox_id,
+    const ResponseMergeFn& merge,
+    const std::function<void ()>& before_write = nullptr);
 
     /**
      * Claim the single live-stream slot for an inbox.

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -21,6 +21,7 @@
 #include "vayu/utils/ascii_case.hpp"
 #include "vayu/utils/diagnostics.hpp"
 #include "vayu/utils/id.hpp"
+#include "vayu/utils/invariant.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/utils/parse.hpp"
 
@@ -717,16 +718,28 @@ std::optional<InboxLimits> InboxManager::limits (const std::string& inbox_id) {
     return it->second->limits;
 }
 
-std::optional<InboxInfo> InboxManager::update_response (const std::string& inbox_id,
-const InboxCannedResponse& response) {
+InboxManager::UpdateResponseResult InboxManager::update_response (const std::string& inbox_id,
+const ResponseMergeFn& merge,
+const std::function<void ()>& before_write) {
+    UpdateResponseResult out;
     std::lock_guard<std::mutex> lock (mutex_);
     auto it = inboxes_.find (inbox_id);
     if (it == inboxes_.end ()) {
-        return std::nullopt;
+        return out;
     }
+    out.found = true;
     std::lock_guard<std::mutex> response_lock (it->second->response_mutex);
-    it->second->response = response;
-    return it->second->info_locked ();
+    auto merged = merge (it->second->response);
+    if (!merged) {
+        out.error = merged.error ();
+        return out;
+    }
+    if (before_write) {
+        before_write ();
+    }
+    it->second->response = std::move (*merged);
+    out.info             = it->second->info_locked ();
+    return out;
 }
 
 namespace {
@@ -848,6 +861,53 @@ int64_t offset) {
     return { 200, out };
 }
 
+/**
+ * Testable core of `PUT /inbox/:id`: the read, the merge and the write are one
+ * lock scope inside `InboxManager::update_response`, the same window issue
+ * #1440 closed for the database-backed resources - closed here in the manager
+ * rather than through `Database::with_lock`, because a canned response lives
+ * in memory, not a row (issue #1454). Extracted so the wiring is covered
+ * without an in-process HTTP server (inbox_test.cpp).
+ *
+ * @param before_write Test seam, invoked with the merged response staged and
+ *        immediately before it is written, still inside the manager's lock;
+ *        see `update_collection_response` in collections.cpp for why it
+ *        exists.
+ */
+std::pair<int, nlohmann::json> update_inbox_response (vayu::db::Database& db,
+InboxManager& manager,
+const std::string& inbox_id,
+const nlohmann::json& body,
+const std::function<void ()>& before_write) {
+    const auto result = manager.update_response (
+    inbox_id,
+    [&body] (const InboxCannedResponse& current) {
+        return parse_inbox_response_update (body, current);
+    },
+    before_write);
+    if (!result.found) {
+        return { 404, error_body (404, "Inbox not found") };
+    }
+    if (result.error) {
+        vayu::utils::log_warning ("PUT /inbox/:id - " + result.error->message);
+        return { result.error->http_status,
+            error_body (result.error->http_status, result.error->message,
+            result.error->code) };
+    }
+    // InboxManager::update_response sets `info` on every path that sets neither
+    // `found = false` nor `error` - the two already handled above.
+    const auto& info = vayu::utils::invariant_value (
+    result.info, "update_response found no error but no info");
+    return { 200, inbox_json (db, info) };
+}
+
+std::pair<int, nlohmann::json> update_inbox_response (vayu::db::Database& db,
+InboxManager& manager,
+const std::string& inbox_id,
+const nlohmann::json& body) {
+    return update_inbox_response (db, manager, inbox_id, body, nullptr);
+}
+
 namespace {
 
 /// limit: default DEFAULT_PAGE_LIMIT, invalid/<=0 -> default, capped at
@@ -947,11 +1007,6 @@ void handle_list_inboxes (RouteContext& ctx, const httplib::Request&, httplib::R
 
 void handle_update_inbox (RouteContext& ctx, const httplib::Request& req, httplib::Response& res) {
     const std::string inbox_id = req.matches[1];
-    auto current               = ctx.inbox_manager.get (inbox_id);
-    if (!current) {
-        send_error (res, 404, "Inbox not found");
-        return;
-    }
     nlohmann::json body;
     if (!read_json_body (req, res, body)) {
         return;
@@ -959,18 +1014,10 @@ void handle_update_inbox (RouteContext& ctx, const httplib::Request& req, httpli
     if (body.is_null ()) {
         body = nlohmann::json::object ();
     }
-    const auto updated = parse_inbox_response_update (body, current->response);
-    if (!updated) {
-        vayu::utils::log_warning ("PUT /inbox/:id - " + updated.error ().message);
-        send_parse_error (res, updated.error ());
-        return;
-    }
-    auto info = ctx.inbox_manager.update_response (inbox_id, *updated);
-    if (!info) {
-        send_error (res, 404, "Inbox not found");
-        return;
-    }
-    send_json (res, inbox_json (ctx.db, *info));
+    auto [status, response_body] =
+    update_inbox_response (ctx.db, ctx.inbox_manager, inbox_id, body);
+    res.status = status;
+    res.set_content (response_body.dump (), "application/json");
 }
 
 void handle_list_inbox_requests (RouteContext& ctx,

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -9,12 +9,14 @@
 #include <httplib.h>
 
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
@@ -35,6 +37,20 @@ int64_t limit,
 int64_t offset);
 // Defined in inbox.cpp; the wire shape every inbox route answers with.
 nlohmann::json inbox_json (vayu::db::Database& db, vayu::http::InboxInfo info);
+// Defined in inbox.cpp; the testable core of PUT /inbox/:id (issue #1454).
+std::pair<int, nlohmann::json> update_inbox_response (vayu::db::Database& db,
+InboxManager& manager,
+const std::string& inbox_id,
+const nlohmann::json& body);
+// The `before_write` overload - invoked with the merged response staged and
+// immediately before it is written, still inside the manager's lock. A
+// separate overload rather than a defaulted parameter, matching the
+// resource-route cores' own convention (resource_write_route_test.cpp).
+std::pair<int, nlohmann::json> update_inbox_response (vayu::db::Database& db,
+InboxManager& manager,
+const std::string& inbox_id,
+const nlohmann::json& body,
+const std::function<void ()>& before_write);
 } // namespace vayu::http::routes
 
 namespace {
@@ -370,9 +386,12 @@ TEST_F (InboxListenerTest, UpdatingTheCannedResponseTakesEffectOnTheNextCall) {
     ASSERT_TRUE (client.Post ("/hook", "", "text/plain"));
 
     InboxCannedResponse updated;
-    updated.status = 202;
-    updated.body   = "queued";
-    ASSERT_HAS_VALUE (manager_->update_response (started.info.inbox_id, updated));
+    updated.status    = 202;
+    updated.body      = "queued";
+    const auto result = manager_->update_response (started.info.inbox_id,
+    [&updated] (const InboxCannedResponse&) { return updated; });
+    ASSERT_TRUE (result.found);
+    ASSERT_FALSE (result.error.has_value ());
 
     auto response = client.Post ("/hook", "", "text/plain");
     ASSERT_TRUE (response);
@@ -380,6 +399,49 @@ TEST_F (InboxListenerTest, UpdatingTheCannedResponseTakesEffectOnTheNextCall) {
     EXPECT_EQ (response->body, "queued");
     // A live update never costs the history.
     EXPECT_EQ (db_->count_inbox_requests (started.info.inbox_id), 2);
+}
+
+/**
+ * The same experiment `resource_write_route_test.cpp` runs against the
+ * database-backed resources for issue #1440: two clients PUT one inbox's
+ * canned response at the same moment, each naming a field the other does
+ * not, and both fields must survive. Merge-patch is what makes that a real
+ * risk - the write carries the whole response, including the fields the body
+ * never named - so the loser of an unheld read has its change overwritten
+ * with a value nobody sent.
+ *
+ * The second writer is started from inside the first one's lock scope,
+ * through the `before_write` seam, and given a window to finish (see
+ * `competing_writer.hpp`). Holding the read to the write makes it block, so
+ * it merges against the committed response and both fields survive; without
+ * `InboxManager::update_response`'s single lock scope it merges against the
+ * response as it was before either write and the first writer's field is
+ * gone. Mutation check: split the read and the write back into two
+ * acquisitions and the case reds on the second field.
+ */
+TEST_F (InboxListenerTest, AConcurrentInboxUpdateWaitsAndKeepsBothFieldsWritten) {
+    auto started = start ();
+
+    int other_status = 0;
+    json other_body;
+    vayu::tests::CompetingWriter other ([&] {
+        auto result = vayu::http::routes::update_inbox_response (
+        *db_, *manager_, started.info.inbox_id, json{ { "status", 202 } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = vayu::http::routes::update_inbox_response (*db_, *manager_,
+    started.info.inbox_id, json{ { "body", "queued" } }, other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+    ASSERT_EQ (other_status, 200) << other_body.dump ();
+
+    const auto info = manager_->get (started.info.inbox_id);
+    ASSERT_HAS_VALUE (info);
+    EXPECT_EQ (info->response.status, 202);
+    EXPECT_EQ (info->response.body, "queued")
+    << "the body merged against the response this write had already staged";
 }
 
 TEST_F (InboxListenerTest, ABodyPastTheCapIsStoredTruncatedAndSaysSo) {

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -27,6 +27,7 @@ using nlohmann::json;
 using vayu::http::InboxCannedResponse;
 using vayu::http::InboxManager;
 using vayu::http::InboxStartRequest;
+using vayu::tests::CompetingWriter;
 
 namespace vayu::http::routes {
 // Defined in inbox.cpp; returns {http_status, json_body}.
@@ -424,7 +425,7 @@ TEST_F (InboxListenerTest, AConcurrentInboxUpdateWaitsAndKeepsBothFieldsWritten)
 
     int other_status = 0;
     json other_body;
-    vayu::tests::CompetingWriter other ([&] {
+    CompetingWriter other ([&] {
         auto result = vayu::http::routes::update_inbox_response (
         *db_, *manager_, started.info.inbox_id, json{ { "status", 202 } });
         other_status = result.first;


### PR DESCRIPTION
## Description

`handle_update_inbox` read the current canned response (`InboxManager::get`), merged the request body onto it with no lock held, then wrote the merge back through a second acquisition of `InboxManager`'s lock (`InboxManager::update_response`). Two concurrent `PUT /inbox/:id` calls naming disjoint fields could interleave as read, read, write, write, silently dropping the first writer's field - the same defect shape #1440 closed for the database-backed resources, but here over `InboxManager`'s own in-memory locks rather than `Database`'s, since a canned response lives in the manager's map, not a row.

**Root cause / approach / rejected alternative:** the race lived entirely in `InboxManager`, which had no `Database::with_lock`-equivalent composite. `Database::with_lock` itself doesn't apply here - no database call is involved - so rather than bolt on a generic `with_lock` primitive, `InboxManager::update_response` now takes a merge function directly and runs the read, the merge and the write under one acquisition of `mutex_` + the per-inbox `response_mutex`, mirroring `MockIssuerManager::update`'s existing shape (which already held its own equivalent composite correctly). `handle_update_inbox` is extracted into a testable `update_inbox_response` core with an optional `before_write` seam, the same shape `update_collection_response`/`update_request_response` use, so a `CompetingWriter`-driven concurrency test can pin the fix deterministically instead of by timing.

Checked while the file was open: no other `InboxManager` public method has this split-lock shape (each already does its own read-modify-write under a single acquisition), so nothing else needed the same fix.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added `InboxListenerTest.AConcurrentInboxUpdateWaitsAndKeepsBothFieldsWritten` (`engine/tests/inbox_test.cpp`), which drives a second `PUT /inbox/:id`-equivalent call into the write window via `CompetingWriter`/`before_write` and asserts both writers' fields survive.
- Updated `InboxListenerTest.UpdatingTheCannedResponseTakesEffectOnTheNextCall` for the new merge-function signature.
- Mutation check (not committed): temporarily split the read-merge-write back into two lock acquisitions - the new concurrency test failed 5/5 runs (`status` reverted to 200 instead of the second writer's 202); restoring the single-lock-scope fix made it pass consistently.
- `engine/tests/inbox_test.cpp`: 35/35 tests passing.
- Full engine suite: `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2942/2942 tests passing**.
- `clang-format --dry-run -Werror` and `clang-tidy-19` clean on all three changed engine files (one pre-existing, unrelated `clang-analyzer-optin.performance.Padding` note on `vayu::Response` in `types.hpp`, reproduced identically against master's version of `inbox.cpp` - not touched here).

No user-visible change: this is an engine-internal concurrency fix. The response payload, status codes and merge-patch semantics of `PUT /inbox/:id` are unchanged; only the locking discipline around the existing behavior changed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1454

## Docs updated
- `docs/engine/api-reference.md`: `PUT /inbox/:inboxId` now states the same atomicity guarantee the resource `PUT`s already document.
- `docs/engine/architecture.md`: "A core that reads, decides and writes holds one lock" now lists `PUT /inbox/:id` as an instance of the same shape, scoped to `InboxManager`'s own lock rather than `Database::with_lock`.
