### PR TITLE
build(app): take the Electron 44.1.0 patch line

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -93,7 +93,7 @@
 		"@vitejs/plugin-react": "^6.1.1",
 		"concurrently": "^10.0.5",
 		"cross-env": "^10.1.0",
-		"electron": "^44.0.0",
+		"electron": "^44.1.0",
 		"electron-builder": "^26.15.3",
 		"eslint": "^10.9.1",
 		"eslint-config-prettier": "^10.1.8",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       electron:
-        specifier: ^44.0.0
-        version: 44.0.0
+        specifier: ^44.1.0
+        version: 44.1.0
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -2207,8 +2207,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@44.0.0:
-    resolution: {integrity: sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==}
+  electron@44.1.0:
+    resolution: {integrity: sha512-kmLg8axOg22DC3fXx5NCwBYW8fx0rK2zzJ3Tf67GjNCkxfoxEcd+yo0QfDjlBtHJs3xeA8fTg64b6iVzFTVErg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6574,7 +6574,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@44.0.0:
+  electron@44.1.0:
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0


### PR DESCRIPTION
## Description

`app/pnpm-workspace.yaml`'s `minimumReleaseAge: 10080` (seven days) now admits 44.1.0 (released 2026-08-31T13:54Z, matured 2026-09-07T13:54Z); 44.1.1 and 44.2.0 are still inside the window as of this PR. 44.1.0 carries three fixes that reach this app without any code change on our side: an intermittent Linux startup crash from a Pango/fontconfig race (Vayu ships an AppImage and a deb), a crash when a `webContents` or parent window is destroyed while still referenced (`oauth.ts` creates and destroys a sign-in window per flow), and region-qualified `--lang` values loading no locale resources on macOS. The Chromium bump (152.0.7977.54 to .65) carries no advisory.

Checked and not applicable, so no code here reacts to them: `chrome.tabs.query()`'s permission leak (no extensions loaded) and the `contextBridge` fixes (`preload.ts` passes plain functions and data, not throwing getters or Proxy traps).

**Deliberate deviation from the issue's acceptance criteria:** the issue asks for `.github/release-notes/v0.26.0.md` to name the Electron version shipping. `v0.26.0.md` is not a draft - the `v0.26.0` tag exists at `cb829ad3`, so that file is the published record of an already-shipped release that went out with 44.0.0. Editing it now would misstate what 0.26.0 actually contained. This bump lands after that release and belongs in whatever notes file covers the next one, written at that release's own cut (per the `releasing` skill), not backdated into a shipped file.

## Type of Change
- [x] Bug fix (three Electron-side crash/locale fixes now apply)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`app/package.json`'s `electron` spec moved to `^44.1.0` and `pnpm install` re-resolved the lockfile to `44.1.0` (diff is the specifier and the one `packages`/`snapshots` entry, nothing else moved). Then, from `app/`:
- `pnpm type-check` - clean (renderer, electron, electron-tests projects)
- `pnpm lint` - clean, zero warnings
- `pnpm format:check` - clean
- `pnpm test` - **714 files, 8127 tests, all passing**, including the electron main-process suite (`oauth`/`sidecar` re-run in isolation: 7 files, 80 tests, all passing)

No engine files touched, so no engine build/test run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - a dependency patch bump with no app-code change; existing suite is the coverage
- [x] I have updated documentation - none of the docs naming "Electron 44" name a patch version, so nothing needed a line change; see the release-notes deviation above

## No screenshot
Dependency-only change with no visible surface.

## Related Issues
Closes #1377