### PR TITLE
fix(app): report the inbox reply's Apply through the save store

### DIFF
--- a/app/src/modules/inbox/CannedResponseControls.test.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.test.tsx
@@ -21,8 +21,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useToastStore } from "@/stores";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useSaveStore, useToastStore } from "@/stores";
 import type { InboxCannedResponse } from "@/types";
 import { CannedResponseControls } from "./CannedResponseControls";
 
@@ -48,6 +48,7 @@ function lastToastMessage(): string | undefined {
 beforeEach(() => {
 	cleanup();
 	useToastStore.setState({ toasts: [] });
+	useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
 });
 
 describe("every field the engine serves", () => {
@@ -248,5 +249,131 @@ describe("the key/value table it borrows", () => {
 		expect(headerValue(0)).toHaveValue("{{trace}}");
 		expect(container.querySelector("[data-variable-token]")).toBeNull();
 		expect(container.querySelector('[aria-label^="Resolved value of"]')).toBeNull();
+	});
+});
+
+describe("Apply reports through the save store (#1450)", () => {
+	/*
+	 * Mutation check: comment out the `startSaving()`/`completeSaveThenIdle()`
+	 * pair in `persist` and this reds - the status never leaves "idle".
+	 */
+	it("moves the Dock's status from saving to saved on a successful apply", async () => {
+		const onApply = vi.fn().mockResolvedValue(undefined);
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped={false}
+				onApply={onApply}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText("Reply status"), { target: { value: "503" } });
+		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+		await waitFor(() => expect(useSaveStore.getState().status).toBe("saved"));
+		expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ status: 503 }));
+		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+
+	/*
+	 * Mutation check: swallow the rejection in `persist` instead of calling
+	 * `failSave` and this reds - the status stays "saved"/"idle" with no toast.
+	 */
+	it("reports a refused apply through failSave, not a bare toast", async () => {
+		const onApply = vi.fn().mockRejectedValue(new Error("Engine refused the update"));
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped={false}
+				onApply={onApply}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText("Reply status"), { target: { value: "503" } });
+		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+		await waitFor(() => expect(useSaveStore.getState().status).toBe("error"));
+		expect(useToastStore.getState().toasts).toHaveLength(1);
+		expect(useToastStore.getState().toasts[0]).toMatchObject({
+			message: "Engine refused the update",
+			variant: "error",
+		});
+	});
+
+	it("registers the reply as a save context, so a quit flush would reach it", () => {
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn().mockResolvedValue(undefined)}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText("Reply status"), { target: { value: "503" } });
+		expect(useSaveStore.getState().contexts.get("inbox-reply")).toMatchObject({
+			hasPendingChanges: true,
+		});
+	});
+});
+
+describe("Apply dims once there is nothing new to send", () => {
+	/*
+	 * Mutation check: drop the `!isDirty` term from `applyDisabled` and the
+	 * first assertion reds - Apply stays enabled on an untouched draft.
+	 */
+	it("starts disabled and enables after an edit", () => {
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn().mockResolvedValue(undefined)}
+			/>
+		);
+
+		expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+
+		fireEvent.change(screen.getByLabelText("Reply delay (ms)"), { target: { value: "10" } });
+		expect(screen.getByRole("button", { name: "Apply" })).toBeEnabled();
+	});
+});
+
+describe("the hint stacks under the controls, never sharing their row", () => {
+	/*
+	 * Mutation check: move the hint `<p>` back inside the row it was extracted
+	 * from and this reds - the row's closest flex container would contain it.
+	 */
+	it("renders the hint as a sibling of the controls row, not a child of it", () => {
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn()}
+			/>
+		);
+
+		const hint = screen.getByText(/Every caller to this inbox gets this reply/);
+		const row = screen.getByLabelText("Reply status").closest(".flex-wrap");
+		expect(row).not.toBeNull();
+		expect(row?.contains(hint)).toBe(false);
+	});
+
+	it("keeps the stopped-inbox hint on the same full-width line", () => {
+		render(
+			<CannedResponseControls
+				response={response()}
+				pending={false}
+				stopped
+				onApply={vi.fn()}
+			/>
+		);
+
+		const hint = screen.getByText(/stopped, so nothing is being served/);
+		const row = screen.getByLabelText("Reply status").closest(".flex-wrap");
+		expect(row?.contains(hint)).toBe(false);
 	});
 });

