### PR TITLE
docs: point CONTRIBUTING.md's branch/toolchain guidance at reality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We are committed to providing a friendly, safe, and welcoming environment. Pleas
 ### Pull Requests
 
 1. **Fork the repository**
-2. **Create a feature branch** from `main`
+2. **Create a feature branch** from `master`
 3. **Make your changes** with clear commits
 4. **Add tests** for new functionality (if applicable)
 5. **Update documentation** if needed
@@ -41,7 +41,7 @@ We are committed to providing a friendly, safe, and welcoming environment. Pleas
 
 ### Prerequisites
 
-- **C++ Engine**: CMake 3.25+, C++20 compiler, vcpkg
+- **C++ Engine**: CMake 3.25+, C++23 compiler, vcpkg
 - **Electron App**: Node.js ≥ 22 LTS, pnpm ≥ 11
 
 ### Quick Start


### PR DESCRIPTION
## Description
`CONTRIBUTING.md` told a new contributor to branch from `main` - a branch this repo doesn't have. The real default is `master` (`git remote show origin`), and none of the last 15 merged PRs branched from anything else. Left as written, a contributor following the doc to the letter gets a "branch not found" before they've made a single change.

Also corrects the C++ prerequisite from C++20 to C++23 while in the same section - root `CLAUDE.md`'s own build section has required C++23 (GCC 13+, Clang 19+, MSVC 2022+) since before this fix, so the older doc was quietly asking for a toolchain a step behind what the code actually needs.

## Type of Change
- [x] Documentation update

## Testing
Doc-only change to a file no test or build reads. Nothing needed to run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, doc text
- [x] I have updated documentation - this is the documentation

## Related Issues
None - direct request, no tracked issue.
