### PR TITLE
fix(engine): batch the header-strip startup pass and back it up before it runs

### DIFF
--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -41,6 +41,12 @@ up looking like a fresh install.
 > `POST /workspace/backup` / `vayu-cli backup`, described in
 > [architecture.md](architecture.md#workspace-backups).
 
+> **`<db>.pre-upgrade.bak` is different: it is written once.** A one-time
+> repair pass (below) takes it immediately before its first rewrite, and
+> nothing after that touches it again - unlike `<db>.bak`, which the *next*
+> clean start would refresh from a file the repair has already rewritten. It
+> is the one place the pre-repair rows survive more than a single restart.
+
 ### The quarantine (issue #984)
 
 A database that fails validation is **moved, not deleted**: `<db>` becomes
@@ -141,6 +147,29 @@ rewrite slow enough to matter is one this line explains.
 Best-effort like the sweeps before it: a failure is a warning, never a daemon that will not start.
 `auto_vacuum` was rejected as the alternative - switching an existing database's mode requires a
 full `VACUUM` anyway, and it changes page bookkeeping for every write thereafter.
+
+### The header-strip pass (issue #1487)
+
+`Database::strip_stored_managed_headers()`, called from `init()`, removes the `X-Vayu-Version`,
+`X-Request-ID` and `User-Agent` rows a pre-#1229 renderer wrote into a saved request's `headers`
+column on the app's own behalf - default headers are applied per transfer now and never stored.
+Like the passes above it runs before `/health` can answer, but it is scoped so a workspace with
+nothing left to strip pays close to nothing for it:
+
+- **A SQL `LIKE` over `headers` first.** Only rows whose header text could contain one of the
+  three names are loaded into a `Request` and JSON-parsed; `LIKE` is ASCII case-insensitive by
+  default, the same fold the exact predicate applies to a matched key. A workspace already
+  stripped costs one scan of the column, not a materialisation of every request's body and
+  script.
+- **One transaction for the rewrite**, not one implicit commit per candidate row - the same shape
+  `seed_default_config` uses.
+- **A one-time marker.** Once a pass finds nothing left to strip, it records a
+  `managedHeadersStripped` config entry (`advanced`, no everyday user story) and every later start
+  skips the scan outright rather than re-running it to confirm nothing changed. #1492 will give
+  this kind of migration bookkeeping a proper home; until then a config entry is where this
+  file's other internal-only flags already live.
+- **`<db>.pre-upgrade.bak`** is written once, immediately before the first row this pass ever
+  rewrites - see the backup note above.
 
 ---
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -324,7 +324,9 @@ Stores individual HTTP request definitions.
 [{"key":"Content-Type","value":"application/json","enabled":true,"description":""}]
 ```
 Disabled rows (`"enabled":false`) are preserved in storage and filtered at HTTP-execution time only.
-Duplicate keys are allowed.
+Duplicate keys are allowed. A pre-#1229 renderer also wrote its own `X-Vayu-Version`,
+`X-Request-ID` and `User-Agent` rows here; [the header-strip pass](#the-header-strip-pass-issue-1487)
+removes them once, at startup.
 
 **body** - discriminated union:
 ```json

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -2028,10 +2028,81 @@ int64_t Database::stamp_hashless_spec_bindings () {
     return stamped;
 }
 
+namespace {
+// A repair that runs once is a migration and gets a migration's bookkeeping
+// (issue #1487). #1492 will give this kind of marker a proper home; until
+// then a `config_entries` row - `advanced`, no everyday user story - is where
+// this file's other internal-only flags already live.
+constexpr std::string_view MANAGED_HEADERS_STRIPPED_KEY =
+"managedHeadersStripped";
+} // namespace
+
 int64_t Database::strip_stored_managed_headers () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    if (get_config_bool (std::string (MANAGED_HEADERS_STRIPPED_KEY), false)) {
+        return 0;
+    }
+
+    // Only rows whose `headers` text could contain one of the three legacy
+    // names are worth loading and JSON-parsing. `LIKE` is ASCII
+    // case-insensitive by default, the same fold `legacy_managed_row` applies
+    // to a matched key, so a workspace with nothing left to strip costs one
+    // scan of this column rather than a materialisation of every request's
+    // body and script (issue #1487).
+    auto candidates = impl_->storage.get_all<Request> (
+    where (like (&Request::headers, "%x-vayu-version%") or
+    like (&Request::headers, "%x-request-id%") or like (&Request::headers, "%user-agent%")));
+
+    auto mark_done = [&] {
+        save_config_entry (ConfigEntry{
+        .key   = std::string (MANAGED_HEADERS_STRIPPED_KEY),
+        .value = "true",
+        .type  = "boolean",
+        .label = "Legacy managed headers stripped",
+        .description =
+        "Whether requests saved before 0.26.0 have had the "
+        "engine's own X-Vayu-Version, X-Request-ID and User-Agent headers "
+        "removed from storage. Internal bookkeeping for a one-time cleanup; "
+        "turning it off re-runs the cleanup on the next start.",
+        .category      = "general_engine",
+        .default_value = "false",
+        .min_value     = std::nullopt,
+        .max_value     = std::nullopt,
+        .options       = std::nullopt,
+        .updated_at    = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+        .count (),
+        .requires_restart = false,
+        .advanced         = true,
+        .keywords         = "[]",
+        .unit             = std::nullopt,
+        });
+    };
+
+    if (candidates.empty ()) {
+        mark_done ();
+        return 0;
+    }
+
+    // `<db>.pre-upgrade.bak` is written once, right before the first row this
+    // pass ever rewrites, and nothing after this call touches it again -
+    // unlike `<db>.bak`, which the *next* clean start refreshes from whatever
+    // the live file holds by then (issue #1487). It is the one place the
+    // pre-strip rows survive more than a single restart.
+    const fs::path db_file (impl_->opened_file);
+    fs::path pre_upgrade_backup = db_file;
+    pre_upgrade_backup += ".pre-upgrade.bak";
+    copy_db_files (db_file, pre_upgrade_backup);
+
+    // One transaction for the whole rewrite, not one implicit commit per row -
+    // the same shape `seed_default_config` uses and for the same reason:
+    // `/health` cannot answer until `init ()` returns, and a workspace with
+    // thousands of candidate rows made every one of them its own commit.
+    auto strip_transaction = impl_->storage.transaction_guard ();
+
     int64_t stripped = 0;
-    for (auto& request : impl_->storage.get_all<Request> ()) {
+    for (auto& request : candidates) {
         auto rewritten = vayu::http::strip_legacy_managed_headers (request.headers);
         if (!rewritten) {
             continue;
@@ -2044,6 +2115,9 @@ int64_t Database::strip_stored_managed_headers () {
         impl_->storage.replace (request);
         ++stripped;
     }
+
+    mark_done ();
+    strip_transaction.commit ();
     return stripped;
 }
 

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -443,7 +443,12 @@ TEST_F (ConfigRouteTest, AdvancedFlagsExactlyTheRecordedInternals) {
         "monitorScrapeTimeoutMs", "liveMaxRetainedTicks", "scriptStackSize",
         // A per-start log file plus the retention count is the bound a user
         // reaches for; this one is the backstop under it (#985).
-        "maxLogFileBytes" };
+        "maxLogFileBytes",
+        // The one-time header-strip migration's "already ran" marker (#1487) -
+        // written by `strip_stored_managed_headers` itself rather than seeded,
+        // but every `init ()` sets it on first run, so it is as reliably
+        // present as the rest of this list.
+        "managedHeadersStripped" };
 
     auto entries = db_->get_all_config_entries ();
     ASSERT_FALSE (entries.empty ()) << "catalogue empty - nothing was scanned";

--- a/engine/tests/default_headers_test.cpp
+++ b/engine/tests/default_headers_test.cpp
@@ -273,6 +273,31 @@ class DefaultHeaderConfigTest : public ::testing::Test {
     static void cleanup () {
         vayu::tests::remove_database_files (DB_PATH);
     }
+    // `SetUp` calls `init ()` on a database with no requests yet, which is
+    // itself enough for `strip_stored_managed_headers` to find nothing and
+    // mark the cleanup done (issue #1487) - correct for a real fresh install,
+    // which can never write the legacy headers again, but it means a test
+    // that adds pre-#1229-shaped data *after* `SetUp` must undo that marker
+    // first, or every direct call below sees it already set and skips.
+    void reset_managed_headers_marker () {
+        db_->save_config_entry (vayu::db::ConfigEntry{
+        .key              = "managedHeadersStripped",
+        .value            = "false",
+        .type             = "boolean",
+        .label            = "Legacy managed headers stripped",
+        .description      = "",
+        .category         = "general_engine",
+        .default_value    = "false",
+        .min_value        = std::nullopt,
+        .max_value        = std::nullopt,
+        .options          = std::nullopt,
+        .updated_at       = 0,
+        .requires_restart = false,
+        .advanced         = true,
+        .keywords         = "[]",
+        .unit             = std::nullopt,
+        });
+    }
     std::unique_ptr<vayu::db::Database> db_;
 };
 
@@ -443,6 +468,7 @@ TEST_F (DefaultHeaderConfigTest, StartupStripsTheStoredRowsAndLeavesTheUsersAlon
     untouched.headers = R"([{"key":"User-Agent","value":"Mozilla/5.0","enabled":true}])";
     db_->save_request (untouched);
 
+    reset_managed_headers_marker ();
     EXPECT_EQ (db_->strip_stored_managed_headers (), 1);
 
     auto stripped = db_->get_request ("req_managed");
@@ -458,6 +484,82 @@ TEST_F (DefaultHeaderConfigTest, StartupStripsTheStoredRowsAndLeavesTheUsersAlon
     // Idempotent: the pass runs at every startup, and a second one must find
     // nothing left to do rather than rewriting rows again.
     EXPECT_EQ (db_->strip_stored_managed_headers (), 0);
+}
+
+// A repair that runs once is a migration and gets a migration's bookkeeping
+// (issue #1487): once nothing is left to strip, the pass records that and
+// trusts it on every later call rather than re-scanning to confirm.
+TEST_F (DefaultHeaderConfigTest, ASecondStartupSkipsTheScanOnceEverythingIsMarkedStripped) {
+    vayu::db::Collection collection;
+    collection.id   = "col_marker";
+    collection.name = "Marker";
+    db_->create_collection (collection);
+
+    vayu::db::Request managed;
+    managed.id            = "req_marker_managed";
+    managed.collection_id = "col_marker";
+    managed.name          = "Managed";
+    managed.url           = "https://example.com/";
+    managed.headers = R"([{"key":"X-Vayu-Version","value":"0.1.1","enabled":true}])";
+    db_->save_request (managed);
+
+    reset_managed_headers_marker ();
+    EXPECT_EQ (db_->strip_stored_managed_headers (), 1);
+    EXPECT_TRUE (db_->get_config_bool ("managedHeadersStripped", false));
+
+    // Added after the marker was set: a real scan would find and strip it,
+    // but the marker means the pass never looks.
+    vayu::db::Request late;
+    late.id            = "req_marker_late";
+    late.collection_id = "col_marker";
+    late.name          = "Late";
+    late.url           = "https://example.com/";
+    late.headers = R"([{"key":"X-Vayu-Version","value":"0.1.1","enabled":true}])";
+    db_->save_request (late);
+
+    EXPECT_EQ (db_->strip_stored_managed_headers (), 0)
+    << "the marker should have skipped the scan outright";
+
+    auto still_has_it = db_->get_request ("req_marker_late");
+    ASSERT_HAS_VALUE (still_has_it);
+    EXPECT_NE (still_has_it->headers.find ("X-Vayu-Version"), std::string::npos);
+}
+
+// Issue #1487, point 3: `<db>.bak` is refreshed from the *current* file on
+// every clean start, including the one that just stripped these rows, so by
+// the next launch it no longer holds them. `<db>.pre-upgrade.bak` is written
+// once, before the first rewrite, and nothing after that touches it again.
+TEST_F (DefaultHeaderConfigTest, ThePreUpgradeBackupPreservesTheRowsBeforeTheFirstRewrite) {
+    vayu::db::Collection collection;
+    collection.id   = "col_backup";
+    collection.name = "Backup";
+    db_->create_collection (collection);
+
+    vayu::db::Request managed;
+    managed.id            = "req_backup_managed";
+    managed.collection_id = "col_backup";
+    managed.name          = "Managed";
+    managed.url           = "https://example.com/";
+    managed.headers = R"([{"key":"X-Vayu-Version","value":"0.1.1","enabled":true}])";
+    db_->save_request (managed);
+
+    const std::string backup_path = std::string (DB_PATH) + ".pre-upgrade.bak";
+    ASSERT_FALSE (std::filesystem::exists (backup_path))
+    << "nothing should exist before the pass has ever rewritten a row";
+
+    reset_managed_headers_marker ();
+    EXPECT_EQ (db_->strip_stored_managed_headers (), 1);
+
+    ASSERT_TRUE (std::filesystem::exists (backup_path))
+    << "the pre-rewrite snapshot was not written";
+
+    vayu::db::Database backup (backup_path);
+    auto pre_rewrite = backup.get_request ("req_backup_managed");
+    ASSERT_HAS_VALUE (pre_rewrite);
+    EXPECT_NE (pre_rewrite->headers.find ("X-Vayu-Version"), std::string::npos)
+    << "the snapshot should hold the row as it was before the strip touched it";
+
+    vayu::tests::remove_database_files (backup_path);
 }
 
 } // namespace

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -131,8 +131,12 @@ inline void remove_database_files (const std::string& path) {
     // The backup is a full copy, sidecars included, so the set is the SQLite
     // trio twice over - `path` and `path.bak`. The hand-copied lists this
     // replaced all stopped at a bare `.bak`, which leaves `.bak-wal` /
-    // `.bak-shm` behind whenever a WAL exists at open time.
-    for (const std::string& base : { path, path + ".bak" }) {
+    // `.bak-shm` behind whenever a WAL exists at open time. `path.pre-upgrade.bak`
+    // is a third copy of the trio, written once by `strip_stored_managed_headers`
+    // the first time it finds a row to rewrite (issue #1487) - most fixtures
+    // never provoke it, but one that does must not leak it into the next test's
+    // scratch directory.
+    for (const std::string& base : { path, path + ".bak", path + ".pre-upgrade.bak" }) {
         for (const char* suffix : { "", "-wal", "-shm" }) {
             std::error_code ec;
             std::filesystem::remove (base + suffix, ec);


### PR DESCRIPTION
## Description

`Database::strip_stored_managed_headers` (`engine/src/db/database.cpp`) rewrote every stored request one row at a time with no transaction, on every engine start, before `/health` could answer - and it never recorded that it had already run, so a clean workspace paid the cost of materialising every request forever. Separately, the constructor's `.bak` refresh happens after `probe_database`'s own `sync_schema()` has already touched the live file, so a schema migration that goes wrong leaves no pre-migration copy to recover from.

**Plan.** Three research passes verified the issue's file:line anchors still held at master `d1fe93d` (the strip loop at `database.cpp:2031-2048`, the constructor's probe-then-backup order at `:1027-1078`, `seed_default_config`'s `transaction_guard` pattern at `:3382`), traced the strip predicate (`strip_legacy_managed_headers`, owned by a separate issue, #1491) and the `.bak`/backup consumers to confirm nothing else depends on the current ordering, and read `engine/CLAUDE.md` plus `docs/engine/db-schema.md` for the documented conventions a fix here has to follow. Root cause: the pass conflated "select every row" with "rewrite the ones that changed", and the constructor's backup is refreshed from whatever the live file holds *after* migration rather than before. Fix: a SQL `LIKE` filter narrows candidates before any JSON parsing, one transaction wraps the actual rewrite, a `config_entries` marker (`managedHeadersStripped`, `advanced`) skips the scan entirely once nothing is left to strip, and a `<db>.pre-upgrade.bak` snapshot - written once, before the first row is ever rewritten - is added alongside the existing `.bak` rather than reordering the constructor, since the existing `.bak`/recovery logic is delicate and untouched by this issue's own fix pathway's first option.

**Alternative considered and rejected:** reordering the constructor to take `.bak` before `probe_database`'s `sync_schema()` (the issue's other suggested option). Rejected because `copy_db_files` there is only trusted after `probe_database` validates the file (issue #984's fix - "the backup is only ever taken from a database that validated"), and moving it earlier would back up an unvalidated file, risking overwriting a good backup with a bad one. The second-file approach the issue also offers gets the same guarantee (pre-rewrite rows survive more than one restart) without touching that validated-backup invariant.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

- `engine/tests/default_headers_test.cpp`: the existing `StartupStripsTheStoredRowsAndLeavesTheUsersAlone` now resets the new marker first (its own `SetUp` already runs `init()` on an empty database, which now marks the migration done before the test seeds its legacy-header rows). Two new cases: `ASecondStartupSkipsTheScanOnceEverythingIsMarkedStripped` (a row added *after* the marker is set is never touched - proves the skip is unconditional, not just "nothing new to find") and `ThePreUpgradeBackupPreservesTheRowsBeforeTheFirstRewrite` (opens `<db>.pre-upgrade.bak` as a second `Database` and asserts it still holds the unstripped row).
- `engine/tests/config_route_test.cpp`: `AdvancedFlagsExactlyTheRecordedInternals` enumerates every seeded `advanced` config key; the new marker is one more, so it's added to the expected set.
- `engine/tests/temp_database.hpp`: `remove_database_files` now also cleans up `<path>.pre-upgrade.bak` and its `-wal`/`-shm` sidecars, so a test that provokes it doesn't leak the file into the next scratch directory.
- Mutation-checked by hand: removing the `get_config_bool` marker guard makes the second-startup test find and strip the "late" row (fails as expected); removing the `copy_db_files` call makes the backup-existence assertion fail outright.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2965/2965 passing**, including the two new cases and every existing `DefaultHeaderConfigTest`/`ConfigRouteTest`/`DatabaseTest`/`ScratchDatabaseCleanup` case.

**Known test gap, stated rather than hidden:** the issue's suggested test for "one transaction" is a SQL trace-hook counting `BEGIN` statements, or a wall-clock bound under `synchronous=FULL`. Neither exists as infrastructure anywhere in this codebase (confirmed by grep for `sqlite3_trace`/`sqlite3_trace_v2`), and a wall-clock assertion in a shared CI runner risks exactly the flakiness this repo's own testing conventions warn against. The transaction-wrap itself is not independently pinned by a test; the marker-skip and pre-upgrade-backup behaviors are, and both would regress visibly if the transaction wrap were removed carelessly alongside them.

## Docs, same commit

`docs/engine/db-schema.md`: a new `.pre-upgrade.bak` note beside the existing `.bak` semantics, and a new "The header-strip pass (issue #1487)" subsection describing the LIKE filter, the transaction, and the one-time marker.

## No user-visible change

Engine-only: `engine/src/db/database.cpp`, its tests, and `docs/engine/db-schema.md`. No `app/` files touched, so `pnpm test`/`pnpm type-check` were not run (nothing in the diff could affect them).

## Checklist
- [x] My code follows the style guidelines (clang-format 19 clean, clang-tidy clean on the changed engine files)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1487