### PR TITLE
feat(engine): control.switch/.loop under load, control.throughput perUser:false, control.transaction includeTimers

### DIFF
--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -80,18 +80,19 @@ are things Vayu plans to catch up on:
   test from many machines. Vayu runs from one.
 - **You have existing `.jmx` test plans**, or a team fluent in them. There is no
   importer for them here.
-- **Your load model needs a shared cadence or a load-run logic jump.** Think
-  time and pacing timers work under load now (`timer.think`, including a
-  gaussian option, and `timer.pacing`), and logic controllers - conditionals,
-  once-only, throughput, loops and named transactions - are elements
-  (`control.if` / `.once` / `.switch` / `.throughput` / `.loop` /
-  `.transaction`) that run fully in a sequential collection run and, for
-  `control.if` / `.once` / `.throughput` / `.transaction`, under load too.
-  What still doesn't: a pacing cadence shared across every virtual user
-  (`perUser: false`), and `control.switch` / `.loop` under load, since both
-  need a load run's virtual users to jump, which they cannot do yet (#1569) -
-  a load run carrying either is refused rather than silently run once
-  through. Correlation across a scenario's steps - a login's token reaching
+- **Your load model needs a shared pacing cadence.** Think time and pacing
+  timers work under load now (`timer.think`, including a gaussian option, and
+  `timer.pacing`), and logic controllers - conditionals, once-only,
+  throughput, loops and named transactions - are elements (`control.if` /
+  `.once` / `.switch` / `.throughput` / `.loop` / `.transaction`) that run
+  fully both in a sequential collection run and under load, including
+  `control.switch` / `.loop`'s own jump/repeat and `control.throughput`'s
+  shared, cross-VU budget (`perUser: false`, #1569). What still doesn't: a
+  `timer.pacing` cadence shared across every virtual user rather than one per
+  user (`perUser: false` on the *timer*, not the throughput controller -
+  #1570) and a constant-throughput shared-rate timer (`timer.throughput`,
+  #1571), both sequenced after each other. Correlation across a scenario's
+  steps - a login's token reaching
   the next step's header, per virtual user - does work under load now too:
   mark the extracting element or script `inline` (or set the run's
   `elements.scripts` override), or let it stay in the post-run replay by

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5655,9 +5655,12 @@ kind table and every config shape.
 sums every member's own response latency into a named total per pass, and the
 run's summary gains
 `scenario.transactions[] = { name, count, errors, latency: { min, p50, p90,
-p95, p99, max } }`, omitted for a transaction the run never closed. The same
-shape reports on a scenario load run's summary, top-level rather than under
-`scenario` - see below.
+p95, p99, max } }`, omitted for a transaction the run never closed.
+`includeTimers: true` (issue #1569) also folds a between-member `timer.*`
+wait into that sum - excluded by default, and always excluded for a wait
+after the folder's own last member, which is outside the transaction's span.
+The same shape reports on a scenario load run's summary, top-level rather
+than under `scenario` - see below.
 
 #### Scenario load runs
 
@@ -5688,7 +5691,6 @@ row exists:
 | `mode: "capacity"` with a `scenario` | The search judges one windowed p99 and a sequence has one per step, so which of them the knee is measured against is a question the mode does not answer. |
 | `rps` / `targetRps` above zero, on any mode | It is what selects the open-loop path regardless of the declared mode. |
 | An unknown `mode` | |
-| The plan carries a `control.switch` or `control.loop` element (issue #1515) | Both need to jump the plan; a scenario load run's virtual users only ever advance forward. Named in the error message. Real, disclosed follow-up work - issue #1569. |
 
 `maxInFlight` is **moot** and is ignored with a warning: in-flight requests are
 bounded by the virtual-user count by construction, so `concurrency` is the only
@@ -5717,9 +5719,13 @@ knob.
   (issue #1515): `control.if`, `control.once` and `control.throughput` skip a
   step the way `pm.execution.skipRequest()` would, counted in the run's
   summary `skipped` key rather than the `0` every scenario load run reported
-  before this; `control.switch` and `control.loop` need to jump, which a load
-  run's virtual users cannot do, so a plan carrying either is refused outright
-  (see the table above) rather than silently run once through.
+  before this; `control.switch` and `control.loop` jump the plan (issue
+  #1569), resolved the same way a script's own `setNextRequest` would be and
+  guarded by the same `maxStepsPerIteration` cycle limit the sequential run
+  uses. `control.throughput`'s `perUser: false` shares one budget across
+  every virtual user instead of one per user, and `control.transaction`'s
+  `includeTimers` folds a between-member `timer.*` wait into its reported
+  sum - both issue #1569 too.
 - **A script that did not run inline stays deferred, keyed per step.** After
   the run drains, that step's own post-request script is replayed against the
   responses that step produced, and the tallies appear on that step's entry in

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -147,7 +147,12 @@ JMeter's logic controllers, as element kinds rather than a nested sub-flow (issu
 resolved `{{variable}}` is false - `{{v}} == x`, `!=`, `matches /re/`, or `{{v}} exists`, refused at
 validate outside that grammar. `control.once` runs on this user's first iteration only. `control.throughput`
 runs a share of occurrences by `percent` (an exact integer-carry accumulator, not a random draw) or
-`everyN`, on the producer's own per-user counter - no lock, no body parse. All three write the same
+`everyN`, on the producer's own counter - no lock, no body parse. `perUser` (default `true`) keeps that
+counter per virtual user; `perUser: false` (issue #1569, JMeter's "All threads" throughput mode) shares
+one atomic counter pair across every VU of a scenario load run instead, allocated up front from a plan
+scan (`SharedThroughputCounters`, `ElementKind::supports_shared_state` read through the registry rather
+than a `kind ==` comparison) - the sequential run's single implicit user already makes its own counter
+the "shared" instance, so `perUser` changes nothing there. All three write the same
 `ScriptControl::Skip` decision `pm.execution.skipRequest()` always has, so a skip is one mechanism
 end to end: `execute_exchange`'s pre-send check, `decide_next_step`, and `classify_step`'s
 `StepOutcome::Skipped` all read it exactly as they read a script's.
@@ -157,7 +162,7 @@ value, through the same `ScriptControl::Next` / `resolve_next_step` a script's o
 `setNextRequest` uses - so a switch's dispatch is an ordinary jump to every reader of the step list,
 not a second flow-control channel.
 
-`control.loop` (`count`) and `control.transaction` (`name`) both sit on a folder and are inherited
+`control.loop` (`count`) and `control.transaction` (`name`, `includeTimers?`) both sit on a folder and are inherited
 into every member beneath it, compiling once per member - so each member's own instance has to
 recognise its folder's first or last position independently rather than being told it.
 `compute_element_spans` (`scenario_plan.cpp`) answers that once per run, from a single pass over the
@@ -171,18 +176,24 @@ latency into a per-iteration accumulator (same keying) and, at the folder's last
 closed sum as its `ElementOutcome::waitedMs` with the transaction's `name` in `message` - the two
 fields the runner (`scenario_runner.cpp` / `scenario_load.cpp`) reads to fold the value into
 `TransactionHistograms`, one HdrHistogram per declared name allocated up front from a plan scan, so
-recording it takes no lock either. The report gains `scenario.transactions[] = { name, count,
-errors, latency: { min, p50, p90, p95, p99, max } }`, omitted for a transaction the run never closed.
+recording it takes no lock either. `includeTimers: true` (issue #1569) also folds a between-member
+`timer.*` wait into the same running sum - the runner's own `step.between` dispatch does this fold
+generically (`fold_between_wait_into_open_transactions`, shared by both run modes, found through the
+registry's `category` field rather than a `kind ==` comparison), skipped for the folder's last member,
+whose sum has already closed and reported by the time any wait after it could run. The report gains
+`scenario.transactions[] = { name, count, errors, latency: { min, p50, p90, p95, p99, max } }`, omitted
+for a transaction the run never closed.
 
-**Sequential-only: `control.switch` and `control.loop`.** A scenario load run's virtual users
-advance through the plan strictly forward (`VirtualUser::step`), with no jump the way a repeat or a
-dispatch needs; `POST /runs` refuses a load run whose plan carries either kind with a `400` naming
-it (`vayu::core::find_load_incompatible_controller`), read through the registry's own
-`jumps_or_repeats` flag. `control.if`, `control.once`, `control.throughput` and
-`control.transaction` all run under load too - see Load paths below for `control.if`'s own skip
-there, which the load path had no equivalent of before this issue. A load-path jump mechanism, plus
-`control.throughput`'s shared `perUser: false` budget and `control.transaction`'s `includeTimers`,
-are real, disclosed follow-up work: issue #1569.
+**`control.switch` and `control.loop` under a scenario load run (issue #1569).** A scenario load run's
+virtual users used to advance through the plan strictly forward (`VirtualUser::step`), with no jump the
+way a repeat or a dispatch needs. They now do: `ScenarioLoadState::step_index` (the load path's own
+`ScenarioStepIndex`, built once per run) resolves a `control.switch` target or a `control.loop`'s
+folder-start name through the same `resolve_next_step` the sequential run's `setNextRequest` uses, and
+`finish_step` applies the result to the VU's own `step`, guarded against a cycle that never closes by
+`VirtualUser::steps_this_iteration` and the same `maxStepsPerIteration` config entry the sequential run
+reads. Neither kind sets the registry's `jumps_or_repeats` flag any more, so `POST /runs`' own refusal
+(`vayu::core::find_load_incompatible_controller`, still there for a future kind that jumps in a way the
+load path cannot support yet) no longer applies to either.
 
 ## The step trace
 
@@ -299,9 +310,9 @@ gap, outside this page's Status callout.
 - #1515 - the controller family (`control.if`, `.once`, `.switch`, `.throughput`, `.loop`,
   `.transaction`), the load path's own `steps_skipped` counter, and `scenario.transactions[]`
   (this page's Controllers section).
-- #1569 - the follow-up disclosed by #1515: a scenario load run's own jump/repeat mechanism for
-  `control.switch` / `control.loop`, `control.throughput`'s shared `perUser: false` budget, and
-  `control.transaction`'s `includeTimers`.
+- #1569 - the follow-up disclosed by #1515, landed: a scenario load run's own jump/repeat
+  mechanism for `control.switch` / `control.loop`, `control.throughput`'s shared `perUser: false`
+  budget, and `control.transaction`'s `includeTimers`.
 - #1500, #1499, #1501 - metrics, setup/teardown and load-time cookies that round out the kind
   table.
 - #1516 - the app's `ElementList` primitive and editor.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -385,10 +385,18 @@ logged as a warning: it means a client skipped composition.
   family (`control.if`, `.once`, `.switch`, `.throughput`, `.loop`,
   `.transaction`) - JMeter-parity logic controllers that decide whether a
   step sends at all, jump to a named member, or sum a folder's members into
-  a named transaction with its own percentiles; `control.switch` /
-  `control.loop` run only in the sequential run today, since a scenario load
-  run's virtual users cannot jump the way either needs (issue #1569 tracks
-  that gap). The pipeline runs in the design send, the sequential (single-VU)
+  a named transaction with its own percentiles. #1569 gave `control.switch`
+  and `control.loop` their own jump/repeat mechanism on the load path too
+  (`ScenarioLoadState::step_index`, `VirtualUser::steps_this_iteration`,
+  `finish_step`'s own `resolve_next_step` call), the same
+  `maxStepsPerIteration` cycle guard the sequential run uses; `perUser:
+  false` on `control.throughput` shares one atomic budget across every
+  virtual user (`SharedThroughputCounters`, allocated up front from a plan
+  scan, no lock) instead of one per VU, and `control.transaction`'s
+  `includeTimers` folds a between-member `timer.*` wait into the sum
+  (`fold_between_wait_into_open_transactions`, shared by both run modes,
+  found through the registry's `category` rather than a `kind ==`
+  comparison). The pipeline runs in the design send, the sequential (single-VU)
   collection run, and - since #1495 - a scenario **load** run's own
   producer/completion hooks
   (`scenario_load.cpp`'s `run_step_before` / `run_step_after`): a declarative

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -28,6 +28,7 @@
  * never a glob" precedent `engine/tests/CMakeLists.txt` already uses.
  */
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -43,6 +44,8 @@
 #include "vayu/types.hpp"
 
 namespace vayu::core {
+
+struct ScenarioPlan;
 
 /**
  * One scope-spanning kind's first and last position in the plan (issue
@@ -62,6 +65,44 @@ struct ElementSpan {
     /// resolves against, so a loop-back is an ordinary `Next` decision to
     /// every reader of the step list, not a second flow-control mechanism.
     std::string first_step_name;
+};
+
+/// The key `control.transaction`'s running-sum accumulator uses inside
+/// `ElementContext::controller_state` (issue #1515), keyed by this element's
+/// id and the current iteration so a later iteration - or an abandoned one -
+/// never adds onto a stale total. Exposed so a caller outside `core/elements`
+/// (`scenario_runner.cpp`'s and `scenario_load.cpp`'s own `step.between`
+/// dispatch) can fold a between-member `timer.*` wait into an *open*
+/// transaction's sum when its config asks to (`includeTimers`, issue #1569),
+/// without either side hardcoding the other's key format twice.
+[[nodiscard]] std::string transaction_sum_key (const std::string& element_id, size_t iteration);
+
+/**
+ * One shared counter pair per element whose registry kind declares
+ * `supports_shared_state` and whose own config asks to share it
+ * (`control.throughput`'s `perUser: false`, issue #1569 - JMeter's "All
+ * threads" throughput mode: one budget for every virtual user of a scenario
+ * load run, rather than one per user). Allocated up front from a scan of the
+ * plan - never discovered mid-run - so a lookup is a hash-map read (built
+ * once, at construction, and never mutated after, so concurrent reads need
+ * no lock) plus one or two atomic operations on the found slot - the same
+ * "no lock" bar `TransactionHistograms` holds itself to.
+ */
+class SharedThroughputCounters {
+    public:
+    explicit SharedThroughputCounters (const ScenarioPlan& plan);
+
+    struct Counters {
+        std::atomic<int64_t> count{ 0 };
+        std::atomic<int64_t> carry{ 0 };
+    };
+
+    /// This element's shared slot, or null when its own config kept a
+    /// per-VU counter instead - the caller falls back to `controller_state`.
+    [[nodiscard]] Counters* find (const std::string& element_id);
+
+    private:
+    std::unordered_map<std::string, std::unique_ptr<Counters>> counters_;
 };
 
 /**
@@ -177,6 +218,14 @@ struct ElementContext {
     /// unified with it - kept separate rather than merged in this PR to
     /// avoid widening either issue's own change.
     std::unordered_map<std::string, int64_t>* controller_state = nullptr;
+    /// Cross-VU counters for a kind whose config asked to share state across
+    /// every virtual user of a scenario load run (issue #1569's
+    /// `control.throughput` `perUser: false`), keyed by `element_id`. Null
+    /// for a design send, the sequential run (whose single implicit user
+    /// already makes `controller_state` above the "shared" instance) and any
+    /// load run whose plan declared no element that asked to share - a kind
+    /// that finds nothing here falls back to `controller_state`.
+    SharedThroughputCounters* shared_controller_state = nullptr;
 
     /// True for the design send and the sequential run, where a `timer.*`
     /// kind's wait blocks the calling thread exactly as it always has; false
@@ -345,6 +394,14 @@ struct ElementKind {
     /// first) rather than unified with it, for the same reason
     /// `controller_state` and `pacing_state` stay two fields above.
     bool tracks_scope_occurrence = false;
+    /// Whether a config value can ask this kind's occurrences to share one
+    /// counter across every virtual user of a scenario load run, rather than
+    /// one per user (issue #1569's `control.throughput` `perUser: false`).
+    /// Read by `SharedThroughputCounters`' own plan scan through the
+    /// registry, never a `kind ==` comparison outside `core/elements`
+    /// (#1512's extensibility contract, rule 1); the config key itself, not
+    /// this flag alone, decides whether a given occurrence actually shares.
+    bool supports_shared_state = false;
     // Absent for a kind that only validates (phase 0's `inherit.disable`);
     // present once a kind actually runs (#1514 onward).
     std::function<std::unique_ptr<Element> (const nlohmann::json& config)> compile;
@@ -445,6 +502,26 @@ struct CompiledElement {
  * has simply never heard of.
  */
 [[nodiscard]] std::vector<CompiledElement> compile_elements (const nlohmann::json& elements);
+
+/**
+ * Folds a just-completed step's `step.between` wait into every *open*
+ * `control.transaction` whose config asked to include it (issue #1569's
+ * `includeTimers`) - shared by the sequential run's `run_iteration` and a
+ * scenario load run's own `run_step_between`, so the rule (and the "never a
+ * `kind ==` comparison outside `core/elements`" way it finds a transaction,
+ * through the registry's `category`) is written once.
+ *
+ * "Open" means this step is not that transaction's own last member: the
+ * last member's `apply` already closed and reported the sum by the time its
+ * own `step.between` could run, so a wait after it belongs to whatever
+ * comes next, never back into a transaction that already finished.
+ */
+void fold_between_wait_into_open_transactions (const std::vector<CompiledElement>& elements,
+const std::unordered_map<std::string, ElementSpan>& spans,
+size_t step_index,
+size_t iteration,
+int64_t wait_ms,
+std::unordered_map<std::string, int64_t>& controller_state);
 
 /**
  * Applies the run's `elements.timers` override (issue #1498) to one

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -93,6 +93,7 @@
 
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/scenario_runner.hpp"
 #include "vayu/core/threshold_eval.hpp"
 #include "vayu/core/transaction_histograms.hpp"
 #include "vayu/db/database.hpp"
@@ -133,14 +134,14 @@ const nlohmann::json& config);
  * @brief The first element kind in @p plan that a scenario load run cannot
  *        honour, or `nullopt` when it carries none.
  *
- * A scenario load run's virtual users advance through the plan strictly
- * forward (`VirtualUser::step`); nothing there can jump the way
- * `control.switch`'s dispatch or `control.loop`'s repeat needs (issue
- * #1515; a load-path jump mechanism is real, disclosed follow-up work,
- * issue #1569). The route refuses the run with a `400` naming the kind,
- * before its row exists - the caller-facing sentence lives there, matching
- * `validate_scenario_load_config`'s own split. The sequential run supports
- * both fully; this check applies only to the load path.
+ * `control.switch` and `control.loop` (issue #1515) needed this refusal
+ * until #1569 gave the load path its own jump/repeat mechanism
+ * (`ScenarioLoadState::step_index`, `VirtualUser::steps_this_iteration`);
+ * neither kind sets the registry's `jumps_or_repeats` flag any more, so this
+ * reads as "nothing today" and exists for a future kind that jumps in a way
+ * the load path genuinely cannot support yet - refusing such a plan with a
+ * `400` naming the kind, before its row exists, rather than silently running
+ * it once and ignoring what it asked for.
  */
 [[nodiscard]] std::optional<std::string> find_load_incompatible_controller (
 const ScenarioPlan& plan);
@@ -186,6 +187,15 @@ struct VirtualUser {
     size_t index = 1;
     /// Next step of the plan this VU will send.
     size_t step = 0;
+    /// Whether `step` is 0 because this VU is *starting* a new iteration, as
+    /// opposed to a `control.loop` jump that landed back on plan position 0
+    /// mid-iteration (issue #1569) - `take_ready_vu` claims a new iteration
+    /// (the run-wide budget, a fresh data row) only when this is true, and
+    /// `finish_step` is the only writer: `true` only in its own
+    /// "end this iteration" branch, so a mid-iteration jump - to position 0
+    /// or anywhere else - never claims a second iteration for the one it is
+    /// still inside of.
+    bool iteration_boundary = true;
     /// 0-based, and only ever advanced by this VU.
     size_t iteration = 0;
     /**
@@ -239,6 +249,12 @@ struct VirtualUser {
      * rather than misread.
      */
     std::unordered_map<std::string, int64_t> controller_state;
+    /// How many steps this VU has executed within its current iteration
+    /// (issue #1569) - the load path's own guard against a `control.switch`
+    /// cycle or a misconfigured `control.loop`, mirroring the sequential
+    /// run's `maxStepsPerIteration`. Reset to 0 at the same iteration
+    /// boundary `cookies` is.
+    size_t steps_this_iteration = 0;
     /// Per-node "when did this node last start" state for this VU's own
     /// `timer.pacing` elements (issue #1498), keyed by element id - the
     /// load-path sibling of `RunContext::pacing_state`'s sequential-run
@@ -377,6 +393,7 @@ struct ScenarioLoadState {
     vayu::runtime::ScriptConfig script_config)
     : steps (plan.steps.size ()), element_spans (compute_element_spans (plan)),
       transactions (plan), element_tallies (plan),
+      step_index (build_step_index (plan)), shared_throughput (plan),
       base_scopes (std::move (base_scopes)),
       base_vars (vayu::http::routes::flatten_variable_scopes (this->base_scopes)),
       script_config (script_config), coverage (std::move (coverage)),
@@ -385,8 +402,8 @@ struct ScenarioLoadState {
 
     StepHistograms steps;
     /// The plan-wide first/last position of every scope-spanning element
-    /// (issue #1515's `control.transaction` - `control.loop` never reaches
-    /// this run mode, see `submit_one`'s own comment), computed once here.
+    /// (issue #1515's `control.transaction` and, since #1569, `control.loop`
+    /// too), computed once here.
     std::unordered_map<std::string, ElementSpan> element_spans;
     /// One histogram per declared `control.transaction` name (issue #1515),
     /// allocated up front from the same plan scan `element_spans` is, so
@@ -401,6 +418,21 @@ struct ScenarioLoadState {
     /// Per-step, per-element pass/fail/skip tallies (issue #1495), written by
     /// the same completion that writes `steps` above - see the class comment.
     StepElementTallies element_tallies;
+    /// Resolves a `control.switch` target or a `control.loop`'s own
+    /// folder-start name to a plan position (issue #1569) - the same index
+    /// the sequential run's own `resolve_next_step` reads, built once here.
+    ScenarioStepIndex step_index;
+    /// `maxStepsPerIteration`, resolved once here (issue #1569): a scenario
+    /// load run's own guard against a `control.switch` cycle or a
+    /// `control.loop` that never reaches its close, on the same config entry
+    /// and the same `resolve_max_steps_per_iteration` the sequential run
+    /// uses - set by `execute_scenario_load` once `db` is in scope.
+    size_t max_steps_per_iteration = 0;
+    /// One shared counter pair per `control.throughput` element whose config
+    /// asked to share it across every virtual user (issue #1569's
+    /// `perUser: false`), allocated up front from the same plan scan
+    /// `element_spans` is.
+    SharedThroughputCounters shared_throughput;
     /// Combined pass/fail of every `pm.test` call an *inline* `script.pre` or
     /// `script.post` element made this run (issue #1497). `element_tallies`
     /// above already records that element's own outcome - did the script run

--- a/engine/src/core/elements/control_loop.cpp
+++ b/engine/src/core/elements/control_loop.cpp
@@ -23,13 +23,12 @@
  * `resolve_next_step` a script's own `pm.execution.setNextRequest` already
  * goes through - a loop-back is not a second flow-control mechanism.
  *
- * Sequential-run only: the load path's virtual users advance through the
- * plan strictly forward (`VirtualUser::step`), with no jump the way a
- * script-driven `setNextRequest` or this element's own `Next` needs, so a
- * scenario load run refuses a plan carrying `control.loop`
- * (`vayu::core::find_load_incompatible_controller`, `scenario_load.cpp`)
- * rather than silently running the folder once per iteration and ignoring
- * `count`.
+ * Runs under a scenario load run too (issue #1569): `scenario_load.cpp`'s
+ * own `finish_step` reads this same `Next` decision off
+ * `run_step_between`'s `ElementContext::pre_script_result` and resolves it
+ * against the run's own `ScenarioLoadState::step_index` - the load path's
+ * counterpart to `run_iteration`'s walk, guarded against a cycle that never
+ * closes by the same `maxStepsPerIteration` the sequential run uses.
  */
 
 #include "vayu/core/elements.hpp"
@@ -95,10 +94,9 @@ ElementKind make_control_loop_kind () {
     kind.label   = "Loop";
     kind.description =
     "Walks a folder's members a fixed number of times per iteration.";
-    kind.category         = "controller";
-    kind.hot_path         = HotPathClass::Declarative;
-    kind.needs_span       = true;
-    kind.jumps_or_repeats = true;
+    kind.category   = "controller";
+    kind.hot_path   = HotPathClass::Declarative;
+    kind.needs_span = true;
     kind.compile = [] (const nlohmann::json& config) -> std::unique_ptr<Element> {
         return std::make_unique<ControlLoopElement> (config);
     };

--- a/engine/src/core/elements/control_transaction.cpp
+++ b/engine/src/core/elements/control_transaction.cpp
@@ -26,11 +26,16 @@
  * reports `waited_ms` absent, which is what tells the two apart without a
  * second field.
  *
- * `includeTimers` (folding a between-member `timer.*` wait into the sum) is
- * real, disclosed follow-up work (issue #1569), not silently dropped: this
- * element sums each member's own response latency only, and does not accept
- * the field in its config schema, so a run cannot ask for behaviour this
- * build does not give it.
+ * `includeTimers` (issue #1569) folds a between-member `timer.*` wait into
+ * the running sum too: this element's own `apply` never changes for it -
+ * the fold is the caller's, done generically in `scenario_runner.cpp`'s and
+ * `scenario_load.cpp`'s own `step.between` dispatch, which reads this
+ * element's config by the registry's `category` (never a `kind ==`
+ * comparison outside `core/elements`, #1512's extensibility contract, rule
+ * 1) and adds the just-completed step's between-phase wait to the same
+ * `controller_state` sum key (`transaction_sum_key`) this file already
+ * accumulates into - skipped for the folder's *last* member, whose sum has
+ * already closed and reported by the time any wait after it could run.
  */
 
 #include "vayu/core/elements.hpp"
@@ -125,7 +130,9 @@ ElementKind make_control_transaction_kind () {
     };
     kind.config_schema = {
         { "type", "object" },
-        { "properties", { { "name", { { "type", "string" }, { "minLength", 1 } } } } },
+        { "properties",
+        { { "name", { { "type", "string" }, { "minLength", 1 } } },
+        { "includeTimers", { { "type", "boolean" } } } } },
         { "required", { "name" } },
         { "additionalProperties", false },
     };

--- a/engine/src/core/elements/controller_kinds.cpp
+++ b/engine/src/core/elements/controller_kinds.cpp
@@ -211,6 +211,20 @@ class ControlThroughputElement final : public Element {
     }
 
     void apply (ElementContext& ctx) override {
+        // `perUser: false` (issue #1569) - a shared, cross-VU budget, kept
+        // in the run's own `SharedThroughputCounters` slot rather than this
+        // VU's `controller_state`. Under the sequential run and a design
+        // send `ctx.shared_controller_state` is always null (the single
+        // implicit user already makes `controller_state` below the
+        // "shared" instance), so `perUser` changes nothing there.
+        if (!config_.value ("perUser", true) && ctx.shared_controller_state != nullptr) {
+            if (auto* shared = ctx.shared_controller_state->find (ctx.element_id);
+            shared != nullptr) {
+                apply_shared (ctx, *shared);
+                return;
+            }
+        }
+
         if (ctx.controller_state == nullptr) {
             ctx.outcome_status = "ok"; // no counter to keep - never skips.
             return;
@@ -248,6 +262,39 @@ class ControlThroughputElement final : public Element {
     }
 
     private:
+    /// The `perUser: false` path: the same `everyN` / `percent` math as the
+    /// per-VU one above, against one atomic pair every virtual user shares -
+    /// `everyN` a plain `fetch_add`, `percent` a CAS loop so two VUs racing
+    /// to spend the last of the budget never both win it. No lock either way.
+    void apply_shared (ElementContext& ctx, SharedThroughputCounters::Counters& shared) {
+        bool run = true;
+        if (config_.contains ("everyN")) {
+            const int64_t every_n = config_.value ("everyN", int64_t{ 1 });
+            const int64_t count =
+            shared.count.fetch_add (1, std::memory_order_relaxed) + 1;
+            run = every_n <= 1 || count % every_n == 0;
+        } else if (config_.contains ("percent")) {
+            const int64_t percent_milli =
+            static_cast<int64_t> (config_.value ("percent", 100.0) * 1000.0);
+            int64_t old_carry = shared.carry.load (std::memory_order_relaxed);
+            int64_t new_carry = 0;
+            do {
+                new_carry = old_carry + percent_milli;
+                run       = new_carry >= 100000;
+                if (run) {
+                    new_carry -= 100000;
+                }
+            } while (!shared.carry.compare_exchange_weak (
+            old_carry, new_carry, std::memory_order_relaxed));
+        }
+
+        if (!run) {
+            mark_skip (ctx, "throughput budget for this occurrence was spent");
+            return;
+        }
+        ctx.outcome_status = "ok";
+    }
+
     nlohmann::json config_;
 };
 
@@ -306,9 +353,8 @@ ElementKind make_control_switch_kind () {
     kind.label   = "Switch";
     kind.description =
     "Routes to a named folder member by a variable's resolved value.";
-    kind.category         = "controller";
-    kind.hot_path         = HotPathClass::Declarative;
-    kind.jumps_or_repeats = true;
+    kind.category = "controller";
+    kind.hot_path = HotPathClass::Declarative;
     kind.compile = [] (const nlohmann::json& config) -> std::unique_ptr<Element> {
         return std::make_unique<ControlSwitchElement> (config);
     };
@@ -337,16 +383,18 @@ ElementKind make_control_throughput_kind () {
     kind.compile = [] (const nlohmann::json& config) -> std::unique_ptr<Element> {
         return std::make_unique<ControlThroughputElement> (config);
     };
-    // `perUser` (a shared, cross-VU budget) is real follow-up work, not
-    // silently dropped: this kind always keeps its counter per user - the
-    // sequential run has only one, and a scenario load run keeps one per
-    // virtual user - so the schema does not accept a key this build cannot
-    // honour. Follow-up: issue #1569.
-    kind.config_schema = {
+    // `perUser: false` (issue #1569, JMeter's "All threads" throughput mode)
+    // asks the run to keep one shared budget across every virtual user
+    // rather than one per user - `supports_shared_state` below is what lets
+    // `SharedThroughputCounters` find this occurrence generically, without
+    // the scan naming this kind (#1512's extensibility contract, rule 1).
+    kind.supports_shared_state = true;
+    kind.config_schema         = {
         { "type", "object" },
         { "properties",
-        { { "percent", { { "type", "number" }, { "minimum", 0 }, { "maximum", 100 } } },
-        { "everyN", { { "type", "integer" }, { "minimum", 1 } } } } },
+                { { "percent", { { "type", "number" }, { "minimum", 0 }, { "maximum", 100 } } },
+                { "everyN", { { "type", "integer" }, { "minimum", 1 } } },
+                { "perUser", { { "type", "boolean" } } } } },
         { "additionalProperties", false },
     };
     return kind;

--- a/engine/src/core/elements/pipeline.cpp
+++ b/engine/src/core/elements/pipeline.cpp
@@ -16,7 +16,63 @@
 
 #include <random>
 
+#include "vayu/core/scenario_plan.hpp"
+
 namespace vayu::core {
+
+std::string transaction_sum_key (const std::string& element_id, size_t iteration) {
+    return element_id + "#" + std::to_string (iteration) + "#sum";
+}
+
+SharedThroughputCounters::SharedThroughputCounters (const ScenarioPlan& plan) {
+    const auto& registry = Registry::instance ();
+    for (const auto& step : plan.steps) {
+        if (!step.elements) {
+            continue;
+        }
+        for (const auto& element : *step.elements) {
+            if (counters_.contains (element.id)) {
+                continue; // Already slotted - a folder-inherited occurrence
+                          // carries the same id at every member position.
+            }
+            const auto* kind = registry.find (element.kind);
+            if (kind == nullptr || !kind->supports_shared_state) {
+                continue;
+            }
+            if (element.config.value ("perUser", true)) {
+                continue; // This occurrence kept its own, per-VU counter.
+            }
+            counters_[element.id] = std::make_unique<Counters> ();
+        }
+    }
+}
+
+SharedThroughputCounters::Counters* SharedThroughputCounters::find (
+const std::string& element_id) {
+    const auto found = counters_.find (element_id);
+    return found == counters_.end () ? nullptr : found->second.get ();
+}
+
+void fold_between_wait_into_open_transactions (const std::vector<CompiledElement>& elements,
+const std::unordered_map<std::string, ElementSpan>& spans,
+size_t step_index,
+size_t iteration,
+int64_t wait_ms,
+std::unordered_map<std::string, int64_t>& controller_state) {
+    const auto& registry = Registry::instance ();
+    for (const auto& compiled : elements) {
+        const auto* kind = registry.find (compiled.kind);
+        if (kind == nullptr || kind->category != "transaction" ||
+        !compiled.config.value ("includeTimers", false)) {
+            continue;
+        }
+        const auto span = spans.find (compiled.id);
+        if (span == spans.end () || span->second.last == step_index) {
+            continue; // Unspanned, or this occurrence already closed it.
+        }
+        controller_state[transaction_sum_key (compiled.id, iteration)] += wait_ms;
+    }
+}
 
 nlohmann::json ElementOutcome::to_json () const {
     nlohmann::json node;

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -445,13 +445,15 @@ size_t vu_index) {
 }
 
 /// `run_step_before`'s answer: elapsed pipeline time on `includeScriptTime`'s
-/// terms, and whether a controller kind (`control.if` / `control.once` /
+/// terms, whether a controller kind (`control.if` / `control.once` /
 /// `control.throughput`, issue #1515) asked to skip this occurrence - the
-/// load path's own `pm.execution.skipRequest()`, which nothing before #1515
-/// could ask for here.
+/// load path's own `pm.execution.skipRequest()` - and `control.switch`'s own
+/// dispatch target, if it fired (issue #1569's `Kind::Next`, read the same
+/// way the sequential run's `decide_next_step` reads a pre-request script's).
 struct StepBeforeResult {
     int64_t elapsed_ms = 0;
     bool skip          = false;
+    std::optional<std::string> next_target;
 };
 
 /**
@@ -508,10 +510,11 @@ vayu::Request& request) {
             vu.scope_overlay.apply_onto (vars);
             return vayu::http::resolve_template (text, vars);
         },
-        .iteration        = iteration,
-        .step_position    = step_index,
-        .element_spans    = &state.element_spans,
-        .controller_state = &vu.controller_state,
+        .iteration               = iteration,
+        .step_position           = step_index,
+        .element_spans           = &state.element_spans,
+        .controller_state        = &vu.controller_state,
+        .shared_controller_state = &state.shared_throughput,
         .blocking_allowed = false, // A worker thread must never block here.
         .rng              = &vu.rng,
         .pacing_state     = &vu.pacing_state,
@@ -528,6 +531,14 @@ vayu::Request& request) {
     // A controller kind's skip (issue #1515) - the load path's own
     // `pm.execution.skipRequest()`.
     const bool skip = pre_result.control.kind == vayu::ScriptControl::Kind::Skip;
+    // `control.switch`'s own dispatch (issue #1569) - a skip always wins
+    // over a dispatch on the same "last write wins" terms `pre_result` is a
+    // single shared field either way, matching the sequential run's own
+    // priority when both a skip and a jump are asked for on one step.
+    std::optional<std::string> next_target;
+    if (!skip && pre_result.control.kind == vayu::ScriptControl::Kind::Next) {
+        next_target = pre_result.control.target;
+    }
     // `pre_result.tests` is populated only when `script.pre` actually ran
     // above (a deferred one never invokes `run_pre_script`, so it stays
     // empty) - the inline half of issue #1497's assertion tally.
@@ -540,13 +551,14 @@ vayu::Request& request) {
     }
 
     if (!start) {
-        return StepBeforeResult{ 0, skip };
+        return StepBeforeResult{ 0, skip, next_target };
     }
     return StepBeforeResult{
         std::chrono::duration_cast<std::chrono::milliseconds> (
         std::chrono::steady_clock::now () - *start)
         .count (),
         skip,
+        next_target,
     };
 }
 
@@ -777,10 +789,16 @@ class ScenarioLoadDriver {
         // `step`'s address is stable for the run's whole life: the plan is
         // immutable, const data shared by the run's context.
         const ScenarioStep* step_ptr = &step;
+        // `control.switch`'s own dispatch (issue #1569), decided above at
+        // `step.before` and carried into the completion for `finish_step` to
+        // resolve once this step's own send (whatever it does) is done -
+        // never consulted on the transport-error path, which ends the
+        // iteration on `errored` alone regardless.
+        std::optional<std::string> next_target_before = before_result.next_target;
         context_->event_loop->submit (request,
-        [context = context_, &db = db_, state = state_, &plan = execution_.plan,
-        step_ptr, vu, step_index, iteration, vu_index, row, pipeline_before_ms,
-        sent_request] (size_t, const vayu::Result<vayu::Response>& result) {
+        [context = context_, &db = db_, state = state_, &plan = execution_.plan, step_ptr,
+        vu, step_index, iteration, vu_index, row, pipeline_before_ms, sent_request,
+        next_target_before] (size_t, const vayu::Result<vayu::Response>& result) {
             if (result.is_error ()) {
                 // No `Response` object exists at all - nothing for `step.after`
                 // to run against, exactly as before #1495. Coverage still
@@ -815,7 +833,8 @@ class ScenarioLoadDriver {
             // happened.
             state->coverage.record (step_index, response.status_code);
             finish_step (context, state, plan, vu, step_index, errored,
-            errored ? nullptr : &response.cookie_lines);
+            errored ? nullptr : &response.cookie_lines,
+            errored ? std::nullopt : next_target_before);
             handle_result (context, db, result,
             ResultAnnotations{ row, step_index, iteration, vu_index });
         });
@@ -850,13 +869,14 @@ class ScenarioLoadDriver {
             if (vu.ready_at_ms > 0 && vu.ready_at_ms > steady_now_ms ()) {
                 continue;
             }
-            if (vu.step == 0) {
+            if (vu.iteration_boundary) {
                 if (max_iterations_ > 0 && state_->iterations_started >= max_iterations_) {
                     vu.retired = true;
                     --live_vus_;
                     continue;
                 }
                 ++state_->iterations_started;
+                vu.iteration_boundary = false;
                 if (state_->data_row_count > 0) {
                     // One claim per iteration off the run-wide cursor, wrapping
                     // always. Claimed here rather than per step so every step
@@ -885,17 +905,27 @@ class ScenarioLoadDriver {
      * `step.between` of whatever preceded it) and reports `waited_ms: 0`, so
      * it contributes nothing through this path - see @ref
      * schedule_next_entry_wait for its actual scheduling.
+     *
+     * Also `control.loop`'s own seam (issue #1569): its `Next` decision -
+     * only the folder's *last* member ever makes one, per its own
+     * `needs_span` check - is returned the same way `run_step_before`
+     * returns `control.switch`'s, for `finish_step` to resolve against the
+     * run's `step_index`.
+     *
+     * @return the folder-start step name a `control.loop` asked to repeat,
+     *         or `nullopt` when nothing at this step decided one.
      */
-    static void run_step_between (const std::shared_ptr<RunContext>& context,
+    static std::optional<std::string> run_step_between (
+    const std::shared_ptr<RunContext>& context,
     ScenarioLoadState& state,
     const ScenarioStep& completed_step,
     size_t step_index,
     VirtualUser& vu) {
         if (!completed_step.elements || completed_step.elements->empty ()) {
-            return;
+            return std::nullopt;
         }
         std::vector<vayu::core::ElementOutcome> outcomes;
-        vayu::ScriptResult unused_pre;
+        vayu::ScriptResult between_control;
         vayu::ScriptResult unused_post;
         vayu::core::ElementContext ctx{
             // Never read or written by a `step.between` kind (`timer.think`,
@@ -906,10 +936,14 @@ class ScenarioLoadDriver {
             .response           = nullptr,
             .run_pre_script     = nullptr,
             .run_post_script    = nullptr,
-            .pre_script_result  = unused_pre,
+            .pre_script_result  = between_control,
             .post_script_result = unused_post,
             .set_variable = [] (std::string_view, const std::string&, const std::string&) {},
             .should_stop      = nullptr,
+            .iteration        = vu.iteration,
+            .step_position    = step_index,
+            .element_spans    = &state.element_spans,
+            .controller_state = &vu.controller_state,
             .blocking_allowed = false,
             .rng              = &vu.rng,
             .pacing_state     = &vu.pacing_state,
@@ -925,7 +959,14 @@ class ScenarioLoadDriver {
         }
         if (total_wait_ms > 0) {
             vu.ready_at_ms = std::max (vu.ready_at_ms, steady_now_ms () + total_wait_ms);
+            fold_between_wait_into_open_transactions (*completed_step.elements,
+            state.element_spans, step_index, vu.iteration, total_wait_ms,
+            vu.controller_state);
         }
+
+        return between_control.control.kind == vayu::ScriptControl::Kind::Next ?
+        std::optional (between_control.control.target) :
+        std::nullopt;
     }
 
     /**
@@ -962,7 +1003,11 @@ class ScenarioLoadDriver {
      * VU left busy permanently shrinks effective concurrency.
      *
      * @p next_cookies is null for an outcome that carries none - an error, or a
-     * step that was never sent.
+     * step that was never sent. @p next_target_from_before is
+     * `control.switch`'s own dispatch (issue #1569, `run_step_before`'s
+     * return), read only when this step did not error - the same "an
+     * instruction that cannot be honoured is this step's failure" priority
+     * `errored` already has over any control decision.
      */
     static void finish_step (const std::shared_ptr<RunContext>& context,
     const std::shared_ptr<ScenarioLoadState>& state,
@@ -970,40 +1015,90 @@ class ScenarioLoadDriver {
     VirtualUser* vu,
     size_t step_index,
     bool errored,
-    const std::vector<std::string>* next_cookies) {
+    const std::vector<std::string>* next_cookies,
+    std::optional<std::string> next_target_from_before = std::nullopt) {
         const size_t step_count = plan.steps.size ();
         state->steps_executed.fetch_add (1, std::memory_order_relaxed);
+        ++vu->steps_this_iteration;
+
+        std::optional<std::string> next_target;
         if (errored) {
             state->steps.record_error (step_index);
             state->steps_errored.fetch_add (1, std::memory_order_relaxed);
         } else {
-            // Skipped for an errored (or never-sent) step, on the same rule
-            // the sequential run's own `step.between` dispatch follows
-            // (`scenario_runner.cpp`'s `run_iteration`).
-            run_step_between (context, *state, plan.steps[step_index], step_index, *vu);
+            // `control.loop`'s own decision (issue #1569) is chronologically
+            // last, so it overrides `control.switch`'s own step.before
+            // decision on the sequential run's own "last call wins" terms
+            // (`decide_next_step` reads its post-script over its pre).
+            next_target = run_step_between (
+            context, *state, plan.steps[step_index], step_index, *vu);
+            if (!next_target) {
+                next_target = std::move (next_target_from_before);
+            }
         }
 
-        const bool last_step = step_index + 1 >= step_count;
-        if (errored || last_step) {
-            // An errored step ends its iteration - and the VU starts the next
-            // one rather than being stranded, which would permanently shrink
-            // effective concurrency for the rest of the run.
-            if (last_step) {
-                state->iterations_completed.fetch_add (1, std::memory_order_relaxed);
+        // A `control.switch` / `control.loop` jump or repeat (issue #1569),
+        // resolved against the plan the same way a script's own
+        // `setNextRequest` is (`resolve_next_step`). A target this run
+        // cannot honour, or a cycle that never reaches
+        // `maxStepsPerIteration`, both end the iteration as abandoned - the
+        // sequential run's own rule for an instruction it cannot honour.
+        std::optional<size_t> jump_target;
+        bool jump_failed = false;
+        if (next_target && !errored) {
+            if (vu->steps_this_iteration >= state->max_steps_per_iteration) {
+                vayu::utils::log_warning ("Scenario load run " +
+                context->run_id + ": iteration exceeded maxStepsPerIteration (" +
+                std::to_string (state->max_steps_per_iteration) + ") - a control.switch/control.loop cycle never reached its end");
+                jump_failed = true;
             } else {
-                state->iterations_abandoned.fetch_add (1, std::memory_order_relaxed);
+                const auto resolution = resolve_next_step (state->step_index, *next_target);
+                switch (resolution.kind) {
+                case NextStepResolution::Kind::Step:
+                    jump_target = resolution.index;
+                    break;
+                case NextStepResolution::Kind::EndIteration:
+                    break; // Ends below, on the same terms a natural last step does.
+                case NextStepResolution::Kind::Unresolved:
+                    vayu::utils::log_warning ("Scenario load run " +
+                    context->run_id + ": " + resolution.error);
+                    jump_failed = true;
+                    break;
+                }
             }
-            vu->step = 0;
+        }
+
+        const bool ends_by_jump = next_target.has_value () && !jump_target && !jump_failed;
+        const bool abandon   = errored || jump_failed;
+        const bool last_step = step_index + 1 >= step_count;
+        const bool end_iteration = abandon || ends_by_jump || (!jump_target && last_step);
+
+        if (end_iteration) {
+            // An abandoned iteration ends here rather than stranding the VU,
+            // which would permanently shrink effective concurrency for the
+            // rest of the run; an ordinary last step or an explicit
+            // `Kind::EndIteration` both count as completed, not abandoned -
+            // neither is a failure.
+            if (abandon) {
+                state->iterations_abandoned.fetch_add (1, std::memory_order_relaxed);
+            } else {
+                state->iterations_completed.fetch_add (1, std::memory_order_relaxed);
+            }
+            vu->step               = 0;
+            vu->iteration_boundary = true;
             ++vu->iteration;
+            vu->steps_this_iteration = 0;
             // Empty at the start of each iteration: a new iteration is a
             // new user, not the same one logging in twice.
             vu->cookies.clear ();
             vu->scope_overlay.clear ();
         } else {
-            vu->step = step_index + 1;
+            vu->step = jump_target.value_or (step_index + 1);
             // Replace, never merge - the captured list is the whole jar the
             // handle held, so merging would resurrect a cookie the server
-            // deleted by expiring it.
+            // deleted by expiring it. This step's own send (a jump target
+            // does not change whether *this* step sent one) is what
+            // @p next_cookies describes either way.
             vu->cookies =
             next_cookies != nullptr ? *next_cookies : std::vector<std::string>{};
         }
@@ -1095,6 +1190,11 @@ const ScenarioExecution& execution) {
     auto state            = std::make_shared<ScenarioLoadState> (plan, vu_count,
                make_coverage_tally (execution), std::move (base_scopes), script_config);
     state->data_row_count = execution.data_rows.size ();
+    // The same cycle guard the sequential run's own `setNextRequest` walk
+    // uses (issue #1569), against a `control.switch`/`control.loop` plan
+    // whose jump never reaches an end.
+    state->max_steps_per_iteration = resolve_max_steps_per_iteration (
+    db.get_config_int ("maxStepsPerIteration", 0), step_count);
     state->vus.reserve (vu_count);
     for (size_t i = 0; i < vu_count; ++i) {
         auto user = std::make_unique<VirtualUser> ();

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -893,6 +893,66 @@ ScenarioStepStore& store) {
 }
 
 /**
+ * `step.between` (issue #1514): `timer.think` and anything else phased here
+ * run after this step's own outcome is decided - so a wait never counts
+ * against the step's own latency - and before flow control reads it, so a
+ * `Stop` mid-wait ends the run promptly rather than after one more step.
+ * Called only for a step whose row bound and did not already error.
+ *
+ * `between_control` is read, not discarded: `control.loop` (issue #1515) is
+ * the one `step.between` kind that can decide where the iteration goes next,
+ * through `ScriptControl`, chronologically the latest decision of the step
+ * and so the one "last call wins" already gives priority to.
+ *
+ * `control.transaction`'s own `includeTimers` (issue #1569) folds this step's
+ * between-phase wait into an *open* transaction's running sum - see
+ * `fold_between_wait_into_open_transactions`'s own comment for why "open"
+ * excludes the folder's last member.
+ */
+void run_step_between (const StepContext& base,
+const ScenarioStep& step,
+vayu::http::routes::ExchangeOutcome& exchange,
+StepRecord& record) {
+    vayu::ScriptResult between_control;
+    vayu::ScriptResult unread_post;
+    vayu::core::ElementContext between_ctx{
+        .request        = exchange.request,
+        .response       = nullptr,
+        .run_pre_script = [] (
+                          const std::string&) { return vayu::ScriptResult{}; },
+        .run_post_script = [] (
+                           const std::string&) { return vayu::ScriptResult{}; },
+        .pre_script_result  = between_control,
+        .post_script_result = unread_post,
+        .set_variable = [] (std::string_view, const std::string&, const std::string&) {},
+        .should_stop = [&] { return base.context->should_stop.load (); },
+        .iteration        = base.iteration,
+        .step_position    = step.index,
+        .element_spans    = &base.element_spans,
+        .controller_state = &base.controller_state,
+        .rng              = &base.context->rng,
+        .pacing_state     = &base.context->pacing_state,
+        .timers_override  = &base.context->timers_override,
+    };
+    const size_t between_start = record.elements.size ();
+    vayu::core::ElementPipeline::run (vayu::core::Phase::StepBetween,
+    between_ctx, *step.elements, record.elements);
+    if (between_control.control.kind != vayu::ScriptControl::Kind::None) {
+        exchange.post_script_result.control = between_control.control;
+    }
+
+    int64_t between_wait_ms = 0;
+    for (size_t i = between_start; i < record.elements.size (); ++i) {
+        between_wait_ms += record.elements[i].waited_ms.value_or (0);
+    }
+    if (between_wait_ms > 0) {
+        vayu::core::fold_between_wait_into_open_transactions (*step.elements,
+        base.element_spans, step.index, base.iteration, between_wait_ms,
+        base.controller_state);
+    }
+}
+
+/**
  * One iteration: a walk over the plan rather than a pass through it.
  *
  * A script may send it backwards, forwards or out early, so the position is a
@@ -957,39 +1017,7 @@ TransactionHistograms& transactions) {
         // could not bind (no exchange ran) or that already errored.
         if (data_bind_error.empty () &&
         record.outcome != StepOutcome::Errored && step.elements) {
-            // `between_control` is read below, not discarded: `control.loop`
-            // (issue #1515) is the one `step.between` kind that can decide
-            // where the iteration goes next, and it says so exactly as a
-            // script's own `pm.execution.setNextRequest` would - through
-            // `ScriptControl`, chronologically the latest decision of the
-            // step and so the one "last call wins" already gives priority to.
-            vayu::ScriptResult between_control;
-            vayu::ScriptResult unread_post;
-            vayu::core::ElementContext between_ctx{
-                .request  = exchange.request,
-                .response = nullptr,
-                .run_pre_script =
-                [] (const std::string&) { return vayu::ScriptResult{}; },
-                .run_post_script =
-                [] (const std::string&) { return vayu::ScriptResult{}; },
-                .pre_script_result  = between_control,
-                .post_script_result = unread_post,
-                .set_variable       = [] (std::string_view, const std::string&,
-                                const std::string&) {},
-                .should_stop = [&] { return base.context->should_stop.load (); },
-                .iteration        = base.iteration,
-                .step_position    = step.index,
-                .element_spans    = &base.element_spans,
-                .controller_state = &base.controller_state,
-                .rng              = &base.context->rng,
-                .pacing_state     = &base.context->pacing_state,
-                .timers_override  = &base.context->timers_override,
-            };
-            vayu::core::ElementPipeline::run (vayu::core::Phase::StepBetween,
-            between_ctx, *step.elements, record.elements);
-            if (between_control.control.kind != vayu::ScriptControl::Kind::None) {
-                exchange.post_script_result.control = between_control.control;
-            }
+            run_step_between (base, step, exchange, record);
         }
 
         bool end_iteration = record.outcome == StepOutcome::Errored;

--- a/engine/tests/elements_controllers_test.cpp
+++ b/engine/tests/elements_controllers_test.cpp
@@ -116,13 +116,19 @@ TEST (ControllerRegistry, ControlOnceAcceptsAnEmptyConfig) {
     .has_value ());
 }
 
-TEST (ControllerRegistry, ControlThroughputRefusesPerUser) {
-    // Deferred, disclosed follow-up (this PR's PR body / docs/engine/elements.md):
-    // this kind's counter is always per-user, so the schema does not accept a
-    // key it cannot honour.
+TEST (ControllerRegistry, ControlThroughputAcceptsPerUser) {
+    // Issue #1569: `perUser: false` shares one budget across every virtual
+    // user of a scenario load run rather than keeping one per user.
     const auto reason = Registry::instance ().validate (json::array (
     { element ("el_1", "control.throughput", { { "perUser", false } }) }));
-    ASSERT_HAS_VALUE (reason);
+    EXPECT_FALSE (reason.has_value ()) << reason.value_or ("");
+}
+
+TEST (ControllerRegistry, ControlTransactionAcceptsIncludeTimers) {
+    // Issue #1569: folds a between-member `timer.*` wait into the sum.
+    const auto reason = Registry::instance ().validate (json::array ({ element ("el_1",
+    "control.transaction", { { "name", "checkout" }, { "includeTimers", true } }) }));
+    EXPECT_FALSE (reason.has_value ()) << reason.value_or ("");
 }
 
 TEST (ControllerRegistry, ControlLoopRequiresCount) {
@@ -150,32 +156,20 @@ vayu::core::ScenarioStep step_with (const std::string& name, std::vector<json> e
     return step;
 }
 
-TEST (LoadIncompatibleController, NamesControlLoop) {
-    vayu::core::ScenarioPlan plan;
-    plan.steps.push_back (
-    step_with ("a", { element ("el_1", "control.loop", { { "count", 2 } }) }));
-    const auto found = vayu::core::find_load_incompatible_controller (plan);
-    ASSERT_HAS_VALUE (found);
-    EXPECT_EQ (*found, "control.loop");
-}
-
-TEST (LoadIncompatibleController, NamesControlSwitch) {
-    vayu::core::ScenarioPlan plan;
-    plan.steps.push_back (step_with ("a",
-    { element ("el_1", "control.switch",
-    { { "variable", "v" }, { "cases", json::object () } }) }));
-    const auto found = vayu::core::find_load_incompatible_controller (plan);
-    ASSERT_HAS_VALUE (found);
-    EXPECT_EQ (*found, "control.switch");
-}
-
-TEST (LoadIncompatibleController, SilentOnEveryOtherController) {
+// Issue #1569: `control.loop` and `control.switch` gained their own
+// load-path jump/repeat mechanism, so neither sets `jumps_or_repeats`
+// any more and both run under a scenario load run instead of being
+// refused - see `ElementsControllersLoadTest` below for the behaviour.
+TEST (LoadIncompatibleController, SilentOnEveryController) {
     vayu::core::ScenarioPlan plan;
     plan.steps.push_back (step_with ("a",
     { element ("el_1", "control.if", { { "condition", "{{x}} exists" } }),
     element ("el_2", "control.once", json::object ()),
     element ("el_3", "control.throughput", { { "everyN", 2 } }),
-    element ("el_4", "control.transaction", { { "name", "t" } }) }));
+    element ("el_4", "control.transaction", { { "name", "t" } }),
+    element ("el_5", "control.loop", { { "count", 2 } }),
+    element ("el_6", "control.switch",
+    { { "variable", "v" }, { "cases", json::object () } }) }));
     EXPECT_FALSE (vayu::core::find_load_incompatible_controller (plan).has_value ());
 }
 
@@ -469,6 +463,49 @@ TEST_F (ElementsControllersTest, ControlTransactionReportsPercentilesOverTheFold
     EXPECT_TRUE (found) << transactions.dump ();
 }
 
+// Issue #1569: `includeTimers` folds a `timer.think` wait between two
+// members into the transaction's own sum - a folder identical to the test
+// above except for the timer and the flag, so the only variable is whether
+// the fold happened.
+double checkout_p50 (const json& summary) {
+    for (const auto& entry : summary["scenario"]["transactions"]) {
+        if (entry["name"] == "checkout") {
+            return entry["latency"]["p50"].get<double> ();
+        }
+    }
+    ADD_FAILURE () << "no 'checkout' transaction in " << summary.dump ();
+    return -1.0;
+}
+
+TEST_F (ElementsControllersTest, ControlTransactionIncludeTimersFoldsAWaitBetweenMembers) {
+    seed_root ();
+    seed_folder ("folder_1",
+    json::array ({ element ("el_txn", "control.transaction",
+    { { "name", "checkout" }, { "includeTimers", true } }) }));
+    seed_request ("req_a", "folder_1", 0, "/a",
+    json::array ({ element ("el_wait", "timer.think", { { "ms", 60 } }) }));
+    seed_request ("req_b", "folder_1", 1, "/b");
+
+    const std::string run_id = start (1);
+    EXPECT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+    EXPECT_GE (checkout_p50 (summary_of (run_id)), 60.0)
+    << "the 60ms wait between the two members must be in the sum";
+}
+
+TEST_F (ElementsControllersTest, ControlTransactionExcludesTimersByDefault) {
+    seed_root ();
+    seed_folder ("folder_1",
+    json::array ({ element ("el_txn", "control.transaction", { { "name", "checkout" } }) }));
+    seed_request ("req_a", "folder_1", 0, "/a",
+    json::array ({ element ("el_wait", "timer.think", { { "ms", 60 } }) }));
+    seed_request ("req_b", "folder_1", 1, "/b");
+
+    const std::string run_id = start (1);
+    EXPECT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+    EXPECT_LT (checkout_p50 (summary_of (run_id)), 60.0)
+    << "without includeTimers the wait must not reach the sum";
+}
+
 // ============================================================================
 // Scenario load run - `execute_scenario_load` directly, no DB collection tree
 // ============================================================================
@@ -481,7 +518,7 @@ class ControllerLoadMockServer {
             std::lock_guard<std::mutex> lock (mtx);
             hits.push_back (req.path);
         };
-        for (const char* path : { "/a", "/b" }) {
+        for (const char* path : { "/a", "/b", "/c" }) {
             svr.Get (path, [record] (const httplib::Request& req, httplib::Response& res) {
                 record (req);
                 res.set_content ("{}", "application/json");
@@ -573,6 +610,49 @@ class ElementsControllersLoadTest : public ::testing::Test {
         return execution;
     }
 
+    /// Three steps a/b/c, for `control.switch`'s own jump - proving it
+    /// actually skips the un-matched member rather than only ever landing on
+    /// the ordinary next step.
+    static vayu::core::ScenarioExecution
+    plan_over_three (ControllerLoadMockServer& server, std::vector<json> elements_a) {
+        vayu::core::ScenarioExecution execution;
+        execution.request.source        = "collection";
+        execution.request.collection_id = "col_test";
+
+        vayu::core::ScenarioStep a;
+        a.index              = 0;
+        a.request_id         = "req_a";
+        a.name               = "a";
+        a.request.method     = vayu::HttpMethod::GET;
+        a.request.url        = server.url ("/a");
+        a.request.timeout_ms = 5000;
+        a.stored_url         = a.request.url;
+        a.elements           = compiled_elements (std::move (elements_a));
+        execution.plan.steps.push_back (std::move (a));
+
+        vayu::core::ScenarioStep b;
+        b.index              = 1;
+        b.request_id         = "req_b";
+        b.name               = "b";
+        b.request.method     = vayu::HttpMethod::GET;
+        b.request.url        = server.url ("/b");
+        b.request.timeout_ms = 5000;
+        b.stored_url         = b.request.url;
+        execution.plan.steps.push_back (std::move (b));
+
+        vayu::core::ScenarioStep c;
+        c.index              = 2;
+        c.request_id         = "req_c";
+        c.name               = "c";
+        c.request.method     = vayu::HttpMethod::GET;
+        c.request.url        = server.url ("/c");
+        c.request.timeout_ms = 5000;
+        c.stored_url         = c.request.url;
+        execution.plan.steps.push_back (std::move (c));
+
+        return execution;
+    }
+
     std::shared_ptr<vayu::core::ScenarioLoadState> run (const json& config,
     const vayu::core::ScenarioExecution& execution,
     size_t pool_size = 50) {
@@ -589,6 +669,14 @@ class ElementsControllersLoadTest : public ::testing::Test {
         auto state = vayu::core::execute_scenario_load (context, *db_, *context->scenario);
         context->event_loop->stop (true, std::chrono::milliseconds (10000));
         return state;
+    }
+
+    /// Override a seeded config value, keeping the rest of its row intact.
+    void set_config (const std::string& key, const std::string& value) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_HAS_VALUE (entry) << key << " is not a seeded config key";
+        entry->value = value;
+        db_->save_config_entry (*entry);
     }
 
     std::unique_ptr<vayu::db::Database> db_;
@@ -633,6 +721,141 @@ TEST_F (ElementsControllersLoadTest, ControlIfSkipsUnderLoadAndNeverReachesTheWi
     EXPECT_EQ (server.hit_count ("/a"), 0u)
     << "an unresolved {{tier}} never equals 'gold', so every occurrence skips";
     EXPECT_GE (state->steps_skipped.load (), 4u);
+}
+
+// ============================================================================
+// Load-path jump/repeat (issue #1569)
+// ============================================================================
+
+TEST_F (ElementsControllersLoadTest, ControlSwitchJumpsPastTheUnmatchedMemberUnderLoad) {
+    ControllerLoadMockServer server;
+    // `{{which}}` resolves to nothing in this fixture (no collection row
+    // backs `col_test`), so it stays its own unresolved literal - matching
+    // that literal in `cases` is a deterministic way to pick a branch
+    // without needing a seeded variable (`ControlIfSkipsUnderLoad...` above
+    // uses the same trick).
+    auto execution = plan_over_three (server,
+    { element ("el_switch", "control.switch",
+    { { "variable", "which" }, { "cases", { { "{{which}}", "c" } } } }) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 2 }, { "iterations", 4 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    EXPECT_EQ (server.hit_count ("/a"), 4u);
+    EXPECT_EQ (server.hit_count ("/b"), 0u)
+    << "the switch must jump past the un-matched member";
+    EXPECT_EQ (server.hit_count ("/c"), 4u);
+}
+
+TEST_F (ElementsControllersLoadTest, ControlSwitchCycleIsCutOffByMaxStepsPerIteration) {
+    set_config ("maxStepsPerIteration", "5");
+    ControllerLoadMockServer server;
+    // Routes back to itself every time - without the cycle guard this would
+    // spin the one VU forever rather than complete the run.
+    auto execution = plan_over (server,
+    { element ("el_switch", "control.switch",
+    { { "variable", "which" }, { "cases", { { "{{which}}", "a" } } } }) },
+    {});
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 1 }, { "iterations", 1 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    EXPECT_GE (state->iterations_abandoned.load (), 1u)
+    << "a cycle that never reaches maxStepsPerIteration must abandon the "
+       "iteration rather than spin the VU forever";
+}
+
+TEST_F (ElementsControllersLoadTest, ControlLoopRepeatsUnderLoad) {
+    ControllerLoadMockServer server;
+    auto execution = plan_over (
+    server, { element ("el_loop", "control.loop", { { "count", 3 } }) }, {});
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 2 }, { "iterations", 4 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    EXPECT_EQ (server.hit_count ("/a"), 12u) << "3 passes x 4 iterations";
+    EXPECT_EQ (server.hit_count ("/b"), 4u)
+    << "one per completed iteration, once the loop closes";
+}
+
+// ============================================================================
+// control.throughput perUser: false, and control.transaction includeTimers
+// (issue #1569)
+// ============================================================================
+
+TEST_F (ElementsControllersLoadTest, ControlThroughputSharesABudgetAcrossVUsWhenPerUserIsFalse) {
+    ControllerLoadMockServer server;
+    auto execution = plan_over (server,
+    { element ("el_thr", "control.throughput", { { "everyN", 2 }, { "perUser", false } }) },
+    {});
+
+    // "iterations" is a run-wide total, claimed opportunistically by
+    // whichever VU is next ready - so a *shared* budget is what makes this
+    // exact: every 2nd of 20 occurrences fires, deterministically, no matter
+    // how the 20 iterations split across the 4 VUs. A `perUser` (default)
+    // counter could not be asserted this precisely, for the same reason.
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 4 }, { "iterations", 20 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    EXPECT_EQ (server.hit_count ("/a"), 10u);
+}
+
+TEST_F (ElementsControllersLoadTest, ControlTransactionIncludeTimersFoldsAWaitUnderLoad) {
+    ControllerLoadMockServer server;
+    auto execution = plan_over (server,
+    { element ("el_txn", "control.transaction",
+      { { "name", "checkout" }, { "includeTimers", true } }),
+    element ("el_wait", "timer.think", { { "ms", 60 } }) },
+    { element ("el_txn", "control.transaction",
+    { { "name", "checkout" }, { "includeTimers", true } }) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 2 }, { "iterations", 2 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    const json summary =
+    vayu::core::build_scenario_load_summary (*state, execution.plan);
+    double p50 = -1.0;
+    for (const auto& entry : summary["transactions"]) {
+        if (entry["name"] == "checkout") {
+            p50 = entry["latency"]["p50"].get<double> ();
+        }
+    }
+    EXPECT_GE (p50, 60.0) << "the 60ms between-member wait must be in the sum";
+}
+
+TEST_F (ElementsControllersLoadTest, ControlTransactionExcludesTimersByDefaultUnderLoad) {
+    ControllerLoadMockServer server;
+    auto execution = plan_over (server,
+    { element ("el_txn", "control.transaction", { { "name", "checkout" } }),
+    element ("el_wait", "timer.think", { { "ms", 60 } }) },
+    { element ("el_txn", "control.transaction", { { "name", "checkout" } }) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "iterations" }, { "concurrency", 2 }, { "iterations", 2 } };
+    auto state = run (config, execution);
+
+    ASSERT_NE (state, nullptr);
+    const json summary =
+    vayu::core::build_scenario_load_summary (*state, execution.plan);
+    double p50 = -1.0;
+    for (const auto& entry : summary["transactions"]) {
+        if (entry["name"] == "checkout") {
+            p50 = entry["latency"]["p50"].get<double> ();
+        }
+    }
+    EXPECT_GE (p50, 0.0);
+    EXPECT_LT (p50, 60.0)
+    << "without includeTimers the wait must not reach the sum";
 }
 
 } // namespace

--- a/engine/tests/fixtures/element-kinds.json
+++ b/engine/tests/fixtures/element-kinds.json
@@ -460,5 +460,155 @@
       "step.before"
     ],
     "version": 1
+  },
+  {
+    "category": "controller",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "pattern": "^\\s*\\{\\{[^}]+\\}\\}\\s*(==|!=|matches)\\s*\\S.*$|^\\s*\\{\\{[^}]+\\}\\}\\s*exists\\s*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "type": "object"
+    },
+    "description": "Skips this step, or every step of a folder it sits on, when a condition against a resolved variable is false.",
+    "hotPathClass": "declarative",
+    "kind": "control.if",
+    "label": "If",
+    "phases": [
+      "step.before"
+    ],
+    "version": 1
+  },
+  {
+    "category": "controller",
+    "configSchema": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "description": "Runs on this user's first iteration only.",
+    "hotPathClass": "declarative",
+    "kind": "control.once",
+    "label": "Once only",
+    "phases": [
+      "step.before"
+    ],
+    "version": 1
+  },
+  {
+    "category": "controller",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "cases": {
+          "type": "object"
+        },
+        "default": {
+          "type": "string"
+        },
+        "variable": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "variable",
+        "cases"
+      ],
+      "type": "object"
+    },
+    "description": "Routes to a named folder member by a variable's resolved value.",
+    "hotPathClass": "declarative",
+    "kind": "control.switch",
+    "label": "Switch",
+    "phases": [
+      "step.before"
+    ],
+    "version": 1
+  },
+  {
+    "category": "controller",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "everyN": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "perUser": {
+          "type": "boolean"
+        },
+        "percent": {
+          "maximum": 100,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "description": "Runs only a share of this occurrence's calls, by percentage or every Nth one, decided on the producer's own counter.",
+    "hotPathClass": "declarative",
+    "kind": "control.throughput",
+    "label": "Throughput",
+    "phases": [
+      "step.before"
+    ],
+    "version": 1
+  },
+  {
+    "category": "controller",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ],
+      "type": "object"
+    },
+    "description": "Walks a folder's members a fixed number of times per iteration.",
+    "hotPathClass": "declarative",
+    "kind": "control.loop",
+    "label": "Loop",
+    "phases": [
+      "step.between"
+    ],
+    "version": 1
+  },
+  {
+    "category": "transaction",
+    "configSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "includeTimers": {
+          "type": "boolean"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "description": "Sums a folder's own member latencies into one named transaction, reported with its own percentiles.",
+    "hotPathClass": "declarative",
+    "kind": "control.transaction",
+    "label": "Transaction",
+    "phases": [
+      "step.after"
+    ],
+    "version": 1
   }
 ]


### PR DESCRIPTION
## Description

Issue #1569, the disclosed follow-up from #1515's controller-kinds PR (#1581, merged just before this run started). Three pieces, each independently landable per the issue's own Fix pathway, all three done here:

1. **`control.switch` / `control.loop` now run under a scenario load run.** Previously `POST /runs` refused a load plan carrying either (`find_load_incompatible_controller`, reading the registry's `jumps_or_repeats` flag), because `VirtualUser::step` only ever advanced forward or wrapped to 0. This PR gives the load path its own jump/repeat mechanism: `ScenarioLoadState::step_index` (a `ScenarioStepIndex`, built once per run) resolves a `control.switch` target or a `control.loop`'s folder-start name through the same `resolve_next_step` the sequential run's `setNextRequest` already uses, and `finish_step` applies the result to the VU's `step` instead of the plain `step_index + 1` / wrap-to-0. Guarded by the same `maxStepsPerIteration` cycle limit the sequential run reads, via a new `VirtualUser::steps_this_iteration` counter. Neither kind sets `jumps_or_repeats` any more, so the refusal is now dormant (kept for a future kind that jumps in a way the load path genuinely can't support).

   **The one non-obvious bug this surfaced**: `take_ready_vu` used `vu.step == 0` as its "this VU is starting a fresh iteration" signal (claim a new iteration slot, bind a new data row). A `control.loop` that loops back to plan position 0 also sets `step = 0`, which the old check couldn't tell apart from a real iteration boundary - every loop pass got miscounted as a brand-new iteration, exhausting the run's iteration budget after a couple of passes. Fixed with an explicit `VirtualUser::iteration_boundary` flag, written only by `finish_step`'s own "end this iteration" branch. Caught by `ControlLoopRepeatsUnderLoad` and `ControlSwitchCycleIsCutOffByMaxStepsPerIteration` before the fix (both failed with the wrong iteration/abandon counts); both pass now.

2. **`control.throughput`'s `perUser: false`** shares one atomic counter pair across every virtual user of a scenario load run (JMeter's "All threads" throughput mode), instead of the existing one-counter-per-VU behaviour. `SharedThroughputCounters` allocates a slot per element up front from a plan scan (mirroring `TransactionHistograms`'s own no-lock pattern) - `everyN` is a plain `fetch_add`, `percent` a CAS loop so two VUs racing to spend the last of the budget never both win it. The scan identifies a shareable occurrence through a new `ElementKind::supports_shared_state` registry flag plus the occurrence's own `perUser` config value, never a `kind ==` comparison outside `core/elements` (the extensibility contract's rule 1). The sequential run's single implicit user already makes its own counter the "shared" instance, so `perUser` changes nothing there.

3. **`control.transaction`'s `includeTimers`** folds a between-member `timer.*` wait into the transaction's own running sum. The fold is generic and shared by both run modes (`fold_between_wait_into_open_transactions`, found through the registry's `category` field): it adds the just-completed step's `step.between` wait to the transaction's `controller_state` sum key whenever that step is not the transaction's own last member (whose sum has already closed and reported by the time any wait after it could run). `control.transaction`'s own `apply()` needed no changes at all - the fold writes into the exact key it already reads.

**Alternative considered and rejected** for `includeTimers`: giving `control.transaction` a second `step.between` occurrence to read the wait directly. Declined because `Element::apply` dispatches through one fixed `phase()` per compiled instance (no multi-phase element exists anywhere in the registry today), and reusing `ElementContext::response == nullptr` there would need a special case this element doesn't otherwise have. The caller-side fold, reading the registry's `category` the same way `TransactionHistograms`'s own plan scan already does, is the smaller, already-precedented change.

**Also fixed in this PR**: `engine/tests/fixtures/element-kinds.json` had not been regenerated since #1515 landed the controller family (commit `693f20f`) - it was missing all six `control.*` kinds entirely, a stale baseline the app's own `element-kinds.conformance.test.tsx` trusts. Running the suite regenerates it from the live registry; committed here alongside this PR's own schema additions (`perUser`, `includeTimers`) since touching the file was unavoidable either way.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e` then `ninja -C engine/build vayu_tests` - clean build, no warnings.
- `ctest --preset linux-dev` - full suite, **3133/3133 passed**, including 16 new/changed cases in `elements_controllers_test.cpp` (7 new `ElementsControllersLoadTest` cases for the jump mechanism, the shared throughput budget and includeTimers under load; 2 new sequential `includeTimers` cases; 2 `ControllerRegistry` schema cases; the old `LoadIncompatibleController` refusal cases replaced with one proving all six kinds are now silent).
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (via the repo's pre-commit hook) both clean on every changed file - one cognitive-complexity finding (`run_iteration` pushed past 25 by the `includeTimers` fold) fixed by extracting the whole `step.between` dispatch into its own `run_step_between` function, and one `performance-unnecessary-value-param` finding fixed with a `std::move`.
- Manually traced the two failing tests above back to the `iteration_boundary` root cause before writing the fix, rather than adjusting the assertions to match the buggy behaviour.

No user-visible change: engine-only, and the issue names no app work.

## Checklist
- [x] My code follows the style guidelines (clang-format 19 / clang-tidy 19 clean)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/elements.md`, `docs/engine/api-reference.md`, `docs/compare/vayu-vs-jmeter.md`, `engine/CLAUDE.md`)

## Related Issues
Closes #1569


---
_Generated by [Claude Code](https://claude.ai/code/session_01Arerqrim6CBaRP2tdBS6Rt)_