### PR TITLE
fix(app): scope baseline resolution to load runs

### DIFF
--- a/app/electron/mcp/engine-client.test.ts
+++ b/app/electron/mcp/engine-client.test.ts
@@ -396,7 +396,10 @@ describe("EngineClient run housekeeping", () => {
 		});
 	});
 
-	it("resolves a baseline through the same query builder", async () => {
+	it("resolves a baseline through the same query builder, scoped to load runs", async () => {
+		// #1509: a design or scenario run can be pinned too, but only a load run
+		// has the percentiles a baseline comparison diffs - an unscoped lookup
+		// would let a more-recently-pinned non-load run shadow the load baseline.
 		const { fetchImpl, calls } = recordingFetch();
 		await client(fetchImpl).listBaselineRuns("req_1");
 		const url = new URL(calls[0].url);
@@ -405,6 +408,7 @@ describe("EngineClient run housekeeping", () => {
 			limit: "1",
 			offset: "0",
 			requestId: "req_1",
+			type: "load",
 			baseline: "true",
 		});
 	});

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -455,9 +455,14 @@ export class EngineClient {
 	 * The runs pinned as baselines for one saved request, newest first. One row
 	 * is all any caller needs - "the baseline" is the most recent pin - so the
 	 * page is bounded to it rather than to the 100 `listRuns` allows.
+	 *
+	 * `type: "load"` because a pin is not load-specific (#1509) but a
+	 * comparison is: only a load run has the percentiles and throughput a
+	 * baseline diff needs, so a more-recently-pinned design or scenario run of
+	 * the same request must never shadow the load baseline this resolves.
 	 */
 	listBaselineRuns(requestId: string, signal?: AbortSignal): Promise<unknown> {
-		return this.listRuns({ baseline: true, limit: 1, requestId }, signal);
+		return this.listRuns({ baseline: true, type: "load", limit: 1, requestId }, signal);
 	}
 
 	getRunReport(runId: string, signal?: AbortSignal): Promise<unknown> {

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -43,6 +43,7 @@ import {
 	useInvalidateRuns,
 	RunNotFoundError,
 	isRunNotFound,
+	useBaselineRunQuery,
 } from "./runs";
 import { queryKeys } from "./keys";
 import { ApiError } from "@/services";
@@ -133,6 +134,45 @@ describe("useLastDesignRunQuery", () => {
 	it("does not fetch when there is no request id", () => {
 		renderHook(() => useLastDesignRunQuery(null), { wrapper: wrapper(makeClient()) });
 		expect(listRuns).not.toHaveBeenCalled();
+	});
+});
+
+describe("useBaselineRunQuery", () => {
+	/**
+	 * #1509: a design or scenario run can be pinned too, but only a load run
+	 * has the percentiles and throughput a baseline comparison diffs. Without
+	 * `type: "load"` a more-recently-pinned non-load run of the same request
+	 * would shadow the load baseline this resolves - mutation check: drop the
+	 * `type: "load"` filter from either branch below and these red.
+	 */
+	it("scopes the requestId lookup to load runs", async () => {
+		listRuns.mockResolvedValue(page([runRow("run_load")]));
+
+		const { result } = renderHook(() => useBaselineRunQuery({ requestId: "req_1" }), {
+			wrapper: wrapper(makeClient()),
+		});
+
+		await waitFor(() => expect(result.current.data?.id).toBe("run_load"));
+		expect(listRuns).toHaveBeenCalledWith({
+			baseline: true,
+			type: "load",
+			requestId: "req_1",
+			limit: 1,
+		});
+	});
+
+	it("scopes the unsaved-request url/method fallback to load runs", async () => {
+		listRuns.mockResolvedValue(page([]));
+
+		renderHook(
+			() => useBaselineRunQuery({ url: "https://api.example.com/users", method: "GET" }),
+			{ wrapper: wrapper(makeClient()) }
+		);
+
+		await waitFor(() => expect(listRuns).toHaveBeenCalledTimes(1));
+		expect(listRuns).toHaveBeenCalledWith(
+			expect.objectContaining({ baseline: true, type: "load" })
+		);
 	});
 });
 

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -465,14 +465,19 @@ function baselineCacheKey(target: BaselineTarget): string | null {
 }
 
 /**
- * The run pinned as baseline for the same request as @p target, or `null` when
- * nothing is pinned.
+ * The load run pinned as baseline for the same request as @p target, or
+ * `null` when nothing is pinned.
  *
  * `GET /runs?baseline=true` is ordered newest-first, so "the baseline" is the
  * first row - the engine allows several pins (one per request is the expected
  * use) and deliberately holds no opinion about which applies where, so choosing
  * is the client's job and this is the one place the renderer does it. The MCP
  * `compare_runs` tool resolves it the same way, against the same endpoint.
+ *
+ * `type: "load"` because a pin is not load-specific (#1509) - a design or
+ * scenario run of the same request can be pinned too - but this comparison
+ * is: only a load run has the percentiles and throughput it diffs, so a
+ * more-recently-pinned non-load run must never shadow the load baseline.
  *
  * `null` and "still loading" are different answers and stay different: the
  * caller renders nothing until this settles, rather than flashing a
@@ -488,6 +493,7 @@ export function useBaselineRunQuery(target: BaselineTarget | null) {
 			if (target?.requestId) {
 				const page = await apiService.listRuns({
 					baseline: true,
+					type: "load",
 					requestId: target.requestId,
 					limit: 1,
 				});
@@ -498,6 +504,7 @@ export function useBaselineRunQuery(target: BaselineTarget | null) {
 			// not mistaken for it.
 			const page = await apiService.listRuns({
 				baseline: true,
+				type: "load",
 				q: target!.url!,
 				limit: BASELINE_SCAN_LIMIT,
 			});

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1364,9 +1364,13 @@ export interface Run {
 	 */
 	resultSummary?: RunResultSummary;
 	/**
-	 * Whether this run is pinned as a baseline - the known-good run later runs
-	 * of the same request are measured against, and the one run the engine's
-	 * retention never expires. Toggled through `PUT /runs/:id/baseline`.
+	 * Whether this run is pinned - kept past the engine's retention and
+	 * findable through `GET /runs?baseline=true`. Toggled through
+	 * `PUT /runs/:id/baseline`, and any run type can carry it: a design run is
+	 * pinned to keep a known-good response, not to be compared. Only a load
+	 * run's pin is also read as *the* baseline the vs-baseline comparison
+	 * diffs (`useBaselineRunQuery`, `listBaselineRuns`) - it is the only type
+	 * with percentiles and throughput to diff.
 	 *
 	 * Optional because a run row from an engine older than this field has none;
 	 * absent reads the same as `false` everywhere.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -7135,10 +7135,10 @@ a **404** in the shared error shape.
 
 ### PUT /runs/:runId/baseline
 
-Pin (or unpin) a run as a **baseline** - the known-good run later runs of the
-same request are compared against. `PUT` rather than `POST` per the
-[create vs update](#resource-writes-create-vs-update) split: the run already
-exists, and this updates it. There is no deprecated alias; the endpoint is new.
+Pin (or unpin) any run - design, load or scenario alike. `PUT` rather than
+`POST` per the [create vs update](#resource-writes-create-vs-update) split: the
+run already exists, and this updates it. There is no deprecated alias; the
+endpoint is new.
 
 Two things follow from a pin, and both are the point of it:
 
@@ -7147,6 +7147,14 @@ Two things follow from a pin, and both are the point of it:
   `maxRunsRetained` either - a pin the cap could expire is not a pin, and pins
   crowding the cap would evict the recent history the cap exists to keep.
 - **Clients can find it**: `GET /runs?baseline=true&requestId=<id>&limit=1`.
+
+The engine's own meaning of the flag stops there - it holds no opinion about
+*why* a run is kept. A client's vs-baseline comparison is a narrower, load-only
+reading of the same flag: only a load run has the percentiles and throughput a
+diff needs, so a comparison lists `type=load` alongside `baseline=true`
+(`GET /runs?baseline=true&type=load&requestId=<id>&limit=1`) rather than
+treating any pinned row as its baseline - otherwise a more-recently-pinned
+design or scenario run of the same request would shadow it.
 
 Several runs may be pinned at once (one per request is the expected use). The
 engine records the pin and holds no opinion about which baseline applies to


### PR DESCRIPTION
## Description

Reopened regression from #1509's own PR (#1533): letting every run type be pinned meant "the baseline" - resolved by `useBaselineRunQuery` (app) and `listBaselineRuns` (MCP, used by `compare_runs`) as `GET /runs?baseline=true&requestId=...`, newest pin wins - could resolve to a design or scenario run once one existed, since neither call filtered by `type`. Before #1533 this was impossible (only load runs could be pinned), so it shipped unnoticed. The vs-baseline strip would then diff the open load run's report against a run with no percentiles.

Fix is narrow: add `type: "load"` to both `listRuns` calls (the engine already supports the filter end to end - `RunListParams`/`RunListQuery` both had it, just unused here). A pin stays type-agnostic (any run can be kept past retention and found under the Pinned toggle, per #1509's original ask); only the *comparison's* resolution of "the" baseline is load-scoped, which is what #1509's third acceptance criterion always asked for.

Docs updated to state that split explicitly: `Run.baseline`'s doc comment in `domain.ts`, and the `PUT /runs/:runId/baseline` section in `docs/engine/api-reference.md` (previously written as if the endpoint were load-only, which is what let the code drift). `docs/app/COMPONENTS.md:481` already documented the load-only comparison rule correctly from #1533 and needed no change.

## Type of Change
- [x] Bug fix

## Testing

- `app/src/queries/runs.query.test.tsx`: new `useBaselineRunQuery` cases assert `type: "load"` on both the `requestId` branch and the unsaved-request url/method fallback. Mutation-checked by hand: reverting either `type: "load"` addition reds the corresponding case (and the existing MCP test below); restored.
- `app/electron/mcp/engine-client.test.ts`: updated `listBaselineRuns`'s existing URL-params assertion to include `type=load`.
- `pnpm test`: **8121/8121 passed**. `pnpm type-check`, `pnpm lint`, `pnpm exec prettier --check` on touched files: all clean.
- `mkdocs build -f .github/mkdocs.yml --strict`: clean (prose-only change to an existing section, no headings/links touched).
- No engine change, so no `ctest` run - nothing under `engine/` is touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1509

## Visual changes

No new UI surface - this only changes which run a comparison resolves against. The vs-baseline strip's rendering is unchanged; proven by the query-level test above rather than a screenshot, since there is no new visual state to capture (a design/scenario run wrongly resolved as baseline would have rendered the *existing* strip against the wrong data, not a distinguishable new one).
