### PR TITLE
fix(engine,app): stop Chromium from caching every engine response to disk

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -64,6 +64,7 @@ import {
 import { createRendererRecovery } from "./renderer-recovery.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
 import { stampInstalledVersion } from "./appimage-stamp.js";
+import { clearResponseCacheOnUpgrade } from "./response-cache-clear.js";
 import { reportStartupIfRequested } from "./startup-probe.js";
 import { revealWhenReady } from "./window-reveal.js";
 /*
@@ -1354,6 +1355,12 @@ app.whenReady().then(async () => {
 		},
 		app.getVersion()
 	);
+
+	// Recover the disk space Chromium spent caching engine responses before
+	// the engine answered `Cache-Control: no-store` (#1507). Once per version,
+	// fire and forget: a skipped clear costs disk space, not correctness, and
+	// the session already exists here because `app.whenReady` has resolved.
+	void clearResponseCacheOnUpgrade(session.defaultSession, app.getVersion());
 
 	// Populate the native About panel (used by Help → About Vayu on
 	// Windows/Linux, and the macOS app menu's About item).

--- a/app/electron/response-cache-clear.test.ts
+++ b/app/electron/response-cache-clear.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The one-time cache clear (issue #1507) must run exactly once per version:
+ * an upgraded install has Chromium's disk cache emptied on first launch of the
+ * fixed version, and never again on every subsequent launch of the same one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as ResponseCacheClear from "./response-cache-clear.js";
+
+/** Mutable because the mock is hoisted above every test that retargets it. */
+const fake = vi.hoisted(() => ({ userData: "" }));
+
+vi.mock("electron", () => {
+	const api = {
+		app: { getPath: () => fake.userData, getVersion: () => "0.0.0-test" },
+		ipcMain: { on: () => {} },
+	};
+	// electron-store reaches for the default export.
+	return { ...api, default: api };
+});
+
+/**
+ * A fresh module instance per test, imported only after `fake.userData` is
+ * seeded to a real directory - the module-scope `new Store(...)` reads it
+ * (and writes a default config into it) at import time, the same reason
+ * `window-state.test.ts` imports this way rather than once, statically.
+ */
+async function importModule(): Promise<typeof ResponseCacheClear> {
+	vi.resetModules();
+	return import("./response-cache-clear.js");
+}
+
+beforeEach(() => {
+	fake.userData = mkdtempSync(join(tmpdir(), "vayu-cache-clear-"));
+});
+
+afterEach(() => {
+	rmSync(fake.userData, { recursive: true, force: true });
+});
+
+describe("needsCacheClear", () => {
+	it("is needed when nothing has been recorded yet", async () => {
+		const { needsCacheClear } = await importModule();
+		expect(needsCacheClear(undefined, "1.0.0")).toBe(true);
+	});
+
+	it("is needed after an upgrade", async () => {
+		const { needsCacheClear } = await importModule();
+		expect(needsCacheClear("1.0.0", "1.1.0")).toBe(true);
+	});
+
+	it("is not needed once the current version is recorded", async () => {
+		const { needsCacheClear } = await importModule();
+		expect(needsCacheClear("1.1.0", "1.1.0")).toBe(false);
+	});
+});
+
+describe("clearResponseCacheOnUpgrade", () => {
+	it("clears and records on the first launch of a version", async () => {
+		const { clearResponseCacheOnUpgrade } = await importModule();
+		const clearCache = vi.fn().mockResolvedValue(undefined);
+
+		await expect(clearResponseCacheOnUpgrade({ clearCache }, "1.0.0")).resolves.toBe(true);
+		expect(clearCache).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not clear again on a second launch of the same version", async () => {
+		const { clearResponseCacheOnUpgrade } = await importModule();
+		const clearCache = vi.fn().mockResolvedValue(undefined);
+
+		await clearResponseCacheOnUpgrade({ clearCache }, "1.0.0");
+		await expect(clearResponseCacheOnUpgrade({ clearCache }, "1.0.0")).resolves.toBe(false);
+		expect(clearCache).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears again after an upgrade", async () => {
+		const { clearResponseCacheOnUpgrade } = await importModule();
+		const clearCache = vi.fn().mockResolvedValue(undefined);
+
+		await clearResponseCacheOnUpgrade({ clearCache }, "1.0.0");
+		await expect(clearResponseCacheOnUpgrade({ clearCache }, "1.1.0")).resolves.toBe(true);
+		expect(clearCache).toHaveBeenCalledTimes(2);
+	});
+
+	// Mutation check: a version left unrecorded on failure means the next
+	// launch retries rather than believing a version was cleared when it
+	// was not. Recording unconditionally would turn this case false.
+	it("leaves the version unrecorded when the clear itself fails", async () => {
+		const { clearResponseCacheOnUpgrade } = await importModule();
+		const failing = vi.fn().mockRejectedValue(new Error("disk full"));
+		await expect(clearResponseCacheOnUpgrade({ clearCache: failing }, "1.0.0")).resolves.toBe(
+			false
+		);
+
+		const retried = vi.fn().mockResolvedValue(undefined);
+		await expect(clearResponseCacheOnUpgrade({ clearCache: retried }, "1.0.0")).resolves.toBe(
+			true
+		);
+	});
+});

--- a/app/electron/response-cache-clear.ts
+++ b/app/electron/response-cache-clear.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Recovers disk space from every engine response Chromium wrote to its HTTP
+ * cache before the engine answered `Cache-Control: no-store` (issue #1507).
+ *
+ * The engine now stops new writes; this clears what an install upgrading from
+ * an older engine already accumulated - measured at 1.2 GB on a 0.26.0 install
+ * whose own database was 12 MB. Once per app version, the same shape
+ * `appimage-stamp.ts` uses for its own one-time repair: read what was last
+ * recorded, skip if it already matches, otherwise act and record.
+ */
+
+import Store from "electron-store";
+import type { Session } from "electron";
+
+const store = new Store<{ lastCacheClearVersion?: string }>({
+	name: "response-cache-clear",
+	// Same reasoning as window-state.ts's flag: this Store is read at
+	// `app.whenReady`, well after `window-state.ts` already proved a corrupt
+	// config file must not stop the app from starting.
+	clearInvalidConfig: true,
+});
+
+/** Whether `version` has not yet had its one-time cache clear recorded. */
+export function needsCacheClear(lastClearedVersion: string | undefined, version: string): boolean {
+	return lastClearedVersion !== version;
+}
+
+/**
+ * Clears `session`'s HTTP cache once per app version and records that it did.
+ *
+ * Never throws: a failed clear costs disk space, not correctness, and must
+ * not interfere with startup. Left unrecorded on failure, so the next launch
+ * retries rather than treating a version as cleared when it was not.
+ */
+export async function clearResponseCacheOnUpgrade(
+	session: Pick<Session, "clearCache">,
+	version: string
+): Promise<boolean> {
+	if (!needsCacheClear(store.get("lastCacheClearVersion"), version)) {
+		return false;
+	}
+	try {
+		await session.clearCache();
+		store.set("lastCacheClearVersion", version);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/app/src/services/http-client.cache-control.test.ts
+++ b/app/src/services/http-client.cache-control.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Belt and braces against Chromium's disk cache (issue #1507).
+ *
+ * The engine answers every response with `Cache-Control: no-store`, but a dev
+ * build can be talking to an older engine, or a future route could forget the
+ * header - so the client asks `fetch` itself never to cache, on every call it
+ * makes.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { httpClient } from "./http-client";
+
+function fetchMock(response: Record<string, unknown>) {
+	const mock = vi.fn().mockResolvedValue(response);
+	vi.stubGlobal("fetch", mock);
+	return mock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("httpClient no-store", () => {
+	it("passes cache: no-store on a plain request", async () => {
+		const mock = fetchMock({ ok: true, status: 200, json: async () => ({}) });
+
+		await httpClient.get("/collections");
+
+		const [, init] = mock.mock.calls[0] as [string, RequestInit];
+		expect(init.cache).toBe("no-store");
+	});
+
+	it("passes cache: no-store on a body-carrying request", async () => {
+		const mock = fetchMock({ ok: true, status: 200, json: async () => ({}) });
+
+		await httpClient.post("/collections", { name: "x" });
+
+		const [, init] = mock.mock.calls[0] as [string, RequestInit];
+		expect(init.cache).toBe("no-store");
+	});
+
+	it("passes cache: no-store on a streamed request", async () => {
+		const mock = fetchMock({
+			ok: true,
+			status: 200,
+			json: async () => ({ done: true }),
+			headers: { get: () => "application/json" },
+			body: null,
+		});
+
+		const iterator = httpClient.stream("/import/fetch", { url: "https://x" });
+		await iterator.next();
+
+		const [, init] = mock.mock.calls[0] as [string, RequestInit];
+		expect(init.cache).toBe("no-store");
+	});
+});

--- a/app/src/services/http-client.ts
+++ b/app/src/services/http-client.ts
@@ -184,10 +184,15 @@ class HttpClient {
 				url += `?${params.toString()}`;
 			}
 
-			// Build fetch options
+			// Build fetch options. `cache: "no-store"` is belt and braces (#1507):
+			// the engine already answers every response with `Cache-Control:
+			// no-store`, but a dev build talking to an older engine, or a future
+			// route that forgets the header, should not refill Chromium's disk
+			// cache with live engine state either.
 			const fetchOptions: RequestInit = {
 				method,
 				signal: controller.signal,
+				cache: "no-store",
 				headers: {
 					"ngrok-skip-browser-warning": "true",
 					...options?.headers,
@@ -280,6 +285,7 @@ class HttpClient {
 			const response = await fetch(`${this.baseURL}${path}`, {
 				method: "POST",
 				signal: controller.signal,
+				cache: "no-store",
 				headers: {
 					"Content-Type": "application/json",
 					Accept: SSE_ACCEPT,

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -55,6 +55,9 @@ Low-level fetch wrapper with error handling and timeout management.
 - **Error Transformation**: Converts HTTP errors to `ApiError` with user-friendly messages
 - **Query Parameters**: Automatic URL encoding
 - **JSON Serialization**: Automatic request/response JSON handling
+- **No Caching**: every request passes `cache: "no-store"`, matching the
+  engine's own `Cache-Control: no-store` on every response (#1507) - nothing
+  the engine answers is valid to replay from Chromium's disk cache
 
 ### Error Handling
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -541,6 +541,12 @@ Variables are resolved with priority: **Environment > Collection > Global**
 
 - **Script Sandboxing**: QuickJS contexts are isolated with no filesystem or network access
 - **Local-Only Communication**: Control API only binds to `127.0.0.1:9876`
+- **No response caching**: every engine response carries `Cache-Control: no-store`
+  and the renderer's fetch client asks for `cache: "no-store"` as well (#1507).
+  Nothing the engine answers is valid to replay from a browser's disk cache - it
+  is a live read of state (a run, a request, a collection) that changes under
+  the client, and TanStack Query, not the HTTP cache, already holds whatever the
+  renderer keeps between polls.
 - **Context Isolation**: Electron renderer runs in isolated context (no Node.js access)
 - **No Cloud Sync**: All data stored locally in SQLite database
 - **No spellchecker**: every window the app opens - the shell and the OAuth

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -7,7 +7,9 @@ description: >-
 
 **Base URL:** `http://127.0.0.1:9876` (default, configurable via `--port`)
 
-All endpoints return JSON. **Every** error response has one shape - an `error`
+All endpoints return JSON. Every response also carries `Cache-Control: no-store`
+(#1507) - see [Listeners](architecture.md#listeners) for why. **Every** error
+response has one shape - an `error`
 object carrying a machine-readable `code` and a human-readable `message`:
 
 ```json

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -165,16 +165,17 @@ four more are opened on demand, and the rule that separates them is where each m
 | [Webhook inbox](api-reference.md#webhook-inbox) | `127.0.0.1` by default; wider only on explicit confirmation | `POST /inbox/start` | Records any method on any path, answers a canned response |
 | [Collection mock server](api-reference.md#mock-server) | `127.0.0.1`, ephemeral port unless one is named | `POST /mock/start` (at most 8) | A collection's saved example responses, on the paths its requests describe, until stopped |
 
+Every management API response also carries `Cache-Control: no-store` (#1507, `server.cpp`): every
+route answers a live read of state that changes under the client, so nothing here is valid to replay
+from a browser's disk cache. The mock server and inbox listeners are separate `ManagedListener`-owned
+servers of their own (see the table above) and set neither this nor the CORS headers below.
+
 **The inbox is the only one that may bind beyond loopback**, and the two reasons the others may not
 are different reasons:
 
 - The **management API** has no route authentication and answers `Access-Control-Allow-Origin: *`
   (`server.cpp`), so anything that can reach it can read every stored request, every credential the
   database holds, and start runs against arbitrary targets.
-- Every response from that same listener also carries `Cache-Control: no-store` (#1507, `server.cpp`):
-  every route answers a live read of state that changes under the client, so nothing here is valid to
-  replay from a browser's disk cache. The mock server and inbox routes inherit it the same way they
-  already inherit the CORS headers above.
 - A **mock issuer** hands out bearer tokens, and the **OAuth callback** carries an authorization
   code; publishing either would publish a credential.
 - An **inbox** serves none of that - it accepts a request, stores it, and replies with what the user

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -171,6 +171,10 @@ are different reasons:
 - The **management API** has no route authentication and answers `Access-Control-Allow-Origin: *`
   (`server.cpp`), so anything that can reach it can read every stored request, every credential the
   database holds, and start runs against arbitrary targets.
+- Every response from that same listener also carries `Cache-Control: no-store` (#1507, `server.cpp`):
+  every route answers a live read of state that changes under the client, so nothing here is valid to
+  replay from a browser's disk cache. The mock server and inbox routes inherit it the same way they
+  already inherit the CORS headers above.
 - A **mock issuer** hands out bearer tokens, and the **OAuth callback** carries an authorization
   code; publishing either would publish a credential.
 - An **inbox** serves none of that - it accepts a request, stores it, and replies with what the user

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -163,12 +163,10 @@ void Server::setup_routes () {
     { "Access-Control-Allow-Headers", "Content-Type, Authorization, ngrok-skip-browser-warning" },
     // Every response here is a live read of state that changes under the
     // client (#1507); none of it is valid to replay from a browser's disk
-    // cache. The mock server and inbox listener answer arbitrary
-    // user-configured bodies to external callers, not this rule's target,
-    // but they run on this same Server and inherit it too - harmless, since
-    // it only ever adds a second cache instruction alongside anything a mock
-    // route already sets, on top of the CORS headers those routes already
-    // inherit the same way.
+    // cache. The mock server and inbox listeners are separate
+    // ManagedListener-owned httplib::Server instances (mock_server.cpp,
+    // routes/inbox.cpp) and never call set_default_headers, so neither this
+    // nor the CORS trio above reaches them; only this management API does.
     { "Cache-Control", "no-store" } });
 
     // Handle OPTIONS preflight requests

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -160,7 +160,16 @@ void Server::setup_routes () {
     // ==========================================
     server_.set_default_headers ({ { "Access-Control-Allow-Origin", "*" },
     { "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS" },
-    { "Access-Control-Allow-Headers", "Content-Type, Authorization, ngrok-skip-browser-warning" } });
+    { "Access-Control-Allow-Headers", "Content-Type, Authorization, ngrok-skip-browser-warning" },
+    // Every response here is a live read of state that changes under the
+    // client (#1507); none of it is valid to replay from a browser's disk
+    // cache. The mock server and inbox listener answer arbitrary
+    // user-configured bodies to external callers, not this rule's target,
+    // but they run on this same Server and inherit it too - harmless, since
+    // it only ever adds a second cache instruction alongside anything a mock
+    // route already sets, on top of the CORS headers those routes already
+    // inherit the same way.
+    { "Cache-Control", "no-store" } });
 
     // Handle OPTIONS preflight requests
     server_.Options (".*",

--- a/engine/tests/server_bind_test.cpp
+++ b/engine/tests/server_bind_test.cpp
@@ -123,9 +123,16 @@ TEST_F (ServerBindTest, EveryResponseCarriesNoStoreCacheControl) {
     ASSERT_TRUE (server.start ());
 
     httplib::Client client ("127.0.0.1", port);
-    auto response = client.Get ("/health");
-    ASSERT_TRUE (response);
-    EXPECT_EQ (response->get_header_value ("Cache-Control"), "no-store");
+    auto health_response = client.Get ("/health");
+    ASSERT_TRUE (health_response);
+    EXPECT_EQ (health_response->get_header_value ("Cache-Control"), "no-store");
+
+    // The header comes from one call site (set_default_headers), but a second,
+    // unrelated JSON route pins that it is truly a server-wide default rather
+    // than something that happened to land on /health alone.
+    auto collections_response = client.Get ("/collections");
+    ASSERT_TRUE (collections_response);
+    EXPECT_EQ (collections_response->get_header_value ("Cache-Control"), "no-store");
 
     server.stop ();
 }

--- a/engine/tests/server_bind_test.cpp
+++ b/engine/tests/server_bind_test.cpp
@@ -111,4 +111,23 @@ TEST_F (ServerBindTest, AFreePortStartsAndServesWithNoRecordedError) {
     server.stop ();
 }
 
+TEST_F (ServerBindTest, EveryResponseCarriesNoStoreCacheControl) {
+    int port = 0;
+    {
+        PortHolder holder;
+        port = holder.port ();
+    }
+    ASSERT_GT (port, 0);
+
+    vayu::http::Server server (*db_, run_manager_, port, false);
+    ASSERT_TRUE (server.start ());
+
+    httplib::Client client ("127.0.0.1", port);
+    auto response = client.Get ("/health");
+    ASSERT_TRUE (response);
+    EXPECT_EQ (response->get_header_value ("Cache-Control"), "no-store");
+
+    server.stop ();
+}
+
 } // namespace


### PR DESCRIPTION
## Description

Owner-measured on an installed 0.26.0 (macOS, 23h uptime): `Cache/Cache_Data` under userData held 1.2 GB across 16,372 files, against a 12 MB database. The engine set no `Cache-Control` (or `ETag`/`Last-Modified`) on any response - confirmed empty on `rg -n "Cache-Control|no-store|ETag|Last-Modified" engine/src` - so Chromium wrote every `GET` body (runs, requests, collections, trace bodies up to 5 MiB) to its disk cache. Nothing in the app ever reads that cache back: TanStack Query holds the in-memory copy and every fetch is a fresh network call by design, so the disk cache is pure write amplification.

**Plan and root cause:** `Server::setup_routes()` (`engine/src/http/server.cpp`) sets the CORS trio via `httplib::Server::set_default_headers`, the one place headers are applied to every response on the management server - the same mechanism now also carries `Cache-Control: no-store`. The mock server and inbox listener each run their **own independent `ManagedListener`-owned `httplib::Server`** (`mock_server.cpp`, `routes/inbox.cpp`) and never call `set_default_headers`, so neither the CORS trio nor the new header reaches them - confirmed by `set_default_headers` appearing exactly once in the whole engine. (An earlier version of this PR's comment and doc line claimed the opposite - that those listeners "inherit" the header - which two independent reviews both caught and this PR corrects.)

For the app side: `http-client.ts` now passes `cache: "no-store"` on every `fetch` call (belt and braces - a dev build talking to an older engine, or a future route that forgets the header, should not refill the cache either). For existing installs, a new `clearResponseCacheOnUpgrade` (`app/electron/response-cache-clear.ts`) empties `session.defaultSession`'s cache once per app version, mirroring the compare-then-act shape `appimage-stamp.ts` already uses for its own one-time repair (an `electron-store`-backed marker, following the same `clearInvalidConfig: true` precedent as `window-state.ts`, rather than the AppImage module's plain-file idiom - the failure mode here is "runs once per version," not "advisory for one platform"). **Deviation from the issue's fix pathway:** the clear runs at `app.whenReady()` right after `stampInstalledVersion`, before `createWindow()`, rather than "after the window is created" as the issue's pathway states - deliberately: `session.defaultSession` exists as soon as the app is ready (it does not need a window), and clearing before the window's own first load means nothing the window is about to write gets wiped a moment later.

**Also fixed in this PR:** the issue's suggested doc target, `docs/engine/api-reference.md`'s "common response headers" section, does not exist - the engine's CORS header (the only other default header) is documented in `docs/engine/architecture.md` instead, so that is where the substantive `Cache-Control` note lives (as its own paragraph, not folded into the adjacent "why a listener may bind beyond loopback" bullet list, which is about a different question); `api-reference.md` gets a one-line cross-reference for discoverability, matching what the issue asked for without duplicating prose.

## Type of Change
- [x] Bug fix

## Testing

- `engine/tests/server_bind_test.cpp` (extended case): starts a real `vayu::http::Server`, hits both `/health` and `/collections` over a live socket, asserts `Cache-Control: no-store` on both - proving the header is a true server-wide default, not something that happened to land on one route. Mutation check performed by hand: removing the header entry from `set_default_headers` reds `EveryResponseCarriesNoStoreCacheControl` (confirmed, then restored, rebuilt, and reconfirmed green).
- `app/src/services/http-client.cache-control.test.ts` (new): asserts `cache: "no-store"` on the `RequestInit` for a plain GET, a body-carrying POST, and the streamed call.
- `app/electron/response-cache-clear.test.ts` (new): `needsCacheClear`'s three cases, and `clearResponseCacheOnUpgrade` clearing+recording on first launch of a version, not clearing again on a repeat launch of the same version, clearing again after an upgrade, and (mutation check) leaving the version unrecorded when the clear itself throws, so the next launch retries.

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2975/2975 passed** (2974 pre-existing + 1 new; the extended case counts as one `TEST_F`).
`cd app && pnpm test`: **8094/8094 passed** (8083 pre-existing + 11 new). `pnpm type-check`, `pnpm lint`, `pnpm format:check`: all clean.
`mkdocs build -f .github/mkdocs.yml --strict`: clean.

Two independent read-only reviews ran against the full diff (acceptance-criteria-by-line, repo-conventions). Both caught the same real defect - the mock/inbox "inherits the header" claim above - which is fixed in the second commit. Two minor points were raised and intentionally left as noted rather than changed: the cache-clear's placement before `createWindow()` (explained above, and arguably safer than the issue's literal wording) and the tests covering `response-cache-clear.ts` directly rather than `main.ts` itself (which has no test file of its own and wires in one line, the same way `stampInstalledVersion`'s existing call is verified by reading rather than a dedicated test).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1507

## Visual changes

No user-visible change - the fix is a response header and a background cache clear, neither with a UI surface.

Docs updated in this commit: `docs/engine/architecture.md` (the Cache-Control paragraph beside the listener table), `docs/engine/api-reference.md` (cross-reference), `docs/architecture.md` (Security section), `docs/app/api-integration.md` (HTTP Client Features list).
