### PR TITLE
fix(engine): record a load run's compression-negotiation policy for baseline comparison

### DIFF
--- a/app/electron/mcp/compare.conformance.test.ts
+++ b/app/electron/mcp/compare.conformance.test.ts
@@ -137,6 +137,15 @@ const CASES: { name: string; base: Record<string, unknown>; target: Record<strin
 		},
 		target: { latency: 7, summary: null, statusCodes: null },
 	},
+	{
+		// A baseline pinned before loadNegotiateCompression's default flipped
+		// (issue #1488) against a run recorded after: the base carries no
+		// `acceptEncoding` at all, which must read the same as an explicit
+		// `false`, not as "unknown".
+		name: "a pre-#1488 baseline against a run that negotiated compression",
+		base: { metadata: { configuration: { mode: "constant_rps" } } },
+		target: { metadata: { configuration: { acceptEncoding: true } } },
+	},
 ];
 
 describe("run comparison mirror", () => {
@@ -173,6 +182,33 @@ describe("run comparison mirror", () => {
 
 		expect(mainCompare("a", "b", base, target).statusCodes).toEqual(expected);
 		expect(rendererCompare("a", "b", base, target).statusCodes).toEqual(expected);
+	});
+
+	/*
+	 * Equality alone (the test.each above) already proves the two sides agree,
+	 * but not that either computed the *right* answer - two implementations
+	 * that both always returned `false` would agree forever. Pin the value.
+	 */
+	test("compressionNegotiationDiffers reads a real difference, and an absent key as false", () => {
+		const negotiated = { metadata: { configuration: { acceptEncoding: true } } };
+		const notNegotiated = { metadata: { configuration: { acceptEncoding: false } } };
+		const preIssue = { metadata: { configuration: { mode: "once" } } };
+
+		for (const compare of [mainCompare, rendererCompare]) {
+			expect(compare("a", "b", negotiated, notNegotiated).compressionNegotiationDiffers).toBe(
+				true
+			);
+			expect(compare("a", "b", negotiated, negotiated).compressionNegotiationDiffers).toBe(
+				false
+			);
+			// Absent reads as false, same as an explicit false - not "unknown".
+			expect(compare("a", "b", preIssue, notNegotiated).compressionNegotiationDiffers).toBe(
+				false
+			);
+			expect(compare("a", "b", preIssue, negotiated).compressionNegotiationDiffers).toBe(
+				true
+			);
+		}
 	});
 
 	test("a malformed pair is dropped rather than keyed by its index", () => {

--- a/app/electron/mcp/compare.ts
+++ b/app/electron/mcp/compare.ts
@@ -35,6 +35,21 @@ function num(obj: unknown, ...path: string[]): number | null {
 }
 
 /**
+ * Like {@link num}, but for a flag whose absence is itself meaningful
+ * (issue #1488): a report from before `metadata.configuration.acceptEncoding`
+ * existed carries no such key, and reads as `false` here - which is what
+ * every such run actually sent, not an unknown value defaulted away.
+ */
+function bool(obj: unknown, ...path: string[]): boolean {
+	let cur: unknown = obj;
+	for (const key of path) {
+		if (cur === null || typeof cur !== "object") return false;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur === true;
+}
+
+/**
  * Which way is better for a metric - the half of a delta a number cannot
  * carry. `neutral` is not a hedge: `summary.totalRequests` moves with how long
  * a run was told to run, so calling either direction an improvement would
@@ -91,6 +106,15 @@ export interface RunComparison {
 	throughput: MetricDelta[];
 	reliability: MetricDelta[];
 	statusCodes: Record<string, { base: number; target: number }>;
+	/**
+	 * Whether the two runs negotiated a compressed response differently
+	 * (issue #1488) - a run recorded before `loadNegotiateCompression`'s
+	 * default flipped in 0.26 reads as `false`, so an older baseline against
+	 * a newer run reports a difference exactly when the newer one negotiated
+	 * and the older did not. `true` means the byte and latency deltas above
+	 * are not measuring the same thing.
+	 */
+	compressionNegotiationDiffers: boolean;
 }
 
 /**
@@ -173,5 +197,17 @@ export function compareReports(
 	collect(base, "base");
 	collect(target, "target");
 
-	return { baseRunId, targetRunId, latency, throughput, reliability, statusCodes };
+	const compressionNegotiationDiffers =
+		bool(base, "metadata", "configuration", "acceptEncoding") !==
+		bool(target, "metadata", "configuration", "acceptEncoding");
+
+	return {
+		baseRunId,
+		targetRunId,
+		latency,
+		throughput,
+		reliability,
+		statusCodes,
+		compressionNegotiationDiffers,
+	};
 }

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -2342,6 +2342,11 @@ const runComparisonSchema = z.object({
 	throughput: z.array(metricDeltaSchema),
 	reliability: z.array(metricDeltaSchema),
 	statusCodes: z.record(z.string(), z.object({ base: z.number(), target: z.number() })),
+	// Whether the two runs negotiated a compressed response differently
+	// (issue #1488) - true means the byte and latency deltas above are not
+	// measuring the same thing. A run recorded before this field existed
+	// reads as not negotiated, same as an explicit false.
+	compressionNegotiationDiffers: z.boolean(),
 });
 
 const engineHealthSchema = z
@@ -6992,7 +6997,7 @@ export const TOOLS: McpTool[] = [
 		category: "read",
 		invalidates: [],
 		description:
-			"Compare two completed runs and return the deltas in latency percentiles, throughput, error rate, and status-code mix, each labelled with which direction is an improvement. Use to answer 'did this change regress performance?'. Omit baseRunId to compare against the run pinned as the baseline for the same saved request.",
+			"Compare two completed runs and return the deltas in latency percentiles, throughput, error rate, and status-code mix, each labelled with which direction is an improvement. Use to answer 'did this change regress performance?'. Omit baseRunId to compare against the run pinned as the baseline for the same saved request. compressionNegotiationDiffers true means the two runs did not negotiate a compressed response the same way, so the byte and latency deltas are not a clean comparison - check the runs' config before reading a regression into them.",
 		annotations: {
 			title: "Compare runs",
 			readOnlyHint: true,

--- a/app/src/lib/run-compare.ts
+++ b/app/src/lib/run-compare.ts
@@ -39,6 +39,21 @@ function num(obj: unknown, ...path: string[]): number | null {
 }
 
 /**
+ * Like {@link num}, but for a flag whose absence is itself meaningful
+ * (issue #1488): a report from before `metadata.configuration.acceptEncoding`
+ * existed carries no such key, and reads as `false` here - which is what
+ * every such run actually sent, not an unknown value defaulted away.
+ */
+function bool(obj: unknown, ...path: string[]): boolean {
+	let cur: unknown = obj;
+	for (const key of path) {
+		if (cur === null || typeof cur !== "object") return false;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur === true;
+}
+
+/**
  * Which way is better for a metric - the half of a delta a number cannot
  * carry. `neutral` is not a hedge: `summary.totalRequests` moves with how long
  * a run was told to run, so calling either direction an improvement would
@@ -95,6 +110,15 @@ export interface RunComparison {
 	throughput: MetricDelta[];
 	reliability: MetricDelta[];
 	statusCodes: Record<string, { base: number; target: number }>;
+	/**
+	 * Whether the two runs negotiated a compressed response differently
+	 * (issue #1488) - a run recorded before `loadNegotiateCompression`'s
+	 * default flipped in 0.26 reads as `false`, so an older baseline against
+	 * a newer run reports a difference exactly when the newer one negotiated
+	 * and the older did not. `true` means the byte and latency deltas above
+	 * are not measuring the same thing.
+	 */
+	compressionNegotiationDiffers: boolean;
 }
 
 /**
@@ -177,5 +201,17 @@ export function compareReports(
 	collect(base, "base");
 	collect(target, "target");
 
-	return { baseRunId, targetRunId, latency, throughput, reliability, statusCodes };
+	const compressionNegotiationDiffers =
+		bool(base, "metadata", "configuration", "acceptEncoding") !==
+		bool(target, "metadata", "configuration", "acceptEncoding");
+
+	return {
+		baseRunId,
+		targetRunId,
+		latency,
+		throughput,
+		reliability,
+		statusCodes,
+		compressionNegotiationDiffers,
+	};
 }

--- a/app/src/modules/history/main/components/BaselineComparison.test.tsx
+++ b/app/src/modules/history/main/components/BaselineComparison.test.tsx
@@ -37,9 +37,23 @@ vi.mock("@/services/api", () => ({
 
 const mocked = vi.mocked(apiService);
 
-function report(over: { p99: number; avgRps: number; errorRate: number }): RunReport {
+function report(over: {
+	p99: number;
+	avgRps: number;
+	errorRate: number;
+	acceptEncoding?: boolean;
+}): RunReport {
 	return {
-		metadata: { runId: "r", runType: "load", status: "completed", startTime: 0, endTime: 1000 },
+		metadata: {
+			runId: "r",
+			runType: "load",
+			status: "completed",
+			startTime: 0,
+			endTime: 1000,
+			...(over.acceptEncoding === undefined
+				? {}
+				: { configuration: { acceptEncoding: over.acceptEncoding } }),
+		},
 		summary: {
 			totalRequests: 1000,
 			successfulRequests: 1000,
@@ -221,5 +235,53 @@ describe("BaselineComparison", () => {
 		expect(mocked.listRuns).toHaveBeenCalledWith(
 			expect.objectContaining({ baseline: true, q: "https://api.example.test/checkout" })
 		);
+	});
+
+	/*
+	 * Issue #1488: a baseline pinned under a different compression-negotiation
+	 * setting than the run it is compared against means the byte and latency
+	 * deltas above are not a clean comparison, so the strip says so.
+	 */
+	it("warns when the baseline and the open run negotiated compression differently", async () => {
+		mocked.getRun.mockResolvedValue(run());
+		mocked.listRuns.mockResolvedValue(
+			baselinePage([run({ id: "run_baseline", baseline: true })])
+		);
+		// Baseline recorded before #1488 (no key at all) - reads as false.
+		mocked.getRunReport.mockResolvedValue(report({ p99: 50, avgRps: 100, errorRate: 1 }));
+
+		render(
+			withQueryClient(
+				<BaselineComparison
+					report={report({ p99: 50, avgRps: 100, errorRate: 1, acceptEncoding: true })}
+					runId="run_target"
+				/>
+			)
+		);
+
+		await waitFor(() => expect(screen.getByText("vs baseline")).toBeInTheDocument());
+		expect(screen.getByText(/Compression negotiation differs/)).toBeInTheDocument();
+	});
+
+	it("says nothing when both runs negotiated compression the same way", async () => {
+		mocked.getRun.mockResolvedValue(run());
+		mocked.listRuns.mockResolvedValue(
+			baselinePage([run({ id: "run_baseline", baseline: true })])
+		);
+		mocked.getRunReport.mockResolvedValue(
+			report({ p99: 50, avgRps: 100, errorRate: 1, acceptEncoding: true })
+		);
+
+		render(
+			withQueryClient(
+				<BaselineComparison
+					report={report({ p99: 50, avgRps: 100, errorRate: 1, acceptEncoding: true })}
+					runId="run_target"
+				/>
+			)
+		);
+
+		await waitFor(() => expect(screen.getByText("vs baseline")).toBeInTheDocument());
+		expect(screen.queryByText(/Compression negotiation differs/)).not.toBeInTheDocument();
 	});
 });

--- a/app/src/modules/history/main/components/BaselineComparison.tsx
+++ b/app/src/modules/history/main/components/BaselineComparison.tsx
@@ -23,7 +23,14 @@
  */
 
 import { useMemo } from "react";
-import { ArrowDownRight, ArrowUpRight, GitCompareArrows, Minus, Pin } from "lucide-react";
+import {
+	AlertTriangle,
+	ArrowDownRight,
+	ArrowUpRight,
+	GitCompareArrows,
+	Minus,
+	Pin,
+} from "lucide-react";
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
@@ -177,6 +184,15 @@ export default function BaselineComparison({ report, runId }: BaselineComparison
 					<DeltaCell key={metric.metric} metric={metric} />
 				))}
 			</div>
