### PR TITLE
feat(engine): run the pipeline on a scenario load run, per virtual user

### DIFF
--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -80,9 +80,13 @@ are things Vayu plans to catch up on:
   test from many machines. Vayu runs from one.
 - **You have existing `.jmx` test plans**, or a team fluent in them. There is no
   importer for them here.
-- **Your load model is elaborate** - timers, ramp profiles, logic controllers,
-  correlation across steps. Vayu runs closed-loop constant concurrency and a
-  linear scenario.
+- **Your load model is elaborate** - think time and pacing timers, logic
+  controllers (loops, conditionals, transactions). Vayu runs closed-loop
+  constant concurrency and a linear scenario. Correlation across a scenario's
+  steps - a login's token reaching the next step's header, per virtual user -
+  does work under load now: mark the extracting element or script `inline`
+  (or set the run's `elements.scripts` override), or let it stay in the
+  post-run replay by default.
 - **It has to be JVM-native** for your infrastructure, monitoring, or compliance
   reasons.
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4883,6 +4883,7 @@ Start a load test run (Vayu Mode).
   "tests": "",               // Optional, deferred validation script
   "data": [],                // Optional data rows, one object per row - see below
   "thresholds": {},          // Optional pass/fail budgets - see below
+  "elements": {},            // Optional element-pipeline override for a scenario load run - see below
   "monitor": {},             // Optional server-vitals scrape - see below
   "followRedirects": true,   // Optional, default true - see POST /execute
   "maxRedirects": 10,        // Optional, default 10
@@ -5040,6 +5041,46 @@ counts toward `failed`: a budget the run could not measure was not met. The
 error rate and the throughput floor have no such gap - `maxErrorRatePct` is
 0/0-safe by request count, and a starved `minThroughputRps` already fails on
 its own - so both are always `evaluated: true`.
+
+#### The `elements` block (element-pipeline override)
+
+A **scenario** load run's `elements` block overrides how the element pipeline
+runs across every step of the run (issue #1495), without editing the
+collection itself.
+
+```jsonc
+{
+  "elements": {
+    "timers": "asConfigured",     // "asConfigured" (default) | "off"
+    "scripts": "asMarked",        // "asMarked" (default) | "allInline" | "allDeferred"
+    "includeScriptTime": false    // default false
+  }
+}
+```
+
+Every key is optional; an unknown key or an out-of-set value is a `400`
+naming the field, the same `invalid_run_config` shape the `scenario` block's
+own unknown-key rule uses, checked before the run row is created.
+
+- **`scripts`** decides whether a `script.pre` / `script.post` element runs
+  inline (on the producer/completion hooks, before or after the step's own
+  send) or stays deferred to the post-run `tests` replay. `"asMarked"` (the
+  default) reads each element's own `config.inline`; `"allInline"` /
+  `"allDeferred"` force every `script.*` element of the run one way,
+  regardless of its own marking. `extract.*` and `assert.*` are unaffected -
+  they always run inline on a scenario load run.
+- **`includeScriptTime`** folds the element pipeline's own elapsed time into
+  a step's recorded latency when `true`; by default (`false`) a step's
+  latency is its transfer alone, exactly as before this issue.
+- **`timers`** is accepted and stored but not yet wired to anything: no
+  kind reads it yet, since `timer.think`'s current phase (`step.between`) and
+  blocking wait are sequential-run-only. Issue #1498 ("the timer family")
+  owns finishing this.
+
+Not part of this block: a **single-request** `POST /runs` payload has no
+`elements` attachment point at all (see `tests` above), so this block is
+accepted there too - the validator does not distinguish the two run shapes -
+but has nothing to override.
 
 #### The `monitor` block (server vitals)
 
@@ -5575,20 +5616,32 @@ knob.
 - **Cookies are per virtual user**, empty at the start of each iteration, and
   the environment jar is untouched. One session shared between 1,000 virtual
   users is not the thing being measured.
-- **Scripts do not run inline. They stay deferred, keyed per step.** After the
-  run drains, each step's own post-request script is replayed against the
+- **The element pipeline runs here too, per virtual user (issue #1495).**
+  `extract.*` and `assert.*` always run - before the send (`step.before`) and
+  after the response (`step.after`). A `script.pre` / `script.post` element
+  runs there only when its own `config.inline` is `true`, or the run's
+  [`elements`](#the-elements-block-element-pipeline-override) override forces
+  it; unmarked, a step's scripts still stay deferred, keyed per step, exactly
+  as before this issue - see the next bullet. Each virtual user writes through
+  its own overlay, never the run's shared scopes, so a name one user's step 1
+  writes (an `extract.json`'s target, an inline script's
+  `pm.environment.set`) is visible only to that same user's later steps, never
+  to another user's concurrent one. `pm.execution` still throws - an inline
+  element can write state and mutate the request, never redirect the
+  sequence; flow control stays design-mode only (and, eventually, a
+  `control.*` element's).
+- **A script that did not run inline stays deferred, keyed per step.** After
+  the run drains, that step's own post-request script is replayed against the
   responses that step produced, and the tallies appear on that step's entry in
-  the breakdown as `tests` (see `scenario.steps` below). A step that carries no
-  script, or whose script never got a sampled response, carries no `tests`
-  object at all rather than a row of zeros. A pre-request script runs nowhere.
-  `pm.execution` still throws - a script that has already run against a recorded
-  response cannot redirect a sequence that already happened. Flow control is
-  design-mode only.
+  the breakdown as `tests` (see `scenario.steps` below). A step that carries
+  no script, whose script ran inline this run, or whose script never got a
+  sampled response, carries no `tests` object at all rather than a row of
+  zeros.
 
   Sampling is keyed per step for the same reason: the run's
   `max_response_samples` budget is split evenly across the steps that carry a
-  script (floored at one apiece), so the last step of a forty-step plan is
-  sampled instead of being crowded out by the first. The whole-run
+  deferred script (floored at one apiece), so the last step of a forty-step
+  plan is sampled instead of being crowded out by the first. The whole-run
   `testValidation` section still reports the aggregate - it says *something*
   failed, and the per-step `tests` say where.
 - **Data rows are claimed from one shared cursor**, one per virtual-user
@@ -5625,8 +5678,14 @@ knob.
   "steps": [
     { "index": 0, "name": "Log in", "requestId": "req_a", "method": "POST",
       "executed": 480, "errors": 0, "unresolvedTokens": 0,
-      "preRequestScript": "skipped",
       "latency": { "min": 1.2, "p50": 4.0, "p95": 9.1, "p99": 12.4, "max": 30.2 },
+      "elements": [
+        { "id": "el_1", "kind": "extract.json", "passed": 480, "failed": 0, "skipped": 0 }
+      ] },
+    { "index": 1, "name": "Get me", "requestId": "req_b", "method": "GET",
+      "executed": 474, "errors": 0, "unresolvedTokens": 0,
+      "preRequestScript": "skipped",
+      "latency": { "min": 0.9, "p50": 3.1, "p95": 7.8, "p99": 10.0, "max": 22.5 },
       "tests": { "sampled": 20, "passed": 20, "failed": 0 } }
   ]
 }
@@ -5635,19 +5694,28 @@ knob.
 One histogram is allocated per plan step at run start, which is the other thing
 `maxScenarioSteps` bounds.
 
-`tests` is the step's deferred validation, and is **absent** for a step that
-asserted nothing or whose script drew no sample - "no assertions" and "no
-failures" are different answers.
+`tests` is the step's *deferred* validation - a script that did not run inline
+this run - and is **absent** for a step whose script ran inline instead
+(its outcome is in `elements`), asserted nothing, or drew no sample - "no
+assertions" and "no failures" are different answers.
+
+`elements` (issue #1495) is the step's per-element pass/fail/skip tally,
+`{ id, kind, passed, failed, skipped }` one entry per compiled element that
+ran at least once this run - **absent** for a step with no elements or none
+that ever ran, the same convention `tests` follows. `skipped` folds in both a
+disabled element and a `script.*` element left deferred to the replay above.
 
 `unresolvedTokens` (issue #1503) counts, per step, how many of its executions
-sent a `{{token}}` composition never resolved - no residual pass runs under
-load, so a value composed at plan time and never bound (a script's
-`pm.environment.set` included, since that script never runs here either) goes
-on the wire literally rather than being refused. `preRequestScript` is
-`"skipped"` for a step whose request carries one and absent otherwise - see
-[scripting.md](scripting.md#pre-request-scripts) for why the mode never runs
-one at all. Neither ever fails the run by itself; both also feed the
-top-level `warnings` array below.
+sent a `{{token}}` composition the residual-token pass still could not answer
+- issue #1495 added a real resolution attempt here (against the executing
+virtual user's own scope overlay, see [`elements.md`](elements.md#load-paths)),
+but the load path's rule is unchanged: never refused, only counted, so a name
+still unanswered (or a header-name collision the attempt itself produced)
+goes on the wire regardless. `preRequestScript` is `"skipped"` for a step
+whose `script.pre` did not run inline this run and absent otherwise - a step
+whose `script.pre` did run inline reports its real outcome in `elements`
+instead, never both. Neither `unresolvedTokens` nor `preRequestScript` ever
+fails the run by itself; both also feed the top-level `warnings` array below.
 
 **Response:**
 ```json

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -1023,11 +1023,14 @@ object the design-mode sequential runner consumes - resolved once, before the ru
 row exists - and the executor is the only thing that differs.
 
 - **`concurrency` is the number of virtual users**, which is what k6 and JMeter
-  mean by it. A VU is a small value, not a thread: a cursor into the shared plan
-  plus its own cookies. On each completion the callback advances that VU's state
-  machine, and `maintain_concurrency`'s refill issues "the next step of VU *k*"
-  in place of "another copy of the one request". The controller, the SPSC
-  submission path and the single-producer discipline are unchanged.
+  mean by it. A VU is a small value, not a thread: a cursor into the shared plan,
+  its own cookies, and (since #1495) a small `ScopeOverlay` of the names it has
+  written - about 200 bytes per written variable, so 1,000 VUs cost kilobytes,
+  never the size of the run's whole scope. On each completion the callback
+  advances that VU's state machine, and `maintain_concurrency`'s refill issues
+  "the next step of VU *k*" in place of "another copy of the one request". The
+  controller, the SPSC submission path and the single-producer discipline are
+  unchanged.
 - **Cookie state is per-VU, never the shared jar** - see the Cookie Jar section's
   "Not on the load path" bullet, which this strengthens rather than contradicts.
   Each VU's list is seeded onto its own transfer and read back from it
@@ -1089,29 +1092,45 @@ row exists - and the executor is the only thing that differs.
   1 walking its passes, and a single send is a run of one.
   This is **template substitution, not a script hook**: two integers written into
   fields a compose-time scan already located, which is why it sits here rather
-  than reopening the recorded non-goal above (inline scripts on the load path).
+  than in the element-pipeline bullet below (issue #1495).
   A request that spells neither token has an empty template and is walked for
   nothing - the executor tests `empty()` and submits the shared request it
   always did. What every run does now pay is one unsynchronised increment per
   submission on the producer thread, which is what lets any load run tell a
   deferred script the iteration and the user a sampled response was sent as
   (`pm.info.iteration` / `pm.info.vu`).
-- **Scripts stay deferred, keyed per step.** Nothing runs inline; after the run
-  drains, each step's own `post_script` is replayed against the responses *that
-  step* produced, and the tallies land on that step's entry in the breakdown
-  (`scenario.steps[].tests`). Sampling is per step index for the same reason -
-  one flat run-wide reservoir lets the hot first step swamp the budget and never
-  samples the last step of a long plan. The run's `max_response_samples` budget
-  is split evenly across the steps that carry a script (not across every step),
-  floored at one apiece; a step with no script is never sampled and never
-  counted as a thinned sample. The byte budget beside it
-  (`max_response_sample_bytes`) is deliberately *not* split: those bodies are
-  resident in one process, so a forty-step plan must not multiply the ceiling by
-  forty, and a step that drops a sample over it is counted like any other thinned
-  one. A `pre_script` runs nowhere: it would have to run
-  before a send this mode never pauses for. `pm.execution` still throws in a
-  load run for the reason the flow-control section gives, and there is
-  deliberately no inline-script path on the load hot path.
+- **The element pipeline runs here too, per VU (issue #1495).** `submit_one` runs
+  `step.before` before binding and submitting; the completion runs `step.after`
+  once the response is in hand, before the VU is released. `extract.*` /
+  `assert.*` always run; a `script.pre` / `script.post` runs here only when its
+  own `config.inline` is set or the run's `elements.scripts` override forces
+  it - unmarked, a step's scripts still defer exactly as before this issue.
+  Each VU writes through its own `ScopeOverlay` (a handful of names, never the
+  run's shared scopes two VUs could race on), materialized against the base
+  scopes only when an inline script actually needs the mutable view
+  `pm.environment.set` writes through; the residual-token pass reads a cheap
+  flattened-map-plus-overlay merge instead, which is what makes correlation
+  (step 1's `extract.json` reaching step 2's `{{token}}`, *for that VU alone*)
+  work under load. `pm.execution` still throws in a load run for the reason the
+  flow-control section gives: an inline element can write state and mutate the
+  request, never redirect the sequence. See
+  [`elements.md`](elements.md#load-paths) for the full mechanics, including
+  what is deliberately still unwired (`elements.timers`, the single-request
+  path below).
+- **Un-inlined scripts stay deferred, keyed per step.** After the run drains,
+  each step's own `post_script` element - the ones that did not run inline
+  this run - is replayed against the responses *that step* produced, and the
+  tallies land on that step's entry in the breakdown (`scenario.steps[].tests`,
+  beside the new `scenario.steps[].elements` per-element tally). Sampling is
+  per step index for the same reason - one flat run-wide reservoir lets the hot
+  first step swamp the budget and never samples the last step of a long plan.
+  The run's `max_response_samples` budget is split evenly across the steps that
+  carry a deferred script (not across every step), floored at one apiece; a
+  step with no deferred script is never sampled and never counted as a thinned
+  sample. The byte budget beside it (`max_response_sample_bytes`) is
+  deliberately *not* split: those bodies are resident in one process, so a
+  forty-step plan must not multiply the ceiling by forty, and a step that drops
+  a sample over it is counted like any other thinned one.
 - The run's `runs.type` is **`load`**, not `scenario`: it publishes metric ticks
   and reports RPS and percentiles like any load run, and `scenario` is what the
   app reads to render a step list instead of the dashboard.

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -17,8 +17,9 @@ shape both sides of the wire agree on; it is generated from, or checked against,
 > kinds below. `elements` is the only script source now - `pre_request_script` /
 > `post_request_script` are gone, cut over by a one-shot migration (see
 > [`db-schema.md`](db-schema.md#the-script-to-elements-migration-issue-1514)); no transitional
-> alias, per the owner's decision. The load paths (a scenario load run's per-step pipeline) are
-> issue #1495 - a load run still executes no element inline.
+> alias, per the owner's decision. Issue #1495 lands the pipeline on a **scenario** load run's
+> producer/completion hooks (below) - a **single-request** load run still executes no element; see
+> that section for why.
 
 ## Shape
 
@@ -122,13 +123,73 @@ wrote? }`. `outcome` is one of `ok` | `failed` | `missing` | `skipped` | `error`
 is reported `skipped` without its `apply` ever running. `POST /execute`'s live response body carries
 the same array under the same key - one object, two homes, on the `scripts` node's own precedent.
 
+## Load paths
+
+A scenario load run's `submit_one` (the producer, one virtual user at a time) runs
+`step.before` before binding and submitting a request; its completion runs `step.after`
+once the response is in hand, before the virtual user (VU) is released back to the pool. A
+**declarative** kind (`extract.*`, `assert.*`) always runs at both points, read off the
+kind's registered `hotPath`, never a `kind ==` comparison (the extensibility contract's rule
+1). A **script** kind (`script.pre`, `script.post`) runs there only when its own
+`config.inline` is `true` or the run's `elements.scripts` override forces it one way or the
+other; otherwise the step keeps its pre-#1495 behaviour, deferred to the post-run `tests`
+replay, which now skips a step whose script already ran inline
+(`RunContext::script_element_runs_inline` is the one place that decision is made, read by
+both sides).
+
+**Per-VU isolation.** A load run's VUs share one event loop, so what an element writes
+(`extract.*`'s target variable, an inline `script.*`'s `pm.environment.set`) cannot land in
+the run's shared scopes the way a design send's or the sequential run's does - two VUs
+writing the same name would be reading and overwriting each other's state. Each `VirtualUser`
+instead carries a small `ScopeOverlay`: a handful of names this VU has written, cleared at
+every iteration boundary exactly `cookies` is. The run's shared scopes are flattened once at
+setup (`flatten_variable_scopes`); the residual-token pass (`resolve_residual_tokens`, see
+[`architecture.md`](architecture.md)) reads a copy of that flattened map with the VU's overlay
+merged on top - proportional to what the VU actually wrote, not to the run's whole variable
+set. An inline script needs the full, mutable scopes `pm.environment.set` writes through, so
+it runs against a `materialize`d copy (base scopes plus the VU's prior overlay) and whatever
+comes out replaces the VU's overlay wholesale - equivalent to a diff, since the copy already
+started as "base plus every override this VU has made so far."
+
+**One `ScriptEngine` per thread, not a shared pool.** Every load run's worker threads - the
+strategy thread and each event-loop worker - are spawned fresh for that run and joined before
+it retains, so `vayu::http::routes::script_engine_for_this_thread` constructs one lazily on
+first use and is never stale, never shared across runs, and never a caller-visible lock.
+
+**`elements.includeScriptTime`.** A step's recorded latency is its transfer alone by default -
+an inline element runs after `Client::send`'s own timing already stopped and before
+`StepHistograms::record` - so opting a script in does not, by itself, change what the latency
+figures measure. Setting the run's `elements.includeScriptTime` folds the pipeline's own
+elapsed time back in for anyone who wants the scripted cost in the figures.
+
+**Per-step tallies.** `scenario.steps[i].elements[] = { id, kind, passed, failed, skipped }`
+beside the existing `tests` node, one row per element that ran at least once this run -
+`StepElementTallies`, sized once from the plan's compiled elements so recording on the
+completion path is a lookup, never a lock or an allocation.
+
+**Not yet wired: timers.** `elements.timers` (`"asConfigured"` | `"off"`) is accepted and
+validated on `POST /runs` and stored on `RunContext`, but nothing reads it to suppress
+`timer.think` under load yet - #1498 ("the timer family... the run-level Timers override end
+to end") owns finishing that wiring, since `timer.think`'s current `step.between` phase and
+blocking wait are sequential-run-only and unreachable from the load hooks above by
+construction. `ready_at` plumbing (`VirtualUser::ready_at_ms`, a `take_ready_vu` skip) exists
+for #1498's `timer.pacing` to write into; nothing writes it yet.
+
+**Not yet wired: the single-request load path.** `load_strategy.cpp` is unchanged: a
+single-request `POST /runs` payload has no `elements` attachment point today (its script model
+is still the legacy `tests` string, `RunContext::test_script`, not a compiled `elements` list),
+so there is no element pipeline call there to gate on inline-vs-deferred - a `ScopeOverlay`
+would have no writer. Wiring a stored request's `elements` into that run shape is a separate
+gap, outside this page's Status callout.
+
 ## Related issues
 
 - #1513 - this page's storage, registry and catalogue.
 - #1514 - the pipeline in the design send and the sequential run, the phase-0 behaviour kinds
   (`extract.*`, `assert.*`, `timer.think`, `script.*`), per-element outcomes in the step trace, and
   the script-to-elements cut-over (this page's Status callout).
-- #1495 - the pipeline on the load paths.
+- #1495 - the pipeline on a scenario load run's producer/completion hooks (this page's Load
+  paths section).
 - #1497, #1515, #1498, #1500, #1499, #1501 - the assertion threshold, controllers, timers,
   metrics, setup/teardown and load-time cookies that round out the kind table.
 - #1516 - the app's `ElementList` primitive and editor.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -951,8 +951,11 @@ Rules worth knowing before you rely on them:
   compose time; a `{{host}}` composition already substituted is finished text
   and this pass does not touch it - assign `pm.request.url` directly to change
   that.
-- **Load tests do not run pre-request scripts** - only the `tests` (post-request)
-  script runs there, so this applies to Send / Design Mode.
+- **A single-request load test still does not run pre-request scripts** -
+  only the `tests` (post-request) script runs there. A **scenario** load
+  run's `script.pre` element does now, but only when marked `inline` or
+  forced by the run's `elements.scripts` override (issue #1495) - see
+  [above](#load-test-scripts).
 
 ### Header methods (`pm.request.headers`)
 
@@ -2458,22 +2461,42 @@ every element at a step shares the one `Request` object being sent - only the
 JavaScript variable scope is per-element. The same holds for `script.post`
 elements and `pm.response`.
 
-**`POST /runs` is unchanged, and still joins.** It calls neither
-`refuse_legacy_script_fields` nor the element pipeline: a single-request load
-run's own deferred validation script still reads `tests` (or
-`postRequestScripts` / `postRequestScript`, tried in that order) exactly as
-before - a list of parts joined with a blank line and run as one script in one
-shared scope. A **scenario** load run (many virtual users replaying a
-collection concurrently) compiles each step's `elements` the same way the
-sequential run does (`resolve_step`), but only to answer two questions the
-load path already asked before elements existed - whether a step carries a
-`script.pre` / `script.post` element at all, for the "scripts do not run under
-load" warning and for deciding whether to sample a step's results - **it does
-not run `ElementPipeline`, and no element kind actually executes under
-load**. Wiring the pipeline into that path is issue #1495's job, not #1514's:
-until then, a design send and a sequential (single-VU) collection run are the
-only two places a `script.pre` / `script.post` element, or any other kind,
-actually runs.
+**A single-request `POST /runs` is unchanged, and still joins.** It calls
+neither `refuse_legacy_script_fields` nor the element pipeline: its own
+deferred validation script still reads `tests` (or `postRequestScripts` /
+`postRequestScript`, tried in that order) exactly as before - a list of parts
+joined with a blank line and run as one script in one shared scope. That
+payload shape has no `elements` attachment point at all, so there is nothing
+for `ElementPipeline` to run there.
+
+**A scenario load run's `elements` run inline now (issue #1495), opt-in per
+element.** `submit_one` (the producer, one virtual user at a time) runs
+`step.before` before binding and submitting; the completion runs `step.after`
+once the response is in hand. `extract.*` and `assert.*` always run there. A
+`script.pre` / `script.post` element runs there only when its own
+`config.inline` is `true`, or the run's `elements.scripts` override
+(`"allInline"` / `"allDeferred"`, beside the default `"asMarked"`) forces it
+one way or the other - unmarked, a step's scripts still defer to the post-run
+`tests` replay exactly as before this issue, and the replay itself now skips a
+step whose script already ran inline rather than running it twice.
+
+Every virtual user (VU) gets its own small write layer over the run's shared
+variable scopes (`ScopeOverlay`, on the VU): what one VU's inline
+`extract.*` or `script.*` writes on step 1 is visible to *that VU's* step 2,
+and invisible to every other VU's concurrent step 2 - two VUs sharing one
+name would otherwise read and overwrite each other's state, which is exactly
+the correlation-under-load bug this issue exists to fix. `pm.execution` still
+throws under load (`in_scenario` is `false`): an inline script can write
+state and mutate the request, the same way `script.pre` always could, but it
+cannot redirect the sequence - that stays the deferred replay's own script
+and, eventually, a `control.*` element's job, neither of which runs inline.
+The overlay is cleared at the same iteration boundary `pm.cookies`' per-VU
+jar is, for the same reason: a new iteration is a new user.
+
+See [`elements.md`](elements.md#load-paths) for the full mechanics -
+`ScopeOverlay`, the per-thread `ScriptEngine`, `elements.includeScriptTime`,
+and what is deliberately still unwired (`elements.timers`, the
+single-request path).
 
 ## Error Handling
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -366,13 +366,21 @@ logged as a warning: it means a client skipped composition.
   folds a pre-cutover row's scripts into `elements` first), and
   `preRequestScript` / `postRequestScript` / `tests` are refused wherever
   `elements` is now the only script source. The pipeline runs in the design
-  send and the sequential (single-VU) collection run; a **load** run
-  (`POST /runs` at scale) runs no element yet - that is #1495's job, so a
-  scenario load run still only inspects a step's compiled `elements` to
-  decide what to warn about and what to sample, and its own deferred `tests`
-  script keeps the pre-#1514 joined-parts shape untouched. Do not add
-  another behaviour column beside `elements`; a new behaviour is an element
-  kind.
+  send, the sequential (single-VU) collection run, and - since #1495 - a
+  scenario **load** run's own producer/completion hooks
+  (`scenario_load.cpp`'s `run_step_before` / `run_step_after`): a declarative
+  kind always runs there, and a `script.*` kind runs there only when its own
+  `config.inline` is set or the run's `elements.scripts` override forces it,
+  read through `HotPathClass` rather than a `kind ==` comparison. An
+  un-inlined script stays exactly where it always was, on the deferred
+  `tests` replay, which now skips a step whose script already ran inline
+  (`RunContext::script_element_runs_inline`, the one place that decision is
+  made, shared by both sides). A **single-request** load run
+  (`load_strategy.cpp`) still runs no element - `POST /runs`'s single-request
+  shape has no `elements` attachment point yet, only the legacy `tests`
+  string (`RunContext::test_script`); wiring one is a separate gap, not
+  #1495's. Do not add another behaviour column beside `elements`; a new
+  behaviour is an element kind.
 - **Saved examples are nested under their request** (`/requests/:id/examples`,
   #481): the owner is checked before the example on every path, so an example
   reached through the wrong request is a `404`, and `delete_request` and the
@@ -657,10 +665,16 @@ before the send, in the same words and with the same code compose uses for the
 `ResidualRefusal` carrying the code). The two rules read different reaches
 (#1095): the empty-name rule reads every header name, the collision rule only
 the names that still held a token. A data row whose header-name column is
-blank is refused at bind time (`core/scenario_data.cpp`), because the load
-path runs no residual pass over what it binds - which is also why a value a
-script sets on step 1 never reaches step 2's `{{token}}` under load (#1495 adds
-the pass, with per-user scopes).
+blank is refused at bind time (`core/scenario_data.cpp`). A scenario load
+run's `submit_one` now runs this pass too (#1495), against a per-VU view: the
+run's scopes flattened once (`vayu::http::routes::flatten_variable_scopes`)
+plus that VU's own small write layer (`ScopeOverlay`, on `VirtualUser`), so a
+value one VU's step 1 sets reaches that same VU's step 2 `{{token}}` without
+two VUs' writes ever landing in one shared map. Never refused under load,
+only counted, on the same #1503 rule the load path has always followed: an
+unresolved name or a header-name collision the pass produces goes on the wire
+regardless. The single-request load path (`load_strategy.cpp`) is unchanged -
+see the element-pipeline bullet above for why.
 
 **The renderer's resolver is preview-only.** `useVariableResolver` /
 `app/src/lib/variable-resolution.ts` back tab titles, previews, unresolved-token

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -294,10 +294,25 @@ struct CompiledElement {
  */
 class ElementPipeline {
     public:
+    /**
+     * @param skip_reason Consulted for an otherwise-runnable (enabled,
+     *        phase-matching) element, before `apply` - `nullopt` from it means
+     *        run as usual, a string means report `"skipped"` with that message
+     *        instead of calling `apply` at all. Null (the default, both callers
+     *        before #1495) runs every enabled element unconditionally, exactly
+     *        as before this parameter existed.
+     *
+     *        This is a load run's one hook for "declarative kinds always run
+     *        here; a `script.*` kind runs here only when it opted in" (#1495):
+     *        the load path reads `HotPathClass` off the registry and a
+     *        `script.*` element's own `config.inline`, never a `kind ==`
+     *        comparison, which stays the extensibility contract's rule.
+     */
     static void run (Phase phase,
     ElementContext& ctx,
     const std::vector<CompiledElement>& elements,
-    std::vector<ElementOutcome>& sink);
+    std::vector<ElementOutcome>& sink,
+    const std::function<std::optional<std::string> (const CompiledElement&)>& skip_reason = nullptr);
 };
 
 } // namespace vayu::core

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -134,6 +134,25 @@ const std::function<bool (int64_t)>& should_continue);
 duration_field_ms (const nlohmann::json& config, const std::string& key, int64_t default_ms);
 
 /**
+ * @brief Why a run payload's top-level `elements` override cannot run, or
+ *        `nullopt` if it can (issue #1495).
+ *
+ * `{ timers: "asConfigured" | "off", scripts: "asMarked" | "allInline" |
+ * "allDeferred", includeScriptTime: false }` - every key optional, an unknown
+ * key or an out-of-set value refused by name rather than ignored, the same
+ * `known_scenario_keys` discipline issue #1503 gave the `scenario` block.
+ * Validated for both load-run shapes - the check does not distinguish them -
+ * though only a scenario load run's element pipeline reads what it resolves
+ * to; a single-request payload has no `elements` attachment point yet (see
+ * `docs/engine/elements.md`'s Load paths section). Checked by the route
+ * before the run row exists; `RunContext`'s constructor re-derives the same
+ * three fields from a payload this has already accepted, so it never has to
+ * throw over one this validator would have refused first.
+ */
+[[nodiscard]] std::optional<std::string> validate_elements_run_override (
+const nlohmann::json& config);
+
+/**
  * @brief How long a `constant_rps` tick sleeps before it spins out the rest of
  *        @p remainder_us, in microseconds. 0 means spin the whole remainder.
  *

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -304,6 +304,60 @@ struct RunContext {
     // Test script for deferred validation
     std::string test_script;
 
+    /**
+     * `elements.scripts` (issue #1495), resolved once here from a payload
+     * `validate_elements_run_override` has already accepted: "asMarked"
+     * leaves each `script.*` element's own `config.inline` to decide,
+     * "allInline" / "allDeferred" force every one regardless of its own
+     * marking. Read by the load paths' producer/completion hooks per
+     * element - `extract.*` / `assert.*` / `timer.think` are never affected,
+     * since this key names only the script.* opt-in.
+     */
+    enum class ScriptsOverrideMode : std::uint8_t {
+        AsMarked,
+        AllInline,
+        AllDeferred
+    };
+    ScriptsOverrideMode scripts_override = ScriptsOverrideMode::AsMarked;
+
+    /// `elements.includeScriptTime` (issue #1495): false (the default) times
+    /// a step's own transfer only, excluding whatever an inline script or
+    /// declarative element spent applying; true folds that time back into
+    /// the recorded sample.
+    bool include_script_time = false;
+
+    /// `elements.timers` (issue #1495), stored for #1498's timer family to
+    /// read once it exists. This issue validates the key and stores the
+    /// choice but does not yet wire "off" to suppress `timer.think` under
+    /// load - see `docs/engine/elements.md`'s Load paths section.
+    bool timers_disabled = false;
+
+    /**
+     * Whether a compiled `script.*` element runs inline on a load run's
+     * producer/completion hooks (issue #1495) rather than being left to the
+     * deferred replay: the run's `elements.scripts` override when it forces
+     * one way or the other, else the element's own `config.inline`.
+     *
+     * A free function taking @p element_config directly - never a
+     * `CompiledElement` - so `run_manager.cpp`'s `find_step_post_script` (a
+     * step's own script text, not its outcome) and `scenario_load.cpp`'s
+     * pipeline hooks share one answer without either including the other's
+     * header. Declarative kinds (`extract.*`, `assert.*`, `timer.think`)
+     * always run inline and never call this - a caller gates on
+     * `HotPathClass` itself, since `core/elements` must not know about
+     * `RunContext`.
+     */
+    [[nodiscard]] static bool script_element_runs_inline (const nlohmann::json& element_config,
+    ScriptsOverrideMode scripts_mode) {
+        if (scripts_mode == ScriptsOverrideMode::AllInline) {
+            return true;
+        }
+        if (scripts_mode == ScriptsOverrideMode::AllDeferred) {
+            return false;
+        }
+        return element_config.value ("inline", false);
+    }
+
     // Latency (ms) past which a completion is captured as an outlier, resolved
     // once from the run config. 0 disables outlier capture - a threshold of
     // zero would mark every completion an outlier, which is the same as

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -48,22 +48,36 @@
  * `{{data.*}}` token has an empty template and does no per-iteration work at
  * all.
  *
- * ## Scripts stay deferred, and are keyed per step (issue #450)
+ * ## The element pipeline runs here too, per VU (issue #1495)
  *
- * A step's `pre_script` / `post_script` are not run inline; the run's deferred
- * `validate_scripts` pass keeps its existing discipline, extended only by being
- * keyed per step index rather than per run. A step's `post_script` is replayed
- * after the run against the responses *that step* produced, which is why
- * sampling is per step too: one flat run-wide reservoir would let the hot first
- * step swamp the budget and never sample the last step of a long plan.
- * A `pre_script` still runs nowhere - it would have to run *before* a send this
- * mode never pauses for.
+ * `submit_one` runs `ElementPipeline::run(StepBefore, ...)` plus the residual-
+ * token pass before binding the request, and the completion runs
+ * `ElementPipeline::run(StepAfter, ...)` before `finish_step`. Declarative
+ * kinds (`extract.*`, `assert.*`) always run; a `script.*` kind runs here only
+ * when its own `config.inline` is set or the run's `elements.scripts` override
+ * forces it, read through `HotPathClass` rather than a `kind ==` comparison -
+ * otherwise the step keeps the pre-#1495 behaviour, deferred to
+ * `validate_scripts`' replay after the run, keyed per step index as before. A
+ * VU's writes (`extract.json` into a variable, an inline `script.pre`'s
+ * `pm.environment.set`) land in its own `VirtualUser::scope_overlay`
+ * (`vayu::http::routes::ScopeOverlay`), never the run's shared scopes - two
+ * users writing the same name is exactly the cross-contamination this rule
+ * exists to prevent, on the same reasoning `cookies` above is per-VU. The
+ * overlay is written on the completion path *before* `finish_step` releases
+ * `busy`, so the same acquire/release pairing that makes `cookies` visible to
+ * this VU's next step makes the overlay visible too, with no extra lock.
  *
- * `pm.execution` therefore still throws in a load run (`in_scenario == false`),
- * because a script that has already run against a recorded response cannot
- * redirect a sequence that already happened. Do not smuggle inline scripts in
- * here - the shape, if it is ever wanted, is a bounded pool of QuickJS contexts
- * per worker, and that is its own issue and its own benchmark.
+ * An inline script still cannot redirect the plan (`pm.execution` throws
+ * exactly as before, `in_scenario == false`): flow control only ever comes
+ * from a `control.*` element or the deferred replay's own script, neither of
+ * which exists on this path yet. What changed is only whether `script.pre` /
+ * `script.post` run now or later - each event-loop worker and the strategy
+ * thread get their own `ScriptEngine`
+ * (`vayu::http::routes::script_engine_for_this_thread`), never a pool behind
+ * one mutex, because a run's worker threads are spawned fresh for that run and
+ * joined before it retains - the same lifetime the event loop itself already
+ * relies on - so a thread-local instance is never stale and never shared
+ * across two runs.
  */
 
 #include <atomic>
@@ -73,11 +87,13 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/request_exchange.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::core {
@@ -155,6 +171,28 @@ struct VirtualUser {
      * token-free plan from ever consulting a row.
      */
     std::optional<size_t> data_row;
+    /**
+     * This VU's own write layer over the run's shared variable scopes (issue
+     * #1495): what an inline `extract.*` or `script.*` element wrote on an
+     * earlier step of this same iteration, read by the residual-token pass
+     * before every later step's send. Cleared at the same iteration boundary
+     * `cookies` is - a new iteration is a new user. Written and read under the
+     * same `busy` acquire/release pairing the struct comment describes; no
+     * VU-local lock is needed for the same reason none is needed for
+     * `cookies`.
+     */
+    vayu::http::routes::ScopeOverlay scope_overlay;
+    /**
+     * Steady-clock milliseconds before which `take_ready_vu` will not select
+     * this VU (issue #1495). Plumbing for a `timer.pacing` / gaussian
+     * `timer.think` to schedule a VU's next submission without blocking the
+     * producer thread; nothing writes a value past 0 yet - `timer.think`'s
+     * existing `apply` blocks the calling thread instead and runs only at
+     * `step.between`, which this load path does not invoke, so it is not
+     * reachable here even by accident. See `docs/engine/elements.md`'s Load
+     * paths section.
+     */
+    int64_t ready_at_ms = 0;
     /// In flight (or retired) when true. See the struct comment.
     std::atomic<bool> busy{ false };
     /// Set once the VU may start no further iteration; it then never becomes
@@ -208,14 +246,54 @@ class StepHistograms {
 };
 
 /**
+ * @brief Per-step, per-element pass/fail/skip tallies for a load run's report
+ *        (issue #1495) - `scenario.steps[i].elements[] = { id, kind, passed,
+ *        failed, skipped }`, the load-path sibling of the sequential run's
+ *        per-step `elements` trace.
+ *
+ * Sized once at construction from the plan's already-compiled `elements` per
+ * step, so recording is a lookup by element id into a fixed-size atomic array
+ * - no lock and no allocation on the completion path. `passed` is an `"ok"`
+ * outcome; `failed` folds in `"error"`; `skipped` folds in `"missing"` (no
+ * kind reports it yet) beside `"skipped"` itself - the report answers "did
+ * this run's steps see this element pass", not which of two failure shapes it
+ * was, matching `scenario.steps[i].elements`'s own three-bucket shape from
+ * #1512's Model section.
+ */
+class StepElementTallies {
+    public:
+    explicit StepElementTallies (const ScenarioPlan& plan);
+
+    /// A no-op for a step or an element id this run's plan does not have -
+    /// the pipeline runs no element outside a step's own compiled list, so
+    /// this only guards against a caller passing the wrong step index.
+    void record (size_t step, const std::string& element_id, const std::string& status);
+
+    /// This step's `elements` array, or an empty one for a step with no
+    /// compiled elements or none that ever ran - the same "absent when
+    /// nothing happened" convention `unresolvedTokens` and `tests` follow.
+    [[nodiscard]] nlohmann::json build (const ScenarioPlan& plan, size_t step) const;
+
+    private:
+    struct Counts {
+        std::atomic<size_t> passed{ 0 };
+        std::atomic<size_t> failed{ 0 };
+        std::atomic<size_t> skipped{ 0 };
+    };
+    std::vector<std::vector<Counts>> counts_by_step_;
+    std::vector<std::unordered_map<std::string, size_t>> index_of_id_by_step_;
+};
+
+/**
  * @brief The `steps` array of the run summary's `scenario` object.
  *
  * One entry per plan step, in plan order, carrying the step's identity beside
  * its numbers - a breakdown indexed only by position is unreadable next to a
  * 40-step sequence.
  */
-[[nodiscard]] nlohmann::json
-build_step_breakdown (const ScenarioPlan& plan, const StepHistograms& steps);
+[[nodiscard]] nlohmann::json build_step_breakdown (const ScenarioPlan& plan,
+const StepHistograms& steps,
+const StepElementTallies& elements);
 
 /**
  * @brief Everything a scenario load run accumulates, shared with its callbacks.
@@ -228,12 +306,43 @@ build_step_breakdown (const ScenarioPlan& plan, const StepHistograms& steps);
  * after the drain, not before.
  */
 struct ScenarioLoadState {
-    ScenarioLoadState (size_t step_count, size_t virtual_users, CoverageTally coverage)
-    : steps (step_count), coverage (std::move (coverage)),
+    ScenarioLoadState (const ScenarioPlan& plan,
+    size_t virtual_users,
+    CoverageTally coverage,
+    vayu::http::routes::ScriptVariableScopes base_scopes,
+    vayu::runtime::ScriptConfig script_config)
+    : steps (plan.steps.size ()), element_tallies (plan),
+      base_scopes (std::move (base_scopes)),
+      base_vars (vayu::http::routes::flatten_variable_scopes (this->base_scopes)),
+      script_config (script_config), coverage (std::move (coverage)),
       virtual_users (virtual_users) {
     }
 
     StepHistograms steps;
+    /// Per-step, per-element pass/fail/skip tallies (issue #1495), written by
+    /// the same completion that writes `steps` above - see the class comment.
+    StepElementTallies element_tallies;
+    /**
+     * This run's shared variable scopes (issue #1495) - the same shape and
+     * source a design send's would be, loaded once here rather than per
+     * submission. An inline `script.*` element materializes a per-VU copy of
+     * this through `VirtualUser::scope_overlay` before running; never mutated
+     * directly - a load run's writes are all per-VU, on the overlay, which is
+     * the isolation this issue exists to add.
+     */
+    vayu::http::routes::ScriptVariableScopes base_scopes;
+    /**
+     * @ref base_scopes, flattened once: every submission's residual-token
+     * pass starts from a copy of this map plus its own VU's small
+     * `ScopeOverlay`, rather than re-walking the collection-ancestor chain
+     * per submission the way a design send's single exchange does.
+     */
+    vayu::http::VariableValues base_vars;
+    /// This run's script configuration (timeout, memory, stack, console,
+    /// `pm.sendRequest`), resolved once and handed to
+    /// `vayu::http::routes::script_engine_for_this_thread` by every inline
+    /// `script.*` element - never re-read from `Database` per step.
+    vayu::runtime::ScriptConfig script_config;
     /**
      * Contract coverage (issue #629), written by every completion callback.
      *

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -25,10 +25,12 @@
  * never receives this one's fixes.
  */
 
+#include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "vayu/core/constants.hpp"
@@ -36,6 +38,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/cookie_jar.hpp"
 #include "vayu/http/default_headers.hpp"
+#include "vayu/http/request_composer.hpp"
 #include "vayu/http/transport_policy.hpp"
 #include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
@@ -165,6 +168,22 @@ vayu::runtime::ScriptContext& ctx,
 const std::string& script_type);
 
 /**
+ * The `ScriptEngine` this OS thread uses for a load run's inline scripts
+ * (issue #1495), constructed once per thread on first use rather than shared
+ * behind one pool mutex - each event-loop worker and the strategy thread run
+ * their own inline scripts locally.
+ *
+ * Safe as a thread-local: a load run's worker threads - the strategy thread
+ * and every event-loop worker - are spawned fresh for that run and joined
+ * before it retains (`RunContext::release_execution_resources`), the same
+ * lifetime `docs/engine/architecture.md` already documents for the event loop
+ * itself, so the first call on a thread this run, this config, and no other
+ * run's config is ever observed here.
+ */
+[[nodiscard]] vayu::runtime::ScriptEngine& script_engine_for_this_thread (
+const vayu::runtime::ScriptConfig& config);
+
+/**
  * Point @p ctx's four variable scopes at @p scopes, and nothing else.
  *
  * The leaf collection scope is handed over writable while its ancestors are
@@ -202,6 +221,91 @@ ScriptVariableScopes& scopes,
 vayu::http::CookieJar& jar,
 const std::string& cookie_scope,
 std::vector<vayu::http::CookieWrite>* writes);
+
+/**
+ * A per-virtual-user write layer over a run's shared @ref ScriptVariableScopes
+ * (issue #1495).
+ *
+ * A load run's `script.*` and `extract.*` elements write through
+ * `ElementContext::set_variable` exactly as a design send's do, but the target
+ * they must land in cannot be the run-wide scopes a design send and the
+ * sequential runner mutate directly: a scenario load run's virtual users share
+ * one event loop, and two users writing the same variable name into one
+ * `ScriptVariableScopes` is the cross-contamination this issue exists to stop
+ * (`docs/engine/architecture.md`'s "a VU is a small value" note - cookies are
+ * per-VU for the identical reason). Each VU instead holds one of these: a
+ * handful of overridden names, not a copy of the run's whole variable set -
+ * about 200 bytes per written name, so 1,000 users cost kilobytes, never the
+ * size of the scopes themselves.
+ *
+ * `apply_onto` layers the overlay onto an already-flattened base map (built
+ * once per run by @ref flatten_variable_scopes, never per submission) in the
+ * same precedence `values_from_scopes` gives the run's own scopes -
+ * environment over the collection chain over globals - so a name this VU wrote
+ * reads back exactly as `pm.variables.get` would report it, and a name it
+ * never touched still falls through to the run's shared value.
+ */
+class ScopeOverlay {
+    public:
+    /// Mirrors `set_scope_variable`'s own target selection, so an `extract.*`
+    /// element's `ElementContext::set_variable` call lands in the same slot
+    /// here it would in a design send's shared scopes.
+    void set (std::string_view scope, const std::string& name, const std::string& value);
+
+    /**
+     * After an inline `script.pre` / `script.post` ran against a
+     * `materialize`d copy, replace this VU's overlay wholesale with what the
+     * script left the three writable scopes as.
+     *
+     * A whole-scope replace rather than a diff, and still correct: the copy
+     * the script mutated already started as the run's base scopes with this
+     * VU's *prior* overlay applied, so "what came out" already **is** "base
+     * plus every override this VU has ever made" - storing it back is the
+     * same operation a diff-then-merge would perform, without needing
+     * `Variable`'s equality to find what changed.
+     */
+    void replace_from (const ScriptVariableScopes& scopes);
+
+    [[nodiscard]] bool empty () const {
+        return environment_.empty () && collection_.empty () && globals_.empty ();
+    }
+
+    /// A new iteration is a new user, not the same one logging in twice - the
+    /// same rule `VirtualUser::cookies` follows, cleared at the same boundary.
+    void clear ();
+
+    /// Applied lowest precedence first, so the highest-precedence overlay
+    /// entry a VU wrote is what survives on @p vars - the same order
+    /// `values_from_scopes` built @p vars in to begin with.
+    void apply_onto (vayu::http::VariableValues& vars) const;
+
+    /**
+     * A full `ScriptVariableScopes` an inline script can run against: @p
+     * base's read-only ancestor chain verbatim, and its environment /
+     * collection / globals with this VU's overlay layered on top - the one
+     * place this issue pays a real copy, and only for a step whose
+     * `script.*` element actually opted into running inline.
+     */
+    [[nodiscard]] ScriptVariableScopes materialize (const ScriptVariableScopes& base) const;
+
+    private:
+    vayu::Environment environment_;
+    vayu::Environment collection_;
+    vayu::Environment globals_;
+};
+
+/**
+ * The scopes as one map, with composition's precedence - environment over the
+ * collection chain over globals - so a name resolves in a script exactly as
+ * `pm.variables.get` answers it.
+ *
+ * Exposed for a load run (issue #1495): computed once per run from the base
+ * scopes (never per submission - the ancestor chain walk this performs is not
+ * a cost every virtual user should pay), then merged per-VU with a small
+ * @ref ScopeOverlay by the residual-token overload below.
+ */
+[[nodiscard]] vayu::http::VariableValues flatten_variable_scopes (
+const ScriptVariableScopes& scopes);
 
 /**
  * `extract.*`'s write target (issue #1514), addressed by the schema's
@@ -371,6 +475,21 @@ struct ResidualRefusal {
  */
 [[nodiscard]] std::optional<ResidualRefusal>
 resolve_residual_tokens (vayu::Request& request, const ScriptVariableScopes& scopes);
+
+/**
+ * The same pass, over an already-flattened variable map rather than a
+ * @ref ScriptVariableScopes (issue #1495).
+ *
+ * A load run's per-VU resolution reads this overload directly: the run's base
+ * map is flattened once (@ref flatten_variable_scopes) and a VU's small
+ * @ref ScopeOverlay is merged onto a copy of it per submission, which costs
+ * proportional to what that VU actually wrote rather than to the run's whole
+ * variable set or its collection-ancestor chain. The @p scopes overload above
+ * is now a thin wrapper over this one, so the two can never disagree about
+ * what "resolve" means.
+ */
+[[nodiscard]] std::optional<ResidualRefusal>
+resolve_residual_tokens (vayu::Request& request, const vayu::http::VariableValues& vars);
 
 /**
  * Every `{{name}}` still on @p request, without attempting to resolve any of

--- a/engine/src/core/elements/pipeline.cpp
+++ b/engine/src/core/elements/pipeline.cpp
@@ -79,7 +79,8 @@ const nlohmann::json* ensure_parsed_body (ElementContext& ctx) {
 void ElementPipeline::run (Phase phase,
 ElementContext& ctx,
 const std::vector<CompiledElement>& elements,
-std::vector<ElementOutcome>& sink) {
+std::vector<ElementOutcome>& sink,
+const std::function<std::optional<std::string> (const CompiledElement&)>& skip_reason) {
     for (const auto& compiled : elements) {
         if (!compiled.element || compiled.element->phase () != phase) {
             continue;
@@ -90,9 +91,16 @@ std::vector<ElementOutcome>& sink) {
         ctx.outcome_waited_ms.reset ();
         ctx.outcome_wrote.reset ();
 
+        std::optional<std::string> skipped;
         if (!compiled.enabled) {
+            skipped = "disabled";
+        } else if (skip_reason) {
+            skipped = skip_reason (compiled);
+        }
+
+        if (skipped) {
             ctx.outcome_status  = "skipped";
-            ctx.outcome_message = "disabled";
+            ctx.outcome_message = skipped;
         } else {
             try {
                 compiled.element->apply (ctx);

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -16,6 +16,7 @@
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 
 #include "vayu/core/load_pacing.hpp"
 #include "vayu/core/refill_deficit.hpp"
@@ -279,6 +280,46 @@ int64_t duration_field_ms (const nlohmann::json& config, const std::string& key,
         "(e.g. \"500ms\", \"30s\", \"5m\", \"2h\")");
     }
     return *parsed;
+}
+
+std::optional<std::string> validate_elements_run_override (const nlohmann::json& config) {
+    const auto elements = config.find ("elements");
+    if (elements == config.end () || elements->is_null ()) {
+        return std::nullopt;
+    }
+    if (!elements->is_object ()) {
+        return "'elements' must be an object";
+    }
+
+    static const std::unordered_set<std::string> known_keys = { "timers",
+        "scripts", "includeScriptTime" };
+    for (const auto& [key, value] : elements->items ()) {
+        (void)value;
+        if (!known_keys.contains (key)) {
+            return "'elements." + key +
+            "' is not a known field - expected one of timers, scripts, "
+            "includeScriptTime";
+        }
+    }
+
+    if (auto timers = elements->find ("timers"); timers != elements->end ()) {
+        if (!timers->is_string () || (*timers != "asConfigured" && *timers != "off")) {
+            return "'elements.timers' must be 'asConfigured' or 'off'";
+        }
+    }
+    if (auto scripts = elements->find ("scripts"); scripts != elements->end ()) {
+        if (!scripts->is_string () ||
+        (*scripts != "asMarked" && *scripts != "allInline" && *scripts != "allDeferred")) {
+            return "'elements.scripts' must be 'asMarked', 'allInline' or "
+                   "'allDeferred'";
+        }
+    }
+    if (auto include_time = elements->find ("includeScriptTime");
+    include_time != elements->end () && !include_time->is_boolean ()) {
+        return "'elements.includeScriptTime' must be a boolean";
+    }
+
+    return std::nullopt;
 }
 
 namespace {

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -290,13 +290,19 @@ std::optional<vayu::db::Request>& linked_request) {
  * this call - the plan owns it for the run's whole life - so a `const
  * std::string*` needs no copy.
  */
-const std::string* find_step_post_script (const ScenarioStep& step) {
+const std::string* find_step_post_script (const ScenarioStep& step,
+RunContext::ScriptsOverrideMode scripts_mode) {
     if (!step.elements) {
         return nullptr;
     }
     for (const auto& element : *step.elements) {
         if (element.kind != "script.post") {
             continue;
+        }
+        // Already ran inline this run (issue #1495) - the pipeline hook
+        // already reported its outcome, so there is nothing left to replay.
+        if (RunContext::script_element_runs_inline (element.config, scripts_mode)) {
+            return nullptr;
         }
         if (auto found = element.config.find ("script");
         found != element.config.end () && found->is_string ()) {
@@ -332,7 +338,8 @@ std::vector<std::string>& failure_messages) {
     for (size_t i = 0; i < steps; ++i) {
         const auto& step = plan.steps[i];
         const auto& samples = context->metrics_collector->step_response_samples (i);
-        const std::string* post_script = find_step_post_script (step);
+        const std::string* post_script =
+        find_step_post_script (step, context->scripts_override);
         // A step with no script, or one whose script never got a sample to
         // run against, reports nothing rather than a row of zeros - the
         // same distinction the whole-run section has always kept.
@@ -750,6 +757,22 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
     // own; before that, a collection-level assertion was silently never
     // checked.
     test_script = vayu::http::read_post_request_script (config);
+
+    // Resolved from a payload `validate_elements_run_override` has already
+    // accepted (the route checks before the run row exists), so a value
+    // outside the known set here falls back to the default rather than
+    // throwing - there is no rejection left to make this late.
+    if (auto elements = config.find ("elements");
+    elements != config.end () && elements->is_object ()) {
+        const std::string scripts = elements->value ("scripts", std::string{});
+        if (scripts == "allInline") {
+            scripts_override = ScriptsOverrideMode::AllInline;
+        } else if (scripts == "allDeferred") {
+            scripts_override = ScriptsOverrideMode::AllDeferred;
+        }
+        include_script_time = elements->value ("includeScriptTime", false);
+        timers_disabled = elements->value ("timers", std::string{}) == "off";
+    }
 
     metrics_collector = std::make_unique<MetricsCollector> (id, mc_config);
 }

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -8,6 +8,7 @@
 #include "vayu/core/scenario_load.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -15,11 +16,13 @@
 #include <vector>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/elements.hpp"
 #include "vayu/core/load_pacing.hpp"
 #include "vayu/core/load_strategy.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/scenario_data.hpp"
 #include "vayu/http/request_exchange.hpp"
+#include "vayu/http/script_parts.hpp"
 #include "vayu/utils/logger.hpp"
 
 namespace vayu::core {
@@ -35,6 +38,15 @@ double requested_rps (const nlohmann::json& config) {
         rps = config.value ("targetRps", 0.0);
     }
     return rps;
+}
+
+/// Steady-clock milliseconds, the same clock `take_ready_vu`'s `ready_at_ms`
+/// check and `timer.think`'s own wait are measured against - never
+/// `system_clock`, which can step backwards under a load run's wall time.
+int64_t steady_now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now ().time_since_epoch ())
+    .count ();
 }
 
 } // namespace
@@ -186,7 +198,68 @@ MetricsCollector::Percentiles StepHistograms::percentiles (size_t step) const {
     return p;
 }
 
-nlohmann::json build_step_breakdown (const ScenarioPlan& plan, const StepHistograms& steps) {
+StepElementTallies::StepElementTallies (const ScenarioPlan& plan) {
+    counts_by_step_.reserve (plan.steps.size ());
+    index_of_id_by_step_.reserve (plan.steps.size ());
+    for (const auto& step : plan.steps) {
+        std::unordered_map<std::string, size_t> index_of_id;
+        size_t element_count = 0;
+        if (step.elements) {
+            element_count = step.elements->size ();
+            index_of_id.reserve (element_count);
+            for (size_t i = 0; i < element_count; ++i) {
+                index_of_id[(*step.elements)[i].id] = i;
+            }
+        }
+        counts_by_step_.emplace_back (element_count);
+        index_of_id_by_step_.push_back (std::move (index_of_id));
+    }
+}
+
+void StepElementTallies::record (size_t step,
+const std::string& element_id,
+const std::string& status) {
+    if (step >= index_of_id_by_step_.size ()) {
+        return;
+    }
+    const auto found = index_of_id_by_step_[step].find (element_id);
+    if (found == index_of_id_by_step_[step].end ()) {
+        return;
+    }
+    Counts& counts = counts_by_step_[step][found->second];
+    if (status == "ok") {
+        counts.passed.fetch_add (1, std::memory_order_relaxed);
+    } else if (status == "failed" || status == "error") {
+        counts.failed.fetch_add (1, std::memory_order_relaxed);
+    } else { // "skipped" | "missing"
+        counts.skipped.fetch_add (1, std::memory_order_relaxed);
+    }
+}
+
+nlohmann::json StepElementTallies::build (const ScenarioPlan& plan, size_t step) const {
+    nlohmann::json array = nlohmann::json::array ();
+    if (step >= counts_by_step_.size () || !plan.steps[step].elements) {
+        return array;
+    }
+    const auto& elements = *plan.steps[step].elements;
+    const auto& counts   = counts_by_step_[step];
+    const size_t count   = std::min (elements.size (), counts.size ());
+    for (size_t i = 0; i < count; ++i) {
+        const size_t passed = counts[i].passed.load (std::memory_order_relaxed);
+        const size_t failed = counts[i].failed.load (std::memory_order_relaxed);
+        const size_t skipped = counts[i].skipped.load (std::memory_order_relaxed);
+        if (passed + failed + skipped == 0) {
+            continue; // never ran under this run - omitted, not a row of zeros
+        }
+        array.push_back ({ { "id", elements[i].id }, { "kind", elements[i].kind },
+        { "passed", passed }, { "failed", failed }, { "skipped", skipped } });
+    }
+    return array;
+}
+
+nlohmann::json build_step_breakdown (const ScenarioPlan& plan,
+const StepHistograms& steps,
+const StepElementTallies& elements) {
     nlohmann::json array = nlohmann::json::array ();
     const size_t count   = std::min (plan.steps.size (), steps.step_count ());
     for (size_t i = 0; i < count; ++i) {
@@ -205,11 +278,26 @@ nlohmann::json build_step_breakdown (const ScenarioPlan& plan, const StepHistogr
               { { "min", percentiles.min }, { "p50", percentiles.p50 },
               { "p95", percentiles.p95 }, { "p99", percentiles.p99 },
               { "max", percentiles.max } } } };
-        // A load run never executes a pre-request script (see this file's
-        // header comment); a step that carries one always reports it skipped
-        // rather than leaving the report silent about it.
-        if (step_has_script (plan.steps[i], "script.pre")) {
+        auto element_outcomes  = elements.build (plan, i);
+        // Whether this step's `script.pre` actually ran this run - inline,
+        // through the hook below - rather than being left to the deferred
+        // replay: a real outcome in `elements` above, not just the pipeline's
+        // own "skipped, deferred" tally. Kept as the field's pre-#1495
+        // meaning for a step that is still deferred, so a reader who only
+        // knew this key keeps reading the same thing; a step that ran inline
+        // reports its real outcome in `elements` instead of this fixed
+        // string, which would otherwise contradict it.
+        const bool pre_script_ran_inline = std::any_of (element_outcomes.begin (),
+        element_outcomes.end (), [] (const nlohmann::json& outcome) {
+            return outcome.value ("kind", "") == "script.pre" &&
+            (outcome.value ("passed", size_t{ 0 }) > 0 ||
+            outcome.value ("failed", size_t{ 0 }) > 0);
+        });
+        if (step_has_script (plan.steps[i], "script.pre") && !pre_script_ran_inline) {
             entry["preRequestScript"] = "skipped";
+        }
+        if (!element_outcomes.empty ()) {
+            entry["elements"] = std::move (element_outcomes);
         }
         array.push_back (std::move (entry));
     }
@@ -230,7 +318,7 @@ const ScenarioPlan& plan) {
         // This mode's own.
         { "virtual_users", state.virtual_users },
         { "iterations_abandoned", state.iterations_abandoned.load (std::memory_order_relaxed) },
-        { "steps", build_step_breakdown (plan, state.steps) }
+        { "steps", build_step_breakdown (plan, state.steps, state.element_tallies) }
     };
 }
 
@@ -251,6 +339,188 @@ nlohmann::json build_scenario_load_coverage (const ScenarioLoadState& state) {
  * `busy` edge - and the ownership rules are only statable where they sit
  * together.
  */
+namespace {
+
+/**
+ * Skip a compiled element under a load run's inline-vs-deferred rule (#1495):
+ * a declarative kind always runs; a `script.*` kind runs only when its own
+ * `config.inline` is set or the run's `elements.scripts` override forces it.
+ * Read through `HotPathClass`, never a `kind ==` comparison, so #1512's
+ * extensibility contract (rule 1) holds outside `core/elements`.
+ */
+std::optional<std::string> load_pipeline_skip_reason (const vayu::core::CompiledElement& element,
+RunContext::ScriptsOverrideMode scripts_mode) {
+    const auto* kind = vayu::core::Registry::instance ().find (element.kind);
+    if (kind == nullptr || kind->hot_path != vayu::core::HotPathClass::Script) {
+        return std::nullopt; // declarative - always runs here
+    }
+    if (scripts_mode == RunContext::ScriptsOverrideMode::AllInline) {
+        return std::nullopt;
+    }
+    if (scripts_mode == RunContext::ScriptsOverrideMode::AllDeferred ||
+    !element.config.value ("inline", false)) {
+        return "deferred to the run's post-run replay";
+    }
+    return std::nullopt;
+}
+
+/// This step's `id`-less request identity, for `pm.info` inside an inline
+/// script - the same fields `execute_exchange`'s own `bind` lambda sets.
+void bind_step_identity (vayu::runtime::ScriptContext& ctx,
+const ScenarioStep& step,
+size_t iteration,
+size_t vu_index) {
+    ctx.request_id = step.request_id.empty () ?
+    std::nullopt :
+    std::optional<std::string> (step.request_id);
+    ctx.request_name =
+    step.name.empty () ? std::nullopt : std::optional<std::string> (step.name);
+    ctx.iteration = iteration;
+    ctx.vu        = vu_index;
+}
+
+/**
+ * Runs this step's `step.before` elements - the residual-token pass is the
+ * caller's, since it is not gated on whether the step carries any elements at
+ * all - for one VU's submission, mutating @p request with whatever an inline
+ * `extract.*` or `script.pre` wrote and tallying every outcome.
+ *
+ * @return elapsed milliseconds spent in the pipeline, or 0 when the run does
+ *         not ask to fold that time back into the recorded latency
+ *         (`elements.includeScriptTime`) - the ordinary case, where this is
+ *         one branch and a clock read cheaper than paid.
+ */
+int64_t run_step_before (const std::shared_ptr<RunContext>& context,
+ScenarioLoadState& state,
+VirtualUser& vu,
+const ScenarioStep& step,
+size_t step_index,
+size_t iteration,
+size_t vu_index,
+vayu::Request& request) {
+    if (!step.elements || step.elements->empty ()) {
+        return 0;
+    }
+    const auto start = context->include_script_time ?
+    std::optional (std::chrono::steady_clock::now ()) :
+    std::nullopt;
+
+    std::vector<vayu::core::ElementOutcome> outcomes;
+    vayu::ScriptResult pre_result;
+    vayu::ScriptResult unused_post_result;
+    vayu::core::ElementContext ctx{
+        .request  = request,
+        .response = nullptr,
+        .run_pre_script =
+        [&] (const std::string& script) {
+            auto& engine =
+            vayu::http::routes::script_engine_for_this_thread (state.script_config);
+            auto scopes = vu.scope_overlay.materialize (state.base_scopes);
+            auto script_ctx = vayu::runtime::ScriptContext::for_prerequest (request);
+            vayu::http::routes::bind_variable_scopes (script_ctx, scopes);
+            bind_step_identity (script_ctx, step, iteration, vu_index);
+            auto result = vayu::http::routes::execute_script (
+            engine, script, script_ctx, "Pre-request");
+            vu.scope_overlay.replace_from (scopes);
+            return result;
+        },
+        .run_post_script    = nullptr,
+        .pre_script_result  = pre_result,
+        .post_script_result = unused_post_result,
+        .set_variable =
+        [&] (std::string_view scope, const std::string& name,
+        const std::string& value) { vu.scope_overlay.set (scope, name, value); },
+        .should_stop = nullptr,
+    };
+
+    vayu::core::ElementPipeline::run (vayu::core::Phase::StepBefore, ctx,
+    *step.elements, outcomes, [&context] (const vayu::core::CompiledElement& element) {
+        return load_pipeline_skip_reason (element, context->scripts_override);
+    });
+    for (const auto& outcome : outcomes) {
+        state.element_tallies.record (step_index, outcome.id, outcome.status);
+    }
+
+    if (!start) {
+        return 0;
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - *start)
+    .count ();
+}
+
+/**
+ * Runs this step's `step.after` elements for one VU's completed submission,
+ * writing anything an inline `extract.*` or `script.post` produced into
+ * @p vu's overlay before the caller retires or advances it.
+ *
+ * @param response Read-only by contract (see `ElementContext::response`'s own
+ *        comment); the `const_cast` exists because the completion callback
+ *        only ever holds a `const Response&` off `Result::value()`, and
+ *        copying a response to avoid it would pay for the body twice.
+ * @return elapsed milliseconds, on the same terms @ref run_step_before returns
+ *         them.
+ */
+int64_t run_step_after (const std::shared_ptr<RunContext>& context,
+ScenarioLoadState& state,
+VirtualUser& vu,
+const ScenarioStep& step,
+size_t step_index,
+vayu::Request& request,
+const vayu::Response& response) {
+    if (!step.elements || step.elements->empty ()) {
+        return 0;
+    }
+    const auto start = context->include_script_time ?
+    std::optional (std::chrono::steady_clock::now ()) :
+    std::nullopt;
+
+    std::vector<vayu::core::ElementOutcome> outcomes;
+    vayu::ScriptResult unused_pre_result;
+    vayu::ScriptResult post_result;
+    vayu::core::ElementContext ctx{
+        .request = request,
+        .response = const_cast<vayu::Response*> (&response), // NOLINT(cppcoreguidelines-pro-type-const-cast)
+        .run_pre_script = nullptr,
+        .run_post_script =
+        [&] (const std::string& script) {
+            auto& engine =
+            vayu::http::routes::script_engine_for_this_thread (state.script_config);
+            auto scopes = vu.scope_overlay.materialize (state.base_scopes);
+            auto script_ctx = vayu::runtime::ScriptContext::for_test (request, response);
+            vayu::http::routes::bind_variable_scopes (script_ctx, scopes);
+            bind_step_identity (script_ctx, step, vu.iteration, vu.index);
+            auto result = vayu::http::routes::execute_script (
+            engine, script, script_ctx, "Post-request");
+            vu.scope_overlay.replace_from (scopes);
+            return result;
+        },
+        .pre_script_result  = unused_pre_result,
+        .post_script_result = post_result,
+        .set_variable =
+        [&] (std::string_view scope, const std::string& name,
+        const std::string& value) { vu.scope_overlay.set (scope, name, value); },
+        .should_stop = nullptr,
+    };
+
+    vayu::core::ElementPipeline::run (vayu::core::Phase::StepAfter, ctx, *step.elements,
+    outcomes, [&context] (const vayu::core::CompiledElement& element) {
+        return load_pipeline_skip_reason (element, context->scripts_override);
+    });
+    for (const auto& outcome : outcomes) {
+        state.element_tallies.record (step_index, outcome.id, outcome.status);
+    }
+
+    if (!start) {
+        return 0;
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - *start)
+    .count ();
+}
+
+} // namespace
+
 class ScenarioLoadDriver {
     public:
     ScenarioLoadDriver (const std::shared_ptr<RunContext>& context,
@@ -321,34 +591,85 @@ class ScenarioLoadDriver {
             }
         }
 
-        // Whatever composition and the bind above left unresolved goes on the
-        // wire regardless (issue #1503): this mode runs no residual pass, so
-        // the request is sent as it stands and the mistake is only counted,
-        // never refused - a literal `{{` can be deliberate in a body.
-        if (auto names = vayu::http::routes::unresolved_token_names (request);
-        !names.empty ()) {
-            state_->steps.record_unresolved_token (step_index);
-            context_->metrics_collector->record_unresolved_token (names);
+        // The element pipeline's `step.before` phase, then the residual pass
+        // over what it (and the bind above) left unresolved (issue #1495) -
+        // against this VU's own scope, so a token an earlier step's inline
+        // `extract.*` wrote for this VU resolves here. Never refused, only
+        // counted: the load path's rule since #1503 is "send it regardless",
+        // which this keeps - a real resolution attempt now runs first, but a
+        // name still unanswered, or a header-name collision the attempt
+        // itself produced, is exactly as survivable as one composition alone
+        // left behind.
+        const int64_t pipeline_before_ms = run_step_before (
+        context_, *state_, *vu, step, step_index, iteration, vu_index, request);
+        {
+            vayu::http::VariableValues vars = state_->base_vars;
+            vu->scope_overlay.apply_onto (vars);
+            const auto refusal =
+            vayu::http::routes::resolve_residual_tokens (request, vars);
+            auto still_unresolved = vayu::http::routes::unresolved_token_names (request);
+            if (refusal || !still_unresolved.empty ()) {
+                state_->steps.record_unresolved_token (step_index);
+                context_->metrics_collector->record_unresolved_token (refusal ?
+                std::vector<std::string>{ refusal->error.message } :
+                std::move (still_unresolved));
+            }
         }
 
+        // `step.after` needs the sent request back (declarative kinds may
+        // read `ctx.request`, e.g. a URL a `metric.record` names), which the
+        // event loop's own copy is not - `EventLoop::submit` copies @p request
+        // for the transfer but does not hand that copy back to the completion.
+        // Held only for a step that actually carries elements, so a
+        // token-free, element-free plan still pays no copy per iteration.
+        std::shared_ptr<vayu::Request> sent_request =
+        step.elements && !step.elements->empty () ?
+        std::make_shared<vayu::Request> (request) :
+        nullptr;
+
+        // `step`'s address is stable for the run's whole life: the plan is
+        // immutable, const data shared by the run's context.
+        const ScenarioStep* step_ptr = &step;
         context_->event_loop->submit (request,
-        [context = context_, &db = db_, state = state_,
+        [context = context_, &db = db_, state = state_, step_ptr,
         step_count = execution_.plan.steps.size (), vu, step_index, iteration,
-        vu_index, row] (size_t, const vayu::Result<vayu::Response>& result) {
-            const bool errored = result.is_error () || result.value ().has_error ();
+        vu_index, row, pipeline_before_ms,
+        sent_request] (size_t, const vayu::Result<vayu::Response>& result) {
+            if (result.is_error ()) {
+                // No `Response` object exists at all - nothing for `step.after`
+                // to run against, exactly as before #1495. Coverage still
+                // counts it: a transport error is a request this operation
+                // was sent and did not answer, reported as status 0 rather
+                // than a status the server never sent (issue #629).
+                state->coverage.record (step_index, 0);
+                finish_step (state, step_count, vu, step_index, /*errored=*/true, nullptr);
+                handle_result (context, db, result,
+                ResultAnnotations{ row, step_index, iteration, vu_index });
+                return;
+            }
+
+            const vayu::Response& response = result.value ();
+            int64_t pipeline_after_ms      = 0;
+            if (sent_request) {
+                pipeline_after_ms = run_step_after (context, *state, *vu,
+                *step_ptr, step_index, *sent_request, response);
+            }
+
+            const bool errored = response.has_error ();
             if (!errored) {
-                state->steps.record (step_index, result.value ().timing.total_ms);
+                const double latency_ms = context->include_script_time ?
+                response.timing.total_ms +
+                static_cast<double> (pipeline_before_ms + pipeline_after_ms) :
+                response.timing.total_ms;
+                state->steps.record (step_index, latency_ms);
             }
             // Every completion, including the failed ones: a transport error is
             // a request this operation was sent and did not answer, and coverage
             // that counted only successes would report the send as if it never
-            // happened. `is_error()` is the no-response case, which records as
-            // status 0 and is reported as a transport error rather than a
-            // status the server never sent (issue #629).
-            state->coverage.record (
-            step_index, result.is_error () ? 0 : result.value ().status_code);
+            // happened.
+            state->coverage.record (step_index, response.status_code);
             finish_step (state, step_count, vu, step_index, errored,
-            errored ? nullptr : &result.value ().cookie_lines);
+            errored ? nullptr : &response.cookie_lines);
             handle_result (context, db, result,
             ResultAnnotations{ row, step_index, iteration, vu_index });
         });
@@ -371,8 +692,16 @@ class ScenarioLoadDriver {
                 continue;
             }
             // Acquire pairs with the completion's release store, so the step,
-            // iteration and cookies this VU was left with are visible here.
+            // iteration, cookies and scope overlay this VU was left with are
+            // visible here.
             if (vu.busy.load (std::memory_order_acquire)) {
+                continue;
+            }
+            // Plumbing for a scheduled wait (#1498's `timer.pacing` / gaussian
+            // `timer.think`) - nothing writes past 0 yet, so this is a no-op
+            // for every run today. Read after the acquire above for the same
+            // reason `step` and `iteration` are.
+            if (vu.ready_at_ms > 0 && vu.ready_at_ms > steady_now_ms ()) {
                 continue;
             }
             if (vu.step == 0) {
@@ -436,6 +765,7 @@ class ScenarioLoadDriver {
             // Empty at the start of each iteration: a new iteration is a
             // new user, not the same one logging in twice.
             vu->cookies.clear ();
+            vu->scope_overlay.clear ();
         } else {
             vu->step = step_index + 1;
             // Replace, never merge - the captured list is the whole jar the
@@ -499,8 +829,31 @@ const ScenarioExecution& execution) {
     std::max<size_t> (1, static_cast<size_t> (config.value ("iterations", 1000))) :
     0;
 
-    auto state = std::make_shared<ScenarioLoadState> (
-    step_count, vu_count, make_coverage_tally (execution));
+    // The run's shared variable scopes (issue #1495), loaded once here on the
+    // same terms `validate_scripts`' replay already loads them for this same
+    // run: the collection being run, since a scenario has no single request
+    // row to derive one from.
+    std::optional<std::string> environment_id;
+    if (auto it = config.find ("environmentId");
+    it != config.end () && it->is_string () && !it->get<std::string> ().empty ()) {
+        environment_id = it->get<std::string> ();
+    }
+    auto base_scopes = vayu::http::routes::load_script_variable_scopes (
+    db, environment_id, execution.request.collection_id);
+
+    vayu::runtime::ScriptConfig script_config;
+    script_config.timeout_ms = static_cast<uint64_t> (
+    db.get_config_int ("scriptTimeout", constants::script_engine::TIMEOUT_MS));
+    script_config.memory_limit = static_cast<size_t> (
+    db.get_config_int ("scriptMemoryLimit", constants::script_engine::MEMORY_LIMIT));
+    script_config.stack_size = static_cast<size_t> (
+    db.get_config_int ("scriptStackSize", constants::script_engine::STACK_SIZE));
+    script_config.enable_console = db.get_config_bool (
+    "scriptEnableConsole", constants::script_engine::ENABLE_CONSOLE);
+    script_config.allow_send_request = vayu::http::read_allow_script_requests (config);
+
+    auto state            = std::make_shared<ScenarioLoadState> (plan, vu_count,
+               make_coverage_tally (execution), std::move (base_scopes), script_config);
     state->data_row_count = execution.data_rows.size ();
     state->vus.reserve (vu_count);
     for (size_t i = 0; i < vu_count; ++i) {

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -334,6 +334,13 @@ const std::string& script_type) {
     return result;
 }
 
+vayu::runtime::ScriptEngine& script_engine_for_this_thread (
+const vayu::runtime::ScriptConfig& config) {
+    thread_local std::unique_ptr<vayu::runtime::ScriptEngine> engine =
+    std::make_unique<vayu::runtime::ScriptEngine> (config);
+    return *engine;
+}
+
 void bind_variable_scopes (vayu::runtime::ScriptContext& ctx, ScriptVariableScopes& scopes) {
     ctx.environment         = &scopes.environment;
     ctx.globals             = &scopes.globals;
@@ -484,8 +491,12 @@ vayu::http::VariableValues values_from_scopes (const ScriptVariableScopes& scope
 
 } // namespace
 
+vayu::http::VariableValues flatten_variable_scopes (const ScriptVariableScopes& scopes) {
+    return values_from_scopes (scopes);
+}
+
 std::optional<ResidualRefusal> resolve_residual_tokens (vayu::Request& request,
-const ScriptVariableScopes& scopes) {
+const vayu::http::VariableValues& vars) {
     auto targets             = resolvable_strings (request);
     const bool anything_left = a_header_name_needs_reading (request.headers) ||
     std::any_of (targets.begin (), targets.end (),
@@ -494,7 +505,6 @@ const ScriptVariableScopes& scopes) {
         return std::nullopt; // composition answered everything - the ordinary case
     }
 
-    const auto vars = values_from_scopes (scopes);
     for (std::string* text : targets) {
         if (holds_a_token (*text)) {
             *text = vayu::http::resolve_template (*text, vars);
@@ -511,6 +521,67 @@ const ScriptVariableScopes& scopes) {
         return refusal;
     }
     return std::nullopt;
+}
+
+std::optional<ResidualRefusal> resolve_residual_tokens (vayu::Request& request,
+const ScriptVariableScopes& scopes) {
+    return resolve_residual_tokens (request, values_from_scopes (scopes));
+}
+
+void ScopeOverlay::set (std::string_view scope, const std::string& name, const std::string& value) {
+    vayu::Environment* target = &collection_;
+    if (scope == "env") {
+        target = &environment_;
+    } else if (scope == "globals") {
+        target = &globals_;
+    }
+    vayu::Variable variable;
+    variable.value  = value;
+    (*target)[name] = variable;
+}
+
+void ScopeOverlay::replace_from (const ScriptVariableScopes& scopes) {
+    environment_ = scopes.environment;
+    collection_  = scopes.collection;
+    globals_     = scopes.globals;
+}
+
+void ScopeOverlay::clear () {
+    environment_.clear ();
+    collection_.clear ();
+    globals_.clear ();
+}
+
+void ScopeOverlay::apply_onto (vayu::http::VariableValues& vars) const {
+    // Lowest precedence first, so environment - highest, matching
+    // `values_from_scopes`'s own order - is applied last and wins.
+    for (const auto& [name, variable] : globals_) {
+        vars[name] = variable.value;
+    }
+    for (const auto& [name, variable] : collection_) {
+        vars[name] = variable.value;
+    }
+    for (const auto& [name, variable] : environment_) {
+        vars[name] = variable.value;
+    }
+}
+
+ScriptVariableScopes ScopeOverlay::materialize (const ScriptVariableScopes& base) const {
+    ScriptVariableScopes scopes;
+    scopes.collection_ancestors = base.collection_ancestors; // read-only, never overlaid
+    scopes.environment = base.environment;
+    scopes.collection  = base.collection;
+    scopes.globals     = base.globals;
+    for (const auto& [name, variable] : environment_) {
+        scopes.environment[name] = variable;
+    }
+    for (const auto& [name, variable] : collection_) {
+        scopes.collection[name] = variable;
+    }
+    for (const auto& [name, variable] : globals_) {
+        scopes.globals[name] = variable;
+    }
+    return scopes;
 }
 
 std::vector<std::string> unresolved_token_names (vayu::Request& request) {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1820,6 +1820,16 @@ validate_load_request (RouteContext& ctx, nlohmann::json& json, bool is_scenario
         }
     }
 
+    // The `elements` override (issue #1495) is validated for both load-run
+    // shapes, not only a scenario's - the validator does not distinguish
+    // them, and a single-request payload has no `elements` attachment point
+    // to apply it to yet (see `docs/engine/elements.md`'s Load paths
+    // section), so this accepts the key there without it doing anything.
+    if (auto invalid = vayu::core::validate_elements_run_override (json)) {
+        vayu::utils::log_warning ("POST /runs - Invalid elements override: " + *invalid);
+        return RouteError{ 400, error_body (400, *invalid, "invalid_run_config") };
+    }
+
     // Validate required fields
     if (!is_scenario) {
         if (!json.contains ("method") || !json.contains ("url")) {

--- a/engine/tests/residual_token_test.cpp
+++ b/engine/tests/residual_token_test.cpp
@@ -455,6 +455,109 @@ TEST (ResidualTokens, ARequestWithNeitherATokenNorAnEmptyNameIsUntouched) {
     EXPECT_EQ (request.url, before.url);
 }
 
+// --- the load path's per-VU overlay (issue #1495) ----------------------------
+//
+// `ScopeOverlay` is what makes `resolve_residual_tokens` safe to call once per
+// VU per submission instead of once per run: a VU's writes land here, never on
+// the run's shared scopes, and `apply_onto` merges them onto a *copy* of the
+// flattened run map at the same precedence the run's own scopes carry.
+
+using vayu::http::routes::flatten_variable_scopes;
+using vayu::http::routes::ScopeOverlay;
+
+TEST (ScopeOverlayTest, AnUnwrittenOverlayChangesNothing) {
+    ScopeOverlay overlay;
+    EXPECT_TRUE (overlay.empty ());
+
+    auto vars = flatten_variable_scopes (environment_with ("token", "base"));
+    overlay.apply_onto (vars);
+    EXPECT_EQ (vars["token"], "base");
+}
+
+TEST (ScopeOverlayTest, AWrittenNameShadowsTheRunsOwnValueForThisVuAlone) {
+    ScopeOverlay overlay;
+    overlay.set ("env", "token", "vu-own");
+    EXPECT_FALSE (overlay.empty ());
+
+    auto vars = flatten_variable_scopes (environment_with ("token", "base"));
+    overlay.apply_onto (vars);
+    EXPECT_EQ (vars["token"], "vu-own");
+
+    // The base map itself is untouched - a second VU merging the same base
+    // must still see "base", never this VU's write.
+    auto other_vars = flatten_variable_scopes (environment_with ("token", "base"));
+    EXPECT_EQ (other_vars["token"], "base");
+}
+
+// `set`'s scope selection mirrors `set_scope_variable`'s: "env" / "globals"
+// name their own slot, anything else (including "collection") is the leaf
+// collection scope - and `apply_onto`'s precedence is environment over
+// collection over globals, the same order `values_from_scopes` builds the
+// base map in. Mutation check: apply the three scopes in a different order
+// and this reds.
+TEST (ScopeOverlayTest, ThreeScopesResolveInCompositionsPrecedenceOrder) {
+    ScopeOverlay overlay;
+    overlay.set ("globals", "name", "from-globals");
+    overlay.set ("collection", "name", "from-collection");
+    auto vars = flatten_variable_scopes ({});
+    overlay.apply_onto (vars);
+    EXPECT_EQ (vars["name"], "from-collection");
+
+    overlay.set ("env", "name", "from-env");
+    vars = flatten_variable_scopes ({});
+    overlay.apply_onto (vars);
+    EXPECT_EQ (vars["name"], "from-env");
+}
+
+TEST (ScopeOverlayTest, ClearRemovesEveryWrittenName) {
+    ScopeOverlay overlay;
+    overlay.set ("env", "a", "1");
+    overlay.set ("collection", "b", "2");
+    overlay.set ("globals", "c", "3");
+    overlay.clear ();
+    EXPECT_TRUE (overlay.empty ());
+}
+
+// `materialize` is the one place this issue pays a real copy - only reached
+// when an inline script needs a mutable `Environment&` to run against, never
+// on the residual-token pass's own hot path.
+TEST (ScopeOverlayTest, MaterializeLayersTheOverlayOntoARealCopyOfTheBaseScopes) {
+    ScriptVariableScopes base = environment_with ("token", "base");
+    base.collection["kept"]   = value_of ("still-here");
+
+    ScopeOverlay overlay;
+    overlay.set ("env", "token", "written");
+    auto materialized = overlay.materialize (base);
+
+    EXPECT_EQ (materialized.environment["token"].value, "written");
+    EXPECT_EQ (materialized.collection["kept"].value, "still-here")
+    << "an untouched scope must survive materialization unchanged";
+    // The base itself must not have been mutated by materializing a copy of
+    // it - the whole point of the overlay is that a VU's write never reaches
+    // the scopes another VU's concurrent submission reads.
+    EXPECT_FALSE (base.environment.contains ("token") &&
+    base.environment.at ("token").value == "written");
+}
+
+// `replace_from` is how an inline script's result becomes this VU's overlay
+// going forward: whatever the script left the materialized copy as, not a
+// diff against what it started with - correct because the copy it mutated
+// already started as base-plus-this-VU's-prior-overlay.
+TEST (ScopeOverlayTest, ReplaceFromAdoptsWhateverTheMaterializedCopyEndedAs) {
+    ScopeOverlay overlay;
+    overlay.set ("env", "keep", "first-write");
+
+    ScriptVariableScopes mutated;
+    mutated.environment["keep"] = value_of ("first-write"); // unchanged by the script
+    mutated.environment["new_name"] = value_of ("second-write"); // the script's own write
+    overlay.replace_from (mutated);
+
+    auto vars = flatten_variable_scopes ({});
+    overlay.apply_onto (vars);
+    EXPECT_EQ (vars["keep"], "first-write");
+    EXPECT_EQ (vars["new_name"], "second-write");
+}
+
 // --- the exchange, on the wire -----------------------------------------------
 
 class ResidualTokenExchangeTest : public ::testing::Test {

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -80,7 +80,11 @@ class ScenarioMockServer {
             }
             const size_t id = ++session_counter_;
             res.set_header ("Set-Cookie", "sid=" + std::to_string (id) + "; Path=/");
-            res.set_content ("{}", "application/json");
+            // A per-session token, distinct per login, so a test can prove
+            // step 2 saw *this* VU's own extracted value rather than
+            // whichever login happened to run last (issue #1495).
+            res.set_content (R"({"token": "tok-)" + std::to_string (id) + R"("})",
+            "application/json");
         });
 
         for (const char* path : { "/echo", "/s0", "/s1", "/s2" }) {
@@ -257,6 +261,20 @@ class ScenarioLoadTest : public ::testing::Test {
     const std::vector<json>& rows) {
         split_steps (execution);
         execution.data_rows = rows;
+    }
+
+    /// A two-step plan (issue #1495): `/login` (step 0) then @p url with an
+    /// `Authorization: Bearer {{token}}` header (step 1) - the shape every
+    /// inline-element test below correlates a step-0 extraction through.
+    /// `{{token}}` is neither a data nor an identity token, so it reaches
+    /// this file's new residual-token pass untouched by `bind_step_iteration`
+    /// - exactly the gap issue #1495 closes.
+    static vayu::core::ScenarioExecution
+    plan_login_then_bearer (ScenarioMockServer& server, const std::string& url) {
+        auto execution = plan_over ({ server.url ("/login"), url });
+        execution.plan.steps[1].request.headers["Authorization"] =
+        "Bearer {{token}}";
+        return execution;
     }
 
     /// Give every step the deferred auth `resolve_scenario` leaves behind for
@@ -995,6 +1013,229 @@ TEST_F (ScenarioLoadTest, PerStepTalliesAreAttachedToTheStoredBreakdown) {
     EXPECT_EQ (summary["steps"][0]["tests"]["failed"], 0);
     EXPECT_FALSE (summary["steps"][1].contains ("tests"))
     << "a step that asserted nothing must carry no tests object at all";
+}
+
+// ============================================================================
+// The element pipeline on the load paths (issue #1495)
+// ============================================================================
+
+// A declarative element (extract.json) always runs inline under load - no
+// `inline` mark needed, only a `script.*` element opts in explicitly. Two VUs
+// held inside `/login` at the same time must each carry their *own* login's
+// token on their own step 1, never the other's - the correlation bug this
+// issue exists to fix, proven the same way cookie isolation is proven above.
+//
+// Mutation check: remove the residual-token-pass call in `submit_one`, and
+// step 1 sends the literal `{{token}}` for both VUs instead of either one's
+// real value.
+TEST_F (ScenarioLoadTest, AnInlineExtractCorrelatesPerVirtualUserAcrossSteps) {
+    ScenarioMockServer server (/*login_rendezvous=*/2);
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::extract_json_element_json ("el_token", "$.token", "token") });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 2 } };
+    run (config, execution, /*pool_size=*/2);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 2u);
+    EXPECT_NE (echoes[0].authorization, echoes[1].authorization)
+    << "both virtual users sent the same token - the extraction is shared "
+       "rather than per-VU";
+    for (const auto& echo : echoes) {
+        ASSERT_TRUE (echo.cookie.rfind ("sid=", 0) == 0)
+        << "no session reached step 1";
+        const std::string session_id = echo.cookie.substr (4);
+        EXPECT_EQ (echo.authorization, "Bearer tok-" + session_id)
+        << "step 1 carried a token that does not match this VU's own login "
+           "session - the two are not being bound to the same VU";
+    }
+}
+
+// The same correlation, through an inline `script.post` instead of a
+// declarative `extract.json` - proving the opt-in itself works, not just the
+// overlay it writes through.
+TEST_F (ScenarioLoadTest, AScriptPostMarkedInlineCorrelatesPerVirtualUserTheSameWayExtractDoes) {
+    ScenarioMockServer server (/*login_rendezvous=*/2);
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_post", "script.post",
+    "pm.environment.set('token', pm.response.json().token);", /*inline_script=*/true) });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 2 } };
+    run (config, execution, /*pool_size=*/2);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 2u);
+    EXPECT_NE (echoes[0].authorization, echoes[1].authorization);
+    for (const auto& echo : echoes) {
+        ASSERT_TRUE (echo.cookie.rfind ("sid=", 0) == 0);
+        EXPECT_EQ (echo.authorization, "Bearer tok-" + echo.cookie.substr (4));
+    }
+}
+
+// Without the `inline` mark, a `script.post` element stays exactly where it
+// always was - deferred to the post-run replay - and the run's wire traffic
+// is byte-for-byte what it was before issue #1495: `{{token}}` reaches the
+// wire literally, and it counts as an unresolved token rather than silently
+// vanishing.
+//
+// Mutation check: mark the element `inline` (as the test above does) and this
+// assertion reds - the literal token would resolve instead.
+TEST_F (ScenarioLoadTest, WithoutTheInlineMarkAScriptPostStaysDeferredAndTheWireIsUnchanged) {
+    ScenarioMockServer server;
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_post", "script.post",
+    "pm.environment.set('token', pm.response.json().token);") }); // no inline mark
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 1u);
+    EXPECT_EQ (echoes[0].authorization, "Bearer {{token}}")
+    << "an un-inlined script must not affect this run's wire traffic at all";
+
+    const auto summary =
+    vayu::core::build_scenario_load_summary (*state, execution.plan);
+    EXPECT_EQ (summary["steps"][1]["unresolvedTokens"], 1)
+    << "the literal token must still be counted, exactly as an unresolved "
+       "token always has been";
+}
+
+// A `script.pre` marked `inline` reaches the wire on *every* submission, not
+// only the first - proving the hook runs from the producer's own steady-state
+// loop rather than once at setup.
+TEST_F (ScenarioLoadTest, AScriptPreMarkedInlineReachesTheWireOnEverySubmission) {
+    ScenarioMockServer server;
+    auto execution                   = plan_over ({ server.url ("/echo") });
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_pre", "script.pre",
+    "pm.request.headers.upsert('Authorization', 'Bearer injected');",
+    /*inline_script=*/true) });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 3 },
+        { "concurrency", 1 } };
+    run (config, execution);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 3u);
+    for (const auto& echo : echoes) {
+        EXPECT_EQ (echo.authorization, "Bearer injected");
+    }
+}
+
+// A step's recorded latency is its transfer alone by default - an inline
+// element's own time is not folded in - and `elements.includeScriptTime`
+// opts a run into folding it back. Asserted as a *relative* difference
+// between two otherwise-identical runs, one with the override and one
+// without, rather than against an absolute millisecond floor: a shared CI
+// machine's baseline transfer latency is itself noisy, but the gap this
+// deliberately slow inline script (a bounded busy loop - a sandboxed script
+// cannot sleep) opens between the two runs is not - tens of milliseconds of
+// real interpreted work, well past any jitter one more request on the same
+// mock could introduce.
+TEST_F (ScenarioLoadTest, IncludeScriptTimeFoldsThePipelinesTimeIntoTheRecordedLatency) {
+    ScenarioMockServer server;
+    const std::string slow_script =
+    "let s = 0; for (let i = 0; i < 8000000; i++) { s += i; }";
+
+    auto excluded_execution = plan_over ({ server.url ("/echo") });
+    excluded_execution.plan.steps[0].elements =
+    vayu::tests::compiled_elements ({ vayu::tests::script_element_json (
+    "el_post", "script.post", slow_script, /*inline_script=*/true) });
+    const json excluded_config    = { { "mode", "iterations" },
+           { "iterations", 1 }, { "concurrency", 1 } };
+    auto excluded_state           = run (excluded_config, excluded_execution);
+    const double excluded_latency = vayu::core::build_scenario_load_summary (
+    *excluded_state, excluded_execution.plan)["steps"][0]["latency"]["min"];
+
+    auto included_execution = plan_over ({ server.url ("/echo") });
+    included_execution.plan.steps[0].elements =
+    vayu::tests::compiled_elements ({ vayu::tests::script_element_json (
+    "el_post", "script.post", slow_script, /*inline_script=*/true) });
+    const json included_config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "elements", { { "includeScriptTime", true } } } };
+    auto included_state           = run (included_config, included_execution);
+    const double included_latency = vayu::core::build_scenario_load_summary (
+    *included_state, included_execution.plan)["steps"][0]["latency"]["min"];
+
+    EXPECT_GT (included_latency - excluded_latency, 15.0)
+    << "excluded=" << excluded_latency << "ms included=" << included_latency
+    << "ms - `elements.includeScriptTime` must fold the slow script's own "
+       "time into the recorded latency, which this margin should show "
+       "however noisy the machine's own baseline transfer latency is";
+}
+
+// `elements.scripts: "allInline"` forces every `script.*` element inline
+// regardless of its own `config.inline` - the override, not the per-element
+// mark, decides.
+TEST_F (ScenarioLoadTest, ElementsScriptsAllInlineForcesAnUnmarkedScriptInline) {
+    ScenarioMockServer server;
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_post", "script.post",
+    "pm.environment.set('token', pm.response.json().token);") }); // no inline mark
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "elements", { { "scripts", "allInline" } } } };
+    run (config, execution);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 1u);
+    EXPECT_NE (echoes[0].authorization, "Bearer {{token}}")
+    << "the run override must force the unmarked script inline";
+}
+
+// `elements.scripts: "allDeferred"` forces every `script.*` element deferred
+// regardless of its own `inline` mark.
+TEST_F (ScenarioLoadTest, ElementsScriptsAllDeferredIgnoresAPerElementInlineMark) {
+    ScenarioMockServer server;
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_post", "script.post",
+    "pm.environment.set('token', pm.response.json().token);", /*inline_script=*/true) });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "elements", { { "scripts", "allDeferred" } } } };
+    run (config, execution);
+
+    const auto echoes = server.hits_for ("/echo");
+    ASSERT_EQ (echoes.size (), 1u);
+    EXPECT_EQ (echoes[0].authorization, "Bearer {{token}}")
+    << "the run override must defer the marked script regardless of its own "
+       "mark";
+}
+
+// Per-step, per-element pass/fail/skip tallies (issue #1495): an inline
+// element that ran reports its outcome under `elements`, and a step with no
+// elements carries no such key at all.
+TEST_F (ScenarioLoadTest, PerStepElementTalliesAreAttachedToTheBreakdown) {
+    ScenarioMockServer server;
+    auto execution = plan_login_then_bearer (server, server.url ("/echo"));
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::extract_json_element_json ("el_token", "$.token", "token") });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    const auto summary =
+    vayu::core::build_scenario_load_summary (*state, execution.plan);
+    ASSERT_TRUE (summary["steps"][0].contains ("elements"));
+    const auto& elements = summary["steps"][0]["elements"];
+    ASSERT_EQ (elements.size (), 1u);
+    EXPECT_EQ (elements[0]["id"], "el_token");
+    EXPECT_EQ (elements[0]["kind"], "extract.json");
+    EXPECT_EQ (elements[0]["passed"], 2);
+    EXPECT_EQ (elements[0]["failed"], 0);
+    EXPECT_EQ (elements[0]["skipped"], 0);
+    EXPECT_FALSE (summary["steps"][1].contains ("elements"))
+    << "a step with no elements at all must carry no such key";
 }
 
 // ============================================================================

