### PR TITLE
feat(engine): timer.pacing perUser:false under a scenario load run

### DIFF
--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -83,8 +83,9 @@ are things Vayu plans to catch up on:
 - **Your load model needs logic controllers** - loops, conditionals,
   transactions. Vayu runs closed-loop constant concurrency and a linear
   scenario. Think time and pacing timers do work under load now (`timer.think`,
-  including a gaussian option, and `timer.pacing`), except a shared cadence
-  across every virtual user (`perUser: false`), which still doesn't. Correlation
+  including a gaussian option, and `timer.pacing`), including `timer.pacing`'s
+  shared-cadence case (`perUser: false`, JMeter's "All threads" pacing) - one
+  cadence held across every virtual user, not one per user. Correlation
   across a scenario's steps - a login's token reaching the next step's header,
   per virtual user - does work under load now too: mark the extracting element
   or script `inline` (or set the run's `elements.scripts` override), or let it

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -118,10 +118,12 @@ sent. The same element is inherited into every request under its scope, so `scen
 in the iteration's step order; every later occurrence is a no-op, reported `skipped`. `perUser`
 (default `true`) gives each virtual user its own cadence; `perUser: false` (one cadence shared by
 every VU, JMeter's "All threads" pacing) works on the sequential run, where a single VU makes the
-two indistinguishable, but is refused with a `400` for a scenario load run - coordinating one
-shared deadline across many VUs without blocking a producer thread is a separate, harder problem,
-tracked as a follow-up issue. `timer.throughput` (a constant-throughput, shared-rate timer) is not
-yet implemented, for the same cross-VU coordination reason.
+two indistinguishable, and, since issue #1570, on a scenario load run too: `SharedPacingClocks`
+(`elements.hpp`) holds one atomic deadline per shared-pacing element id, advanced by a
+compare-exchange retry rather than a mutex, so every VU's entry into the scope claims the next slot
+of the same clock without blocking the producer thread for a lock. `timer.throughput` (a
+constant-throughput, shared-rate timer) is not yet implemented; issue #1571 tracks it and names this
+same primitive as its intended reuse for the shared (`perUser: false`) case.
 
 The JSON-reading kinds (`extract.json`, `assert.jsonpath`) share one parse of the response body per
 step, through `ElementContext`'s lazily filled slot - a body over `maxElementBodyBytes` (default 1
@@ -211,8 +213,11 @@ only once a VU has already been selected as ready - too late to defer non-blocki
 deciding which step comes next and before the VU can be selected again, and applies the returned
 delay to `VirtualUser::ready_at_ms`, which already gated VU selection but, before #1498, had
 nothing writing to it. Per-node "last started" timestamps live in `VirtualUser::pacing_state`
-(one map per VU, so VUs pacing the same folder run independent cadences) for load, and in
-`RunContext::pacing_state` for the sequential run.
+(one map per VU, so VUs pacing the same folder run independent cadences) for `perUser: true` and
+for the sequential run; a `perUser: false` element instead advances its own entry in
+`ScenarioLoadState::shared_pacing` (a `SharedPacingClocks`, issue #1570), one atomic per
+shared-pacing element id in the plan, so two VUs' concurrent completions claim distinct slots of
+the same clock rather than racing onto the same one.
 
 **Not yet wired: the single-request load path.** `load_strategy.cpp` is unchanged: a
 single-request `POST /runs` payload has no `elements` attachment point today (its script model
@@ -236,8 +241,11 @@ gap, outside this page's Status callout.
 - #1498 - `timer.think`'s gaussian option, the `timer.pacing` kind, a per-run seeded RNG
   (`elements.seed`) and the `elements.timers` override wired end to end (this page's Timers
   paragraphs and Load paths section). `timer.pacing`'s `perUser: false` under load and
-  `timer.throughput` (a constant-throughput, shared-rate timer) are deliberately deferred to a
-  follow-up issue.
+  `timer.throughput` (a constant-throughput, shared-rate timer) were deliberately deferred to
+  follow-up issues.
+- #1570 - `timer.pacing`'s `perUser: false` under a scenario load run (this page's `timer.pacing`
+  and Non-blocking waits paragraphs). `timer.throughput` (#1571) is still deferred, tracked to
+  reuse the same `SharedPacingClocks` primitive.
 - #1515, #1500, #1499, #1501 - controllers, metrics, setup/teardown and load-time cookies that
   round out the kind table.
 - #1516 - the app's `ElementList` primitive and editor.

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -28,6 +28,7 @@
  * never a glob" precedent `engine/tests/CMakeLists.txt` already uses.
  */
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -43,6 +44,43 @@
 #include "vayu/types.hpp"
 
 namespace vayu::core {
+
+/**
+ * @brief Cross-instance shared clocks, one atomic per name (issue #1570) -
+ *        `timer.pacing(perUser: false)`'s coordination for one cadence
+ *        shared across every virtual user under a scenario load run, kept
+ *        generic over what a "name" is so a future kind with the same
+ *        shape (`timer.throughput`'s own shared-rate case, issue #1571,
+ *        names this type as its intended reuse) never needs a second one.
+ *
+ * Sized once at construction from an explicit name list the caller already
+ * knows - `std::atomic` is neither copyable nor movable, so growing this
+ * afterwards is not an option - which keeps this type decoupled from
+ * `ScenarioPlan` / `CompiledElement`: the scan for which names need a clock
+ * lives with whoever builds that list (`ScenarioLoadState`'s constructor,
+ * `scenario_load.cpp`), not here. `advance` is a compare-exchange retry
+ * loop, never a mutex: the load path's completion callback runs on every
+ * event-loop worker at once, and per `engine/CLAUDE.md`'s hot-path
+ * discipline nothing on it blocks for a lock.
+ */
+class SharedPacingClocks {
+    public:
+    explicit SharedPacingClocks (const std::vector<std::string>& names);
+
+    /// Advances @p name's shared deadline by @p every_ms from wherever it
+    /// currently stands (0 = never started - the first pass is never
+    /// delayed, the same convention a per-VU clock uses) and returns the
+    /// resulting wait, clamped to never negative. Returns 0 for a name this
+    /// instance was not sized for, which does not happen in practice - the
+    /// caller sizes this from exactly the names it will ever pass - but a
+    /// defensive default costs less than a crash on a future caller's
+    /// mistake.
+    [[nodiscard]] int64_t advance (const std::string& name, int64_t every_ms, int64_t now_ms);
+
+    private:
+    std::vector<std::atomic<int64_t>> clocks_;
+    std::unordered_map<std::string, size_t> index_of_id_;
+};
 
 /**
  * The run-level `elements.timers` override (issue #1498), read once at run
@@ -218,12 +256,19 @@ class Element {
      * sleeping inside `apply` (which the load path never lets block). @p
      * pacing_state is the same per-VU map `ElementContext::pacing_state`
      * would bind for this VU; a kind that writes through it here must leave
-     * `apply` free to run again without double-booking the wait.
+     * `apply` free to run again without double-booking the wait. @p
+     * shared_pacing (issue #1570) is the cross-VU sibling for a kind whose
+     * own config asks for one cadence shared across every virtual user
+     * (`timer.pacing`'s `perUser: false`) instead of one per VU; never null
+     * on the load path, which always constructs one from the plan even when
+     * nothing in it needs it.
      */
     [[nodiscard]] virtual std::optional<int64_t> scheduled_ready_delay_ms (
     std::unordered_map<std::string, int64_t>& pacing_state,
+    SharedPacingClocks* shared_pacing,
     int64_t now_ms) const {
         (void)pacing_state;
+        (void)shared_pacing;
         (void)now_ms;
         return std::nullopt;
     }

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -272,6 +272,16 @@ class StepHistograms {
 };
 
 /**
+ * @brief Every `timer.pacing` element id in @p plan whose own `perUser` is
+ *        `false` (issue #1570) - what `ScenarioLoadState` sizes its
+ *        `SharedPacingClocks` from, so the plan-scanning stays with the one
+ *        type that already knows `CompiledElement`'s shape rather than
+ *        leaking into `elements.hpp`'s deliberately plan-agnostic clock
+ *        primitive.
+ */
+[[nodiscard]] std::vector<std::string> shared_pacing_element_ids (const ScenarioPlan& plan);
+
+/**
  * @brief Per-step, per-element pass/fail/skip tallies for a load run's report
  *        (issue #1495) - `scenario.steps[i].elements[] = { id, kind, passed,
  *        failed, skipped }`, the load-path sibling of the sequential run's
@@ -347,6 +357,7 @@ struct ScenarioLoadState {
     vayu::http::routes::ScriptVariableScopes base_scopes,
     vayu::runtime::ScriptConfig script_config)
     : steps (plan.steps.size ()), element_tallies (plan),
+      shared_pacing (shared_pacing_element_ids (plan)),
       base_scopes (std::move (base_scopes)),
       base_vars (vayu::http::routes::flatten_variable_scopes (this->base_scopes)),
       script_config (script_config), coverage (std::move (coverage)),
@@ -357,6 +368,9 @@ struct ScenarioLoadState {
     /// Per-step, per-element pass/fail/skip tallies (issue #1495), written by
     /// the same completion that writes `steps` above - see the class comment.
     StepElementTallies element_tallies;
+    /// This run's cross-VU pacing clocks (issue #1570) - empty (and free) for
+    /// a plan with no `timer.pacing(perUser: false)` element at all.
+    SharedPacingClocks shared_pacing;
     /// Combined pass/fail of every `pm.test` call an *inline* `script.pre` or
     /// `script.post` element made this run (issue #1497). `element_tallies`
     /// above already records that element's own outcome - did the script run

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -134,18 +134,6 @@ struct ScenarioPlan {
 [[nodiscard]] bool step_has_script (const ScenarioStep& step, std::string_view kind);
 
 /**
- * `nullopt` if @p plan can run under load, or the caller-facing refusal
- * naming why not (issue #1498): a `timer.pacing` element whose own
- * `config.perUser` is `false` asks for one cadence shared across every
- * virtual user, which needs cross-VU coordination this engine does not yet
- * have on the load path - see `timer_pacing.cpp`'s file comment. The
- * sequential run never calls this: a single virtual user makes
- * `perUser: false` and `perUser: true` the same thing.
- */
-[[nodiscard]] std::optional<std::string> refuse_shared_pacing_under_load (
-const ScenarioPlan& plan);
-
-/**
  * The validated `scenario` block of a `POST /runs` payload.
  *
  * `data` rows themselves are deliberately absent, and their absence here is

--- a/engine/src/core/elements/pipeline.cpp
+++ b/engine/src/core/elements/pipeline.cpp
@@ -14,9 +14,38 @@
 
 #include "vayu/core/elements.hpp"
 
+#include <algorithm>
 #include <random>
 
 namespace vayu::core {
+
+SharedPacingClocks::SharedPacingClocks (const std::vector<std::string>& names) {
+    for (const auto& name : names) {
+        index_of_id_.try_emplace (name, index_of_id_.size ());
+    }
+    // Sized exactly once, from the count just discovered above - growing a
+    // `vector<atomic<...>>` afterwards would need to move-construct an
+    // atomic, which is neither copyable nor movable.
+    clocks_ = std::vector<std::atomic<int64_t>> (index_of_id_.size ());
+    for (auto& clock : clocks_) {
+        clock.store (0, std::memory_order_relaxed);
+    }
+}
+
+int64_t SharedPacingClocks::advance (const std::string& name, int64_t every_ms, int64_t now_ms) {
+    const auto found = index_of_id_.find (name);
+    if (found == index_of_id_.end ()) {
+        return 0;
+    }
+    std::atomic<int64_t>& clock = clocks_[found->second];
+    int64_t prev                = clock.load (std::memory_order_relaxed);
+    int64_t deadline            = 0;
+    do {
+        deadline = prev <= 0 ? now_ms : prev + every_ms;
+    } while (!clock.compare_exchange_weak (
+    prev, deadline, std::memory_order_relaxed, std::memory_order_relaxed));
+    return std::max<int64_t> (0, deadline - now_ms);
+}
 
 nlohmann::json ElementOutcome::to_json () const {
     nlohmann::json node;

--- a/engine/src/core/elements/timer_pacing.cpp
+++ b/engine/src/core/elements/timer_pacing.cpp
@@ -34,14 +34,17 @@
  *
  * `perUser: false` (one shared cadence for every virtual user, JMeter's "All
  * threads" pacing) is accepted for the sequential run, where a single
- * virtual user makes it indistinguishable from `perUser: true`, but refused
- * for a scenario load run: coordinating a shared deadline across many VUs
- * without either blocking a producer thread or racing two VUs onto the same
- * slot is a materially different piece of work than the per-VU case this
- * issue's acceptance criteria ask for, and is tracked as its own follow-up
- * rather than rushed into this kind. `validate_scenario_load_config`
- * (`scenario_load.cpp`) is where that refusal lives, not here, because only
- * the plan resolver knows a run is a load run at all.
+ * virtual user makes it indistinguishable from `perUser: true` (both read
+ * and write the one map `ElementContext::pacing_state` binds there). Under a
+ * scenario load run (issue #1570) it instead advances a shared, run-scoped
+ * `SharedPacingClocks` entry through a compare-exchange retry rather than
+ * the per-VU `pacing_state` map `perUser: true` uses - the same "next
+ * deadline is the last one plus everyMs" math, just applied to one atomic so
+ * two VUs' concurrent completions never race onto the same slot and neither
+ * ever blocks the producer thread for a lock. `scheduled_ready_delay_ms`
+ * below is where that split is made; `apply`'s own `blocking_allowed` branch
+ * never runs under load at all (see its own comment), so it never needs to
+ * know which case it is.
  */
 
 #include "vayu/core/elements.hpp"
@@ -78,7 +81,8 @@ class TimerPacingElement final : public Element {
     : config_ (std::move (config)),
       element_id_ (config_.value ("_elementId", std::string{})),
       scope_entry_ (config_.value ("_scopeEntry", false)),
-      every_ms_ (config_.value ("everyMs", int64_t{ 0 })) {
+      every_ms_ (config_.value ("everyMs", int64_t{ 0 })),
+      per_user_ (config_.value ("perUser", true)) {
     }
 
     [[nodiscard]] Phase phase () const override {
@@ -139,6 +143,7 @@ class TimerPacingElement final : public Element {
 
     [[nodiscard]] std::optional<int64_t> scheduled_ready_delay_ms (
     std::unordered_map<std::string, int64_t>& pacing_state,
+    SharedPacingClocks* shared_pacing,
     int64_t now_ms) const override {
         if (!scope_entry_) {
             return std::nullopt;
@@ -152,6 +157,14 @@ class TimerPacingElement final : public Element {
         // outcome truthfully once the (already-elapsed) wait is confirmed.
         // Disclosed in the PR as a known load-path limitation of the
         // override, not present on the sequential run.
+        if (!per_user_) {
+            // One cadence shared across every virtual user (issue #1570):
+            // `shared_pacing` is always non-null here, sized by the plan
+            // scan that found this very element's id in the first place.
+            return shared_pacing != nullptr ?
+            shared_pacing->advance (element_id_, every_ms_, now_ms) :
+            int64_t{ 0 };
+        }
         const int64_t last_started = pacing_state[element_id_];
         const int64_t deadline = last_started <= 0 ? now_ms : last_started + every_ms_;
         pacing_state[element_id_] = deadline;
@@ -163,6 +176,7 @@ class TimerPacingElement final : public Element {
     std::string element_id_;
     bool scope_entry_;
     int64_t every_ms_;
+    bool per_user_;
 };
 
 } // namespace

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -210,6 +210,29 @@ MetricsCollector::Percentiles StepHistograms::percentiles (size_t step) const {
     return p;
 }
 
+// ============================================================================
+// Cross-VU shared pacing clocks (issue #1570)
+// ============================================================================
+
+std::vector<std::string> shared_pacing_element_ids (const ScenarioPlan& plan) {
+    std::vector<std::string> ids;
+    for (const auto& step : plan.steps) {
+        if (!step.elements) {
+            continue;
+        }
+        for (const auto& element : *step.elements) {
+            if (element.kind != "timer.pacing" || !element.enabled ||
+            element.config.value ("perUser", true)) {
+                continue; // per-VU case (the default) needs no shared clock.
+            }
+            if (std::find (ids.begin (), ids.end (), element.id) == ids.end ()) {
+                ids.push_back (element.id);
+            }
+        }
+    }
+    return ids;
+}
+
 StepElementTallies::StepElementTallies (const ScenarioPlan& plan) {
     counts_by_step_.reserve (plan.steps.size ());
     index_of_id_by_step_.reserve (plan.steps.size ());
@@ -856,9 +879,14 @@ class ScenarioLoadDriver {
      * Called here, before the VU can next be selected, because `step.before`
      * (where `timer.pacing` actually dispatches) only ever runs *after*
      * `take_ready_vu` has already chosen this VU - too late to defer without
-     * blocking the caller.
+     * blocking the caller. @p shared_pacing (issue #1570) is the run's own
+     * cross-VU clock set, threaded through unconditionally: a `perUser: true`
+     * element never touches it, and a plan with no shared-pacing element at
+     * all leaves it empty.
      */
-    static void schedule_next_entry_wait (const ScenarioStep& next_step, VirtualUser& vu) {
+    static void schedule_next_entry_wait (const ScenarioStep& next_step,
+    VirtualUser& vu,
+    SharedPacingClocks& shared_pacing) {
         if (!next_step.elements || next_step.elements->empty ()) {
             return;
         }
@@ -867,8 +895,8 @@ class ScenarioLoadDriver {
             if (!compiled.element) {
                 continue;
             }
-            if (auto delay =
-                compiled.element->scheduled_ready_delay_ms (vu.pacing_state, now)) {
+            if (auto delay = compiled.element->scheduled_ready_delay_ms (
+                vu.pacing_state, &shared_pacing, now)) {
                 vu.ready_at_ms = std::max (vu.ready_at_ms, now + *delay);
             }
         }
@@ -933,7 +961,7 @@ class ScenarioLoadDriver {
         // pacing must hold whether the pass that just ended succeeded or
         // not - "regardless of the folder's own duration" includes an
         // error's duration too.
-        schedule_next_entry_wait (plan.steps[vu->step], *vu);
+        schedule_next_entry_wait (plan.steps[vu->step], *vu, state->shared_pacing);
 
         // Released *before* handle_result, which is what increments the
         // completion count `in_flight()` is derived from: a VU that became

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -733,26 +733,4 @@ bool step_has_script (const ScenarioStep& step, std::string_view kind) {
     [&] (const CompiledElement& element) { return element.kind == kind; });
 }
 
-std::optional<std::string> refuse_shared_pacing_under_load (const ScenarioPlan& plan) {
-    for (const auto& step : plan.steps) {
-        if (!step.elements) {
-            continue;
-        }
-        for (const auto& element : *step.elements) {
-            if (element.kind != "timer.pacing" || !element.enabled) {
-                continue;
-            }
-            if (!element.config.value ("perUser", true)) {
-                return "step " + std::to_string (step.index) +
-                "'s 'timer.pacing' element sets 'perUser: false' - one "
-                "cadence shared across every virtual user is not yet "
-                "supported for a scenario load run (issue #1498's "
-                "follow-up); use 'perUser: true', or run this collection "
-                "sequentially.";
-            }
-        }
-    }
-    return std::nullopt;
-}
-
 } // namespace vayu::core

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1904,12 +1904,6 @@ nlohmann::json& scenario_manifest) {
         vayu::utils::log_warning ("POST /runs - Invalid scenario: " + resolved.error);
         return RouteError{ 400, error_body (400, resolved.error, "invalid_scenario") };
     }
-    if (vayu::core::is_scenario_load_run (json)) {
-        if (auto reason = vayu::core::refuse_shared_pacing_under_load (resolved.plan)) {
-            return RouteError{ 400, error_body (400, *reason, "invalid_run_config") };
-        }
-    }
-
     scenario_manifest = vayu::core::build_scenario_manifest (
     resolved.request, resolved.plan, resolved.spec);
 

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -19,12 +19,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <random>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -200,6 +202,76 @@ TEST (DeriveVuRngTest, DifferentVuIndexProducesADifferentFirstDraw) {
     << "two adjacent VU indices collided on their very first draw - "
        "astronomically unlikely unless derive_vu_rng regressed to something "
        "like a plain XOR of the seed and the index";
+}
+
+// ============================================================================
+// F. SharedPacingClocks - a direct call, no run needed (issue #1570).
+// ============================================================================
+
+TEST (SharedPacingClocksTest, AnUnstartedNameIsNeverDelayed) {
+    vayu::core::SharedPacingClocks clocks ({ "a" });
+    EXPECT_EQ (clocks.advance ("a", 100, 1000), 0)
+    << "a name's first-ever claim must never be delayed";
+}
+
+TEST (SharedPacingClocksTest, ASecondClaimWaitsOutTheFirstsInterval) {
+    vayu::core::SharedPacingClocks clocks ({ "a" });
+    ASSERT_EQ (clocks.advance ("a", 100, 1000), 0);
+    EXPECT_EQ (clocks.advance ("a", 100, 1010), 90)
+    << "10ms into a 100ms cadence should leave 90ms to wait";
+}
+
+TEST (SharedPacingClocksTest, DifferentNamesHoldIndependentClocks) {
+    vayu::core::SharedPacingClocks clocks ({ "a", "b" });
+    ASSERT_EQ (clocks.advance ("a", 100, 1000), 0);
+    EXPECT_EQ (clocks.advance ("b", 100, 1000), 0)
+    << "b's first claim was delayed by a's history - the clocks are sharing "
+       "state that should be per-name";
+}
+
+TEST (SharedPacingClocksTest, AnUnknownNameIsANoOp) {
+    vayu::core::SharedPacingClocks clocks ({ "a" });
+    EXPECT_EQ (clocks.advance ("never-registered", 100, 1000), 0);
+}
+
+// Eight threads race 50 claims each onto one shared 10ms clock. Every claim
+// must land on its own deadline - if the compare-exchange loop ever lost a
+// race, two threads would compute the same deadline from the same stale
+// `prev` and this collapses two distinct slots into one.
+//
+// Mutation check: replacing the `compare_exchange_weak` loop with a plain
+// (non-atomic) load-then-store reproduces exactly that collision, and this
+// test reds with duplicate deadlines.
+TEST (SharedPacingClocksTest, ConcurrentClaimsNeverCollideOnTheSameSlot) {
+    vayu::core::SharedPacingClocks clocks ({ "shared" });
+    constexpr int kThreads     = 8;
+    constexpr int kPerThread   = 50;
+    constexpr int64_t kNow     = 5000;
+    constexpr int64_t kEveryMs = 10;
+
+    std::vector<int64_t> deadlines (
+    static_cast<size_t> (kThreads) * static_cast<size_t> (kPerThread));
+    std::vector<std::thread> threads;
+    threads.reserve (kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back ([&, t] {
+            for (int i = 0; i < kPerThread; ++i) {
+                const int64_t wait = clocks.advance ("shared", kEveryMs, kNow);
+                deadlines[(static_cast<size_t> (t) * kPerThread) + static_cast<size_t> (i)] =
+                kNow + wait;
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join ();
+    }
+
+    std::sort (deadlines.begin (), deadlines.end ());
+    const auto unique_end = std::unique (deadlines.begin (), deadlines.end ());
+    EXPECT_EQ (std::distance (deadlines.begin (), unique_end),
+    static_cast<long> (deadlines.size ()))
+    << "two concurrent claims landed on the same deadline - the "
+       "compare-exchange loop lost a race";
 }
 
 // ============================================================================

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -1776,6 +1776,48 @@ TEST_F (ScenarioLoadTest, ConcurrencyIsTheVirtualUserCountAndBoundsInFlight) {
 }
 
 // ============================================================================
+// Cross-VU shared pacing (issue #1570)
+// ============================================================================
+
+// `timer.pacing(perUser: false)` holds one cadence across every virtual
+// user, not one cadence per user (which `perUser: true` already gave under
+// load). Every VU's own first entry is unthrottled (the element has no
+// history yet), so ten VUs produce an initial burst of about ten
+// completions; every entry after that claims the next slot of the same
+// shared 200ms clock, however many VUs are contending for it. Over a 2s run
+// that is roughly ten (the burst) plus one more per 200ms tick - nowhere
+// near the ~110 ten *independently* paced 200ms cadences would produce in
+// the same window (each doing its own burst-of-one plus about nine ticks).
+//
+// Mutation check: making `TimerPacingElement::scheduled_ready_delay_ms`
+// ignore `per_user_` and always take the per-VU `pacing_state` branch
+// reproduces that old per-VU rate here too - completions clear 50 - and
+// this test reds.
+TEST_F (ScenarioLoadTest, SharedPacingHoldsOneCadenceAcrossEveryVirtualUser) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0") });
+    execution.plan.steps[0].elements =
+    vayu::tests::compiled_elements ({ vayu::tests::timer_pacing_element_json (
+    "el_pacing", /*every_ms=*/200, /*scope_entry=*/true, /*per_user=*/false) });
+
+    const size_t VUS  = 10;
+    const json config = { { "mode", "constant_concurrency" },
+        { "duration", "2s" }, { "concurrency", VUS } };
+    auto state        = run (config, execution);
+
+    const size_t completed = state->steps.completed (0);
+    EXPECT_GE (completed, VUS) << "not even the unthrottled first-entry burst "
+                                  "completed - the shared clock is holding "
+                                  "back requests it never saw before";
+    EXPECT_LT (completed, 50u)
+    << "completed " << completed
+    << " over 2s at a shared 200ms cadence - "
+       "looks like every virtual user paced itself independently instead "
+       "of sharing one clock (ten independent 200ms cadences would clear "
+       "100 in this window)";
+}
+
+// ============================================================================
 // Deferred schema validation over the sampled responses (issue #682)
 // ============================================================================
 


### PR DESCRIPTION
## Description

Issue #1570: `timer.pacing`'s `perUser: false` (JMeter's "All threads" pacing - one cadence shared across every virtual user) already worked on the sequential run, where a single VU makes it indistinguishable from `perUser: true`, but was refused with a `400` on a scenario load run. The refusal existed because nothing coordinated a shared deadline across the load path's per-VU completion callbacks, which run concurrently on every event-loop worker with no lock on the hot path by design (`VirtualUser`'s own struct comment; `scenario_load.hpp:135-136`'s existing "a mutex would be a lock on the hot path" precedent for the same class of problem).

**Approach.** `SharedPacingClocks` (`elements.hpp` / `elements/pipeline.cpp`) is one `std::atomic<int64_t>` per shared-pacing element id, advanced by a compare-exchange retry loop rather than a mutex - each call reads the clock's current value, computes the next deadline from it (`TimerPacingElement`'s own per-VU math, unchanged: "the next deadline is the last one plus `everyMs`"), and retries only if another VU's concurrent completion updated the clock in the meantime. This is the "slot allocation" design the issue's own Problem section named as an alternative to a locked "last started" read-modify-write: every VU's entry into the scope claims the next slot of the same clock, so entries spread out rather than racing onto one. `SharedPacingClocks` is deliberately decoupled from `ScenarioPlan`/`CompiledElement` (a plain name list in, sized once at construction since `std::atomic` is neither copyable nor movable) so it can be reused as-is for `timer.throughput`'s own shared-rate case, which issue #1571 names as its intended follow-on. `ScenarioLoadState` owns one instance, built from a plan scan (`shared_pacing_element_ids`) that stays with `scenario_load.cpp`, the one file that already knows `CompiledElement`'s shape.

**Alternative considered and rejected**: a mutex-guarded shared "last started" timestamp. Rejected per the issue's own reasoning - one mutex per run serializes every VU's pacing check across the whole run, and one mutex per element id is more state to manage for no benefit over a lock-free CAS, which the codebase already prefers for exactly this shape of cross-worker aggregation (`StepHistograms`'s `hdr_record_value_atomic`, `StepElementTallies`'s atomic counters).

`refuse_shared_pacing_under_load` (`scenario_plan.cpp`) and its `POST /runs` call site (`execution.cpp`) are removed outright rather than narrowed, since the case they refused is now fully implemented. `perUser: true` and the sequential run are untouched - same code paths, same math.

**Merge note**: PR #1581 (the controller elements) merged into `master` while this branch was in flight and touched two of the same files (`elements.hpp`'s namespace-open insertion point, `scenario_plan.cpp`'s `refuse_shared_pacing_under_load` region). Merged `master` in and resolved by hand: both `SharedPacingClocks` and `#1581`'s `ElementSpan`/`compute_element_spans` are kept side by side, and `refuse_shared_pacing_under_load` stays removed (that PR didn't touch its logic, only sat next to it textually). Full suite re-run after the merge, green.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **3113/3113 passed** before the merge with master; **3132/3132 passed** after (the +19 are #1581's own controller tests, unaffected by this PR).
- New coverage: `SharedPacingClocksTest` (`elements_timers_test.cpp`) exercises the primitive directly - an unstarted name is never delayed, a second claim waits out the first's interval, different names hold independent clocks, an unknown name is a no-op, and eight threads racing 50 claims each onto one shared clock never collide on the same deadline. `ScenarioLoadTest.SharedPacingHoldsOneCadenceAcrossEveryVirtualUser` (`scenario_load_test.cpp`) drives a real 10-VU, 2s scenario load run and asserts the aggregate completion count sits near "one shared 200ms cadence" (~10-25) rather than "ten independent 200ms cadences" (~110).
- Mutation-checked by hand, both directions:
  - Forcing `TimerPacingElement::scheduled_ready_delay_ms` to always take the per-VU branch (ignoring `perUser: false`) reproduced the old per-VU rate in the new load-run test - **110 completions**, comfortably failing its `< 50` bound. Reverted.
  - Replacing `SharedPacingClocks::advance`'s compare-exchange loop with a plain (non-atomic) load-then-store reproduced a same-deadline collision in the new concurrency test, reddening it in 2 of 3 runs (expected: a genuine data race is not perfectly reproducible on every run, but the mutation is real and the test catches it). Reverted.
- `engine/tests/fixtures/element-kinds.json` regenerated after the merge (picks up #1581's `control.*` kinds; this PR added none of its own).

## No user-visible change

Engine-only: no `app/` files touched, and the App/MCP layers already pass `perUser` through generically with no client-side gate on this combination (confirmed by `rg -rn "perUser"` finding no `app/` or MCP hits tied to this rule).

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19 clean on every changed file)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/elements.md`'s `timer.pacing` paragraph, Non-blocking waits paragraph, and Related issues log; `docs/compare/vayu-vs-jmeter.md`'s pacing sentence)

## Related Issues
Closes #1570


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXutaqA2RxA7hsmMjoZbq8)_