### PR TITLE
fix(app): keep a content-based body's mode when its content is emptied

### DIFF
--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -81,10 +81,10 @@ function toBodyPayload(request: RequestState): RequestBody {
 	if (request.bodyMode === "x-www-form-urlencoded") {
 		return { mode: "x-www-form-urlencoded", fields: toKeyValueEntries(request.urlEncoded) };
 	}
-	if (request.bodyMode !== "none" && request.body) {
+	if (request.bodyMode !== "none") {
 		return {
 			mode: request.bodyMode as "json" | "text" | "graphql" | "jsonrpc" | "xml",
-			content: request.body,
+			content: request.body ?? "",
 		};
 	}
 	return { mode: "none" };

--- a/app/src/modules/request-builder/request-builder.empty-body-mode.test.tsx
+++ b/app/src/modules/request-builder/request-builder.empty-body-mode.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Clearing a content-based body must keep its mode (issue #1490).
+ *
+ * `toBodyPayload` used to test `request.bodyMode !== "none" && request.body`:
+ * an empty string is falsy, so a JSON/text/XML/GraphQL/JSON-RPC body with no
+ * content collapsed to `{ mode: "none" }` on save. The mode selector then read
+ * JSON until the next reload (the in-memory draft still said "json"), and
+ * after a reload it read None, with the mode's auto-written `Content-Type`
+ * header left behind - a stored shape that contradicts what the user picked.
+ *
+ * The fix tests the mode alone and sends the empty string as `content` rather
+ * than dropping it, which is what the reverse read (seeding `bodyMode` from
+ * `body.mode` on load) already expects.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useTabsStore, useSessionStore, useDashboardStore } from "@/stores";
+import type { RequestState, MergeableRequestField } from "./types";
+
+const updateRequest = vi.fn();
+
+const requestQuery = {
+	get data() {
+		return {
+			id: "req_1",
+			collectionId: "col_1",
+			name: "Get user",
+			method: "GET",
+			url: "https://api.test/u",
+			params: [],
+			headers: [],
+			body: { mode: "json", content: '{"a":1}' },
+			auth: { mode: "none" },
+			preRequestScript: "",
+			postRequestScript: "",
+			followRedirects: true,
+			maxRedirects: 10,
+			httpVersion: "auto",
+			verifySSL: true,
+			stream: false,
+		} as unknown;
+	},
+	isLoading: false,
+	isError: false,
+	error: null as unknown,
+	refetch: vi.fn(),
+};
+
+vi.mock("@/queries", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/queries")>();
+	return {
+		...actual,
+		useRequestQuery: () => requestQuery,
+		useUpdateRequestMutation: () => ({ mutateAsync: updateRequest, mutate: vi.fn() }),
+		useCollectionAncestors: () => [],
+	};
+});
+
+vi.mock("@/hooks", () => ({
+	useEngine: () => ({ composeRequest: vi.fn(), executeRequest: vi.fn() }),
+	useVariableResolver: () => ({ resolveObject: <T,>(value: T) => value }),
+}));
+
+vi.mock("@/services", () => ({
+	apiService: { startLoadTest: vi.fn(), executeStreamRequest: vi.fn() },
+	loadTestService: { startMonitoring: vi.fn() },
+}));
+
+let providerProps: Record<string, unknown> = {};
+
+vi.mock("./context", () => ({
+	RequestBuilderProvider: (props: Record<string, unknown>) => {
+		providerProps = props;
+		return null;
+	},
+}));
+vi.mock("./components/RequestBuilderLayout", () => ({ default: () => null }));
+vi.mock("./components/LoadTestCommandSurface", () => ({ default: () => null }));
+vi.mock("./components/SendRequestCommandSurface", () => ({ default: () => null }));
+vi.mock("./components/LoadTestConfigDialog", () => ({ default: () => null }));
+
+const { default: RequestBuilder } = await import("./index");
+
+function renderBuilder() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	render(<RequestBuilder />, { wrapper });
+}
+
+/** The editor state the builder seeded, which is what the user then edits. */
+function seededState(overrides: Partial<RequestState> = {}): RequestState {
+	const initial = providerProps.initialRequest as Partial<RequestState>;
+	return { ...(initial as RequestState), disabledDefaultHeaders: [], ...overrides };
+}
+
+async function save(state: RequestState, changedFields: Iterable<MergeableRequestField>) {
+	await act(async () => {
+		await (
+			providerProps.onSave as (
+				r: RequestState,
+				changed: ReadonlySet<MergeableRequestField>
+			) => Promise<void>
+		)(state, new Set(changedFields));
+	});
+	return updateRequest.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+	updateRequest.mockReset().mockResolvedValue({});
+	providerProps = {};
+	useTabsStore.setState({
+		openTabs: [{ id: "t1", type: "request", entityId: "req_1", title: "Req" } as never],
+		activeTabId: "t1",
+	});
+	useSessionStore.setState({ activeEnvironmentId: "env_1" });
+	useDashboardStore.getState().setStreaming(false);
+});
+
+describe("emptying a content-based body", () => {
+	it("keeps the mode and sends an empty content string", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ bodyMode: "json", body: "" }), ["body"]);
+
+		expect(patch?.body).toEqual({ mode: "json", content: "" });
+		expect(patch).toHaveProperty("bodyType", "json");
+	});
+
+	it("still collapses to none when the mode itself is switched to None", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ bodyMode: "none", body: "" }), ["bodyMode", "body"]);
+
+		expect(patch?.body).toEqual({ mode: "none" });
+		expect(patch).toHaveProperty("bodyType", "none");
+	});
+
+	it("a body untouched since the last save is never resent", async () => {
+		renderBuilder();
+		const patch = await save(seededState({ url: "https://api.test/v2" }), ["url"]);
+
+		expect(patch).toHaveProperty("url", "https://api.test/v2");
+		expect(patch).not.toHaveProperty("body");
+		expect(patch).not.toHaveProperty("bodyType");
+	});
+});