--- a/engine/tests/step_elements_test_helper.hpp
+++ b/engine/tests/step_elements_test_helper.hpp
@@ -57,4 +57,44 @@ step_elements_with_post_script (const std::string& script) {
     return step_elements_with_scripts ("", script);
 }
 
+/**
+ * One `element` array entry, for a test building a step with more than the
+ * two-script shape above covers (issue #1495: an `extract.*` beside a
+ * `script.*` marked `inline`, several elements on one step, and so on).
+ * Combine with @ref compiled_elements.
+ */
+inline nlohmann::json extract_json_element_json (const std::string& id,
+const std::string& path,
+const std::string& variable,
+const std::string& scope = "collection") {
+    return { { "id", id }, { "kind", "extract.json" }, { "enabled", true },
+        { "config", { { "path", path }, { "variable", variable }, { "scope", scope } } } };
+}
+
+/// @copydoc extract_json_element_json, a `script.pre` / `script.post` entry.
+/// @p inline_script matches `config.inline` - the load path's own opt-in
+/// (issue #1495); design mode and the sequential run ignore it.
+inline nlohmann::json script_element_json (const std::string& id,
+const std::string& kind,
+const std::string& script,
+bool inline_script = false) {
+    nlohmann::json config = { { "script", script } };
+    if (inline_script) {
+        config["inline"] = true;
+    }
+    return { { "id", id }, { "kind", kind }, { "enabled", true }, { "config", config } };
+}
+
+/// Compile an arbitrary list of element JSON entries (@ref extract_json_element_json,
+/// @ref script_element_json) the same way plan resolution does.
+inline std::shared_ptr<const std::vector<vayu::core::CompiledElement>>
+compiled_elements (std::vector<nlohmann::json> entries) {
+    nlohmann::json array = nlohmann::json::array ();
+    for (auto& entry : entries) {
+        array.push_back (std::move (entry));
+    }
+    return std::make_shared<const std::vector<vayu::core::CompiledElement>> (
+    vayu::core::compile_elements (array));
+}
+
 } // namespace vayu::tests


