### PR TITLE
docs(CLAUDE.md): the September sweeps' mechanisms - build ceilings, one worktree per agent, the issue shape, repair passes, the lock rule, the element model, the save pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,17 @@ nothing forces it (ninja re-runs CMake itself when `CMakeLists.txt` or
 clean rebuilds and branch switches. Details:
 `docs/engine/building.md#faster-rebuilds`.
 
+**The cloud box has a ceiling.** Two engine builds fit on its 16 GB at once;
+three do not, and the one the OOM killer takes fails with no compiler error.
+`build.py -e -t` also compiles the test suite, so when only the binary is
+wanted run `ninja -C engine/build vayu-engine`, and `-j3` beside another
+build. Writable disk is a per-session allowance: two build trees plus a
+worktree's `node_modules` reach it, and a full disk fails a *link*, not a
+compile. `/opt/vcpkg/buildtrees` and a finished worktree's `node_modules` are
+the safe things to delete. After a `builtin-baseline` bump, objects compiled
+against the old headers still link and then crash at startup (a library type
+gained members); delete `engine/build` rather than bisecting.
+
 **Three build failures that look like walls and are not.** Each has one cure;
 they are listed here, not only in `engine/CLAUDE.md`, because the message
 appears while running `build.py` from the repo root.
@@ -182,6 +193,7 @@ Repo-level docs:
 | `docs/lock-file-handling.md` | Lock / concurrency behaviour |
 | `docs/request-storage-design.md` | How requests are stored |
 | `CONTRIBUTING.md` | PR process or style rules |
+| `docs/compare/*.md` | Any capability claim a comparison page makes: timers, correlation, controllers, import formats, scripting |
 
 **Deferred work is filed as a GitHub issue in the same commit that defers it.**
 There is no backlog file; the tracker is the only backlog. A comment saying
@@ -192,12 +204,20 @@ it does it, or what it can do.** Lint scope, test shape, tooling ergonomics and
 dev-script hygiene are noted in the PR body, not filed. If it would not change
 a user's experience or a measurement, it is not tracked work.
 
+**An issue is written for the session that will implement it without this
+conversation.** Problem with `file:line` anchors at a named master SHA, Fix
+pathway, App changes, Tests with the mutation check named, Docs to update in
+the same commit, Sequencing against the open issues it touches, Acceptance
+criteria a fresh checkout can verify. Phased work is a parent with sub-issues
+and a landing order. A closure is verified against those criteria, not against
+the PR's description; a PARTIAL reopens with exactly what is missing.
+
 **`docs/` is published** to <https://athrvk.github.io/vayu/> via MkDocs, and
 `mkdocs build --strict` gates every docs-touching PR: a broken relative link or
 a missing heading anchor is a build failure. Before adding, moving or renaming a
 page, load the **`docs-site`** skill.
 
-## Subagents in worktrees - check the base first
+## Subagents in worktrees - check the base, own the worktree
 
 Worktree provisioning cuts from **`master`**, not the branch you are on, and
 not always from its tip. An agent that does not check produces findings against
@@ -214,6 +234,15 @@ git merge-base --is-ancestor HEAD <expected>   # ok to fast-forward if clean
 A strict ancestor with a clean tree can be repaired losslessly
 (`git reset --hard <expected>`); anything else should stop and report. Have the
 agent state which case applied, so a silent misfire still shows up.
+
+**One worktree per agent, never a shared one**, cut by the orchestrator
+(`git -C /home/user/vayu worktree add <scratch>/<name> <sha>`) and removed by
+the agent at the end (`git worktree remove --force`, then `git worktree list`
+to confirm). A shared tree mixes one agent's mutation check or stray test file
+into another's findings. Each agent picks its own engine and vite ports, kills
+what it started by saved PID (never `pkill -f`: another agent's engine has the
+same name), reverts every mutation check with `git checkout -- <file>`, and
+ends with `git status --short` empty.
 
 ## Where the rest lives
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -60,6 +60,20 @@ everything.
   editable-target check is `isTextEntryTarget`, which is `ownsEnterKey` plus a
   plain input. One list, not two.
 - State: Zustand for UI state, TanStack Query for server state.
