### PR TITLE
fix(engine): tally a load replay's mixed pass/fail pm.test results

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -2360,7 +2360,13 @@ The **language** is current; what is missing is the **host environment**:
 - `samplesTested` in the report (`TestsSampled`) is the **size of that sample**,
   not the run's request count, and `sampling.responseSamplesDropped` beside it
   says how many responses the bound thinned away
-- Results are aggregated and reported in the final report
+- Results are aggregated and reported in the final report: `testsPassed` /
+  `testsFailed` tally every `pm.test` call across every sampled response, so a
+  script whose assertions are a mix of passing and failing reports both counts
+  and names each failing assertion (`name: message`) rather than collapsing
+  the sample to one opaque failure. Only a script that threw before any
+  `pm.test` ran reports a single script-level failure, carrying the thrown
+  message (issue #1502)
 - `pm.info` reports the same identity a Send does: `eventName` is `"test"`, and
   `requestId` / `requestName` are the run's linked request when it has one. It
   also reports `iteration` - the index the sampled submission claimed before it

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -172,8 +172,11 @@ std::vector<std::string>& failure_messages) {
             }
             auto result = engine.execute (*replay.script, script_ctx);
 
-            if (result.success) {
-                // Check individual test results
+            // Tally every test the script actually ran before falling back to
+            // a script-level verdict - `result.tests` is populated whether or
+            // not the script went on to throw (issue #1502), so a mixed
+            // pass/fail script must not be collapsed to one opaque failure.
+            if (!result.tests.empty ()) {
                 for (const auto& test : result.tests) {
                     if (test.passed) {
                         totals.passed++;
@@ -182,10 +185,9 @@ std::vector<std::string>& failure_messages) {
                         record_failure (test.name + ": " + test.error_message);
                     }
                 }
-                if (result.tests.empty ()) {
-                    // Script ran but had no pm.test() calls - count as passed
-                    totals.passed++;
-                }
+            } else if (result.success) {
+                // Script ran but had no pm.test() calls - count as passed
+                totals.passed++;
             } else {
                 totals.failed++;
                 record_failure ("Script error: " + result.error_message);

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -92,6 +92,42 @@ struct ScriptReplay {
 };
 
 /**
+ * @brief Tally one replayed script's verdict into @p totals.
+ *
+ * `result.tests` is populated whether or not the script went on to throw, so
+ * it is read first: a mixed pass/fail script must not collapse into one
+ * opaque failure (issue #1502). A throw after tests already ran (or a failed
+ * `pm.request` writeback) is a second, distinct failure and is recorded
+ * alongside them, never dropped just because the tests that did run are
+ * counted - the same distinction `script_errored` draws in the design path.
+ */
+template <typename RecordFailure>
+void tally_replay_result (const vayu::ScriptResult& result,
+ScriptValidationTotals& totals,
+RecordFailure&& record_failure) {
+    if (!result.tests.empty ()) {
+        for (const auto& test : result.tests) {
+            if (test.passed) {
+                totals.passed++;
+            } else {
+                totals.failed++;
+                record_failure (test.name + ": " + test.error_message);
+            }
+        }
+        if (!result.success && !result.error_message.empty ()) {
+            totals.failed++;
+            record_failure ("Script error: " + result.error_message);
+        }
+    } else if (result.success) {
+        // Script ran but had no pm.test() calls - count as passed
+        totals.passed++;
+    } else {
+        totals.failed++;
+        record_failure ("Script error: " + result.error_message);
+    }
+}
+
+/**
  * @brief Replay one script against one set of samples, tallying the results.
  *
  * @param scopes The run's stored variable scopes, shared by every replay of the
@@ -171,27 +207,7 @@ std::vector<std::string>& failure_messages) {
                 script_ctx.response_events = &stream_events;
             }
             auto result = engine.execute (*replay.script, script_ctx);
-
-            // Tally every test the script actually ran before falling back to
-            // a script-level verdict - `result.tests` is populated whether or
-            // not the script went on to throw (issue #1502), so a mixed
-            // pass/fail script must not be collapsed to one opaque failure.
-            if (!result.tests.empty ()) {
-                for (const auto& test : result.tests) {
-                    if (test.passed) {
-                        totals.passed++;
-                    } else {
-                        totals.failed++;
-                        record_failure (test.name + ": " + test.error_message);
-                    }
-                }
-            } else if (result.success) {
-                // Script ran but had no pm.test() calls - count as passed
-                totals.passed++;
-            } else {
-                totals.failed++;
-                record_failure ("Script error: " + result.error_message);
-            }
+            tally_replay_result (result, totals, record_failure);
         } catch (const std::exception& e) {
             totals.failed++;
             record_failure ("Exception: " + std::string (e.what ()));

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -785,9 +785,44 @@ TEST_F (ScenarioLoadTest, AMixedPassAndFailScriptReportsBothTalliesAndNamesTheFa
     const auto results = db_->get_results ("test-scenario-load");
     ASSERT_FALSE (results.empty ());
     const std::string& trace = results.back ().trace_data;
-    EXPECT_NE (trace.find ("body has a unicorn"), std::string::npos) << trace;
+    EXPECT_NE (trace.find ("body has a unicorn: AssertionError: Expected "
+                           "undefined to equal 'yes'"),
+    std::string::npos)
+    << trace;
     EXPECT_EQ (trace.find ("Script error: "), std::string::npos)
     << "a named assertion failure was reported as an opaque script error: " << trace;
+}
+
+// A script can run a test to completion and still throw afterwards - that is
+// a second, distinct failure and must not vanish just because the test that
+// already ran is tallied (issue #1502).
+TEST_F (ScenarioLoadTest, AScriptThatThrowsAfterAPassingTestStillReportsTheThrow) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0") });
+    execution.plan.steps[0].post_script =
+    "pm.test('ok', function () { pm.expect(1).to.equal(1); });"
+    "throw new Error('late boom');";
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto validation = vayu::core::validate_scripts (context_, *db_, false);
+
+    ASSERT_EQ (validation.steps.size (), 1u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 1u)
+    << "the test that ran before the throw was dropped";
+    EXPECT_EQ (first_step->failed, 1u)
+    << "the throw after the test was silently dropped";
+
+    const auto results = db_->get_results ("test-scenario-load");
+    ASSERT_FALSE (results.empty ());
+    const std::string& trace = results.back ().trace_data;
+    EXPECT_NE (trace.find ("Script error: "), std::string::npos) << trace;
+    EXPECT_NE (trace.find ("late boom"), std::string::npos)
+    << "the thrown message was dropped: " << trace;
 }
 
 // A script that throws before ever calling `pm.test` has no tests to tally,

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -757,6 +757,67 @@ TEST_F (ScenarioLoadTest, AFailingAssertionIsAttributedToItsOwnStep) {
     EXPECT_EQ (validation.run->passed, 2u);
 }
 
+// A script whose `pm.test` calls are a mix of passing and failing must not
+// collapse to one opaque failure (issue #1502): every test result is tallied
+// and every failure is named.
+TEST_F (ScenarioLoadTest, AMixedPassAndFailScriptReportsBothTalliesAndNamesTheFailure) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0") });
+    execution.plan.steps[0].post_script =
+    "pm.test('status is 200', function () { "
+    "pm.expect(pm.response.code).to.equal(200); });"
+    "pm.test('body has a unicorn', function () { "
+    "pm.expect(undefined).to.equal('yes'); });";
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto validation = vayu::core::validate_scripts (context_, *db_, false);
+
+    ASSERT_EQ (validation.steps.size (), 1u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 1u)
+    << "the passing assertion was discarded once a sibling assertion failed";
+    EXPECT_EQ (first_step->failed, 1u);
+
+    const auto results = db_->get_results ("test-scenario-load");
+    ASSERT_FALSE (results.empty ());
+    const std::string& trace = results.back ().trace_data;
+    EXPECT_NE (trace.find ("body has a unicorn"), std::string::npos) << trace;
+    EXPECT_EQ (trace.find ("Script error: "), std::string::npos)
+    << "a named assertion failure was reported as an opaque script error: " << trace;
+}
+
+// A script that throws before ever calling `pm.test` has no tests to tally,
+// so it still takes the script-error path - but with the real thrown message,
+// never an empty one (issue #1502).
+TEST_F (ScenarioLoadTest, AThrowingScriptWithNoTestsNamesTheThrownMessage) {
+    ScenarioMockServer server;
+    auto execution                      = plan_over ({ server.url ("/s0") });
+    execution.plan.steps[0].post_script = "throw new Error('boom');";
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto validation = vayu::core::validate_scripts (context_, *db_, false);
+
+    ASSERT_EQ (validation.steps.size (), 1u);
+    const auto& first_step = validation.steps[0];
+    ASSERT_HAS_VALUE (first_step);
+    EXPECT_EQ (first_step->passed, 0u);
+    EXPECT_EQ (first_step->failed, 1u);
+
+    const auto results = db_->get_results ("test-scenario-load");
+    ASSERT_FALSE (results.empty ());
+    const std::string& trace = results.back ().trace_data;
+    EXPECT_NE (trace.find ("Script error: "), std::string::npos) << trace;
+    EXPECT_NE (trace.find ("boom"), std::string::npos)
+    << "the thrown message was dropped, leaving an empty \"Script error: \": " << trace;
+}
+
 // The replayed script reads the iteration it actually ran in and the data row
 // that iteration was bound to - a real index, not a reservoir position.
 TEST_F (ScenarioLoadTest, ADeferredStepScriptReadsItsIterationAndDataRow) {


### PR DESCRIPTION
## Description

A load run's deferred script replay (`run_replay` in `engine/src/core/run_manager.cpp`) branched on `ScriptResult::success`. `script_engine.cpp` sets that flag to `false` whenever *any* `pm.test` assertion in the script fails, with no `error_message` set for that reason alone (an empty message is reserved for a real script-level error). Because `run_replay`'s `else` branch never read `result.tests`, any script with even one failing assertion reported `testsPassed 0, testsFailed 1` and the failure text `"Script error: "` with an empty message - discarding every assertion that actually passed, and hiding which assertion failed.

**Plan.** Three research passes: one verified the issue's file:line anchors against current code (`run_manager.cpp:175-192`, `script_engine.cpp:8757-8763`, and the non-load `append_tests` in `engine/src/http/routes/execution.cpp:701-715` it should mirror - the issue cited `engine/src/core/execution.cpp`, which has moved), one traced every consumer of the load report's `testValidation`/failure-message shape (the app's `TestValidationSummary.tsx`, `types/domain.ts`, the MCP `get_run_report` tool) to confirm the fix changes only the counting logic and not the JSON shape, and one read `docs/engine/scripting.md`'s Load Test Scripts section for the sentence that goes stale under the real fix. Root cause: `result.success` conflates "the script threw" with "an assertion failed" into one flag, and the load path's counting branched on that flag instead of on whether `result.tests` (which is always populated, whether or not the script went on to throw) is empty.

**Fix.** `run_replay` now reads `result.tests` first whenever it is non-empty and tallies each test individually - exactly what the design (non-load) path already does via `append_tests`. Only a script with *no* tests at all falls back to `result.success`: a clean no-assertion script still counts as passed, and a script that threw before ever reaching a `pm.test` call still reports its real thrown message under `"Script error: "`, never an empty one.

**A gap an adversarial review pass caught and this PR also closes**: a script that runs a test to completion and *then* throws (or fails the `pm.request` writeback) has a non-empty `result.tests`, so the first version of this fix tallied the completed test(s) but silently dropped the throw - worse than the pre-fix behaviour for that one sub-case, which at least reported it as one opaque failure. `run_replay` now records that throw as an additional failure alongside whatever tests already ran, carrying its real message. The tally logic was extracted into its own `tally_replay_result` helper in the same commit: adding this branch inline pushed `run_replay`'s cognitive complexity past clang-tidy's gate (26 vs. threshold 25), and the tally reads better as one self-contained decision than as more nesting in an already-long loop body.

**Alternative considered and rejected.** Making the script-level error message additive in the *tests-empty* branches too (there is only one such branch, so this was never actually a fork) - not applicable here; the one real design choice was the additive-vs-dropped question above, resolved as described.

## Type of Change
- [x] Bug fix

## Testing

- `engine/tests/scenario_load_test.cpp`: three new cases next to the existing `AFailingAssertionIsAttributedToItsOwnStep`.
  - `AMixedPassAndFailScriptReportsBothTalliesAndNamesTheFailure` - the issue's own repro (one passing `pm.test`, one failing) - asserts `passed 1, failed 1` and that the stored failure text is the exact `body has a unicorn: AssertionError: Expected undefined to equal 'yes'`, not `"Script error: "`.
  - `AThrowingScriptWithNoTestsNamesTheThrownMessage` - a script with no `pm.test` calls that throws - asserts the stored failure text carries the real thrown message (`boom`), not an empty one.
  - `AScriptThatThrowsAfterAPassingTestStillReportsTheThrow` - a script whose single `pm.test` passes and which then throws - asserts `passed 1, failed 1` and that the thrown message (`late boom`) is recorded, not dropped.
- Mutation-checked by hand, twice: reverting `run_manager.cpp` to the pre-fix branch reddens exactly the mixed-tally test (1 of 2965 engine tests); separately reverting just the new throw-after-tests branch reddens exactly the third test above (the failure row goes missing entirely). Everything else is unaffected either time.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2965/2965 passing** on the final state, including all 44 `ScenarioLoadTest` cases and the `ScriptSendRequestCap*`/`LoadIdentityTest` suites the issue named.
- No app files touched, so `pnpm test` / `pnpm type-check` were not run (nothing in the diff could affect them).

## Docs, same commit

`docs/engine/scripting.md`'s Load Test Scripts section: the "aggregated and reported" bullet now states that `testsPassed`/`testsFailed` tally every `pm.test` call across sampled responses (mixed pass/fail included) and that only a script that threw before any test ran gets a single script-level message.

## No user-visible change

Engine-only: the load report's JSON shape (`testValidation`, the stored failure row's `failures`/`totalFailed`/`totalPassed`) is unchanged, only the values populating it are corrected. No app files were touched.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 clean, clang-tidy clean including the cognitive-complexity gate, on the two changed engine files)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1502
