### PR TITLE
feat: has_warnings signal on the run list row (issue #1527)

### DIFF
--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -30,6 +30,7 @@ import {
 	FolderTree,
 	Pin,
 	PinOff,
+	AlertTriangle,
 } from "lucide-react";
 
 interface RunItemProps {
@@ -253,6 +254,17 @@ export default function RunItem({
 									<Pin className="w-2.5 h-2.5" />
 									{isLoadRun ? "Baseline" : "Pinned"}
 								</Badge>
+							)}
+							{/* #1527: the run finished with something to say - an
+							    unresolved variable, a pre-request script the load
+							    path skipped - that only its full report shows. No
+							    adjacent text carries this, so the icon names itself. */}
+							{run.summary?.hasWarnings && (
+								<AlertTriangle
+									className="w-3.5 h-3.5 shrink-0 text-warning-text"
+									role="img"
+									aria-label="This run has warnings - see its report"
+								/>
 							)}
 						</div>
 						{/* z-10: sits above the stretched activator below, so delete

--- a/app/src/modules/history/sidebar/RunItem.warnings.test.tsx
+++ b/app/src/modules/history/sidebar/RunItem.warnings.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The History row's warning glyph (issue #1527).
+ *
+ * `RunSummary.hasWarnings` is the only signal the row has for issue #1503's
+ * `warnings` array - the row never sees the array itself, only this boolean -
+ * so the glyph's presence is a straight read of that one field. No adjacent
+ * text says "this run has warnings" the way the status text explains the
+ * status dot, so the icon has to carry its own accessible name.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RunItem from "./RunItem";
+import type { Run } from "@/types";
+
+function loadRun(overrides: Partial<Run> = {}): Run {
+	return {
+		id: "run_1",
+		type: "load",
+		status: "completed",
+		startTime: 1_750_000_000_000,
+		endTime: 1_750_000_003_000,
+		requestId: "req_1",
+		environmentId: null,
+		summary: { url: "https://api.example.test/checkout", method: "POST" },
+		...overrides,
+	} as Run;
+}
+
+const noop = () => {};
+
+describe("RunItem warning glyph", () => {
+	it("shows the glyph when the row's summary carries hasWarnings", () => {
+		render(
+			<RunItem
+				run={loadRun({ summary: { hasWarnings: true } })}
+				onSelect={noop}
+				onDelete={noop}
+				isDeleting={false}
+			/>
+		);
+		expect(
+			screen.getByRole("img", { name: "This run has warnings - see its report" })
+		).toBeInTheDocument();
+	});
+
+	it("shows no glyph when hasWarnings is absent", () => {
+		render(
+			<RunItem
+				run={loadRun({ summary: { url: "https://api.example.test/checkout" } })}
+				onSelect={noop}
+				onDelete={noop}
+				isDeleting={false}
+			/>
+		);
+		expect(
+			screen.queryByRole("img", { name: "This run has warnings - see its report" })
+		).not.toBeInTheDocument();
+	});
+
+	// The false half, not only the absent one: a stale row from before this
+	// field existed and a row explicitly cleared both read the same way.
+	it("shows no glyph when hasWarnings is explicitly false", () => {
+		render(
+			<RunItem
+				run={loadRun({ summary: { hasWarnings: false } })}
+				onSelect={noop}
+				onDelete={noop}
+				isDeleting={false}
+			/>
+		);
+		expect(
+			screen.queryByRole("img", { name: "This run has warnings - see its report" })
+		).not.toBeInTheDocument();
+	});
+
+	it("shows no glyph on a run with no summary at all", () => {
+		render(
+			<RunItem
+				run={loadRun({ summary: undefined })}
+				onSelect={noop}
+				onDelete={noop}
+				isDeleting={false}
+			/>
+		);
+		expect(
+			screen.queryByRole("img", { name: "This run has warnings - see its report" })
+		).not.toBeInTheDocument();
+	});
+});

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1501,6 +1501,14 @@ export interface RunSummary {
 	 * show for one.
 	 */
 	scenario?: RunScenarioSummary;
+	/**
+	 * Whether the run's terminal report carries a non-empty `warnings` array
+	 * (issue #1527, extending #1503). Omitted, not `false`, for a run with
+	 * nothing to report - still running, or finished clean - which is what
+	 * lets the history row skip the glyph with a plain presence check rather
+	 * than an explicit `=== true`.
+	 */
+	hasWarnings?: boolean;
 }
 
 export interface Run {

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -6579,6 +6579,17 @@ itself - a row that shipped every step's name, method and URL would undo the
 reason `summary` exists. The manifest stays on `GET /runs/:runId`. Each of the
 four keys is omitted when the stored snapshot has no such key.
 
+**`hasWarnings`** (issue #1527) is `summary`'s eleventh key, `true` on a run
+whose stored `summary.warnings` array (issue #1503) is non-empty and
+**omitted** otherwise - a run still in progress, one whose terminal write
+failed, or one that finished with nothing to say. Unlike the other keys
+above, it is not read out of `config_snapshot` and not part of the cached
+compact summary: it is a completion-time fact, read fresh off the row on
+every poll, so a history surface that polled a still-running run sees the
+glyph appear on the next poll after it finishes, never stuck at the answer
+its first poll cached. The full `warnings` array itself stays on
+`GET /runs/:runId`'s `summary`.
+
 **`baseline`** is on every row, `true` only for a run pinned through
 [PUT /runs/:runId/baseline](#put-runsrunidbaseline). It is also on
 `GET /runs/:runId`, so a client that opened a run directly can draw the pin

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -892,6 +892,7 @@ struct is `db::Run` in `engine/include/vayu/types.hpp`.
 | `end_time`        | INTEGER | Unix ms; `0` = no end recorded (readers guard on `> 0`)      |
 | `summary`         | TEXT    | JSON: whole-run results, written once at terminal status (`""` = not written) |
 | `baseline`        | INTEGER | `1` when the run is pinned as a baseline. NOT NULL DEFAULT `0`               |
+| `has_warnings`    | INTEGER | `1` when `summary.warnings` is non-empty. NOT NULL DEFAULT `0`               |
 
 **`end_time`** is stamped on every terminal status write (`update_run_status`), and refined
 mid-run by `update_run_end_time` when a load run finishes generating. Both inserts also *seed*
@@ -911,6 +912,16 @@ which is what lets `sync_schema` `ALTER TABLE ADD COLUMN` it onto an existing
 `runs` table (the same pattern as `summary` and `requests.follow_redirects`);
 rows written before the column read as unpinned. **Retention reads it** - see
 below.
+
+**`has_warnings`** (issue #1527) is derived, never written directly: every
+`Database::update_run_summary` call parses the JSON it is about to store into
+`summary` and sets this column to whether that JSON's `warnings` array (issue
+#1503) is non-empty, in the same row write. The two columns are stamped
+together and can never disagree. It exists apart from `summary` so
+[`GET /runs`](api-reference.md#get-runs)'s paginated list can read it straight
+off the row it already fetched for every page - no extra query, and no risk
+of the compact-summary cache (`RunSummaryCache`, keyed on the immutable
+`config_snapshot`) ever caching a completion-time fact.
 
 **`summary`** holds the aggregates `GET /runs/:runId/report` used to rebuild by scanning every
 metric row of the run: totals, the cumulative latency percentiles, the status-code distribution,

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -1335,6 +1335,16 @@ struct Run {
     // sync_schema can ALTER TABLE ADD COLUMN it onto an existing runs table -
     // the same pattern as `summary` above and `requests.follow_redirects`.
     bool baseline = false; // INTEGER NOT NULL DEFAULT 0
+    // Whether the terminal `summary` above carries a non-empty `warnings`
+    // array (issue #1503). Derived and stamped by `Database::update_run_summary`
+    // itself, from the same JSON it is about to store, so the two can never
+    // disagree - never set anywhere else. Narrow and separate from `summary`
+    // (issue #1527) so the paginated list route can read it straight off the
+    // row already fetched for every page, with no cache and no per-row JSON
+    // parse: `RunSummaryCache` keys on the immutable `config_snapshot` and
+    // must never learn a completion-time fact, or a row cached while the run
+    // was still running would show no warnings forever.
+    bool has_warnings = false; // INTEGER NOT NULL DEFAULT 0
 };
 
 /**

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -369,7 +369,10 @@ inline auto make_storage (const std::string& path) {
     // finished; report from the sampled results alone".
     make_column ("summary", &Run::summary, default_value ("")),
     // Pinned-as-baseline flag; see Run::baseline for why retention reads it.
-    make_column ("baseline", &Run::baseline, default_value (false))),
+    make_column ("baseline", &Run::baseline, default_value (false)),
+    // Whether `summary` carries warnings; see Run::has_warnings. Same
+    // ADD-COLUMN-onto-an-existing-table shape as `baseline` above.
+    make_column ("has_warnings", &Run::has_warnings, default_value (false))),
 
     // Metric ticks: one wide row per persisted tick (the time series)
     make_table ("metric_ticks",
@@ -2893,6 +2896,14 @@ void Database::update_run_summary (const std::string& id, const std::string& sum
             return;
         }
         run->summary = summary;
+        // Derived here, from the same bytes about to be stored, rather than
+        // taken as a second parameter every caller would have to keep in sync
+        // by hand (issue #1527). A summary that fails to parse or carries no
+        // `warnings` array leaves the flag false.
+        const auto parsed =
+        nlohmann::json::parse (summary, nullptr, /*allow_exceptions=*/false);
+        run->has_warnings = parsed.is_object () && parsed.contains ("warnings") &&
+        parsed["warnings"].is_array () && !parsed["warnings"].empty ();
         impl_->storage.update (*run);
     });
 }

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -120,7 +120,11 @@ void add_scenario (nlohmann::json& dst, const nlohmann::json& src) {
 // `scenario` on a collection run only, both omitted rather than defaulted
 // when the snapshot carries neither. A malformed config_snapshot yields an
 // empty object, never an error - the full snapshot stays available on
-// GET /runs/:id.
+// GET /runs/:id. `hasWarnings` (issue #1527) is not built here and never
+// cached with the rest of this object - it is a completion-time fact, not
+// part of the immutable config_snapshot this function reads, so it is
+// merged into the row by `get_runs_response` after this (possibly cached)
+// object is retrieved.
 nlohmann::json build_run_summary (const std::string& config_snapshot) {
     nlohmann::json summary = nlohmann::json::object ();
     try {
@@ -656,7 +660,10 @@ nlohmann::json serialize_run_row (const vayu::db::Run& run, nlohmann::json summa
  * `summary` (nine keys) instead of the full `config_snapshot`, wrapped in the
  * same `{data, pagination}` envelope GET /runs/:id/metrics uses (post-#86); a
  * design run's row also carries `resultSummary` (statusCode + latencyMs), which
- * is what a reader would otherwise fetch a report per row to learn.
+ * is what a reader would otherwise fetch a report per row to learn. A row
+ * whose run finished with warnings carries `summary.hasWarnings: true`
+ * (#1527), read fresh off this page's own `Run` rows rather than through
+ * `summaries` - see the comment at its call site below for why.
  *
  * `summaries` spares the poll the work it would otherwise repeat: this is the
  * endpoint a visible history surface re-asks every 5s, and each call used to
@@ -695,6 +702,16 @@ vayu::http::RunSummaryCache& summaries) {
         auto row = serialize_run_row (run, summaries.summary_for (run.id, [&run] {
             return build_run_summary (run.config_snapshot);
         }));
+        // `hasWarnings` (issue #1527) is read straight off the `Run` row this
+        // page already fetched, never through `summaries` - `has_warnings` is
+        // a completion-time fact (`Database::update_run_summary` stamps it),
+        // and that cache keys on the immutable `config_snapshot` alone. Merged
+        // into this call's own copy of the cached summary, never back into the
+        // cache entry, so a row polled while still running is never stuck
+        // reporting no warnings once the run finishes.
+        if (run.has_warnings) {
+            row["summary"]["hasWarnings"] = true;
+        }
         if (const auto found = outcomes.find (run.id); found != outcomes.end ()) {
             row["resultSummary"]["statusCode"] = found->second.status_code;
             row["resultSummary"]["latencyMs"]  = found->second.latency_ms;
@@ -882,7 +899,13 @@ const std::string& body) {
     if (!updated) {
         return { 404, error_body (404, "Run not found") };
     }
-    return { 200, serialize_run_row (*updated, build_run_summary (updated->config_snapshot)) };
+    auto row = serialize_run_row (*updated, build_run_summary (updated->config_snapshot));
+    // Same merge as get_runs_response, and for the same reason: this
+    // docstring promises the list's own row shape (#1527).
+    if (updated->has_warnings) {
+        row["summary"]["hasWarnings"] = true;
+    }
+    return { 200, row };
 }
 
 /**

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1849,6 +1849,59 @@ TEST_F (DatabaseTest, UpdateRunSummaryForMissingRunIsIgnored) {
     EXPECT_FALSE (db.get_run ("run_gone").has_value ());
 }
 
+// Issue #1527: `has_warnings` is derived from the same bytes `update_run_summary`
+// stores, never set anywhere else - these mutation-check the derivation both
+// ways, so a change that drops it (or that always sets it) reddens one of them.
+TEST_F (DatabaseTest, UpdateRunSummaryStampsHasWarningsWhenWarningsIsNonEmpty) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    vayu::db::Run run;
+    run.id              = "run_1";
+    run.type            = vayu::RunType::Load;
+    run.status          = vayu::RunStatus::Completed;
+    run.start_time      = 1000;
+    run.config_snapshot = "{}";
+    db.create_run (run);
+
+    db.update_run_summary (
+    "run_1", R"({"warnings":[{"code":"unresolved_tokens","message":"x"}]})");
+
+    auto after = db.get_run ("run_1");
+    ASSERT_HAS_VALUE (after);
+    EXPECT_TRUE (after->has_warnings);
+}
+
+TEST_F (DatabaseTest, UpdateRunSummaryLeavesHasWarningsFalseWhenWarningsIsAbsentOrEmpty) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    vayu::db::Run run;
+    run.id              = "run_1";
+    run.type            = vayu::RunType::Load;
+    run.status          = vayu::RunStatus::Completed;
+    run.start_time      = 1000;
+    run.config_snapshot = "{}";
+    db.create_run (run);
+
+    db.update_run_summary ("run_1", R"({"total_requests":42})");
+    auto after_absent = db.get_run ("run_1");
+    ASSERT_HAS_VALUE (after_absent);
+    EXPECT_FALSE (after_absent->has_warnings);
+
+    db.update_run_summary ("run_1", R"({"total_requests":42,"warnings":[]})");
+    auto after_empty = db.get_run ("run_1");
+    ASSERT_HAS_VALUE (after_empty);
+    EXPECT_FALSE (after_empty->has_warnings);
+
+    // A summary a later write cannot parse must not crash and must not stamp
+    // a stale true forward.
+    db.update_run_summary ("run_1", "not json at all");
+    auto after_malformed = db.get_run ("run_1");
+    ASSERT_HAS_VALUE (after_malformed);
+    EXPECT_FALSE (after_malformed->has_warnings);
+}
+
 // ==================== Scratch-file cleanup ====================
 
 // `remove_database_files` is the single definition of what a scratch Database

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -408,6 +408,57 @@ TEST_F (RunsRouteTest, RepeatedPollsBuildEachSummaryOnce) {
     EXPECT_EQ (third["data"][0]["id"], "run_d");
 }
 
+// Issue #1527: a run with nothing to report carries no `hasWarnings` key at
+// all - "absent, not false" is this row's rule for every optional flag.
+TEST_F (RunsRouteTest, HasWarningsKeyOmittedWhenRunCarriesNone) {
+    seed ({ .id = "run_clean" });
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_FALSE (body["data"][0]["summary"].contains ("hasWarnings"));
+}
+
+// A run whose terminal summary carried warnings (#1503) surfaces that on its
+// list row, which is the whole of what this issue asks for.
+TEST_F (RunsRouteTest, HasWarningsTrueWhenTerminalSummaryCarriesWarnings) {
+    seed ({ .id = "run_warned" });
+    db_->update_run_summary ("run_warned",
+    R"({"warnings":[{"code":"unresolved_tokens","message":"x"}]})");
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["summary"]["hasWarnings"], true);
+}
+
+// The case #1527 exists to prove: `hasWarnings` must never be trapped behind
+// the compact summary's cache. A row polled while still running is cached
+// with no warnings (correctly, none exist yet); the run then finishes with
+// warnings; the very next poll - against the same cache, with no new build -
+// must show them. Reverting the merge in `get_runs_response` to read
+// `hasWarnings` off the cached summary instead of the live `Run` row would
+// pass every other case here and fail only this one.
+TEST_F (RunsRouteTest, HasWarningsReflectsCompletionDespiteTheCachedSummary) {
+    seed ({ .id = "run_finishing", .status = vayu::RunStatus::Running });
+
+    auto [first_status, first] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    EXPECT_EQ (first_status, 200);
+    EXPECT_FALSE (first["data"][0]["summary"].contains ("hasWarnings"));
+    EXPECT_EQ (summaries_.build_count (), 1u);
+
+    db_->update_run_summary ("run_finishing",
+    R"({"warnings":[{"code":"unresolved_tokens","message":"x"}]})");
+    db_->update_run_status_with_retry ("run_finishing", vayu::RunStatus::Completed);
+
+    auto [second_status, second] =
+    vayu::http::routes::get_runs_response (*db_, {}, 50, 0, summaries_);
+    EXPECT_EQ (second_status, 200);
+    EXPECT_EQ (second["data"][0]["summary"]["hasWarnings"], true);
+    // The compact summary itself was never rebuilt - only `hasWarnings`,
+    // merged in fresh every call, changed between the two polls.
+    EXPECT_EQ (summaries_.build_count (), 1u);
+}
+
 // A malformed snapshot reads as an empty summary on every call, not only the
 // first: the failure is cached like any other answer, and never becomes a 500.
 TEST_F (RunsRouteTest, MalformedSnapshotStaysEmptyAcrossPolls) {


### PR DESCRIPTION
## Description

The History sidebar's run list is built entirely from `config_snapshot` (what
was requested), so a run that finished with warnings (issue #1503 - an
unresolved `{{token}}`, a pre-request script the load path skipped) looked
identical to a clean one until you opened its report.

The wrinkle the linked issue called out: the list's compact `summary` is
cached by run id (`RunSummaryCache`, #1150), keyed on the assumption that
`config_snapshot` never changes after creation - which does not hold for a
completion-time fact like warnings. Reading `run.summary`'s `warnings` array
through that same cache risked permanently caching "no warnings" for a row
first polled while the run was still running.

Two shapes were on the table (per the issue). I went with a narrow
`has_warnings` column rather than parsing `run.summary` through the cache:
`Database::update_run_summary` derives it from the same JSON it is about to
store (so the two columns can never disagree, and no caller has to remember
to set it), and the list route reads it straight off the `Run` row it
already fetched for that page - no new query, and no cache involvement at
all, so `RunSummaryCache`'s cost characteristics are completely untouched.
`PUT /runs/:id/baseline` carries the same field, since its own docstring
already promises the list's row shape.

Also fixed in this PR: two clang-format-19 violations pre-existing on
`master` in `database.cpp` and `runs.cpp` (both files this PR already
touches, and CI's `Engine formatting` job lints whole touched files, so
they'd otherwise fail this PR's own format gate) - one-line whitespace
fixes, no behavioral change.

## Type of Change
- [x] New feature

## Testing

Engine: `python build.py -e -t`, then `ctest --preset linux-dev` for the full
`DatabaseTest`/`RunsRouteTest` suites (130/130 passed) plus the whole `-t`
suite build.py itself runs. Added:
- `DatabaseTest.UpdateRunSummaryStampsHasWarningsWhenWarningsIsNonEmpty` /
  `...LeavesHasWarningsFalseWhenWarningsIsAbsentOrEmpty` - the derivation,
  both directions, plus a malformed-JSON case.
- `RunsRouteTest.HasWarningsKeyOmittedWhenRunCarriesNone` /
  `...TrueWhenTerminalSummaryCarriesWarnings` - the row shape.
- `RunsRouteTest.HasWarningsReflectsCompletionDespiteTheCachedSummary` - the
  case the issue exists for: a row polled while running, then completed with
  warnings, shows them on the very next poll while `RunSummaryCache`'s
  `build_count()` stays unchanged (the compact summary was never rebuilt).

Mutation-checked by hand: reverted the merge in `get_runs_response` to a
no-op, confirmed the two `HasWarnings` route tests go red, restored it,
confirmed green again.

Also ran `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (via the
pre-commit hook) on every touched engine file - clean.

App: `pnpm test RunItem` (31/31), `pnpm type-check`, `pnpm lint`,
`pnpm format:check` - all clean. Added `RunItem.warnings.test.tsx`: the
glyph shows only when `hasWarnings` is `true` (not absent, not explicit
`false`, not on a run with no `summary` at all).

## Visual changes

No screenshot this run - this is a renderer-only icon addition (no native OS
UI, so the in-page-change carve-out applies), and the component test above
renders it and asserts both the icon's presence and its absence by role and
accessible name. Budget for this run went to the engine-side sanitizer/
format/tidy verification instead of also standing up a live Electron+Xvfb
session to seed a warned run and screenshot it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1527

---
_Generated by [Claude Code](https://claude.ai/code/session_016Hr2AJ1bsSEGU5czkaAHDx)_