### PR TITLE
feat(engine,app): maxAssertionFailureRatePct threshold and thresholds.failRun

### DIFF
--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -6745,8 +6745,18 @@ export const TOOLS: McpTool[] = [
 					latencyP99Ms: z.number().positive().max(86_400_000).optional(),
 					maxErrorRatePct: z.number().min(0).max(100).optional(),
 					minThroughputRps: z.number().positive().max(1_000_000_000).optional(),
+					maxAssertionFailureRatePct: z.number().min(0).max(100).optional(),
+					// Not a budget - whether a missed one fails the run, not itself
+					// measured against anything, so it is excluded from the
+					// at-least-one-budget refinement below.
+					failRun: z
+						.boolean()
+						.optional()
+						.describe(
+							"When true, a missed budget sets this run's terminal status to failed rather than only reporting the verdict. Default false."
+						),
 				})
-				.refine((t) => Object.keys(t).length > 0, {
+				.refine((t) => Object.keys(t).filter((key) => key !== "failRun").length > 0, {
 					// `error`, not zod 3's `message`: v4 still reads the old key as a
 					// deprecated alias, and a deprecated alias is what the next major
 					// takes away.

--- a/app/src/components/shared/ThresholdVerdict.test.tsx
+++ b/app/src/components/shared/ThresholdVerdict.test.tsx
@@ -95,6 +95,28 @@ describe("ThresholdVerdict", () => {
 		expect(screen.getByText(/≤ 50ms/)).toBeInTheDocument();
 	});
 
+	it("labels the assertion failure rate budget (issue #1497)", () => {
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [
+						{
+							metric: "maxAssertionFailureRatePct",
+							limit: 0,
+							actual: 10,
+							passed: false,
+						},
+					],
+					passed: 0,
+					failed: 1,
+					verdict: "failed",
+				})}
+			/>
+		);
+		expect(screen.getByText(/Assertion failure rate/)).toBeInTheDocument();
+		expect(screen.getByText(/≤ 0%/)).toBeInTheDocument();
+	});
+
 	it("shows a metric it has no label for rather than dropping it", () => {
 		// The counts come from the engine. A check rendered away would leave
 		// "1 of 2 budgets met" above a single row and no way to see the other.

--- a/app/src/components/shared/ThresholdVerdict.tsx
+++ b/app/src/components/shared/ThresholdVerdict.tsx
@@ -40,6 +40,7 @@ const METRIC_LABELS: Record<string, { label: string; unit: string; floor?: boole
 	latencyP99Ms: { label: "p99 latency", unit: "ms" },
 	maxErrorRatePct: { label: "Error rate", unit: "%" },
 	minThroughputRps: { label: "Throughput", unit: "req/s", floor: true },
+	maxAssertionFailureRatePct: { label: "Assertion failure rate", unit: "%" },
 };
 
 /** Trailing zeros are noise on a budget the user typed as a whole number. */

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.test.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.test.ts
@@ -61,6 +61,19 @@ describe("budget validation", () => {
 		expect(budgetError(draft({ minThroughputRps: "0" }))).toMatch(/throughput/i);
 	});
 
+	it("accepts a zero assertion-failure-rate budget, the same real ask as the error rate", () => {
+		expect(budgetError(draft({ maxAssertionFailureRatePct: "0" }))).toBeNull();
+		expect(buildThresholds(draft({ maxAssertionFailureRatePct: "0" }))).toEqual({
+			maxAssertionFailureRatePct: 0,
+		});
+	});
+
+	it("rejects an assertion failure rate outside 0-100", () => {
+		expect(budgetError(draft({ maxAssertionFailureRatePct: "101" }))).toMatch(
+			/assertion failure rate/i
+		);
+	});
+
 	it("rejects text rather than sending NaN", () => {
 		expect(budgetError(draft({ latencyP99Ms: "fast" }))).toMatch(/number/i);
 	});
@@ -82,6 +95,7 @@ describe("the payload the dialog builds", () => {
 					latencyP99Ms: "50",
 					maxErrorRatePct: "0.1",
 					minThroughputRps: "10000",
+					maxAssertionFailureRatePct: "1",
 				})
 			)
 		).toEqual({
@@ -90,7 +104,22 @@ describe("the payload the dialog builds", () => {
 			latencyP99Ms: 50,
 			maxErrorRatePct: 0.1,
 			minThroughputRps: 10000,
+			maxAssertionFailureRatePct: 1,
 		});
+	});
+
+	it("folds failRun in only alongside a declared budget", () => {
+		expect(buildThresholds(draft({ latencyP99Ms: "50" }), true)).toEqual({
+			latencyP99Ms: 50,
+			failRun: true,
+		});
+		expect(buildThresholds(draft({ latencyP99Ms: "50" }), false)).toEqual({
+			latencyP99Ms: 50,
+		});
+		// No budget declared - the engine rejects `{ failRun: true }` alone the
+		// same way it rejects `{}`, so the flag must not turn an empty draft
+		// into a non-empty payload.
+		expect(buildThresholds(emptyBudgetDraft(), true)).toBeUndefined();
 	});
 
 	it("omits the object entirely rather than sending an empty one", () => {

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
@@ -22,7 +22,12 @@
 
 import type { RunThresholds } from "@/types";
 
-export type BudgetKey = keyof RunThresholds;
+/**
+ * `failRun` is not a budget - it is a flag over the budgets below, rendered
+ * as its own switch rather than a numeric field - so it is excluded from the
+ * table-driven machinery here.
+ */
+export type BudgetKey = Exclude<keyof RunThresholds, "failRun">;
 
 export interface BudgetField {
 	key: BudgetKey;
@@ -90,6 +95,18 @@ export const BUDGET_FIELDS: readonly BudgetField[] = [
 		minInclusive: false,
 		max: 1_000_000_000,
 	},
+	{
+		key: "maxAssertionFailureRatePct",
+		id: "lt-budget-assertion-failure-rate",
+		label: "Assertion failure rate at most",
+		unit: "%",
+		// Same reasoning as the error rate above: "no assertion may fail" is a
+		// real budget.
+		min: 0,
+		minInclusive: true,
+		max: 100,
+		hint: "Counts every assert.* element and pm.test call this run made, inline or replayed.",
+	},
 ];
 
 /** What the user has typed, per budget. Blank means "not declared". */
@@ -102,6 +119,7 @@ export function emptyBudgetDraft(): BudgetDraft {
 		latencyP99Ms: "",
 		maxErrorRatePct: "",
 		minThroughputRps: "",
+		maxAssertionFailureRatePct: "",
 	};
 }
 
@@ -137,9 +155,11 @@ export function budgetError(draft: BudgetDraft): string | null {
  * starting a run no verdict will be computed for.
  *
  * Assumes {@link budgetError} passed; an unparseable field is skipped rather
- * than sent as `NaN`.
+ * than sent as `NaN`. `failRun` is folded in only when at least one budget
+ * was declared - the engine rejects `{ failRun: true }` alone, and a lone
+ * flag with no budget to judge means the same thing here.
  */
-export function buildThresholds(draft: BudgetDraft): RunThresholds | undefined {
+export function buildThresholds(draft: BudgetDraft, failRun = false): RunThresholds | undefined {
 	const thresholds: RunThresholds = {};
 	for (const field of BUDGET_FIELDS) {
 		const raw = draft[field.key].trim();
@@ -148,5 +168,7 @@ export function buildThresholds(draft: BudgetDraft): RunThresholds | undefined {
 		if (!Number.isFinite(value)) continue;
 		thresholds[field.key] = value;
 	}
-	return Object.keys(thresholds).length > 0 ? thresholds : undefined;
+	if (Object.keys(thresholds).length === 0) return undefined;
+	if (failRun) thresholds.failRun = true;
+	return thresholds;
 }

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
@@ -10,7 +10,7 @@
  * unusable, and what payload it builds.
  *
  * Kept component-free so the rules can be tested without rendering, and kept in
- * one table because the same five metrics drive the fields, the validation and
+ * one table because the same metrics drive the fields, the validation and
  * the payload - three hand-written lists would drift, and the way that failure
  * shows up is a budget the user typed and the engine never judged.
  *

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -113,6 +113,11 @@ interface SavedLoadTestConfig {
 	 */
 	budgets: BudgetDraft;
 	/**
+	 * Whether a missed budget above should fail the run, not only report it -
+	 * memoed alongside `budgets` for the same reason.
+	 */
+	failRun: boolean;
+	/**
 	 * The monitoring endpoint, memoed for the same reason the budgets are: it is
 	 * a property of the *target* rather than of one run, so retyping a
 	 * `/metrics` URL and its metric names for every run is the same friction the
@@ -329,6 +334,7 @@ export default function LoadTestConfigDialog({
 				latencyP99Ms: String(sloThresholdMs),
 			}
 	);
+	const [failRun, setFailRun] = useState(saved.failRun ?? false);
 	const [budgetsOpen, setBudgetsOpen] = useState(false);
 	/**
 	 * Server monitoring. The cadence and the metric cap are engine settings
@@ -584,6 +590,7 @@ export default function LoadTestConfigDialog({
 			streamDuration,
 			streamMaxEvents,
 			budgets,
+			failRun,
 			monitor,
 		});
 
@@ -598,7 +605,7 @@ export default function LoadTestConfigDialog({
 			comment: comment || undefined,
 			// Absent when nothing was declared - the engine rejects an empty
 			// object rather than starting a run no verdict can be computed for.
-			thresholds: buildThresholds(budgets),
+			thresholds: buildThresholds(budgets, failRun),
 			// Absent when no endpoint was given, for the same reason.
 			monitor: buildMonitor(monitor),
 		};
@@ -1055,6 +1062,23 @@ export default function LoadTestConfigDialog({
 									hint={field.hint}
 								/>
 							))}
+							<div className="flex items-start justify-between gap-3">
+								<Label
+									htmlFor="lt-fail-run"
+									className="text-xs font-normal leading-snug"
+								>
+									Fail the run when a budget is missed
+									<span className="block text-[11px] text-muted-foreground">
+										Otherwise a missed budget is reported but the run still ends
+										Completed.
+									</span>
+								</Label>
+								<Switch
+									id="lt-fail-run"
+									checked={failRun}
+									onCheckedChange={setFailRun}
+								/>
+							</div>
 						</CollapsibleContent>
 					</Collapsible>
 

--- a/app/src/services/load-test-service.progress.test.ts
+++ b/app/src/services/load-test-service.progress.test.ts
@@ -71,10 +71,10 @@ function tick(elapsed: number): LoadTestMetrics {
 }
 
 /** The two private handlers the SSE client calls in production. */
-function closeStream(status: "Completed" | "Stopped" | "Failed" | null = null): Promise<void> {
+function closeStream(status: "completed" | "stopped" | "failed" | null = null): Promise<void> {
 	return (
 		loadTestService as unknown as {
-			handleClose: (status: "Completed" | "Stopped" | "Failed" | null) => Promise<void>;
+			handleClose: (status: "completed" | "stopped" | "failed" | null) => Promise<void>;
 		}
 	).handleClose(status);
 }
@@ -192,14 +192,14 @@ describe("LoadTestService - the OS progress indicator", () => {
 	 * failed frame painted the bar itself the Windows taskbar error state was
 	 * never reached by a real failure - the close cleared the bar instead.
 	 *
-	 * Mutation check: drop the `status === "Failed"` branch in `handleClose`
+	 * Mutation check: drop the `status === "failed"` branch in `handleClose`
 	 * and this reddens twice over - no `fail`, and a `clear` that wipes the bar
 	 * the criterion is about.
 	 */
 	it("says failed when the engine's frame says the run failed", async () => {
 		loadTestService.startMonitoring("run_3");
 
-		await closeStream("Failed");
+		await closeStream("failed");
 
 		expect(mockFail).toHaveBeenCalledWith(LOAD_RUN, "run_3");
 		expect(mockClear).not.toHaveBeenCalled();
@@ -208,7 +208,7 @@ describe("LoadTestService - the OS progress indicator", () => {
 	it("clears rather than reddens when the frame says the run completed", async () => {
 		loadTestService.startMonitoring("run_4");
 
-		await closeStream("Completed");
+		await closeStream("completed");
 
 		expect(mockFail).not.toHaveBeenCalled();
 		expect(mockClear).toHaveBeenCalledWith(LOAD_RUN, "run_4");
@@ -227,7 +227,7 @@ describe("LoadTestService - the OS progress indicator", () => {
 		vi.spyOn(console, "warn").mockImplementation(() => {});
 		loadTestService.startMonitoring("run_5");
 
-		await closeStream("Failed");
+		await closeStream("failed");
 
 		expect(mockFail).toHaveBeenCalledWith(LOAD_RUN, "run_5");
 		expect(mockClear).not.toHaveBeenCalled();

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -83,10 +83,10 @@ import { NOTIFY_KINDS } from "./notify";
  * the status off the engine's completion frame (#1415). `null` is a stream that
  * ended without one - a dropped connection, or an older engine.
  */
-function closeStream(status: "Completed" | "Stopped" | "Failed" | null = null): Promise<void> {
+function closeStream(status: "completed" | "stopped" | "failed" | null = null): Promise<void> {
 	return (
 		loadTestService as unknown as {
-			handleClose: (status: "Completed" | "Stopped" | "Failed" | null) => Promise<void>;
+			handleClose: (status: "completed" | "stopped" | "failed" | null) => Promise<void>;
 		}
 	).handleClose(status);
 }
@@ -392,7 +392,7 @@ describe("LoadTestService", () => {
 			dashboard.currentRunId = "run_15d";
 			loadTestService.startMonitoring("run_15d");
 
-			await closeStream("Failed");
+			await closeStream("failed");
 
 			expect(mockOsIconRunFailed).toHaveBeenCalledTimes(1);
 			expect(mockNotifyPost).toHaveBeenCalledWith(
@@ -410,7 +410,7 @@ describe("LoadTestService", () => {
 			vi.mocked(apiService.getRunReport).mockResolvedValueOnce({
 				summary: {},
 				latency: {},
-				metadata: { status: "Failed" },
+				metadata: { status: "failed" },
 			} as Awaited<ReturnType<typeof apiService.getRunReport>>);
 			dashboard.currentRunId = "run_15e";
 			loadTestService.startMonitoring("run_15e");
@@ -435,7 +435,7 @@ describe("LoadTestService", () => {
 			dashboard.currentRunId = "run_15g";
 			loadTestService.startMonitoring("run_15g");
 
-			await closeStream("Failed");
+			await closeStream("failed");
 
 			expect(mockOsIconRunFailed).toHaveBeenCalledTimes(1);
 			expect(mockNotifyPost).toHaveBeenCalledWith(
@@ -450,7 +450,7 @@ describe("LoadTestService", () => {
 			dashboard.currentRunId = "run_15f";
 			loadTestService.startMonitoring("run_15f");
 
-			await closeStream("Completed");
+			await closeStream("completed");
 
 			expect(mockOsIconRunFailed).not.toHaveBeenCalled();
 			expect(mockNotifyPost).toHaveBeenCalledWith(

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -360,7 +360,7 @@ class LoadTestService {
 		// failures never reach, so a real failure cleared the bar instead of
 		// reddening it. Marking it also sets `progressFailedRunId`, which is
 		// what makes the clear below leave the flash standing.
-		if (status === "Failed") this.failProgress(runId);
+		if (status === "failed") this.failProgress(runId);
 		// Same reason, and the same moment: the run is over, so the taskbar stops
 		// claiming one is going. A run that already reported its failure keeps
 		// that flash instead - see `progressFailedRunId`. A close with no run to
@@ -415,7 +415,7 @@ class LoadTestService {
 			// The frame first, deliberately - the fetch above can fail, and a
 			// failure that could not be read must still report a failure rather
 			// than quietly report success.
-			const failed = status === "Failed" || (status === null && reportStatus === "Failed");
+			const failed = status === "failed" || (status === null && reportStatus === "failed");
 			this.notifyTerminal(
 				runId,
 				failed ? NOTIFY_KINDS.loadRunFailed : NOTIFY_KINDS.loadRunFinished,

--- a/app/src/services/run-supersession.test.ts
+++ b/app/src/services/run-supersession.test.ts
@@ -376,7 +376,7 @@ describe("a run superseded by the other service's run", () => {
 			scenarioRunService as unknown as {
 				handleClose: (status: string | null) => Promise<void>;
 			}
-		).handleClose("Completed");
+		).handleClose("completed");
 
 		expect(mockNotifyPost).toHaveBeenCalledTimes(1);
 		expect(mockNotifyPost.mock.calls[0]?.[0]).toMatchObject({

--- a/app/src/services/scenario-run-service.test.ts
+++ b/app/src/services/scenario-run-service.test.ts
@@ -127,10 +127,10 @@ const FLUSH_MS = 500;
  * the status off the engine's completion frame (#1415). `null` is a stream that
  * ended without one.
  */
-function closeStream(status: "Completed" | "Stopped" | "Failed" | null = null): Promise<void> {
+function closeStream(status: "completed" | "stopped" | "failed" | null = null): Promise<void> {
 	return (
 		scenarioRunService as unknown as {
-			handleClose: (status: "Completed" | "Stopped" | "Failed" | null) => Promise<void>;
+			handleClose: (status: "completed" | "stopped" | "failed" | null) => Promise<void>;
 		}
 	).handleClose(status);
 }
@@ -622,14 +622,14 @@ describe("ScenarioRunService", () => {
 		 * error state was never reached by a real failure - the close cleared
 		 * the bar instead.
 		 *
-		 * Mutation check: drop the `status === "Failed"` branch in `handleClose`
+		 * Mutation check: drop the `status === "failed"` branch in `handleClose`
 		 * and this reddens twice over - no `fail`, and a `clear` that wipes the
 		 * bar the criterion is about.
 		 */
 		it("says failed when the engine's frame says the run failed", async () => {
 			scenarioRunService.startMonitoring("run_24");
 
-			await closeStream("Failed");
+			await closeStream("failed");
 
 			expect(mockProgressFail).toHaveBeenCalledWith(
 				RUN_PROGRESS_KEYS.collectionRun,
@@ -641,7 +641,7 @@ describe("ScenarioRunService", () => {
 		it("clears rather than reddens when the frame says the run completed", async () => {
 			scenarioRunService.startMonitoring("run_25");
 
-			await closeStream("Completed");
+			await closeStream("completed");
 
 			expect(mockProgressFail).not.toHaveBeenCalled();
 			expect(mockProgressClear).toHaveBeenCalledWith(
@@ -703,7 +703,7 @@ describe("ScenarioRunService", () => {
 		it("marks the icon when the engine's frame says the run failed", async () => {
 			scenarioRunService.startMonitoring("run_32");
 
-			await closeStream("Failed");
+			await closeStream("failed");
 
 			expect(mockOsIconRunFailed).toHaveBeenCalledTimes(1);
 		});
@@ -711,7 +711,7 @@ describe("ScenarioRunService", () => {
 		it("marks nothing when the frame says the run completed", async () => {
 			scenarioRunService.startMonitoring("run_33");
 
-			await closeStream("Completed");
+			await closeStream("completed");
 
 			expect(mockOsIconRunFailed).not.toHaveBeenCalled();
 		});

--- a/app/src/services/scenario-run-service.ts
+++ b/app/src/services/scenario-run-service.ts
@@ -352,7 +352,7 @@ class ScenarioRunService {
 		// #1415 `runProgress.fail` was reachable only from `handleError`, which
 		// the engine's own failures never reach, so a real failure cleared the
 		// taskbar instead of reddening it.
-		if (status === "Failed") this.failProgress(runId);
+		if (status === "failed") this.failProgress(runId);
 		this.releaseRun(runId);
 		if (!runId) return;
 
@@ -367,7 +367,7 @@ class ScenarioRunService {
 		// carries (#1415).
 		this.notifyTerminal(
 			runId,
-			status === "Failed"
+			status === "failed"
 				? NOTIFY_KINDS.collectionRunFailed
 				: NOTIFY_KINDS.collectionRunFinished,
 			stepOutcomeLine(useScenarioRunStore.getState().summary.counts)

--- a/app/src/services/sse-client.test.ts
+++ b/app/src/services/sse-client.test.ts
@@ -237,20 +237,20 @@ describe("parseTerminalStatus", () => {
 	 * stream never produces one at all.
 	 */
 	it("reads the three statuses the engine emits", () => {
-		expect(parseTerminalStatus('{"status":"Completed"}')).toBe("Completed");
-		expect(parseTerminalStatus('{"status":"Stopped"}')).toBe("Stopped");
-		expect(parseTerminalStatus('{"status":"Failed"}')).toBe("Failed");
+		expect(parseTerminalStatus('{"status":"completed"}')).toBe("completed");
+		expect(parseTerminalStatus('{"status":"stopped"}')).toBe("stopped");
+		expect(parseTerminalStatus('{"status":"failed"}')).toBe("failed");
 	});
 
 	/*
 	 * Null is "ask the report", never "it finished" - which is the distinction
 	 * the whole fix turns on. Mutation check: default an unparseable frame to
-	 * "Completed" and a failed run whose frame was malformed reports success.
+	 * "completed" and a failed run whose frame was malformed reports success.
 	 */
 	it("answers null for a frame that carries no status it knows", () => {
 		for (const raw of [
 			'{"event":"complete","runId":"r1"}',
-			'{"status":"Running"}',
+			'{"status":"running"}',
 			'{"status":42}',
 			"not json",
 			"",
@@ -378,8 +378,8 @@ describe("SSEClient - the hand-off when a run is displaced", () => {
 		const first = handlers();
 
 		attach(client, "run_1", first);
-		MockEventSource.instances[0]?.complete("Completed");
-		expect(first.onClose).toHaveBeenCalledWith("Completed");
+		MockEventSource.instances[0]?.complete("completed");
+		expect(first.onClose).toHaveBeenCalledWith("completed");
 
 		attach(client, "run_2", handlers());
 		expect(first.onSuperseded).not.toHaveBeenCalled();

--- a/app/src/services/sse-client.ts
+++ b/app/src/services/sse-client.ts
@@ -180,7 +180,7 @@ export type SSEErrorHandler = (error: Error) => void;
  * converges on the stored report either way, and a null here means "ask it",
  * never "it finished".
  */
-export type SSETerminalStatus = "Completed" | "Stopped" | "Failed" | null;
+export type SSETerminalStatus = "completed" | "stopped" | "failed" | null;
 
 export type SSECloseHandler = (status: SSETerminalStatus) => void;
 
@@ -194,7 +194,13 @@ export type SSECloseHandler = (status: SSETerminalStatus) => void;
 export function parseTerminalStatus(raw: string): SSETerminalStatus {
 	try {
 		const { status } = JSON.parse(raw) as { status?: unknown };
-		if (status === "Completed" || status === "Stopped" || status === "Failed") return status;
+		// Lowercase, matching the engine's `to_string(RunStatus)` - the same
+		// values `RunReport["status"]` and a stored report's `metadata.status`
+		// already carry (issue #1497's `failRun` makes `Failed` a run-of-the-mill
+		// outcome rather than a crash-only rarity, which is what made this
+		// case mismatch worth closing: capitalized comparisons here never
+		// matched a real frame).
+		if (status === "completed" || status === "stopped" || status === "failed") return status;
 		return null;
 	} catch {
 		return null;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1617,6 +1617,18 @@ export interface RunThresholds {
 	/** Share of the run's requests allowed to fail, 0-100. */
 	maxErrorRatePct?: number;
 	minThroughputRps?: number;
+	/**
+	 * Share of the run's assertions - `assert.*` element outcomes and
+	 * `pm.test` calls alike - allowed to fail, 0-100 (issue #1497).
+	 */
+	maxAssertionFailureRatePct?: number;
+	/**
+	 * A budget this run missed changes its terminal status to `failed`
+	 * rather than only being reported (issue #1497). Not a budget itself, so
+	 * it needs at least one of the above declared to mean anything - the
+	 * engine rejects `{ failRun: true }` alone the same way it rejects `{}`.
+	 */
+	failRun?: boolean;
 }
 
 /**

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -1376,6 +1376,18 @@ section renders exactly as it did before budgets existed. The dialog seeds its
 p99 field from the client `sloThresholdMs` setting, which until then only
 annotated a chart.
 
+`maxAssertionFailureRatePct` (issue #1497) is the sixth budget, judged against
+the run's combined `assert.*` element and `pm.test` tally rather than against
+`testValidation`'s per-response view. `thresholds.failRun: true`
+(`LoadTestConfigDialog`'s own Switch, beside the budget fields rather than in
+`BUDGET_FIELDS` - it is a flag over the budgets, not one itself) changes what a
+missed budget *does*: the run's terminal status becomes `"failed"` instead of
+`"completed"`, so the history list and the taskbar failure cue pick it up, not
+only the verdict section. Load runs only, today - see
+[POST /runs](../engine/api-reference.md#post-runs)'s thresholds section for the
+collection-run gap this is tracked against
+([#1564](https://github.com/athrvk/vayu/issues/1564)).
+
 The engine range-checks this payload before it creates the run row and answers a
 violation with `400 invalid_run_config` (accepted ranges are tabulated under
 [POST /runs](../engine/api-reference.md#post-runs)). The renderer's own limits

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5025,26 +5025,47 @@ its report has no such section at all.
     "latencyP95Ms": 40,        // ceiling, ms
     "latencyP99Ms": 50,        // ceiling, ms
     "maxErrorRatePct": 0.1,    // ceiling, percent of the run's requests; 0-100
-    "minThroughputRps": 10000  // floor, completed requests per second; > 0
+    "minThroughputRps": 10000, // floor, completed requests per second; > 0
+    "maxAssertionFailureRatePct": 0, // ceiling, percent of assert.* and pm.test outcomes; 0-100
+    "failRun": true            // a missed budget sets status "failed"; default false
   }
 }
 ```
 
-Every key is optional and at least one must be present. An unknown key, a
-non-numeric or out-of-range value, or an object that declares nothing is a `400`
-`invalid_run_config` naming the field - and, like every other run-config
-rejection, it happens before the run row is created, so a rejected request
-leaves no trace. A `null` value reads as absent, the same rule the flat numeric
-fields follow.
+Every key but `failRun` is a budget; at least one budget must be present (a
+`thresholds` object holding only `failRun` is rejected the same way an empty
+one is - it names nothing to judge). An unknown key, a non-numeric or
+out-of-range budget value, a non-boolean `failRun`, or an object that declares
+no budget is a `400` `invalid_run_config` naming the field - and, like every
+other run-config rejection, it happens before the run row is created, so a
+rejected request leaves no trace. A `null` value reads as absent, the same
+rule the flat numeric fields follow.
 
 `maxErrorRatePct` is measured against every response outside 2xx/3xx **plus** the
 transport failures that never got one - the same figure `summary.errorRate`
 reports. This is deliberately wider than the script-level `pm.test` view: a run
 of nothing but HTTP 500s has a transport error rate of zero.
 
+`maxAssertionFailureRatePct` (issue #1497) is measured against this run's
+combined assertion tally: every `assert.*` element outcome and every
+`pm.test` call, however the script that made it ran - inline on the load
+path or through the deferred replay. Unevaluated, like a latency percentile,
+when the run made no assertion at all - a run with no `assert.*` element and
+no test script is unaffected by declaring this budget. **Load runs only**
+(a single-request or a scenario load run, `POST /runs` with no `scenario`
+block or with one carrying a load `mode`): a **collection** (sequential,
+design-mode) run's config is still accepted with a `thresholds` block, but
+nothing evaluates it yet and its report carries no `thresholdValidation`
+section - the same "measured, not judged" behavior as a run that declared no
+budgets at all. Tracked in
+[#1564](https://github.com/athrvk/vayu/issues/1564).
+
 The verdict is the run's, not the process's: a run **stopped early** is judged on
-what it measured up to that point, and its status stays `completed` / `stopped`
-whatever the verdict says. A failing budget is reported, never a failed run.
+what it measured up to that point, and its status stays `stopped` whatever the
+verdict says. A **completed** run whose config set `thresholds.failRun: true`
+and whose budgets it missed ends `failed` instead of `completed`; without the
+flag, or on a run that met every budget, a failing budget is reported but
+never changes the terminal status.
 
 Each check carries `evaluated`. A latency percentile needs a completed request
 to mean anything, so a run that recorded none for that metric (every request

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -190,8 +190,11 @@ gap, outside this page's Status callout.
   the script-to-elements cut-over (this page's Status callout).
 - #1495 - the pipeline on a scenario load run's producer/completion hooks (this page's Load
   paths section).
-- #1497, #1515, #1498, #1500, #1499, #1501 - the assertion threshold, controllers, timers,
-  metrics, setup/teardown and load-time cookies that round out the kind table.
+- #1497 - the `maxAssertionFailureRatePct` run threshold and `thresholds.failRun`, over the
+  combined `assert.*` element and `pm.test` tally (load runs only; see `api-reference.md`'s
+  thresholds section).
+- #1515, #1498, #1500, #1499, #1501 - controllers, timers, metrics, setup/teardown and
+  load-time cookies that round out the kind table.
 - #1516 - the app's `ElementList` primitive and editor.
 - #1517 - MCP's `elements` fields and the `vayu://elements/kinds` resource.
 - #1518 - Postman/OpenAPI round-trip and a JMeter `.jmx` importer.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -924,6 +924,12 @@ struct RunSummaryInputs {
     // Absent when the run had no test script or no sampled responses - the
     // report then omits its testValidation section, as it always has.
     std::optional<ScriptValidationTotals> tests;
+    // This run's combined assert.* element and pm.test tally (issue #1497):
+    // `tests` above plus every declarative assertion and inline script
+    // assertion, folded together for `maxAssertionFailureRatePct`. Absent
+    // when the run made no assertion at all, which is what keeps that metric
+    // unevaluated rather than a trivial pass at 0/0.
+    std::optional<AssertionTotals> assertions;
     // The verdict on the budgets this run's config declared. Absent when it
     // declared none, which keeps the report's thresholdValidation section out
     // rather than reporting a run that passed zero checks. Sibling of `tests`,

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -92,6 +92,7 @@
 
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/threshold_eval.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_exchange.hpp"
 #include "vayu/types.hpp"
@@ -274,6 +275,15 @@ class StepElementTallies {
     /// nothing happened" convention `unresolvedTokens` and `tests` follow.
     [[nodiscard]] nlohmann::json build (const ScenarioPlan& plan, size_t step) const;
 
+    /// Summed passed/failed across every step, for elements whose kind is
+    /// `assert.*` - the declarative half of issue #1497's combined assertion
+    /// tally. A `script.*` element's own outcome is not a `pass/fail` of its
+    /// assertions (see `script_kinds.cpp`'s file comment) and is deliberately
+    /// excluded here; its `pm.test` calls are tallied separately, on
+    /// `ScenarioLoadState::inline_script_tests_passed` /
+    /// `_failed`.
+    [[nodiscard]] AssertionTotals assertion_totals (const ScenarioPlan& plan) const;
+
     private:
     struct Counts {
         std::atomic<size_t> passed{ 0 };
@@ -322,6 +332,17 @@ struct ScenarioLoadState {
     /// Per-step, per-element pass/fail/skip tallies (issue #1495), written by
     /// the same completion that writes `steps` above - see the class comment.
     StepElementTallies element_tallies;
+    /// Combined pass/fail of every `pm.test` call an *inline* `script.pre` or
+    /// `script.post` element made this run (issue #1497). `element_tallies`
+    /// above already records that element's own outcome - did the script run
+    /// without throwing - which is a different question from whether its own
+    /// assertions passed (`script_kinds.cpp`'s file comment: "a script's own
+    /// `pm.test` assertions travel inside that `ScriptResult` untouched").
+    /// Nothing read those before this run's `maxAssertionFailureRatePct`; a
+    /// deferred (non-inline) script's tests are counted separately, in the
+    /// post-run replay's `ScriptValidationTotals`.
+    std::atomic<size_t> inline_script_tests_passed{ 0 };
+    std::atomic<size_t> inline_script_tests_failed{ 0 };
     /**
      * This run's shared variable scopes (issue #1495) - the same shape and
      * source a design send's would be, loaded once here rather than per

--- a/engine/include/vayu/core/threshold_eval.hpp
+++ b/engine/include/vayu/core/threshold_eval.hpp
@@ -59,6 +59,15 @@ struct ThresholdOutcome {
     size_t failed = 0;
 };
 
+/// This run's combined assertion tally: every `assert.*` element outcome and
+/// every `pm.test` call, however the script that made it ran - inline on the
+/// load path or through the deferred replay. What `maxAssertionFailureRatePct`
+/// is measured against; nothing else in the report reads it.
+struct AssertionTotals {
+    size_t passed = 0;
+    size_t failed = 0;
+};
+
 /**
  * @brief Reject a `thresholds` object the run could not act on.
  *
@@ -91,5 +100,16 @@ struct ThresholdOutcome {
  */
 [[nodiscard]] std::optional<ThresholdOutcome>
 evaluate_thresholds (const nlohmann::json& config, const RunSummaryInputs& inputs);
+
+/**
+ * @brief Does this run's config ask a failed budget to fail the run?
+ *
+ * Reads `thresholds.failRun`, defaulting to `false` - the pre-existing
+ * history semantics, where a budget miss is reported but never changes the
+ * terminal status, are what every run gets without asking for this. Absent,
+ * `null` or anything but `true` reads as `false`; `validate_thresholds`
+ * already refuses anything else the key could hold.
+ */
+[[nodiscard]] bool thresholds_fail_run (const nlohmann::json& config);
 
 } // namespace vayu::core

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1446,6 +1446,33 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
         // the payload builder treats as absent.
         inputs.coverage = build_scenario_load_coverage (*scenario_state);
     }
+    // Issue #1497's combined assertion tally: the deferred replay's pm.test
+    // results (already in `inputs.tests`, both single-request and scenario
+    // runs), plus - for a scenario run - every `assert.*` element outcome and
+    // every inline script's own pm.test calls, neither of which anything else
+    // reads at run level. Absent when the run made no assertion, so
+    // `maxAssertionFailureRatePct` stays unevaluated rather than a trivial
+    // pass at 0/0.
+    {
+        AssertionTotals assertions;
+        if (inputs.tests) {
+            assertions.passed += inputs.tests->passed;
+            assertions.failed += inputs.tests->failed;
+        }
+        if (scenario_state) {
+            const auto element_totals =
+            scenario_state->element_tallies.assertion_totals (context->scenario->plan);
+            assertions.passed += element_totals.passed;
+            assertions.failed += element_totals.failed;
+            assertions.passed += scenario_state->inline_script_tests_passed.load (
+            std::memory_order_relaxed);
+            assertions.failed += scenario_state->inline_script_tests_failed.load (
+            std::memory_order_relaxed);
+        }
+        if (assertions.passed + assertions.failed > 0) {
+            inputs.assertions = assertions;
+        }
+    }
     // Beside coverage, and deliberately not inside the `scenario_state`
     // block above: this pass reads the sample reservoirs, which are the
     // collector's, so it is available whether or not the executor left
@@ -1523,21 +1550,35 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
     }
 
     // Store the whole-run summary: everything the report used to rebuild by
-    // scanning the run's metric rows, written once, here.
+    // scanning the run's metric rows, written once, here. Hoisted out of the
+    // try so the terminal-status decision below can read its verdict - the
+    // budgets this run just measured, never a second query for them (a core
+    // that reads, decides and writes holds one lock; engine/CLAUDE.md).
+    RunSummaryInputs inputs;
+    bool summary_stored = false;
     try {
         const RunTotals totals{ completed, actual_rps, total_duration_s,
             setup_overhead_s, avg_latency, percentiles };
-        const RunSummaryInputs inputs = collect_summary_inputs (
+        inputs = collect_summary_inputs (
         context, totals, validation, schema_totals, scenario_state);
         db.update_run_summary (
         context->run_id, build_run_summary_payload (inputs).dump ());
+        summary_stored = true;
     } catch (const std::exception& e) {
         vayu::utils::log_error ("Failed to store run summary: " + std::string (e.what ()));
     }
 
-    // Update run status with retry logic to handle any remaining contention
+    // Update run status with retry logic to handle any remaining contention.
+    // A stopped run keeps reporting Stopped regardless of verdict (issue
+    // #1497's failRun judges only a run that reached its own natural end);
+    // a completed run whose config asked `thresholds.failRun: true` and
+    // whose budgets it missed is judged too.
     vayu::RunStatus final_status =
     context->should_stop ? vayu::RunStatus::Stopped : vayu::RunStatus::Completed;
+    if (!context->should_stop && summary_stored && inputs.thresholds &&
+    inputs.thresholds->failed > 0 && thresholds_fail_run (context->config)) {
+        final_status = vayu::RunStatus::Failed;
+    }
     db.update_run_status_with_retry (context->run_id, final_status);
 
     // Terminal status reached - trim old runs per the retention knobs.

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -268,7 +268,13 @@ AssertionTotals StepElementTallies::assertion_totals (const ScenarioPlan& plan) 
         const auto& counts   = counts_by_step_[step];
         const size_t count   = std::min (elements.size (), counts.size ());
         for (size_t i = 0; i < count; ++i) {
-            if (!elements[i].kind.starts_with ("assert.")) {
+            // Read through the registry's own category, never a `kind ==` or
+            // prefix comparison outside `core/elements` (#1512's extensibility
+            // contract, rule 1) - the same lookup `load_pipeline_skip_reason`
+            // above uses for `HotPathClass`.
+            const auto* registered =
+            vayu::core::Registry::instance ().find (elements[i].kind);
+            if (registered == nullptr || registered->category != "assert") {
                 continue;
             }
             totals.passed += counts[i].passed.load (std::memory_order_relaxed);

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -257,6 +257,27 @@ nlohmann::json StepElementTallies::build (const ScenarioPlan& plan, size_t step)
     return array;
 }
 
+AssertionTotals StepElementTallies::assertion_totals (const ScenarioPlan& plan) const {
+    AssertionTotals totals;
+    const size_t step_count = std::min (plan.steps.size (), counts_by_step_.size ());
+    for (size_t step = 0; step < step_count; ++step) {
+        if (!plan.steps[step].elements) {
+            continue;
+        }
+        const auto& elements = *plan.steps[step].elements;
+        const auto& counts   = counts_by_step_[step];
+        const size_t count   = std::min (elements.size (), counts.size ());
+        for (size_t i = 0; i < count; ++i) {
+            if (!elements[i].kind.starts_with ("assert.")) {
+                continue;
+            }
+            totals.passed += counts[i].passed.load (std::memory_order_relaxed);
+            totals.failed += counts[i].failed.load (std::memory_order_relaxed);
+        }
+    }
+    return totals;
+}
+
 nlohmann::json build_step_breakdown (const ScenarioPlan& plan,
 const StepHistograms& steps,
 const StepElementTallies& elements) {
@@ -440,6 +461,16 @@ vayu::Request& request) {
     for (const auto& outcome : outcomes) {
         state.element_tallies.record (step_index, outcome.id, outcome.status);
     }
+    // `pre_result.tests` is populated only when `script.pre` actually ran
+    // above (a deferred one never invokes `run_pre_script`, so it stays
+    // empty) - the inline half of issue #1497's assertion tally.
+    for (const auto& test : pre_result.tests) {
+        if (test.passed) {
+            state.inline_script_tests_passed.fetch_add (1, std::memory_order_relaxed);
+        } else {
+            state.inline_script_tests_failed.fetch_add (1, std::memory_order_relaxed);
+        }
+    }
 
     if (!start) {
         return 0;
@@ -509,6 +540,14 @@ const vayu::Response& response) {
     });
     for (const auto& outcome : outcomes) {
         state.element_tallies.record (step_index, outcome.id, outcome.status);
+    }
+    // Same rule as `run_step_before`: empty unless `script.post` ran inline.
+    for (const auto& test : post_result.tests) {
+        if (test.passed) {
+            state.inline_script_tests_passed.fetch_add (1, std::memory_order_relaxed);
+        } else {
+            state.inline_script_tests_failed.fetch_add (1, std::memory_order_relaxed);
+        }
     }
 
     if (!start) {

--- a/engine/src/core/threshold_eval.cpp
+++ b/engine/src/core/threshold_eval.cpp
@@ -68,9 +68,30 @@ double measured_error_rate (const RunSummaryInputs& inputs) {
 constexpr double MAX_LATENCY_BUDGET_MS = 86400000.0; // a day; past it nothing completes
 constexpr double MAX_THROUGHPUT_BUDGET_RPS = 1e9;
 
+/// Share of this run's assertions - `assert.*` element outcomes and `pm.test`
+/// calls alike, inline or replayed - that failed, as a percentage. Zero when
+/// the run made none, which `assertion_data_present` is what keeps this
+/// metric out of the verdict for rather than a trivial pass.
+double measured_assertion_failure_rate (const RunSummaryInputs& inputs) {
+    if (!inputs.assertions) {
+        return 0.0;
+    }
+    const size_t total = inputs.assertions->passed + inputs.assertions->failed;
+    if (total == 0) {
+        return 0.0;
+    }
+    return static_cast<double> (inputs.assertions->failed) * 100.0 /
+    static_cast<double> (total);
+}
+
+bool assertion_data_present (const RunSummaryInputs& inputs) {
+    return inputs.assertions.has_value () &&
+    (inputs.assertions->passed + inputs.assertions->failed) > 0;
+}
+
 /// Every budget a run may declare, in the order the report lists them.
-const std::array<ThresholdMetric, 5>& metrics () {
-    static const std::array<ThresholdMetric, 5> table = { {
+const std::array<ThresholdMetric, 6>& metrics () {
+    static const std::array<ThresholdMetric, 6> table = { {
     { "latencyP50Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
     "greater than 0 and at most 86400000", "It is a latency ceiling in milliseconds.",
     [] (const RunSummaryInputs& in) { return in.latency.p50; },
@@ -88,6 +109,9 @@ const std::array<ThresholdMetric, 5>& metrics () {
     { "minThroughputRps", Direction::AtLeast, 0.0, false, MAX_THROUGHPUT_BUDGET_RPS,
     "greater than 0 and at most 1000000000", "It is a completed-requests-per-second floor.",
     [] (const RunSummaryInputs& in) { return in.throughput; }, nullptr },
+    { "maxAssertionFailureRatePct", Direction::AtMost, 0.0, true, 100.0,
+    "between 0 and 100", "It is a percentage of this run's assert.* and pm.test outcomes.",
+    measured_assertion_failure_rate, assertion_data_present },
     } };
     return table;
 }
@@ -157,6 +181,18 @@ std::optional<std::string> validate_thresholds (const nlohmann::json& config) {
 
     size_t declared = 0;
     for (const auto& [key, value] : thresholds.items ()) {
+        // Not a budget: whether a failed one fails the run, not itself
+        // measured against anything, so it never joins `declared` below.
+        if (key == "failRun") {
+            if (value.is_null ()) {
+                continue; // Same null-means-absent rule every other key follows.
+            }
+            if (!value.is_boolean ()) {
+                return "'thresholds.failRun' must be a boolean (got " +
+                std::string (value.type_name ()) + ")";
+            }
+            continue;
+        }
         const ThresholdMetric* metric = find_metric (key);
         if (metric == nullptr) {
             return "'thresholds." + key +
@@ -229,6 +265,18 @@ const RunSummaryInputs& inputs) {
         outcome.checks.push_back (std::move (check));
     }
     return outcome;
+}
+
+bool thresholds_fail_run (const nlohmann::json& config) {
+    if (!config.is_object () || !config.contains ("thresholds")) {
+        return false;
+    }
+    const auto& thresholds = config["thresholds"];
+    if (!thresholds.is_object () || !thresholds.contains ("failRun")) {
+        return false;
+    }
+    const auto& value = thresholds["failRun"];
+    return value.is_boolean () && value.get<bool> ();
 }
 
 } // namespace vayu::core

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -5,8 +5,10 @@
 #include <chrono>
 #include <thread>
 
+#include "mock_server.hpp"
 #include "temp_database.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/platform/platform.hpp"
 
@@ -645,4 +647,105 @@ TEST (ReadRetention, CarriesTheResponseSampleBudgetMarkerIntoTheSummary) {
     EXPECT_FALSE (build_run_summary_payload (
     uniform)["sampling"]["response_sample_budget_spent"]
     .get<bool> ());
+}
+
+// ============================================================================
+// finish_load_test's terminal-status decision (issue #1497). `finish_load_test`
+// itself is not declared in run_manager.hpp, so this drives it the only way a
+// test can: a real run, end to end through RunManager::start_run exactly as
+// the route does, the way run_stop_test.cpp's StoppedRunReachesTerminalStatus-
+// Promptly drives the stop path. The issue's own Tests section asked for this
+// case by name: "run_manager test: failRun: true with a failed budget stores
+// Failed."
+// ============================================================================
+
+class FailRunTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_run_manager_fail_run.db";
+
+    void SetUp () override {
+        vayu::http::global_init ();
+        server = std::make_unique<vayu::tests::SlowMockServer> ();
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+        server.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    /// Create the row `start_run` expects to already exist (the route's own
+    /// job), then drive the run to completion and hand back its stored status.
+    /// Waits well past a healthy run's own duration on purpose: a slow-but-
+    /// finishing run fails the caller's status assertion, not this wait.
+    std::optional<vayu::RunStatus> run_to_terminal_status (const std::string& run_id,
+    const nlohmann::json& config) {
+        vayu::db::Run row;
+        row.id              = run_id;
+        row.type            = vayu::RunType::Load;
+        row.status          = vayu::RunStatus::Pending;
+        row.config_snapshot = "{}";
+        row.start_time = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                         .count ();
+        row.end_time = 0;
+        db->create_run (row);
+
+        vayu::core::RunManager manager;
+        manager.start_run (run_id, config, *db);
+
+        const auto deadline =
+        std::chrono::steady_clock::now () + std::chrono::seconds (20);
+        while (manager.get_run (run_id) != nullptr &&
+        std::chrono::steady_clock::now () < deadline) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (20));
+        }
+        if (manager.get_run (run_id) != nullptr) {
+            ADD_FAILURE () << "the run never reached a terminal status";
+            return std::nullopt;
+        }
+
+        auto stored = db->get_run (run_id);
+        if (!stored.has_value ()) {
+            ADD_FAILURE () << "the finished run left no row behind";
+            return std::nullopt;
+        }
+        return stored->status;
+    }
+
+    nlohmann::json base_config () const {
+        return { { "mode", "iterations" }, { "iterations", 3 }, { "concurrency", 1 },
+            { "url", server->fast_url () }, { "method", "GET" }, { "workers", 1 },
+            { "tests", "pm.test('always fails', function () { pm.expect(1).to.equal(2); });" } };
+    }
+
+    std::unique_ptr<vayu::tests::SlowMockServer> server;
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+// Mutation check: comment out the `final_status = vayu::RunStatus::Failed`
+// assignment in `finish_load_test` and this reddens to Completed.
+TEST_F (FailRunTest, AFailedAssertionBudgetWithFailRunEndsTheRunFailed) {
+    auto config = base_config ();
+    config["thresholds"] = { { "maxAssertionFailureRatePct", 0 }, { "failRun", true } };
+
+    auto status = run_to_terminal_status ("run-fail-run-e2e", config);
+    ASSERT_HAS_VALUE (status);
+    EXPECT_EQ (*status, vayu::RunStatus::Failed);
+}
+
+// The companion: without `failRun`, the same missed budget is still reported
+// (this run's `thresholdValidation.verdict` is "failed", asserted at the unit
+// level in threshold_eval_test.cpp) but the terminal status is untouched - the
+// pre-existing history semantics nobody who did not opt in should see change.
+TEST_F (FailRunTest, TheSameMissedBudgetWithoutFailRunStaysCompleted) {
+    auto config          = base_config ();
+    config["thresholds"] = { { "maxAssertionFailureRatePct", 0 } };
+
+    auto status = run_to_terminal_status ("run-fail-run-optout-e2e", config);
+    ASSERT_HAS_VALUE (status);
+    EXPECT_EQ (*status, vayu::RunStatus::Completed);
 }

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -1297,17 +1297,23 @@ TEST_F (ScenarioLoadTest, AnInlineScriptsPmTestCallsAreTalliedSeparatelyFromItsE
         { "concurrency", 1 } };
     auto state        = run (config, execution);
 
+    // `ScriptResult::success` already folds a failed `pm.test` into "did the
+    // script run cleanly" (`script_engine.cpp`'s post-eval loop over
+    // `result.tests`), so `StepElementTallies` - a single pass/fail bit per
+    // script *run* - already marks this element failed; that part predates
+    // this issue. What did not exist before this PR is the assertion-level
+    // count behind that one bit: one `pm.test` call passed and one failed,
+    // and only `inline_script_tests_passed`/`_failed` can tell the two apart
+    // from a run where *both* calls failed - the element tally reads
+    // identically either way.
     EXPECT_EQ (state->inline_script_tests_passed.load (), 1u);
     EXPECT_EQ (state->inline_script_tests_failed.load (), 1u);
 
-    // The element's own outcome is unaffected: the script did not throw, so
-    // it still reports "ok" even though one of its assertions failed - this
-    // test's whole point is that the two are different questions.
     const auto summary =
     vayu::core::build_scenario_load_summary (*state, execution.plan);
     ASSERT_TRUE (summary["steps"][0].contains ("elements"));
-    EXPECT_EQ (summary["steps"][0]["elements"][0]["passed"], 1);
-    EXPECT_EQ (summary["steps"][0]["elements"][0]["failed"], 0);
+    EXPECT_EQ (summary["steps"][0]["elements"][0]["passed"], 0);
+    EXPECT_EQ (summary["steps"][0]["elements"][0]["failed"], 1);
 }
 
 // ============================================================================

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -1239,6 +1239,78 @@ TEST_F (ScenarioLoadTest, PerStepElementTalliesAreAttachedToTheBreakdown) {
 }
 
 // ============================================================================
+// The combined assertion tally (issue #1497): assert.* elements and an
+// inline script's own pm.test calls, summed for maxAssertionFailureRatePct.
+// ============================================================================
+
+TEST_F (ScenarioLoadTest, AssertionTotalsSumsOnlyAssertStarKindsAcrossSteps) {
+    ScenarioMockServer server;
+    auto execution                   = plan_over ({ server.url ("/echo") });
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { { { "id", "el_status" }, { "kind", "assert.status" }, { "enabled", true },
+      { "config", { { "in", json::array ({ 200 }) } } } },
+    // A non-assert kind beside it, to prove it is excluded from the sum -
+    // an extract.* pass/fail here must not inflate the assertion tally.
+    vayu::tests::extract_json_element_json ("el_extract", "$.ok", "ok") });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 3 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    const auto totals = state->element_tallies.assertion_totals (execution.plan);
+    EXPECT_EQ (totals.passed, 3u);
+    EXPECT_EQ (totals.failed, 0u);
+}
+
+TEST_F (ScenarioLoadTest, AFailingAssertStatusElementCountsAsAFailedAssertion) {
+    ScenarioMockServer server;
+    auto execution                   = plan_over ({ server.url ("/echo") });
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { { { "id", "el_status" }, { "kind", "assert.status" }, { "enabled", true },
+    { "config", { { "in", json::array ({ 404 }) } } } } }); // /echo answers 200
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    const auto totals = state->element_tallies.assertion_totals (execution.plan);
+    EXPECT_EQ (totals.passed, 0u);
+    EXPECT_EQ (totals.failed, 2u);
+}
+
+// The gap this issue closes: `script_kinds.cpp`'s `apply` reports the
+// element's own outcome as "did the script throw", never whether its
+// `pm.test` calls passed - so before this, a failing inline assertion was
+// invisible at run level. Mutation check: remove the `pre_result.tests` /
+// `post_result.tests` loops in `scenario_load.cpp`'s `run_step_before` /
+// `run_step_after` and both counters here stay zero.
+TEST_F (ScenarioLoadTest, AnInlineScriptsPmTestCallsAreTalliedSeparatelyFromItsElementOutcome) {
+    ScenarioMockServer server;
+    auto execution                   = plan_over ({ server.url ("/echo") });
+    execution.plan.steps[0].elements = vayu::tests::compiled_elements (
+    { vayu::tests::script_element_json ("el_post", "script.post",
+    "pm.test('passes', function () { pm.expect(1).to.equal(1); });"
+    "pm.test('fails', function () { pm.expect(1).to.equal(2); });",
+    /*inline_script=*/true) });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    EXPECT_EQ (state->inline_script_tests_passed.load (), 1u);
+    EXPECT_EQ (state->inline_script_tests_failed.load (), 1u);
+
+    // The element's own outcome is unaffected: the script did not throw, so
+    // it still reports "ok" even though one of its assertions failed - this
+    // test's whole point is that the two are different questions.
+    const auto summary =
+    vayu::core::build_scenario_load_summary (*state, execution.plan);
+    ASSERT_TRUE (summary["steps"][0].contains ("elements"));
+    EXPECT_EQ (summary["steps"][0]["elements"][0]["passed"], 1);
+    EXPECT_EQ (summary["steps"][0]["elements"][0]["failed"], 0);
+}
+
+// ============================================================================
 // Data rows in load mode (issue #449)
 // ============================================================================
 

--- a/engine/tests/threshold_eval_test.cpp
+++ b/engine/tests/threshold_eval_test.cpp
@@ -30,9 +30,11 @@
 
 namespace {
 
+using vayu::core::AssertionTotals;
 using vayu::core::evaluate_thresholds;
 using vayu::core::RunSummaryInputs;
 using vayu::core::ThresholdOutcome;
+using vayu::core::thresholds_fail_run;
 using vayu::core::validate_thresholds;
 
 /// A run that completed 1000 requests: 990 OK, 8 server errors, 2 transport
@@ -154,11 +156,12 @@ TEST (ThresholdEval, AThroughputFloorOfZeroIsRejected) {
 
 TEST (ThresholdEval, EveryKnownBudgetIsAcceptedTogether) {
     nlohmann::json thresholds{ { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 },
-        { "latencyP99Ms", 50 }, { "maxErrorRatePct", 0.1 }, { "minThroughputRps", 10000 } };
+        { "latencyP99Ms", 50 }, { "maxErrorRatePct", 0.1 },
+        { "minThroughputRps", 10000 }, { "maxAssertionFailureRatePct", 5 } };
     EXPECT_FALSE (validate_thresholds (config_with (thresholds)).has_value ());
     auto outcome = evaluate_thresholds (config_with (thresholds), measured_run ());
     ASSERT_HAS_VALUE (outcome);
-    EXPECT_EQ (outcome->checks.size (), 5u);
+    EXPECT_EQ (outcome->checks.size (), 6u);
 }
 
 // --- The verdict: each budget passes and fails off the run's own numbers ---
@@ -307,6 +310,82 @@ TEST (ThresholdEval, AThroughputOrErrorRateBudgetIsAlwaysEvaluated) {
     evaluate_thresholds (config_with ({ { "minThroughputRps", 10 } }), empty));
     EXPECT_TRUE (throughput.evaluated);
     EXPECT_FALSE (throughput.passed); // 0 rps never meets a floor above zero
+}
+
+// --- maxAssertionFailureRatePct (issue #1497): assert.* elements and
+// pm.test calls, folded together, over a run's combined assertion tally ---
+
+TEST (ThresholdEval, AZeroAssertionFailureRateBudgetIsAccepted) {
+    // Same reasoning as the error rate: "no assertion may fail" is a real ask.
+    EXPECT_FALSE (
+    validate_thresholds (config_with ({ { "maxAssertionFailureRatePct", 0 } })).has_value ());
+}
+
+TEST (ThresholdEval, AnAssertionFailureRateBudgetOutsideZeroToHundredIsRejected) {
+    expect_rejected ({ { "maxAssertionFailureRatePct", -0.1 } }, "maxAssertionFailureRatePct");
+    expect_rejected ({ { "maxAssertionFailureRatePct", 100.5 } }, "maxAssertionFailureRatePct");
+}
+
+TEST (ThresholdEval, AnAssertionFailureRateBudgetIsUnevaluatedWithNoAssertions) {
+    // The run made no assertion at all - `inputs.assertions` stays unset, the
+    // same "no data" state a latency percentile with zero completions has.
+    auto check = only_check (evaluate_thresholds (
+    config_with ({ { "maxAssertionFailureRatePct", 0 } }), measured_run ()));
+    EXPECT_FALSE (check.evaluated);
+    EXPECT_FALSE (check.passed);
+}
+
+TEST (ThresholdEval, AnAssertionFailureRateBudgetReadsTheCombinedTally) {
+    RunSummaryInputs inputs = measured_run ();
+    inputs.assertions = AssertionTotals{ .passed = 18, .failed = 2 }; // 10%
+
+    auto pass = only_check (evaluate_thresholds (
+    config_with ({ { "maxAssertionFailureRatePct", 10 } }), inputs));
+    EXPECT_TRUE (pass.evaluated);
+    EXPECT_DOUBLE_EQ (pass.actual, 10.0);
+    EXPECT_TRUE (pass.passed);
+
+    auto fail = only_check (evaluate_thresholds (
+    config_with ({ { "maxAssertionFailureRatePct", 9 } }), inputs));
+    EXPECT_FALSE (fail.passed);
+}
+
+// --- thresholds.failRun (issue #1497): a flag, not a budget -----------------
+
+TEST (ThresholdEval, FailRunAcceptsOnlyABoolean) {
+    EXPECT_FALSE (validate_thresholds (
+    config_with ({ { "maxErrorRatePct", 5 }, { "failRun", true } }))
+    .has_value ());
+    EXPECT_FALSE (validate_thresholds (
+    config_with ({ { "maxErrorRatePct", 5 }, { "failRun", nullptr } }))
+    .has_value ()); // null reads as absent, the rule every other key follows
+    expect_rejected ({ { "maxErrorRatePct", 5 }, { "failRun", "yes" } }, "failRun");
+}
+
+TEST (ThresholdEval, FailRunAloneDeclaresNoBudget) {
+    // Not a budget itself - it needs at least one to mean anything, the same
+    // rejection an empty `{}` gets.
+    auto reason = validate_thresholds (config_with ({ { "failRun", true } }));
+    ASSERT_HAS_VALUE (reason);
+    EXPECT_NE (reason->find ("no budget"), std::string::npos) << *reason;
+}
+
+TEST (ThresholdEval, FailRunDoesNotBecomeASixthCheck) {
+    // The evaluator's declared-budget count must ignore it too, or `failRun`
+    // would show up in the report as a phantom, unjudgeable check.
+    auto outcome = evaluate_thresholds (
+    config_with ({ { "maxErrorRatePct", 5 }, { "failRun", true } }), measured_run ());
+    ASSERT_HAS_VALUE (outcome);
+    EXPECT_EQ (outcome->checks.size (), 1u);
+}
+
+TEST (ThresholdEval, ThresholdsFailRunReadsTheFlag) {
+    EXPECT_TRUE (thresholds_fail_run (
+    config_with ({ { "maxErrorRatePct", 5 }, { "failRun", true } })));
+    EXPECT_FALSE (thresholds_fail_run (config_with ({ { "maxErrorRatePct", 5 } })));
+    EXPECT_FALSE (thresholds_fail_run (
+    config_with ({ { "maxErrorRatePct", 5 }, { "failRun", false } })));
+    EXPECT_FALSE (thresholds_fail_run (nlohmann::json{ { "url", "http://localhost/" } }));
 }
 
 TEST (ThresholdEval, AStoredBudgetOfTheWrongTypeIsSkippedRatherThanGuessed) {


### PR DESCRIPTION
## Description

Issue #1497: assertion outcomes (`assert.*` elements, `pm.test` calls) never touched a run's verdict. Two research passes against current master (`0c7f22ce`) found #1495 and #1514 - the issue's own prerequisites - already merged, and turned up a scope question the issue's acceptance criteria settle: they test only **load** runs. The sequential/collection run path (`scenario_runner.cpp`) never evaluates thresholds at all today - `evaluate_thresholds` has exactly one call site in the whole engine - so wiring it in would mean inventing how `ScenarioSummaryInputs` maps onto `evaluate_thresholds`'s input shape, a design decision the issue doesn't settle either. Filed as a follow-up, #1564, and linked from the docs section this PR touches, mirroring PR #1560's precedent for the identical class of gap.

**What's new.**
- `maxAssertionFailureRatePct`, a sixth `ThresholdMetric` (`threshold_eval.cpp`), measured against a new `RunSummaryInputs::assertions` (`AssertionTotals{passed,failed}`).
- `thresholds.failRun: true` (default false): when a load run's config sets it and a declared budget failed, the run's terminal status becomes `Failed` instead of `Completed`. Decided before `finish_load_test`'s single locked status write, never a second read (`engine/CLAUDE.md`'s "reads, decides and writes holds one lock" rule) - `RunStatus::Failed` already existed (used for crashes), so this is new *wiring* to it, not a new enum value or DB migration.
- The combined assertion tally itself needed real plumbing, not just a read: `StepElementTallies` already tracks `assert.*` pass/fail correctly (`assert_kinds.cpp` pushes into the same `tests` list a `pm.test` call does), but a `script.pre`/`script.post` element's own per-run outcome collapses every `pm.test` call it made into one pass/fail bit (`ScriptResult::success` already folds a failed test in) - so a script with one passing and one failing assertion is indistinguishable, at the element-tally level, from one where both failed. `scenario_load.cpp`'s `run_step_before`/`run_step_after` now tally `pre_result.tests` / `post_result.tests` individually (`ScenarioLoadState::inline_script_tests_passed/failed`), for *inline* load-run scripts; a deferred (non-inline) script's tests still come from the existing `ScriptValidationTotals` replay. `assertion_totals` reads which elements are assertions through the registry's own `category` field (`Registry::instance().find(kind)->category == "assert"`), never a kind-name string comparison, per #1512's extensibility contract.

**Also fixed in this PR:** the app compared SSE terminal-status frames against capitalized `"Completed"|"Stopped"|"Failed"` (`sse-client.ts`) while the engine has only ever emitted lowercase (`to_string(RunStatus)`) - so `parseTerminalStatus` always returned `null` in production, and the taskbar/Dock failure cue (`os-icon.ts`'s `runFailed`, gated on this same comparison in `load-test-service.ts`/`scenario-run-service.ts`) never fired for a real failure. Couldn't defer this: #1497's own Verdict criterion says "the run list and the taskbar cue show it," and that claim is false without this fix. Existing tests masked the bug by seeding capitalized fixtures on both sides of the comparison; fixed to lowercase throughout, matching `dashboard-store.ts` and `RunReport["status"]`'s existing (correct) lowercase union.

**Two independent reviews** (one against the issue's acceptance criteria, one against repo conventions) each found one real gap, both fixed in a follow-up commit:
1. `finish_load_test` - the function containing the actual status-flip logic - had zero test coverage; only its `thresholds_fail_run()` helper was unit-tested. Added `run_manager_test.cpp`'s `FailRunTest` suite: a real run driven end to end through `RunManager::start_run` (the same harness `run_stop_test.cpp` uses for the stop path) proves `failRun: true` with a missed budget ends `RunStatus::Failed`, and a companion proves the same missed budget without the flag stays `Completed`. This is the exact case the issue's own Tests section asked for by name.
2. `assertion_totals` originally matched `elements[i].kind.starts_with("assert.")` - a string-prefix comparison outside `core/elements`, against `engine/CLAUDE.md`'s explicit rule (and this same file's own `load_pipeline_skip_reason`, a few lines below, doing it the right way). Fixed to read `ElementKind::category` through the registry.

Also fixed: a stale "same five metrics" doc comment in `budgets.ts` (now six), and `docs/app/api-integration.md`'s Budgets section, which described only the original five.

## Type of Change
- [x] Bug fix (the SSE status-case mismatch)
- [x] New feature (the metric and `failRun`)
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd engine && ctest --preset linux-dev --output-on-failure` - **3072/3072 passed**, 0 failed (this environment's vcpkg needed `vcpkg-fix-port` first, per `CLAUDE.md`'s cloud-egress gotcha). New/updated coverage: `threshold_eval_test.cpp` (the new metric's accept/reject/evaluate cases, `failRun`'s accept/reject and that it never becomes a phantom seventh check, `thresholds_fail_run`'s own reads), `scenario_load_test.cpp` (`assertion_totals` sums only registry-`category`-"assert" kinds and excludes a sibling `extract.*`; a failing `assert.status` counts as a failed assertion; the inline-script gap itself - two `pm.test` calls, one pass one fail, tallied individually even though the element's own aggregate outcome collapses both into one "failed" bit), `run_manager_test.cpp` (the end-to-end `failRun` status flip, and its opt-out companion).
- `clang-format-19 --dry-run -Werror` and the `clang-tidy-19` pre-commit hook - both clean on every touched engine file.
- `cd app && pnpm test sse-client load-test-service scenario-run-service budgets ThresholdVerdict run-supersession LoadTestConfigDialog` - **255/255 passed**. `pnpm type-check` and `pnpm lint` - clean.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19 clean; `pnpm lint` / `pnpm format:check` clean)
- [x] I have performed a self-review, plus two independent adversarial reviews (see above)
- [x] I have added tests (see Testing)
- [x] I have updated documentation (`docs/engine/api-reference.md`'s thresholds section: the new metric, `failRun`, the load-runs-only scope note and its link to #1564; `docs/engine/elements.md`'s Related issues list; `docs/app/api-integration.md`'s Budgets section)

## No screenshot
The one app-visible surface is a new `NumberField` row and a `Switch` inside `LoadTestConfigDialog`'s existing "Pass/fail budgets" disclosure - both are direct reuses of the same primitives already rendered immediately beside them for the same purpose (`BUDGET_FIELDS.map`, the `saveTimingBreakdown` switch), with no new component or visual pattern. Given the scope of this PR is primarily engine-side, a full Xvfb/Electron capture was judged not worth the added time against what it would show: the identical row/switch treatment already visible a few lines up in the same file.

## Related Issues
Closes #1497. Follow-up filed: #1564 (wiring the same metric and `failRun` into the collection/sequential run path and `RunCollectionDialog`, deferred per the Description above).