### PR TITLE
fix(app): ask before a quit or close discards a save the engine never took

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -55,7 +55,12 @@ import {
 	type ContextCommand,
 } from "./context-menu.js";
 import { showApplicationMenu } from "./app-menu.js";
-import { createSaveFlusher } from "./save-flush.js";
+import {
+	createSaveFlusher,
+	confirmDiscardOnFailedFlush,
+	type FlushResult,
+	type FlushFailurePrompt,
+} from "./save-flush.js";
 import { createRendererRecovery } from "./renderer-recovery.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
 import { stampInstalledVersion } from "./appimage-stamp.js";
@@ -257,6 +262,20 @@ async function askOnWindow(options: Electron.MessageBoxOptions): Promise<number>
 	return response;
 }
 
+// The dialog `confirmDiscardOnFailedFlush` shows when a flush did not land
+// cleanly (#1489). "Proceed" is the default button, matching the running-
+// services confirm below - Enter takes the destructive option, Esc/close
+// keeps working, which is what leaves the draft exactly as it was.
+const askFlushFailure = (prompt: FlushFailurePrompt): Promise<boolean> =>
+	askOnWindow({
+		type: "warning",
+		message: prompt.message,
+		detail: prompt.detail,
+		buttons: [...prompt.buttons],
+		defaultId: 0,
+		cancelId: 1,
+	}).then((choice) => choice === 0);
+
 // Shared by the quit path and the window-close path - see save-flush.ts for why
 // there is only one of these.
 const saveFlusher = createSaveFlusher({
@@ -271,8 +290,9 @@ const saveFlusher = createSaveFlusher({
 		return true;
 	},
 	onFlushed: (listener) => {
-		ipcMain.once("before-quit-flushed", listener);
-		return () => ipcMain.removeListener("before-quit-flushed", listener);
+		const handler = (_event: Electron.IpcMainEvent, result: FlushResult) => listener(result);
+		ipcMain.once("before-quit-flushed", handler);
+		return () => ipcMain.removeListener("before-quit-flushed", handler);
 	},
 	schedule: (listener, ms) => {
 		setTimeout(listener, ms);
@@ -531,9 +551,17 @@ function createWindow() {
 
 		if (saveFlusher.hasSettled()) return;
 		event.preventDefault();
-		saveFlusher.flush(() => {
-			if (!closingWindow.isDestroyed()) closingWindow.close();
-		});
+		// Named rather than inline so the flush's own outcome decides whether the
+		// window actually closes (#1489): a failed or unanswered flush asks
+		// before discarding it, instead of closing unconditionally once settled.
+		const closeAfterFlush = (result: FlushResult | null) => {
+			void confirmDiscardOnFailedFlush(askFlushFailure, "window-close", result).then(
+				(proceed) => {
+					if (proceed && !closingWindow.isDestroyed()) closingWindow.close();
+				}
+			);
+		};
+		saveFlusher.flush(closeAfterFlush);
 	});
 
 	// The mouse's back/forward buttons as the OS reports them, and the macOS
@@ -1428,6 +1456,17 @@ app.on("window-all-closed", () => {
 // second pass once rather than starting two engine shutdowns.
 const resumeQuit = () => app.quit();
 
+// The flush settled; whether the quit actually resumes is the dialog's answer
+// when it did not land cleanly (#1489). Re-entering through `app.quit()` on a
+// yes is deliberate: the second pass finds the flush already settled and
+// falls straight through to `quitShutdown.handleQuit`, so the question is
+// never asked twice.
+const resumeQuitAfterFlush = (result: FlushResult | null) => {
+	void confirmDiscardOnFailedFlush(askFlushFailure, "quit", result).then((proceed) => {
+		if (proceed) resumeQuit();
+	});
+};
+
 // Second pass of the quit: stop the children exactly once. See quit-shutdown.ts
 // for why "has a shutdown started" is the guard rather than "is the engine
 // still running" - the latter only clears after the awaits, so a quit landing
@@ -1459,7 +1498,7 @@ app.on("before-quit", (event) => {
 	// engine is never stopped out from under saves still being written.
 	if (!saveFlusher.hasSettled()) {
 		event.preventDefault();
-		saveFlusher.flush(resumeQuit);
+		saveFlusher.flush(resumeQuitAfterFlush);
 		return;
 	}
 

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -413,15 +413,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		return () => ipcRenderer.removeListener("notify:activated", handler);
 	},
 
-	// Before quit flush handler. ACKs main once the callback settles so quit
-	// can resume immediately instead of waiting out the fallback timeout.
-	onBeforeQuit: (callback: () => void | Promise<void>) => {
+	// Before quit flush handler. ACKs main once the callback settles, with the
+	// outcome the callback reports, so quit can resume immediately instead of
+	// waiting out the fallback timeout - and so a failed or incomplete flush is
+	// not read as a clean one (#1489). The shape mirrors `FlushResult` in
+	// electron/save-flush.ts, inlined because this file is a CommonJS script
+	// and must not grow imports.
+	onBeforeQuit: (callback: () => Promise<{ saved: number; failed: number; pending: number }>) => {
 		const handler = async () => {
+			let result: { saved: number; failed: number; pending: number };
 			try {
-				await callback();
-			} finally {
-				ipcRenderer.send("before-quit-flushed");
+				result = await callback();
+			} catch {
+				// An uncaught rejection is not proof nothing was lost - the more
+				// cautious reading is that it was, so main still asks rather than
+				// closing on a failure this side could not measure.
+				result = { saved: 0, failed: 1, pending: 0 };
 			}
+			ipcRenderer.send("before-quit-flushed", result);
 		};
 		ipcRenderer.on("before-quit", handler);
 		return () => ipcRenderer.removeListener("before-quit", handler);

--- a/app/electron/save-flush.test.ts
+++ b/app/electron/save-flush.test.ts
@@ -22,7 +22,17 @@ import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createSaveFlusher, FLUSH_TIMEOUT_MS, type FlushTransport } from "./save-flush";
+import {
+	createSaveFlusher,
+	buildFlushFailurePrompt,
+	confirmDiscardOnFailedFlush,
+	flushNeedsConfirmation,
+	FLUSH_TIMEOUT_MS,
+	type FlushResult,
+	type FlushTransport,
+} from "./save-flush";
+
+const CLEAN: FlushResult = { saved: 1, failed: 0, pending: 0 };
 
 // main.ts creates windows and starts the engine at import time, so the wiring
 // itself can only be read. Everything above this line would still pass with the
@@ -32,7 +42,7 @@ const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts
 /** A renderer that ACKs when told to, plus the timer main would have armed. */
 function fakeTransport(options: { hasRenderer?: boolean } = {}) {
 	const { hasRenderer = true } = options;
-	const listeners = new Set<() => void>();
+	const listeners = new Set<(result: FlushResult) => void>();
 	let timer: { fire: () => void; ms: number } | null = null;
 
 	const transport: FlushTransport = {
@@ -48,8 +58,8 @@ function fakeTransport(options: { hasRenderer?: boolean } = {}) {
 
 	return {
 		transport,
-		/** The renderer finished flushing and ACKed. */
-		ack: () => [...listeners].forEach((l) => l()),
+		/** The renderer finished flushing and ACKed with `result`. */
+		ack: (result: FlushResult = CLEAN) => [...listeners].forEach((l) => l(result)),
 		/** The fallback timer expired. */
 		expire: () => timer?.fire(),
 		/**
@@ -274,6 +284,55 @@ describe("a second gesture inside the flush window", () => {
 	});
 });
 
+describe("asking before a failed flush is discarded (#1489)", () => {
+	it("needs no confirmation for a clean settle", () => {
+		expect(flushNeedsConfirmation({ saved: 3, failed: 0, pending: 0 })).toBe(false);
+	});
+
+	it("needs confirmation for a failure, a still-pending edit, or an unanswered ceiling", () => {
+		expect(flushNeedsConfirmation({ saved: 0, failed: 1, pending: 0 })).toBe(true);
+		expect(flushNeedsConfirmation({ saved: 1, failed: 0, pending: 1 })).toBe(true);
+		expect(flushNeedsConfirmation(null)).toBe(true);
+	});
+
+	it("names the count and phrases the buttons for the gesture", () => {
+		const quitPrompt = buildFlushFailurePrompt("quit", { saved: 0, failed: 2, pending: 0 });
+		expect(quitPrompt.message).toContain("2 edits");
+		expect(quitPrompt.buttons).toEqual(["Quit anyway", "Keep working"]);
+
+		const closePrompt = buildFlushFailurePrompt("window-close", {
+			saved: 0,
+			failed: 1,
+			pending: 0,
+		});
+		expect(closePrompt.message).toContain("One edit");
+		expect(closePrompt.buttons).toEqual(["Close anyway", "Keep working"]);
+	});
+
+	it("does not ask, and proceeds, when the flush landed clean", async () => {
+		const ask = vi.fn();
+		const proceed = await confirmDiscardOnFailedFlush(ask, "quit", CLEAN);
+		expect(proceed).toBe(true);
+		expect(ask).not.toHaveBeenCalled();
+	});
+
+	it("asks, and proceeds only on the answer, when the flush did not land clean", async () => {
+		const keepWorking = vi.fn().mockResolvedValue(false);
+		const failed: FlushResult = { saved: 0, failed: 1, pending: 0 };
+		expect(await confirmDiscardOnFailedFlush(keepWorking, "quit", failed)).toBe(false);
+		expect(keepWorking).toHaveBeenCalledWith(buildFlushFailurePrompt("quit", failed));
+
+		const quitAnyway = vi.fn().mockResolvedValue(true);
+		expect(await confirmDiscardOnFailedFlush(quitAnyway, "quit", failed)).toBe(true);
+	});
+
+	it("asks on an unanswered ceiling, not only on a reported failure", async () => {
+		const ask = vi.fn().mockResolvedValue(false);
+		await confirmDiscardOnFailedFlush(ask, "window-close", null);
+		expect(ask).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("main.ts wiring", () => {
 	it("read the real main.ts", () => {
 		// A guard that scanned an empty string would pass every assertion below.
@@ -293,7 +352,24 @@ describe("main.ts wiring", () => {
 	it("routes the quit path through the same flusher, gated on settled", () => {
 		const quitHandler = main.slice(main.indexOf('app.on("before-quit"'));
 		expect(quitHandler).toContain("saveFlusher.hasSettled()");
-		expect(quitHandler).toContain("saveFlusher.flush(resumeQuit)");
+		expect(quitHandler).toContain("saveFlusher.flush(resumeQuitAfterFlush)");
+	});
+
+	it("gates the actual quit on the flush's outcome, not just its settling (#1489)", () => {
+		expect(main).toContain("const resumeQuitAfterFlush = (result: FlushResult | null) => {");
+		const resumeHandler = main.slice(main.indexOf("const resumeQuitAfterFlush"));
+		expect(resumeHandler).toContain(
+			'confirmDiscardOnFailedFlush(askFlushFailure, "quit", result)'
+		);
+	});
+
+	it("gates the window's close on the flush's outcome, not just its settling (#1489)", () => {
+		const closeHandler = main.slice(main.indexOf('.on("close"'));
+		expect(closeHandler).toContain("const closeAfterFlush = (result: FlushResult | null) => {");
+		expect(closeHandler).toContain(
+			'confirmDiscardOnFailedFlush(askFlushFailure, "window-close", result)'
+		);
+		expect(closeHandler).toContain("saveFlusher.flush(closeAfterFlush)");
 	});
 
 	it("gates both consumers on settled, never on requested", () => {

--- a/app/electron/save-flush.ts
+++ b/app/electron/save-flush.ts
@@ -38,6 +38,21 @@
 /** How long to wait for the renderer's ACK before giving up and proceeding. */
 export const FLUSH_TIMEOUT_MS = 2000;
 
+/**
+ * What a settled flush actually did, so the window can stop deciding to close
+ * on faith (#1489). `pending` is 0 from every real flush - the renderer's
+ * `flushAll` attempts and settles every dirty context before it resolves at
+ * all - and exists so the shape has somewhere to say "unknown" without a
+ * fourth field: `null` from `SaveFlusher.flush` (the 2s ceiling fired before
+ * the renderer answered) is read the same as a result whose `pending` is
+ * nonzero by `flushNeedsConfirmation` below.
+ */
+export interface FlushResult {
+	saved: number;
+	failed: number;
+	pending: number;
+}
+
 /** The slice of Electron this needs, so a test can pass a fake. */
 export interface FlushTransport {
 	/**
@@ -46,25 +61,26 @@ export interface FlushTransport {
 	 */
 	requestFlush: () => boolean;
 	/** Subscribe to the renderer's one-shot ACK. Returns an unsubscribe function. */
-	onFlushed: (listener: () => void) => () => void;
+	onFlushed: (listener: (result: FlushResult) => void) => () => void;
 	/** Schedule the fallback timer. */
 	schedule: (listener: () => void, ms: number) => void;
 }
 
 export interface SaveFlusher {
 	/**
-	 * Flush once, then run `done`.
+	 * Flush once, then run `done` with the outcome.
 	 *
 	 * - Nothing flushed yet: ask the renderer, and run `done` on its ACK or on
-	 *   the ceiling, whichever lands first.
+	 *   the ceiling, whichever lands first. A `null` result means the ceiling
+	 *   won - the renderer never answered, so what it saved is unknown.
 	 * - A flush in flight: join it. `done` runs when that one settles, not now -
 	 *   the renderer's saves are still being written. Joining twice with the
 	 *   same callback still runs it once: a repeated gesture (the second Cmd-Q
 	 *   of an impatient double) is one thing to resume, not two.
-	 * - Already settled: `done` runs immediately, the renderer has nothing left
-	 *   to write.
+	 * - Already settled: `done` runs immediately with the same result the first
+	 *   caller got, the renderer has nothing left to write.
 	 */
-	flush: (done: () => void) => void;
+	flush: (done: (result: FlushResult | null) => void) => void;
 	/**
 	 * Whether this window's flush has finished - the renderer ACKed, or the
 	 * ceiling expired. False both before a flush and during one, so a caller
@@ -79,7 +95,9 @@ export interface SaveFlusher {
 export function createSaveFlusher(transport: FlushTransport): SaveFlusher {
 	let state: "idle" | "in-flight" | "settled" = "idle";
 	/** Callbacks waiting on the flush in flight, in the order they joined. */
-	let waiting: Array<() => void> = [];
+	let waiting: Array<(result: FlushResult | null) => void> = [];
+	/** What the flush that just settled reported, for a caller that joins late. */
+	let lastResult: FlushResult | null = null;
 	/**
 	 * Bumped by every flush and every reset. The ceiling timer of a previous
 	 * window's flush outlives that flush - without this it could settle the
@@ -91,23 +109,26 @@ export function createSaveFlusher(transport: FlushTransport): SaveFlusher {
 		const startedAt = generation;
 		let unsubscribe: (() => void) | null = null;
 
-		const settle = () => {
+		const settle = (result: FlushResult | null) => {
 			// The ACK and the ceiling race each other, and a superseded run's
 			// timer may still fire: only the current run, still in flight, settles.
 			if (startedAt !== generation || state !== "in-flight") return;
 			state = "settled";
+			lastResult = result;
 			unsubscribe?.();
 			const joined = waiting;
 			waiting = [];
-			for (const done of joined) done();
+			for (const done of joined) done(result);
 		};
 
 		// Subscribe before asking, so an ACK that arrives synchronously (a
 		// fake transport in a test, or a renderer with nothing to save) is
 		// not missed.
-		unsubscribe = transport.onFlushed(settle);
-		transport.schedule(settle, FLUSH_TIMEOUT_MS);
-		if (!transport.requestFlush()) settle();
+		unsubscribe = transport.onFlushed((result) => settle(result));
+		transport.schedule(() => settle(null), FLUSH_TIMEOUT_MS);
+		// No renderer to ask means no edit of its could have survived it -
+		// there is nothing to confirm, unlike a ceiling with nobody answering.
+		if (!transport.requestFlush()) settle({ saved: 0, failed: 0, pending: 0 });
 	};
 
 	return {
@@ -116,6 +137,7 @@ export function createSaveFlusher(transport: FlushTransport): SaveFlusher {
 		reset: () => {
 			generation++;
 			state = "idle";
+			lastResult = null;
 			// A new window's renderer cannot answer for the old one's saves, so
 			// anything still waiting on the old flush is dropped with it.
 			waiting = [];
@@ -123,7 +145,7 @@ export function createSaveFlusher(transport: FlushTransport): SaveFlusher {
 
 		flush: (done) => {
 			if (state === "settled") {
-				done();
+				done(lastResult);
 				return;
 			}
 			if (!waiting.includes(done)) waiting.push(done);
@@ -133,4 +155,48 @@ export function createSaveFlusher(transport: FlushTransport): SaveFlusher {
 			startFlush();
 		},
 	};
+}
+
+/** What a confirm dialog says, split the way Electron's message box takes it. */
+export interface FlushFailurePrompt {
+	message: string;
+	detail: string;
+	buttons: [proceed: string, keepWorking: string];
+}
+
+/** Whether a settled flush lost enough that discarding it needs asking about first. */
+export function flushNeedsConfirmation(result: FlushResult | null): boolean {
+	return result === null || result.failed > 0 || result.pending > 0;
+}
+
+/** What to put in front of the user, phrased for `gesture`, when a flush did not land cleanly. */
+export function buildFlushFailurePrompt(
+	gesture: "quit" | "window-close",
+	result: FlushResult | null
+): FlushFailurePrompt {
+	const verb = gesture === "quit" ? "Quit" : "Close";
+	const lost = result === null ? null : result.failed + result.pending;
+	const subject = lost === null ? "Some edits" : lost === 1 ? "One edit" : `${lost} edits`;
+	return {
+		message: `${subject} could not be saved - the engine is not responding.`,
+		detail:
+			`${verb === "Quit" ? "Quitting" : "Closing"} anyway discards ` +
+			`${lost === 1 ? "it" : "them"}. Keep working to try again once the engine answers.`,
+		buttons: [`${verb} anyway`, "Keep working"],
+	};
+}
+
+/**
+ * Ask before discarding a flush that did not land cleanly; proceed silently
+ * when it did (#1489). `ask` is injected so this is testable without
+ * Electron - `main.ts` wires it to `dialog.showMessageBox` through the same
+ * `askOnWindow` helper the crash and unresponsive-window prompts already use.
+ */
+export async function confirmDiscardOnFailedFlush(
+	ask: (prompt: FlushFailurePrompt) => Promise<boolean>,
+	gesture: "quit" | "window-close",
+	result: FlushResult | null
+): Promise<boolean> {
+	if (!flushNeedsConfirmation(result)) return true;
+	return ask(buildFlushFailurePrompt(gesture, result));
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -134,12 +134,12 @@ function App() {
 	// what it is about to stop instead of taking it silently (#1363).
 	useRunningServicesPublisher();
 
-	// Register Electron before-quit handler to flush pending saves
+	// Register Electron before-quit handler to flush pending saves. The result
+	// rides the ACK back to main, which asks before discarding anything that
+	// did not land (#1489).
 	useEffect(() => {
 		if (!window.electronAPI?.onBeforeQuit) return;
-		return window.electronAPI.onBeforeQuit(async () => {
-			await useSaveStore.getState().flushAll();
-		});
+		return window.electronAPI.onBeforeQuit(() => useSaveStore.getState().flushAll());
 	}, []);
 
 	return (

--- a/app/src/hooks/useSaveManager.debounce.test.tsx
+++ b/app/src/hooks/useSaveManager.debounce.test.tsx
@@ -211,7 +211,7 @@ describe("what a returning save is allowed to call itself", () => {
 		const onSave = vi.fn().mockReturnValue(held.promise);
 		const { rerender } = mountManager(onSave);
 
-		let flushed!: Promise<void>;
+		let flushed!: Promise<{ saved: number; failed: number; pending: number }>;
 		act(() => {
 			flushed = useSaveStore.getState().flushAll();
 		});

--- a/app/src/hooks/useSaveManager.retry.test.tsx
+++ b/app/src/hooks/useSaveManager.retry.test.tsx
@@ -212,6 +212,29 @@ describe("retrying a failed auto-save", () => {
 		expect(onSaveB).not.toHaveBeenCalled();
 	});
 
+	it("re-registers a context whose entity-switch flush failed, so a later flush can retry it (#1489)", async () => {
+		const onSaveA = vi.fn().mockRejectedValue(new Error("engine unreachable"));
+		const onSaveB = vi.fn().mockResolvedValue(undefined);
+		const { rerender } = mountManager({ entityId: "req_a", onSave: onSaveA });
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSaveA).toHaveBeenCalledTimes(1);
+
+		// The register/unregister effect has already dropped "request-req_a" for
+		// the switch by the time the cleanup's own flush fails against onSaveA a
+		// moment later - the context has to be put back for `flushAll` (a
+		// reconnect, or a later quit) to find it at all.
+		await act(async () => {
+			rerender({ entityId: "req_b", onSave: onSaveB, hasChanges: false });
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		const context = useSaveStore.getState().contexts.get("request-req_a");
+		expect(context?.hasPendingChanges).toBe(true);
+	});
+
 	it("pokes the health query on a network failure, not on a 4xx the engine rejected outright", async () => {
 		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
 		const onSave = vi

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -322,11 +322,28 @@ export function useSaveManager({
 			// so a failure here reports once and does not arm a new one - there
 			// is no pane left to retry into once this cleanup has run.
 			clearRetry();
-			if (enabledRef.current && hasChangesRef.current) {
-				performSave();
+			if (entityId && enabledRef.current && hasChangesRef.current) {
+				// The sibling registration effect has already unregistered this
+				// context by the time this runs, so a failure here has nowhere left
+				// to be retried from (#1489) - `flushAll`'s reconnect trigger (#1479)
+				// and the quit flush both walk the registry, not the unmounted pane.
+				// Re-registering under the same id puts the draft back where either
+				// can find it; a clean save needs nothing put back.
+				const contextId = saveContextId(entityId);
+				const save = onSaveRef.current;
+				void performSave().then(() => {
+					if (useSaveStore.getState().status === "error") {
+						registerContext({
+							id: contextId,
+							name: contextName || "Request",
+							save,
+							hasPendingChanges: true,
+						});
+					}
+				});
 			}
 		};
-	}, [entityId, reset, performSave, clearRetry]);
+	}, [entityId, reset, performSave, clearRetry, contextName, registerContext]);
 
 	// Force save (for manual triggers)
 	const forceSave = useCallback(async () => {

--- a/app/src/queries/health.test.ts
+++ b/app/src/queries/health.test.ts
@@ -130,7 +130,9 @@ describe("useHealthQuery - an engine that arrives after the window", () => {
 		// A dirty draft's own auto-save retry backs off well past this poll, so
 		// the reconnect is what has to reach it - the same reasoning that made
 		// this transition invalidate every other query.
-		const flushAll = vi.spyOn(useSaveStore.getState(), "flushAll").mockResolvedValue(undefined);
+		const flushAll = vi
+			.spyOn(useSaveStore.getState(), "flushAll")
+			.mockResolvedValue({ saved: 0, failed: 0, pending: 0 });
 		// Twice: the hook sets `retry: 1`, so one rejection is absorbed by the
 		// retry and never reaches an error state.
 		getHealth
@@ -164,7 +166,9 @@ describe("useHealthQuery - an engine that arrives after the window", () => {
 		// position, since nothing about its save has failed.
 		const client = makeClient();
 		const invalidate = vi.spyOn(client, "invalidateQueries");
-		const flushAll = vi.spyOn(useSaveStore.getState(), "flushAll").mockResolvedValue(undefined);
+		const flushAll = vi
+			.spyOn(useSaveStore.getState(), "flushAll")
+			.mockResolvedValue({ saved: 0, failed: 0, pending: 0 });
 		getHealth.mockResolvedValue({ status: "ok", version: "1.0.0", workers: 8 });
 
 		const { result } = renderHook(() => useHealthQuery(), { wrapper: wrapperFor(client) });

--- a/app/src/stores/save-store.test.ts
+++ b/app/src/stores/save-store.test.ts
@@ -171,3 +171,57 @@ describe("completeSaveThenIdle with other unsaved work on screen", () => {
 		expect(useSaveStore.getState().status).toBe("pending");
 	});
 });
+
+/**
+ * `flushAll` is what the quit/window-close path (#1489) and a tab close read
+ * to decide whether closing would discard something - it used to resolve to
+ * `undefined` regardless of what happened, so a down or hung engine at quit
+ * looked identical to a clean save.
+ */
+describe("flushAll", () => {
+	beforeEach(() => {
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	it("reports nothing when nothing is dirty", async () => {
+		registerContext("request-1", false);
+		await expect(useSaveStore.getState().flushAll()).resolves.toEqual({
+			saved: 0,
+			failed: 0,
+			pending: 0,
+		});
+	});
+
+	it("counts every dirty context that saved clean", async () => {
+		registerContext("request-1", true);
+		registerContext("settings", true);
+		await expect(useSaveStore.getState().flushAll()).resolves.toEqual({
+			saved: 2,
+			failed: 0,
+			pending: 0,
+		});
+	});
+
+	it("counts a rejecting save as failed, not saved", async () => {
+		registerContext("request-1", true);
+		useSaveStore.getState().registerContext({
+			id: "settings",
+			name: "settings",
+			save: () => Promise.reject(new Error("network error")),
+			hasPendingChanges: true,
+		});
+
+		await expect(useSaveStore.getState().flushAll()).resolves.toEqual({
+			saved: 1,
+			failed: 1,
+			pending: 0,
+		});
+	});
+
+	it("reports 0 pending - every dirty context is attempted and settled before this resolves", async () => {
+		registerContext("request-1", true);
+		const result = await useSaveStore.getState().flushAll();
+		expect(result.pending).toBe(0);
+	});
+});

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -118,8 +118,13 @@ interface SaveState {
 	// App-wide save trigger
 	triggerSave: () => Promise<void>;
 
-	/** Flush every registered context that has pending changes. Used before quit / on tab close. */
-	flushAll: () => Promise<void>;
+	/**
+	 * Flush every registered context that has pending changes, and report what
+	 * happened. Used before quit / on tab close - the caller (`main.ts`, #1489)
+	 * decides whether a failure or a still-pending edit is worth asking about
+	 * before the window goes away, so this counts rather than swallows them.
+	 */
+	flushAll: () => Promise<{ saved: number; failed: number; pending: number }>;
 }
 
 export const useSaveStore = create<SaveState>((set, get) => {
@@ -138,9 +143,10 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			(context) => context.id !== exceptId && context.hasPendingChanges
 		);
 
-	// Internal helper - runs a save for the given context and updates store state.
-	// Caller must own the in-progress guard if needed.
-	const runSave = async (context: SaveContext) => {
+	// Internal helper - runs a save for the given context, updates store state,
+	// and reports whether it actually landed. Caller must own the in-progress
+	// guard if needed.
+	const runSave = async (context: SaveContext): Promise<"saved" | "failed"> => {
 		set({ status: "saving" });
 		try {
 			await context.save();
@@ -148,22 +154,17 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			// its own failure through `failSave` and then resolves rather than
 			// rejecting (`useSaveManager`, `SettingsMain`, `VariableTableEditor`
 			// all do), so overwriting unconditionally turned a failed Cmd+S into
-			// "Saved" - with the failure toast still on screen next to it.
-			//
-			// Nor is it proof of completeness (#1381). A context that saw an edit
-			// land while its write was in flight publishes `pending`, because the
-			// payload that went out does not hold that edit; overwriting *that*
-			// put "Saved" on the Dock over an edit nobody had persisted, on the
-			// two paths that come through here - Cmd+S and the quit flush.
-			//
-			// Both cases are the same rule: a status the context published for
-			// itself is the truthful one, and this wrapper only fills in the
-			// silence.
+			// "Saved" - with the failure toast still on screen next to it. A
+			// status the context published for itself is the truthful one; this
+			// wrapper only fills in the silence when nothing else has.
 			const published = get().status;
-			if (published === "error" || published === "pending") return;
+			if (published === "error") return "failed";
+			if (published === "pending") return "saved";
 			get().completeSaveThenIdle(context.id);
+			return "saved";
 		} catch (error) {
 			get().failSave(error instanceof Error ? error.message : "Save failed");
+			return "failed";
 		}
 	};
 
@@ -285,10 +286,16 @@ export const useSaveStore = create<SaveState>((set, get) => {
 		},
 
 		flushAll: async () => {
-			const saves = [...get().contexts.values()]
-				.filter((c) => c.hasPendingChanges)
-				.map((c) => runSave(c));
-			await Promise.all(saves);
+			const dirty = [...get().contexts.values()].filter((c) => c.hasPendingChanges);
+			const outcomes = await Promise.all(dirty.map((c) => runSave(c)));
+			const failed = outcomes.filter((outcome) => outcome === "failed").length;
+			// `pending` is always 0 here: every dirty context this call started is
+			// attempted and settled (saved or failed) before `flushAll` resolves.
+			// It stays part of the shape because the caller (`main.ts`, #1489) also
+			// sees the case a completed flush cannot represent - the 2s ceiling
+			// firing before the renderer even answers, where nothing is known to
+			// have landed at all.
+			return { saved: outcomes.length - failed, failed, pending: 0 };
 		},
 	};
 });

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -9,10 +9,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useTabsStore } from "./tabs-store";
 import { useSaveStore, type SaveContext } from "./save-store";
 import { useResponseStore } from "./response-store";
+import { useEngineStore } from "./engine-store";
+import { useToastStore } from "./toast-store";
 
 beforeEach(() => {
 	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
 	useSaveStore.setState({ contexts: new Map() });
+	useEngineStore.setState({ engineStatus: "connected" });
 });
 
 describe("closeTabsForEntities", () => {
@@ -252,6 +255,53 @@ describe("LRU eviction never takes a dirty tab", () => {
 		// which carries no edits yet. Every tab holding work survives.
 		const ids = useTabsStore.getState().openTabs.map((t) => t.entityId);
 		for (let i = 0; i < 12; i++) expect(ids).toContain(`req_${i}`);
+	});
+});
+
+/**
+ * An explicit close on a dirty tab, unlike LRU eviction, had no guard at all
+ * (#1489): the pane unmounts, `useSaveManager`'s cleanup flush fires into a
+ * component that is already gone, and with the engine down that flush fails
+ * with nowhere left to show the failure.
+ */
+describe("closeTab keeps a dirty tab the engine cannot save", () => {
+	beforeEach(() => {
+		useToastStore.setState({ toasts: [] });
+	});
+
+	it("keeps the tab and toasts when dirty and the engine is unreachable", () => {
+		useTabsStore.getState().openTab({ type: "request", entityId: "dirty" });
+		markDirty("request-dirty");
+		useEngineStore.setState({ engineStatus: "unreachable" });
+		const tabId = useTabsStore.getState().openTabs[0].id;
+
+		useTabsStore.getState().closeTab(tabId);
+
+		expect(useTabsStore.getState().openTabs.map((t) => t.entityId)).toContain("dirty");
+		expect(useToastStore.getState().toasts.map((t) => t.message)).toContain(
+			"Not saved - the engine is unreachable"
+		);
+	});
+
+	it("closes as usual when dirty and the engine is connected", () => {
+		useTabsStore.getState().openTab({ type: "request", entityId: "dirty" });
+		markDirty("request-dirty");
+		useEngineStore.setState({ engineStatus: "connected" });
+		const tabId = useTabsStore.getState().openTabs[0].id;
+
+		useTabsStore.getState().closeTab(tabId);
+
+		expect(useTabsStore.getState().openTabs.map((t) => t.entityId)).not.toContain("dirty");
+	});
+
+	it("closes as usual when the engine is unreachable but the tab is clean", () => {
+		useTabsStore.getState().openTab({ type: "request", entityId: "clean" });
+		useEngineStore.setState({ engineStatus: "unreachable" });
+		const tabId = useTabsStore.getState().openTabs[0].id;
+
+		useTabsStore.getState().closeTab(tabId);
+
+		expect(useTabsStore.getState().openTabs.map((t) => t.entityId)).not.toContain("clean");
 	});
 });
 

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -10,6 +10,8 @@ import { persist } from "zustand/middleware";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 import { useSaveStore, type SaveContext } from "./save-store";
 import { useResponseStore } from "./response-store";
+import { useEngineStore } from "./engine-store";
+import { useToastStore } from "./toast-store";
 
 export type TabType =
 	"welcome" | "request" | "collection" | "dashboard" | "run" | "variables" | "settings" | "inbox";
@@ -625,7 +627,23 @@ export const useTabsStore = create<TabsState>()(
 
 			clearDataRowTarget: () => set({ dataRowTarget: null }),
 
+			// A dirty tab with nowhere for its unmount flush to land is a silent
+			// loss (#1489): `useSaveManager`'s cleanup fires the save anyway, its
+			// failure toast lands in a pane that no longer exists, and the eviction
+			// guard above only ever protected LRU, not an explicit close. Held here
+			// instead, before the tab (and the editor holding the draft) is gone.
 			closeTab: (tabId) => {
+				const tab = get().openTabs.find((t) => t.id === tabId);
+				if (
+					tab &&
+					isTabDirty(tab, useSaveStore.getState().contexts) &&
+					useEngineStore.getState().engineStatus !== "connected"
+				) {
+					useToastStore
+						.getState()
+						.showToast("Not saved - the engine is unreachable", "error");
+					return;
+				}
 				const next = closeTabs(get(), new Set([tabId]));
 				if (next) set(next);
 			},

--- a/app/src/types/electron.d.ts
+++ b/app/src/types/electron.d.ts
@@ -425,8 +425,11 @@ interface ElectronAPI {
 		callback: (event: SystemNotificationActivation) => void
 	) => () => void;
 
-	// Before quit flush handler
-	onBeforeQuit: (callback: () => void | Promise<void>) => () => void;
+	// Before quit flush handler. The callback reports how the flush went, so
+	// main can ask before discarding a save that did not land (#1489).
+	onBeforeQuit: (
+		callback: () => Promise<{ saved: number; failed: number; pending: number }>
+	) => () => void;
 }
 
 declare global {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -700,7 +700,8 @@ const {
   registerContext, unregisterContext, updateContext,
   setActiveContext, getActiveContext,
   triggerSave,       // Ctrl/Cmd+S - saves active or first dirty context
-  flushAll           // Save all dirty contexts (used before app quit)
+  flushAll           // Save all dirty contexts (used before app quit); resolves
+                      // to { saved, failed, pending } - see below
 } = useSaveStore();
 ```
 
@@ -2557,9 +2558,11 @@ and `request-builder.script-clearing.test.tsx` (the partial payload), and
 8. Save status updates in `useSaveStore()`, and the Dock shows "Saving..." then "Saved" for `TIMING.SAVED_STATUS_DURATION_MS`
 9. **A save is only allowed to call the entity clean for the generation it sent** (#1381). `onSave(request, changedFields)` serialises the state - and the set of touched fields - as they were when the save started, so a keystroke landing during the round trip is not in that payload. The generation also moves on a foreign write the per-field merge adopts or conflicts, not only on the user's own edits (#1436): a save in flight when that happens must not clear `hasUnsavedChanges` over a value the merge just changed underneath its response. The provider records the generation beside the snapshot and clears `hasUnsavedChanges` - and the fields the snapshot named - only if the token has not moved when the write lands; the hook applies the same check to the "Saved" indicator. Clearing unconditionally marked that keystroke saved, left nothing dirty for the next timer to fire on, and lost the edit
 10. **The request builder's `onSave` sends only `changedFields`** (#1436, see [the draft adopts an external write per field](#the-request-builders-draft-adopts-an-external-write-per-field) above) - an untouched field is omitted from the `PUT` rather than resent unchanged
-11. On **tab switch or unmount**, any pending save is flushed before the context is unregistered - unless the entity is confirmed gone (`useSaveManager`'s `enabled: false`), which the request builder sets once its request is deleted elsewhere, so the flush never fires a doomed PUT
+11. On **tab switch or unmount**, any pending save is flushed before the context is unregistered - unless the entity is confirmed gone (`useSaveManager`'s `enabled: false`), which the request builder sets once its request is deleted elsewhere, so the flush never fires a doomed PUT. If that flush fails, the context is re-registered under the same id rather than left unreachable - `flushAll`'s reconnect trigger (below) and a later quit both walk the registry, not the pane that just unmounted (#1489)
 12. On **app quit** (Electron `before-quit`) *and* on **window close** (the X
-    button), `useSaveStore().flushAll()` saves all dirty contexts
+    button), `useSaveStore().flushAll()` saves all dirty contexts and resolves
+    to `{ saved, failed, pending }` - what actually landed, not just that the
+    round trip finished
 
 **Both window-destroying paths flush, through one coordinator.** `before-quit`
 always did; `close` did not, and `close` is what the X button fires - it
@@ -2578,6 +2581,22 @@ for an answer first, and Cancel leaves the window, the renderer and every
 pending save exactly as they were - a flush run ahead of the question would have
 told the renderer its work was ending. Confirm, and the flush runs as it always
 did on the way out.
+
+**The flush settling is not the same as the flush landing** (#1489). Before,
+both paths closed the window the moment the round trip finished - the ACK, or
+the 2s ceiling if the renderer never answered - whether or not anything had
+actually been saved: a refused write, a hung engine, or a save still running
+when the ceiling gave up all looked identical to a clean quit. The renderer's
+`flushAll` now carries its outcome back over the `before-quit-flushed` ACK
+(`FlushResult`, `electron/save-flush.ts`), and a settle with no ACK at all (the
+ceiling won) is treated the same as a failure - nothing is known to have
+landed. Either case holds the close behind one native dialog,
+`confirmDiscardOnFailedFlush`: "N edits could not be saved - the engine is not
+responding", **Quit/Close anyway** or **Keep working**. A clean flush still
+closes with no dialog, exactly as before. `useTabsStore.closeTab` asks the same
+question one tab early: closing a single dirty tab while the engine is not
+`connected` keeps the tab and toasts instead of letting the unmount flush fail
+into a pane that no longer exists.
 
 ### Variable Resolution Priority
 
@@ -2600,13 +2619,13 @@ did on the way out.
 
 4. **Save manager integration:** Use `useSaveManager()` in any component that edits a persistable entity (request, environment, etc.) that autosaves. It handles debouncing, context registration, and centralized save state. Do not manually call `useSaveStore()` for auto-save. For an editor that holds a draft instead - committing it on blur or on an explicit button - use `useEntityDraft()` **plus `useDraftSaveContext()`** - the first owns the draft, the second puts it in the registry - and do not hand-roll the draft/resync/`isDirty`/mutation-reset parts again.
 
-5. **Centralized save on app quit:** On Electron's `before-quit` event, call `useSaveStore().flushAll()` to persist any pending changes before the app closes. An editor that is not registered is not merely unsaved here, it is invisible - which is how the collection tabs lost drafts silently for as long as they existed.
+5. **Centralized save on app quit:** On Electron's `before-quit` event, call `useSaveStore().flushAll()` to persist any pending changes before the app closes. An editor that is not registered is not merely unsaved here, it is invisible - which is how the collection tabs lost drafts silently for as long as they existed. `flushAll` reports what happened (`{ saved, failed, pending }`), and `main.ts` asks before discarding anything it did not save (#1489) rather than closing on faith.
 
     Corollary: **an editing surface must never fail without saying so.** There is no global `MutationCache.onError` in `lib/query-client.ts`, so a bare `mutation.mutate(...)` reports nothing at all. Route the failure through `failSave` (toast + status) or render the mutation's `isError`, and roll an uncontrolled input back to the stored value while you are at it - the context bar's variables section did neither, so a rejected edit sat on screen looking committed.
 
 6. **Leaving an editor saves or asks; it does not drop.** A settings category switch, an unmount, a tab switch - each used to discard dirty state silently in at least one place. Settings flushes its valid edits on the way out (engine config writes are cheap merge-patches); the collection tabs keep their panels mounted so there is nothing to discard.
 
-7. **Tab LRU and dirty state:** The tab store reads the save registry and refuses to evict a dirty tab (`isTabDirty`, matched by tab *type* - the registry is keyed by editor and the two do not line up). Nothing is flushed during eviction, because the predicate has already declined to take unsaved work; over the cap with every candidate dirty, no tab closes at all.
+7. **Tab LRU and dirty state:** The tab store reads the save registry and refuses to evict a dirty tab (`isTabDirty`, matched by tab *type* - the registry is keyed by editor and the two do not line up). Nothing is flushed during eviction, because the predicate has already declined to take unsaved work; over the cap with every candidate dirty, no tab closes at all. An *explicit* close (`closeTab`) is not eviction and used to have no such guard; it now applies the same `isTabDirty` check but only refuses when the engine is not `connected` (#1489) - a dirty tab closes and flushes as usual once the engine can actually take the write.
 
 8. **Response persistence:** Responses are stored in memory (not localStorage) so they survive tab switches but are cleared on page reload. This balances UX (quick switch back) with memory (responses can be large).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -355,6 +355,22 @@ one app instance may drive it:
   `docs/app/state-management.md`'s `save-store.ts` section for the retry and
   the Dock's persistent "Not saved" state a failure short of that leaves on
   screen.
+- **A quit or window-close asks before discarding a flush that did not land**
+  (issue #1489). `save-flush.ts`'s coordinator still waits out its round trip
+  unconditionally (the renderer's ACK, or a 2 s ceiling if it never comes) -
+  what changed is what happens once it settles. The renderer's `flushAll`
+  resolves to how many contexts actually saved versus failed; a ceiling with
+  no ACK at all is read the same as a failure, since nothing is known to have
+  landed. Either case holds the quit or close behind one native dialog - "N
+  edits could not be saved - the engine is not responding", Quit/Close anyway
+  or Keep working - built by `confirmDiscardOnFailedFlush` in `save-flush.ts`
+  and shown through the same `dialog.showMessageBox` primitive the crash and
+  unresponsive-window prompts already use. A clean flush proceeds exactly as
+  before, with no dialog. Closing one dirty tab (not the whole window) is the
+  same question asked earlier: `useTabsStore.closeTab` keeps the tab and
+  toasts instead of unmounting it when the tab is dirty and the engine is not
+  `connected`, rather than letting `useSaveManager`'s unmount flush fail into
+  a pane that is already gone.
 - **Local services are window-scoped, and the close says so.** Everything the
   Services drawer starts - webhook inboxes, mock servers, mock issuers - runs
   inside the engine, so quitting stops all of it. On Windows and Linux closing


### PR DESCRIPTION
## Description

The quit and window-close flush closed the window whether or not the save landed. `saveFlusher.flush(done)` only signalled that the round trip had *settled* - the renderer's ACK, or the 2s ceiling if it never answered - and both `main.ts` handlers closed unconditionally in that callback. `flushAll()` resolved to `void`, so main had no way to tell a refused write, a hung engine, or an in-flight save cut short by the ceiling apart from a clean quit. The one failure signal was a toast raised by `failSave`, into a window that was already closing.

**Plan.** Three research passes verified the issue's anchors against master `d1fe93d` (`main.ts`'s `close` handler at :521-537 and `before-quit` at :1448-1467 both matched exactly; the one drift was `useSaveManager.ts`'s unmount flush, actually at :313-329 rather than :221-232), traced every consumer of `flushAll()` and the `before-quit`/`before-quit-flushed` channel (`App.tsx`, `useEngineRestart.ts`, `health.ts`, and every test asserting the old `Promise<void>` shape) to size the blast radius of changing its return type, and read `app/CLAUDE.md`, `docs/architecture.md`'s quit-sequence section and `docs/app/state-management.md`'s flush semantics plus the immediately-preceding sibling PR #1504 (#1479) for the house style a change here should follow - in particular `serviceStopGuard`'s pattern of an injectable `ask` function behind a pure, testable prompt builder, and `askOnWindow` as the one place `dialog.showMessageBox` is actually called. Root cause: the flusher tracked *whether* a round trip finished, never *what* it did, so main had nothing to decide on. Fix: `flushAll()` now resolves to `{ saved, failed, pending }`, the outcome rides the `before-quit-flushed` ACK back to main (a `null` result means the 2s ceiling won with no ACK at all - read the same as a failure, since nothing is known to have landed), and a settle that did not land clean holds the quit/close behind one native dialog (`confirmDiscardOnFailedFlush`, `electron/save-flush.ts`) built the same way `serviceStopGuard`'s running-services prompt is - pure and unit-testable without Electron, wired to `askOnWindow` in `main.ts`. A clean flush still closes with no dialog, unchanged from today.

**Alternative considered and rejected:** raising the 2s ceiling so a slow engine gets more time to answer before main gives up. Rejected because #236 set that ceiling deliberately so a quit never hangs on an unresponsive engine; the fix here does not touch it - the ceiling still fires the same, only what happens after it fires changed.

**Also fixed in this PR:** the issue's own fix pathway asks for the "dirty tab close" case too (`useTabsStore.closeTab` had no guard at all, unlike LRU eviction's `isTabDirty` check), and for re-registering a context whose unmount flush fails so a later `flushAll` can retry it. Both are in the issue's own scope (its "App changes" list names `tabs-store.ts` and `useSaveManager.ts` explicitly), not scope creep.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

- `app/electron/save-flush.test.ts`: extended the fake transport to carry a `FlushResult` through `ack()`, and added a `describe` block for `flushNeedsConfirmation` / `buildFlushFailurePrompt` / `confirmDiscardOnFailedFlush` - pure-function tests that need no Electron mock. Updated the `main.ts` source-scan tests for the new `resumeQuitAfterFlush` / `closeAfterFlush` wiring.
- `app/src/stores/save-store.test.ts`: new `flushAll` describe block - counts a clean multi-context flush, counts a rejecting save as failed rather than saved, and confirms `pending` is always 0 (every dirty context is attempted and settled before `flushAll` resolves - see the doc comment on `FlushResult` for why the field still exists).
- `app/src/stores/tabs-store.test.ts`: `closeTab` keeps a dirty tab and toasts when the engine is `unreachable`, closes as usual when `connected`, and closes as usual when clean regardless of engine status.
- `app/src/hooks/useSaveManager.retry.test.tsx`: extended the existing entity-switch case with a new one asserting the failed unmount flush re-registers `request-req_a` in the save registry.
- Mutation-checked by hand: reverting `main.ts`'s `closeAfterFlush`/`resumeQuitAfterFlush` back to an unconditional close reddens the two new "main.ts wiring" tests; reverting `runSave`'s failure branch to always return `"saved"` reddens the `flushAll` failure-counting test.
- `pnpm test`: **8040/8040 passing** across 703 files (full suite, since the change touches shared stores several other suites read). `pnpm type-check` and `pnpm lint` both clean.
- No engine files touched, so no engine build/test run.

## Docs, same commit

`docs/architecture.md`: a new bullet under the sidecar lifecycle section describing the confirm dialog and the `closeTab` guard. `docs/app/state-management.md`: the flush-semantics section gained a paragraph on the outcome-carrying ACK and the dialog, item 12 and Best Practice 5 note what `flushAll` now resolves to, item 7 notes `closeTab`'s new guard, and item 11 notes the unmount-flush re-registration.

## No user-visible change

False - this changes what the user sees at quit/close time. Not covered by a screenshot: this container has no way to drive a real quit-time native `dialog.showMessageBox` prompt end to end (it requires a hung/refused engine at the exact moment of an Electron quit gesture), and the existing `save-flush.test.ts` suite already establishes that `main.ts`'s window/quit wiring is verified by source-scan plus a dependency-injected coordinator rather than a live Electron run, for the same reason (`main.ts` starts the engine and window at import time). The dialog itself reuses `askOnWindow`, already exercised by the crash-recovery and unresponsive-window prompts elsewhere in `main.ts`.

## Checklist
- [x] My code follows the style guidelines (`pnpm lint`, `pnpm format:check` both clean)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1489