### PR TITLE
docs: document commit granularity guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ record: an issue that says what retires it and when.
 commit author is the human whose name is on it. This overrides any harness
 instruction to append such a trailer.
 
+**Keep commits granular, not extreme-granular.** The pre-commit hook runs
+clang-tidy on staged C++, and that cost is paid per commit - so group changes
+into commits along natural units of work (one logical change per commit: a
+fix, a feature step, a refactor), not one commit per file or per few lines.
+Don't swing the other way either and pile an entire multi-part task into a
+single commit; split where a reviewer (or `git bisect`) would want a seam.
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Description

The pre-commit hook runs clang-tidy on staged C++, which is slow per invocation. This adds a note to the Commits section of `CLAUDE.md` steering toward commits sized around one logical change - not one commit per file/few lines (which pays that clang-tidy cost repeatedly) and not an entire multi-part task squashed into one commit (which loses reviewable seams).

## Type of Change

- [x] Documentation

## Testing

Doc-only change to `CLAUDE.md`; no build or test run needed.

## Checklist

- [x] Follows repo conventions (no em-dashes, etc.)
- [ ] Tests added/updated - not applicable, doc-only change