--- a/docs/request-storage-design.md
+++ b/docs/request-storage-design.md
@@ -59,6 +59,16 @@ user happened to edit the Params table once. Imports now restore the invariant a
 parse time (`parseImport`, see
 [app/import-collections/README.md](app/import-collections/README.md)).
 
+#### An empty body keeps its mode
+
+A content-based body (`json`, `text`, `graphql`, `jsonrpc`, `xml`) is stored as
+`{ "mode": "<mode>", "content": "<string>" }`, and an empty `content` is still a
+body of that mode - clearing the editor to retype it is not the same action as
+picking **None**. The save path tests `bodyMode` alone rather than falling back
+to `mode: "none"` when the content is an empty (falsy) string, which used to
+collapse a cleared JSON/text/XML/GraphQL/JSON-RPC body to `none` on save (issue
+#1490) while the mode selector kept showing the old mode until the next reload.
+
 ### 2. Request Execution
 
 **Process**:


### PR DESCRIPTION
## Description

Flagged by the static write-read audit and confirmed by the persistence sweep at master `cb829ad3`, re-anchored at `228f1131` and again at `26fb827` for this PR (line numbers had drifted, the defect and fix pathway had not).

Pick JSON, type a body, wait for Saved, select all, delete (to retype it). The autosave stored `bodyType: "none"`, `body: {"mode":"none"}`. The UI still showed JSON until the next reload, when the mode selector read None and the `Content-Type: application/json` row the mode wrote was still in the headers (the removal on leaving a mode is interactive only - issue #1481, already fixed).

**Root cause and approach:** `toBodyPayload` (`app/src/modules/request-builder/index.tsx`), shared between the save path and the deleted-request pane's cURL-snippet fallback, tested `request.bodyMode !== "none" && request.body`. An empty string is falsy, so a JSON/text/XML/GraphQL/JSON-RPC body with no content collapsed to `{ mode: "none" }` on save. The fix tests `bodyMode` alone and sends `content: request.body ?? ""`, which is what the reverse read (seeding `bodyMode` from `body.mode` on load, verified unchanged in `index.tsx`'s `initialRequest` builder) already expects - confirmed by reading that path rather than assuming it, per this issue's own fix-pathway note.

**Alternative considered:** none - the issue's fix pathway names exactly this change, and the reverse read already round-trips an empty `content` correctly, so no second-side fix was needed.

The `form-data` and `x-www-form-urlencoded` branches return earlier in the same function and are untouched. The other consumer of `toBodyPayload` (`DeletedRequestBanner`'s cURL-snippet generation) now also gets `{ mode: "json", content: "" }` instead of `{ mode: "none" }` for an emptied body, but `codegen/prepare.ts`'s `shape.content ? … : undefined` already treats empty content as no body at the codegen layer, so the generated snippet is unaffected (`codegen.test.ts`'s existing case for this pins it).

## Type of Change
- [x] Bug fix

## Testing

- `app/src/modules/request-builder/request-builder.empty-body-mode.test.tsx` (new): a JSON body cleared to `""` saves `{ mode: "json", content: "" }` and `bodyType: "json"` (the fixed case); switching the mode itself to None still collapses to `{ mode: "none" }`; a body untouched since the last save is never resent (issue #1436's partial-save merge patch). Mutation check: reverting the `toBodyPayload` condition to `!== "none" && request.body` reddens the first case (`{ mode: 'none' }` vs `{ mode: 'json', content: '' }`), confirmed and reverted.
- `pnpm test request-builder` (110 files, 1165 tests) - all green, no regressions.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - all clean.

## Docs

`docs/request-storage-design.md` gains a "An empty body keeps its mode" subsection under Request Definitions, alongside the existing `url`/`params` invariant section, naming the rule and this issue.

## No user-visible change beyond the one it fixes

The mode selector now stays correct across a save and a reload for a cleared content-based body; nothing else in the panel changes. Not screenshotted: the observable behavior is "which value round-trips through storage", already covered by the unit test above in the same way the sibling `content-type.test.tsx` covers the related header issue.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1490


---
_Generated by [Claude Code](https://claude.ai/code/session_01QyzbgxNMjYzqRg5s1paQPQ)_