### PR TITLE
feat(engine,app): retire an unrecognised config row, refuse a mismatched adopted engine

### DIFF
--- a/app/electron/sidecar.test.ts
+++ b/app/electron/sidecar.test.ts
@@ -141,6 +141,9 @@ function fakeSystem(overrides: Partial<SidecarSystem> = {}) {
 			return killed;
 		}),
 		probeHealth: vi.fn(async () => state.healthy),
+		// Matches the mocked `app.getVersion()` below, so existing adoption
+		// cases keep adopting unless a test overrides it to something else.
+		probeVersion: vi.fn(async () => "0.0.0-test"),
 		requestShutdown: vi.fn(async () => true),
 		isPortFree: vi.fn(async () => !state.healthy),
 		sleep: vi.fn(async () => {}),
@@ -198,6 +201,59 @@ describe("EngineSidecar - adoption", () => {
 
 		await sidecar.start();
 
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	// Issue #1492: a daemon built for a different Vayu version is not safe to
+	// adopt silently - it is stopped, the same way `stop()` stops any adopted
+	// engine, and this instance spawns its own. Mutation check: read
+	// `probeVersion`'s answer as advisory (adopt regardless), and both of these
+	// red on `spawnEngine` never being called.
+	it("stops a mismatched-version engine at the lock-PID adoption path and spawns its own", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.probeVersion as ReturnType<typeof vi.fn>).mockResolvedValue("0.1.0-old");
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.alivePids.delete(ADOPTED_PID);
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.requestShutdown).toHaveBeenCalledWith(TEST_PORT);
+		expect(system.spawnEngine).toHaveBeenCalledOnce();
+		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	it("stops a mismatched-version engine at the no-lock-PID adoption path and spawns its own", async () => {
+		const { system, state } = fakeSystem();
+		state.healthy = true;
+		(system.probeVersion as ReturnType<typeof vi.fn>).mockResolvedValue("0.1.0-old");
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.requestShutdown).toHaveBeenCalledWith(TEST_PORT);
+		expect(system.spawnEngine).toHaveBeenCalledOnce();
+		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	it("adopts rather than disrupts a healthy engine when its version cannot be read", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.probeVersion as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.requestShutdown).not.toHaveBeenCalled();
 		expect(system.spawnEngine).not.toHaveBeenCalled();
 		expect(sidecar.isRunning()).toBe(true);
 	});

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -72,19 +72,34 @@ function isPortAvailable(port: number): Promise<boolean> {
 	});
 }
 