--- a/app/src/modules/inbox/CannedResponseControls.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.tsx
@@ -33,8 +33,16 @@ import {
 import KeyValueEditor from "@/components/shared/KeyValueEditor";
 import { toKeyValueItems } from "@/components/shared/KeyValueEditor/key-value";
 import type { InboxCannedResponse, KeyValueItem } from "@/types";
-import { useToastStore } from "@/stores";
+import { useDraftSaveContext } from "@/hooks";
+import { useSaveStore, useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
+
+/**
+ * One inbox tab exists at a time (see the file this exports into), so one
+ * static id names the reply's save context - there is never a second canned
+ * response registered under it to collide with.
+ */
+const INBOX_REPLY_SAVE_CONTEXT = "inbox-reply";
 
 /**
  * The engine's cap on the artificial delay (`MAX_RESPONSE_DELAY_MS`).
@@ -62,6 +70,28 @@ function toHeaderRows(headers: Record<string, string>): KeyValueItem[] {
 	);
 }
 
+/**
+ * The header rows as a plain object, for comparing a draft against what the
+ * engine last served - not for applying, which is `collect`'s job and
+ * additionally refuses a blank name or a name set twice. A row with either of
+ * those problems still counts toward dirtiness: the point is "does this
+ * differ from what was served", not "is this valid to send".
+ */
+function draftHeaders(rows: KeyValueItem[]): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const row of rows) {
+		const name = row.key.trim();
+		if (name === "" && row.value === "") continue;
+		headers[name] = row.value;
+	}
+	return headers;
+}
+
+function headersEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+	const keys = Object.keys(a);
+	return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
+}
+
 interface CannedResponseControlsProps {
 	response: InboxCannedResponse;
 	pending: boolean;
@@ -71,7 +101,8 @@ interface CannedResponseControlsProps {
 	 * serve - the panel says so and takes no input rather than lying twice.
 	 */
 	stopped: boolean;
-	onApply: (response: Partial<InboxCannedResponse>) => void;
+	/** Rejecting is how a failed apply is reported - see `persist` below. */
+	onApply: (response: Partial<InboxCannedResponse>) => Promise<void>;
 }
 
 export function CannedResponseControls({
@@ -94,7 +125,22 @@ export function CannedResponseControls({
 		response.body !== "" || Object.keys(response.headers).length > 0
 	);
 
+	const startSaving = useSaveStore((s) => s.startSaving);
+	const completeSaveThenIdle = useSaveStore((s) => s.completeSaveThenIdle);
+	const failSave = useSaveStore((s) => s.failSave);
+
 	const disabled = stopped || pending;
+
+	// The visible "applied" state: true the moment any field diverges from what
+	// the engine last served, false once it matches again - which happens on its
+	// own after a successful apply, since the parent remounts this component on
+	// the served response (see the file comment on why that is a remount and not
+	// an effect).
+	const isDirty =
+		statusDraft !== String(response.status) ||
+		delayDraft !== String(response.delayMs) ||
+		bodyDraft !== response.body ||
+		!headersEqual(draftHeaders(headerRows), response.headers);
 
 	/**
 	 * Read the four drafts back, or say which one is wrong.
@@ -144,10 +190,40 @@ export function CannedResponseControls({
 		return { status, delayMs, body: bodyDraft, headers: Object.fromEntries(headers) };
 	};
 
-	const apply = () => {
+	/**
+	 * Reports through the save store rather than a bare toast (issue #1450): a
+	 * refused apply calls `failSave`, which is both the app's one save-failure
+	 * seam and how the Dock's error state gets shown, and a landed one clears
+	 * through `completeSaveThenIdle` the same way every other explicit save
+	 * does. Registered below as this reply's save, so this same function is
+	 * what a quit flush or Ctrl/Cmd+S runs - `useDraftSaveContext` wraps it in
+	 * its own `failSave` catch, which never fires here since this already
+	 * resolves instead of throwing.
+	 */
+	const persist = async () => {
 		const next = collect();
-		if (next) onApply(next);
+		if (!next) return;
+		startSaving();
+		try {
+			await onApply(next);
+			completeSaveThenIdle(INBOX_REPLY_SAVE_CONTEXT);
+		} catch (error) {
+			failSave(error instanceof Error ? error.message : "Could not update the response");
+		}
 	};
+
+	useDraftSaveContext({
+		id: INBOX_REPLY_SAVE_CONTEXT,
+		name: "Inbox reply",
+		isDirty,
+		// The inbox tab's content only mounts while it is the active tab (see
+		// `Shell.tsx`'s `renderTabContent`), so whenever this is mounted it is
+		// the one a quit flush or Ctrl/Cmd+S should reach.
+		isActive: true,
+		save: persist,
+	});
+
+	const applyDisabled = disabled || !isDirty;
 
 	const headerCount = headerRows.filter((row) => row.key.trim() !== "").length;
 
@@ -157,58 +233,68 @@ export function CannedResponseControls({
 			onOpenChange={setDetailsOpen}
 			className="border-b border-border"
 		>
-			<div className="flex flex-wrap items-end gap-3 px-3 py-2">
-				<div className="flex flex-col gap-1">
-					<Label htmlFor="inbox-status" className="text-xs">
-						Reply status
-					</Label>
-					<Input
-						id="inbox-status"
-						className="h-7 w-24 font-mono text-xs"
-						value={statusDraft}
-						disabled={disabled}
-						onChange={(e) => setStatusDraft(e.target.value)}
-					/>
-				</div>
-				<div className="flex flex-col gap-1">
-					<Label htmlFor="inbox-delay" className="text-xs">
-						Reply delay (ms)
-					</Label>
-					<Input
-						id="inbox-delay"
-						className="h-7 w-24 font-mono text-xs"
-						value={delayDraft}
-						disabled={disabled}
-						onChange={(e) => setDelayDraft(e.target.value)}
-					/>
-				</div>
-
-				<CollapsibleTrigger asChild>
-					<Button variant="ghost" size="sm" className="h-7">
-						<ChevronDown
-							className={cn(
-								"mr-2 h-3.5 w-3.5 transition-transform",
-								detailsOpen && "rotate-180"
-							)}
-							aria-hidden="true"
+			<div className="px-3 py-2">
+				<div className="flex flex-wrap items-end gap-3">
+					<div className="flex flex-col gap-1">
+						<Label htmlFor="inbox-status" className="text-xs">
+							Reply status
+						</Label>
+						<Input
+							id="inbox-status"
+							className="h-7 w-24 font-mono text-xs"
+							value={statusDraft}
+							disabled={disabled}
+							onChange={(e) => setStatusDraft(e.target.value)}
 						/>
-						{`Body and headers${headerCount > 0 ? ` (${headerCount})` : ""}`}
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label htmlFor="inbox-delay" className="text-xs">
+							Reply delay (ms)
+						</Label>
+						<Input
+							id="inbox-delay"
+							className="h-7 w-24 font-mono text-xs"
+							value={delayDraft}
+							disabled={disabled}
+							onChange={(e) => setDelayDraft(e.target.value)}
+						/>
+					</div>
+
+					<CollapsibleTrigger asChild>
+						<Button variant="ghost" size="sm" className="h-7">
+							<ChevronDown
+								className={cn(
+									"mr-2 h-3.5 w-3.5 transition-transform",
+									detailsOpen && "rotate-180"
+								)}
+								aria-hidden="true"
+							/>
+							{`Body and headers${headerCount > 0 ? ` (${headerCount})` : ""}`}
+						</Button>
+					</CollapsibleTrigger>
+
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => void persist()}
+						disabled={applyDisabled}
+					>
+						Apply
 					</Button>
-				</CollapsibleTrigger>
+				</div>
 
-				<Button variant="outline" size="sm" onClick={apply} disabled={disabled}>
-					Apply
-				</Button>
-
-				{/* The set exists to test a sender's retry and error handling; saying
-				    so is cheaper than a doc nobody opens mid-debug. On a stopped
-				    inbox it says the other thing - that none of this is being
-				    served - because the controls above would otherwise read as an
-				    inbox waiting for callers it can no longer receive. */}
-				<p className="text-xs text-muted-foreground">
+				{/* Stacked under the row, not sharing it (docs/design-system.md's
+				    hint rule): a wrapping row would hand its width to this text and
+				    pin the shorter control wherever the wrap put it. The set exists
+				    to test a sender's retry and error handling; saying so is cheaper
+				    than a doc nobody opens mid-debug. On a stopped inbox it says the
+				    other thing - that none of this is being served - because the
+				    controls above would otherwise read as an inbox waiting for
+				    callers it can no longer receive. */}
+				<p className="text-xs text-muted-foreground mt-1.5">
 					{stopped
 						? "This inbox is stopped, so nothing is being served. Start a new one to change what callers receive."
-						: "What every caller receives - a 500 with a delay exercises their retries."}
+						: "Every caller to this inbox gets this reply. Apply sends the changes to the engine; the Dock reports the save."}
 				</p>
 			</div>
 

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -258,13 +258,13 @@ export default function InboxView() {
 		);
 	};
 
-	const applyResponse = (response: Partial<InboxCannedResponse>) => {
-		if (!inbox) return;
-		updateResponse.mutate(
-			{ inboxId: inbox.inboxId, response },
-			{ onError: reportFailure("Could not update the response") }
-		);
-	};
+	// A rejection is how `CannedResponseControls` learns the apply failed - it
+	// reports through the save store (`persist`'s `failSave`), which replaced
+	// this call's own toast (issue #1450).
+	const applyResponse = (response: Partial<InboxCannedResponse>): Promise<void> =>
+		inbox
+			? updateResponse.mutateAsync({ inboxId: inbox.inboxId, response }).then(() => undefined)
+			: Promise.resolve();
 
 	if (!inbox) {
 		return (

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -670,7 +670,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   `setState` inside an effect. Apply sends the whole response, not a diff: `PUT /inbox/:id` is a
   merge-patch, so an omitted `headers` is how a header the user deleted comes back. On a **stopped**
   inbox every control is disabled and says why - the route still merge-patches a stopped record, so
-  a live-looking panel there is an edit accepted for a reply nothing will ever send. The reply
+  a live-looking panel there is an edit accepted for a reply nothing will ever send. Apply reports
+  through the save store like every other explicit save (issue #1450): it dims once the drafts match
+  what the engine last served, and a press moves the Dock through its Saving/Saved or error states
+  instead of a bare success-free toast; the reply is also a registered `useDraftSaveContext`, so a
+  quit mid-apply or Ctrl/Cmd+S reaches it. The hint under the controls is a full-width line, never a
+  sibling in the controls' own flex row, per `docs/design-system.md`'s hint-stacking rule. The reply
   headers are
   [`KeyValueEditor`](#shared-keyvalue-editor-componentssharedkeyvalueeditor) rows, with no `variables` scope
   passed - a canned reply is echoed verbatim, so there is nothing to resolve. They were local

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -555,13 +555,19 @@ Orchestrates auto-save across the app with a registry of saveable contexts (e.g.
 **`failSave` is the app's single failure seam.** It sets `status: "error"` *and*
 raises an error toast carrying the reason. Its call sites are the collection
 tree's create / delete / duplicate / rename, `useSaveManager`, `SettingsMain`,
-`VariableTableEditor`, `useDraftSaveContext` and the context bar's
-`VariablesSection` - and doing the reporting here rather than at each of them
-means a new caller cannot forget to report. The last two were added because both
-could fail in complete silence: the variables section fired three mutations with
-no `onError` at all, and the
+`VariableTableEditor`, `useDraftSaveContext`, the context bar's
+`VariablesSection` and the inbox's `CannedResponseControls` - and doing the
+reporting here rather than at each of them means a new caller cannot forget to
+report. The last two were added because both could fail in complete silence:
+the variables section fired three mutations with no `onError` at all, and the
 manual-draft editors rendered an inline callout that a quit flush has no screen
-to show.
+to show. `CannedResponseControls` (#1450) is a direct writer like
+`SettingsMain`: pressing Apply calls `startSaving`/`completeSaveThenIdle`/
+`failSave` itself around the PUT, rather than only through the
+`useDraftSaveContext`-registered `save` those two functions also serve to
+Ctrl/Cmd+S and the quit flush - the registration alone would report nothing
+for a direct click, since only `triggerSave`/`flushAll` route a registered
+context's `save` through the store's own status wrapper.
 
 `VariablesSection` also **registers a context** (`context-bar-variables`),
 because `failSave` alone only covers the failure. A variable commit is a plain


### PR DESCRIPTION
## Description

Verified at master `6d9d0a2` (current line numbers below match this base).

**Root cause.** `applyResponse` (`app/src/modules/inbox/index.tsx:261-267`) called `updateResponse.mutate` with only an `onError` handler - no `onSuccess` beyond the mutation hook's own cache invalidation, so a successful apply produced no feedback anywhere. `CannedResponseControls`'s Apply button (`:199`) was `disabled={stopped || pending}` - no comparison against what the engine last served, so it stayed identically clickable whether or not anything had changed. The hint `<p>` (`:203-212`) was the last child of the same `flex flex-wrap items-end gap-3` row as the inputs and the button (`:160`), so its position depended on where the row happened to wrap.

**Plan (root cause, approach, rejected alternative).** Every other explicit save in the app reports through the central save-status store (`useSaveStore`) and, where the save has an off-screen quit or Ctrl/Cmd+S path, registers with it via `useDraftSaveContext` - the exact pattern `AuthTab` uses for its own manual Save button. I mirrored both halves rather than reinventing a third: `CannedResponseControls` now derives `isDirty` (drafts vs. the served `response`, compared header-set-wise so row order doesn't matter) and a single `persist` function wraps the apply in `startSaving`/`completeSaveThenIdle`/`failSave`, used both as the button's `onClick` and as the registered `save` for `useDraftSaveContext` - giving the inbox tab quit-flush protection for free, per the issue's own suggested fix pathway.

I considered leaving the direct-click reporting to `useDraftSaveContext`'s own internal wrapper alone (as `AuthTab` does), but that wrapper only reports status when a save is invoked *through* the store (`triggerSave`/`flushAll` - i.e. Ctrl/Cmd+S or quit); a direct button click bypasses it entirely, which would have left the click itself silent - the exact defect this issue is about. `persist` therefore does its own status reporting and never rejects, so the hook's own `failSave` catch is inert for this component (no double-reporting).

Also considered a success toast (rejected explicitly by the issue - the Dock's status is the app's one answer to "did it save") and keeping the hint in the row with `basis-full` (rejected - it still hangs off `items-end` alignment rather than fixing the row-sharing itself).

## App changes

`app/src/modules/inbox/CannedResponseControls.tsx`, `app/src/modules/inbox/index.tsx`. No engine or MCP change; `PUT /inbox/:id` is unchanged - this is a renderer-only wiring and layout fix.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test CannedResponseControls InboxView` - 7 files, 48 tests, all passing, including 6 new cases:
  - `Apply reports through the save store (#1450)`: a successful apply moves `useSaveStore` to `"saved"` with no toast; a refused apply moves it to `"error"` with exactly one toast carrying the engine's message (not a bare toast); the reply registers a `"inbox-reply"` save context with `hasPendingChanges` tracking the draft.
  - `Apply dims once there is nothing new to send`: starts disabled on an unedited draft, enables after any field changes.
  - `the hint stacks under the controls, never sharing their row`: asserts the hint element is not contained by the controls row's closest `.flex-wrap` ancestor, for both the running and stopped-inbox hints.
- Mutation-checked by hand (also noted inline as comments beside each case): reverting the `startSaving`/`completeSaveThenIdle` pair, swallowing the rejection instead of calling `failSave`, dropping the `!isDirty` term from `applyDisabled`, and moving the hint back inside the row each reds exactly the case naming it.
- `pnpm type-check && pnpm lint` - clean.
- `npx prettier --check` on every changed file - clean.
- Full `pnpm test` - **698 files / 7992 tests, all passing** (no pre-existing failures on this base).

## No user-visible design change beyond what the issue asks for

The Apply button, its disabled styling, and the hint's typography are the same primitives already on screen (`Button variant="outline" size="sm"`, `text-xs text-muted-foreground`) - only the button's `disabled` condition and the hint's position/wording changed, both covered by the tests above. Screenshots were not captured: this container's vcpkg install hits the documented `curl operation failed with response code 403` GitHub-archive block on `cpp-httplib` (see the root `CLAUDE.md`'s build-failures section), and building the engine to run the real Electron app for a two-file renderer change wasn't a proportionate use of this run's time given the mutation-checked test coverage above already pins the exact behavior (dirty-gating, save-store transitions, hint placement) a screenshot would otherwise be showing.

## Docs, same commit

- `docs/app/COMPONENTS.md`'s `CannedResponseControls.tsx` bullet: Apply now reports through the save store and dims when nothing changed; the hint is a full-width line.
- `docs/app/state-management.md`'s `failSave` call-site list gains `CannedResponseControls`, with a paragraph on why it wires the status calls directly rather than relying on `useDraftSaveContext` alone (a direct click bypasses the store's own wrapper).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1450