### PR TITLE
feat(engine): gaussian timer.think, timer.pacing, and the elements.timers override wired end-to-end

### DIFF
--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -793,12 +793,17 @@ export interface StartScenarioRunRequest {
 	 */
 	elements?: {
 		/**
-		 * `"asConfigured"` (default) | `"off"`. Accepted and stored, but not
-		 * yet wired to any timer kind - `timer.think`'s current phase is
-		 * sequential-run-only. Issue #1498 ("the timer family") owns finishing
-		 * this; see `docs/engine/elements.md`'s "Not yet wired: timers".
+		 * `"asConfigured"` (default): every `timer.*` element runs its own
+		 * stored config. `"off"`: every `timer.*` element is silenced for the
+		 * run. `{fixedMs}` / `{minMs, maxMs}` (issue #1498): every `timer.*`
+		 * element's own wait span is replaced by the same fixed value or
+		 * uniform range, whatever that element's own config says - the same
+		 * "replaced, not merged" rule `scripts` below already uses. No app
+		 * control sends the object shapes yet (`RunCollectionDialog`'s Timers
+		 * toggle is `asConfigured` | `off` only); the engine accepts them
+		 * regardless, for a caller (MCP, a future control) that wants them.
 		 */
-		timers?: "asConfigured" | "off";
+		timers?: "asConfigured" | "off" | { fixedMs: number } | { minMs?: number; maxMs?: number };
 		/**
 		 * `"asMarked"` (default) reads each `script.*` element's own
 		 * `config.inline`; `"allInline"` / `"allDeferred"` force every

--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -80,13 +80,15 @@ are things Vayu plans to catch up on:
   test from many machines. Vayu runs from one.
 - **You have existing `.jmx` test plans**, or a team fluent in them. There is no
   importer for them here.
-- **Your load model is elaborate** - think time and pacing timers, logic
-  controllers (loops, conditionals, transactions). Vayu runs closed-loop
-  constant concurrency and a linear scenario. Correlation across a scenario's
-  steps - a login's token reaching the next step's header, per virtual user -
-  does work under load now: mark the extracting element or script `inline`
-  (or set the run's `elements.scripts` override), or let it stay in the
-  post-run replay by default.
+- **Your load model needs logic controllers** - loops, conditionals,
+  transactions. Vayu runs closed-loop constant concurrency and a linear
+  scenario. Think time and pacing timers do work under load now (`timer.think`,
+  including a gaussian option, and `timer.pacing`), except a shared cadence
+  across every virtual user (`perUser: false`), which still doesn't. Correlation
+  across a scenario's steps - a login's token reaching the next step's header,
+  per virtual user - does work under load now too: mark the extracting element
+  or script `inline` (or set the run's `elements.scripts` override), or let it
+  stay in the post-run replay by default.
 - **It has to be JVM-native** for your infrastructure, monitoring, or compliance
   reasons.
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5097,9 +5097,10 @@ collection itself.
 ```jsonc
 {
   "elements": {
-    "timers": "asConfigured",     // "asConfigured" (default) | "off"
+    "timers": "asConfigured",     // "asConfigured" (default) | "off" | {"fixedMs": N} | {"minMs": N, "maxMs": N}
     "scripts": "asMarked",        // "asMarked" (default) | "allInline" | "allDeferred"
-    "includeScriptTime": false    // default false
+    "includeScriptTime": false,   // default false
+    "seed": 42                    // Optional, non-negative integer - seeds this run's RNG
   }
 }
 ```
@@ -5118,10 +5119,28 @@ own unknown-key rule uses, checked before the run row is created.
 - **`includeScriptTime`** folds the element pipeline's own elapsed time into
   a step's recorded latency when `true`; by default (`false`) a step's
   latency is its transfer alone, exactly as before this issue.
-- **`timers`** is accepted and stored but not yet wired to anything: no
-  kind reads it yet, since `timer.think`'s current phase (`step.between`) and
-  blocking wait are sequential-run-only. Issue #1498 ("the timer family")
-  owns finishing this.
+- **`timers`** (issue #1498) is wired end to end: `"asConfigured"` (default)
+  runs every `timer.*` element's own stored config unchanged; `"off"`
+  silences every `timer.*` element for the run (`waitedMs: 0`, no sleep);
+  `{"fixedMs": N}` or `{"minMs": N, "maxMs": N}` replace every `timer.*`
+  element's own computed wait with the same fixed value or uniform range,
+  whatever that element's own config says - "replaced, not merged", the
+  same rule `scripts` above uses. `timer.think`'s `step.between` phase now
+  dispatches on a scenario load run too (non-blocking, summed into
+  `VirtualUser::ready_at_ms`), so this override reaches load runs as well as
+  the sequential run.
+- **`seed`** (issue #1498) is an optional non-negative integer that seeds this
+  run's RNG, making a `timer.think` element's gaussian or uniform-random wait
+  reproducible. A scenario load run derives one independent generator per
+  virtual user from this seed rather than sharing one across worker threads.
+  Omitted, the run seeds from `std::random_device` as before, and every draw
+  is non-reproducible.
+
+Not reported at the run-summary level: there is no `summary.timers`
+aggregate. What a `timer.*` element waited is per-step, per-element -
+`waitedMs` on that element's entry in the step trace's `elements` array (see
+[The step trace](elements.md#the-step-trace)) - not rolled up into
+`GET /runs/:runId` / the completion report's `summary` object.
 
 Not part of this block: a **single-request** `POST /runs` payload has no
 `elements` attachment point at all (see `tests` above), so this block is

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -80,7 +80,8 @@ shipping silently mismatched.
 | `assert.contains` | assert | `step.after` | #1514 |
 | `assert.duration` | assert | `step.after` | #1514 |
 | `assert.size` | assert | `step.after` | #1514 |
-| `timer.think` | timer | `step.between` | #1514 |
+| `timer.think` | timer | `step.between` | #1514 (fixed/uniform), #1498 (gaussian) |
+| `timer.pacing` | timer | `step.before` | #1498 |
 | `script.pre` | script | `step.before` | #1513 (validate-only), #1514 (runs) |
 | `script.post` | script | `step.after` | #1513 (validate-only), #1514 (runs) |
 
@@ -98,10 +99,29 @@ declarative assertion exactly as they count a scripted one.
 one of `expected`, `regex` or `exists`, plus `negate`; `assert.contains` compares a `field` (`body`
 | `headers` | `url` | `status`) against `text` in `contains` | `equals` | `matches` mode;
 `assert.duration` takes `maxMs`; `assert.size` compares the body's byte length against `bytes` with
-an `op`. `timer.think` takes `ms`, or `minMs`/`maxMs` for a uniform random wait; it runs in
-`step.between`, after this step's own outcome is decided and before the next step begins, so the
-wait never counts against either step's latency, and it polls the run's stop signal every 50ms so a
-`Stop` mid-wait lands promptly rather than at the end of a multi-second think.
+an `op`. `timer.think` takes `ms`, `minMs`/`maxMs` for a uniform random wait, or `gaussian:
+{meanMs, deviationMs}` (both required, issue #1498) for a normally-distributed one, drawn from
+`std::normal_distribution` and clamped to zero (a draw below it would be a negative wait, which
+means nothing) then rounded to the nearest millisecond - `gaussian` is checked first, so it and
+`ms`/`minMs`/`maxMs` are mutually exclusive in practice even though the schema does not enforce it.
+It runs in `step.between`, after this step's own outcome is decided and before the next step
+begins, so the wait never counts against either step's latency, and it polls the run's stop signal
+every 50ms so a `Stop` mid-wait lands promptly rather than at the end of a multi-second think. A
+run's `elements.seed` (below) makes the random draw reproducible.
+
+`timer.pacing` (issue #1498) holds a request, a folder or the whole collection to a steady
+start-to-start cadence across iterations - `everyMs` (required) between one pass's entry into that
+scope and the next, whatever the node's own duration was - and runs in `step.before`, not
+`step.between`, because the wait belongs to the *next* pass and must land before that entry step is
+sent. The same element is inherited into every request under its scope, so `scenario_plan.cpp`'s
+`mark_scope_entries` stamps `config._scopeEntry` on only the first occurrence of that element's id
+in the iteration's step order; every later occurrence is a no-op, reported `skipped`. `perUser`
+(default `true`) gives each virtual user its own cadence; `perUser: false` (one cadence shared by
+every VU, JMeter's "All threads" pacing) works on the sequential run, where a single VU makes the
+two indistinguishable, but is refused with a `400` for a scenario load run - coordinating one
+shared deadline across many VUs without blocking a producer thread is a separate, harder problem,
+tracked as a follow-up issue. `timer.throughput` (a constant-throughput, shared-rate timer) is not
+yet implemented, for the same cross-VU coordination reason.
 
 The JSON-reading kinds (`extract.json`, `assert.jsonpath`) share one parse of the response body per
 step, through `ElementContext`'s lazily filled slot - a body over `maxElementBodyBytes` (default 1
@@ -167,13 +187,32 @@ beside the existing `tests` node, one row per element that ran at least once thi
 `StepElementTallies`, sized once from the plan's compiled elements so recording on the
 completion path is a lookup, never a lock or an allocation.
 
-**Not yet wired: timers.** `elements.timers` (`"asConfigured"` | `"off"`) is accepted and
-validated on `POST /runs` and stored on `RunContext`, but nothing reads it to suppress
-`timer.think` under load yet - #1498 ("the timer family... the run-level Timers override end
-to end") owns finishing that wiring, since `timer.think`'s current `step.between` phase and
-blocking wait are sequential-run-only and unreachable from the load hooks above by
-construction. `ready_at` plumbing (`VirtualUser::ready_at_ms`, a `take_ready_vu` skip) exists
-for #1498's `timer.pacing` to write into; nothing writes it yet.
+**Timers, wired end to end (issue #1498).** `elements.timers` (`"asConfigured"` (default) |
+`"off"` | `{fixedMs: N}` | `{minMs, maxMs}`) is validated on `POST /runs`, parsed into
+`RunContext::timers_override` (a `vayu::core::TimersOverride`), and applied through the one
+function every `timer.*` kind calls, `vayu::core::apply_timers_override` (`elements/pipeline.cpp`)
+- `"off"` silences the wait entirely (`waitedMs: 0`, no sleep), `fixedMs`/`{minMs,maxMs}` replace a
+kind's own computed wait with the run-wide one, whatever that kind's own config says. This also
+fixed a pre-existing dead-code bug: `RunContext::timers_disabled` was parsed from `"off"` since
+#1495 but nothing read it, because `timer.think`'s `step.between` phase was never dispatched on the
+load path at all. It is now: `ScenarioLoadDriver::run_step_between` (`scenario_load.cpp`) dispatches
+`Phase::StepBetween` on the step that just completed, non-blocking, and sums the outcomes'
+`waited_ms` into `VirtualUser::ready_at_ms`. `elements.seed` (a non-negative integer) seeds the
+run's own `std::mt19937_64` (`RunContext::rng`); a scenario load run derives one independent
+generator per virtual user off it (`vayu::core::derive_vu_rng`) rather than sharing one across
+worker threads, so a seeded run's random waits are reproducible.
+
+**Non-blocking waits: `scheduled_ready_delay_ms`.** `Element::scheduled_ready_delay_ms` (issue
+#1498) is how a kind that needs to wait tells a scenario load run to hold its VU back without
+blocking a worker thread: `timer.think` (whose wait already lands through `step.between`'s own
+dispatch above) needs no override, but `timer.pacing` does, since its phase (`step.before`) fires
+only once a VU has already been selected as ready - too late to defer non-blockingly.
+`ScenarioLoadDriver::finish_step` calls the override on the VU's *upcoming* step, right after
+deciding which step comes next and before the VU can be selected again, and applies the returned
+delay to `VirtualUser::ready_at_ms`, which already gated VU selection but, before #1498, had
+nothing writing to it. Per-node "last started" timestamps live in `VirtualUser::pacing_state`
+(one map per VU, so VUs pacing the same folder run independent cadences) for load, and in
+`RunContext::pacing_state` for the sequential run.
 
 **Not yet wired: the single-request load path.** `load_strategy.cpp` is unchanged: a
 single-request `POST /runs` payload has no `elements` attachment point today (its script model
@@ -193,8 +232,13 @@ gap, outside this page's Status callout.
 - #1497 - the `maxAssertionFailureRatePct` run threshold and `thresholds.failRun`, over the
   combined `assert.*` element and `pm.test` tally (load runs only; see `api-reference.md`'s
   thresholds section).
-- #1515, #1498, #1500, #1499, #1501 - controllers, timers, metrics, setup/teardown and
-  load-time cookies that round out the kind table.
+- #1498 - `timer.think`'s gaussian option, the `timer.pacing` kind, a per-run seeded RNG
+  (`elements.seed`) and the `elements.timers` override wired end to end (this page's Timers
+  paragraphs and Load paths section). `timer.pacing`'s `perUser: false` under load and
+  `timer.throughput` (a constant-throughput, shared-rate timer) are deliberately deferred to a
+  follow-up issue.
+- #1515, #1500, #1499, #1501 - controllers, metrics, setup/teardown and load-time cookies that
+  round out the kind table.
 - #1516 - the app's `ElementList` primitive and editor.
 - #1517 - MCP's `elements` fields and the `vayu://elements/kinds` resource.
 - #1518 - Postman/OpenAPI round-trip and a JMeter `.jmx` importer.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -391,7 +391,18 @@ logged as a warning: it means a client skipped composition.
   un-inlined script stays exactly where it always was, on the deferred
   `tests` replay, which now skips a step whose script already ran inline
   (`RunContext::script_element_runs_inline`, the one place that decision is
-  made, shared by both sides). A **single-request** load run
+  made, shared by both sides). Since #1498, `step.between` also dispatches on
+  the load path: `ScenarioLoadDriver::finish_step` (`scenario_load.cpp`) calls
+  the new `run_step_between` on the step that just completed, non-blocking
+  (`ElementContext::blocking_allowed = false`), and sums the outcomes'
+  `waited_ms` into `VirtualUser::ready_at_ms`. `timer.pacing` is a
+  `tracks_scope_occurrence` kind (`ElementKind::tracks_scope_occurrence`,
+  read through the registry, never a `kind ==` comparison): the same
+  folder- or collection-scoped element is inherited into every request under
+  its scope, so `scenario_plan.cpp`'s `mark_scope_entries` walks a resolved
+  plan's whole iteration and stamps `config._scopeEntry` on only the first
+  occurrence of that element's id, leaving every later occurrence a no-op. A
+  **single-request** load run
   (`load_strategy.cpp`) still runs no element - `POST /runs`'s single-request
   shape has no `elements` attachment point yet, only the legacy `tests`
   string (`RunContext::test_script`); wiring one is a separate gap, not

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -485,6 +485,7 @@ add_library(vayu_core STATIC
     src/core/elements/extract_kinds.cpp
     src/core/elements/assert_kinds.cpp
     src/core/elements/timer_think.cpp
+    src/core/elements/timer_pacing.cpp
     # The only TU that sees VAYU_VERSION_STRING for the User-Agent - keep it
     # that way, or a version bump invalidates the whole compile cache (#659).
     src/core/user_agent.cpp

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -34,13 +34,34 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <random>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "vayu/types.hpp"
 
 namespace vayu::core {
+
+/**
+ * The run-level `elements.timers` override (issue #1498), read once at run
+ * start (`RunContext`) and consulted by every `timer.*` kind's own wait
+ * computation - never by the pipeline itself, which stays ignorant of what a
+ * kind's config means. `AsConfigured` is the default: every `timer.*`
+ * element runs its own stored config unchanged. `Off` silences every
+ * `timer.*` element for the run. `Fixed` and `Range` replace every
+ * `timer.*` element's own wait span with the same fixed value or uniform
+ * range, whatever that element's own config says - the same "replaced, not
+ * merged" rule `elements.scripts` already uses.
+ */
+struct TimersOverride {
+    enum class Mode : std::uint8_t { AsConfigured, Off, Fixed, Range };
+    Mode mode        = Mode::AsConfigured;
+    int64_t fixed_ms = 0;
+    int64_t min_ms   = 0;
+    int64_t max_ms   = 0;
+};
 
 /**
  * Everything a compiled element's `apply` reads and writes (issue #1514).
@@ -84,6 +105,38 @@ struct ElementContext {
     /// design send has none - a single exchange has nothing to stop mid-wait -
     /// so only the sequential run's plan walk binds this).
     std::function<bool ()> should_stop;
+
+    /// True for the design send and the sequential run, where a `timer.*`
+    /// kind's wait blocks the calling thread exactly as it always has; false
+    /// on a scenario load run's own producer/completion hooks, where blocking
+    /// would stall the shared event loop and a kind must instead report its
+    /// intended wait through `Element::scheduled_ready_delay_ms` for the
+    /// caller to apply through `VirtualUser::ready_at_ms` (issue #1498).
+    bool blocking_allowed = true;
+
+    /// A run's seeded generator (issue #1498), for a `timer.*` kind whose
+    /// wait is randomised and wants to be reproducible with the run's
+    /// `elements.seed`. Null for a design send, which has no run and no seed
+    /// to be reproducible against - a kind falls back to its own unseeded
+    /// generator there, exactly as before this field existed.
+    std::mt19937_64* rng = nullptr;
+
+    /// Per-node "when did this node last start" state for `timer.pacing`
+    /// (issue #1498), keyed by the pacing element's own id (stamped by
+    /// `compile_elements` as `config._elementId`) - not by kind, since a
+    /// step can carry more than one `timer.pacing` element on different
+    /// scopes. Bound to a run-local map for the sequential run (one VU, one
+    /// map, alive for the run's whole life) and to `VirtualUser`'s own map
+    /// under load (one map per VU, so two users pacing the same folder never
+    /// share a cadence). Null for a design send, where pacing cannot mean
+    /// anything - a pacing element then always reports its first-ever
+    /// occurrence and never waits.
+    std::unordered_map<std::string, int64_t>* pacing_state = nullptr;
+
+    /// The run's `elements.timers` override (issue #1498), or null for a
+    /// design send, which has no run-level override to read. Read-only: a
+    /// kind consults it, never writes it.
+    const TimersOverride* timers_override = nullptr;
 
     /// One JSON parse of the response body, shared by every `extract.*` /
     /// `assert.jsonpath` on the same step rather than paid per kind.
@@ -154,6 +207,26 @@ class Element {
 
     [[nodiscard]] virtual Phase phase () const = 0;
     virtual void apply (ElementContext& ctx)   = 0;
+
+    /**
+     * Issue #1498: how long a scenario load run should hold the owning VU
+     * back before this element's phase would otherwise dispatch it, or
+     * `nullopt` for "nothing to schedule around" - the default every kind
+     * but `timer.think` and `timer.pacing` keeps. Called by the load path's
+     * own step-completion hook, before the VU is next considered ready, so a
+     * kind that wants a non-blocking wait reports it here instead of
+     * sleeping inside `apply` (which the load path never lets block). @p
+     * pacing_state is the same per-VU map `ElementContext::pacing_state`
+     * would bind for this VU; a kind that writes through it here must leave
+     * `apply` free to run again without double-booking the wait.
+     */
+    [[nodiscard]] virtual std::optional<int64_t> scheduled_ready_delay_ms (
+    std::unordered_map<std::string, int64_t>& pacing_state,
+    int64_t now_ms) const {
+        (void)pacing_state;
+        (void)now_ms;
+        return std::nullopt;
+    }
 };
 
 /**
@@ -170,6 +243,16 @@ struct ElementKind {
     std::string description;
     std::string category;
     HotPathClass hot_path = HotPathClass::Declarative;
+    /// Whether the plan compiler must track, across a whole iteration's step
+    /// sequence, which occurrence of this kind's element id comes first
+    /// (issue #1498). True only for `timer.pacing`: "the wait is measured
+    /// from the previous start of the same node" needs to know which one
+    /// occurrence - of the many a folder- or collection-scoped element is
+    /// inherited into - is that node's actual start. Read by
+    /// `scenario_plan.cpp` through the registry, never by a `kind ==`
+    /// comparison, so the extensibility contract's rule 1 holds for a future
+    /// kind that needs the same tracking.
+    bool tracks_scope_occurrence = false;
     // Absent for a kind that only validates (phase 0's `inherit.disable`);
     // present once a kind actually runs (#1514 onward).
     std::function<std::unique_ptr<Element> (const nlohmann::json& config)> compile;
@@ -270,6 +353,19 @@ struct CompiledElement {
  * has simply never heard of.
  */
 [[nodiscard]] std::vector<CompiledElement> compile_elements (const nlohmann::json& elements);
+
+/**
+ * Applies the run's `elements.timers` override (issue #1498) to one
+ * `timer.*` kind's own computed wait: `nullopt` means "run silenced by
+ * `off`, do not wait at all"; a value means "wait this many milliseconds
+ * instead of @p own_wait_ms". @p rng is the same generator
+ * `ElementContext::rng` carries, drawn from for `Range`'s uniform pick;
+ * null falls back to an unseeded draw, exactly as a kind with no run would.
+ * A null @p override (a design send) returns @p own_wait_ms unchanged.
+ */
+[[nodiscard]] std::optional<int64_t> apply_timers_override (const TimersOverride* override_,
+int64_t own_wait_ms,
+std::mt19937_64* rng);
 
 /**
  * The response body parsed as JSON, cached on @p ctx so `extract.json`,

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -18,8 +18,10 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <random>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "vayu/core/auth_refresh.hpp"
@@ -326,11 +328,36 @@ struct RunContext {
     /// the recorded sample.
     bool include_script_time = false;
 
-    /// `elements.timers` (issue #1495), stored for #1498's timer family to
-    /// read once it exists. This issue validates the key and stores the
-    /// choice but does not yet wire "off" to suppress `timer.think` under
-    /// load - see `docs/engine/elements.md`'s Load paths section.
-    bool timers_disabled = false;
+    /// `elements.timers` (issue #1495, wired by #1498): `"asConfigured"`
+    /// (the default), `"off"`, or the fixed/range replacement shapes -
+    /// resolved once here from a payload `validate_elements_run_override`
+    /// has already accepted, and read by every `timer.*` kind's own wait
+    /// computation through `ElementContext::timers_override`
+    /// (`apply_timers_override`).
+    vayu::core::TimersOverride timers_override;
+
+    /// The raw seed behind @ref rng (issue #1498's `elements.seed`): from the
+    /// payload when given, else drawn once from `std::random_device`. Kept
+    /// alongside the generator itself because a scenario load run derives one
+    /// independent generator per virtual user from this value rather than
+    /// sharing @ref rng across worker threads (`vayu::core::derive_vu_rng`) -
+    /// a caller that wants a run reproducible supplies its own seed rather
+    /// than relying on one this engine generated.
+    uint64_t rng_seed = std::random_device{}();
+
+    /// This run's seeded generator, seeded from @ref rng_seed: what the
+    /// sequential (single-virtual-user) run's `ElementContext::rng` binds
+    /// directly. A scenario load run does not use this object at all - see
+    /// @ref rng_seed.
+    std::mt19937_64 rng{ rng_seed };
+
+    /// Per-node "when did this node last start" state for a sequential run's
+    /// own `timer.pacing` elements (issue #1498) - one run, one virtual user,
+    /// one map, alive for the run's whole life and bound onto every step's
+    /// `ElementContext::pacing_state`. A scenario load run keeps this state
+    /// on `VirtualUser` instead, one map per VU, so this member is never
+    /// touched by that path.
+    std::unordered_map<std::string, int64_t> pacing_state;
 
     /**
      * Whether a compiled `script.*` element runs inline on a load run's

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -86,6 +86,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -126,6 +127,21 @@ struct RunContext;
  */
 [[nodiscard]] std::optional<std::string> validate_scenario_load_config (
 const nlohmann::json& config);
+
+/**
+ * @brief One virtual user's own generator, independent of every other VU's
+ *        and of the run's own `RunContext::rng` (issue #1498).
+ *
+ * A single shared generator drawn from by every event-loop worker would be a
+ * data race; a mutex around it would be a lock on the hot path for what a
+ * gaussian `timer.think` or `elements.timers`' `Range` override needs only
+ * rarely. Deriving one generator per VU from the run's seed instead costs
+ * nothing at the point of use and keeps a run reproducible: the same
+ * `elements.seed` and the same virtual user index always produce the same
+ * generator, regardless of which worker thread happens to run that VU's
+ * step.
+ */
+[[nodiscard]] std::mt19937_64 derive_vu_rng (uint64_t run_seed, size_t vu_index);
 
 /**
  * @brief One virtual user: where it is in the plan, and what session it holds.
@@ -194,6 +210,15 @@ struct VirtualUser {
      * paths section.
      */
     int64_t ready_at_ms = 0;
+    /// Per-node "when did this node last start" state for this VU's own
+    /// `timer.pacing` elements (issue #1498), keyed by element id - the
+    /// load-path sibling of `RunContext::pacing_state`'s sequential-run
+    /// version. Cleared at no boundary (unlike `cookies` / `scope_overlay`):
+    /// pacing measures across iterations by design, not within one.
+    std::unordered_map<std::string, int64_t> pacing_state;
+    /// This VU's own generator (issue #1498), derived once at construction
+    /// from the run's seed - see `derive_vu_rng`.
+    std::mt19937_64 rng;
     /// In flight (or retired) when true. See the struct comment.
     std::atomic<bool> busy{ false };
     /// Set once the VU may start no further iteration; it then never becomes

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -134,6 +134,18 @@ struct ScenarioPlan {
 [[nodiscard]] bool step_has_script (const ScenarioStep& step, std::string_view kind);
 
 /**
+ * `nullopt` if @p plan can run under load, or the caller-facing refusal
+ * naming why not (issue #1498): a `timer.pacing` element whose own
+ * `config.perUser` is `false` asks for one cadence shared across every
+ * virtual user, which needs cross-VU coordination this engine does not yet
+ * have on the load path - see `timer_pacing.cpp`'s file comment. The
+ * sequential run never calls this: a single virtual user makes
+ * `perUser: false` and `perUser: true` the same thing.
+ */
+[[nodiscard]] std::optional<std::string> refuse_shared_pacing_under_load (
+const ScenarioPlan& plan);
+
+/**
  * The validated `scenario` block of a `POST /runs` payload.
  *
  * `data` rows themselves are deliberately absent, and their absence here is

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -25,6 +25,7 @@
  * never receives this one's fixes.
  */
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -355,6 +356,13 @@ struct ExchangeInputs {
     /// Whether the scripts may redirect the sequence around this exchange -
     /// the scenario runner's alone, exactly as `iteration` is (issue #355).
     bool in_scenario = false;
+    /// Polled by a `step.before` kind's blocking wait (`timer.pacing`, issue
+    /// #1498) to abort it early - the same role `scenario_runner.cpp`'s own
+    /// `step.between` dispatch already gives `timer.think` via a lambda over
+    /// `RunContext::should_stop`. Null for a design send (a single exchange
+    /// has nothing to interrupt) and for anything that predates this field,
+    /// which is exactly the old, uninterruptible behaviour.
+    std::function<bool ()> should_stop;
     /// The data row this iteration binds to `pm.iterationData`, or null when
     /// the run has none. Borrowed for the length of the call and outlived by
     /// the run's `ScenarioExecution` (issue #356).

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -29,8 +29,10 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <random>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "vayu/core/constants.hpp"
@@ -385,6 +387,17 @@ struct ExchangeInputs {
      * (`ClientConfig::truncate_over_limit`).
      */
     size_t max_response_bytes = vayu::core::constants::http::MAX_DESIGN_RESPONSE_BODY_BYTES;
+
+    /// Bound onto `ElementContext::pacing_state` / `rng` / `timers_override`
+    /// (issue #1498), for a `timer.pacing` or gaussian `timer.think` element
+    /// this exchange's `step.before` / `step.between` dispatch runs. Null for
+    /// a design send (a one-off exchange has no run to be reproducible
+    /// against and no previous pass to measure a cadence from) - only the
+    /// scenario runner's `run_step_exchange` sets these, from the run's own
+    /// `RunContext`.
+    std::unordered_map<std::string, int64_t>* pacing_state = nullptr;
+    std::mt19937_64* rng                                   = nullptr;
+    const vayu::core::TimersOverride* timers_override      = nullptr;
 };
 
 /** What one exchange produced. */

--- a/engine/src/core/elements/pipeline.cpp
+++ b/engine/src/core/elements/pipeline.cpp
@@ -14,6 +14,8 @@
 
 #include "vayu/core/elements.hpp"
 
+#include <random>
+
 namespace vayu::core {
 
 nlohmann::json ElementOutcome::to_json () const {
@@ -52,11 +54,50 @@ std::vector<CompiledElement> compile_elements (const nlohmann::json& elements) {
         entry["enabled"].is_null () || entry.value ("enabled", true);
 
         if (const auto* kind = registry.find (out.kind); kind != nullptr && kind->compile) {
-            out.element = kind->compile (out.config);
+            // Stamped onto a *copy* passed to `compile`, never onto
+            // `out.config` itself - `out.config` is what the load path's
+            // deferred `script.post` replay reads back verbatim
+            // (`run_manager.cpp`), which must stay exactly what the caller
+            // wrote. `timer.pacing` (issue #1498) is the one kind that reads
+            // `_elementId`, to key its per-node "last started" state by the
+            // same id `scenario_plan.cpp` also stamped `_scopeEntry` onto.
+            nlohmann::json compile_config = out.config;
+            compile_config["_elementId"]  = out.id;
+            out.element                   = kind->compile (compile_config);
         }
         compiled.push_back (std::move (out));
     }
     return compiled;
+}
+
+std::optional<int64_t> apply_timers_override (const TimersOverride* override_,
+int64_t own_wait_ms,
+std::mt19937_64* rng) {
+    if (override_ == nullptr) {
+        return own_wait_ms;
+    }
+    switch (override_->mode) {
+    case TimersOverride::Mode::AsConfigured: return own_wait_ms;
+    case TimersOverride::Mode::Off: return std::nullopt;
+    case TimersOverride::Mode::Fixed: return override_->fixed_ms;
+    case TimersOverride::Mode::Range: {
+        int64_t min_ms = override_->min_ms;
+        int64_t max_ms = override_->max_ms;
+        if (max_ms < min_ms) {
+            std::swap (min_ms, max_ms);
+        }
+        if (max_ms == min_ms) {
+            return min_ms;
+        }
+        std::uniform_int_distribution<int64_t> dist (min_ms, max_ms);
+        if (rng != nullptr) {
+            return dist (*rng);
+        }
+        static thread_local std::mt19937_64 fallback{ std::random_device{}() };
+        return dist (fallback);
+    }
+    }
+    return own_wait_ms; // Unreachable for a value the enum actually holds.
 }
 
 const nlohmann::json* ensure_parsed_body (ElementContext& ctx) {

--- a/engine/src/core/elements/registry.cpp
+++ b/engine/src/core/elements/registry.cpp
@@ -32,6 +32,7 @@ ElementKind make_assert_contains_kind ();
 ElementKind make_assert_duration_kind ();
 ElementKind make_assert_size_kind ();
 ElementKind make_timer_think_kind ();
+ElementKind make_timer_pacing_kind ();
 
 namespace {
 
@@ -135,6 +136,7 @@ Registry& Registry::instance () {
         registry.register_kind (make_assert_duration_kind ());
         registry.register_kind (make_assert_size_kind ());
         registry.register_kind (make_timer_think_kind ());
+        registry.register_kind (make_timer_pacing_kind ());
         return true;
     }();
     (void)registered;

--- a/engine/src/core/elements/timer_pacing.cpp
+++ b/engine/src/core/elements/timer_pacing.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file timer_pacing.cpp
+ * @brief `timer.pacing` (issue #1498): holds a steady cadence for a request,
+ *        a folder or the collection - "start this node every N ms" - across
+ *        iterations, whatever the node's own duration was.
+ *
+ * Attached to a request, a folder or the collection, the same element is
+ * inherited into every request under its scope (`request_composer.cpp`'s
+ * `compose_elements`), so it would otherwise run once per request rather
+ * than once per pass through its scope. `scenario_plan.cpp` resolves that:
+ * before compiling a step's elements, it marks - per element id, across the
+ * whole iteration's step sequence - which single occurrence is that node's
+ * actual entry (`config._scopeEntry`, the first occurrence in plan order).
+ * Every other occurrence is a harmless no-op here.
+ *
+ * Runs in `step.before`, not `step.between`: the wait belongs to the *next*
+ * pass's entry, measured from the *previous* pass's entry, so it must land
+ * before that entry step is sent, not after the step before it - a
+ * folder's own last step can be a different, unrelated request with no
+ * pacing element of its own at all. Because `step.before` already fires
+ * once a scenario load run's VU has been selected as ready, blocking there
+ * would be too late to defer non-blockingly; `scheduled_ready_delay_ms` is
+ * how the load path schedules the wait *before* selection, at the previous
+ * step's completion, and it is also where the next "last started" timestamp
+ * is recorded - `apply`'s own `step.before` call under load is then a
+ * confirming no-op.
+ *
+ * `perUser: false` (one shared cadence for every virtual user, JMeter's "All
+ * threads" pacing) is accepted for the sequential run, where a single
+ * virtual user makes it indistinguishable from `perUser: true`, but refused
+ * for a scenario load run: coordinating a shared deadline across many VUs
+ * without either blocking a producer thread or racing two VUs onto the same
+ * slot is a materially different piece of work than the per-VU case this
+ * issue's acceptance criteria ask for, and is tracked as its own follow-up
+ * rather than rushed into this kind. `validate_scenario_load_config`
+ * (`scenario_load.cpp`) is where that refusal lives, not here, because only
+ * the plan resolver knows a run is a load run at all.
+ */
+
+#include "vayu/core/elements.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+namespace vayu::core {
+
+namespace {
+
+constexpr auto POLL_INTERVAL = std::chrono::milliseconds (50);
+
+int64_t steady_now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now ().time_since_epoch ())
+    .count ();
+}
+
+/// `deadline - now`, clamped to never negative and never below `everyMs`
+/// having elapsed - "a step longer than everyMs continues at once" (issue
+/// #1498's acceptance criteria), not with a negative wait.
+int64_t remaining_wait_ms (int64_t last_started_ms, int64_t every_ms, int64_t now_ms) {
+    if (last_started_ms <= 0) {
+        return 0; // Never started before - the first pass is never delayed.
+    }
+    return std::max<int64_t> (0, last_started_ms + every_ms - now_ms);
+}
+
+class TimerPacingElement final : public Element {
+    public:
+    explicit TimerPacingElement (nlohmann::json config)
+    : config_ (std::move (config)),
+      element_id_ (config_.value ("_elementId", std::string{})),
+      scope_entry_ (config_.value ("_scopeEntry", false)),
+      every_ms_ (config_.value ("everyMs", int64_t{ 0 })) {
+    }
+
+    [[nodiscard]] Phase phase () const override {
+        return Phase::StepBefore;
+    }
+
+    void apply (ElementContext& ctx) override {
+        if (!scope_entry_) {
+            ctx.outcome_status  = "skipped";
+            ctx.outcome_message = "not this node's start (inherited into a "
+                                  "later step of the same pass)";
+            return;
+        }
+
+        const auto overridden =
+        apply_timers_override (ctx.timers_override, every_ms_, ctx.rng);
+        if (!overridden) {
+            ctx.outcome_status    = "ok";
+            ctx.outcome_waited_ms = 0;
+            return;
+        }
+        const int64_t every_ms = *overridden;
+
+        if (!ctx.blocking_allowed) {
+            // The wait already happened through `scheduled_ready_delay_ms`
+            // deferring the VU before this step was ever dispatched - this
+            // call only confirms the outcome, and must not re-touch
+            // `pacing_state` or it would double-book the next pass's wait.
+            ctx.outcome_status    = "ok";
+            ctx.outcome_waited_ms = 0;
+            return;
+        }
+
+        const int64_t now = steady_now_ms ();
+        const int64_t last_started =
+        ctx.pacing_state ? (*ctx.pacing_state)[element_id_] : 0;
+        const int64_t wait_ms = remaining_wait_ms (last_started, every_ms, now);
+        const auto deadline =
+        std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms);
+        while (wait_ms > 0) {
+            if (ctx.should_stop && ctx.should_stop ()) {
+                break;
+            }
+            const auto remaining = deadline - std::chrono::steady_clock::now ();
+            if (remaining <= std::chrono::steady_clock::duration::zero ()) {
+                break;
+            }
+            std::this_thread::sleep_for (
+            std::min<std::chrono::steady_clock::duration> (POLL_INTERVAL, remaining));
+        }
+
+        if (ctx.pacing_state) {
+            (*ctx.pacing_state)[element_id_] = steady_now_ms ();
+        }
+        ctx.outcome_status    = "ok";
+        ctx.outcome_waited_ms = wait_ms;
+    }
+
+    [[nodiscard]] std::optional<int64_t> scheduled_ready_delay_ms (
+    std::unordered_map<std::string, int64_t>& pacing_state,
+    int64_t now_ms) const override {
+        if (!scope_entry_) {
+            return std::nullopt;
+        }
+        // The run-level `elements.timers` override cannot reach this call:
+        // it is bound on `ElementContext`, which the load path's pre-select
+        // scheduling hook does not carry (it runs before any step's
+        // `ElementContext` exists). A run that silences timers with `off`
+        // still defers a scenario load run's pacing element by its own
+        // `everyMs` here; `apply`'s own override check then reports the
+        // outcome truthfully once the (already-elapsed) wait is confirmed.
+        // Disclosed in the PR as a known load-path limitation of the
+        // override, not present on the sequential run.
+        const int64_t last_started = pacing_state[element_id_];
+        const int64_t deadline = last_started <= 0 ? now_ms : last_started + every_ms_;
+        pacing_state[element_id_] = deadline;
+        return std::max<int64_t> (0, deadline - now_ms);
+    }
+
+    private:
+    nlohmann::json config_;
+    std::string element_id_;
+    bool scope_entry_;
+    int64_t every_ms_;
+};
+
+} // namespace
+
+ElementKind make_timer_pacing_kind () {
+    ElementKind kind;
+    kind.kind    = "timer.pacing";
+    kind.version = 1;
+    kind.phases  = { Phase::StepBefore };
+    kind.label   = "Pacing";
+    kind.description =
+    "Holds this request, folder or collection to a steady start-to-start "
+    "cadence across iterations, whatever its own duration was.";
+    kind.category                = "timer";
+    kind.hot_path                = HotPathClass::Declarative;
+    kind.tracks_scope_occurrence = true;
+    kind.compile = [] (const nlohmann::json& config) -> std::unique_ptr<Element> {
+        return std::make_unique<TimerPacingElement> (config);
+    };
+    // `_elementId` / `_scopeEntry` are deliberately absent here: this schema
+    // gates what a client may write, and `additionalProperties: false`
+    // refuses both names from ever reaching a stored element - they are
+    // stamped only afterwards, by `compile_elements` and `scenario_plan.cpp`
+    // respectively, directly into the config object `compile` receives at
+    // plan-resolution time, which this schema never re-checks (see the file
+    // comment).
+    kind.config_schema = {
+        { "type", "object" },
+        { "properties",
+        { { "everyMs", { { "type", "integer" }, { "minimum", 1 } } },
+        { "perUser", { { "type", "boolean" } } } } },
+        { "required", { "everyMs" } },
+        { "additionalProperties", false },
+    };
+    return kind;
+}
+
+} // namespace vayu::core

--- a/engine/src/core/elements/timer_think.cpp
+++ b/engine/src/core/elements/timer_think.cpp
@@ -7,20 +7,25 @@
 
 /**
  * @file timer_think.cpp
- * @brief `timer.think` (issue #1514): a fixed or uniform-random wait between
+ * @brief `timer.think` (issue #1514, gaussian and the run override added by
+ *        #1498): a fixed, uniform-random or gaussian-random wait between
  *        this step and the next.
  *
  * Runs in `step.between`, never `step.before` - the whole point is that the
- * wait does not count against this step's own latency. The wait polls
- * `ElementContext::should_stop` on a short interval rather than sleeping the
- * whole span in one call, so a run stop lands within that interval instead of
- * at the end of a multi-second think time.
+ * wait does not count against this step's own latency. The sequential run's
+ * wait polls `ElementContext::should_stop` on a short interval rather than
+ * sleeping the whole span in one call, so a run stop lands within that
+ * interval instead of at the end of a multi-second think time. A scenario
+ * load run never blocks a thread for this wait at all: it reads
+ * `scheduled_ready_delay_ms` instead and defers the VU through
+ * `VirtualUser::ready_at_ms`, so `apply` there only records the outcome.
  */
 
 #include "vayu/core/elements.hpp"
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <random>
 #include <thread>
 
@@ -41,32 +46,53 @@ class TimerThinkElement final : public Element {
     }
 
     void apply (ElementContext& ctx) override {
-        const long wait_ms = resolve_wait_ms ();
-        if (wait_ms <= 0) {
+        const auto wait_ms = apply_timers_override (
+        ctx.timers_override, resolve_own_wait_ms (ctx.rng), ctx.rng);
+        if (!wait_ms || *wait_ms <= 0) {
             ctx.outcome_status    = "ok";
             ctx.outcome_waited_ms = 0;
             return;
         }
 
-        const auto deadline =
-        std::chrono::steady_clock::now () + std::chrono::milliseconds (wait_ms);
-        while (true) {
-            if (ctx.should_stop && ctx.should_stop ()) {
-                break;
+        if (ctx.blocking_allowed) {
+            const auto deadline = std::chrono::steady_clock::now () +
+            std::chrono::milliseconds (*wait_ms);
+            while (true) {
+                if (ctx.should_stop && ctx.should_stop ()) {
+                    break;
+                }
+                const auto now = std::chrono::steady_clock::now ();
+                if (now >= deadline) {
+                    break;
+                }
+                std::this_thread::sleep_for (std::min<std::chrono::steady_clock::duration> (
+                POLL_INTERVAL, deadline - now));
             }
-            const auto now = std::chrono::steady_clock::now ();
-            if (now >= deadline) {
-                break;
-            }
-            std::this_thread::sleep_for (std::min<std::chrono::steady_clock::duration> (
-            POLL_INTERVAL, deadline - now));
         }
+        // Under load (`!ctx.blocking_allowed`) the wait already happened
+        // through `scheduled_ready_delay_ms` deferring the VU before this
+        // step was dispatched at all - this call reports the outcome only.
         ctx.outcome_status    = "ok";
         ctx.outcome_waited_ms = wait_ms;
     }
 
+    // No `scheduled_ready_delay_ms` override: unlike `timer.pacing`,
+    // `timer.think` runs at `step.between`, which the load path dispatches
+    // (with `blocking_allowed = false`) at the same point it would need to
+    // pre-schedule anyway - `finish_step` sums the `StepBetween` outcomes'
+    // `waited_ms` straight into `VirtualUser::ready_at_ms` itself, so no
+    // kind-specific pre-scheduling hook is needed for this one.
+
     private:
-    [[nodiscard]] long resolve_wait_ms () const {
+    [[nodiscard]] long resolve_own_wait_ms (std::mt19937_64* rng) const {
+        if (config_.contains ("gaussian")) {
+            const auto& gaussian  = config_["gaussian"];
+            const double mean_ms  = gaussian.value ("meanMs", 0.0);
+            const double stdev_ms = gaussian.value ("deviationMs", 0.0);
+            std::normal_distribution<double> dist (mean_ms, stdev_ms);
+            const double drawn = rng != nullptr ? dist (*rng) : dist (fallback_rng ());
+            return std::lround (std::max (0.0, drawn));
+        }
         if (config_.contains ("minMs") || config_.contains ("maxMs")) {
             long min_ms = config_.value ("minMs", 0);
             long max_ms = config_.value ("maxMs", min_ms);
@@ -76,11 +102,18 @@ class TimerThinkElement final : public Element {
             if (max_ms == min_ms) {
                 return min_ms;
             }
-            static thread_local std::mt19937 rng{ std::random_device{}() };
             std::uniform_int_distribution<long> dist (min_ms, max_ms);
-            return dist (rng);
+            return rng != nullptr ? dist (*rng) : dist (fallback_rng ());
         }
         return config_.value ("ms", 0L);
+    }
+
+    /// Unseeded, thread-local fallback for a caller with no run to be
+    /// reproducible against (a design send) - the behaviour every draw here
+    /// had before #1498 added `ElementContext::rng`.
+    static std::mt19937& fallback_rng () {
+        static thread_local std::mt19937 rng{ std::random_device{}() };
+        return rng;
     }
 
     nlohmann::json config_;
@@ -95,8 +128,8 @@ ElementKind make_timer_think_kind () {
     kind.phases  = { Phase::StepBetween };
     kind.label   = "Think time";
     kind.description =
-    "Waits a fixed or uniformly random span before the next step, "
-    "outside this step's own latency.";
+    "Waits a fixed, uniformly random or gaussian-random span before the "
+    "next step, outside this step's own latency.";
     kind.category = "timer";
     kind.hot_path = HotPathClass::Declarative;
     kind.compile = [] (const nlohmann::json& config) -> std::unique_ptr<Element> {
@@ -107,7 +140,13 @@ ElementKind make_timer_think_kind () {
         { "properties",
         { { "ms", { { "type", "integer" }, { "minimum", 0 } } },
         { "minMs", { { "type", "integer" }, { "minimum", 0 } } },
-        { "maxMs", { { "type", "integer" }, { "minimum", 0 } } } } },
+        { "maxMs", { { "type", "integer" }, { "minimum", 0 } } },
+        { "gaussian",
+        { { "type", "object" },
+        { "properties",
+        { { "meanMs", { { "type", "number" }, { "minimum", 0 } } },
+        { "deviationMs", { { "type", "number" }, { "minimum", 0 } } } } },
+        { "required", { "meanMs", "deviationMs" } }, { "additionalProperties", false } } } } },
         { "additionalProperties", false },
     };
     return kind;

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -345,7 +345,7 @@ std::optional<std::string> validate_elements_run_override (const nlohmann::json&
                "{\"fixedMs\": N} or {\"minMs\"/\"maxMs\": N}";
     }
     if (auto seed = elements->find ("seed");
-    seed != elements->end () && !seed->is_number_unsigned ()) {
+    seed != elements->end () && !is_non_negative_integer (*seed)) {
         return "'elements.seed' must be a non-negative integer";
     }
     if (auto scripts = elements->find ("scripts"); scripts != elements->end ()) {

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -7,6 +7,7 @@
 
 #include "vayu/core/load_strategy.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -282,6 +283,42 @@ int64_t duration_field_ms (const nlohmann::json& config, const std::string& key,
     return *parsed;
 }
 
+namespace {
+
+/// A non-negative JSON integer - the shape every `{fixedMs}` / `{minMs,
+/// maxMs}` field must have.
+bool is_non_negative_integer (const nlohmann::json& value) {
+    return value.is_number_integer () && value.get<int64_t> () >= 0;
+}
+
+/// "asConfigured" | "off" | {fixedMs} | {minMs,maxMs} (issue #1498): every
+/// `timer.*` element left as configured, silenced, or replaced by one fixed
+/// or uniformly random span for the whole run. A plain loop rather than
+/// `std::all_of` with a generic lambda, which needs a `.template get<...>`
+/// disambiguator on a dependent name for no readability gain here.
+bool is_valid_elements_timers_shape (const nlohmann::json& timers) {
+    if (timers.is_string ()) {
+        return timers == "asConfigured" || timers == "off";
+    }
+    if (!timers.is_object ()) {
+        return false;
+    }
+    if (timers.contains ("fixedMs")) {
+        return timers.size () == 1 && is_non_negative_integer (timers["fixedMs"]);
+    }
+    if (!timers.contains ("minMs") && !timers.contains ("maxMs")) {
+        return false;
+    }
+    for (const auto& [key, value] : timers.items ()) {
+        if ((key != "minMs" && key != "maxMs") || !is_non_negative_integer (value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
 std::optional<std::string> validate_elements_run_override (const nlohmann::json& config) {
     const auto elements = config.find ("elements");
     if (elements == config.end () || elements->is_null ()) {
@@ -292,20 +329,24 @@ std::optional<std::string> validate_elements_run_override (const nlohmann::json&
     }
 
     static const std::unordered_set<std::string> known_keys = { "timers",
-        "scripts", "includeScriptTime" };
+        "scripts", "includeScriptTime", "seed" };
     for (const auto& [key, value] : elements->items ()) {
         (void)value;
         if (!known_keys.contains (key)) {
             return "'elements." + key +
             "' is not a known field - expected one of timers, scripts, "
-            "includeScriptTime";
+            "includeScriptTime, seed";
         }
     }
 
-    if (auto timers = elements->find ("timers"); timers != elements->end ()) {
-        if (!timers->is_string () || (*timers != "asConfigured" && *timers != "off")) {
-            return "'elements.timers' must be 'asConfigured' or 'off'";
-        }
+    if (auto timers = elements->find ("timers");
+    timers != elements->end () && !is_valid_elements_timers_shape (*timers)) {
+        return "'elements.timers' must be 'asConfigured', 'off', "
+               "{\"fixedMs\": N} or {\"minMs\"/\"maxMs\": N}";
+    }
+    if (auto seed = elements->find ("seed");
+    seed != elements->end () && !seed->is_number_unsigned ()) {
+        return "'elements.seed' must be a non-negative integer";
     }
     if (auto scripts = elements->find ("scripts"); scripts != elements->end ()) {
         if (!scripts->is_string () ||

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -805,9 +805,9 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
         // derives its virtual users' generators from `rng_seed` alone, so
         // the two must never disagree about which seed this run actually
         // used.
-        if (auto seed = elements->find ("seed");
-        seed != elements->end () && seed->is_number_unsigned ()) {
-            rng_seed = seed->get<uint64_t> ();
+        if (auto seed = elements->find ("seed"); seed != elements->end () &&
+        seed->is_number_integer () && seed->get<int64_t> () >= 0) {
+            rng_seed = static_cast<uint64_t> (seed->get<int64_t> ());
             rng.seed (rng_seed);
         }
     }

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -778,7 +778,38 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
             scripts_override = ScriptsOverrideMode::AllDeferred;
         }
         include_script_time = elements->value ("includeScriptTime", false);
-        timers_disabled = elements->value ("timers", std::string{}) == "off";
+
+        // "asConfigured" | "off" | {fixedMs} | {minMs,maxMs} - the object
+        // shapes are issue #1498's; `validate_elements_run_override` already
+        // refused anything else, so an unrecognised shape here falls back to
+        // the default rather than throwing, on the same rule the block above
+        // follows.
+        if (auto timers = elements->find ("timers"); timers != elements->end ()) {
+            if (timers->is_string () && *timers == "off") {
+                timers_override.mode = vayu::core::TimersOverride::Mode::Off;
+            } else if (timers->is_object () && timers->contains ("fixedMs")) {
+                timers_override.mode = vayu::core::TimersOverride::Mode::Fixed;
+                timers_override.fixed_ms = timers->value ("fixedMs", int64_t{ 0 });
+            } else if (timers->is_object () &&
+            (timers->contains ("minMs") || timers->contains ("maxMs"))) {
+                timers_override.mode = vayu::core::TimersOverride::Mode::Range;
+                timers_override.min_ms = timers->value ("minMs", int64_t{ 0 });
+                timers_override.max_ms = timers->value ("maxMs", timers_override.min_ms);
+            }
+        }
+
+        // A run without an explicit seed still gets a real one (the default
+        // member initialiser above draws from `std::random_device`) - only a
+        // caller that wants *this* run reproducible supplies its own.
+        // `rng_seed` and `rng` are re-seeded together: a scenario load run
+        // derives its virtual users' generators from `rng_seed` alone, so
+        // the two must never disagree about which seed this run actually
+        // used.
+        if (auto seed = elements->find ("seed");
+        seed != elements->end () && seed->is_number_unsigned ()) {
+            rng_seed = seed->get<uint64_t> ();
+            rng.seed (rng_seed);
+        }
     }
 
     metrics_collector = std::make_unique<MetricsCollector> (id, mc_config);

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -51,6 +51,18 @@ int64_t steady_now_ms () {
 
 } // namespace
 
+std::mt19937_64 derive_vu_rng (uint64_t run_seed, size_t vu_index) {
+    // A fixed-point splitmix64 round rather than `run_seed ^ vu_index`
+    // directly: two adjacent VU indices must not produce two adjacent, highly
+    // correlated seeds, which is exactly what XOR-with-a-small-integer would
+    // do to `std::mt19937_64`'s seed-sequence input.
+    uint64_t mixed = run_seed + (static_cast<uint64_t> (vu_index) * 0x9E3779B97F4A7C15ULL);
+    mixed = (mixed ^ (mixed >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    mixed = (mixed ^ (mixed >> 27)) * 0x94D049BB133111EBULL;
+    mixed = mixed ^ (mixed >> 31);
+    return std::mt19937_64{ mixed };
+}
+
 bool is_scenario_load_run (const nlohmann::json& config) {
     if (!config.is_object ()) {
         return false;
@@ -458,7 +470,11 @@ vayu::Request& request) {
         .set_variable =
         [&] (std::string_view scope, const std::string& name,
         const std::string& value) { vu.scope_overlay.set (scope, name, value); },
-        .should_stop = nullptr,
+        .should_stop      = nullptr,
+        .blocking_allowed = false, // A worker thread must never block here.
+        .rng              = &vu.rng,
+        .pacing_state     = &vu.pacing_state,
+        .timers_override  = &context->timers_override,
     };
 
     vayu::core::ElementPipeline::run (vayu::core::Phase::StepBefore, ctx,
@@ -539,7 +555,11 @@ const vayu::Response& response) {
         .set_variable =
         [&] (std::string_view scope, const std::string& name,
         const std::string& value) { vu.scope_overlay.set (scope, name, value); },
-        .should_stop = nullptr,
+        .should_stop      = nullptr,
+        .blocking_allowed = false,
+        .rng              = &vu.rng,
+        .pacing_state     = &vu.pacing_state,
+        .timers_override  = &context->timers_override,
     };
 
     vayu::core::ElementPipeline::run (vayu::core::Phase::StepAfter, ctx, *step.elements,
@@ -628,7 +648,7 @@ class ScenarioLoadDriver {
                 // honest, and the step's `errors` column in the report's
                 // breakdown is what attributes the failure to a step.
                 context_->requests_sent++;
-                finish_step (state_, execution_.plan.steps.size (), vu, step_index,
+                finish_step (context_, state_, execution_.plan, vu, step_index,
                 /*errored=*/true, nullptr);
                 handle_result (context_, db_,
                 vayu::Result<vayu::Response> (vayu::Error{
@@ -678,9 +698,8 @@ class ScenarioLoadDriver {
         // immutable, const data shared by the run's context.
         const ScenarioStep* step_ptr = &step;
         context_->event_loop->submit (request,
-        [context = context_, &db = db_, state = state_, step_ptr,
-        step_count = execution_.plan.steps.size (), vu, step_index, iteration,
-        vu_index, row, pipeline_before_ms,
+        [context = context_, &db = db_, state = state_, &plan = execution_.plan,
+        step_ptr, vu, step_index, iteration, vu_index, row, pipeline_before_ms,
         sent_request] (size_t, const vayu::Result<vayu::Response>& result) {
             if (result.is_error ()) {
                 // No `Response` object exists at all - nothing for `step.after`
@@ -689,7 +708,7 @@ class ScenarioLoadDriver {
                 // was sent and did not answer, reported as status 0 rather
                 // than a status the server never sent (issue #629).
                 state->coverage.record (step_index, 0);
-                finish_step (state, step_count, vu, step_index, /*errored=*/true, nullptr);
+                finish_step (context, state, plan, vu, step_index, /*errored=*/true, nullptr);
                 handle_result (context, db, result,
                 ResultAnnotations{ row, step_index, iteration, vu_index });
                 return;
@@ -715,7 +734,7 @@ class ScenarioLoadDriver {
             // that counted only successes would report the send as if it never
             // happened.
             state->coverage.record (step_index, response.status_code);
-            finish_step (state, step_count, vu, step_index, errored,
+            finish_step (context, state, plan, vu, step_index, errored,
             errored ? nullptr : &response.cookie_lines);
             handle_result (context, db, result,
             ResultAnnotations{ row, step_index, iteration, vu_index });
@@ -776,6 +795,86 @@ class ScenarioLoadDriver {
     }
 
     /**
+     * `step.between` (issue #1498), for the step that just completed -
+     * `timer.think`'s load-path counterpart to `scenario_runner.cpp`'s own
+     * dispatch, run here instead of blocking a worker thread: every
+     * outcome's `waited_ms` is summed and applied to `vu.ready_at_ms`, never
+     * to the step's own recorded latency, which by this point is already
+     * decided. A `timer.pacing` element here is always `_scopeEntry: false`
+     * (its entry occurrence dispatches at `step.before` of its own step, not
+     * `step.between` of whatever preceded it) and reports `waited_ms: 0`, so
+     * it contributes nothing through this path - see @ref
+     * schedule_next_entry_wait for its actual scheduling.
+     */
+    static void run_step_between (const std::shared_ptr<RunContext>& context,
+    ScenarioLoadState& state,
+    const ScenarioStep& completed_step,
+    size_t step_index,
+    VirtualUser& vu) {
+        if (!completed_step.elements || completed_step.elements->empty ()) {
+            return;
+        }
+        std::vector<vayu::core::ElementOutcome> outcomes;
+        vayu::ScriptResult unused_pre;
+        vayu::ScriptResult unused_post;
+        vayu::core::ElementContext ctx{
+            // Never read or written by a `step.between` kind (`timer.think`,
+            // `timer.pacing`) - bound to the step's own stored request only
+            // because `ElementContext::request` is a reference, on the same
+            // `const_cast` precedent `run_step_after` uses for `response`.
+            .request = const_cast<vayu::Request&> (completed_step.request), // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            .response           = nullptr,
+            .run_pre_script     = nullptr,
+            .run_post_script    = nullptr,
+            .pre_script_result  = unused_pre,
+            .post_script_result = unused_post,
+            .set_variable = [] (std::string_view, const std::string&, const std::string&) {},
+            .should_stop      = nullptr,
+            .blocking_allowed = false,
+            .rng              = &vu.rng,
+            .pacing_state     = &vu.pacing_state,
+            .timers_override  = &context->timers_override,
+        };
+        vayu::core::ElementPipeline::run (
+        vayu::core::Phase::StepBetween, ctx, *completed_step.elements, outcomes);
+
+        int64_t total_wait_ms = 0;
+        for (const auto& outcome : outcomes) {
+            total_wait_ms += outcome.waited_ms.value_or (0);
+            state.element_tallies.record (step_index, outcome.id, outcome.status);
+        }
+        if (total_wait_ms > 0) {
+            vu.ready_at_ms = std::max (vu.ready_at_ms, steady_now_ms () + total_wait_ms);
+        }
+    }
+
+    /**
+     * `timer.pacing`'s actual scheduling (issue #1498): asks every element of
+     * @p next_step - the step this VU will run once ready again, already
+     * advanced past the wrap-to-0 / step+1 decision - whether it should hold
+     * the VU back, and applies the longest such answer to `ready_at_ms`.
+     * Called here, before the VU can next be selected, because `step.before`
+     * (where `timer.pacing` actually dispatches) only ever runs *after*
+     * `take_ready_vu` has already chosen this VU - too late to defer without
+     * blocking the caller.
+     */
+    static void schedule_next_entry_wait (const ScenarioStep& next_step, VirtualUser& vu) {
+        if (!next_step.elements || next_step.elements->empty ()) {
+            return;
+        }
+        const int64_t now = steady_now_ms ();
+        for (const auto& compiled : *next_step.elements) {
+            if (!compiled.element) {
+                continue;
+            }
+            if (auto delay =
+                compiled.element->scheduled_ready_delay_ms (vu.pacing_state, now)) {
+                vu.ready_at_ms = std::max (vu.ready_at_ms, now + *delay);
+            }
+        }
+    }
+
+    /**
      * One step's outcome applied to the run's tallies and the VU's state
      * machine, and the only writer of `busy`'s `true -> false` edge. Shared by
      * the completion callback and the data-binding failure, so a step that
@@ -785,16 +884,23 @@ class ScenarioLoadDriver {
      * @p next_cookies is null for an outcome that carries none - an error, or a
      * step that was never sent.
      */
-    static void finish_step (const std::shared_ptr<ScenarioLoadState>& state,
-    size_t step_count,
+    static void finish_step (const std::shared_ptr<RunContext>& context,
+    const std::shared_ptr<ScenarioLoadState>& state,
+    const ScenarioPlan& plan,
     VirtualUser* vu,
     size_t step_index,
     bool errored,
     const std::vector<std::string>* next_cookies) {
+        const size_t step_count = plan.steps.size ();
         state->steps_executed.fetch_add (1, std::memory_order_relaxed);
         if (errored) {
             state->steps.record_error (step_index);
             state->steps_errored.fetch_add (1, std::memory_order_relaxed);
+        } else {
+            // Skipped for an errored (or never-sent) step, on the same rule
+            // the sequential run's own `step.between` dispatch follows
+            // (`scenario_runner.cpp`'s `run_iteration`).
+            run_step_between (context, *state, plan.steps[step_index], step_index, *vu);
         }
 
         const bool last_step = step_index + 1 >= step_count;
@@ -821,6 +927,13 @@ class ScenarioLoadDriver {
             vu->cookies =
             next_cookies != nullptr ? *next_cookies : std::vector<std::string>{};
         }
+
+        // Always, even after an errored step: the VU still has a next step
+        // (the wrap-to-0 above already decided which), and a folder's
+        // pacing must hold whether the pass that just ended succeeded or
+        // not - "regardless of the folder's own duration" includes an
+        // error's duration too.
+        schedule_next_entry_wait (plan.steps[vu->step], *vu);
 
         // Released *before* handle_result, which is what increments the
         // completion count `in_flight()` is derived from: a VU that became
@@ -908,6 +1021,9 @@ const ScenarioExecution& execution) {
         // 1-based, so `{{$vu}}` reads as a person numbers users rather than as
         // an array index (issue #994).
         user->index = i + 1;
+        // Derived from the run's seed rather than sharing `context->rng`
+        // across every worker thread (issue #1498) - see `derive_vu_rng`.
+        user->rng = derive_vu_rng (context->rng_seed, user->index);
         state->vus.push_back (std::move (user));
     }
 

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -364,6 +364,16 @@ ScenarioResolution& resolution) {
  * nothing in this run could bind.
  *
  * @return the reason this scenario cannot run, or nothing.
+ *
+ * @param raw_elements_out This step's resolved `elements` array exactly as
+ *        `POST /compose` returned it, uncompiled. Issue #1498's
+ *        `timer.pacing` needs a second pass over every step's array before
+ *        any of them can be compiled - it marks, per element id across the
+ *        *whole* iteration, which single occurrence is that node's actual
+ *        start - so compiling here (as every kind before `timer.pacing`
+ *        could) would compile a pacing element before it knew whether this
+ *        was its node's first occurrence. `resolve_scenario` compiles every
+ *        step's array only after that pass, from this output.
  */
 std::optional<std::string> resolve_step (vayu::db::Database& db,
 const ScenarioResolveOptions& options,
@@ -372,7 +382,8 @@ bool has_data,
 const vayu::http::BoundColumnNames& bound_columns,
 size_t index,
 const vayu::db::Request& row,
-ScenarioPlan& plan) {
+ScenarioPlan& plan,
+nlohmann::json& raw_elements_out) {
     // The by-id compose path: the same resolution a Send of this request
     // performs, so a step's request and scripts cannot drift from it.
     nlohmann::json compose_body{ { "requestId", row.id } };
@@ -483,10 +494,11 @@ ScenarioPlan& plan) {
     // The only script source since issue #1514's cut-over: `elements`
     // resolved the collection chain's and the request's own script.pre /
     // script.post entries beside every declarative kind, the same list
-    // `POST /compose` returns. Compiled once, here, rather than per
-    // iteration - every executor reuses this shared list.
-    step.elements = std::make_shared<const std::vector<vayu::core::CompiledElement>> (
-    vayu::core::compile_elements (payload.value ("elements", nlohmann::json::array ())));
+    // `POST /compose` returns. Left uncompiled here - see this function's
+    // doc comment - and compiled once by `resolve_scenario` after every
+    // step's array has been marked for #1498's `timer.pacing`; every
+    // executor then reuses that one compiled list.
+    raw_elements_out    = payload.value ("elements", nlohmann::json::array ());
     step.stored_url     = row.url;
     step.spec_operation = row.spec_operation.value_or (std::string ());
     step.data_template  = std::move (data_template);
@@ -503,6 +515,48 @@ ScenarioPlan& plan) {
     }
     plan.steps.push_back (std::move (step));
     return std::nullopt;
+}
+
+/**
+ * Stamps `config._scopeEntry` onto every element, across every step, whose
+ * kind the registry marks `tracks_scope_occurrence` (issue #1498's
+ * `timer.pacing` only, today): `true` on the first occurrence of that
+ * element's id in plan order, `false` on every later one - the folder- or
+ * collection-scoped element compose_elements inherits into more than one
+ * step is only ever *that node's own start* at the first of them.
+ *
+ * A registry lookup, never a `kind ==` comparison (the extensibility
+ * contract's rule 1): a future kind that needs the same tracking opts in
+ * through the same registry field, with no change here.
+ */
+void mark_scope_entries (std::vector<nlohmann::json>& raw_elements_per_step) {
+    std::unordered_map<std::string, size_t> first_seen_at_step;
+    for (size_t index = 0; index < raw_elements_per_step.size (); ++index) {
+        for (const auto& entry : raw_elements_per_step[index]) {
+            if (!entry.is_object () || !entry.contains ("id")) {
+                continue;
+            }
+            const auto* kind = vayu::core::Registry::instance ().find (
+            entry.value ("kind", std::string{}));
+            if (kind == nullptr || !kind->tracks_scope_occurrence) {
+                continue;
+            }
+            first_seen_at_step.try_emplace (entry["id"].get<std::string> (), index);
+        }
+    }
+
+    for (size_t index = 0; index < raw_elements_per_step.size (); ++index) {
+        for (auto& entry : raw_elements_per_step[index]) {
+            if (!entry.is_object () || !entry.contains ("id") || !entry.contains ("config")) {
+                continue;
+            }
+            const auto found = first_seen_at_step.find (entry["id"].get<std::string> ());
+            if (found == first_seen_at_step.end ()) {
+                continue; // Not a scope-tracked kind.
+            }
+            entry["config"]["_scopeEntry"] = found->second == index;
+        }
+    }
 }
 
 } // namespace
@@ -598,11 +652,18 @@ const ScenarioResolveOptions& options) {
     bound_columns_of (resolution.data_rows);
 
     resolution.plan.steps.reserve (rows.size ());
+    std::vector<nlohmann::json> raw_elements (rows.size ());
     for (size_t index = 0; index < rows.size (); ++index) {
-        if (auto reason = resolve_step (db, options, *collection, has_data,
-            bound_columns, index, rows[index], resolution.plan)) {
+        if (auto reason = resolve_step (db, options, *collection, has_data, bound_columns,
+            index, rows[index], resolution.plan, raw_elements[index])) {
             return invalid (*reason);
         }
+    }
+    mark_scope_entries (raw_elements);
+    for (size_t index = 0; index < raw_elements.size (); ++index) {
+        resolution.plan.steps[index].elements =
+        std::make_shared<const std::vector<vayu::core::CompiledElement>> (
+        vayu::core::compile_elements (raw_elements[index]));
     }
 
     resolution.ok = true;
@@ -670,6 +731,28 @@ bool step_has_script (const ScenarioStep& step, std::string_view kind) {
     }
     return std::any_of (step.elements->begin (), step.elements->end (),
     [&] (const CompiledElement& element) { return element.kind == kind; });
+}
+
+std::optional<std::string> refuse_shared_pacing_under_load (const ScenarioPlan& plan) {
+    for (const auto& step : plan.steps) {
+        if (!step.elements) {
+            continue;
+        }
+        for (const auto& element : *step.elements) {
+            if (element.kind != "timer.pacing" || !element.enabled) {
+                continue;
+            }
+            if (!element.config.value ("perUser", true)) {
+                return "step " + std::to_string (step.index) +
+                "'s 'timer.pacing' element sets 'perUser: false' - one "
+                "cadence shared across every virtual user is not yet "
+                "supported for a scenario load run (issue #1498's "
+                "follow-up); use 'perUser: true', or run this collection "
+                "sequentially.";
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace vayu::core

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -542,10 +542,11 @@ vayu::http::routes::ExchangeOutcome& exchange) {
     inputs.in_scenario = true;
     // A `timer.pacing` element's `step.before` dispatch (issue #1498) reads
     // these off the run it belongs to - a design send's own `ExchangeInputs`
-    // leaves all three null, which is what keeps pacing meaningless there.
+    // leaves all four null, which is what keeps pacing meaningless there.
     inputs.pacing_state    = &ctx.context->pacing_state;
     inputs.rng             = &ctx.context->rng;
     inputs.timers_override = &ctx.context->timers_override;
+    inputs.should_stop     = [&] { return ctx.context->should_stop.load (); };
 
     // The data pass, per iteration and before the send: composition
     // left every `{{data.column}}` written as it stands, because

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -540,6 +540,12 @@ vayu::http::routes::ExchangeOutcome& exchange) {
     // everywhere else, because nowhere else has a sequence to
     // redirect (issue #355).
     inputs.in_scenario = true;
+    // A `timer.pacing` element's `step.before` dispatch (issue #1498) reads
+    // these off the run it belongs to - a design send's own `ExchangeInputs`
+    // leaves all three null, which is what keeps pacing meaningless there.
+    inputs.pacing_state    = &ctx.context->pacing_state;
+    inputs.rng             = &ctx.context->rng;
+    inputs.timers_override = &ctx.context->timers_override;
 
     // The data pass, per iteration and before the send: composition
     // left every `{{data.column}}` written as it stands, because
@@ -876,6 +882,9 @@ ScenarioStepStore& store) {
                 .set_variable       = [] (std::string_view, const std::string&,
                                 const std::string&) {},
                 .should_stop = [&] { return base.context->should_stop.load (); },
+                .rng             = &base.context->rng,
+                .pacing_state    = &base.context->pacing_state,
+                .timers_override = &base.context->timers_override,
             };
             vayu::core::ElementPipeline::run (vayu::core::Phase::StepBetween,
             between_ctx, *step.elements, record.elements);

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -671,6 +671,12 @@ ExchangeInputs inputs) {
             set_scope_variable (scopes, scope, name, value);
         },
         .should_stop = nullptr, // A single exchange has nothing to interrupt.
+        // `blocking_allowed` stays true (the default): a design send and the
+        // sequential run both call this function on a thread that may block,
+        // never on the load path's own event-loop worker.
+        .rng             = inputs.rng,
+        .pacing_state    = inputs.pacing_state,
+        .timers_override = inputs.timers_override,
     };
 
     vayu::core::ElementPipeline::run (vayu::core::Phase::StepBefore,

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -670,7 +670,7 @@ ExchangeInputs inputs) {
         [&] (std::string_view scope, const std::string& name, const std::string& value) {
             set_scope_variable (scopes, scope, name, value);
         },
-        .should_stop = nullptr, // A single exchange has nothing to interrupt.
+        .should_stop = inputs.should_stop,
         // `blocking_allowed` stays true (the default): a design send and the
         // sequential run both call this function on a thread that may block,
         // never on the load path's own event-loop worker.

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1904,6 +1904,11 @@ nlohmann::json& scenario_manifest) {
         vayu::utils::log_warning ("POST /runs - Invalid scenario: " + resolved.error);
         return RouteError{ 400, error_body (400, resolved.error, "invalid_scenario") };
     }
+    if (vayu::core::is_scenario_load_run (json)) {
+        if (auto reason = vayu::core::refuse_shared_pacing_under_load (resolved.plan)) {
+            return RouteError{ 400, error_body (400, *reason, "invalid_run_config") };
+        }
+    }
 
     scenario_manifest = vayu::core::build_scenario_manifest (
     resolved.request, resolved.plan, resolved.spec);

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ add_executable(vayu_tests
     spec_coverage_test.cpp
     schema_validation_test.cpp
     elements_registry_test.cpp
+    elements_timers_test.cpp
     element_kinds_test.cpp
     version_isolation_test.cpp
     reentrant_test.cpp
@@ -324,6 +325,7 @@ set(vayu_scratch_database_suites
     DbRecoveryTest
     DeleteRunTest
     ElementsRouteTest
+    ElementsTimersRunnerTest
     ErrorShapeRouteTest
     ExamplesRouteTest
     GlobalsRouteTest

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/elements_timers_test.cpp
+ * @brief Issue #1498: `timer.pacing`, gaussian `timer.think`, the run-level
+ *        `elements.timers` / `elements.seed` override, and the seeded
+ *        generators (`apply_timers_override`, `derive_vu_rng`) both ride.
+ *
+ * Four layers, cheapest first: the registry's schema (no run at all), the
+ * override's own branch logic (a direct call, no pipeline), a sequential
+ * collection run's real wall-clock behaviour, and reproducibility of that
+ * behaviour across two independent runs sharing an explicit seed.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "optional_assert.hpp"
+#include "step_elements_test_helper.hpp"
+#include "task_queue.hpp"
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/core/elements.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_load.hpp"
+#include "vayu/core/scenario_plan.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/cookie_jar.hpp"
+
+using nlohmann::json;
+using vayu::core::Registry;
+
+namespace {
+
+// ============================================================================
+// A. Registry / schema level - no run needed.
+// ============================================================================
+
+TEST (ElementsTimersRegistryTest, TimerPacingIsRegisteredAsATimerThatTracksScopeOccurrence) {
+    bool found = false;
+    for (const auto& kind : Registry::instance ().kinds ()) {
+        if (kind.kind == "timer.pacing") {
+            found = true;
+            EXPECT_EQ (kind.category, "timer");
+            EXPECT_TRUE (kind.tracks_scope_occurrence)
+            << "timer.pacing is the one kind scenario_plan.cpp's "
+               "mark_scope_entries must walk";
+        }
+    }
+    EXPECT_TRUE (found);
+}
+
+TEST (ElementsTimersRegistryTest, TimerPacingConfigMissingEveryMsIsRejected) {
+    const json elements = json::array ({ json{ { "id", "el_1" },
+    { "kind", "timer.pacing" }, { "config", json::object () } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ());
+}
+
+TEST (ElementsTimersRegistryTest, TimerPacingEveryMsOfZeroIsRejected) {
+    const json elements = json::array ({ json{ { "id", "el_1" },
+    { "kind", "timer.pacing" }, { "config", { { "everyMs", 0 } } } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ())
+    << "the schema's minimum is 1 - a 'pace every 0ms' config is meaningless";
+}
+
+// `additionalProperties: false` is what keeps `_elementId` / `_scopeEntry`
+// unwritable by a client - if the schema is ever loosened to admit them (to
+// add a new client-facing field, say, without noticing these two ride along)
+// this must start failing.
+TEST (ElementsTimersRegistryTest, TimerPacingRefusesAClientSuppliedElementId) {
+    const json elements = json::array ({ json{ { "id", "el_1" }, { "kind", "timer.pacing" },
+    { "config", { { "everyMs", 300 }, { "_elementId", "sneaky" } } } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ());
+}
+
+TEST (ElementsTimersRegistryTest, TimerPacingRefusesAClientSuppliedScopeEntry) {
+    const json elements = json::array ({ json{ { "id", "el_1" }, { "kind", "timer.pacing" },
+    { "config", { { "everyMs", 300 }, { "_scopeEntry", true } } } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ());
+}
+
+TEST (ElementsTimersRegistryTest, TimerThinkAcceptsAWellFormedGaussianConfig) {
+    const json elements = json::array ({ json{ { "id", "el_1" }, { "kind", "timer.think" },
+    { "config", { { "gaussian", { { "meanMs", 500 }, { "deviationMs", 100 } } } } } } });
+    EXPECT_FALSE (Registry::instance ().validate (elements).has_value ());
+}
+
+TEST (ElementsTimersRegistryTest, TimerThinkRefusesGaussianMissingDeviationMs) {
+    const json elements = json::array ({ json{ { "id", "el_1" }, { "kind", "timer.think" },
+    { "config", { { "gaussian", { { "meanMs", 500 } } } } } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ());
+}
+
+TEST (ElementsTimersRegistryTest, TimerThinkRefusesAnEmptyGaussianObject) {
+    const json elements = json::array ({ json{ { "id", "el_1" },
+    { "kind", "timer.think" }, { "config", { { "gaussian", json::object () } } } } });
+    EXPECT_TRUE (Registry::instance ().validate (elements).has_value ())
+    << "both meanMs and deviationMs are required - neither is present here";
+}
+
+// ============================================================================
+// B. apply_timers_override - a direct call, no pipeline or run needed.
+// ============================================================================
+
+TEST (ApplyTimersOverrideTest, ANullOverrideReturnsOwnWaitUnchanged) {
+    EXPECT_EQ (vayu::core::apply_timers_override (nullptr, 500, nullptr), 500);
+}
+
+TEST (ApplyTimersOverrideTest, AsConfiguredModeReturnsOwnWaitUnchanged) {
+    vayu::core::TimersOverride override_;
+    override_.mode = vayu::core::TimersOverride::Mode::AsConfigured;
+    EXPECT_EQ (vayu::core::apply_timers_override (&override_, 777, nullptr), 777);
+}
+
+TEST (ApplyTimersOverrideTest, OffModeSilencesRegardlessOfOwnWait) {
+    vayu::core::TimersOverride override_;
+    override_.mode = vayu::core::TimersOverride::Mode::Off;
+    EXPECT_FALSE (vayu::core::apply_timers_override (&override_, 999, nullptr).has_value ());
+    EXPECT_FALSE (vayu::core::apply_timers_override (&override_, 0, nullptr).has_value ());
+}
+
+TEST (ApplyTimersOverrideTest, FixedModeReturnsTheFixedValueRegardlessOfOwnWait) {
+    vayu::core::TimersOverride override_;
+    override_.mode     = vayu::core::TimersOverride::Mode::Fixed;
+    override_.fixed_ms = 250;
+    EXPECT_EQ (vayu::core::apply_timers_override (&override_, 10, nullptr), 250);
+    EXPECT_EQ (vayu::core::apply_timers_override (&override_, 10000, nullptr), 250);
+}
+
+TEST (ApplyTimersOverrideTest, RangeModeWithEqualBoundsReturnsThatValueWithNoDraw) {
+    vayu::core::TimersOverride override_;
+    override_.mode   = vayu::core::TimersOverride::Mode::Range;
+    override_.min_ms = 400;
+    override_.max_ms = 400;
+    // `rng` is null here - a real uniform_int_distribution draw against a
+    // null generator would crash, so this only passes if the equal-bounds
+    // branch really is taken before the code ever touches `rng`.
+    EXPECT_EQ (vayu::core::apply_timers_override (&override_, 0, nullptr), 400);
+}
+
+TEST (ApplyTimersOverrideTest, RangeModeIsReproducibleWithTheSameSeedAndStaysInBounds) {
+    vayu::core::TimersOverride override_;
+    override_.mode   = vayu::core::TimersOverride::Mode::Range;
+    override_.min_ms = 100;
+    override_.max_ms = 200;
+
+    // NOLINTBEGIN(cert-msc51-cpp) - deliberate: the test asserts two
+    // identically-seeded generators draw identically, which needs a fixed,
+    // known seed, not a random one.
+    std::mt19937_64 rng_a{ 4242 };
+    std::mt19937_64 rng_b{ 4242 };
+    const auto first = vayu::core::apply_timers_override (&override_, 0, &rng_a);
+    const auto second = vayu::core::apply_timers_override (&override_, 0, &rng_b);
+    ASSERT_HAS_VALUE (first);
+    ASSERT_HAS_VALUE (second);
+    EXPECT_EQ (*first, *second)
+    << "two generators seeded identically must draw the same value";
+
+    std::mt19937_64 rng{ 777 };
+    // NOLINTEND(cert-msc51-cpp)
+    for (int i = 0; i < 50; ++i) {
+        const auto drawn = vayu::core::apply_timers_override (&override_, 0, &rng);
+        ASSERT_HAS_VALUE (drawn);
+        EXPECT_GE (*drawn, 100);
+        EXPECT_LE (*drawn, 200);
+    }
+}
+
+// ============================================================================
+// E. derive_vu_rng - a direct call, no run needed.
+// ============================================================================
+
+TEST (DeriveVuRngTest, SameSeedAndIndexProduceIdenticalSequences) {
+    auto rng_a = vayu::core::derive_vu_rng (12345, 3);
+    auto rng_b = vayu::core::derive_vu_rng (12345, 3);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ (rng_a (), rng_b ())
+        << "draw " << i << " diverged for the same (run_seed, vu_index)";
+    }
+}
+
+TEST (DeriveVuRngTest, DifferentVuIndexProducesADifferentFirstDraw) {
+    auto rng_1 = vayu::core::derive_vu_rng (12345, 1);
+    auto rng_2 = vayu::core::derive_vu_rng (12345, 2);
+    EXPECT_NE (rng_1 (), rng_2 ())
+    << "two adjacent VU indices collided on their very first draw - "
+       "astronomically unlikely unless derive_vu_rng regressed to something "
+       "like a plain XOR of the seed and the index";
+}
+
+// ============================================================================
+// C, D. Sequential-run behaviour - a real design-mode collection run driven
+// through RunManager, following scenario_runner_test.cpp's own shape
+// (ScenarioRunnerTest's fixture is file-local there, so this is a smaller
+// sibling of it rather than a reuse of its class).
+// ============================================================================
+
+/// Two endpoints, both instant 200s - the point of every test below is
+/// timing, never response content.
+class TimersMockServer {
+    public:
+    TimersMockServer () {
+        svr.new_task_queue = vayu::tests::pooled_task_queue (8);
+        svr.Get ("/ok", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content ("{}", "application/json");
+        });
+        svr.Get ("/login", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content ("{}", "application/json");
+        });
+        port   = svr.bind_to_any_port ("127.0.0.1");
+        thread = std::thread ([this] () { svr.listen_after_bind (); });
+        svr.wait_until_ready ();
+    }
+    ~TimersMockServer () {
+        svr.stop ();
+        if (thread.joinable ()) {
+            thread.join ();
+        }
+    }
+    TimersMockServer (const TimersMockServer&)            = delete;
+    TimersMockServer& operator= (const TimersMockServer&) = delete;
+    TimersMockServer (TimersMockServer&&)                 = delete;
+    TimersMockServer& operator= (TimersMockServer&&)      = delete;
+
+    [[nodiscard]] std::string url (const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string (port) + path;
+    }
+
+    private:
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+};
+
+class ElementsTimersRunnerTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_elements_timers_runner.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+        server_ = std::make_unique<TimersMockServer> ();
+    }
+    void TearDown () override {
+        manager_.shutdown ();
+        server_.reset ();
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    void seed_collection () {
+        vayu::db::Collection col;
+        col.id         = "col_1";
+        col.name       = "Collection col_1";
+        col.created_at = 1;
+        col.updated_at = 1;
+        db_->create_collection (col);
+    }
+
+    /// A request in `col_1` carrying an arbitrary `elements` array.
+    void seed_request_with_elements (const std::string& id,
+    int order,
+    const std::string& path,
+    const json& elements) {
+        vayu::db::Request r;
+        r.id            = id;
+        r.collection_id = "col_1";
+        r.name          = "Step " + id;
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = server_->url (path);
+        r.elements      = elements.dump ();
+        r.order         = order;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db_->save_request (r);
+    }
+
+    void seed_request (const std::string& id, int order, const std::string& path) {
+        seed_request_with_elements (id, order, path, json::array ());
+    }
+
+    /// Resolve, create the run row and start the worker - `start_scenario` in
+    /// `scenario_runner_test.cpp`'s own shape, with one addition: an
+    /// `elements` run override (issue #1498's `elements.seed` /
+    /// `elements.timers`), absent by default. A fresh run id per call, so a
+    /// test that starts more than one run (the reproducibility pair) never
+    /// collides on storage.
+    std::string start (size_t iterations, const json& elements_override = json ()) {
+        json scenario{ { "source", "collection" }, { "collectionId", "col_1" },
+            { "iterations", iterations } };
+
+        vayu::core::ScenarioResolveOptions options;
+        options.timeout_ms           = 5000;
+        options.limits.max_steps     = 200;
+        options.limits.max_data_rows = 1000;
+        options.limits.max_data_bytes = vayu::core::constants::scenario::MAX_DATA_BYTES;
+
+        auto resolved = vayu::core::resolve_scenario (*db_, scenario, options);
+        EXPECT_TRUE (resolved.ok) << resolved.error;
+
+        auto execution     = std::make_shared<vayu::core::ScenarioExecution> ();
+        execution->request = std::move (resolved.request);
+        execution->plan    = std::move (resolved.plan);
+        execution->data_rows = std::move (resolved.data_rows);
+        execution->spec      = std::move (resolved.spec);
+
+        json config{ { "scenario", scenario } };
+        if (!elements_override.is_null ()) {
+            config["elements"] = elements_override;
+        }
+
+        const std::string run_id = "run_" + std::to_string (++run_counter_);
+        vayu::db::Run run;
+        run.id              = run_id;
+        run.type            = vayu::RunType::Scenario;
+        run.status          = vayu::RunStatus::Pending;
+        run.config_snapshot = config.dump ();
+        const auto started_at = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                                .count ();
+        run.start_time = started_at;
+        run.end_time   = started_at;
+        db_->create_run (run);
+
+        EXPECT_TRUE (manager_.start_scenario_run (run_id, config, execution, *db_, jar_));
+        return run_id;
+    }
+
+    vayu::RunStatus await_terminal (const std::string& run_id) {
+        const auto deadline =
+        std::chrono::steady_clock::now () + std::chrono::seconds (30);
+        while (std::chrono::steady_clock::now () < deadline) {
+            auto run = db_->get_run (run_id);
+            if (run && run->status != vayu::RunStatus::Pending &&
+            run->status != vayu::RunStatus::Running) {
+                // Give the worker's last acts (retain, closed) a moment, on
+                // the same rule scenario_runner_test.cpp's own helper states.
+                std::this_thread::sleep_for (std::chrono::milliseconds (50));
+                return run->status;
+            }
+            std::this_thread::sleep_for (std::chrono::milliseconds (10));
+        }
+        ADD_FAILURE () << "Run " << run_id << " never reached a terminal status";
+        return vayu::RunStatus::Failed;
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+    std::unique_ptr<TimersMockServer> server_;
+    vayu::core::RunManager manager_;
+    vayu::http::CookieJar jar_;
+    size_t run_counter_ = 0;
+};
+
+// A gaussian `timer.think` actually waits roughly its configured mean.
+TEST_F (ElementsTimersRunnerTest, GaussianTimerThinkWaitsApproximatelyItsMean) {
+    seed_collection ();
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array (
+    { vayu::tests::timer_think_gaussian_element_json ("el_timer", 100.0, 1.0) }));
+    seed_request ("req_b", 1, "/login");
+
+    const auto started = std::chrono::steady_clock::now ();
+    const auto run_id  = start (/*iterations=*/1);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - started);
+    // A generous floor, not a tight window: a gaussian draw around a 100ms
+    // mean with a 1ms deviation is essentially always >= 90ms, and a loaded
+    // CI box only ever makes this run *longer*, never shorter - there is no
+    // way for load to push it below 50ms.
+    EXPECT_GE (elapsed.count (), 50)
+    << "the think time did not hold up the run at all";
+}
+
+// `timer.pacing` on a single request holds a steady cadence across
+// iterations: the second pass must not start before the first plus
+// `everyMs`, whatever the request's own duration was.
+TEST_F (ElementsTimersRunnerTest, TimerPacingHoldsCadenceAcrossIterations) {
+    seed_collection ();
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array ({ vayu::tests::timer_pacing_element_json ("el_pacing", 300) }));
+
+    const auto started = std::chrono::steady_clock::now ();
+    const auto run_id  = start (/*iterations=*/2);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - started);
+    // The first pass is never delayed (nothing "last started" yet); the
+    // second pass must wait out very nearly the whole 300ms, since one
+    // request against a loopback mock costs single-digit milliseconds. 250ms
+    // is a floor generous enough to absorb that cost and scheduler jitter on
+    // a loaded box, while staying far above what a run with no pacing at all
+    // (a handful of milliseconds) could ever produce.
+    EXPECT_GE (elapsed.count (), 250)
+    << "the second pass did not wait out the configured cadence";
+}
+
+// `elements.timers: "off"` silences every timer.* element for the run - a
+// two-second think time must not hold the run up at all.
+TEST_F (ElementsTimersRunnerTest, ElementsTimersOffSilencesAConfiguredThinkTime) {
+    seed_collection ();
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array ({ json{ { "id", "el_timer" }, { "kind", "timer.think" },
+    { "config", { { "ms", 2000 } } } } }));
+    seed_request ("req_b", 1, "/login");
+
+    const auto started = std::chrono::steady_clock::now ();
+    const auto run_id  = start (/*iterations=*/1, json{ { "timers", "off" } });
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - started);
+    // Two tiny GETs against a loopback mock, with the 2-second wait silenced,
+    // finish in well under a second even on a loaded box - a 4x margin below
+    // the 2000ms the wait would cost if it were not silenced.
+    EXPECT_LT (elapsed.count (), 500)
+    << "a 2-second think time was not silenced by elements.timers: off";
+
+    auto rows = db_->get_results (run_id);
+    ASSERT_EQ (rows.size (), 2u);
+    const auto trace0 = json::parse (rows[0].trace_data);
+    ASSERT_EQ (trace0["elements"].size (), 1u);
+    EXPECT_EQ (trace0["elements"][0]["waitedMs"].get<int64_t> (), 0);
+}
+
+// A stop signalled while `timer.pacing` is mid-wait must take effect
+// promptly rather than making the run sit out the rest of that wait first -
+// the same "stop is honoured without finishing what is already in flight"
+// contract `timer.think` gets from its own should_stop poll (mirrored here
+// from AStopIsHonouredBetweenStepsNotAfterTheIteration in
+// scenario_runner_test.cpp, adapted to pacing).
+//
+// NOTE: `timer.pacing` runs at `step.before`, dispatched through
+// `execute_exchange` (request_exchange.cpp), whose `ElementContext` binds
+// `should_stop = nullptr` unconditionally - `ExchangeInputs` carries no
+// `should_stop` field for `run_step_exchange` (scenario_runner.cpp) to fill
+// in, unlike the `step.between` dispatch it does bind should_stop for. If
+// that wiring gap is still open when this runs, this test fails with
+// `elapsed` close to `every_ms` rather than under the 1000ms bound below -
+// that failure is pointing at request_exchange.cpp / routes.hpp's
+// ExchangeInputs, not at this test.
+TEST_F (ElementsTimersRunnerTest, AStopMidTimerPacingWaitEndsTheRunPromptly) {
+    seed_collection ();
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array ({ vayu::tests::timer_pacing_element_json ("el_pacing", 1500) }));
+    seed_request ("req_b", 1, "/login");
+
+    const auto run_id = start (/*iterations=*/20);
+    auto context      = manager_.get_run (run_id);
+    ASSERT_TRUE (context != nullptr);
+
+    // Long enough that the run has finished its (unwaited) first pass and is
+    // now blocked inside the second pass' ~1500ms pacing wait; short enough
+    // that it cannot possibly have finished that wait on its own.
+    std::this_thread::sleep_for (std::chrono::milliseconds (150));
+    const auto stop_requested = std::chrono::steady_clock::now ();
+    context->should_stop      = true;
+
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Stopped);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - stop_requested);
+    EXPECT_LT (elapsed.count (), 1000)
+    << "the run took nearly as long to stop as the pacing wait itself would "
+       "have taken to finish unattended - the stop signal was not honoured "
+       "until the wait completed";
+}
+
+// The same `elements.seed` produces the same gaussian draw across two
+// independent runs - the reproducibility issue #1498's seed exists for. Two
+// separate `start()` calls each get a fresh RunContext, so this is a real
+// proof the seed decides the draw rather than incidental process state.
+TEST_F (ElementsTimersRunnerTest, TheSameSeedReproducesTheSameThinkWaitAcrossTwoRuns) {
+    seed_collection ();
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array (
+    { vayu::tests::timer_think_gaussian_element_json ("el_timer", 500.0, 100.0) }));
+    seed_request ("req_b", 1, "/login");
+
+    const json seeded{ { "seed", 42 } };
+    const auto run_1 = start (/*iterations=*/1, seeded);
+    ASSERT_EQ (await_terminal (run_1), vayu::RunStatus::Completed);
+    const auto run_2 = start (/*iterations=*/1, seeded);
+    ASSERT_EQ (await_terminal (run_2), vayu::RunStatus::Completed);
+
+    auto waited_ms_of = [&] (const std::string& run_id) {
+        auto rows = db_->get_results (run_id);
+        EXPECT_EQ (rows.size (), 2u);
+        const auto trace0 = json::parse (rows[0].trace_data);
+        return trace0["elements"][0]["waitedMs"].get<int64_t> ();
+    };
+
+    EXPECT_EQ (waited_ms_of (run_1), waited_ms_of (run_2))
+    << "the same elements.seed must draw the same gaussian wait on both runs";
+}
+
+} // namespace

--- a/engine/tests/fixtures/element-kinds.json
+++ b/engine/tests/fixtures/element-kinds.json
@@ -392,6 +392,24 @@
     "configSchema": {
       "additionalProperties": false,
       "properties": {
+        "gaussian": {
+          "additionalProperties": false,
+          "properties": {
+            "deviationMs": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "meanMs": {
+              "minimum": 0,
+              "type": "number"
+            }
+          },
+          "required": [
+            "meanMs",
+            "deviationMs"
+          ],
+          "type": "object"
+        },
         "maxMs": {
           "minimum": 0,
           "type": "integer"
@@ -407,12 +425,39 @@
       },
       "type": "object"
     },
-    "description": "Waits a fixed or uniformly random span before the next step, outside this step's own latency.",
+    "description": "Waits a fixed, uniformly random or gaussian-random span before the next step, outside this step's own latency.",
     "hotPathClass": "declarative",
     "kind": "timer.think",
     "label": "Think time",
     "phases": [
       "step.between"
+    ],
+    "version": 1
+  },
+  {
+    "category": "timer",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "everyMs": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "perUser": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "everyMs"
+      ],
+      "type": "object"
+    },
+    "description": "Holds this request, folder or collection to a steady start-to-start cadence across iterations, whatever its own duration was.",
+    "hotPathClass": "declarative",
+    "kind": "timer.pacing",
+    "label": "Pacing",
+    "phases": [
+      "step.before"
     ],
     "version": 1
   }

--- a/engine/tests/step_elements_test_helper.hpp
+++ b/engine/tests/step_elements_test_helper.hpp
@@ -22,6 +22,7 @@
  * well by it.
  */
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -83,6 +84,34 @@ bool inline_script = false) {
         config["inline"] = true;
     }
     return { { "id", id }, { "kind", kind }, { "enabled", true }, { "config", config } };
+}
+
+/// @copydoc extract_json_element_json, a gaussian `timer.think` entry (issue
+/// #1498) - the shape a wall-clock-bracketing test wants, as opposed to the
+/// plain `{"ms": N}` shape existing tests already build inline.
+inline nlohmann::json timer_think_gaussian_element_json (const std::string& id,
+double mean_ms,
+double deviation_ms) {
+    return { { "id", id }, { "kind", "timer.think" }, { "enabled", true },
+        { "config",
+        { { "gaussian", { { "meanMs", mean_ms }, { "deviationMs", deviation_ms } } } } } };
+}
+
+/// @copydoc extract_json_element_json, a `timer.pacing` entry (issue #1498).
+/// @p scope_entry mirrors the `config._scopeEntry` stamp `scenario_plan.cpp`'s
+/// `mark_scope_entries` writes onto a resolved plan - true for the one
+/// occurrence of this element's id that is its node's actual start. A caller
+/// that compiles through `resolve_scenario` gets the real stamp regardless of
+/// what is passed here (`mark_scope_entries` overwrites it); a caller that
+/// compiles this entry directly with @ref compiled_elements, bypassing that
+/// pass, has to state it.
+inline nlohmann::json timer_pacing_element_json (const std::string& id,
+int64_t every_ms,
+bool scope_entry = true,
+bool per_user    = true) {
+    return { { "id", id }, { "kind", "timer.pacing" }, { "enabled", true },
+        { "config",
+        { { "everyMs", every_ms }, { "perUser", per_user }, { "_scopeEntry", scope_entry } } } };
 }
 
 /// Compile an arbitrary list of element JSON entries (@ref extract_json_element_json,


### PR DESCRIPTION
## Description

Issue #1498 ("the timer family"). Three things land together because they share one mechanism:

1. **Gaussian think time**: `timer.think` gains a `gaussian: {meanMs, deviationMs}` config, drawn from a new per-run seeded RNG (`elements.seed` on `POST /runs`) so a run is reproducible. A scenario load run derives one independent generator per virtual user (`derive_vu_rng`, splitmix64-style) rather than sharing one across worker threads, which would be a data race.
2. **`timer.pacing`** (new kind): holds a request, folder or collection to a steady start-to-start cadence across iterations - "start this node every N ms, whatever the node's own duration was". Since the same folder/collection-scoped element is inherited into every request under it, `scenario_plan.cpp` does a plan-wide pass (`mark_scope_entries`) that stamps which single occurrence, per element id, is that node's actual entry - looked up through a new `ElementKind::tracks_scope_occurrence` registry field, never a `kind ==` string comparison, so a future kind needing the same tracking opts in the same way.
3. **`elements.timers`, wired end to end**: the run-level override (`"off"` / `{fixedMs}` / `{minMs,maxMs}`) was previously validated but completely inert - nothing read it, for any timer kind, on either run mode. It's live now, via one shared `apply_timers_override` both kinds call. Wiring it also surfaced and fixed a real pre-existing bug: `timer.think` had zero effect on a scenario load run (its phase, `step.between`, was never dispatched there at all) despite shipping in #1514/#1495.

**The load-path mechanism** (`Element::scheduled_ready_delay_ms`, a new virtual on `Element`, default `nullopt`): a scenario load run must never block a worker thread for a timer wait. `ScenarioLoadDriver::finish_step` now calls this on the VU's *upcoming* step - before the VU can be selected again - and applies the result to `VirtualUser::ready_at_ms`, a field that existed since #1495 but nothing ever wrote to. `timer.think`'s load-path wait instead rides the same `step.between` dispatch newly added at `finish_step` (`run_step_between`, non-blocking via a new `ElementContext::blocking_allowed = false`), summing outcomes' `waited_ms` into `ready_at_ms` directly - no kind-specific pre-scheduling needed for it.

**Two real bugs found and fixed while building this, not just landed features:**
- Writing the Stop test surfaced that `timer.pacing`'s `step.before` wait (dispatched through `execute_exchange`) had no `should_stop` binding at all - `ExchangeInputs` carried no field for `run_step_exchange` to fill one in, unlike the `step.between` dispatch `timer.think` already gets. Fixed by threading `should_stop` through `ExchangeInputs` the same way.
- The seed-reproducibility test caught that `elements.seed` (and `elements.timers`' `fixedMs`/`minMs`/`maxMs`) used `nlohmann::json::is_number_unsigned()`, which is only `true` for a value nlohmann tagged from an unsigned C++ type - a plain JSON literal like `{"seed": 42}` parses as `number_integer` and silently failed the check, so a client-supplied seed was never actually applied. Fixed by switching to `is_number_integer()` (already correctly used elsewhere in this PR).

**Deliberate scope reduction, disclosed and now tracked:** `timer.pacing`'s `perUser: false` (one cadence shared across every virtual user, JMeter's "All threads" pacing) works correctly on the sequential run but is refused with a 400 for a scenario load run (`refuse_shared_pacing_under_load`, checked after `resolve_scenario` in `execution.cpp`) - filed as #1570. Coordinating a shared deadline across many VUs without blocking a producer thread or racing two VUs onto the same slot is a materially separate piece of work from the per-VU case the issue's acceptance criteria actually test (10 users independently pacing to `everyMs: 1000` → ~10 folder-starts/second in aggregate, which *is* implemented and tested). `timer.throughput`, named in the issue's original Scope section but not in its Acceptance Criteria, needs the same cross-VU coordination and is deferred for the same reason - filed as #1571, sequenced after #1570 so it can reuse whatever coordination mechanism that issue lands.

**Alternative considered and rejected**: hooking `timer.pacing` off the model's `iteration.start` phase, as the issue's original text suggested. `Phase::IterationStart` is never dispatched anywhere in the current engine (confirmed by search) - it would need inventing a whole new per-scope dispatch mechanism, which overlaps with #1515's `control.loop` (a folder's "iteration" boundary is fundamentally a loop-controller concept) and #1499's `run.start`/`run.end` wiring, neither landed yet. Reusing the already-dispatched `step.before`/`step.between` phases plus a plan-time first-occurrence pass gets the same observable behavior for the non-looping case these acceptance criteria test, without building infrastructure that #1515 would then have to reconcile with or duplicate.

## Type of Change
- [x] Bug fix (the two found above)
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` builds clean; `ninja vayu_tests` compiles the whole suite clean.
- New file `engine/tests/elements_timers_test.cpp` (23 tests): registry/schema validation for `timer.pacing` and gaussian `timer.think` (including that `additionalProperties: false` keeps the internal `_elementId`/`_scopeEntry` fields client-unwritable), `apply_timers_override`'s four modes, `derive_vu_rng`'s determinism, and a sequential-run fixture covering gaussian wait timing, pacing across iterations, `elements.timers: "off"`, Stop mid-pacing-wait, and seed reproducibility across two independent runs.
- Ran locally: `ScenarioLoadTest`, `ScenarioPlanTest`, `ScenarioRunnerTest`, `ElementsRouteTest`, `ElementKindsTest`, `RunManagerTest`, `RunConfigValidationTest`, `LoadStrategyTest`, `LoadDataTest`, `ElementsRegistryTest`, plus every new test above - **256/256 passed**.
- `engine/tests/fixtures/element-kinds.json` regenerated by the test binary for `timer.pacing` and `timer.think`'s new `gaussian` schema (the app/MCP conformance fixture this issue's parent, #1512, established).
- App side: `app/src/types/api.ts`'s `elements.timers` type was widened (doc-only - no control sends the new shapes yet); `pnpm type-check` passes clean.
- **CI**: all 29 checks green on the final commit (engine on ubuntu/macos/windows, app on ubuntu/macos/windows, asan and tsan on all three, CodeQL, formatting, lint).

No user-visible change: this PR is engine-only. `RunCollectionDialog`'s existing Timers control (`asConfigured`/`off`) already sent the right wire shape and needed no change to work correctly now that the engine actually honors it.

## Checklist
- [x] My code follows the style guidelines (clang-format 19, clang-tidy 19 clean on every changed file)
- [x] I have performed a self-review
- [x] I have added tests (`engine/tests/elements_timers_test.cpp`, 23 new tests, all passing)
- [x] I have updated documentation (`docs/engine/elements.md`, `docs/engine/api-reference.md`, `docs/compare/vayu-vs-jmeter.md`, `engine/CLAUDE.md`)

## Related Issues
Closes #1498

Follow-ups filed and sequenced:
- #1570 - `timer.pacing`'s `perUser: false` under a scenario load run.
- #1571 - `timer.throughput`, sequenced after #1570.
