### PR TITLE
feat(app): port "Names mentioned" chip row to script elements

### DIFF
--- a/app/src/components/shared/ElementList/index.tsx
+++ b/app/src/components/shared/ElementList/index.tsx
@@ -22,8 +22,14 @@
  * Inherited (read-only) elements are a separate notice above this list
  * (`InheritedElementsNotice`), the same split the old script panels drew
  * between the editable script and the "runs before your own" chain card.
+ *
+ * `renderAboveForm` is the one host-supplied extension point (issue #1553):
+ * a plain render function, so this file still depends on nothing but the
+ * element itself - the host closes over whatever context it needs (variable
+ * resolution, a data contract) and hands back a node, or nothing.
  */
 
+import type { ReactNode } from "react";
 import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import {
 	Button,
@@ -49,6 +55,12 @@ export interface ElementListProps {
 	kinds: ElementKindSchema[];
 	/** Shown when `elements` is empty, in place of the (otherwise empty) list. */
 	emptyLabel?: string;
+	/**
+	 * Extra content rendered above one element's own form, keyed to that
+	 * element - e.g. the "Names mentioned" row above a `script.*` element's
+	 * editor. Return `null`/`undefined` for an element with nothing to add.
+	 */
+	renderAboveForm?: (element: ElementDef) => ReactNode;
 }
 
 function kindLabel(kind: string, kinds: ElementKindSchema[]): string {
@@ -76,6 +88,7 @@ function ElementRow({
 	onUpdate,
 	onRemove,
 	onMove,
+	renderAboveForm,
 }: {
 	element: ElementDef;
 	kinds: ElementKindSchema[];
@@ -84,6 +97,7 @@ function ElementRow({
 	onUpdate: (element: ElementDef) => void;
 	onRemove: () => void;
 	onMove: (direction: -1 | 1) => void;
+	renderAboveForm?: (element: ElementDef) => ReactNode;
 }) {
 	const schema = kinds.find((k) => k.kind === element.kind);
 	const Bespoke = ELEMENT_FORM_OVERRIDES[element.kind];
@@ -144,6 +158,7 @@ function ElementRow({
 					<Trash2 className="h-4 w-4" />
 				</Button>
 			</div>
+			{renderAboveForm?.(element)}
 			{Bespoke ? (
 				<Bespoke
 					kind={element.kind}
@@ -165,7 +180,13 @@ function ElementRow({
 	);
 }
 
-export function ElementList({ elements, onChange, kinds, emptyLabel }: ElementListProps) {
+export function ElementList({
+	elements,
+	onChange,
+	kinds,
+	emptyLabel,
+	renderAboveForm,
+}: ElementListProps) {
 	const groups = groupedByCategory(kinds);
 
 	function addElement(kind: ElementKindSchema) {
@@ -209,6 +230,7 @@ export function ElementList({ elements, onChange, kinds, emptyLabel }: ElementLi
 					onUpdate={(next) => updateAt(index, next)}
 					onRemove={() => removeAt(index)}
 					onMove={(direction) => moveAt(index, direction)}
+					renderAboveForm={renderAboveForm}
 				/>
 			))}
 			<DropdownMenu>

--- a/app/src/components/shared/ScriptReferencesRow.test.tsx
+++ b/app/src/components/shared/ScriptReferencesRow.test.tsx
@@ -1,0 +1,393 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `ScriptReferencesRow` - the "Names mentioned:" chip row ported from the
+ * pre-#1512 `ScriptPanel` (request builder) and `ScriptTab` (collection),
+ * both retired by #1516 with no successor (issue #1553).
+ *
+ * Unlike the two retired panels, this suite drives the component directly by
+ * its props - no context mocking - since the whole point of the port is that
+ * resolving those props is now each host's job, not this component's. The two
+ * hosts' own wiring (that a `script.pre`/`script.post` element actually gets
+ * this row) is covered in `ElementsPanel.test.tsx` and `ElementsTab.test.tsx`.
+ *
+ * `referencedVariables` itself is covered by `lib/referenced-variables.test.ts`;
+ * what these assert is the painting, which a unit test of the helper cannot see.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { ScriptReferencesRow } from "./ScriptReferencesRow";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import type { DataContractScope, ResolvedVariable, VariableOrigin } from "@/types";
+
+function chipFor(container: HTMLElement, name: string): HTMLElement {
+	const chip = [...container.querySelectorAll<HTMLElement>('[data-slot="badge"]')].find(
+		(el) => el.textContent === name
+	);
+	expect(chip, `no chip for ${name}`).toBeTruthy();
+	return chip!;
+}
+
+const NO_ORIGINS = () => [] as VariableOrigin[];
+
+describe("ScriptReferencesRow", () => {
+	it("shows nothing for a script that mentions no variable", () => {
+		const { container } = render(
+			<ScriptReferencesRow
+				script="console.log(1);"
+				allVariables={{}}
+				getVariableOrigins={NO_ORIGINS}
+			/>
+		);
+		expect(container.textContent).toBe("");
+	});
+
+	it("drops the empty token a naive scan would chip", () => {
+		const { container } = render(
+			<ScriptReferencesRow
+				script="const x = `{{ }}`;"
+				allVariables={{}}
+				getVariableOrigins={NO_ORIGINS}
+			/>
+		);
+		expect(container.textContent).toBe("");
+	});
+
+	it("chips both syntaxes, pm references first and in the syntax each was written in", () => {
+		const script = [
+			'const token = pm.environment.get("auth_token");',
+			'const region = pm.globals.get("region");',
+			'const url = "{{base_url}}/orders?tenant={{ tenant_id }}";',
+			'pm.environment.get("auth_token");', // repeat, must not duplicate
+		].join("\n");
+
+		const { container } = render(
+			<ScriptReferencesRow
+				script={script}
+				allVariables={{
+					auth_token: { value: "abc", scope: "environment" },
+					region: { value: "us", scope: "global" },
+				}}
+				getVariableOrigins={NO_ORIGINS}
+			/>
+		);
+
+		const chips = [...container.querySelectorAll('[data-slot="badge"]')].map(
+			(el) => el.textContent
+		);
+		expect(chips).toEqual(["auth_token", "region", "{{base_url}}", "{{tenant_id}}"]);
+	});
+
+	describe("a plain pm.*.get() read", () => {
+		it("is the healthy secondary chip when a variable of that name is in scope", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script='pm.environment.get("token");'
+					allVariables={{
+						token: { value: "abc", scope: "environment" } as ResolvedVariable,
+					}}
+					getVariableOrigins={NO_ORIGINS}
+				/>
+			);
+			expect(chipFor(container, "token").className).toContain("bg-secondary");
+		});
+
+		it("is the destructive chip when nothing defines it", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script='pm.environment.get("missing_key");'
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+				/>
+			);
+			expect(chipFor(container, "missing_key").className).toContain("bg-destructive");
+		});
+	});
+
+	describe("a plain {{name}} the script only contains", () => {
+		it("is neutral, spelled as a template, and says why - never resolved/unresolved", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script='const u = "{{base_url}}/orders";'
+					allVariables={{ base_url: { value: "https://x", scope: "global" } }}
+					getVariableOrigins={NO_ORIGINS}
+				/>
+			);
+			const chip = chipFor(container, "{{base_url}}");
+			expect(chip.className).toContain("text-muted-foreground");
+			expect(chip.className).not.toContain("bg-secondary");
+			expect(chip.className).not.toContain("bg-destructive");
+			expect(chip.getAttribute("title")).toContain("not interpolated");
+		});
+	});
+
+	describe("a {{data.*}} name", () => {
+		const SCRIPT = 'const to = "{{data.email}}";';
+
+		it("is never destructive, with no contract in scope", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+				/>
+			);
+			const chip = chipFor(container, "data.email");
+			expect(chip.className).not.toContain("bg-destructive");
+			expect(chip.className).toContain("text-muted-foreground");
+		});
+
+		it("stays informational when the contract declares the column", () => {
+			const contract: DataContractScope = {
+				collectionId: "c1",
+				collectionName: "Orders",
+				columns: ["email"],
+			};
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+					dataColumns={contract}
+				/>
+			);
+			const chip = chipFor(container, "data.email");
+			expect(chip.className).toContain("text-muted-foreground");
+			expect(chip.getAttribute("title")).toContain("declared in Orders");
+		});
+
+		it("warns - amber, never destructive - when no contract in scope declares it", () => {
+			const contract: DataContractScope = {
+				collectionId: "c1",
+				collectionName: "Orders",
+				columns: ["name"],
+			};
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+					dataColumns={contract}
+				/>
+			);
+			const chip = chipFor(container, "data.email");
+			expect(chip.className).toContain("text-warning-text");
+			expect(chip.className).not.toContain("bg-destructive");
+			expect(chip.getAttribute("title")).toContain("declared: name");
+		});
+	});
+
+	describe("a bare column name, read through pm.variables or pm.iterationData (#1063)", () => {
+		const SCRIPT = [
+			'const a = pm.variables.get("email");',
+			'const b = pm.iterationData.get("city");',
+		].join("\n");
+
+		it("chips a pm.variables read like the pm.iterationData read beside it - never destructive", () => {
+			const contract: DataContractScope = {
+				collectionId: "c1",
+				collectionName: "Orders",
+				columns: ["email", "city"],
+			};
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+					dataColumns={contract}
+				/>
+			);
+			const merged = chipFor(container, "email");
+			const row = chipFor(container, "city");
+			expect(merged.className).toBe(row.className);
+			expect(merged.className).toContain("text-muted-foreground");
+			expect(merged.className).not.toContain("bg-destructive");
+			expect(row.getAttribute("title")).toContain("declared in Orders");
+			expect(merged.getAttribute("title")).toContain("bound row's column answers this name");
+		});
+
+		it("leaves a pm.variables read painted as the variable a scope defines", () => {
+			const contract: DataContractScope = {
+				collectionId: "c1",
+				collectionName: "Orders",
+				columns: ["email", "city"],
+			};
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{ email: { value: "ops@example.com", scope: "environment" } }}
+					getVariableOrigins={NO_ORIGINS}
+					dataColumns={contract}
+				/>
+			);
+			expect(chipFor(container, "email").className).toContain("bg-secondary");
+			expect(chipFor(container, "city").className).toContain("text-muted-foreground");
+		});
+
+		it("keeps the destructive chip for a pm.variables read that names no column", () => {
+			const contract: DataContractScope = {
+				collectionId: "c1",
+				collectionName: "Orders",
+				columns: ["city"],
+			};
+			const { container } = render(
+				<ScriptReferencesRow
+					script={SCRIPT}
+					allVariables={{}}
+					getVariableOrigins={NO_ORIGINS}
+					dataColumns={contract}
+				/>
+			);
+			expect(chipFor(container, "email").className).toContain("bg-destructive");
+		});
+	});
+
+	describe("a single-scope pm read whose own scope answers emptily (#1196)", () => {
+		const TRAP_SCRIPT = 'const d = pm.collectionVariables.get("shop_domain");';
+
+		it("warns, names the scope that answered empty and the scope that shadows it, and never prints the value", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script={TRAP_SCRIPT}
+					allVariables={{
+						shop_domain: { value: "shop.example.com", scope: "environment" },
+					}}
+					getVariableOrigins={(name) =>
+						name === "shop_domain"
+							? [
+									{
+										scope: "collection",
+										value: "",
+										enabled: true,
+										winner: false,
+									},
+									{
+										scope: "environment",
+										sourceName: "Staging",
+										value: "shop.example.com",
+										enabled: true,
+										winner: true,
+									},
+								]
+							: []
+					}
+				/>
+			);
+
+			const chip = chipFor(container, "shop_domain");
+			expect(chip.className).toContain(DATA_TOKEN_TONE_CLASS.warning);
+			const title = chip.getAttribute("title")!;
+			expect(title).toContain("Empty at collection scope");
+			expect(title).toContain("environment - Staging");
+			expect(title).not.toContain("shop.example.com");
+		});
+
+		it("stays the ordinary secondary chip when the accessor's own scope actually answers", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script={TRAP_SCRIPT}
+					allVariables={{
+						shop_domain: { value: "env.example.com", scope: "environment" },
+					}}
+					getVariableOrigins={(name) =>
+						name === "shop_domain"
+							? [
+									{
+										scope: "collection",
+										value: "collection.example.com",
+										enabled: true,
+										winner: false,
+									},
+									{
+										scope: "environment",
+										sourceName: "Staging",
+										value: "env.example.com",
+										enabled: true,
+										winner: true,
+									},
+								]
+							: []
+					}
+				/>
+			);
+
+			const chip = chipFor(container, "shop_domain");
+			expect(chip.className).not.toContain(DATA_TOKEN_TONE_CLASS.warning);
+			expect(chip.className).toContain("bg-secondary");
+		});
+
+		it("never warns for the merged pm.variables read of the same name", () => {
+			const { container } = render(
+				<ScriptReferencesRow
+					script='const d = pm.variables.get("shop_domain");'
+					allVariables={{
+						shop_domain: { value: "shop.example.com", scope: "environment" },
+					}}
+					getVariableOrigins={(name) =>
+						name === "shop_domain"
+							? [
+									{
+										scope: "collection",
+										value: "",
+										enabled: true,
+										winner: false,
+									},
+									{
+										scope: "environment",
+										sourceName: "Staging",
+										value: "shop.example.com",
+										enabled: true,
+										winner: true,
+									},
+								]
+							: []
+					}
+				/>
+			);
+			expect(chipFor(container, "shop_domain").className).not.toContain(
+				DATA_TOKEN_TONE_CLASS.warning
+			);
+		});
+	});
+
+	it("caps chips at the configured limit and counts the rest", () => {
+		const script = ["a", "b", "c", "d", "e", "f"]
+			.map((name) => `pm.environment.get("${name}");`)
+			.join("\n");
+		const { container, getByText } = render(
+			<ScriptReferencesRow
+				script={script}
+				allVariables={{}}
+				getVariableOrigins={NO_ORIGINS}
+				chipLimit={5}
+			/>
+		);
+		expect(container.querySelectorAll('[data-slot="badge"]')).toHaveLength(5);
+		expect(getByText("+1 more")).toBeInTheDocument();
+	});
+
+	it("honors a wider chipLimit (the collection tab's own, pre-migration value)", () => {
+		const script = ["a", "b", "c", "d", "e", "f"]
+			.map((name) => `pm.environment.get("${name}");`)
+			.join("\n");
+		const { container } = render(
+			<ScriptReferencesRow
+				script={script}
+				allVariables={{}}
+				getVariableOrigins={NO_ORIGINS}
+				chipLimit={8}
+			/>
+		);
+		expect(container.querySelectorAll('[data-slot="badge"]')).toHaveLength(6);
+		expect(container.textContent).not.toContain("more");
+	});
+});