### PR DESCRIPTION
## Description

The `ElementPipeline` #1513/#1514 landed runs in the design send and the sequential (single-VU) collection run, but a scenario **load** run's `submit_one` only ever bound the data/identity templates and submitted - it called neither the pipeline nor the residual-token pass. So a collection with a `login` step (a `script.post` doing `pm.environment.set("token", ...)`) and a `me` step (`Authorization: Bearer {{token}}`) sent `Bearer {{token}}` literally on every one of a load run's step-2 requests: the extraction only ever ran in the post-run deferred replay, against *recorded* responses, never live, so it could never feed a later step of the same run.

This closes that gap on the scenario load path: `submit_one` now runs `step.before` (plus the residual-token pass) before binding, and the completion runs `step.after` before the VU is released. Declarative kinds (`extract.*`, `assert.*`) always run there; a `script.*` kind runs there only when its own `config.inline` is set or the run's new `elements.scripts` override forces it - unmarked, a step's scripts stay exactly where they always were, deferred to the post-run replay (which now skips a step whose script already ran inline).

The one real design problem was per-VU isolation: a scenario load run's virtual users share one event loop, so an extraction can't write into the run's shared scopes the way a design send does - two VUs writing the same variable name would race and cross-contaminate. Each `VirtualUser` instead carries a small `ScopeOverlay` (a handful of written names, not a copy of the run's whole variable set), written on the completion path before `finish_step` releases the VU - the same `busy` acquire/release pairing that already makes per-VU cookies visible to that VU's next step makes the overlay visible too, with no additional lock. The residual-token pass merges a copy of that overlay onto the run's scopes flattened once at setup, so it stays proportional to what a VU actually wrote rather than to the run's whole variable set or its collection-ancestor chain; an inline script needs the real mutable `Environment&` `pm.environment.set` writes through, so it runs against a `materialize`d copy and replaces the VU's overlay with whatever came out (equivalent to a diff, since the copy already started as base-plus-this-VU's-prior-overlay).

**Alternative rejected:** giving each event-loop worker its own `ScriptEngine` member (the shape #1495's own scope text describes). I found the codebase already builds a fresh `ScriptEngine` per call site everywhere (design send, sequential run, deferred replay) rather than sharing one behind a pool mutex, so there was no existing "shared pool" to split up. A load run's worker threads - the strategy thread and every event-loop worker - are spawned fresh per run and joined before it retains, so a `thread_local` `ScriptEngine` (`script_engine_for_this_thread`) gets the same "no cross-worker contention" property without touching `http/event_loop`'s public API or its threading model, which is otherwise shared, perf-critical infrastructure this issue has no reason to widen into.

**Scope decisions, both documented in `docs/engine/elements.md`'s new Load paths section and in `engine/CLAUDE.md`:**
- `elements.timers` is accepted and validated (unknown-key/value checks) but not yet wired to suppress anything - `timer.think`'s current phase (`step.between`) and blocking wait are sequential-run-only and unreachable from the new load hooks by construction, and #1498 ("the timer family... the run-level Timers override end to end") explicitly owns finishing that wiring.
- The **single-request** load path (`load_strategy.cpp`) is unchanged. `POST /runs`'s single-request shape has no `elements` attachment point today (its script model is still the legacy `tests` string, `RunContext::test_script`) - there is no element pipeline call there to gate on inline-vs-deferred, so a `ScopeOverlay` there would have no writer. Wiring a stored request's `elements` into that run shape is a separate, pre-existing gap, not one this issue introduced.
- `ready_at_ms` is threaded onto `VirtualUser` and `take_ready_vu` (structural plumbing named in the issue's own title) but nothing writes it yet - the same "groundwork, no behavior" pattern #1513's `HotPathClass` used.

## Type of Change
- [x] Bug fix (a scenario load run's step-to-step correlation)
- [x] New feature (`elements.scripts` / `elements.includeScriptTime` run override, `scenario.steps[i].elements`)
- [ ] Breaking change
- [x] Documentation update

## Testing
- `python build.py -e -t && cd engine && ctest --preset linux-dev` - **3047/3047 passed**, engine-wide (nothing outside the touched files regressed).
- New coverage, all engine-side (`ctest -R "ScenarioLoad|ResidualTokens|ScopeOverlay"`, 83 cases):
  - `AnInlineExtractCorrelatesPerVirtualUserAcrossSteps` / `AScriptPostMarkedInlineCorrelatesPerVirtualUserTheSameWayExtractDoes` - two VUs held inside `/login` at the same time each carry their *own* session's token onto their own step 2, proven against the wire (mutation check: remove the residual-token-pass call in `submit_one` and both VUs send the literal `{{token}}` instead).
  - `WithoutTheInlineMarkAScriptPostStaysDeferredAndTheWireIsUnchanged` - an un-inlined script leaves the run's wire traffic byte-for-byte what it was before this issue.
  - `AScriptPreMarkedInlineReachesTheWireOnEverySubmission` - proven across 3 iterations, not just the first.
  - `IncludeScriptTimeFoldsThePipelinesTimeIntoTheRecordedLatency` - asserted as a relative gap between two runs (one with the override, one without) rather than an absolute millisecond floor, so it isn't sensitive to the test machine's own baseline noise.
  - `ElementsScriptsAllInlineForcesAnUnmarkedScriptInline` / `ElementsScriptsAllDeferredIgnoresAPerElementInlineMark` - the run override outranks the per-element mark in both directions.
  - `PerStepElementTalliesAreAttachedToTheBreakdown` - `scenario.steps[i].elements[]`, absent when a step carries none.
  - `ScopeOverlayTest` (7 cases) - precedence order, `materialize`/`replace_from`'s copy-then-adopt round trip, and that a VU's write never reaches another read of the same base map.
- `clang-format-19 --dry-run -Werror` and `clang-format-19 -i` on every touched file - clean.
- `clang-tidy-19` on every touched `.cpp` (with the pre-commit hook's own `-Wno-ignored-gch` flag) - clean, via the pre-commit hook that ran on this commit.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19, both via the pre-commit hook)
- [x] I have performed a self-review
- [x] I have added tests (see Testing)
- [x] I have updated documentation (`docs/engine/elements.md`, `docs/engine/scripting.md`, `docs/engine/api-reference.md`, `docs/engine/architecture.md`, `docs/compare/vayu-vs-jmeter.md`, `engine/CLAUDE.md`)

## No screenshot
Engine-only change with no App changes section in the issue and no acceptance criterion naming one; `docs/engine/elements.md`'s Load paths section is the fuller writeup. `scenario.steps[i].elements` is additive to the run report JSON - no app code asserts an exact key set on it (confirmed against `RunScenarioStepStat` in `app/src/types/domain.ts`), and displaying it is #1516's own scope (the app's Elements tab / ElementList primitive), not named as required here.

## Related Issues
Closes #1495

---
_Generated by [Claude Code](https://claude.ai/code/session_014trgjV5v3tPHd1Dnt84PYc)_