### PR TITLE
fix(engine,app): mark a threshold check unevaluated when its metric has no samples

### DIFF
--- a/app/src/components/shared/ThresholdVerdict.test.tsx
+++ b/app/src/components/shared/ThresholdVerdict.test.tsx
@@ -112,6 +112,36 @@ describe("ThresholdVerdict", () => {
 		expect(screen.getByText("90")).toBeInTheDocument();
 	});
 
+	it("shows no samples for a check the run could not measure, and counts it as unmeasurable", () => {
+		// Issue #1484: a latency ceiling with zero completed requests used to
+		// print "0ms" and pass. Mutation check: reverting the `evaluated`
+		// branch back to always formatting `check.actual` prints "0ms" here
+		// instead, and this assertion fails.
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [
+						{ metric: "latencyP99Ms", limit: 200, passed: false, evaluated: false },
+					],
+					passed: 0,
+					failed: 1,
+					verdict: "failed",
+				})}
+			/>
+		);
+		expect(screen.getByText("no samples")).toBeInTheDocument();
+		expect(screen.getByText("0 of 1 budgets met, 1 not measurable.")).toBeInTheDocument();
+	});
+
+	it("treats a report with no evaluated field at all as fully measured", () => {
+		// A pre-#1484 engine never wrote the key. Mutation check: reading
+		// `check.evaluated !== false` as `check.evaluated === true` instead
+		// would print "no samples" for every check such a report carries.
+		render(<ThresholdVerdict verdict={verdict()} />);
+		expect(screen.getByText("1 of 1 budgets met.")).toBeInTheDocument();
+		expect(screen.queryByText("no samples")).not.toBeInTheDocument();
+	});
+
 	it("keeps a whole-number budget whole", () => {
 		cleanup();
 		render(

--- a/app/src/components/shared/ThresholdVerdict.tsx
+++ b/app/src/components/shared/ThresholdVerdict.tsx
@@ -18,6 +18,10 @@
  * drifting. Silent when the run declared no budgets: an absent section says
  * "not judged", which is a different claim from "judged and passed nothing" and
  * is the reason a run without budgets renders exactly as it did before.
+ *
+ * A single check can itself be unmeasurable (issue #1484): a latency ceiling
+ * checked against zero completed requests has no number to compare, and
+ * showing "0ms" there would read as a real - and passing - measurement.
  */
 
 import { Badge, Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
@@ -52,6 +56,9 @@ export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) 
 	if (!verdict || verdict.checks.length === 0) return null;
 
 	const failed = verdict.failed > 0;
+	// Absent (a pre-#1484 engine) reads as evaluated - that engine never wrote
+	// the field and never had the gap it now closes either.
+	const unmeasurable = verdict.checks.filter((check) => check.evaluated === false).length;
 
 	return (
 		<Card className={className}>
@@ -87,7 +94,8 @@ export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) 
 			</CardHeader>
 			<CardContent>
 				<p className="mb-3 text-xs text-muted-foreground">
-					{verdict.passed} of {verdict.passed + verdict.failed} budgets met.
+					{verdict.passed} of {verdict.passed + verdict.failed} budgets met
+					{unmeasurable > 0 ? `, ${unmeasurable} not measurable` : ""}.
 				</p>
 				<ul className="space-y-1.5">
 					{verdict.checks.map((check) => {
@@ -98,6 +106,9 @@ export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) 
 						// "≤" would describe the opposite budget from the one the
 						// verdict beside it was computed against.
 						const comparator = meta?.floor ? "≥" : "≤";
+						// A pre-#1484 report has no `evaluated` key at all and reads as
+						// measured, the same value that engine effectively assumed.
+						const evaluated = check.evaluated !== false;
 
 						return (
 							<li
@@ -119,8 +130,14 @@ export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) 
 											: "text-destructive-text"
 									)}
 								>
-									{formatValue(check.actual)}
-									{unit}
+									{evaluated ? (
+										<>
+											{formatValue(check.actual ?? 0)}
+											{unit}
+										</>
+									) : (
+										"no samples"
+									)}
 								</span>
 							</li>
 						);

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2021,8 +2021,18 @@ export interface RunReport {
 		checks: {
 			metric: string;
 			limit: number;
-			actual: number;
+			/** Absent when `evaluated` is false - there is no measurement to show. */
+			actual?: number;
 			passed: boolean;
+			/**
+			 * False when the run recorded no sample for this metric (issue #1484:
+			 * a latency percentile with zero completions used to read as 0ms,
+			 * trivially meeting an "at most" ceiling). Absent on a report a
+			 * pre-fix engine wrote, which never carried the field and never had
+			 * the bug's blind spot corrected either - reads as evaluated, the
+			 * same value that engine effectively assumed everywhere.
+			 */
+			evaluated?: boolean;
 		}[];
 		passed: number;
 		failed: number;

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1297,6 +1297,15 @@ The comparator follows the metric (`≥` for the throughput floor, `≤` for the
 ceilings), and a metric key this build has no label for renders under its raw
 name rather than vanishing from a verdict whose counts still include it.
 
+A single check can itself carry no measurement (issue #1484): a latency
+ceiling checked against zero completed requests reports `evaluated: false`,
+which the card shows as "no samples" in place of a number rather than the
+`0` a run of nothing but errors would otherwise default to and trivially
+pass. Such a check counts toward `failed`, and the summary line grows a
+"N not measurable" clause. A report from a pre-#1484 engine carries no
+`evaluated` key at all and renders exactly as before - absence reads as
+measured, the value that engine effectively assumed everywhere.
+
 ## Capacity Summary (`components/shared/CapacitySummary.tsx`)
 
 What a `mode: "capacity"` run's adaptive search found (`RunReport.capacity`):

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4929,6 +4929,16 @@ The verdict is the run's, not the process's: a run **stopped early** is judged o
 what it measured up to that point, and its status stays `completed` / `stopped`
 whatever the verdict says. A failing budget is reported, never a failed run.
 
+Each check carries `evaluated`. A latency percentile needs a completed request
+to mean anything, so a run that recorded none for that metric (every request
+errored before a response arrived) reports `evaluated: false` and omits
+`actual` entirely rather than the default `0`, which would otherwise read as a
+measured 0ms and trivially satisfy an "at most" ceiling. An unevaluated check
+counts toward `failed`: a budget the run could not measure was not met. The
+error rate and the throughput floor have no such gap - `maxErrorRatePct` is
+0/0-safe by request count, and a starved `minThroughputRps` already fails on
+its own - so both are always `evaluated: true`.
+
 #### The `monitor` block (server vitals)
 
 A run may name a metrics endpoint on the target, which the engine scrapes for
@@ -6693,7 +6703,9 @@ named it.
   },
   "testValidation": { "samplesTested": 500, "testsPassed": 498, "testsFailed": 2, "successRate": 99.6 },
   "thresholdValidation": {
-    "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 47.2, "passed": true } ],
+    "checks": [
+      { "metric": "latencyP99Ms", "limit": 50, "actual": 47.2, "passed": true, "evaluated": true }
+    ],
     "passed": 1, "failed": 0, "verdict": "passed"
   },
   "auth": { "refreshes": [ { "atSeconds": 3620.4 } ], "refreshFailures": 0 },

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -812,7 +812,9 @@ default, so `sync_schema()` can
   },
   "tests": { "sampled": 10, "passed": 9, "failed": 1 },
   "thresholds": {
-    "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 30.0, "passed": true } ],
+    "checks": [
+      { "metric": "latencyP99Ms", "limit": 50, "actual": 30.0, "passed": true, "evaluated": true }
+    ],
     "passed": 1, "failed": 0
   },
   "schemaValidation": {
@@ -847,7 +849,11 @@ the same rule and for the same reason: absent when the run declared no
 [budgets](api-reference.md#the-thresholds-block-passfail-budgets), so the report's
 `thresholdValidation` section is left out rather than claiming a run passed nothing. Its `metric`
 keys are the wire names the payload declared, carried through unchanged; the report derives
-`verdict` from `failed` rather than storing it, so the two cannot contradict. The writer is
+`verdict` from `failed` rather than storing it, so the two cannot contradict. Each check's
+`evaluated` follows the same absent-vs-zero rule one level down (issue #1484): a latency percentile
+with no completed requests writes `evaluated: false` and omits `actual` rather than storing the
+default `0`, which a reader could not tell apart from a genuine 0ms measurement; such a check counts
+toward `failed`. The writer is
 `vayu::core::build_run_summary_payload` and the reader is `apply_run_summary`
 (`http/routes/runs.cpp`); `runs_route_test.cpp` round-trips the pair, so the key names cannot
 drift apart silently.

--- a/engine/include/vayu/core/threshold_eval.hpp
+++ b/engine/include/vayu/core/threshold_eval.hpp
@@ -44,6 +44,12 @@ struct ThresholdCheck {
     double limit  = 0.0;
     double actual = 0.0;
     bool passed   = false;
+    /// False when the run recorded no sample for this metric - a latency
+    /// percentile with zero completed requests reads as 0ms, which trivially
+    /// satisfies an "at most" ceiling. `actual` is meaningless then, and the
+    /// check counts toward `failed`: a budget the run could not measure was
+    /// not met.
+    bool evaluated = true;
 };
 
 /// Every declared budget's verdict. `failed == 0` is the run's pass.

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1803,8 +1803,16 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     if (inputs.thresholds.has_value ()) {
         nlohmann::json checks = nlohmann::json::array ();
         for (const auto& check : inputs.thresholds->checks) {
-            checks.push_back ({ { "metric", check.metric }, { "limit", check.limit },
-            { "actual", check.actual }, { "passed", check.passed } });
+            nlohmann::json row = { { "metric", check.metric }, { "limit", check.limit },
+                { "passed", check.passed }, { "evaluated", check.evaluated } };
+            // Omitted rather than zeroed when unevaluated, the same rule this
+            // report follows for a section the run never populated - a
+            // ceiling of 0ms next to "passed": false would read as a real
+            // measurement instead of the absence it is.
+            if (check.evaluated) {
+                row["actual"] = check.actual;
+            }
+            checks.push_back (std::move (row));
         }
         summary["thresholds"] = { { "checks", checks },
             { "passed", inputs.thresholds->passed },

--- a/engine/src/core/threshold_eval.cpp
+++ b/engine/src/core/threshold_eval.cpp
@@ -41,6 +41,12 @@ struct ThresholdMetric {
     const char* range; // the accepted span, spelled for the rejection message
     const char* why;   // appended to a rejection, explains the bound
     double (*measured) (const RunSummaryInputs&);
+    /// Whether this run's numbers mean anything for this metric. `nullptr`
+    /// means always yes: the error rate and throughput are 0/0-safe already
+    /// (see `measured_error_rate`, and a starved throughput floor already
+    /// fails on its own). A latency percentile needs a real completion to
+    /// mean anything, so it is not evaluated when the run recorded none.
+    bool (*has_data) (const RunSummaryInputs&);
 };
 
 /// Share of this run's requests that did not succeed, as a percentage - the
@@ -67,18 +73,21 @@ const std::array<ThresholdMetric, 5>& metrics () {
     static const std::array<ThresholdMetric, 5> table = { {
     { "latencyP50Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
     "greater than 0 and at most 86400000", "It is a latency ceiling in milliseconds.",
-    [] (const RunSummaryInputs& in) { return in.latency.p50; } },
+    [] (const RunSummaryInputs& in) { return in.latency.p50; },
+    [] (const RunSummaryInputs& in) { return in.latency.count > 0; } },
     { "latencyP95Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
     "greater than 0 and at most 86400000", "It is a latency ceiling in milliseconds.",
-    [] (const RunSummaryInputs& in) { return in.latency.p95; } },
+    [] (const RunSummaryInputs& in) { return in.latency.p95; },
+    [] (const RunSummaryInputs& in) { return in.latency.count > 0; } },
     { "latencyP99Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
     "greater than 0 and at most 86400000", "It is a latency ceiling in milliseconds.",
-    [] (const RunSummaryInputs& in) { return in.latency.p99; } },
+    [] (const RunSummaryInputs& in) { return in.latency.p99; },
+    [] (const RunSummaryInputs& in) { return in.latency.count > 0; } },
     { "maxErrorRatePct", Direction::AtMost, 0.0, true, 100.0, "between 0 and 100",
-    "It is a percentage of the run's requests.", measured_error_rate },
+    "It is a percentage of the run's requests.", measured_error_rate, nullptr },
     { "minThroughputRps", Direction::AtLeast, 0.0, false, MAX_THROUGHPUT_BUDGET_RPS,
     "greater than 0 and at most 1000000000", "It is a completed-requests-per-second floor.",
-    [] (const RunSummaryInputs& in) { return in.throughput; } },
+    [] (const RunSummaryInputs& in) { return in.throughput; }, nullptr },
     } };
     return table;
 }
@@ -201,10 +210,17 @@ const RunSummaryInputs& inputs) {
         ThresholdCheck check;
         check.metric = metric->key;
         check.limit  = limit;
-        check.actual = metric->measured (inputs);
-        check.passed = metric->direction == Direction::AtMost ?
-        check.actual <= check.limit :
-        check.actual >= check.limit;
+        check.evaluated = metric->has_data == nullptr || metric->has_data (inputs);
+        if (check.evaluated) {
+            check.actual = metric->measured (inputs);
+            check.passed = metric->direction == Direction::AtMost ?
+            check.actual <= check.limit :
+            check.actual >= check.limit;
+        } else {
+            // A budget the run could not measure was not met - counted below
+            // as a failure, never silently dropped from the tally.
+            check.passed = false;
+        }
         if (check.passed) {
             ++outcome.passed;
         } else {

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -791,6 +791,7 @@ vayu::core::RunSummaryInputs summary_inputs () {
     inputs.bytes_sent              = 1024;
     inputs.bytes_received          = 8192;
     inputs.status_codes            = { { 200, 90 }, { 500, 7 }, { 0, 3 } };
+    inputs.latency.count           = 100;
     inputs.latency.min             = 1.0;
     inputs.latency.max             = 90.0;
     inputs.latency.p50             = 10.0;
@@ -1060,12 +1061,41 @@ TEST_F (RunsRouteTest, ReportCarriesTheThresholdVerdict) {
     EXPECT_DOUBLE_EQ (verdict["checks"][0]["limit"].get<double> (), 50.0);
     EXPECT_DOUBLE_EQ (verdict["checks"][0]["actual"].get<double> (), 30.0);
     EXPECT_TRUE (verdict["checks"][0]["passed"].get<bool> ());
+    EXPECT_TRUE (verdict["checks"][0]["evaluated"].get<bool> ());
     EXPECT_EQ (verdict["checks"][1]["metric"].get<std::string> (), "maxErrorRatePct");
     EXPECT_FALSE (verdict["checks"][1]["passed"].get<bool> ());
 
     // The one assertion that pins the two sides together.
     EXPECT_DOUBLE_EQ (verdict["checks"][1]["actual"].get<double> (),
     body["summary"]["errorRate"].get<double> ());
+}
+
+// Issue #1484: a run whose every request errored before completing has no
+// latency samples at all, and its stored `evaluated: false` / omitted
+// `actual` must survive the round trip through the summary column exactly
+// like every other absent-vs-zero section this report carries.
+TEST_F (RunsRouteTest, ReportOmitsActualAndMarksUnevaluatedForALatencyCheckWithNoSamples) {
+    seed ({ .id = "run_no_samples", .start_time = 1000 });
+    vayu::core::RunSummaryInputs inputs;
+    inputs.total_requests = 5999;
+    inputs.status_codes   = { { 0, 5999 } };
+    inputs.thresholds     = vayu::core::evaluate_thresholds (
+    nlohmann::json{ { "thresholds", { { "latencyP99Ms", 200 } } } }, inputs);
+    db_->update_run_summary (
+    "run_no_samples", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_samples");
+    ASSERT_EQ (status, 200);
+
+    ASSERT_TRUE (body.contains ("thresholdValidation"));
+    const auto& verdict = body["thresholdValidation"];
+    EXPECT_EQ (verdict["verdict"].get<std::string> (), "failed");
+    EXPECT_EQ (verdict["failed"].get<size_t> (), 1u);
+    ASSERT_EQ (verdict["checks"].size (), 1u);
+    const auto& check = verdict["checks"][0];
+    EXPECT_FALSE (check["evaluated"].get<bool> ());
+    EXPECT_FALSE (check["passed"].get<bool> ());
+    EXPECT_FALSE (check.contains ("actual"));
 }
 
 TEST_F (RunsRouteTest, AThresholdVerdictPassesOnlyWhenNothingFailed) {

--- a/engine/tests/threshold_eval_test.cpp
+++ b/engine/tests/threshold_eval_test.cpp
@@ -43,6 +43,7 @@ RunSummaryInputs measured_run () {
     inputs.total_requests = 1000;
     inputs.throughput     = 500.0;
     inputs.status_codes   = { { 200, 990 }, { 500, 8 }, { 0, 2 } };
+    inputs.latency.count  = 1000;
     inputs.latency.p50    = 10.0;
     inputs.latency.p95    = 40.0;
     inputs.latency.p99    = 47.0;
@@ -236,6 +237,76 @@ TEST (ThresholdEval, ARunThatSentNothingHasNoErrorRate) {
     evaluate_thresholds (config_with ({ { "maxErrorRatePct", 1 } }), empty));
     EXPECT_DOUBLE_EQ (check.actual, 0.0);
     EXPECT_TRUE (check.passed);
+}
+
+// --- Zero samples: a latency ceiling must not read a default as a measurement
+// (issue #1484: a run where every request failed reported its budgets met) ---
+
+TEST (ThresholdEval, ALatencyBudgetWithNoCompletionsIsNotEvaluatedAndCountsAsFailed) {
+    // Every request sent, none completed - a timeout or a connection refusal
+    // on all of them, the exact shape a 100% error rate run has. `latency`
+    // keeps its all-default Percentiles (count 0, p99 0.0), which must not
+    // read as "p99 was 0ms".
+    RunSummaryInputs inputs;
+    inputs.total_requests = 5999;
+    inputs.status_codes   = { { 0, 5999 } };
+
+    auto check = only_check (
+    evaluate_thresholds (config_with ({ { "latencyP99Ms", 200 } }), inputs));
+    EXPECT_FALSE (check.evaluated);
+    EXPECT_FALSE (check.passed);
+}
+
+TEST (ThresholdEval, ARunWithSomeCompletionsStillEvaluatesEveryDeclaredLatencyBudget) {
+    // The guard reads each metric's own sample count, not a single run-wide
+    // flag - a run that completed at least one request must not blanket every
+    // percentile as unevaluated.
+    RunSummaryInputs inputs;
+    inputs.total_requests = 10;
+    inputs.status_codes   = { { 200, 10 } };
+    inputs.latency.count  = 10;
+    inputs.latency.p99    = 5.0;
+
+    auto check = only_check (
+    evaluate_thresholds (config_with ({ { "latencyP99Ms", 200 } }), inputs));
+    EXPECT_TRUE (check.evaluated);
+    EXPECT_TRUE (check.passed);
+    EXPECT_DOUBLE_EQ (check.actual, 5.0);
+}
+
+TEST (ThresholdEval, AnUnevaluatedLatencyCheckDoesNotHideAFailingErrorRateBudget) {
+    // The bug's own reproduction: a 100% error rate run with both a latency
+    // ceiling and an error-rate ceiling declared. The error rate still reads
+    // correctly (measured_error_rate has always been 0/0-safe by total
+    // requests, not by latency samples); the fix must not disturb it.
+    RunSummaryInputs inputs;
+    inputs.total_requests = 5999;
+    inputs.status_codes   = { { 0, 5999 } };
+
+    auto outcome = evaluate_thresholds (
+    config_with ({ { "latencyP99Ms", 200 }, { "maxErrorRatePct", 1 } }), inputs);
+    ASSERT_HAS_VALUE (outcome);
+    ASSERT_EQ (outcome->checks.size (), 2u);
+    EXPECT_FALSE (outcome->checks[0].evaluated); // latencyP99Ms: no completions
+    EXPECT_FALSE (outcome->checks[0].passed);
+    EXPECT_TRUE (outcome->checks[1].evaluated); // maxErrorRatePct: always evaluated
+    EXPECT_FALSE (outcome->checks[1].passed); // 100% > 1%
+    EXPECT_EQ (outcome->passed, 0u);
+    EXPECT_EQ (outcome->failed, 2u);
+}
+
+TEST (ThresholdEval, AThroughputOrErrorRateBudgetIsAlwaysEvaluated) {
+    // Neither metric has a "no data" state of its own: 0/0 error rate is
+    // already correct (ARunThatSentNothingHasNoErrorRate) and a starved
+    // throughput floor already fails on its own numbers.
+    RunSummaryInputs empty;
+    auto rate = only_check (
+    evaluate_thresholds (config_with ({ { "maxErrorRatePct", 50 } }), empty));
+    EXPECT_TRUE (rate.evaluated);
+    auto throughput = only_check (
+    evaluate_thresholds (config_with ({ { "minThroughputRps", 10 } }), empty));
+    EXPECT_TRUE (throughput.evaluated);
+    EXPECT_FALSE (throughput.passed); // 0 rps never meets a floor above zero
 }
 
 TEST (ThresholdEval, AStoredBudgetOfTheWrongTypeIsSkippedRatherThanGuessed) {


### PR DESCRIPTION
## Description

Owner-measured (issue #1484): a Constant RPS run whose every request failed (5,999 of 5,999 errors) reported `ERROR RATE 100.0%` beside `Pass/fail budgets - Passed · 1 of 1 budgets met · p99 latency (≤ 200ms) 0ms`. `threshold_eval.cpp`'s `measured` lambdas for the three latency percentiles read `in.latency.p50/p95/p99` directly with no guard, so a metric with zero completed requests read its all-default `0.0` as a genuine measurement, which trivially satisfies an "at most" ceiling.

**Root cause and plan:** `MetricsCollector::Percentiles` already carries a `count` field for exactly this reason ("Zero is the only way to tell 'nothing completed' from 'everything completed instantly'" - `metrics_collector.hpp:716`), but the threshold evaluator never consulted it. `ThresholdCheck` gains `evaluated`, driven by a new per-metric `has_data` function pointer on the `ThresholdMetric` table (`nullptr` for a metric that is always meaningful): the three latency percentiles check `in.latency.count > 0`, while the error rate (already 0/0-safe by `total_requests`, pinned by the existing `ARunThatSentNothingHasNoErrorRate` test) and the throughput floor (a starved 0 rps already fails an `AtLeast` budget above zero on its own) stay always-evaluated - neither has the gap the issue describes, so neither changes behavior. An unevaluated check counts toward `failed` rather than being silently dropped, following the acceptance criteria's "a budget the run could not measure was not met."

**Alternative considered and rejected:** making `actual` a `std::optional<double>` directly on `ThresholdCheck` instead of adding a separate `evaluated` bool plus a `has_data` guard function. Rejected because the existing `ThresholdMetric` table is data-driven specifically so the route's validation and the run's verdict can never drift apart (`threshold_eval.hpp`'s own doc comment), and a per-metric predicate keeps that same shape - a `std::optional` return from `measured` itself would have required every one of the five lambdas (including the two that are never affected) to thread an extra branch, for no benefit over a single `nullptr`-means-always-yes function pointer that only the three affected entries populate.

**Wire shape:** the stored summary and the report's `thresholdValidation.checks[]` gain `evaluated` (always present) and omit `actual` entirely when `evaluated` is `false`, following this report's existing absent-vs-zero rule (the same one `tests`/`thresholds`/`schemaValidation` already follow) rather than writing a `0` a reader could not tell apart from a genuine 0ms measurement.

**App side:** `ThresholdVerdict.tsx` renders "no samples" in place of a number for such a check and adds a "N not measurable" clause to the summary line ("0 of 1 budgets met, 1 not measurable"). `domain.ts`'s `evaluated`/`actual` are both optional so a report from a pre-existing engine - which never wrote either field - reads as fully measured, matching what that engine effectively assumed everywhere; no migration or version gate is needed.

## Type of Change
- [x] Bug fix

## Testing

- `engine/tests/threshold_eval_test.cpp` (new cases): a latency budget against zero completions is `evaluated: false` and counted as failed; a run with at least one completion still evaluates every declared latency budget (the guard reads each metric's own sample count, not a run-wide flag); the bug's own reproduction (100% error rate, both a latency and an error-rate budget declared) shows the latency check unevaluated while the error-rate check still correctly fails on its own numbers; the error rate and throughput floor are always evaluated regardless of sample count. Mutation check performed by hand: disabling the `has_data` guard (forcing `evaluated = true` unconditionally) reds exactly the three tests targeting this fix - `ALatencyBudgetWithNoCompletionsIsNotEvaluatedAndCountsAsFailed`, `AnUnevaluatedLatencyCheckDoesNotHideAFailingErrorRateBudget`, and the route-level `ReportOmitsActualAndMarksUnevaluatedForALatencyCheckWithNoSamples` - while every other test in the suite (2979 total) stayed green; reverted and rebuilt clean afterward.
- `engine/tests/runs_route_test.cpp` (new case): the report round-trips `evaluated: false` and omits `actual` through the stored summary column exactly like every other absent-vs-zero section this report carries; existing threshold tests gained an explicit `evaluated: true` assertion. `measured_run()` / `summary_inputs()` fixtures gained `latency.count` so the existing (already-passing) latency-budget tests stay meaningful under the new guard.
- `app/src/components/shared/ThresholdVerdict.test.tsx` (new cases): an unevaluated check renders "no samples" and the "N not measurable" clause; a report carrying no `evaluated` key at all (a pre-fix engine) renders exactly as before.

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2979/2979 passed**.
`cd app && pnpm test ThresholdVerdict`: **11/11 passed**. `pnpm type-check`, `pnpm lint`, `pnpm format:check`: all clean (run against the full touched-file set).
`mkdocs build -f .github/mkdocs.yml --strict`: clean.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1484

## Visual changes

Engine-only report shape change plus a small, additive rendering change to an existing card (`ThresholdVerdict.tsx`): a check with no samples now shows the text "no samples" in place of a number, and the summary line gains a trailing "N not measurable" clause when applicable. Not captured with a screenshot: verified instead through `ThresholdVerdict.test.tsx`'s rendered-text assertions (`no samples`, `0 of 1 budgets met, 1 not measurable.`), which pin the exact wording more precisely than an image would; every other row and layout in the card is untouched.

Docs updated in this commit: `docs/engine/api-reference.md` (the `evaluated` field, the example JSON), `docs/engine/db-schema.md` (the stored `thresholds.checks[]` shape), `docs/app/COMPONENTS.md` (the Threshold Verdict card's no-samples behavior).