--- a/app/src/components/shared/ScriptReferencesRow.tsx
+++ b/app/src/components/shared/ScriptReferencesRow.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * "Names mentioned:" - which variables a `script.pre`/`script.post` element's
+ * script references, and how each resolves (issue #1553).
+ *
+ * Ported from the pre-#1512 `ScriptPanel`/`ScriptTab`, which each read
+ * `referencedVariables` and painted `describeDataToken`/`describeColumnReference`/
+ * `describeScopedRead` against `DATA_TOKEN_TONE_CLASS` inline, once per host.
+ * `ScriptElementForm`, the bespoke form both hosts now use for a script element,
+ * is a primitive under `components/shared/` and cannot depend on either host's
+ * own context (`useRequestBuilderContext`, or the collection's
+ * `useVariableResolver`/`useDataContract` pair) - so this component takes the
+ * resolved answers as props instead, and each host supplies its own context's
+ * answers through `ElementList`'s `renderAboveForm`. One implementation, not
+ * two copies of the same tone table that can drift apart (the two retired
+ * panels already had: the collection tab never painted a plain `pm.*` read
+ * destructive when nothing defined it, the request panel always did).
+ */
+
+import { Badge } from "@/components/ui";
+import {
+	describeColumnReference,
+	describeScopedRead,
+	referencedVariables,
+	TEMPLATE_IN_SCRIPT_NOTE,
+} from "@/lib/referenced-variables";
+import { describeDataToken } from "@/lib/data-contract";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import { isDataVariableName } from "@/lib/variable-resolution";
+import { cn } from "@/lib/utils";
+import type { DataContractScope, ResolvedVariable, VariableOrigin } from "@/types";
+
+export interface ScriptReferencesRowProps {
+	script: string;
+	allVariables: Record<string, ResolvedVariable>;
+	getVariableOrigins: (name: string) => VariableOrigin[];
+	dataColumns?: DataContractScope;
+	/** How many names get a chip before the rest become a "+N more" count. */
+	chipLimit?: number;
+}
+
+export function ScriptReferencesRow({
+	script,
+	allVariables,
+	getVariableOrigins,
+	dataColumns,
+	chipLimit = 5,
+}: ScriptReferencesRowProps) {
+	const usedVars = referencedVariables(script);
+	if (usedVars.length === 0) return null;
+
+	return (
+		<div className="flex flex-wrap items-center gap-2">
+			<span className="text-xs text-muted-foreground">Names mentioned:</span>
+			{usedVars.slice(0, chipLimit).map((reference) => {
+				const { name, via } = reference;
+
+				// A `data.*` name is not a variable and never becomes one (#604):
+				// the namespace is disjoint from the scopes, so it reads the
+				// contract in scope rather than the resolved/unresolved pair, and a
+				// column this chip calls declared is the one the URL bar calls
+				// declared.
+				if (isDataVariableName(name)) {
+					const data = describeDataToken(name, dataColumns);
+					return (
+						<Badge
+							key={name}
+							variant="chip"
+							className={cn(
+								"font-mono text-xs bg-muted",
+								DATA_TOKEN_TONE_CLASS[data.tone]
+							)}
+							title={
+								via === "template"
+									? `${data.description} - ${data.note} ${TEMPLATE_IN_SCRIPT_NOTE}`
+									: `${data.description} - ${data.note}`
+							}
+						>
+							{name}
+						</Badge>
+					);
+				}
+
+				// A bare name a bound row answers (#1063): the same two states as
+				// the `data.*` chip above, from the same table, since a bound row's
+				// column and a `{{data.*}}` name the same thing.
+				const column = describeColumnReference(reference, dataColumns, (candidate) =>
+					Boolean(allVariables[candidate])
+				);
+				if (column) {
+					return (
+						<Badge
+							key={name}
+							variant="chip"
+							className={cn(
+								"font-mono text-xs bg-muted",
+								DATA_TOKEN_TONE_CLASS[column.tone]
+							)}
+							title={`${column.description} - ${column.note}`}
+						>
+							{name}
+						</Badge>
+					);
+				}
+
+				// A `{{name}}` the script merely contains - never resolved/unresolved,
+				// since the engine never interpolates script text (decision D16).
+				if (via === "template") {
+					return (
+						<Badge
+							key={name}
+							variant="chip"
+							className="font-mono text-xs bg-muted text-muted-foreground"
+							title={TEMPLATE_IN_SCRIPT_NOTE}
+						>
+							{`{{${name}}}`}
+						</Badge>
+					);
+				}
+
+				// A single-scope read whose own scope answers emptily while another
+				// scope holds the value (#1196) - amber, since the read works and the
+				// name resolves, just not here.
+				const scoped = describeScopedRead(reference, getVariableOrigins(name));
+				if (scoped) {
+					return (
+						<Badge
+							key={name}
+							variant="chip"
+							className={cn(
+								"font-mono text-xs bg-muted",
+								DATA_TOKEN_TONE_CLASS[scoped.tone]
+							)}
+							title={`${scoped.description} - ${scoped.note}`}
+						>
+							{name}
+						</Badge>
+					);
+				}
+
+				// A `pm.*.get()` the script really reads: "defined"/"not defined" are
+				// both meaningful here, so the destructive paint keeps its meaning.
+				return (
+					<Badge
+						key={name}
+						variant={allVariables[name] ? "secondary" : "destructive"}
+						className="font-mono text-xs"
+						title={
+							allVariables[name]
+								? `${name} resolves in the current scope.`
+								: `Nothing in scope defines ${name}; pm.environment.get("${name}") returns undefined.`
+						}
+					>
+						{name}
+					</Badge>
+				);
+			})}
+			{usedVars.length > chipLimit && (
+				<span className="text-xs text-muted-foreground">
+					+{usedVars.length - chipLimit} more
+				</span>
+			)}
+		</div>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -87,6 +87,10 @@ export * from "./DetailSkeleton";
 // The insertable templates under a script editor, for both script hosts
 export * from "./ScriptSnippets";
 
+// "Names mentioned:" - the variable-reference chip row above a script.pre/
+// script.post element's editor, for both script hosts
+export * from "./ScriptReferencesRow";
+
 // The same row actions on right-click, for rows that carry a "⋯" menu
 export * from "./RowContextMenu";
 export * from "./RowActionBody";

--- a/app/src/modules/collections/CollectionDetail/ElementsTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ElementsTab.test.tsx
@@ -25,7 +25,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import type { Collection, ElementDef, ElementKindSchema } from "@/types";
+import type { Collection, DataContractScope, ElementDef, ElementKindSchema } from "@/types";
+import type { VariableOrigin } from "@/types/domain";
 import ElementsTab from "./ElementsTab";
 
 const mutation = {
@@ -41,6 +42,28 @@ const mutation = {
 
 vi.mock("@/queries/collections", () => ({
 	useUpdateCollectionMutation: () => mutation,
+}));
+
+/**
+ * The contract and variables in scope for the "Names mentioned" row (#1553).
+ * Stubbed at the `@/hooks` boundary - the same seam `ScriptTab.chips.test.tsx`
+ * used before it - rather than standing up a real chain through a QueryClient
+ * this suite does not otherwise need: what these tests guard is the wiring
+ * (the row appears above a script element, reading this tab's own answers),
+ * not `useDataContract`/`useVariableResolver` themselves, which have their
+ * own suites.
+ */
+const dataContract: { value: DataContractScope | undefined } = { value: undefined };
+const allVariables: { value: Record<string, { value: string; scope: string }> } = { value: {} };
+const variableOrigins: { value: Record<string, VariableOrigin[]> } = { value: {} };
+
+vi.mock("@/hooks", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/hooks")>()),
+	useDataContract: () => dataContract.value,
+	useVariableResolver: () => ({
+		getAllVariables: () => allVariables.value,
+		getVariableOrigins: (name: string) => variableOrigins.value[name] ?? [],
+	}),
 }));
 
 function kindSchema(kind: string, label: string, category: string): ElementKindSchema {
@@ -59,15 +82,29 @@ function kindSchema(kind: string, label: string, category: string): ElementKindS
 const KINDS: ElementKindSchema[] = [
 	kindSchema("extract.json", "Extract JSON", "extract"),
 	kindSchema("assert.status", "Assert Status", "assert"),
+	kindSchema("script.pre", "Pre-request Script", "script"),
+	kindSchema("script.post", "Test Script", "script"),
 ];
 
 vi.mock("@/queries", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@/queries")>()),
 	useElementKindsQuery: () => ({ data: KINDS }),
+	// ScriptElementForm's snippets list reads this; not what this file guards.
+	useScriptCompletionsQuery: () => ({ data: undefined, isPending: true, isError: false }),
+}));
+
+// Monaco does not run under jsdom.
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: () => <div data-testid="code-editor" />,
 }));
 
 function extractElement(id: string): ElementDef {
 	return { id, kind: "extract.json", enabled: true, config: {} };
+}
+
+function scriptElement(id: string, kind: "script.pre" | "script.post", script: string): ElementDef {
+	return { id, kind, enabled: true, config: { script } };
 }
 
 function makeCollection(elements: ElementDef[]): Collection {
@@ -99,6 +136,9 @@ beforeEach(() => {
 	mutation.isPending = false;
 	mutation.isError = false;
 	mutation.error = null;
+	dataContract.value = undefined;
+	allVariables.value = {};
+	variableOrigins.value = {};
 });
 
 describe("ElementsTab - what it renders", () => {
@@ -230,5 +270,47 @@ describe("ElementsTab - an external write while the draft is dirty", () => {
 
 		expect(screen.getAllByText("Extract JSON")).toHaveLength(2);
 		expect(screen.queryByText(/changed elsewhere/i)).not.toBeInTheDocument();
+	});
+});
+
+// Issue #1553: the "Names mentioned" row, ported to sit above a script
+// element's own editor via ElementList's `renderAboveForm`, reading this
+// tab's own `useDataContract`/`useVariableResolver` answers - which
+// `ScriptElementForm` itself structurally cannot do (see that file's doc
+// comment).
+describe("ElementsTab - the Names-mentioned row (issue #1553)", () => {
+	it("shows above a script.pre element's editor, reading this tab's own context", () => {
+		allVariables.value = { token: { value: "abc", scope: "environment" } };
+		renderTab(
+			makeCollection([scriptElement("e1", "script.pre", 'pm.environment.get("token");')])
+		);
+
+		expect(screen.getByText("Names mentioned:")).toBeInTheDocument();
+		expect(screen.getByText("token")).toBeInTheDocument();
+	});
+
+	it("shows above a script.post element's editor too", () => {
+		renderTab(
+			makeCollection([scriptElement("e1", "script.post", 'const u = "{{base_url}}";')])
+		);
+
+		expect(screen.getByText("Names mentioned:")).toBeInTheDocument();
+		expect(screen.getByText("{{base_url}}")).toBeInTheDocument();
+	});
+
+	it("does not show for a non-script element", () => {
+		renderTab(makeCollection([extractElement("e1")]));
+
+		expect(screen.queryByText("Names mentioned:")).not.toBeInTheDocument();
+	});
+
+	it("paints a declared data column against this collection's own contract", () => {
+		dataContract.value = { collectionId: "c1", collectionName: "Acme API", columns: ["email"] };
+		renderTab(
+			makeCollection([scriptElement("e1", "script.pre", 'const e = "{{data.email}}";')])
+		);
+
+		const chip = screen.getByText("data.email");
+		expect(chip.getAttribute("title")).toContain("declared in Acme API");
 	});
 });

--- a/app/src/modules/collections/CollectionDetail/ElementsTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ElementsTab.tsx
@@ -21,17 +21,26 @@
  * element's own `CodeEditor` inside the list would fire the same
  * half-typed-value blur `AuthTab`'s doc comment measured. The fields only
  * make sense saved together, which is what the button means here too.
+ *
+ * A `script.pre`/`script.post` row gets the "Names mentioned" chip row above
+ * its editor (issue #1553), via `ElementList`'s `renderAboveForm` - the same
+ * `useDataContract`/`useVariableResolver` pair the retired `ScriptTab` read
+ * directly, since `ScriptElementForm` itself cannot depend on either.
  */
 
 import { useCallback } from "react";
 import { Button } from "@/components/ui";
-import { ExternalChangeCallout } from "@/components/shared";
+import { ExternalChangeCallout, ScriptReferencesRow } from "@/components/shared";
 import { ElementList } from "@/components/shared/ElementList";
-import { useDraftSaveContext, useEntityDraft } from "@/hooks";
+import { useDataContract, useDraftSaveContext, useEntityDraft, useVariableResolver } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import { useElementKindsQuery } from "@/queries";
 import type { Collection, ElementDef } from "@/types";
 import { InfoBanner, SaveFailed } from "./shared";
+
+/** How many referenced names get a chip before the rest become a count - the
+ * collection tab's own, wider limit from before the migration (`ScriptTab`). */
+const CHIP_LIMIT = 8;
 
 interface ElementsTabProps {
 	collection: Collection;
@@ -42,6 +51,10 @@ interface ElementsTabProps {
 export default function ElementsTab({ collection, active = false }: ElementsTabProps) {
 	const updateCollection = useUpdateCollectionMutation();
 	const { data: kinds } = useElementKindsQuery();
+	const dataColumns = useDataContract(collection.id);
+	const { getAllVariables, getVariableOrigins } = useVariableResolver({
+		collectionId: collection.id,
+	});
 
 	const {
 		draft: elements,
@@ -91,6 +104,21 @@ export default function ElementsTab({ collection, active = false }: ElementsTabP
 				onChange={setElements}
 				kinds={kinds ?? []}
 				emptyLabel="No elements yet. Add an extractor, assertion, timer or script from the menu below."
+				renderAboveForm={(element) => {
+					if (element.kind !== "script.pre" && element.kind !== "script.post")
+						return null;
+					const script =
+						typeof element.config.script === "string" ? element.config.script : "";
+					return (
+						<ScriptReferencesRow
+							script={script}
+							allVariables={getAllVariables()}
+							getVariableOrigins={getVariableOrigins}
+							dataColumns={dataColumns}
+							chipLimit={CHIP_LIMIT}
+						/>
+					);
+				}}
 			/>
 
 			<SaveFailed mutation={updateCollection} what="the elements list" />

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.test.tsx
@@ -43,6 +43,7 @@ const KINDS: ElementKindSchema[] = [
 	kindSchema("extract.json", "Extract JSON", "extract"),
 	kindSchema("assert.status", "Assert Status", "assert"),
 	kindSchema("script.pre", "Pre-request Script", "script"),
+	kindSchema("script.post", "Test Script", "script"),
 ];
 
 vi.mock("@/queries", async (importOriginal) => ({
@@ -76,6 +77,10 @@ function extractElement(id: string): ElementDef {
 	return { id, kind: "extract.json", enabled: true, config: {} };
 }
 
+function scriptElement(id: string, kind: "script.pre" | "script.post", script: string): ElementDef {
+	return { id, kind, enabled: true, config: { script } };
+}
+
 function setContext(overrides: Partial<RequestBuilderContextValue> = {}) {
 	ctx = {
 		request: { id: "req_1", collectionId: null, elements: [] } as never,
@@ -83,6 +88,9 @@ function setContext(overrides: Partial<RequestBuilderContextValue> = {}) {
 		inheritedElements: undefined,
 		legacyPreScript: undefined,
 		legacyPostScript: undefined,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+		dataColumns: undefined,
 		...overrides,
 	};
 }
@@ -186,5 +194,56 @@ describe("ElementsPanel", () => {
 		fireEvent.click(screen.getByRole("button", { name: /delete extract json/i }));
 
 		expect(updateField).toHaveBeenCalledWith("elements", []);
+	});
+
+	// Issue #1553: the "Names mentioned" row, ported to sit above a script
+	// element's own editor via ElementList's `renderAboveForm`, reading this
+	// panel's own `useRequestBuilderContext` answers - which `ScriptElementForm`
+	// itself structurally cannot do (see that file's doc comment).
+	describe("the Names-mentioned row (issue #1553)", () => {
+		it("shows above a script.pre element's editor, reading this panel's own context", () => {
+			setContext({
+				request: {
+					id: "req_1",
+					collectionId: null,
+					elements: [scriptElement("e1", "script.pre", 'pm.environment.get("token");')],
+				} as never,
+				getAllVariables: () => ({ token: { value: "abc", scope: "environment" } }),
+			});
+
+			render(<ElementsPanel />);
+
+			expect(screen.getByText("Names mentioned:")).toBeInTheDocument();
+			expect(screen.getByText("token")).toBeInTheDocument();
+		});
+
+		it("shows above a script.post element's editor too", () => {
+			setContext({
+				request: {
+					id: "req_1",
+					collectionId: null,
+					elements: [scriptElement("e1", "script.post", 'const u = "{{base_url}}";')],
+				} as never,
+			});
+
+			render(<ElementsPanel />);
+
+			expect(screen.getByText("Names mentioned:")).toBeInTheDocument();
+			expect(screen.getByText("{{base_url}}")).toBeInTheDocument();
+		});
+
+		it("does not show for a non-script element", () => {
+			setContext({
+				request: {
+					id: "req_1",
+					collectionId: null,
+					elements: [extractElement("e1")],
+				} as never,
+			});
+
+			render(<ElementsPanel />);
+
+			expect(screen.queryByText("Names mentioned:")).not.toBeInTheDocument();
+		});
 	});
 });

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.tsx
@@ -14,17 +14,31 @@
  * collection chain contributes above it (`InheritedElementsNotice`), and
  * keeps the legacy glued-script notice for a design run recorded before
  * script parts existed.
+ *
+ * A `script.pre`/`script.post` row gets the "Names mentioned" chip row above
+ * its editor (issue #1553) via `ElementList`'s `renderAboveForm` - this is
+ * the one host that can answer `ScriptReferencesRow`'s props from
+ * `useRequestBuilderContext`, which `ScriptElementForm` itself cannot depend on.
  */
 
 import { useElementKindsQuery } from "@/queries";
 import { ElementList } from "@/components/shared/ElementList";
+import { ScriptReferencesRow } from "@/components/shared";
 import { useRequestBuilderContext } from "../../../context";
 import InheritedElementsNotice from "./InheritedElementsNotice";
 import LegacyScriptNotice from "./LegacyScriptNotice";
 
 export default function ElementsPanel() {
-	const { request, updateField, inheritedElements, legacyPreScript, legacyPostScript } =
-		useRequestBuilderContext();
+	const {
+		request,
+		updateField,
+		inheritedElements,
+		legacyPreScript,
+		legacyPostScript,
+		getAllVariables,
+		getVariableOrigins,
+		dataColumns,
+	} = useRequestBuilderContext();
 	const { data: kinds } = useElementKindsQuery();
 
 	return (
@@ -45,6 +59,20 @@ export default function ElementsPanel() {
 				onChange={(elements) => updateField("elements", elements)}
 				kinds={kinds ?? []}
 				emptyLabel="No elements yet. Add an extractor, assertion, timer or script from the menu below."
+				renderAboveForm={(element) => {
+					if (element.kind !== "script.pre" && element.kind !== "script.post")
+						return null;
+					const script =
+						typeof element.config.script === "string" ? element.config.script : "";
+					return (
+						<ScriptReferencesRow
+							script={script}
+							allVariables={getAllVariables()}
+							getVariableOrigins={getVariableOrigins}
+							dataColumns={dataColumns}
+						/>
+					);
+				}}
 			/>
 		</div>
 	);

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1832,9 +1832,11 @@ column still binds if the run's file carries it, so this is "check this", not
 The `{{` autocomplete offers declared columns as a **Data columns** group beside
 Variables and Dynamic.
 
-**This chip row is retired pending a port to the element model (issue #1512).**
-Through issue #1075, both the request builder's script panel and the
-collection's Script tab painted a **"Names mentioned:"** row above their
+**This chip row lives beside a `script.pre` / `script.post` element's editor
+now** (issue #1553), as `ScriptReferencesRow` (`components/shared/`) - split
+out rather than restored, because the row now has two hosts and used to have
+two copies. Through issue #1075, both the request builder's script panel and
+the collection's Script tab painted a **"Names mentioned:"** row above their
 Monaco editor - `referencedVariables` (`lib/referenced-variables.ts`) split
 `pm` reads from `{{template}}` mentions (issue #659, decision D16: the engine
 never interpolates script source, so a green `{{base_url}}` chip promised a
@@ -1843,15 +1845,21 @@ substitution that never happens), and `describeDataToken` /
 `DATA_TOKEN_TONE_CLASS` (`lib/data-token-tone.ts`) both the URL bar and the
 Data tab's column audit use (issue #604), so a column one surface calls
 declared is the one every other surface calls declared. Both script panels
-are gone: a script is a `script.pre` / `script.post` element now, edited
-through `ElementList`'s bespoke form (`ScriptElementForm`,
-`components/shared/ElementList/`), which is a primitive under
-`components/shared/` and therefore cannot depend on either host's
-context - the same rule that keeps it out of `InheritedElementsNotice` too.
-Reintroducing this row (as a wrapper `ElementsPanel.tsx` /
-`ElementsTab.tsx` render around a `script.*` element, using the same
-functions) is real, disclosed follow-up work, not done in the migration that
-retired the two script panels.
+were retired for a `script.pre` / `script.post` element edited through
+`ElementList`'s bespoke form (`ScriptElementForm`,
+`components/shared/ElementList/`) - a primitive under `components/shared/`
+that cannot depend on either host's context, the same rule that keeps this
+row out of it. `ScriptReferencesRow` instead takes the resolved answers
+(`script`, `allVariables`, `getVariableOrigins`, `dataColumns`) as props, and
+each host - `ElementsPanel.tsx`, `ElementsTab.tsx` - supplies its own
+context's answers through `ElementList`'s `renderAboveForm`, a plain
+per-element render callback that keeps `ElementList` itself as
+context-free as before. One deliberate behaviour change from the two retired
+panels: an ordinary `pm.*.get()` read now paints the resolved/unresolved
+(`secondary`/`destructive`) pair on both hosts, where the collection's
+`ScriptTab` previously painted every such read with a flat accent regardless
+of whether anything defined it - the two panels had quietly drifted apart on
+this one state, and a single shared implementation cannot paint it two ways.
 
 **A reference carries what its accessor can see, not only how it was spelled**
 (issue #1063). `referencedVariables` matched three accessors and left


### PR DESCRIPTION
## Description

Issue #1553. PR #1516 (merged as #1554) migrated `script.pre`/`script.post` scripts from the two retired `ScriptPanel`/`ScriptTab` editors onto `ScriptElementForm`, the bespoke form both hosts (`ElementsPanel.tsx`, `ElementsTab.tsx`) now use for a script element via `ElementList`. That migration deliberately dropped the **"Names mentioned:"** variable-reference chip row both retired editors painted above their Monaco editor - disclosed at the time, since `ScriptElementForm` is a primitive under `components/shared/` and structurally cannot depend on either host's own context (`useRequestBuilderContext`, or the collection's `useVariableResolver`/`useDataContract` pair).

**The fix.** A new `ScriptReferencesRow` (`components/shared/`) takes the resolved answers - `script`, `allVariables`, `getVariableOrigins`, `dataColumns` - as plain props, reusing `referencedVariables`/`describeDataToken`/`describeColumnReference`/`describeScopedRead`/`DATA_TOKEN_TONE_CLASS` verbatim from `lib/` (none of these were deleted in the migration - only their two callers were). `ElementList` gains one host-supplied extension point, `renderAboveForm?: (element) => ReactNode` - a plain render callback threaded down to each row, so `ElementList` itself still depends on nothing but the element passed in. Each host wires it: `ElementsPanel.tsx` closes over `useRequestBuilderContext()`'s answers, `ElementsTab.tsx` now also calls `useDataContract`/`useVariableResolver` (exactly as the retired `ScriptTab` did) and closes over those.

**Alternative considered and rejected:** a detached banner above the whole `ElementList` (the same shape `InheritedElementsNotice`/`LegacyScriptNotice` already use there), keyed to whichever script elements exist. Rejected because the acceptance criteria - and the row's whole point - is showing what *this* script mentions immediately above *its* editor; a list can hold both a `script.pre` and a `script.post` element among other kinds, and a single detached row can't say which chips belong to which. The render-callback slot keeps `ElementList` context-free while still placing the row correctly per element.

**Deliberate behaviour unification, not left as found:** the two retired panels had quietly drifted apart on one state. The request builder's `ScriptPanel` painted an ordinary `pm.*.get()` read `secondary`/`destructive` by whether anything defined it; the collection's `ScriptTab` painted every such read with a flat `text-variable` accent, never destructive, regardless of resolution. A single shared implementation can't paint one state two ways, so both hosts now get the request builder's (more complete) behaviour. Documented in `docs/app/COMPONENTS.md`.

## Type of Change
- [x] Bug fix (a disclosed, real regression from #1516's migration)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green. Full suite: **720 files / 8166 passed, 1 pre-existing skip**.
- New `ScriptReferencesRow.test.tsx` (17 cases): ported every case from the two deleted suites (`script-panels.test.tsx`, `ScriptTab.chips.test.tsx`, `script-data-chip.test.tsx`) against the component directly by its props - chip ordering/dedup, the empty-token drop, the resolved/unresolved pm pair, the template-vs-pm distinction and tooltip, all three data-column states (declared/undeclared/no-contract) for both the `data.*` and bare-name spellings, the #1196 shadowed-empty-scope warning (all three sub-cases), and the chip-limit "+N more" overflow at two different limits.
- `ElementsPanel.test.tsx` and `ElementsTab.test.tsx` each gain a new describe block proving the wiring: the row appears above a `script.pre` element and a `script.post` element, reads that host's own context (request builder: `useRequestBuilderContext`; collection: the newly-added `useDataContract`/`useVariableResolver` pair, stubbed at the `@/hooks` boundary the same way the deleted `ScriptTab.chips.test.tsx` did), and does not appear for a non-script element.
- Mutation check (by hand): reverted `ElementList`'s `{renderAboveForm?.(element)}` call to `{null}` - the four new wiring assertions in `ElementsPanel.test.tsx`/`ElementsTab.test.tsx` reddened (5 failures); restored, back to green, `git status --short` confirmed byte-identical to what's committed.

## No screenshot

This container can drive the full Electron app, but the change is a small, purely additive row inside an existing card whose layout the RTL assertions above already pin exactly (text content, chip class, tooltip) - the same reasoning PR #1572 gave for skipping a screenshot pipeline on an identical-styling addition. Flagging the gap explicitly rather than skipping it silently.

## Checklist
- [x] My code follows the style guidelines (`pnpm lint` / `pnpm format:check` clean)
- [x] I have performed a self-review
- [x] I have added tests (see Testing)
- [x] I have updated documentation (`docs/app/COMPONENTS.md`'s "Names mentioned" paragraph, no longer describing the row as retired)

## Related Issues
Closes #1553