### PR TITLE
fix(engine): hold POST /config's validation and write to one lock and one transaction

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -943,6 +943,13 @@ entries, its `min`/`max` range; `boolean` entries must be `"true"` or `"false"`;
 `options` values. Validation is all-or-nothing: if any key is unknown or out of
 range, nothing is applied and the response is `400` with the specific reason(s):
 
+**The validation and the write are one lock scope, and the write is one
+transaction** (issue #1453): a reader (`GET /config`, or an internal reader
+like the proxy policy resolver that reads `proxyMode` and `proxyUrl` as two
+separate calls) can never observe some of a batch's keys applied and the rest
+still stale, and a failure partway through the write leaves every row
+unchanged rather than the ones written before it.
+
 ```json
 { "error": { "code": "invalid_config", "message": "'workers' must be at most 128 (got 9999)" } }
 ```

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -943,19 +943,19 @@ entries, its `min`/`max` range; `boolean` entries must be `"true"` or `"false"`;
 `options` values. Validation is all-or-nothing: if any key is unknown or out of
 range, nothing is applied and the response is `400` with the specific reason(s):
 
-**The validation and the write are one lock scope, and the write is one
-transaction** (issue #1453): a reader (`GET /config`, or an internal reader
-like the proxy policy resolver that reads `proxyMode` and `proxyUrl` as two
-separate calls) can never observe some of a batch's keys applied and the rest
-still stale, and a failure partway through the write leaves every row
-unchanged rather than the ones written before it.
-
 ```json
 { "error": { "code": "invalid_config", "message": "'workers' must be at most 128 (got 9999)" } }
 ```
 
 **Success response:** `200` - the full updated entries array (same shape as
 `GET /config`) plus `"success": true`.
+
+**The validation and the write are one lock scope, and the write is one
+transaction** (issue #1453): a reader (`GET /config`, or an internal reader
+like the proxy policy resolver that reads `proxyMode` and `proxyUrl` as two
+separate calls) can never observe some of a batch's keys applied and the rest
+still stale, and a failure partway through the write leaves every row
+unchanged rather than the ones written before it.
 
 ## Workspace
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -106,8 +106,13 @@ lambda calls the same public `get_*` / `save_*` methods everything else does.
 Two shapes need it, and both are in the code today:
 
 - **The validate-then-commit batch** - `POST /reorder`, `POST /import/apply`,