+- **A save that fails is retried, and the failure stays on screen until it
+  lands** (#1479): `useSaveManager` backs off up to `SAVE_RETRY_MAX_DELAY_MS`,
+  the health poll's reconnect branch flushes every dirty registered context
+  (`queries/health.ts`), and the Dock renders `error` as **Not saved**. **A
+  quit or close never discards a save silently** (#1489): `save-flush.ts`
+  answers `{ saved, failed, pending }` and `flushNeedsConfirmation` decides
+  whether the main process asks before the window goes. An editor takes part
+  by registering a save context; one that saves on its own is outside all of
+  it, which is the defect #1450 was.
+- **The builder's PUT is a merge-patch of changed fields** (`buildUpdatePayload`,
+  #1436), never the whole record. The converse rule for a copy: spread the
+  record, never a hand-written field list, because the list drops every field
+  added after it was written (`useTreeCrud.ts`'s Duplicate omits the execution
+  settings, #1519).
 - Styling: Tailwind CSS v4; all colours via CSS custom properties.
 - **Design system: `docs/design-system.md`**: tokens, elevation, typography,
   component patterns, accessibility. **Read it before touching any UI file.**
@@ -206,6 +220,20 @@ use across the tree; a new surface declares one rather than picking a token.
 On an element whose primitive already sets a background utility
 (`DialogContent`'s `bg-background`), `surface-card` alone loses the cascade:
 write the pair `bg-card surface-card` (see `docs/design-system.md`).
+
+## Driving the renderer without Electron
+
+A sweep or a probe runs the renderer under vite and drives it with
+playwright-core, no Electron: `pnpm exec vite --port <N> --strictPort`, the
+engine on a port of its own, and `ENGINE_PORT` in `src/config/network.ts`
+patched in a worktree only (it is a compile-time constant). Chromium is
+pre-installed at `/opt/pw-browsers/chromium` and needs `--no-sandbox`.
+`window.electronAPI` is absent there, so every preload-only path (file parts,
+the quit flush, system notifications, the OS proxy) is off and its fallback is
+what you measure. Every root poll is a TanStack `refetchInterval` with the
+background default, so a hidden window measures the paused case; an idle
+figure needs the window visible and untouched, and the health log's 30 s
+cadence is the proxy that proves it was.
 
 ## Docs to keep in step
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -175,6 +175,29 @@ a change touches (#946), so nothing else holds an untouched file at zero.
 - **A fixture that opens a scratch `Database` cleans up with
   `vayu::tests::remove_database_files`** (`engine/tests/temp_database.hpp`),
   never a hand-written suffix list: an opened database writes six files (#413).
+- **A startup repair pass is scoped, transactional, marked done, and backed up
+  first** (#1487, `Database::strip_stored_managed_headers`, the repair section
+  of `docs/engine/db-schema.md`). `/health` does not answer until `init ()`
+  returns, so a pass that loads every row is a startup hang on a large
+  workspace: select candidates with a SQL predicate, rewrite them inside one
+  `transaction_guard` (the `seed_default_config` shape), record a done marker
+  so the next start skips the scan, and write `<db>.pre-upgrade.bak`
+  immediately before the first rewrite. `<db>.bak` is not that copy: the next
+  clean start refreshes it from a file the repair has already rewritten.
+- **Removing a column from a `make_table` mapping is `ALTER TABLE DROP COLUMN`
+  at the constructor's probe `sync_schema ()`** (sqlite_orm on SQLite 3.35 or
+  later; the bundled one is 3.53), which runs before `init ()` and therefore
+  before any repair pass can read the column. Read the data out in a step
+  that runs ahead of the probe (the `PRAGMA user_version`-gated migration
+  #1513 introduces) or keep the column mapped; a pass that runs after the
+  probe reads a column that is already gone.
+- **The logger has two switches, and the request log is not yet one of them.**
+  `vayu::utils::Logger` has a console verbosity (`-v 0|1|2`: warnings and
+  errors, info, debug) and a separate file level (`logLevel`, default debug,
+  with rotation under `maxLogFileBytes`). A route's request line is
+  hand-written per route today and about half the routes have none, `GET
+  /inbox` and the mock listings among them, so an absent log line is not
+  evidence a route did not run; #1510 centralises one line per call.
 - **vcpkg manages every C++ dependency**: add one in `engine/vcpkg.json`. In
   the cloud dev environment a port fetched by `vcpkg_from_github` fails on a
   cold cache with `curl operation failed with response code 403` (the egress
@@ -185,6 +208,11 @@ a change touches (#946), so nothing else holds an untouched file at zero.
   `ryml`) fetches three `vcpkg_download_distfile` sub-archives the fixer leaves
   alone; rewrite those to `vcpkg_from_git` in the overlay. Only this
   environment needs it; CI reaches the archives.
+  The same environment ships `/opt/vcpkg-overlay-ports`, pinned to the
+  manifest's current versions, so a checkout at an older tag (a migration or
+  upgrade sweep) wants older ports: copy the overlay and run
+  `VAYU_ENGINE_DIR=<checkout>/engine VCPKG_OVERLAY_PORTS=<copy> vcpkg-fix-port
+  <ports>`, then `touch engine/vcpkg.json` so ninja re-runs the configure.
 - **The git pre-commit hook installs itself** with `python build.py --setup`,
   which `.claude/hooks/session-start.sh` also runs - `.git/hooks` is not tracked,
   so every clone and every cloud session would otherwise start without the one
@@ -303,6 +331,23 @@ logged as a warning: it means a client skipped composition.
   per-resource appliers (`apply_collection_fields` / `apply_request_fields` /
   `apply_environment_fields`, declared in `routes.hpp`) back both paths, so a
   field added there reaches bulk import too.
+- **A core that reads, decides and writes holds one lock** (#386, #1440,
+  #1453, #1454, #1455). `Database::with_lock` scopes the mutex around the
+  whole composite; a merge-patch is `update_<resource>_locked` called inside
+  it, with a `before_write` seam that `tests/competing_writer.hpp` uses to
+  drive a second writer into the window. The manager-backed resources (an
+  inbox's reply, a mock issuer) hold their own mutex across merge and write
+  the same way. A PUT that reads under one acquisition and writes under
+  another loses the other writer's fields with no error on either side.
+  `docs/engine/architecture.md` names the two shapes that need it.
+- **A behaviour attached to a request or collection at a phase of a step is
+  an element kind, not a column** (#1512): extractors, assertions, timers,
+  controllers, scripts and metrics each register once under
+  `engine/src/core/elements/`, are validated against that registry, served by
+  `GET /elements/kinds`, and run by one pipeline in every execution path.
+  #1513 lands the registry, the `elements` column and the migration of the two
+  script columns; until it does, do not add another behaviour column beside
+  `pre_request_script` / `post_request_script`.
 - **Saved examples are nested under their request** (`/requests/:id/examples`,
   #481): the owner is checked before the example on every path, so an example
   reached through the wrong request is a `404`, and `delete_request` and the
@@ -585,7 +630,9 @@ before the send, in the same words and with the same code compose uses for the
 (#1095): the empty-name rule reads every header name, the collision rule only
 the names that still held a token. A data row whose header-name column is
 blank is refused at bind time (`core/scenario_data.cpp`), because the load
-path runs no residual pass over what it binds.
+path runs no residual pass over what it binds - which is also why a value a
+script sets on step 1 never reaches step 2's `{{token}}` under load (#1495 adds
+the pass, with per-user scopes).
 
 **The renderer's resolver is preview-only.** `useVariableResolver` /
 `app/src/lib/variable-resolution.ts` back tab titles, previews, unresolved-token


### PR DESCRIPTION
## Description
The three guides had their review pass on 2026-09-03. Since then the persistence, migration, scripting and element-model sweeps established rules the next session should not have to rediscover. This adds them, each stated once with its mechanism, and touches nothing else.

Root `CLAUDE.md`:
- The cloud box's build and disk ceilings (two engine builds fit, three do not; `ninja -C engine/build vayu-engine` and `-j3`; what is safe to delete) and the stale-object crash after a `builtin-baseline` bump.
- `docs/compare/*.md` in the repo-level doc map, since #1512's children change what those pages claim.
- What an implementer-ready issue carries, that phased work is a parent with sub-issues, and that a closure is verified against acceptance criteria.
- One worktree per subagent, own ports, kill by PID, revert mutation checks, end clean.

`engine/CLAUDE.md`:
- The overlay ports in the cloud environment and how an older checkout gets older ports (`VAYU_ENGINE_DIR`, `VCPKG_OVERLAY_PORTS`).
- How a startup repair pass is scoped, transactional, marked done and backed up first (#1487, as landed in `d4956ba0`).
- Removing a mapped column is `DROP COLUMN` at the probe's `sync_schema()`, before any pass can read it (verified against the bundled sqlite_orm and SQLite 3.53).
- The logger's two switches and that about half the routes write no request line (#1510).
- The one-lock rule for read-decide-write cores (#386, #1440, #1453, #1454, #1455), with the `update_*_locked` and `before_write` shape.
- A per-step behaviour is an element kind, not a column (#1512, #1513).
- The load path's missing residual pass and what it costs (#1495).

`app/CLAUDE.md`:
- The save retry and the quit-flush confirmation as landed for #1479 and #1489.
- The merge-patch PUT (#1436) and the spread-a-copy rule (#1519).
- Driving the renderer under vite and playwright-core without Electron, and what that measures.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Markdown-only, so no test can go red. Checked: `app/CLAUDE.md` is prettier-clean (`pnpm exec prettier --check CLAUDE.md` from `app/`); no em-dash in any of the three files; every backticked path in the three files exists on master (`compile_commands.json` is generated and is the one expected miss). CI's area filters exclude Markdown, so no job runs on this diff by design.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
None closed. References #1436, #1440, #1453, #1454, #1455, #1479, #1487, #1489, #1495, #1510, #1512, #1513, #1519.