### PR TITLE
fix(engine,app): cap a design run's stored config snapshot body

### DIFF
--- a/app/src/modules/history/main/design-run-seed.test.ts
+++ b/app/src/modules/history/main/design-run-seed.test.ts
@@ -363,5 +363,19 @@ describe("seedFromRun", () => {
 		it("leaves it undefined for an untruncated run", () => {
 			expect(seedFromRun(run(), liveRequest).requestBodyTruncated).toBeUndefined();
 		});
+
+		it("sets requestBodyTruncated from the config snapshot's own cap, with no trace cut", () => {
+			// sanitize_config_snapshot caps body.content independently of the
+			// trace, so a run can be truncated there with the trace untouched.
+			const truncatedSnapshotOnly = run({
+				configSnapshot: {
+					method: "POST",
+					url: "https://api.example.test/users?page=2",
+					body: { mode: "json", content: "SLICE", bodyTruncated: true, bodyBytes: 5_242_880 },
+				},
+			} as Partial<Run>);
+
+			expect(seedFromRun(truncatedSnapshotOnly, liveRequest).requestBodyTruncated).toBe(true);
+		});
 	});
 });

--- a/app/src/modules/history/main/design-run-seed.test.ts
+++ b/app/src/modules/history/main/design-run-seed.test.ts
@@ -371,7 +371,12 @@ describe("seedFromRun", () => {
 				configSnapshot: {
 					method: "POST",
 					url: "https://api.example.test/users?page=2",
-					body: { mode: "json", content: "SLICE", bodyTruncated: true, bodyBytes: 5_242_880 },
+					body: {
+						mode: "json",
+						content: "SLICE",
+						bodyTruncated: true,
+						bodyBytes: 5_242_880,
+					},
 				},
 			} as Partial<Run>);
 

--- a/app/src/modules/history/main/design-run-seed.ts
+++ b/app/src/modules/history/main/design-run-seed.ts
@@ -38,7 +38,15 @@ interface DesignSnapshot {
 	method?: string;
 	url?: string;
 	headers?: Record<string, string>;
-	body?: { mode?: string; content?: string; fields?: KeyValueEntry[] };
+	body?: {
+		mode?: string;
+		content?: string;
+		fields?: KeyValueEntry[];
+		/** Set by `sanitize_config_snapshot` when `content` exceeded `maxTraceBodyBytes`. */
+		bodyTruncated?: boolean;
+		/** The body's original byte length, present only when truncated. */
+		bodyBytes?: number;
+	};
 	auth?: { mode?: string };
 	preRequestScripts?: ScriptPart[];
 	postRequestScripts?: ScriptPart[];
@@ -78,10 +86,9 @@ export interface DesignRunSeed {
 	recordedAuthMode?: string;
 	/**
 	 * True when the engine truncated this run's stored request body
-	 * (`maxTraceBodyBytes`). The editable copy still shows the full body from the
-	 * config snapshot (which is not capped), but "Save this run to the request"
-	 * must not write a possibly-incomplete body back - see
-	 * {@link applyRunToRequest}. Read from `trace.request.bodyTruncated`.
+	 * (`maxTraceBodyBytes`), on the trace or on the config snapshot itself -
+	 * both are capped at the same limit. "Save this run to the request" must
+	 * not write a possibly-incomplete body back - see {@link applyRunToRequest}.
 	 */
 	requestBodyTruncated?: boolean;
 }
@@ -172,7 +179,10 @@ export function seedFromRun(run: Run, liveRequest?: Request | null): DesignRunSe
 		// "none" carries no information the absence would not, so normalise it away.
 		recordedAuthMode:
 			snapshot.auth?.mode && snapshot.auth.mode !== "none" ? snapshot.auth.mode : undefined,
-		// Only surfaces `true`; an untruncated run leaves it undefined.
-		requestBodyTruncated: trace?.request?.bodyTruncated ? true : undefined,
+		// Only surfaces `true`; an untruncated run leaves it undefined. Either
+		// source cutting the body is enough - the trace and the config snapshot
+		// are capped independently, at the same limit.
+		requestBodyTruncated:
+			trace?.request?.bodyTruncated || body?.bodyTruncated ? true : undefined,
 	};
 }

--- a/app/src/modules/history/main/save-run-to-request.ts
+++ b/app/src/modules/history/main/save-run-to-request.ts
@@ -29,9 +29,10 @@
  * and run it twice.
  *
  * **Body, for a run whose stored request body was truncated.** The engine caps