-  `POST /specs/sync`, `POST /specs/bind`. The validation the write is based on
-  has to still be true when the write lands.
+  `POST /specs/sync`, `POST /specs/bind`, `POST /config` (issue #1453). The
+  validation the write is based on has to still be true when the write lands.
+  `POST /config`'s batch also needs its own transaction
+  (`Database::save_config_entries`) rather than one `save_config_entry` call
+  per row: the mutex stops a reader from landing mid-batch, but only a
+  transaction stops a mid-batch failure from leaving the rows before it
+  written.
 - **The merge-patch update** - every `PUT /<resource>/:id` (issue #1440). The
   write carries each field the body did not name, read a moment earlier, so a
   read not held to its write loses whichever of two concurrent updates read

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -824,6 +824,16 @@ class Database {
 
     // Config Entries - Structured configuration with metadata
     void save_config_entry (const ConfigEntry& entry);
+    /**
+     * @brief Write a batch of config entries in one sqlite transaction (#1453).
+     *
+     * `POST /config`'s own comment claims the batch is all-or-nothing; a loop
+     * of `save_config_entry` calls only made that true for validation, not for
+     * the write, since each call was its own transaction. This is the write
+     * half: every row lands or none does, the same shape `apply_reorder` and
+     * `spec_sync_apply` use for their own batches.
+     */
+    void save_config_entries (const std::vector<ConfigEntry>& entries);
     std::optional<ConfigEntry> get_config_entry (const std::string& key);
     std::vector<ConfigEntry> get_all_config_entries ();
     void seed_default_config (); // Initialize default config values if empty

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -3210,6 +3210,27 @@ void Database::save_config_entry (const ConfigEntry& entry) {
     impl_->storage.replace (entry);
 }
 
+// Same shape as apply_reorder and spec_sync_apply: retry_on_busy holds the
+// recursive mutex while the transaction runs, so a row an earlier call in the
+// batch just wrote is visible to the check or write after it. Unlike those two
+// there is no existence check - config entries are seeded once at startup and
+// never deleted through any route - so a mid-batch failure here is a genuine
+// SQLITE_BUSY-past-retry or disk error, which `impl_->storage.transaction`
+// rolls back in full rather than leaving the rows written before it landed.
+void Database::save_config_entries (const std::vector<ConfigEntry>& entries) {
+    if (entries.empty ()) {
+        return;
+    }
+    retry_on_busy ("apply config batch", 5, std::chrono::milliseconds (100), [&] {
+        impl_->storage.transaction ([&] {
+            for (const auto& entry : entries) {
+                impl_->storage.replace (entry);
+            }
+            return true; // Commit
+        });
+    });
+}
+
 std::optional<ConfigEntry> Database::get_config_entry (const std::string& key) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     auto entries =

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <expected>
 #include <format>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -315,17 +316,15 @@ const std::unordered_map<std::string, std::string>& updates) {
 } // namespace
 
 /**
- * @brief Parse, validate, and apply a POST /config request body.
+ * The parse-validate-write of POST /config, run under the caller's lock.
  *
- * Split out of the route handler so the validation path (and the specific
- * failure reason it now returns) is unit-testable without a live server.
- *
- * @return {http_status, json_body}. On validation failure the body carries the
- *         specific reason(s) - which key, and why (bad type / out of range) -
- *         so the app can show it instead of a generic "check the logs".
+ * @param before_write Test seam, invoked inside the lock scope immediately
+ *        before the batch is written - the only way to drive a competing
+ *        client into the window this closes (`tests/competing_writer.hpp`).
  */
-std::pair<int, nlohmann::json>
-apply_config_update (vayu::db::Database& db, const std::string& body) {
+static std::pair<int, nlohmann::json> apply_config_update_locked (vayu::db::Database& db,
+const std::string& body,
+const std::function<void ()>& before_write) {
     nlohmann::json json;
     try {
         json = nlohmann::json::parse (body);
@@ -341,6 +340,11 @@ apply_config_update (vayu::db::Database& db, const std::string& body) {
     }
 
     // Validate every key first; apply nothing unless all pass (all-or-nothing).
+    // True on both halves since #1453: the caller's lock (see
+    // apply_config_update below) holds this validation and the write below to
+    // one scope, so no reader can observe the keys that passed applied one at
+    // a time, and the write itself is one transaction (Database::with_lock is
+    // a mutex, not a transaction, so the write still needs its own atomicity).
     std::vector<vayu::db::ConfigEntry> to_update;
     std::vector<std::string> errors;
 
@@ -383,9 +387,10 @@ apply_config_update (vayu::db::Database& db, const std::string& body) {
         return { 400, config_error (joined) };
     }
 
-    for (const auto& entry : to_update) {
-        db.save_config_entry (entry);
+    if (before_write) {
+        before_write ();
     }
+    db.save_config_entries (to_update);
 
     vayu::utils::log_info ("POST /config - Updated " +
     std::to_string (to_update.size ()) + " config entries");
@@ -399,6 +404,41 @@ apply_config_update (vayu::db::Database& db, const std::string& body) {
     response["entries"] = entries_array;
     response["success"] = true;
     return { 200, response };
+}
+
+/**
+ * @brief Parse, validate, and apply a POST /config request body.
+ *
+ * Split out of the route handler so the validation path (and the specific
+ * failure reason it now returns) is unit-testable without a live server.
+ *
+ * **The validation and the write are one lock scope** (#1453). A batch that
+ * wrote each row under its own separate acquisition of the database mutex let
+ * a concurrent reader - `GET /config`, or an internal reader like
+ * `resolve_transport_policy` that reads `proxyMode` and `proxyUrl` as two
+ * separate calls - land between two of the batch's writes and see one key
+ * updated and the other stale, and let a mid-batch failure leave the rows
+ * before it applied. Holding the lock across the whole composite closes the
+ * reader window the same way `update_request_response` closes it for a
+ * merge-patch (#1440); `Database::save_config_entries` closes the failure
+ * window by writing every row in one transaction rather than one per call.
+ *
+ * @return {http_status, json_body}. On validation failure the body carries the
+ *         specific reason(s) - which key, and why (bad type / out of range) -
+ *         so the app can show it instead of a generic "check the logs".
+ */
+std::pair<int, nlohmann::json> apply_config_update (vayu::db::Database& db,
+const std::string& body,
+const std::function<void ()>& before_write) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock (
+    [&] { result = apply_config_update_locked (db, body, before_write); });
+    return result;
+}
+
+std::pair<int, nlohmann::json>
+apply_config_update (vayu::db::Database& db, const std::string& body) {
+    return apply_config_update (db, body, nullptr);
 }
 
 /**

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -19,6 +20,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "competing_writer.hpp"
 #include "optional_assert.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
@@ -31,6 +33,10 @@ namespace vayu::http::routes {
 // Declared in config.cpp; returns {http_status, json_body}.
 std::pair<int, nlohmann::json>
 apply_config_update (vayu::db::Database& db, const std::string& body);
+// The `before_write` overload, the seam a CompetingWriter drives (#1453).
+std::pair<int, nlohmann::json> apply_config_update (vayu::db::Database& db,
+const std::string& body,
+const std::function<void ()>& before_write);
 } // namespace vayu::http::routes
 
 namespace {
@@ -895,6 +901,45 @@ TEST_F (ConfigRouteTest, UnknownProxyModeIs400) {
     auto [status, body] = vayu::http::routes::apply_config_update (
     *db_, R"({"entries":{"proxyMode":"sometimes"}})");
     EXPECT_EQ (status, 400) << body.dump ();
+}
+
+// ---------------------------------------------------------------------------
+// Batch atomicity (issue #1453): validation and the write are one lock scope,
+// so a second POST /config's own cross-field validation - which reads whatever
+// key it did not name off the database, the same fallback `proxy_batch_rejection`
+// uses - never reads a key the first batch already decided to change but has
+// not yet written.
+// ---------------------------------------------------------------------------
+
+using vayu::tests::CompetingWriter;
+
+TEST_F (ConfigRouteTest, AConcurrentValidationNeverReadsAStaleProxyModeMidBatch) {
+    ASSERT_EQ (vayu::http::routes::apply_config_update (*db_,
+               R"({"entries":{"proxyMode":"manual","proxyUrl":"http://old.example:8080"}})")
+               .first,
+    200);
+
+    // Started from inside the first batch's own lock scope, right before it
+    // writes: with the fix, this cannot run until that batch has fully
+    // committed `proxyMode: "off"`, so its own validation reads the *new*
+    // mode and clearing an already-empty proxyUrl is fine under "off". With
+    // the lock removed, this runs immediately against the still-stored
+    // "manual" and is refused for a mode the batch it raced is about to undo.
+    int other_status = 0;
+    json other_body;
+    CompetingWriter other ([&] {
+        auto result = vayu::http::routes::apply_config_update (
+        *db_, R"({"entries":{"proxyUrl":""}})");
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"proxyMode":"off","proxyUrl":""}})", other.probe ());
+    ASSERT_EQ (status, 200) << body.dump ();
+    other.join ();
+
+    EXPECT_EQ (other_status, 200) << other_body.dump ();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`apply_config_update` (`engine/src/http/routes/config.cpp`) states its own contract in a comment: "Validate every key first; apply nothing unless all pass (all-or-nothing)." The validation half honoured it, but the write half looped `db.save_config_entry (entry)` over the staged rows - each its own separate acquisition of the database mutex and its own implicit transaction. Two consequences the comment didn't admit:

- A concurrent reader (`GET /config`, or an internal reader like `resolve_transport_policy`, which reads `proxyMode` and `proxyUrl` as two separate calls) could land between two of the batch's writes and see one key updated and the other stale.
- A write that threw partway through (a `SQLITE_BUSY` past the retry, a disk error) left the rows already written in place rather than rolling the whole batch back.

**Plan (root cause, approach, rejected alternative).** The race lives entirely above SQLite, in the route composing multiple separate `Database` calls with no lock spanning them. `Database::with_lock` (#386) already exists for exactly this composite and is used by `/reorder`, `/import/apply`, `spec_bind` and `spec_sync`, but not by `POST /config`. Following the shape #1440 established for the merge-patch routes, `apply_config_update` is now a thin wrapper over `apply_config_update_locked`, which runs the whole parse-validate-write composite under `db.with_lock`. A held mutex alone stops a reader from landing mid-batch, but it is not a transaction, so a mid-write failure would still have left earlier rows written - closing that required a real write-side fix too: `Database::save_config_entries` writes the whole batch in one sqlite transaction, the same shape `apply_reorder` and `spec_sync_apply` already use for their own batches. I considered leaving the mutex-only fix and weakening the all-or-nothing comment instead (the issue's stated fallback), but the transaction is a small, well-precedented addition and makes the existing comment literally true rather than requiring it to be rewritten to describe a weaker guarantee.

`apply_config_update` keeps its existing two-argument signature (it has call sites across four other test files); the `before_write` test seam is a new three-argument overload, the same choice `update_request_response` made and for the same reason.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- Added `ConfigRouteTest.AConcurrentValidationNeverReadsAStaleProxyModeMidBatch` (`engine/tests/config_route_test.cpp`), driven through `vayu::tests::CompetingWriter`: a second `POST /config` batch is started from inside the first batch's lock scope, right before it writes, and clears `proxyUrl` on its own. Its own `proxy_batch_rejection` validation reads whatever `proxyMode` is currently stored: with the fix, the second call cannot run until the first has fully committed `proxyMode: "off"`, so clearing an already-empty `proxyUrl` is accepted; without the fix it runs immediately against the still-stored `"manual"` and is refused for a mode the racing batch is about to undo.
- Mutation-checked by hand: temporarily reverted `apply_config_update` to call `apply_config_update_locked` with no `with_lock` around it, rebuilt, and confirmed exactly the new test failed (1 of 2942) while every other test, including the rest of the 47 `ConfigRouteTest` cases, stayed green. Restored, full suite green again.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2942/2942 tests passing**, 0 failures.
- `clang-format-19 --dry-run -Werror` and the repo's clang-tidy pre-commit hook both pass clean on all four changed engine files.

No app or MCP change: `POST /config` keeps its payload, status codes and response body - traced the app's `updateConfig`/`useUpdateConfigMutation` and the MCP `update_engine_config`/`get_engine_config` tools, and neither depends on interleaved partial writes; an atomicity-only fix is invisible to both. No user-visible change: this is an engine-internal concurrency fix.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1453

## Docs updated
- `docs/engine/api-reference.md`: `POST /config` now states the same atomicity guarantee the resource `PUT`s and other validate-then-commit batches already document.
- `docs/engine/architecture.md`: "A core that reads, decides and writes holds one lock" now lists `POST /config` among the validate-then-commit batches, and notes why its batch also needed its own transaction rather than only the mutex.