-/**
- * Check if our engine is already running on a port
- */
-async function isEngineRunning(port: number): Promise<boolean> {
+/** `GET /health`'s body, or null on any transport, timeout or parse failure. */
+async function fetchHealth(port: number): Promise<{ status?: string; version?: string } | null> {
 	try {
 		const response = await fetch(`http://127.0.0.1:${port}/health`, {
 			signal: AbortSignal.timeout(ENGINE_HEALTH_REQUEST_TIMEOUT_MS),
 		});
-		const data = await response.json();
-		return data?.status === "ok";
+		return await response.json();
 	} catch {
-		return false;
+		return null;
 	}
+}
+
+/**
+ * Check if our engine is already running on a port
+ */
+async function isEngineRunning(port: number): Promise<boolean> {
+	const data = await fetchHealth(port);
+	return data?.status === "ok";
+}
+
+/**
+ * The running engine's own `version` (issue #1492), or null when the probe
+ * failed or answered with no readable version - callers read null as "could
+ * not tell", not as "no engine here"; `isEngineRunning` already answers that.
+ */
+async function probeEngineVersion(port: number): Promise<string | null> {
+	const data = await fetchHealth(port);
+	return typeof data?.version === "string" ? data.version : null;
 }
 
 /**
@@ -279,6 +294,8 @@ export interface SidecarSystem {
 	killEngineProcess(pid: number): boolean;
 	/** Does an engine answer `/health` with `status: ok` on this port? */
 	probeHealth(port: number): Promise<boolean>;
+	/** The `version` a healthy engine on this port answers with, or null. */
+	probeVersion(port: number): Promise<string | null>;
 	/** `POST /shutdown`. True means accepted, not that the process has gone. */
 	requestShutdown(port: number): Promise<boolean>;
 	/** Can we bind this port, i.e. is nothing at all listening? */
@@ -295,6 +312,7 @@ export const defaultSidecarSystem: SidecarSystem = {
 	isEngineProcessAlive: isVayuEngineRunning,
 	killEngineProcess: killVayuEngineProcess,
 	probeHealth: isEngineRunning,
+	probeVersion: probeEngineVersion,
 	requestShutdown: requestEngineShutdown,
 	isPortFree: isPortAvailable,
 	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -447,6 +465,49 @@ export class EngineSidecar {
 	}
 
 	/**
+	 * Decide whether a healthy engine already on the port is safe to adopt,
+	 * and stop it instead when it is not (issue #1492).
+	 *
+	 * A crash-then-relaunch, or two installed builds sharing a data
+	 * directory, can land this instance next to a daemon built for a
+	 * different Vayu version - a `/request-defaults` shape this renderer was
+	 * not built against, a config key this build cannot validate, a database
+	 * schema this build refuses to open (`Database::migrate_before_sync`
+	 * already refuses the *file* on that mismatch; nothing stopped the app
+	 * from talking to a live *process* built for a different one). Adopting
+	 * it silently would run every request through a sidecar this session
+	 * never agreed to. `probeVersion` returning null - the probe answered but
+	 * the version could not be read - adopts rather than disrupts a healthy
+	 * engine on an ambiguous answer, the same direction `isPidCertainlyDead`
+	 * takes for its own unclear case.
+	 *
+	 * @returns whether the engine on the port was adopted. `false` means it
+	 *          was stopped instead, and the caller falls through to spawning.
+	 */
+	private async adoptIfVersionMatches(pid: number | null): Promise<boolean> {
+		const runningVersion = await this.system.probeVersion(this.port);
+		if (runningVersion === null || runningVersion === app.getVersion()) {
+			console.log(
+				`[Sidecar] Adopting the engine already running on port ${this.port}` +
+					(pid !== null ? ` (PID ${pid})` : " (no lock PID)")
+			);
+			this.ownership = { kind: "adopted", pid };
+			return true;
+		}
+
+		console.warn(
+			`[Sidecar] Engine on port ${this.port} is version ${runningVersion}, this app ` +
+				`is ${app.getVersion()} - stopping it instead of adopting a mismatched daemon`
+		);
+		this.ownership = { kind: "adopted", pid };
+		await this.system.requestShutdown(this.port);
+		await this.stopAdopted(pid);
+		// Same gap `restart()` waits out between a stop and the spawn that follows.
+		await this.system.sleep(ENGINE_PORT_RELEASE_DELAY_MS);
+		return false;
+	}
+
+	/**
 	 * Start the engine process
 	 */
 	async start(): Promise<void> {
@@ -469,11 +530,10 @@ export class EngineSidecar {
 				);
 				// Verify engine is actually responding on the port
 				if (await this.system.probeHealth(this.port)) {
-					console.log(
-						`[Sidecar] Adopting the engine already running on port ${this.port} (PID ${lockStatus.pid})`
-					);
-					this.ownership = { kind: "adopted", pid: lockStatus.pid };
-					return;
+					if (await this.adoptIfVersionMatches(lockStatus.pid)) {
+						return;
+					}
+					// Mismatched daemon stopped instead of adopted - fall through to spawn.
 				} else {
 					console.warn(
 						`[Sidecar] Lock file indicates process ${lockStatus.pid} is running, but engine is not responding on port ${this.port}`
@@ -501,11 +561,10 @@ export class EngineSidecar {
 		// crash). No lock file to read a PID from, so ownership is by port only -
 		// stop() falls back to watching health for the exit.
 		if (await this.system.probeHealth(this.port)) {
-			console.log(
-				`[Sidecar] Adopting the engine already running on port ${this.port} (no lock PID)`
-			);
-			this.ownership = { kind: "adopted", pid: readPidFromLock(lockPath) };
-			return;
+			if (await this.adoptIfVersionMatches(readPidFromLock(lockPath))) {
+				return;
+			}
+			// Mismatched daemon stopped instead of adopted - fall through to spawn.
 		}
 
 		// Check if port is in use by something else

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,7 +338,10 @@ one app instance may drive it:
   orphan left by a crashed session, or in development one started by hand - the
   app *adopts* it: it is tracked by the PID in the lock file (`vayu.lock` in the
   data directory), reported as running, restarted for real when Settings asks,
-  and shut down on quit like any engine the app spawned itself.
+  and shut down on quit like any engine the app spawned itself. Adoption checks
+  the running engine's `/health.version` against this app's own first (issue
+  #1492): a mismatch is stopped rather than adopted, and this instance starts
+  its own build instead - see `docs/lock-file-handling.md`.
 - **Quit leaves nothing behind.** Shutdown is `POST /shutdown` first, then a
   wait for the process to go, then a name-verified kill by PID if it outstays
   the grace period. The name check is what keeps a recycled PID from being

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -625,6 +625,14 @@ min/max/options):
 }
 ```
 
+**Only entries this engine's own build declares are listed** (issue #1492): a
+row a *newer* engine wrote to the same workspace, then left behind for an
+older one to reopen, is never in `entries` - this engine has no label,
+validator or bounds for it, so serving it would describe a setting it cannot
+actually explain. `POST /config` applies the same rule to writes: a key
+outside this build's catalogue is refused as `"Unknown config key"`, the same
+message a key with no stored row at all gets.
+
 `min` and `max` are present only for entries that declare them (numeric
 types). `options` is present only for `type: "enum"` entries - a JSON array of
 `{value, label}`, so the renderer can draw a picker without a second,
@@ -968,8 +976,11 @@ In both shapes, non-string values (numbers, booleans) are coerced to strings.
 Each key is validated against its registered `type` and, for `integer` / `number`
 entries, its `min`/`max` range; `boolean` entries must be `"true"` or `"false"`;
 `enum` entries (e.g. `defaultHttpVersion`) must equal one of that entry's stored
-`options` values. Validation is all-or-nothing: if any key is unknown or out of
-range, nothing is applied and the response is `400` with the specific reason(s):
+`options` values. "Unknown" means outside this engine's own catalogue (see
+[GET /config](#get-config)) - a stored row from a different engine's build
+does not make a key known to this one. Validation is all-or-nothing: if any
+key is unknown or out of range, nothing is applied and the response is `400`
+with the specific reason(s):
 
 ```json
 { "error": { "code": "invalid_config", "message": "'workers' must be at most 128 (got 9999)" } }

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -1501,6 +1501,19 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 | `keywords`      | TEXT    | JSON array of extra search terms; `"[]"` when the entry declares none |
 | `unit`          | TEXT    | What a numeric value measures (`ms`, `sec`, `days`, `bytes`); NULL for a count |
 
+**A row can outlive the catalogue that wrote it** (issue #1492). `seed_default_config`
+only touches two lists on every start - the keys it upserts and a fixed retired-key
+list it deletes - so a row for a key neither list names (a workspace a *newer* engine
+opened, then reopened by this one) is left untouched: still on disk, still readable by
+`get_config_entry`, but not one this build's `seed_default_config` declared. `GET
+/config` and a successful `POST /config`'s echoed `entries` both filter to
+`Database::is_known_config_key`, the set `seed_default_config` populated on this
+start, rather than to "every row in the table" - so neither ever describes a setting
+this build has no label, no validator and no bounds for. `POST /config` refuses a
+write to such a key the same way it refuses a key with no row at all: "Unknown config
+key", `invalid_config`. `is_known_config_key` answers from that populated set, never
+from whether a row exists - a row existing is exactly the case this guards.
+
 **category** is a closed set, and it is the app that closes it: the renderer
 draws one sidebar row per category it declares
 (`app/src/modules/settings/engine-categories.ts`) and drops an entry whose

--- a/docs/lock-file-handling.md
+++ b/docs/lock-file-handling.md
@@ -117,6 +117,19 @@ This ensures that:
 - Reinstalls work correctly
 - No manual intervention needed
 
+**A live engine is adopted only when its version matches this app's** (issue
+#1492). The lock file can point at a PID that is alive and answering `/health`
+but was built for a different Vayu release - a crash-then-relaunch across an
+upgrade, or two installed builds sharing a data directory. Adopting it
+silently would run every request through a sidecar the renderer was not built
+against, so `EngineSidecar` compares the running engine's `/health.version`
+against `app.getVersion()` before attaching to it: a match adopts as before,
+and a mismatch stops the daemon (`POST /shutdown`, then the same PID kill the
+graceful path already falls back to) and starts this build's own instead,
+logging both versions. A version that could not be read at all (the probe
+answered but the field was missing or malformed) adopts rather than disrupts
+a healthy engine on an ambiguous answer.
+
 ## Manual Cleanup
 
 If needed, users can manually remove the lock file:
@@ -153,6 +166,7 @@ rm ~/Library/Application\ Support/vayu-client/vayu.lock
 ### Electron Sidecar
 - Function: `checkLockFile()` - checks lock file and verifies PID
 - Function: `isVayuEngineRunning()` - cross-platform process check with process name verification. `process.kill(pid, 0)` first on every platform (no subprocess, and the stale-lock case ends there), then `tasklist` / `ps` to verify the name against PID reuse
+- Method: `adoptIfVersionMatches()` - the version gate above, called at both places `start()` finds a healthy engine already on the port
 - Automatic cleanup in `start()` method
 - File: `app/electron/sidecar.ts`
 

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -842,6 +843,24 @@ class Database {
     void seed_default_config (); // Initialize default config values if empty
 
     /**
+     * @brief Whether @p key is one this running engine's build declares -
+     *        i.e. one `seed_default_config` upserts, not merely one with a row
+     *        in the table (issue #1492).
+     *
+     * A row can outlive the catalogue that wrote it: a workspace opened by a
+     * newer engine, then reopened by this one, still carries that newer
+     * engine's config rows (`seed_default_config` only deletes its own fixed
+     * retired-key list, never a key it does not recognise at all - deleting an
+     * unrecognised row would be this build guessing that a row it cannot
+     * explain is safe to destroy). Without this check `GET /config` would list
+     * a setting this build cannot describe or validate, and `POST /config`
+     * would accept a write to it merely because the row already existed.
+     * Populated once, by `seed_default_config`, from the exact set of keys it
+     * upserts - never the retired list, and never read before the first seed.
+     */
+    bool is_known_config_key (const std::string& key) const;
+
+    /**
      * @brief SQLite page-cache size in force on the last connection opened, in
      * bytes (0 before the first one).
      *
@@ -881,6 +900,10 @@ class Database {
     /// The startup recovery record, read from the marker file in the
     /// constructor. See `recovery()`.
     std::optional<RecoveryRecord> recovery_;
+
+    /// The keys `seed_default_config` upserted on this engine's last seed
+    /// pass - this build's config catalogue. See `is_known_config_key`.
+    std::unordered_set<std::string> known_config_keys_;
 
     /**
      * @brief Delete a run and every child row it owns (ticks, metrics, results).

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -3607,6 +3607,11 @@ std::vector<ConfigEntry> Database::get_all_config_entries () {
     return impl_->storage.get_all<ConfigEntry> ();
 }
 
+bool Database::is_known_config_key (const std::string& key) const {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return known_config_keys_.contains (key);
+}
+
 int Database::applied_cache_size_bytes () const {
     // No DB mutex: the value is an atomic the open callback writes, and taking
     // the mutex here would order this read behind whatever query is running.
@@ -3843,6 +3848,7 @@ void Database::seed_default_config () {
     // - New entries get default values
     // - Existing entries preserve user-modified values but get updated metadata
     auto upsert_config = [&] (const ConfigEntry& new_entry) {
+        known_config_keys_.insert (new_entry.key);
         auto it = existing_map.find (new_entry.key);
         if (it != existing_map.end ()) {
             // Preserve user's value but update metadata (description, label, etc.)

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -113,6 +113,20 @@ nlohmann::json config_error (const std::string& message) {
     return error_body (400, message, "invalid_config");
 }
 
+// Every stored config row this engine's own catalogue declares (issue #1492) -
+// the one list `GET /config` and `POST /config`'s echoed `entries` both serve,
+// so a row a newer engine wrote and this one does not understand never reaches
+// a client through either path.
+nlohmann::json catalogued_config_entries_json (vayu::db::Database& db) {
+    nlohmann::json entries_array = nlohmann::json::array ();
+    for (const auto& entry : db.get_all_config_entries ()) {
+        if (db.is_known_config_key (entry.key)) {
+            entries_array.push_back (config_entry_json (entry));
+        }
+    }
+    return entries_array;
+}
+
 // One config value as the string the store holds. Shared by the two body
 // shapes below so a number or a boolean cannot mean different text depending
 // on which of them carried it.
@@ -349,8 +363,21 @@ const std::function<void ()>& before_write) {
     std::vector<std::string> errors;
 
     for (const auto& [key, value] : updates) {
+        // Checked against this engine's own catalogue (issue #1492), not
+        // merely against whether a row exists: a workspace a newer engine
+        // opened can carry a row for a key this build's `seed_default_config`
+        // does not declare, and this build has no validator for it - accepting
+        // the write on the strength of the row alone would apply a value this
+        // engine cannot check against the rules the key was defined with.
+        if (!db.is_known_config_key (key)) {
+            errors.push_back ("Unknown config key '" + key + "'");
+            continue;
+        }
         auto existing = db.get_config_entry (key);
         if (!existing) {
+            // Not reachable in practice - every catalogued key has a row by
+            // the time a request is served, seeded before the listener
+            // starts - kept as the honest answer if it ever is.
             errors.push_back ("Unknown config key '" + key + "'");
             continue;
         }
@@ -395,13 +422,8 @@ const std::function<void ()>& before_write) {
     vayu::utils::log_info ("POST /config - Updated " +
     std::to_string (to_update.size ()) + " config entries");
 
-    nlohmann::json entries_array = nlohmann::json::array ();
-    for (const auto& entry : db.get_all_config_entries ()) {
-        entries_array.push_back (config_entry_json (entry));
-    }
-
     nlohmann::json response;
-    response["entries"] = entries_array;
+    response["entries"] = catalogued_config_entries_json (db);
     response["success"] = true;
     return { 200, response };
 }
@@ -545,13 +567,8 @@ void register_config_routes (RouteContext& ctx) {
     ctx.server.Get ("/config", [&ctx] (const httplib::Request&, httplib::Response& res) {
         vayu::utils::log_info ("GET /config - Fetching configuration entries");
         try {
-            nlohmann::json entries_array = nlohmann::json::array ();
-            for (const auto& entry : ctx.db.get_all_config_entries ()) {
-                entries_array.push_back (config_entry_json (entry));
-            }
-
             nlohmann::json response;
-            response["entries"] = entries_array;
+            response["entries"] = catalogued_config_entries_json (ctx.db);
             res.set_content (response.dump (2), "application/json");
         } catch (const std::exception& e) {
             vayu::utils::log_error ("GET /config - Error: " + std::string (e.what ()));

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -134,6 +134,53 @@ TEST_F (ConfigRouteTest, UnknownKeyNamesTheKey) {
     EXPECT_NE (message.find ("totally_made_up_key"), std::string::npos);
 }
 
+// A row a newer engine's `seed_default_config` wrote and this build never
+// upserted (issue #1492): the row is real, but the key is not in this
+// engine's catalogue. Refused the same way a key with no row at all is -
+// mutation check: gate `is_known_config_key` on `db.get_config_entry`
+// existing instead, and this reds, because the row makes `existing` true.
+TEST_F (ConfigRouteTest, ARowFromANewerEngineIsRefusedAsUnknown) {
+    vayu::db::ConfigEntry future_row;
+    future_row.key           = "futureEngineOnlyKey";
+    future_row.value         = "1";
+    future_row.type          = "integer";
+    future_row.label         = "Not Ours";
+    future_row.description   = "Declared by a build newer than this one.";
+    future_row.category      = "general_engine";
+    future_row.default_value = "1";
+    db_->save_config_entry (future_row);
+
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"futureEngineOnlyKey":"2"}})");
+    EXPECT_EQ (status, 400);
+    const auto message = body["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("Unknown config key"), std::string::npos);
+    EXPECT_NE (message.find ("futureEngineOnlyKey"), std::string::npos);
+}
+
+// The same row must not surface through a successful response's echoed
+// `entries` either - a client reading that list would otherwise render a
+// setting this build cannot describe or validate.
+TEST_F (ConfigRouteTest, ARowFromANewerEngineIsExcludedFromEchoedEntries) {
+    vayu::db::ConfigEntry future_row;
+    future_row.key           = "futureEngineOnlyKey";
+    future_row.value         = "1";
+    future_row.type          = "integer";
+    future_row.label         = "Not Ours";
+    future_row.description   = "Declared by a build newer than this one.";
+    future_row.category      = "general_engine";
+    future_row.default_value = "1";
+    db_->save_config_entry (future_row);
+
+    auto [status, body] =
+    vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"2"}})");
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    for (const auto& entry : body["entries"]) {
+        EXPECT_NE (entry["key"].get<std::string> (), "futureEngineOnlyKey");
+    }
+}
+
 TEST_F (ConfigRouteTest, OutOfRangeReportsBoundAndValue) {
     // "workers" is seeded as an integer with min 1 / max 128.
     auto [status, body] =

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -217,6 +217,40 @@ TEST_F (DatabaseTest, RequestsInCollectionSortedByOrder) {
 // dynamically from GET /config - an upgraded database must lose the row too,
 // or the dead knob keeps showing up. Simulates the upgrade by planting the
 // row before re-running the seed.
+// `is_known_config_key` is the catalogue check `POST`/`GET /config` refuse an
+// unrecognised row by (issue #1492) - a row this build did not seed is not the
+// same as a row that does not exist, and only the seed pass can say which keys
+// this engine declares.
+TEST_F (DatabaseTest, KnownConfigKeyIsWhateverSeedDefaultConfigUpserted) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    EXPECT_TRUE (db.is_known_config_key ("workers"));
+    EXPECT_FALSE (db.is_known_config_key ("totally_made_up_key"));
+}
+
+// A row saved directly (as if a newer engine's own seed wrote it) has a real
+// row - `get_config_entry` finds it - but is not in this build's catalogue.
+// Mutation check: read `is_known_config_key` as "any row present" instead of
+// the seeded set, and this reds.
+TEST_F (DatabaseTest, ARowWithNoSeedingEntryIsNotAKnownConfigKey) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    ConfigEntry future_row;
+    future_row.key           = "futureEngineOnlyKey";
+    future_row.value         = "1";
+    future_row.type          = "integer";
+    future_row.label         = "Not Ours";
+    future_row.description   = "Declared by a build newer than this one.";
+    future_row.category      = "general_engine";
+    future_row.default_value = "1";
+    db.save_config_entry (future_row);
+
+    ASSERT_HAS_VALUE (db.get_config_entry ("futureEngineOnlyKey"));
+    EXPECT_FALSE (db.is_known_config_key ("futureEngineOnlyKey"));
+}
+
 TEST_F (DatabaseTest, SeedRemovesRetiredRequestBatchSizeEntry) {
     Database db (TEST_DB_PATH);
     db.init ();


### PR DESCRIPTION
## Description

Issue #1492 found five gaps in how the engine handles a workspace opened across versions. Two research passes against current `master` (`23e31ea3`) found the first two already closed by since-landed work, so this PR's actual scope is narrower than the issue's original fix pathway:

- **Already done, verified rather than reimplemented:** `Database::migrate_before_sync` (#1514) already stamps `PRAGMA user_version`, refuses to open a database written by a newer engine (throwing before the file is touched), and takes a pre-migration backup first. An unstamped 0.25 database opens on head and is stamped. A schema-refusal exit already surfaces through the app's existing generic spawn-failure dialog (`describeSpawnFailure` in `sidecar.ts`, which tails the engine's stderr - the engine's own refusal message names both versions), so the issue's "the app shows the dialog" criterion is met without new UI.
- **Deliberately not implemented:** the issue's fix-pathway item 3 (`sync_schema(preserve = true)` everywhere) is superseded by the mechanism above. `engine/CLAUDE.md`'s own documented convention for removing a column is now "read the data out ahead of `sync_schema()` via a `user_version`-gated migration, then let `sync_schema()` `DROP COLUMN` it" (`Database::migrate_before_sync`, written for #1514) - and since an older engine now refuses to open a newer-schema file at all, it can never reach a `sync_schema()` call that would drop a column it doesn't understand. Adding `preserve` on top would fight that established design for no reachable case.
- **What this PR actually implements** (fix-pathway items 4-6): an old engine no longer offers a setting it does not read, and the app no longer talks to a running engine of the wrong version.

**Config catalogue (engine).** `seed_default_config` only ever touches two lists on every start: the keys it upserts, and a fixed retired-key list it deletes. A row for neither list (a workspace a *newer* engine opened, then reopened by this one) was left untouched - readable, and previously servable and writable, even though this build has no label, validator or bounds for it. `Database::is_known_config_key` is a new set populated from exactly the keys `seed_default_config` upserted this start; `GET /config` and a successful `POST /config`'s echoed `entries` now filter through it (`catalogued_config_entries_json`, one helper, two call sites), and `POST /config`'s existing "Unknown config key" refusal now gates on catalogue membership instead of on whether a row happens to exist - the row existing is exactly the case this closes.

**Engine-version adoption (app).** `EngineSidecar.start()` had two places that adopt a healthy engine already on the port with no check beyond "it answers `/health`". `adoptIfVersionMatches` compares the running engine's `/health.version` against `app.getVersion()` first: a match adopts as before; a mismatch is stopped the same way `stop()` stops any adopted engine (`POST /shutdown`, then the existing PID-kill fallback if it outlives the grace period) and this instance spawns its own build instead. A version that could not be read (a malformed or missing field) adopts rather than disrupts a healthy engine on an ambiguous answer - the same direction `isPidCertainlyDead`'s own comment takes for its unclear case.

**Alternative considered and rejected:** keying the adoption refusal on `Database::migrate_before_sync`'s existing schema-version guard alone, on the theory that a version mismatch always implies a schema mismatch. Rejected because the two are independent facts: a patch release can ship an app-side or MCP-side fix with no schema change at all, and adopting that daemon would still run every request through a sidecar the current renderer was not built against (a stale `/request-defaults` shape, in particular). The app's own release version is the fact that actually answers "is this the daemon I ship."

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **3043/3043 passed**, 0 failed (this environment's vcpkg needed `vcpkg-fix-port cpp-httplib` and `vcpkg-fix-port curl` first, per `CLAUDE.md`'s cloud-egress gotcha). New tests all green: `ConfigRouteTest.ARowFromANewerEngineIsRefusedAsUnknown`, `ARowFromANewerEngineIsExcludedFromEchoedEntries`, `DatabaseTest.KnownConfigKeyIsWhateverSeedDefaultConfigUpserted`, `ARowWithNoSeedingEntryIsNotAKnownConfigKey`.
- `clang-format-19 --dry-run -Werror` on every touched engine file - clean. `clang-tidy-19` clean via the pre-commit hook that ran on the commit.
- `cd app && pnpm test sidecar && pnpm type-check && pnpm lint` - all green: **24/24 sidecar tests passed (4 new)**, clean type-check across all three TS projects, zero lint errors/warnings.
- New engine coverage: `ConfigRouteTest.ARowFromANewerEngineIsRefusedAsUnknown` / `ARowFromANewerEngineIsExcludedFromEchoedEntries` (seed a row directly, bypassing `seed_default_config`, then assert both routes treat it as unknown - mutation-noted: gating on `get_config_entry` existing instead of the seeded set reds both); `DatabaseTest.KnownConfigKeyIsWhateverSeedDefaultConfigUpserted` / `ARowWithNoSeedingEntryIsNotAKnownConfigKey` (the `Database`-level check).
- New app coverage: two `sidecar.test.ts` cases drive both adoption call sites (lock-PID and no-lock-PID) into a version mismatch and assert `requestShutdown` + a fresh `spawnEngine` rather than silent adoption; one case asserts a null `probeVersion` answer still adopts.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19 via the repo's pre-commit hook; `pnpm lint` / `pnpm format:check` clean)
- [x] I have performed a self-review
- [x] I have added tests (see Testing)
- [x] I have updated documentation (`docs/engine/db-schema.md`'s `config_entries` section, `docs/engine/api-reference.md`'s `GET`/`POST /config`, `docs/lock-file-handling.md`'s adoption sections, `docs/architecture.md`'s sidecar-ownership bullet)

## No screenshot
No renderer UI changed - the config catalogue filter is an engine response-shape change with no new client surface (Settings already only renders what `GET /config` sends), and the adoption check is main-process logic with no window to capture. Existing behaviour (a healthy same-version adoption) is unchanged and already covered by `sidecar.test.ts`'s prior cases.

## Related Issues
Closes #1492