- * a stored trace body at `maxTraceBodyBytes`, so such a run holds only a slice
- * of what was sent; writing that slice back would corrupt the saved body. When
- * `seed.requestBodyTruncated` is set the body is left off the patch.
+ * a stored trace body, and the config snapshot's own body, at `maxTraceBodyBytes`,
+ * so such a run holds only a slice of what was sent; writing that slice back
+ * would corrupt the saved body. When `seed.requestBodyTruncated` is set the
+ * body is left off the patch.
  *
  * None is silent: {@link buildChangeset} emits each as a `kept` row, in the
  * same list as every change, with the reason inline. That is what makes "an

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6412,6 +6412,12 @@ holds only the first `maxTraceBodyBytes` of the original. Absent when the body
 fit. Clients surface this as a "body truncated for storage" notice and re-send
 to fetch the whole body.
 
+`configSnapshot.body` is capped the same way, independently of the trace
+(issue #1486): `content` over `maxTraceBodyBytes` is cut to that length and the
+`body` object gains the same `bodyTruncated` / `bodyBytes` pair. A run can be
+truncated on one side and not the other, since each is written by its own call
+into `sanitize_config_snapshot`.
+
 ### POST /runs/:runId/stop
 
 > Alias: `POST /run/:runId/stop` (deprecated - see [Deprecated aliases](#deprecated-aliases)).

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -889,6 +889,19 @@ reduced to just `{"mode": "..."}` (via `sanitize_config_snapshot` in
 `utils/json.cpp`) - an allowlist, so no current or future auth field
 (`clientSecret`, `password`, tokens) leaks into a stored run.
 
+**`config_snapshot`'s body is capped at `maxTraceBodyBytes`** (issue #1486), the
+same limit and the same sibling-key shape the [`results`](#results) trace bodies
+use - `sanitize_config_snapshot` truncates `body.content` in place and records
+`bodyTruncated: true` / `bodyBytes: <original length>` on the `body` object when
+it cuts. Without this cap a single oversized send (a large upload, a big JSON
+fixture) left a permanently bloated `config_snapshot` behind: the one-time
+summary build the cache above pays per run id, and the `q` filter's `LIKE` /
+`collectionId`'s `json_extract` (`run_filter_where`, `db/database.cpp`, run
+unconditionally as part of every list query's `WHERE`) all scan the stored
+string's full length on every call that uses them. The by-id route
+(`GET /runs/:id`) returns whatever was stored, cap included - it never
+re-derives or re-truncates.
+
 **`config_snapshot` for a scenario run** - a run started from a `scenario` block
 (see [POST /runs](api-reference.md#post-runs)) stores a **step manifest**, never
 the resolved plan. The manifest *replaces* the block as sent, rather than

--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -202,7 +202,14 @@ void serialize_to_stream (const vayu::db::Request& request, std::ostream& out);
  * allowlist (keep `mode`) rather than a blocklist of known secret names, so no
  * future auth field can leak into the stored snapshot. Non-auth fields are left
  * intact. If `body` is not valid JSON it is returned unchanged.
+ *
+ * `body.content` (the request body being tested, not `body` itself) is capped
+ * at `max_body_bytes`, the same limit `cap_trace_bodies` applies to a stored
+ * trace, so one oversized send cannot leave a permanently bloated snapshot
+ * behind. A cut records `bodyTruncated`/`bodyBytes` on the `body` object,
+ * mirroring `cap_node_body`'s sibling-key shape.
  */
-[[nodiscard]] std::string sanitize_config_snapshot (const std::string& body);
+[[nodiscard]] std::string
+sanitize_config_snapshot (const std::string& body, size_t max_body_bytes);
 
 } // namespace vayu::json

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -540,8 +540,9 @@ namespace {
 std::string run_config_snapshot (const std::string& body,
 bool is_scenario,
 const nlohmann::json& scenario_manifest,
-const vayu::core::LoadDataSet* data) {
-    std::string sanitized = vayu::json::sanitize_config_snapshot (body);
+const vayu::core::LoadDataSet* data,
+size_t max_body_bytes) {
+    std::string sanitized = vayu::json::sanitize_config_snapshot (body, max_body_bytes);
     if (is_scenario) {
         return scenario_snapshot (sanitized, scenario_manifest);
     }
@@ -1208,7 +1209,11 @@ DesignSend& send) {
     // payload nobody will store is work with no reader.
     if (!payload.transient) {
         send.run.id = vayu::utils::generate_id ("run_");
-        send.run.config_snapshot = vayu::json::sanitize_config_snapshot (req.body);
+        const auto max_snapshot_body_bytes =
+        static_cast<size_t> (ctx.db.get_config_int ("maxTraceBodyBytes",
+        static_cast<int> (vayu::core::constants::json::MAX_TRACE_BODY_BYTES)));
+        send.run.config_snapshot =
+        vayu::json::sanitize_config_snapshot (req.body, max_snapshot_body_bytes);
         send.run_id = send.run.id;
     }
 
@@ -1875,8 +1880,11 @@ httplib::Response& res) {
     run.type   = (is_scenario && !is_scenario_load) ? vayu::RunType::Scenario :
                                                       vayu::RunType::Load;
     run.status = vayu::RunStatus::Pending;
-    run.config_snapshot = run_config_snapshot (
-    req.body, is_scenario, scenario_manifest, load_data.set.get ());
+    const auto max_snapshot_body_bytes =
+    static_cast<size_t> (ctx.db.get_config_int ("maxTraceBodyBytes",
+    static_cast<int> (vayu::core::constants::json::MAX_TRACE_BODY_BYTES)));
+    run.config_snapshot = run_config_snapshot (req.body, is_scenario,
+    scenario_manifest, load_data.set.get (), max_snapshot_body_bytes);
     seed_run_times (run, now_ms ());
 
     if (json.contains ("requestId") && !json["requestId"].is_null ()) {

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -1243,7 +1243,32 @@ void serialize_to_stream (const vayu::db::Request& r, std::ostream& out) {
     out << "}";
 }
 
-std::string sanitize_config_snapshot (const std::string& body) {
+namespace {
+
+// Cap a config snapshot's `body.content` in place, recording bodyTruncated +
+// bodyBytes (the original length) on the `body` object when cut - the same
+// sibling-key shape `cap_node_body` records on a trace node, one level down
+// here because `content` lives inside `body` rather than being it.
+void cap_snapshot_body (nlohmann::json& parsed, size_t max_body_bytes) {
+    auto body_it = parsed.find ("body");
+    if (body_it == parsed.end () || !body_it->is_object ()) {
+        return;
+    }
+    auto content_it = body_it->find ("content");
+    if (content_it == body_it->end () || !content_it->is_string ()) {
+        return;
+    }
+    const std::string content = content_it->get<std::string> ();
+    if (content.size () > max_body_bytes) {
+        *content_it                 = content.substr (0, max_body_bytes);
+        (*body_it)["bodyTruncated"] = true;
+        (*body_it)["bodyBytes"]     = content.size ();
+    }
+}
+
+} // namespace
+
+std::string sanitize_config_snapshot (const std::string& body, size_t max_body_bytes) {
     Json parsed;
     try {
         parsed = Json::parse (body);
@@ -1251,15 +1276,16 @@ std::string sanitize_config_snapshot (const std::string& body) {
         return body; // not JSON; store as-is
     }
 
-    // Allowlist within the auth subtree: keep only the mode, drop every
-    // credential field. Because we keep a fixed key rather than blocking known
-    // secret names, no future auth field (client secrets, tokens, private keys)
-    // can leak into the persisted snapshot.
     if (parsed.is_object ()) {
+        // Allowlist within the auth subtree: keep only the mode, drop every
+        // credential field. Because we keep a fixed key rather than blocking
+        // known secret names, no future auth field (client secrets, tokens,
+        // private keys) can leak into the persisted snapshot.
         if (auto it = parsed.find ("auth"); it != parsed.end () && it->is_object ()) {
             const std::string mode = it->value ("mode", std::string{ "none" });
             *it                    = Json::object ({ { "mode", mode } });
         }
+        cap_snapshot_body (parsed, max_body_bytes);
     }
     return parsed.dump ();
 }

--- a/engine/tests/request_builder_test.cpp
+++ b/engine/tests/request_builder_test.cpp
@@ -7,12 +7,15 @@
 
 #include <nlohmann/json.hpp>
 
+#include "vayu/core/constants.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/utils/json.hpp"
 
 using nlohmann::json;
 
 namespace {
+
+constexpr size_t kMaxBodyBytes = vayu::core::constants::json::MAX_TRACE_BODY_BYTES;
 
 TEST (RequestBuilder, BuildsValidRequestAndAppliesTimeoutAndAuth) {
     const json cfg = { { "method", "GET" }, { "url", "https://api.example.com/v1" },
@@ -42,7 +45,7 @@ TEST (RequestBuilder, NoAuthLeavesHeadersEmpty) {
 TEST (SanitizeConfigSnapshot, ReducesAuthToModeOnly) {
     const std::string body =
     R"({"method":"GET","url":"https://x/y","auth":{"mode":"basic","username":"u","password":"secret"}})";
-    const auto out    = vayu::json::sanitize_config_snapshot (body);
+    const auto out = vayu::json::sanitize_config_snapshot (body, kMaxBodyBytes);
     const auto parsed = json::parse (out);
     EXPECT_EQ (parsed["url"], "https://x/y");
     EXPECT_EQ (parsed["auth"], (json{ { "mode", "basic" } }));
@@ -54,17 +57,19 @@ TEST (SanitizeConfigSnapshot, DropsUnknownFutureSecretFields) {
     // Even fields the engine has never heard of must not survive.
     const std::string body =
     R"({"url":"https://x","auth":{"mode":"oauth2","clientSecret":"s","privateKey":"pk","assertion":"a"}})";
-    const auto parsed = json::parse (vayu::json::sanitize_config_snapshot (body));
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (body, kMaxBodyBytes));
     EXPECT_EQ (parsed["auth"], (json{ { "mode", "oauth2" } }));
 }
 
 TEST (SanitizeConfigSnapshot, NonJsonPassesThrough) {
-    EXPECT_EQ (vayu::json::sanitize_config_snapshot ("not json"), "not json");
+    EXPECT_EQ (vayu::json::sanitize_config_snapshot ("not json", kMaxBodyBytes), "not json");
 }
 
 TEST (SanitizeConfigSnapshot, MissingAuthLeavesBodyIntact) {
     const std::string body = R"({"method":"GET","url":"https://x"})";
-    const auto parsed = json::parse (vayu::json::sanitize_config_snapshot (body));
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (body, kMaxBodyBytes));
     EXPECT_EQ (parsed["method"], "GET");
     EXPECT_FALSE (parsed.contains ("auth"));
 }
@@ -74,8 +79,41 @@ TEST (SanitizeConfigSnapshot, MissingAuthLeavesBodyIntact) {
 // subtree - nothing in the execution route needs to copy it there separately.
 TEST (SanitizeConfigSnapshot, PreservesPerRunHttpVersionOverride) {
     const std::string body = R"({"method":"GET","url":"https://x","httpVersion":"http1.1"})";
-    const auto parsed = json::parse (vayu::json::sanitize_config_snapshot (body));
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (body, kMaxBodyBytes));
     EXPECT_EQ (parsed["httpVersion"], "http1.1");
+}
+
+TEST (SanitizeConfigSnapshot, CapsOversizedBodyContentAndMarksIt) {
+    const std::string oversized (kMaxBodyBytes + 10, 'x');
+    const json cfg = { { "method", "POST" }, { "url", "https://x" },
+        { "body", { { "mode", "raw" }, { "content", oversized } } } };
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (cfg.dump (), kMaxBodyBytes));
+    EXPECT_EQ (parsed["body"]["content"].get<std::string> ().size (), kMaxBodyBytes);
+    EXPECT_TRUE (parsed["body"]["bodyTruncated"]);
+    EXPECT_EQ (parsed["body"]["bodyBytes"], kMaxBodyBytes + 10);
+}
+
+TEST (SanitizeConfigSnapshot, LeavesBodyWithinCapUntouched) {
+    const json cfg = { { "method", "POST" }, { "url", "https://x" },
+        { "body", { { "mode", "raw" }, { "content", "small" } } } };
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (cfg.dump (), kMaxBodyBytes));
+    EXPECT_EQ (parsed["body"]["content"], "small");
+    EXPECT_FALSE (parsed["body"].contains ("bodyTruncated"));
+    EXPECT_FALSE (parsed["body"].contains ("bodyBytes"));
+}
+
+TEST (SanitizeConfigSnapshot, ANonScenarioBodyLeavesFieldsWithoutContentAlone) {
+    // form-data / no-body payloads carry no `content` string; the cap must not
+    // touch `fields` or crash on a body object it does not recognize.
+    const json cfg = { { "method", "POST" }, { "url", "https://x" },
+        { "body", { { "mode", "none" } } } };
+    const auto parsed =
+    json::parse (vayu::json::sanitize_config_snapshot (cfg.dump (), kMaxBodyBytes));
+    EXPECT_EQ (parsed["body"]["mode"], "none");
+    EXPECT_FALSE (parsed["body"].contains ("bodyTruncated"));
 }
 
 } // namespace


### PR DESCRIPTION
## Description

Owner-measured (issue #1486): a design run's `config_snapshot` stored the raw request body with no cap, so one 50 MB send left a permanently bloated row behind - `sanitize_config_snapshot` (`engine/src/utils/json.cpp`) redacted `auth` but never bounded `body.content`, unlike the trace body it sits beside, which is already capped at `maxTraceBodyBytes` with a `bodyTruncated`/`bodyBytes` marker.

**Root cause and plan - and a deviation from the issue's literal fix pathway, with reasoning.** Three parallel research passes (issue-verification, consumer-tracing, docs/conventions) found that the issue's *second* half - "stop the compact list from re-parsing every row's full snapshot", proposed as a new `runs.summary` column backfilled at run creation - is already solved, differently and more cheaply, by issue #1150's `RunSummaryCache` (merged in PR #1374): a run's list-row summary is derived from `config_snapshot` **once per run id** and held in a bounded in-memory cache for the process's life, because `config_snapshot` is write-once. `docs/engine/db-schema.md` documents this explicitly and warns that persisting a summary column would fight that design. Worse, the issue's proposed column name, `runs.summary`, is **already a mapped column** holding a completely different thing (the whole-run terminal results payload) - adding a second, differently-timed `summary` would collide with it outright.

So this PR implements only the half of the issue that is still open: capping `config_snapshot`'s `body.content` at the same `maxTraceBodyBytes` limit the trace already uses, with the identical `bodyTruncated`/`bodyBytes` sibling-key marker `cap_node_body` uses for a trace node (one level down here, since `content` lives inside `body` rather than being it). This still satisfies the issue's substantive complaint: the `q` filter's SQL `LIKE` and `collectionId`'s `json_extract` (`run_filter_where`, `engine/src/db/database.cpp`, run unconditionally on every list query) scan `config_snapshot`'s full stored length on every call, and the one-time cache-population parse also pays for it - all now bounded regardless of how large a client's original body was.

**Alternative considered and rejected:** adding the `runs.summary` column anyway, under a different name (e.g. `list_summary`) to dodge the collision. Rejected because it would re-litigate a settled, documented design (#1150) for no measured benefit - the cache already makes the per-poll cost O(1) after the first parse, and the remaining costs (initial parse, `q`/`collectionId` scan) are exactly what capping the body fixes directly, without a schema change or a backfill pass.

**A consumer the issue didn't mention, found and fixed:** capping `config_snapshot`'s body broke an explicit assumption in `design-run-seed.ts` - its doc comment said the snapshot's body "is not capped" and is why the editable copy showed the full body even when the trace was truncated. `requestBodyTruncated` (which gates whether "Save this run to the request" is allowed to write the body back) now folds in the snapshot's own `bodyTruncated` flag alongside the trace's, so a run truncated only on the config-snapshot side can no longer have a partial body silently written back as if complete.

## Type of Change
- [x] Bug fix

## Testing

- `engine/tests/request_builder_test.cpp` (new cases): an oversized `body.content` is cut to `maxTraceBodyBytes` and marked `bodyTruncated`/`bodyBytes`; a body within the cap is untouched (no marker keys added); a body shape with no `content` field (`mode: "none"`) is left alone rather than crashing. All existing `SanitizeConfigSnapshot` cases updated for the new required `max_body_bytes` parameter.
- `app/.../design-run-seed.test.ts` (new case): a run truncated only on the config-snapshot side (trace untouched) still sets `requestBodyTruncated`, proving `save-run-to-request`'s guard fires for either source.

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **2977/2977 passed** (2971 pre-existing + 6 new `SanitizeConfigSnapshot` cases; the 3 existing cases were updated for the new parameter, not added).
`cd app && pnpm test design-run-seed save-run-to-request`: **47/47 passed**. `pnpm lint`: clean (fixed one prettier wrap CI caught on the first push).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1486

## Visual changes

No user-visible change to any screen: the fix is a storage-side cap plus a truncation marker. The one behavioral surface - "Save this run to the request" refusing to write back a truncated body - already had a notice for the trace-truncated case (`buildChangeset`'s `kept` row, in `save-run-to-request.ts`); this PR only widens when that existing notice fires, so no new UI was added.

Docs updated in this commit: `docs/engine/db-schema.md` (a new `config_snapshot`-body-cap paragraph beside the existing redaction note, and why a persisted summary column was rejected), `docs/engine/api-reference.md` (`configSnapshot.body`'s cap documented beside the existing trace-truncation note on `GET /runs/:runId`).