+			{comparison.compressionNegotiationDiffers && (
+				<div className="flex items-center gap-2 mt-2 text-xs text-status-warning-text">
+					<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+					<span>
+						Compression negotiation differs between these runs; byte and latency figures
+						are not directly comparable.
+					</span>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -863,6 +863,19 @@ export interface RunConfigSnapshot {
 	 * *negotiated* protocol on a single exchange (`ResponseState.httpVersion`).
 	 */
 	httpVersion?: HttpVersion;
+	/**
+	 * A load or collection run's resolved default-header decision at start
+	 * (issue #1488) - `userAgent` is the value verbatim, `requestId` and
+	 * `acceptEncoding` are whether each was negotiated at all. Absent on a
+	 * design run and on any run recorded before this field existed. Never
+	 * re-applied to a send; kept only so a baseline comparison can tell
+	 * whether two runs measured under the same conditions.
+	 */
+	defaultHeaders?: {
+		userAgent: string;
+		requestId: boolean;
+		acceptEncoding: boolean;
+	};
 	[key: string]: unknown;
 }
 
@@ -1308,7 +1321,7 @@ export interface RunScenarioSummary {
 
 /**
  * The compact per-row summary the paginated `GET /runs` list carries in place
- * of the full {@link RunConfigSnapshot}. Mirrors all ten keys
+ * of the full {@link RunConfigSnapshot}. Mirrors all eleven keys
  * `build_run_summary` sends (`engine/src/http/routes/runs.cpp`); each is
  * omitted by the engine when absent from the stored snapshot, except
  * `httpVersion` which the engine always normalizes to a value (see
@@ -1335,6 +1348,14 @@ export interface RunSummary {
 	followRedirects?: boolean;
 	/** Sent by the engine, not yet rendered - see the note above. */
 	maxRedirects?: number;
+	/**
+	 * Whether this run negotiated a compressed response (issue #1488) - see
+	 * {@link RunConfigSnapshot.defaultHeaders}. Omitted, not `false`, for a
+	 * run recorded before this field existed; the baseline comparison is the
+	 * one reader that treats an absent value as `false`, matching what such a
+	 * run actually sent.
+	 */
+	acceptEncoding?: boolean;
 	/**
 	 * A collection run's sequence, and nothing else's - see
 	 * {@link RunScenarioSummary}. Read by the history row, which has no `url` to
@@ -1849,6 +1870,8 @@ export interface RunReport {
 			followRedirects?: boolean;
 			/** Sent by the engine since 0.11.0; not rendered anywhere yet. */
 			maxRedirects?: number;
+			/** See {@link RunSummary.acceptEncoding} (issue #1488). */
+			acceptEncoding?: boolean;
 		};
 		/**
 		 * The document this run was measured against (issue #637), echoed from

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6371,7 +6371,14 @@ Every parameter composes with every other; each one left out is a wildcard.
 `duration`, `concurrency`, `comment`, `followRedirects`, `maxRedirects`, and
 `httpVersion`. The first eight are each **omitted** when absent from the
 snapshot (a malformed snapshot yields an empty `summary`, never a `500`);
-`httpVersion` alone is always present. A raw `POST /runs` body of
+`httpVersion` alone is always present. Every run since issue #1488 adds a
+tenth, `acceptEncoding`: `true` when the run negotiated a compressed response
+(`negotiateCompression` for a collection run, `loadNegotiateCompression` for a
+load run - see [Default request headers](#default-request-headers)), `false`
+when it did not, and **omitted**, not defaulted, for a run recorded before
+that issue -
+the baseline comparison (below) is the one reader that treats an absent key as
+`false`, matching what every such run actually sent. A raw `POST /runs` body of
 `"httpVersion": null` (erased before execution, so it behaves exactly like an
 absent key - see [POST /runs](#post-runs)) lands in the stored snapshot
 verbatim, and a run predating this field has no key at all; neither case
@@ -6533,6 +6540,20 @@ to fetch the whole body.
 `body` object gains the same `bodyTruncated` / `bodyBytes` pair. A run can be
 truncated on one side and not the other, since each is written by its own call
 into `sanitize_config_snapshot`.
+
+A load or collection run's `configSnapshot` also carries `defaultHeaders`
+(issue #1488), the run's resolved decision at start about what the engine
+would add to a request nobody wrote it into - never re-read for the send
+itself (see [Default request headers](#default-request-headers)), kept only
+so a later run's report can say whether the two measured under the same
+conditions:
+
+```json
+"defaultHeaders": { "userAgent": "Vayu/0.26.0", "requestId": false, "acceptEncoding": true }
+```
+
+Absent on a design run (it carries no throughput to compare) and on any run
+recorded before this issue.
 
 ### POST /runs/:runId/stop
 
@@ -6742,7 +6763,8 @@ named it.
       "followRedirects": true,
       "maxRedirects": 10,
       "httpVersion": "auto",
-      "dataRowCount": 2
+      "dataRowCount": 2,
+      "acceptEncoding": true
     },
     "openapi": {
       "specId": "spec_3f2b1c9a-...",
@@ -7035,7 +7057,9 @@ snapshot (`mode`, `duration`, `concurrency`, `startConcurrency`,
 `rampUpDuration`, `timeout`, `comment`, `followRedirects`, `maxRedirects` -
 each omitted when absent) plus `httpVersion`, which is always present with the
 same `"auto"`-when-unknown normalization `GET /runs`'s `summary` uses (see
-above). `rps` in the raw snapshot is renamed to `targetRps` here.
+above), and `acceptEncoding` (issue #1488), read out of the snapshot's
+`defaultHeaders` and omitted on the same terms as `GET /runs`'s `summary` key
+of the same name. `rps` in the raw snapshot is renamed to `targetRps` here.
 
 ### GET /runs/:runId/samples
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -1016,6 +1016,20 @@ snapshotted either: they are user data of unknown sensitivity, and the manifest
 records only their count. The writer is `vayu::core::build_scenario_manifest`
 (`core/scenario_plan.cpp`).
 
+**`config_snapshot`'s `defaultHeaders`** (issue #1488) - a load or collection
+run's snapshot also carries the run's resolved default-header decision at
+start: `{"userAgent": "Vayu/0.26.0", "requestId": false, "acceptEncoding":
+true}`. This is a deliberate, narrow exception to
+[Default request headers](api-reference.md#default-request-headers)'s "nothing
+here is stored" rule - that rule is about not writing an applied default back
+into a *saved request*, the way the renderer used to freeze `X-Request-ID`
+into one before issue #1229. Here nothing is applied to anything: the value is
+read back only to compare one run's report against another's, most often a
+pinned baseline against a newer run after `loadNegotiateCompression`'s default
+changed underneath both. Written once at `POST /runs` alongside the rest of
+the snapshot (`with_default_headers_snapshot`, `http/routes/execution.cpp`);
+absent on a design run and on any run recorded before this issue.
+
 **Retention** - runs are append-only in normal use (every design-mode click adds a `runs` row,
 every load run its `metric_ticks`/`results`), so `Database::prune_runs(max_runs, max_age_days)` trims
 the history. A run is a victim when it falls **beyond the `maxRunsRetained` most-recent runs**

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -537,7 +537,10 @@ logged as a warning: it means a client skipped composition.
   `X-Vayu-Version` and a frozen `X-Request-ID` into the saved request, which a
   load run then replayed. `Accept-Encoding` is the one recorded without being
   appended: libcurl writes that line itself from `CURLOPT_ACCEPT_ENCODING`,
-  which is what makes it decode. Add a default there, never in a driver.
+  which is what makes it decode. Add a default there, never in a driver. A
+  load or collection run's `config_snapshot` records the resolved decision
+  too (#1488), for a later run's report to compare against - never re-applied
+  to a send, the one deliberate exception to "none of it is stored".
 - **Every outbound transfer leaves through one `TransportPolicy`** (#705,
   `include/vayu/http/transport_policy.hpp`), resolved from `proxyMode` /
   `proxyUrl` / `proxyBypass` at the point of use (run-scoped on the load and

--- a/engine/include/vayu/http/default_headers.hpp
+++ b/engine/include/vayu/http/default_headers.hpp
@@ -43,6 +43,11 @@ class Database;
  *   one with no `User-Agent` at all.
  * - **Nothing here is stored.** These are applied at send time from config, so
  *   they cannot go stale in a saved request the way the renderer's copies did.
+ *   A load or collection run's `config_snapshot` is the one deliberate
+ *   exception (issue #1488, `with_default_headers_snapshot` in
+ *   `http/routes/execution.cpp`): it records the resolved decision for a
+ *   later run's report to compare itself against, and never reads it back
+ *   into a send.
  * - **The correlation id is namespaced and off by default.** `X-Request-ID` is
  *   a public name gateways give their own meaning to; the default here is
  *   `X-Vayu-Request-Id`, and the name is configurable for a server that reads

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -523,6 +523,49 @@ std::string load_data_snapshot (const std::string& sanitized, size_t row_count) 
     return parsed.dump ();
 }
 
+/**
+ * @brief Record the run's resolved default-header decisions in the stored
+ *        snapshot (issue #1488), so a baseline pinned before a config change
+ *        - an engine upgrade that flipped `loadNegotiateCompression`'s
+ *        default included - stays distinguishable from a run recorded after.
+ *
+ * `default_headers.hpp` documents "nothing here is stored", about the
+ * request a user saves: applying a default at send time and then writing it
+ * back into the saved request is what let a load run replay a frozen
+ * `X-Request-ID` (issue #1229). This is a different fact - what the *run*
+ * decided, kept only for a later run's report to compare itself against, and
+ * never read back into a send. `userAgent` is the resolved value verbatim,
+ * since it can itself change across an engine upgrade; `requestId` and
+ * `acceptEncoding` collapse to booleans, because a comparison needs to know
+ * whether each was negotiated, not the exact header name or the
+ * content-encoding list libcurl advertised.
+ *
+ * A snapshot that is not JSON (which `sanitize_config_snapshot` passes
+ * through verbatim) is left alone, matching `scenario_snapshot` and
+ * `load_data_snapshot` beside it.
+ *
+ * Non-static: run_row_seed_test.cpp declares and drives it directly, the way
+ * it does its two siblings above.
+ */
+std::string with_default_headers_snapshot (const std::string& snapshot,
+const vayu::http::DefaultHeaderPolicy& header_policy) {
+    nlohmann::json parsed;
+    try {
+        parsed = nlohmann::json::parse (snapshot);
+    } catch (const std::exception&) {
+        return snapshot;
+    }
+    if (!parsed.is_object ()) {
+        return snapshot;
+    }
+    parsed["defaultHeaders"] = {
+        { "userAgent", header_policy.user_agent },
+        { "requestId", !header_policy.correlation_header.empty () },
+        { "acceptEncoding", !header_policy.accept_encoding.empty () },
+    };
+    return parsed.dump ();
+}
+
 namespace {
 
 /**
@@ -541,17 +584,31 @@ std::string run_config_snapshot (const std::string& body,
 bool is_scenario,
 const nlohmann::json& scenario_manifest,
 const vayu::core::LoadDataSet* data,
+const vayu::http::DefaultHeaderPolicy& header_policy,
 size_t max_body_bytes) {
     std::string sanitized = vayu::json::sanitize_config_snapshot (body, max_body_bytes);
+    std::string shaped = sanitized;
     if (is_scenario) {
-        return scenario_snapshot (sanitized, scenario_manifest);
-    }
-    if (data != nullptr && !data->rows.empty ()) {
+        shaped = scenario_snapshot (sanitized, scenario_manifest);
+    } else if (data != nullptr && !data->rows.empty ()) {
         // The rows out, their count in - the same rule the scenario manifest
         // keeps, and for the same reason (issue #993).
-        return load_data_snapshot (sanitized, data->rows.size ());
+        shaped = load_data_snapshot (sanitized, data->rows.size ());
     }
-    return sanitized;
+    return with_default_headers_snapshot (shaped, header_policy);
+}
+
+/**
+ * @brief Which compression key a run's `config_snapshot` decision should read
+ *        (issue #1488): `Load` for anything the event loop drives (a plain
+ *        load run or a scenario with a load mode), `Design` for a sequential
+ *        collection run, which negotiates the way any other collection send
+ *        does. Extracted so the branch does not add to
+ *        `handle_start_load_test`'s own cognitive complexity.
+ */
+vayu::http::DefaultHeaderScope compression_scope_of (vayu::RunType type) {
+    return type == vayu::RunType::Load ? vayu::http::DefaultHeaderScope::Load :
+                                         vayu::http::DefaultHeaderScope::Design;
 }
 
 /**
@@ -1883,8 +1940,11 @@ httplib::Response& res) {
     const auto max_snapshot_body_bytes =
     static_cast<size_t> (ctx.db.get_config_int ("maxTraceBodyBytes",
     static_cast<int> (vayu::core::constants::json::MAX_TRACE_BODY_BYTES)));
+    // Issue #1488 - see compression_scope_of's doc comment.
+    const auto header_policy = vayu::http::resolve_default_header_policy (
+    ctx.db, compression_scope_of (run.type));
     run.config_snapshot = run_config_snapshot (req.body, is_scenario,
-    scenario_manifest, load_data.set.get (), max_snapshot_body_bytes);
+    scenario_manifest, load_data.set.get (), header_policy, max_snapshot_body_bytes);
     seed_run_times (run, now_ms ());
 
     if (json.contains ("requestId") && !json["requestId"].is_null ()) {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -566,6 +566,22 @@ const vayu::http::DefaultHeaderPolicy& header_policy) {
     return parsed.dump ();
 }
 
+/**
+ * @brief Which compression key a run's `config_snapshot` decision should read
+ *        (issue #1488): `Load` for anything the event loop drives (a plain
+ *        load run or a scenario with a load mode), `Design` for a sequential
+ *        collection run, which negotiates the way any other collection send
+ *        does. Extracted so the branch does not add to
+ *        `handle_start_load_test`'s own cognitive complexity.
+ *
+ * Non-static: run_row_seed_test.cpp declares and drives it directly, the way
+ * it does the other snapshot helpers above.
+ */
+vayu::http::DefaultHeaderScope compression_scope_of (vayu::RunType type) {
+    return type == vayu::RunType::Load ? vayu::http::DefaultHeaderScope::Load :
+                                         vayu::http::DefaultHeaderScope::Design;
+}
+
 namespace {
 
 /**
@@ -596,19 +612,6 @@ size_t max_body_bytes) {
         shaped = load_data_snapshot (sanitized, data->rows.size ());
     }
     return with_default_headers_snapshot (shaped, header_policy);
-}
-
-/**
- * @brief Which compression key a run's `config_snapshot` decision should read
- *        (issue #1488): `Load` for anything the event loop drives (a plain
- *        load run or a scenario with a load mode), `Design` for a sequential
- *        collection run, which negotiates the way any other collection send
- *        does. Extracted so the branch does not add to
- *        `handle_start_load_test`'s own cognitive complexity.
- */
-vayu::http::DefaultHeaderScope compression_scope_of (vayu::RunType type) {
-    return type == vayu::RunType::Load ? vayu::http::DefaultHeaderScope::Load :
-                                         vayu::http::DefaultHeaderScope::Design;
 }
 
 /**

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -64,6 +64,27 @@ void add_http_version (nlohmann::json& dst, const nlohmann::json& src) {
     }
 }
 
+// Whether this run negotiated a compressed response, read out of the nested
+// `defaultHeaders` object issue #1488 added to the snapshot at run start.
+// Nested rather than flat so it cannot collide with a client-controlled
+// top-level key `add_if_present` would otherwise copy verbatim.
+//
+// Omitted, not defaulted, when the snapshot predates this field - unlike
+// httpVersion, an absent key here does not mean "the engine's own default
+// applied at read time", it means "no run-scoped decision was ever
+// recorded". The baseline comparison (app side) is the one place that reads
+// an absent key as false, because that is what every pre-0.26 run actually
+// sent.
+void add_accept_encoding (nlohmann::json& dst, const nlohmann::json& src) {
+    if (!src.contains ("defaultHeaders") || !src["defaultHeaders"].is_object ()) {
+        return;
+    }
+    const auto& headers = src["defaultHeaders"];
+    if (headers.contains ("acceptEncoding") && headers["acceptEncoding"].is_boolean ()) {
+        dst["acceptEncoding"] = headers["acceptEncoding"];
+    }
+}
+
 // A scenario run's list-row descriptor, or an absent key when the snapshot is
 // not a scenario's.
 //
@@ -95,9 +116,11 @@ void add_scenario (nlohmann::json& dst, const nlohmann::json& src) {
 
 // The compact list-row summary: exactly the nine keys the history/dashboard
 // list UIs read, each omitted when absent from the snapshot (httpVersion
-// excepted - see add_http_version), plus `scenario` on a collection run only.
-// A malformed config_snapshot yields an empty object, never an error - the full
-// snapshot stays available on GET /runs/:id.
+// excepted - see add_http_version), plus `acceptEncoding` (issue #1488) and
+// `scenario` on a collection run only, both omitted rather than defaulted
+// when the snapshot carries neither. A malformed config_snapshot yields an
+// empty object, never an error - the full snapshot stays available on
+// GET /runs/:id.
 nlohmann::json build_run_summary (const std::string& config_snapshot) {
     nlohmann::json summary = nlohmann::json::object ();
     try {
@@ -108,6 +131,7 @@ nlohmann::json build_run_summary (const std::string& config_snapshot) {
                 add_if_present (summary, config, key);
             }
             add_http_version (summary, config);
+            add_accept_encoding (summary, config);
             add_scenario (summary, config);
         }
     } catch (...) {
@@ -781,10 +805,11 @@ int64_t offset) {
 
 /**
  * The GET /runs/:runId/report `configuration` object: the load-test tuning
- * knobs plus httpVersion/followRedirects/maxRedirects (ten keys total), built
- * from an already-parsed config_snapshot. `rps`/`targetRps` is the one
- * rename, so it stays as an inline branch in the caller rather than living in
- * this key list.
+ * knobs plus httpVersion/followRedirects/maxRedirects (ten keys total) and,
+ * when the snapshot carries one, `acceptEncoding` (issue #1488), built from
+ * an already-parsed config_snapshot. `rps`/`targetRps` is the one rename, so
+ * it stays as an inline branch in the caller rather than living in this key
+ * list.
  *
  * Extracted (like get_runs_response above) so this is covered directly - see
  * runs_route_test.cpp - without the full report handler's DB/metrics reads.
@@ -803,6 +828,7 @@ nlohmann::json build_run_report_config (const nlohmann::json& config) {
         add_if_present (config_obj, config, key);
     }
     add_http_version (config_obj, config);
+    add_accept_encoding (config_obj, config);
     return config_obj;
 }
 

--- a/engine/tests/run_row_seed_test.cpp
+++ b/engine/tests/run_row_seed_test.cpp
@@ -24,6 +24,11 @@
  * `scenario_snapshot` sits here for the same reason: it is the other thing
  * `POST /runs` does to a row before writing it, and what it keeps out of the
  * store is a security property rather than a formatting choice.
+ *
+ * `with_default_headers_snapshot` sits here for a related but distinct
+ * reason (issue #1488): what it adds to the row is not user data at all, so
+ * there is nothing to keep out - the property under test is that the merge
+ * happens and survives whatever the other two rewrites already did.
  */
 
 #include <gtest/gtest.h>
@@ -33,6 +38,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "vayu/http/default_headers.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::http::routes {
@@ -40,14 +46,20 @@ namespace vayu::http::routes {
 void seed_run_times (vayu::db::Run& run, int64_t started_at);
 std::string scenario_snapshot (const std::string& sanitized, const nlohmann::json& manifest);
 std::string load_data_snapshot (const std::string& sanitized, size_t row_count);
+std::string with_default_headers_snapshot (const std::string& snapshot,
+const vayu::http::DefaultHeaderPolicy& header_policy);
+vayu::http::DefaultHeaderScope compression_scope_of (vayu::RunType type);
 } // namespace vayu::http::routes
 
 namespace {
 
 using nlohmann::json;
+using vayu::http::DefaultHeaderPolicy;
+using vayu::http::routes::compression_scope_of;
 using vayu::http::routes::load_data_snapshot;
 using vayu::http::routes::scenario_snapshot;
 using vayu::http::routes::seed_run_times;
+using vayu::http::routes::with_default_headers_snapshot;
 
 TEST (SeedRunTimes, SeedsEndTimeAlongsideStartTime) {
     vayu::db::Run run;
@@ -137,6 +149,58 @@ TEST (LoadDataSnapshot, ReplacesTheRowsWithTheirCount) {
 TEST (LoadDataSnapshot, LeavesANonObjectSnapshotAlone) {
     EXPECT_EQ (load_data_snapshot ("not json at all", 1), "not json at all");
     EXPECT_EQ (load_data_snapshot ("[1,2,3]", 1), "[1,2,3]");
+}
+
+// A baseline pinned before loadNegotiateCompression's 0.26 default flip (or
+// any later config change) needs to say what it measured under - issue
+// #1488. userAgent is recorded verbatim; requestId/acceptEncoding collapse
+// to whether each was negotiated at all.
+TEST (DefaultHeadersSnapshot, RecordsUserAgentRequestIdAndAcceptEncoding) {
+    DefaultHeaderPolicy policy;
+    policy.user_agent         = "Vayu/0.26.0";
+    policy.correlation_header = "X-Vayu-Request-Id";
+    policy.accept_encoding    = "gzip, br, deflate";
+
+    const std::string sanitized =
+    json{ { "method", "POST" }, { "url", "https://api.test/" } }.dump ();
+    const auto stored = json::parse (with_default_headers_snapshot (sanitized, policy));
+
+    ASSERT_TRUE (stored.contains ("defaultHeaders"));
+    const auto& headers = stored["defaultHeaders"];
+    EXPECT_EQ (headers["userAgent"], "Vayu/0.26.0");
+    EXPECT_EQ (headers["requestId"], true);
+    EXPECT_EQ (headers["acceptEncoding"], true);
+    // Everything else the client sent is left alone.
+    EXPECT_EQ (stored["method"], "POST");
+    EXPECT_EQ (stored["url"], "https://api.test/");
+}
+
+TEST (DefaultHeadersSnapshot, RecordsFalseWhenNegotiationIsOff) {
+    DefaultHeaderPolicy policy; // correlation_header / accept_encoding default-empty
+    ASSERT_TRUE (policy.correlation_header.empty ());
+    ASSERT_TRUE (policy.accept_encoding.empty ());
+
+    const auto stored =
+    json::parse (with_default_headers_snapshot (json::object ().dump (), policy));
+
+    EXPECT_EQ (stored["defaultHeaders"]["requestId"], false);
+    EXPECT_EQ (stored["defaultHeaders"]["acceptEncoding"], false);
+}
+
+TEST (DefaultHeadersSnapshot, LeavesANonObjectSnapshotAlone) {
+    DefaultHeaderPolicy policy;
+    EXPECT_EQ (with_default_headers_snapshot ("not json at all", policy), "not json at all");
+    EXPECT_EQ (with_default_headers_snapshot ("[1,2,3]", policy), "[1,2,3]");
+}
+
+// A load run (including a scenario carrying a load mode) reads the load
+// scope's own compression key; a sequential collection run negotiates the
+// way any other collection send does (issue #1488).
+TEST (CompressionScopeOf, PicksLoadForLoadAndDesignForScenario) {
+    EXPECT_EQ (compression_scope_of (vayu::RunType::Load),
+    vayu::http::DefaultHeaderScope::Load);
+    EXPECT_EQ (compression_scope_of (vayu::RunType::Scenario),
+    vayu::http::DefaultHeaderScope::Design);
 }
 
 } // namespace

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -237,6 +237,27 @@ TEST_F (RunsRouteTest, SummaryHttpVersionDefaultsToAutoOnNullOrAbsent) {
     EXPECT_EQ (body["data"][1]["summary"]["httpVersion"], "auto");
 }
 
+// A baseline's list row needs the same compression signal the open run's full
+// snapshot carries, since the baseline comparison reads the pinned run
+// through this list endpoint rather than GET /runs/:id (issue #1488).
+TEST_F (RunsRouteTest, SummaryCarriesAcceptEncodingWhenSnapshotHasIt) {
+    seed ({ .id = "run_negotiated",
+    .config_snapshot = R"({"url":"https://a/","defaultHeaders":{"userAgent":"Vayu/0.26.0","requestId":true,"acceptEncoding":true}})" });
+    seed ({ .id = "run_not_negotiated",
+    .start_time = 1,
+    .config_snapshot = R"({"url":"https://b/","defaultHeaders":{"userAgent":"Vayu/0.26.0","requestId":false,"acceptEncoding":false}})" });
+    seed ({ .id = "run_pre_1488", .start_time = 2, .config_snapshot = R"({"url":"https://c/"})" });
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    // Newest first: run_pre_1488, run_not_negotiated, run_negotiated.
+    EXPECT_EQ (body["data"][0]["id"], "run_pre_1488");
+    EXPECT_FALSE (body["data"][0]["summary"].contains ("acceptEncoding"));
+    EXPECT_EQ (body["data"][1]["id"], "run_not_negotiated");
+    EXPECT_EQ (body["data"][1]["summary"]["acceptEncoding"], false);
+    EXPECT_EQ (body["data"][2]["id"], "run_negotiated");
+    EXPECT_EQ (body["data"][2]["summary"]["acceptEncoding"], true);
+}
+
 // A collection run's row has no url and no method - its work is a sequence -
 // so `scenario` is the only thing on it that says what ran. The step manifest
 // itself stays off the row: it is the size of the plan, and the row is the part
@@ -769,6 +790,20 @@ TEST (RunReportConfigTest, OmitsFollowRedirectsAndMaxRedirectsWhenAbsent) {
     EXPECT_FALSE (config_obj.contains ("followRedirects"));
     EXPECT_FALSE (config_obj.contains ("maxRedirects"));
     EXPECT_EQ (config_obj.size (), 2u); // mode + httpVersion("auto")
+}
+
+// Same field as SummaryCarriesAcceptEncodingWhenSnapshotHasIt, read for
+// GET /runs/:runId/report's `configuration` object rather than the list row
+// (issue #1488).
+TEST (RunReportConfigTest, CarriesAcceptEncodingWhenSnapshotHasItAndOmitsItOtherwise) {
+    auto negotiated = json::parse (
+    R"({"mode":"once","defaultHeaders":{"userAgent":"Vayu/0.26.0","requestId":false,"acceptEncoding":true}})");
+    auto pre_1488 = json::parse (R"({"mode":"once"})");
+
+    EXPECT_EQ (
+    vayu::http::routes::build_run_report_config (negotiated)["acceptEncoding"], true);
+    EXPECT_FALSE (vayu::http::routes::build_run_report_config (pre_1488).contains (
+    "acceptEncoding"));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description
`loadNegotiateCompression` defaulted to `false` before 0.26 and `true` since. A load-run baseline pinned under 0.25 and compared against a run started on head silently mixed two different measurement conditions: the stored `config_snapshot` never recorded whether a run negotiated a compressed response, so `bytesReceived`/`bytesSent`/latency deltas in the baseline comparison read as a regression or an improvement that was really just the compression setting changing underneath both runs, with nothing in the report or the UI saying why.

**Root cause / approach**: `DefaultHeaderPolicy` (`engine/include/vayu/http/default_headers.hpp`) is resolved fresh per request or per run and, by design, never stored - the doc comment says so explicitly, because it exists to keep a saved *request* from going stale the way a frozen `X-Request-ID` used to. This issue asks for a narrow, deliberate exception: record the *decision* on the *run*, not on any request, purely so a later run's report can compare itself against an earlier one. `run_config_snapshot` (`engine/src/http/routes/execution.cpp`) now resolves the policy (Load scope for anything the event loop drives, Design scope for a sequential collection run - extracted into `compression_scope_of` to keep `handle_start_load_test`'s cognitive complexity under the repo's clang-tidy threshold) and merges `defaultHeaders: { userAgent, requestId, acceptEncoding }` into the stored snapshot via a new `with_default_headers_snapshot` step, mirroring the existing `scenario_snapshot`/`load_data_snapshot` pattern exactly. `userAgent` is kept verbatim (it can itself change across an engine upgrade); `requestId`/`acceptEncoding` collapse to booleans, since a comparison only needs "was this negotiated at all". Read back through both `GET /runs`'s compact list summary (`build_run_summary`) and `GET /runs/:runId/report`'s `metadata.configuration` (`build_run_report_config`), each via a small `add_accept_encoding` helper that omits the key rather than defaulting it when the snapshot predates this change - the same "absent is not false, until a specific reader treats it that way" convention `httpVersion` set.

On the app side, `lib/run-compare.ts` (mirrored in `electron/mcp/compare.ts` for the MCP `compare_runs` tool - `compare.conformance.test.ts` keeps the two honest, including a new fixture pinning the exact boolean logic) computes `compressionNegotiationDiffers` by comparing `metadata.configuration.acceptEncoding` on both reports, treating an absent key as `false`. `BaselineComparison.tsx` renders a one-line warning ("Compression negotiation differs between these runs...") when it's `true`. A run recorded before this change has no `defaultHeaders` key at all; every reader treats that absence as "did not negotiate", which is exactly what a pre-0.26 run actually sent.

**Alternative rejected**: storing the raw resolved `Accept-Encoding` value (and correlation-id header name) verbatim instead of collapsing to booleans. The feature only needs "did negotiation happen", and the raw string is libcurl-build-specific (`gzip, br, deflate` vs `gzip, deflate` depending on what the build linked) - comparing it verbatim would flag a false "differs" note driven by which machine built the engine rather than by the `loadNegotiateCompression` setting the issue is actually about.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- Engine: `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **3011/3011 passed**, including the new cases named individually below. `engine/tests/run_row_seed_test.cpp` - `with_default_headers_snapshot` (records userAgent/requestId/acceptEncoding, collapses an off policy to `false`, leaves a non-object snapshot alone) and `compression_scope_of` (Load vs Design), mirroring the existing `scenario_snapshot`/`load_data_snapshot` test shape. `engine/tests/runs_route_test.cpp` - a new case each for `build_run_summary` (`GET /runs` list row) and `build_run_report_config` (`GET /runs/:runId/report`) reading the nested `defaultHeaders.acceptEncoding` and omitting it when absent. Mutation-checked by hand (removing `with_default_headers_snapshot`'s merge, and removing `add_accept_encoding`'s call sites) - each case reds, then restored. `clang-format-19`/`clang-tidy-19` on every touched engine file both passed clean via the repo's own pre-commit hook, including the cognitive-complexity check that caught the first version of this change.
  - **Self-review caught a real link error before push, not after**: the first version placed `compression_scope_of` inside `execution.cpp`'s anonymous namespace, so the new test's forward declaration couldn't resolve it. `clang-tidy` lints translation units individually and didn't see it; a full `ninja vayu_tests` link did. Fixed by moving it beside its non-static siblings (`scenario_snapshot`, `load_data_snapshot`, `with_default_headers_snapshot`) in a follow-up commit on this branch, then re-verified with the full 3011-test `ctest` run above rather than trusting a clean compile again.
- App: `pnpm test` - **8129/8129 passed** (713 files), including the new/updated `BaselineComparison.test.tsx` cases (warns when compression differs, silent when it matches) and `compare.conformance.test.ts` (the mirror pins `compressionNegotiationDiffers` on real values, not just structural equality, plus a case for the "absent reads as false" rule). `pnpm type-check` passed. `pnpm lint`/`pnpm format:check` clean on every touched file (fixed one MCP `outputSchema` regression this diff caused: `compare_runs`'s Zod schema needed the new field or a real comparison came back "additional properties" over MCP - caught by the existing `protocol.integration.test.ts` handshake test, not written new for this).

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19 on engine; ESLint / Prettier on app, all via the repo's pre-commit hook)
- [x] I have performed a self-review (see the link-error note under Testing)
- [x] I have added tests (see Testing)
- [x] I have updated documentation (`docs/engine/api-reference.md`, `docs/engine/db-schema.md`, `engine/CLAUDE.md`, and the `default_headers.hpp` doc comment recording the "nothing is stored" exception)

## Related Issues
Closes #1488

## No screenshot
The only user-visible surface is a one-line conditional warning row added to the existing `BaselineComparison` strip, using the same `AlertTriangle` / `text-status-warning-text` pattern already shipped in `ScenarioStepsTab.tsx`. Triggering it for a real screenshot needs two runs pinned as baseline/current with different `config_snapshot.defaultHeaders.acceptEncoding` values, which in practice means either an old (pre-0.26) database or hand-seeding raw JSON into a run row - not something a fresh screenshot run demonstrates more convincingly than the rendered-DOM assertions in `BaselineComparison.test.tsx` already do (both the "warns" and "silent" cases, with the exact copy asserted). Given that and the container's build budget already spent on a from-scratch engine rebuild this run, I left it at the component test rather than standing up Xvfb + Electron for one text line.