### PR TITLE
fix(app): guard the source-marker clear/preserve rule with a test, document the field

### DIFF
--- a/app/src/components/shared/KeyValueEditor/source-marker.test.tsx
+++ b/app/src/components/shared/KeyValueEditor/source-marker.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `handleUpdate` (index.tsx) clears a row's `source` marker (issue #1481) only
+ * on a retyped key or value - disabling the row must not, or a hand-disabled
+ * auto-written Content-Type would look user-owned on the next reload. Nothing
+ * exercised that guard through the actual component: `content-type.test.tsx`
+ * strips `source` by hand on its fixtures rather than driving an edit through
+ * `KeyValueEditor`, so a regression in the field check on line 93 would pass
+ * every existing test in the tree.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { KeyValueItem } from "@/types";
+import KeyValueEditor from "./index";
+
+function markedRow(overrides: Partial<KeyValueItem> = {}): KeyValueItem {
+	return {
+		id: "r1",
+		key: "Content-Type",
+		value: "application/json",
+		enabled: true,
+		source: "body-mode",
+		...overrides,
+	};
+}
+
+describe("a row's auto-write source marker", () => {
+	it("is cleared once the user retypes the value", () => {
+		const onChange = vi.fn();
+		const { getByPlaceholderText } = render(
+			<KeyValueEditor items={[markedRow()]} onChange={onChange} />
+		);
+
+		fireEvent.change(getByPlaceholderText("Value"), {
+			target: { value: "application/graphql" },
+		});
+
+		const [updated] = onChange.mock.calls[0][0] as KeyValueItem[];
+		expect(updated.source).toBeUndefined();
+	});
+
+	it("survives the row being disabled", () => {
+		const onChange = vi.fn();
+		const { container } = render(<KeyValueEditor items={[markedRow()]} onChange={onChange} />);
+
+		fireEvent.click(container.querySelector('input[type="checkbox"]')!);
+
+		const [updated] = onChange.mock.calls[0][0] as KeyValueItem[];
+		expect(updated.enabled).toBe(false);
+		expect(updated.source).toBe("body-mode");
+	});
+});

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -357,7 +357,11 @@ Stores individual HTTP request definitions.
 Disabled rows (`"enabled":false`) are preserved in storage and filtered at HTTP-execution time only.
 Duplicate keys are allowed. A pre-#1229 renderer also wrote its own `X-Vayu-Version`,
 `X-Request-ID` and `User-Agent` rows here; [the header-strip pass](#the-header-strip-pass-issue-1487)
-removes them once, at startup.
+removes them once, at startup. An optional `source` key (`"body-mode"` | `"stream"`)
+marks a row an app setting wrote rather than the user - the auto `Content-Type` a
+body-mode change adds, the `Accept` the Event stream toggle adds - so it can tell its
+own row apart from a hand-typed one across a reload; retyping the row's key or value
+clears it (issue #1481).
 
 **elements** - same shape and the same additive relationship to `pre_request_script` /
 `post_request_script` as [`collections.elements`](#collections) above; see that entry.


### PR DESCRIPTION
## Description

Issue #1481 was implemented by PR #1506 (merged) but a closure-check review found it PARTIAL and reopened it with exactly two remaining items.

**Research first, since the closure check's second item reads like a missing code fix but isn't one.** Three parallel read-only passes against current master (`cc8b01c6`) found:

1. **Doc gap - real.** `docs/engine/db-schema.md`'s params/headers row-shape reference (the `**params / headers**` section) never mentions the optional `source` key that PR #1506 added to `KeyValueEntry`, even though both app-side docs (`docs/app/COMPONENTS.md`, `docs/app/state-management.md`) already describe it. This is the one doc the closure check says was missed.
2. **"Unguarded line" - already fixed, only untested.** The closure check's wording ("Removing that delete leaves all 51 KeyValueEditor tests green") describes an experiment, not a missing fix: `KeyValueEditor/index.tsx:93` already reads `if (field === "key" || field === "value") delete updated.source;` - correctly guarded, added in the original PR #1506 commit (`640e823`), never touched since. What's actually missing is a test that exercises this guard through the real component: every existing reference to the marker (`content-type.test.tsx`, `auto-header.test.ts`, `settings-stream-toggle.test.tsx`) strips `source` by hand on a fixture rather than driving an edit through `KeyValueEditor`, so a regression in the field check (or reverting the guard entirely) would pass the whole suite today.

So this PR adds the missing test coverage rather than a code change to `index.tsx`, plus the one doc line.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

- `app/src/components/shared/KeyValueEditor/source-marker.test.tsx` (new): renders `KeyValueEditor` with a row carrying `source: "body-mode"`; retyping the value clears `source`, disabling the row leaves it untouched. Mutation check performed by hand: widening `index.tsx`'s guard to an unconditional `delete updated.source` reds the "survives being disabled" case; reverted after confirming.

`cd app && pnpm test source-marker KeyValueEditor content-type auto-header`: **73/73 passed**. `pnpm type-check`, `pnpm lint`, `npx prettier --check` on the new file: all clean.
`pip install -r requirements-docs.txt && mkdocs build -f .github/mkdocs.yml --strict`: clean (the doc edit adds prose to an existing paragraph, no new links or anchors).

No engine changes, so no engine build was needed for this PR (this session's vcpkg cache also can't fetch `cpp-httplib`'s GitHub archive under the sandboxed egress policy - unrelated to this change, noted for transparency).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1481

## Visual changes

No user-visible change: this PR adds test coverage for an already-shipped behavior and one documentation sentence. No UI or wire-format change.
