### PR TITLE
fix(engine): scan a single-request load run's fast path for unresolved tokens

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6868,7 +6868,9 @@ they are counted, not fixed. Each entry carries `code` and a human-readable
 `names` (a few of the unresolved names, capped); `pre_request_script_skipped`
 carries `steps` (how many carried one). Absent, not an empty array, for a run
 with nothing to report - which is every run before this field existed and
-every run that genuinely had nothing to say.
+every run that genuinely had nothing to say. `unresolved_tokens` covers every
+load shape alike (issue #1540): a single-request run with no data set and a
+scenario step report the same warning for the same mistake.
 
 **A streaming run adds a `stream` section** and no other run carries one:
 

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -415,17 +415,16 @@ struct RunContext {
 
     /**
      * A *single-request* load run's unresolved `{{token}}` names (issue #1540),
-     * scanned once off the built request before @ref load_template is derived
-     * from it - the token-free fast path (`submit_one_request`,
-     * `load_strategy.cpp`) never copies the request per submission, so this is
-     * how it still reports what every submission sent unresolved without
-     * re-scanning.
+     * scanned once off the built request beside @ref load_template - the
+     * token-free fast path (`submit_one_request`, `load_strategy.cpp`) never
+     * copies the request per submission, so this is how it still reports what
+     * every submission sent unresolved without re-scanning.
      *
      * **Empty for every run whose request resolved cleanly**, the same
      * structural guard @ref load_template is. Written once by `build_load_request`
      * before the first submission, read on the run's worker thread afterwards.
      */
-    std::vector<std::string> template_unresolved_tokens;
+    std::vector<std::string> load_unresolved_tokens;
 
     /**
      * How a *single-request* load run's credentials resolve (issue #1055) - the

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -414,6 +414,20 @@ struct RunContext {
     StepDataTemplate load_template;
 
     /**
+     * A *single-request* load run's unresolved `{{token}}` names (issue #1540),
+     * scanned once off the built request before @ref load_template is derived
+     * from it - the token-free fast path (`submit_one_request`,
+     * `load_strategy.cpp`) never copies the request per submission, so this is
+     * how it still reports what every submission sent unresolved without
+     * re-scanning.
+     *
+     * **Empty for every run whose request resolved cleanly**, the same
+     * structural guard @ref load_template is. Written once by `build_load_request`
+     * before the first submission, read on the run's worker thread afterwards.
+     */
+    std::vector<std::string> template_unresolved_tokens;
+
+    /**
      * How a *single-request* load run's credentials resolve (issue #1055) - the
      * parsed auth and its split, read once off the payload before the run
      * starts.

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -413,6 +413,10 @@ SubmissionRequest& live) {
     // template, and skipping the bind here would send it unauthenticated.
     if (data == nullptr && context->load_template.empty () &&
     context->load_auth.credentials.empty ()) {
+        if (!context->template_unresolved_tokens.empty ()) {
+            context->metrics_collector->record_unresolved_token (
+            context->template_unresolved_tokens);
+        }
         submit_to_loop (context, db, live.current (), annotations);
         return;
     }
@@ -440,8 +444,8 @@ SubmissionRequest& live) {
     // (issue #1503): a single-request load run runs no residual pass either,
     // so the mistake is only counted, never refused. The token-free fast
     // path above never copies `request` at all (issue #992) and is not
-    // scanned here for that reason - a plain `{{var}}` with no data or
-    // credential behind it is this scan's one remaining gap.
+    // scanned here for that reason - it records `context->template_unresolved_tokens`,
+    // scanned once by `start_run` before this loop began (issue #1540).
     if (auto names = vayu::http::routes::unresolved_token_names (request);
     !names.empty ()) {
         context->metrics_collector->record_unresolved_token (names);

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -413,9 +413,8 @@ SubmissionRequest& live) {
     // template, and skipping the bind here would send it unauthenticated.
     if (data == nullptr && context->load_template.empty () &&
     context->load_auth.credentials.empty ()) {
-        if (!context->template_unresolved_tokens.empty ()) {
-            context->metrics_collector->record_unresolved_token (
-            context->template_unresolved_tokens);
+        if (!context->load_unresolved_tokens.empty ()) {
+            context->metrics_collector->record_unresolved_token (context->load_unresolved_tokens);
         }
         submit_to_loop (context, db, live.current (), annotations);
         return;
@@ -444,7 +443,7 @@ SubmissionRequest& live) {
     // (issue #1503): a single-request load run runs no residual pass either,
     // so the mistake is only counted, never refused. The token-free fast
     // path above never copies `request` at all (issue #992) and is not
-    // scanned here for that reason - it records `context->template_unresolved_tokens`,
+    // scanned here for that reason - it records `context->load_unresolved_tokens`,
     // scanned once by `start_run` before this loop began (issue #1540).
     if (auto names = vayu::http::routes::unresolved_token_names (request);
     !names.empty ()) {

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1264,8 +1264,7 @@ vayu::Request& request) {
     // in `submit_one_request` never copies the request to scan it itself. The
     // scan is one-time because the fast path's bytes never change between
     // submissions.
-    context->template_unresolved_tokens =
-    vayu::http::routes::unresolved_token_names (request);
+    context->load_unresolved_tokens = vayu::http::routes::unresolved_token_names (request);
 
     // A streaming run's caps ride on the request itself, because the
     // event loop is what enforces them and the request is all it sees.

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1257,6 +1257,16 @@ vayu::Request& request) {
     context->load_template = tokenize_bindable_fields (request,
     context->load_data ? context->load_data->bound_columns : vayu::http::BoundColumnNames{});
 
+    // Scanned here, while the request is still owned and about to become the
+    // shared template every fast-path submission sends unchanged (issue
+    // #1540): a bare `{{token}}` with no data set and no credential behind it
+    // splits nothing above, so `load_template` stays empty and the fast path
+    // in `submit_one_request` never copies the request to scan it itself. The
+    // scan is one-time because the fast path's bytes never change between
+    // submissions.
+    context->template_unresolved_tokens =
+    vayu::http::routes::unresolved_token_names (request);
+
     // A streaming run's caps ride on the request itself, because the
     // event loop is what enforces them and the request is all it sees.
     // Attached after `build_request` rather than inside it: the caps

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -222,7 +223,7 @@ TEST_F (LoadStrategyTest, RampUpDurationShorterThanRampStillRuns) {
 // copies the request per submission (issue #992), so it cannot re-scan for
 // an unresolved `{{token}}` the way the copying branch does at line ~445 of
 // load_strategy.cpp. `start_run` scans once instead and hands the names down
-// through `RunContext::template_unresolved_tokens`, which this test sets
+// through `RunContext::load_unresolved_tokens`, which this test sets
 // directly since it drives the strategy without going through `start_run`.
 // Mutation check: remove the `record_unresolved_token` call from the fast
 // path in `submit_one_request` and this reds, because nothing else on that
@@ -236,7 +237,7 @@ TEST_F (LoadStrategyTest, FastPathWithAnUnresolvedTokenCountsAndWarnsWithoutRefu
     };
     auto context =
     std::make_shared<vayu::core::RunContext> ("test-fastpath-unresolved", config);
-    context->template_unresolved_tokens = { "missing" };
+    context->load_unresolved_tokens = { "missing" };
     vayu::http::EventLoopConfig loop_config;
     loop_config.max_concurrent = 2000;
     loop_config.max_per_host   = 2000;
@@ -261,7 +262,7 @@ TEST_F (LoadStrategyTest, FastPathWithAnUnresolvedTokenCountsAndWarnsWithoutRefu
     EXPECT_EQ (names[0], "missing");
 }
 
-// The companion shapes: `template_unresolved_tokens` left empty (a request
+// The companion shapes: `load_unresolved_tokens` left empty (a request
 // resolved cleanly, or carries only a reserved name like `{{$vu}}`, which
 // `start_run` never puts in the set) records nothing on the fast path.
 TEST_F (LoadStrategyTest, FastPathWithNoUnresolvedTokenRecordsNoWarning) {
@@ -290,6 +291,58 @@ TEST_F (LoadStrategyTest, FastPathWithNoUnresolvedTokenRecordsNoWarning) {
 
     EXPECT_EQ (context->metrics_collector->unresolved_token_requests (), 0u);
     EXPECT_TRUE (context->metrics_collector->unresolved_token_names ().empty ());
+}
+
+// The two cases above set `load_unresolved_tokens` directly, so neither
+// exercises `RunManager::start_run` actually populating it (`run_manager.cpp`,
+// beside the `load_template` build) before a real run reaches the fast path.
+// This one drives a real run end to end so a regression that dropped that
+// wiring - not just the fast-path record call above - fails a test.
+TEST_F (LoadStrategyTest, StartRunWiresTheFastPathScanIntoARealRunsReport) {
+    const size_t ITERATIONS = 3;
+    vayu::db::Database db (TEST_DB_PATH);
+
+    vayu::db::Run row;
+    row.id              = "run-fastpath-wiring";
+    row.type            = vayu::RunType::Load;
+    row.status          = vayu::RunStatus::Pending;
+    row.config_snapshot = "{}";
+    row.start_time = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                     .count ();
+    row.end_time = 0;
+    db.create_run (row);
+
+    const nlohmann::json config = { { "mode", "iterations" },
+        { "iterations", ITERATIONS }, { "concurrency", 1 },
+        { "url", mock_server->fast_url () + "?auth={{token}}" },
+        { "method", "GET" }, { "timeout", 5000 } };
+
+    vayu::core::RunManager run_manager;
+    ASSERT_TRUE (run_manager.start_run (row.id, config, db, false));
+
+    const auto deadline = std::chrono::steady_clock::now () + std::chrono::seconds (30);
+    while (std::chrono::steady_clock::now () < deadline) {
+        const auto stored = db.get_run (row.id);
+        if (stored && stored->status != vayu::RunStatus::Running &&
+        stored->status != vayu::RunStatus::Pending) {
+            break;
+        }
+        std::this_thread::sleep_for (std::chrono::milliseconds (20));
+    }
+    run_manager.shutdown (std::chrono::milliseconds (15000));
+
+    const auto stored = db.get_run (row.id);
+    ASSERT_HAS_VALUE (stored);
+    ASSERT_FALSE (stored->summary.empty ()) << "the run produced no summary";
+    const auto summary = nlohmann::json::parse (stored->summary);
+    ASSERT_TRUE (summary.contains ("warnings")) << summary.dump ();
+    ASSERT_FALSE (summary["warnings"].empty ()) << summary.dump ();
+    EXPECT_EQ (summary["warnings"][0]["code"], "unresolved_tokens");
+    EXPECT_EQ (summary["warnings"][0]["count"], ITERATIONS);
+    const auto& names = summary["warnings"][0]["names"];
+    EXPECT_NE (std::find (names.begin (), names.end (), "token"), names.end ())
+    << summary.dump ();
 }
 
 // Closed-loop iterations: submit exactly M, never exceed N in flight.

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -218,6 +218,80 @@ TEST_F (LoadStrategyTest, RampUpDurationShorterThanRampStillRuns) {
     << "duration<ramp submitted nothing; partial-ramp behavior not implemented";
 }
 
+// A single-request load run's token-free fast path (issue #1540) never
+// copies the request per submission (issue #992), so it cannot re-scan for
+// an unresolved `{{token}}` the way the copying branch does at line ~445 of
+// load_strategy.cpp. `start_run` scans once instead and hands the names down
+// through `RunContext::template_unresolved_tokens`, which this test sets
+// directly since it drives the strategy without going through `start_run`.
+// Mutation check: remove the `record_unresolved_token` call from the fast
+// path in `submit_one_request` and this reds, because nothing else on that
+// branch ever looks at the field.
+TEST_F (LoadStrategyTest, FastPathWithAnUnresolvedTokenCountsAndWarnsWithoutRefusingTheRun) {
+    const size_t M        = 5;
+    nlohmann::json config = {
+        { "mode", "iterations" },
+        { "iterations", M },
+        { "concurrency", 1 },
+    };
+    auto context =
+    std::make_shared<vayu::core::RunContext> ("test-fastpath-unresolved", config);
+    context->template_unresolved_tokens = { "missing" };
+    vayu::http::EventLoopConfig loop_config;
+    loop_config.max_concurrent = 2000;
+    loop_config.max_per_host   = 2000;
+    context->event_loop = std::make_unique<vayu::http::EventLoop> (loop_config);
+    context->event_loop->start ();
+
+    vayu::Request request;
+    request.method     = vayu::HttpMethod::GET;
+    request.url        = mock_server->fast_url () + "?token={{missing}}";
+    request.timeout_ms = 30000;
+
+    vayu::db::Database db (TEST_DB_PATH);
+    auto strategy = vayu::core::LoadStrategy::create (config);
+    strategy->execute (context, db, request);
+    context->event_loop->stop (false);
+
+    ASSERT_EQ (context->requests_sent.load (), M);
+    EXPECT_EQ (context->metrics_collector->unresolved_token_requests (), M)
+    << "the fast path sends the same unresolved bytes on every submission";
+    const auto names = context->metrics_collector->unresolved_token_names ();
+    ASSERT_EQ (names.size (), 1u);
+    EXPECT_EQ (names[0], "missing");
+}
+
+// The companion shapes: `template_unresolved_tokens` left empty (a request
+// resolved cleanly, or carries only a reserved name like `{{$vu}}`, which
+// `start_run` never puts in the set) records nothing on the fast path.
+TEST_F (LoadStrategyTest, FastPathWithNoUnresolvedTokenRecordsNoWarning) {
+    nlohmann::json config = {
+        { "mode", "iterations" },
+        { "iterations", 3 },
+        { "concurrency", 1 },
+    };
+    auto context =
+    std::make_shared<vayu::core::RunContext> ("test-fastpath-clean", config);
+    vayu::http::EventLoopConfig loop_config;
+    loop_config.max_concurrent = 2000;
+    loop_config.max_per_host   = 2000;
+    context->event_loop = std::make_unique<vayu::http::EventLoop> (loop_config);
+    context->event_loop->start ();
+
+    vayu::Request request;
+    request.method     = vayu::HttpMethod::GET;
+    request.url        = mock_server->fast_url () + "?vu={{$vu}}";
+    request.timeout_ms = 30000;
+
+    vayu::db::Database db (TEST_DB_PATH);
+    auto strategy = vayu::core::LoadStrategy::create (config);
+    strategy->execute (context, db, request);
+    context->event_loop->stop (false);
+
+    EXPECT_EQ (context->metrics_collector->unresolved_token_requests (), 0u);
+    EXPECT_TRUE (context->metrics_collector->unresolved_token_names ().empty ());
+}
+
 // Closed-loop iterations: submit exactly M, never exceed N in flight.
 // N kept within the httplib test-mock thread pool so /fast completes promptly;
 // stop(false) skips the drain (peak is already captured during execute).


### PR DESCRIPTION
## Description
The #1503 unresolved-token warning landed for the scenario path and for the single-request load path's *copying* branch, but not its token-free fast path (issue #992's zero-copy branch for a run with no data set and no credential): that branch reuses the same request bytes on every submission and was never scanned, so a run whose only request carries a bare `{{token}}` nothing resolves reports `errors: 0` and no warning at all - the shape a first-time user with a typo'd variable and no data file actually hits.

`RunContext` gains `load_unresolved_tokens`, scanned once by `start_run` right after the request is built (beside where `load_template` is derived from it), instead of adding `unresolved.empty()` to the fast-path condition - that alternative would push every such run through the copying branch and give up #992's zero-copy handling for the exact runs that are cheapest to serve.

A self-review pass after the first commit found the new field's initial name (`template_unresolved_tokens`) broke the `load_` prefix its siblings `load_data` / `load_template` / `load_auth` carry, and that neither of the first two tests exercised `RunManager::start_run` actually populating the field (both set it directly on a hand-built `RunContext`) - a regression dropping that wiring line would have passed every test. The second commit renames the field and adds an end-to-end test that drives a real run through `start_run` and reads the stored report.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure -R "LoadStrategy|RunsRoute|ScenarioLoad"`: **148/148 passed**, including all three new `LoadStrategyTest` cases.
- Full suite: `ctest --preset linux-dev --output-on-failure`: **3008/3008 passed** (run once given the renamed field touches a widely-included header).
- `cd app && pnpm type-check`: passed (no app changes; `RunWarnings.tsx` already renders `unresolved_tokens` unmodified).
- Mutation check performed by hand on both new fast-path-relevant tests: removing the fast path's `record_unresolved_token` call reds `FastPathWithAnUnresolvedTokenCountsAndWarnsWithoutRefusingTheRun`; removing the `run_manager.cpp` scan line reds `StartRunWiresTheFastPathScanIntoARealRunsReport`. Both restored and re-verified green.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 applied; pre-commit hook's clang-tidy passed on both commits)
- [x] I have performed a self-review (see Description - caught a naming inconsistency and a test coverage gap before requesting review)
- [x] I have added tests (`load_strategy_test.cpp`, mutation-check verified above)
- [x] I have updated documentation (`docs/engine/api-reference.md`)

## Related Issues
Closes #1540
