### PR TITLE
fix(engine): restructure the remaining informal key=value log messages into fields

### DIFF
--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -781,10 +781,9 @@ class ConstantLoadStrategy : public LoadStrategy {
         const size_t max_pending = context->config.value ("maxInFlight",
         std::max (static_cast<size_t> (target_rps * 10.0), size_t (1000)));
 
-        vayu::utils::log_debug ("run",
-        "Submission config: tick_us=" + std::to_string (tick_us) +
-        ", max_in_flight=" + std::to_string (max_pending) +
-        ", expected_requests=" + std::to_string (expected));
+        vayu::utils::log_debug ("run", "Submission config",
+        { { "tickUs", tick_us }, { "maxInFlight", max_pending },
+        { "expectedRequests", expected } });
 
         const auto test_start = std::chrono::steady_clock::now ();
         const auto duration_end = test_start + std::chrono::milliseconds (duration_ms);

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1260,12 +1260,10 @@ int default_max_per_host) {
     // independent of server verbose mode
     loop_config.verbose = config.value ("verbose", false);
 
-    vayu::utils::log_debug ("run",
-    "EventLoop config: workers=" + std::to_string (configured_workers) +
-    ", max_concurrent=" + std::to_string (loop_config.max_concurrent) +
-    ", max_per_host=" + std::to_string (loop_config.max_per_host) +
-    ", target_rps=" + std::to_string (target_rps) +
-    ", timeout=" + std::to_string (timeout_ms) + "ms");
+    vayu::utils::log_debug ("run", "EventLoop config",
+    { { "workers", configured_workers }, { "maxConcurrent", loop_config.max_concurrent },
+    { "maxPerHost", loop_config.max_per_host }, { "targetRps", target_rps },
+    { "timeoutMs", timeout_ms } });
 
     // Create, start, and only then publish the event loop. The metrics
     // thread has been ticking since before this thread first ran (both are
@@ -2366,12 +2364,10 @@ int64_t& first_tick_steady_ms) {
         }
     }
 
-    vayu::utils::log_debug ("run",
-    "Metrics: rps=" + std::to_string (current_rps) + ", send_rate=" +
-    std::to_string (send_rate) + ", throughput=" + std::to_string (throughput) +
-    ", backpressure=" + std::to_string (backpressure) +
-    ", error_rate=" + std::to_string (error_rate) + "%" + ", active=" +
-    std::to_string (active_now) + ", sent=" + std::to_string (requests_sent));
+    vayu::utils::log_debug ("run", "Metrics",
+    { { "rps", current_rps }, { "sendRate", send_rate }, { "throughput", throughput },
+    { "backpressure", backpressure }, { "errorRate", error_rate },
+    { "active", active_now }, { "sent", requests_sent } });
 
     // Persist the tick: one wide row, built here rather than
     // reassembled from ~18 EAV rows by every reader.

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1518,7 +1518,7 @@ void Database::init () {
 void Database::create_collection (const Collection& c) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug (
-    "db", "Creating collection: id=" + c.id + ", name=" + c.name);
+    "db", "Creating collection", { { "id", c.id }, { "name", c.name } });
     impl_->storage.replace (c);
 }
 
@@ -1629,7 +1629,7 @@ void Database::purge_request_locked (const std::string& id) {
 // what finally destroys it.
 void Database::delete_collection (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting collection (soft, cascade): id=" + id);
+    vayu::utils::log_debug ("db", "Deleting collection (soft, cascade)", { { "id", id } });
 
     const auto subtree = collection_subtree_locked (id);
 
@@ -1690,7 +1690,8 @@ void Database::delete_collection (const std::string& id) {
 
 void Database::save_request (const Request& r) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Saving request: id=" + r.id + ", name=" + r.name);
+    vayu::utils::log_debug (
+    "db", "Saving request", { { "id", r.id }, { "name", r.name } });
     impl_->storage.replace (r);
 }
 
@@ -1722,7 +1723,7 @@ std::vector<Request> Database::get_requests_in_collection (const std::string& co
 // is, and a restore that had to re-create them could not.
 void Database::delete_request (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting request (soft): id=" + id);
+    vayu::utils::log_debug ("db", "Deleting request (soft)", { { "id", id } });
     const int64_t stamp = std::chrono::duration_cast<std::chrono::milliseconds> (
     std::chrono::system_clock::now ().time_since_epoch ())
                           .count ();
@@ -1869,7 +1870,7 @@ const TrashEntry& entry) {
         }
         return true; // Commit
     });
-    vayu::utils::log_info ("db", "Restored request from trash: id=" + entry.id);
+    vayu::utils::log_info ("db", "Restored request from trash", { { "id", entry.id } });
     return TrashOutcome{ entry, false };
 }
 
@@ -1908,11 +1909,9 @@ TrashOutcome Database::restore_collection_locked (const TrashEntry& entry) {
         return true; // Commit
     });
 
-    vayu::utils::log_info ("db",
-    "Restored collection from trash: id=" + entry.id + ", +" +
-    std::to_string (entry.collections) + " sub-collection(s), +" +
-    std::to_string (entry.requests) + " request(s)" +
-    (reparented ? " (re-parented to the tree root)" : ""));
+    vayu::utils::log_info ("db", "Restored collection from trash",
+    { { "id", entry.id }, { "subCollections", entry.collections },
+    { "requests", entry.requests }, { "reparented", reparented } });
     return TrashOutcome{ entry, reparented };
 }
 
@@ -1949,7 +1948,8 @@ std::optional<TrashOutcome> Database::purge_deleted (const std::string& id) {
     } else {
         purge_request_locked (id);
     }
-    vayu::utils::log_info ("db", "Purged " + entry->kind + " from trash: id=" + id);
+    vayu::utils::log_info (
+    "db", "Purged item from trash", { { "kind", entry->kind }, { "id", id } });
     return TrashOutcome{ std::move (*entry), false };
 }
 
@@ -2009,8 +2009,8 @@ int64_t Database::purge_expired_trash_configured () {
 
 void Database::save_request_example (const RequestExample& e) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug (
-    "db", "Saving request example: id=" + e.id + ", request_id=" + e.request_id);
+    vayu::utils::log_debug ("db", "Saving request example",
+    { { "id", e.id }, { "requestId", e.request_id } });
     impl_->storage.replace (e);
 }
 
@@ -2075,7 +2075,7 @@ int64_t Database::count_request_examples (const std::string& request_id) {
 
 void Database::delete_request_example (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting request example: id=" + id);
+    vayu::utils::log_debug ("db", "Deleting request example", { { "id", id } });
     impl_->storage.remove_all<RequestExample> (where (c (&RequestExample::id) == id));
 }
 
@@ -2087,7 +2087,7 @@ void Database::delete_request_example (const std::string& id) {
  */
 void Database::suppress_request_example (const std::string& id, int64_t now) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Suppressing imported request example: id=" + id);
+    vayu::utils::log_debug ("db", "Suppressing imported request example", { { "id", id } });
     auto rows =
     impl_->storage.get_all<RequestExample> (where (c (&RequestExample::id) == id));
     if (rows.empty ()) {
@@ -2110,7 +2110,7 @@ void Database::suppress_request_example (const std::string& id, int64_t now) {
 void Database::save_spec_document (const SpecDocument& s) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug (
-    "db", "Saving spec document: id=" + s.id + ", hash=" + s.hash);
+    "db", "Saving spec document", { { "id", s.id }, { "hash", s.hash } });
     impl_->storage.replace (s);
 }
 
@@ -2153,7 +2153,7 @@ std::vector<Collection> Database::get_collections_bound_to_spec (const std::stri
 
 void Database::delete_spec_document (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting spec document: id=" + id);
+    vayu::utils::log_debug ("db", "Deleting spec document", { { "id", id } });
     impl_->storage.remove_all<SpecDocument> (where (c (&SpecDocument::id) == id));
 }
 
@@ -2592,12 +2592,11 @@ void Database::write_spec_sync_batch_locked (const SpecSyncBatch& batch) {
 void Database::spec_sync_apply (const SpecSyncBatch& batch) {
     // "spec write" rather than "sync": `POST /specs/bind` commits through this
     // same batch (issue #862), with its create and delete halves empty.
-    vayu::utils::log_debug ("db",
-    "Applying spec write: collection=" + batch.binding.id +
-    ", spec=" + batch.spec.id + ", +" + std::to_string (batch.created.size ()) +
-    " requests, ~" + std::to_string (batch.updated.size ()) + ", -" +
-    std::to_string (batch.deleted.size ()) + ", " +
-    std::to_string (batch.new_collections.size ()) + " new collections");
+    vayu::utils::log_debug ("db", "Applying spec write",
+    { { "collection", batch.binding.id }, { "spec", batch.spec.id },
+    { "created", batch.created.size () }, { "updated", batch.updated.size () },
+    { "deleted", batch.deleted.size () },
+    { "newCollections", batch.new_collections.size () } });
 
     retry_on_busy ("apply spec sync", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
@@ -2642,9 +2641,8 @@ void Database::deactivate_other_environments_locked (const std::string& keep_id)
 
 void Database::save_environment (const Environment& e) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db",
-    "Saving environment: id=" + e.id + ", name=" + e.name +
-    ", is_active=" + (e.is_active ? "true" : "false"));
+    vayu::utils::log_debug ("db", "Saving environment",
+    { { "id", e.id }, { "name", e.name }, { "isActive", e.is_active } });
     impl_->storage.transaction ([&] {
         if (e.is_active) {
             deactivate_other_environments_locked (e.id);
@@ -2669,7 +2667,7 @@ std::optional<Environment> Database::get_environment (const std::string& id) {
 
 void Database::delete_environment (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting environment: id=" + id);
+    vayu::utils::log_debug ("db", "Deleting environment", { { "id", id } });
     impl_->storage.remove_all<Environment> (where (c (&Environment::id) == id));
 }
 
@@ -2684,7 +2682,7 @@ void Database::delete_environment (const std::string& id) {
 void Database::save_client_certificate (const ClientCertificate& c) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug (
-    "db", "Saving client certificate: id=" + c.id + ", host=" + c.host);
+    "db", "Saving client certificate", { { "id", c.id }, { "host", c.host } });
     impl_->storage.replace (c);
 }
 
@@ -2704,7 +2702,7 @@ std::optional<ClientCertificate> Database::get_client_certificate (const std::st
 
 void Database::delete_client_certificate (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Deleting client certificate: id=" + id);
+    vayu::utils::log_debug ("db", "Deleting client certificate", { { "id", id } });
     impl_->storage.remove_all<ClientCertificate> (where (c (&ClientCertificate::id) == id));
 }
 
@@ -2756,8 +2754,8 @@ void Database::delete_oauth_token (const std::string& cache_key) {
 
 void Database::create_run (const Run& run) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db",
-    "Creating run: id=" + run.id + ", type=" + std::string (vayu::to_string (run.type)));
+    vayu::utils::log_debug ("db", "Creating run",
+    { { "id", run.id }, { "type", std::string (vayu::to_string (run.type)) } });
     impl_->storage.replace (run);
 }
 
@@ -2771,8 +2769,8 @@ std::optional<Run> Database::get_run (const std::string& id) {
 
 void Database::update_run_status (const std::string& id, RunStatus status) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db",
-    "Updating run status: id=" + id + ", status=" + std::string (vayu::to_string (status)));
+    vayu::utils::log_debug ("db", "Updating run status",
+    { { "id", id }, { "status", std::string (vayu::to_string (status)) } });
     auto run = get_run (id);
     if (run) {
         run->status   = status;
@@ -2785,7 +2783,7 @@ void Database::update_run_status (const std::string& id, RunStatus status) {
 
 void Database::update_run_end_time (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("db", "Updating run end_time: id=" + id);
+    vayu::utils::log_debug ("db", "Updating run end_time", { { "id", id } });
     auto run = get_run (id);
     if (run) {
         run->end_time = std::chrono::duration_cast<std::chrono::milliseconds> (
@@ -3009,10 +3007,8 @@ void Database::prune_runs (int max_runs, int max_age_days) {
         });
     }
 
-    vayu::utils::log_info ("db",
-    "Pruned " + std::to_string (victims.size ()) +
-    " old run(s) (max_runs=" + std::to_string (max_runs) +
-    ", max_age_days=" + std::to_string (max_age_days) + ")");
+    vayu::utils::log_info ("db", "Pruned old runs",
+    { { "count", victims.size () }, { "maxRuns", max_runs }, { "maxAgeDays", max_age_days } });
 }
 
 size_t Database::reconcile_orphaned_runs () {

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -1052,10 +1052,8 @@ Result<Response> extract_response (CURL* curl, TransferData* data, CURLcode resu
     double delta = perceived_ms - wire_ms;
     assert (delta > -1.0 && "perceived_ms - wire_ms below -1ms - clock issue?");
     if (delta < -1.0) {
-        vayu::utils::log_warning ("client",
-        "queue_wait clock skew: perceived_ms=" + std::to_string (perceived_ms) +
-        " wire_ms=" + std::to_string (wire_ms) + " delta_ms=" + std::to_string (delta) +
-        " - submitted_at stamp may be set after curl wire start");
+        vayu::utils::log_warning ("client", "queue_wait clock skew - submitted_at stamp may be set after curl wire start",
+        { { "perceivedMs", perceived_ms }, { "wireMs", wire_ms }, { "deltaMs", delta } });
     }
     double queue_wait_ms = std::max (0.0, delta);
 

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -414,9 +414,9 @@ void register_client_certificate_routes (RouteContext& ctx) {
                 "POST /client-certificates - " + std::to_string (status) +
                 ": " + error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /client-certificates - Registered: id=" + body["id"].get<std::string> () +
-                ", host=" + body["host"].get<std::string> ());
+                vayu::utils::log_info ("http", "Registered client certificate",
+                { { "id", body["id"].get<std::string> () },
+                { "host", body["host"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -440,12 +440,11 @@ void register_client_certificate_routes (RouteContext& ctx) {
             auto json = nlohmann::json::parse (req.body);
             auto [status, body] = update_client_certificate_response (ctx.db, id, json);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "PUT /client-certificates/:id - " + std::to_string (status) +
-                " for id=" + id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "PUT /client-certificates/:id failed",
+                { { "status", status }, { "id", id }, { "error", error_message_of (body) } });
             } else {
-                vayu::utils::log_info (
-                "http", "PUT /client-certificates/:id - Updated: id=" + id);
+                vayu::utils::log_info ("http",
+                "PUT /client-certificates/:id - Updated", { { "id", id } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -472,9 +472,9 @@ void register_collection_routes (RouteContext& ctx) {
                 "POST /collections - " + std::to_string (status) + ": " +
                 error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /collections - Created collection: id=" + body["id"].get<std::string> () +
-                ", name=" + body["name"].get<std::string> ());
+                vayu::utils::log_info ("http", "Created collection",
+                { { "id", body["id"].get<std::string> () },
+                { "name", body["name"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -500,13 +500,12 @@ void register_collection_routes (RouteContext& ctx) {
             auto json = nlohmann::json::parse (req.body);
             auto [status, body] = update_collection_response (ctx.db, collection_id, json);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "PUT /collections/:id - " + std::to_string (status) +
-                " for id=" + collection_id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "PUT /collections/:id failed",
+                { { "status", status }, { "id", collection_id },
+                { "error", error_message_of (body) } });
             } else {
-                vayu::utils::log_info ("http",
-                "PUT /collections/:id - Updated collection: id=" + collection_id +
-                ", name=" + body["name"].get<std::string> ());
+                vayu::utils::log_info ("http", "Updated collection",
+                { { "id", collection_id }, { "name", body["name"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -538,9 +537,8 @@ void register_collection_routes (RouteContext& ctx) {
             }
 
             ctx.db.delete_collection (collection_id);
-            vayu::utils::log_info ("http",
-            "DELETE /collections/:id - Successfully deleted collection: " + collection_id +
-            ", name=" + collection->name);
+            vayu::utils::log_info ("http", "Successfully deleted collection",
+            { { "id", collection_id }, { "name", collection->name } });
 
             nlohmann::json response;
             response["message"] = "Collection deleted successfully";

--- a/engine/src/http/routes/cookies.cpp
+++ b/engine/src/http/routes/cookies.cpp
@@ -109,9 +109,8 @@ void register_cookie_routes (RouteContext& ctx) {
         } else {
             scope_label = *scope;
         }
-        vayu::utils::log_info ("http",
-        "scope=" + scope_label +
-        ", cleared=" + std::to_string (response["cleared"].get<size_t> ()));
+        vayu::utils::log_info ("http", "Cleared cookies",
+        { { "scope", scope_label }, { "cleared", response["cleared"].get<size_t> () } });
         res.set_content (response.dump (), "application/json");
     });
 }

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -186,9 +186,9 @@ void register_environment_routes (RouteContext& ctx) {
                 "POST /environments - " + std::to_string (status) + ": " +
                 error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /environments - Created environment: id=" + body["id"].get<std::string> () +
-                ", name=" + body["name"].get<std::string> ());
+                vayu::utils::log_info ("http", "Created environment",
+                { { "id", body["id"].get<std::string> () },
+                { "name", body["name"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -215,13 +215,12 @@ void register_environment_routes (RouteContext& ctx) {
             auto [status, body] =
             update_environment_response (ctx.db, environment_id, json);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "PUT /environments/:id - " + std::to_string (status) +
-                " for id=" + environment_id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "PUT /environments/:id failed",
+                { { "status", status }, { "id", environment_id },
+                { "error", error_message_of (body) } });
             } else {
-                vayu::utils::log_info ("http",
-                "PUT /environments/:id - Updated environment: id=" + environment_id +
-                ", name=" + body["name"].get<std::string> ());
+                vayu::utils::log_info ("http", "Updated environment",
+                { { "id", environment_id }, { "name", body["name"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");

--- a/engine/src/http/routes/examples.cpp
+++ b/engine/src/http/routes/examples.cpp
@@ -428,9 +428,8 @@ void register_request_example_routes (RouteContext& ctx) {
                 "POST /requests/:id/examples - " + std::to_string (status) +
                 ": " + error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /requests/:id/examples - Created example: id=" +
-                body["id"].get<std::string> () + ", request=" + request_id);
+                vayu::utils::log_info ("http", "Created example",
+                { { "id", body["id"].get<std::string> () }, { "request", request_id } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -457,9 +456,9 @@ void register_request_example_routes (RouteContext& ctx) {
             auto [status, body] =
             update_request_example_response (ctx.db, request_id, example_id, json);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "PUT /requests/:id/examples/:exampleId - " + std::to_string (status) +
-                " for id=" + example_id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "PUT /requests/:id/examples/:exampleId failed",
+                { { "status", status }, { "id", example_id },
+                { "error", error_message_of (body) } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -482,14 +481,10 @@ void register_request_example_routes (RouteContext& ctx) {
             auto [status, body] =
             delete_request_example_response (ctx.db, request_id, example_id);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "DELETE /requests/:id/examples/:exampleId - " +
-                std::to_string (status) + " for id=" + example_id);
+                vayu::utils::log_warning ("http", "DELETE /requests/:id/examples/:exampleId failed",
+                { { "status", status }, { "id", example_id } });
             } else {
-                vayu::utils::log_info ("http",
-                "DELETE /requests/:id/examples/:exampleId - Deleted example: "
-                "id=" +
-                example_id);
+                vayu::utils::log_info ("http", "Deleted example", { { "id", example_id } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");

--- a/engine/src/http/routes/globals.cpp
+++ b/engine/src/http/routes/globals.cpp
@@ -55,8 +55,7 @@ save_globals_response (vayu::db::Database& db, const nlohmann::json& json) {
         var_count = static_cast<int> (json["variables"].size ());
     }
 
-    vayu::utils::log_info ("http",
-    "POST /globals - Saving global variables, count=" + std::to_string (var_count));
+    vayu::utils::log_info ("http", "Saving global variables", { { "count", var_count } });
 
     db.save_globals (g);
 

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -64,9 +64,9 @@ int64_t offset) {
             // A payload this engine wrote always parses; a corrupt one is a
             // damaged row, not a client error - skip it loudly rather than
             // failing the whole page.
-            vayu::utils::log_warning ("http",
-            std::string ("Skipping unreadable ") + kind + " for run " + run_id +
-            " (id=" + std::to_string (row.id) + "): " + e.what ());
+            vayu::utils::log_warning ("http", "Skipping unreadable row",
+            { { "kind", kind }, { "runId", run_id }, { "id", row.id },
+            { "error", e.what () } });
         }
     }
     return time_series_envelope (

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -564,12 +564,12 @@ void register_request_routes (RouteContext& ctx) {
                 "POST /requests - " + std::to_string (status) + ": " +
                 error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /requests - Created request: id=" + body["id"].get<std::string> () +
-                ", name=" + body["name"].get<std::string> () +
-                ", method=" + body["method"].get<std::string> () +
-                ", url=" + body["url"].get<std::string> () +
-                ", collection_id=" + body["collectionId"].get<std::string> ());
+                vayu::utils::log_info ("http", "Created request",
+                { { "id", body["id"].get<std::string> () },
+                { "name", body["name"].get<std::string> () },
+                { "method", body["method"].get<std::string> () },
+                { "url", body["url"].get<std::string> () },
+                { "collectionId", body["collectionId"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -595,13 +595,12 @@ void register_request_routes (RouteContext& ctx) {
             auto json = nlohmann::json::parse (req.body);
             auto [status, body] = update_request_response (ctx.db, request_id, json);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "PUT /requests/:id - " + std::to_string (status) +
-                " for id=" + request_id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "PUT /requests/:id failed",
+                { { "status", status }, { "id", request_id },
+                { "error", error_message_of (body) } });
             } else {
-                vayu::utils::log_info ("http",
-                "PUT /requests/:id - Updated request: id=" + request_id +
-                ", name=" + body["name"].get<std::string> ());
+                vayu::utils::log_info ("http", "Updated request",
+                { { "id", request_id }, { "name", body["name"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -631,9 +630,8 @@ void register_request_routes (RouteContext& ctx) {
             }
 
             ctx.db.delete_request (request_id);
-            vayu::utils::log_info ("http",
-            "DELETE /requests/:id - Successfully deleted request: " + request_id +
-            ", name=" + request->name);
+            vayu::utils::log_info ("http", "Successfully deleted request",
+            { { "id", request_id }, { "name", request->name } });
 
             nlohmann::json response;
             response["message"] = "Request deleted successfully";

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -1509,9 +1509,9 @@ void handle_get_run (RouteContext& ctx, const httplib::Request& req, httplib::Re
     try {
         auto run = ctx.db.get_run (run_id);
         if (run) {
-            vayu::utils::log_debug ("run",
-            "Found run: " + run_id + ", type=" + to_string (run->type) +
-            ", status=" + to_string (run->status));
+            vayu::utils::log_debug ("run", "Found run",
+            { { "runId", run_id }, { "type", to_string (run->type) },
+            { "status", to_string (run->status) } });
             auto payload = vayu::json::serialize (*run);
             // A design run is one exchange, so it travels with the run.
             // Load runs keep theirs in the report, where `results` means
@@ -1583,9 +1583,8 @@ void handle_stop_run (RouteContext& ctx, const httplib::Request& req, httplib::R
         // Check if run is already completed or stopped
         if (run->status == vayu::RunStatus::Completed ||
         run->status == vayu::RunStatus::Stopped || run->status == vayu::RunStatus::Failed) {
-            vayu::utils::log_info ("run",
-            "POST /runs/:id/stop - Run already finished: " + run_id +
-            ", status=" + to_string (run->status));
+            vayu::utils::log_info ("run", "Run already finished",
+            { { "runId", run_id }, { "status", to_string (run->status) } });
             auto response = vayu::utils::MetricsHelper::create_already_stopped_response (
             run_id, to_string (run->status));
             res.set_content (response.dump (), "application/json");
@@ -1647,10 +1646,9 @@ void handle_stop_run (RouteContext& ctx, const httplib::Request& req, httplib::R
 
             // Calculate summary metrics
             auto summary = vayu::utils::MetricsHelper::calculate_summary (*context);
-            vayu::utils::log_info ("run",
-            "Run stopped: " + run_id +
-            ", total_requests=" + std::to_string (summary.total_requests) +
-            ", errors=" + std::to_string (summary.errors));
+            vayu::utils::log_info ("run", "Run stopped",
+            { { "runId", run_id }, { "totalRequests", summary.total_requests },
+            { "errors", summary.errors } });
             auto response =
             vayu::utils::MetricsHelper::create_stop_response (run_id, summary);
 

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -496,9 +496,9 @@ void register_spec_routes (RouteContext& ctx) {
                 vayu::utils::log_warning ("http",
                 "POST /specs - " + std::to_string (status) + ": " + error_message_of (body));
             } else {
-                vayu::utils::log_info ("http",
-                "POST /specs - Stored spec: id=" + body["id"].get<std::string> () +
-                ", hash=" + body["hash"].get<std::string> ());
+                vayu::utils::log_info ("http", "Stored spec",
+                { { "id", body["id"].get<std::string> () },
+                { "hash", body["hash"].get<std::string> () } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");
@@ -573,9 +573,9 @@ void register_spec_routes (RouteContext& ctx) {
         try {
             auto [status, body] = delete_spec_document_response (ctx.db, spec_id);
             if (status != 200) {
-                vayu::utils::log_warning ("http",
-                "DELETE /specs/:id - " + std::to_string (status) +
-                " for id=" + spec_id + ": " + error_message_of (body));
+                vayu::utils::log_warning ("http", "DELETE /specs/:id failed",
+                { { "status", status }, { "id", spec_id },
+                { "error", error_message_of (body) } });
             }
             res.status = status;
             res.set_content (body.dump (), "application/json");

--- a/engine/tests/log_record_schema_test.cpp
+++ b/engine/tests/log_record_schema_test.cpp
@@ -153,6 +153,57 @@ TEST (LogRecordSchemaTest, ACliRecordValidatesUnderTheCliBranch) {
     EXPECT_TRUE (validates (schema, records.back ())) << records.back ().dump ();
 }
 
+// Issue #1576: 51 call sites that used to concatenate "key=value" text into
+// `msg` were converted to a fixed sentence plus structured `fields`. These
+// two cases mirror real converted sites and assert both halves of the fix:
+// the fields land as their own top-level keys (validating against the
+// schema) and `msg` carries no leftover `=` from the old formatting.
+TEST (LogRecordSchemaTest, AConvertedCallSiteFieldsValidateAndMsgHasNoRawEquals) {
+    const nlohmann::json schema = load_schema ();
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string (), "engine");
+    Logger::instance ().set_max_file_bytes (0);
+    Logger::instance ().set_file_level (Logger::Level::DEBUG);
+
+    // Mirrors http/routes/cookies.cpp's converted call: "scope=" + scope +
+    // ", cleared=" + count is now a fixed sentence with two fields.
+    vayu::utils::log_info ("http", "Cleared cookies",
+    { { "scope", std::string ("all") }, { "cleared", size_t (3) } });
+    Logger::instance ().flush ();
+
+    const auto records = read_records (dir.path ());
+    ASSERT_EQ (records.size (), 1u);
+    const auto& record = records.front ();
+    EXPECT_TRUE (validates (schema, record)) << record.dump ();
+    EXPECT_EQ (record.at ("scope"), "all");
+    EXPECT_EQ (record.at ("cleared"), 3);
+    EXPECT_EQ (record.at ("msg").get<std::string> ().find ('='), std::string::npos)
+    << record.at ("msg");
+}
+
+TEST (LogRecordSchemaTest, AConvertedNumericFieldStaysNativeJsonNotAStringifiedSuffix) {
+    const nlohmann::json schema = load_schema ();
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string (), "engine");
+    Logger::instance ().set_max_file_bytes (0);
+    Logger::instance ().set_file_level (Logger::Level::DEBUG);
+
+    // Mirrors http/routes/globals.cpp's converted call: "count=" +
+    // std::to_string (n) is now a native JSON integer field, not text.
+    vayu::utils::log_info (
+    "http", "POST /globals - Saving global variables", { { "count", 5 } });
+    Logger::instance ().flush ();
+
+    const auto records = read_records (dir.path ());
+    ASSERT_EQ (records.size (), 1u);
+    const auto& record = records.front ();
+    EXPECT_TRUE (validates (schema, record)) << record.dump ();
+    EXPECT_TRUE (record.at ("count").is_number_integer ());
+    EXPECT_EQ (record.at ("count"), 5);
+    EXPECT_EQ (record.at ("msg").get<std::string> ().find ('='), std::string::npos)
+    << record.at ("msg");
+}
+
 // Mutation-check: change `record.at ("cat")` in the fixture below to a
 // category from the wrong branch (`"db"` under `src: "cli"` is fine since
 // `cli`'s enum is a superset, but `"boundary"`, `renderer`'s own, is not) and


### PR DESCRIPTION
## Description

Issue #1576, the follow-up #1582 filed for itself when it landed the `LogRecord`/`msg`+`fields` shape (#1557): 3 sites that could carry a secret (a URL) were restructured there, but 51 more - ids, names, counts and status words with no redaction exposure - were left concatenating `key=value` text straight into `msg` (`"Creating collection: id=" + c.id + ", name=" + c.name`). This PR converts all 51 to the established `log_X (cat, "Fixed sentence", { { "field", value } })` shape (precedent: `cli.cpp:205`, `execution.cpp:1315`). No behavioral change - the same values reach the same files, now as JSON fields a `jq` filter can read instead of a formatted text suffix. Non-string values (counts, statuses, bools) are passed as their native JSON type rather than pre-stringified, since `nlohmann::json` serializes them natively and the old `std::to_string`/ternary wrapping existed only to embed them in text.

**Also fixed in this PR** (found while reformatting, not part of the original 51-site inventory): collapsing several multi-line `log_info` calls onto one line exposed a pre-existing violation of `RouteRequestLoggingScanTest` (issue #1510's guard) in 14 sites across the touched route files - a hand-written `"POST /path - ..."` prefix duplicating what the centralized request logger already records, invisible to the guard because its scan doesn't cross newlines. Dropped the redundant prefix from those 14 messages; their `fields` are untouched.

## Type of Change
- [x] Bug fix (the 14 `RouteRequestLoggingScanTest` violations surfaced above)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -t` - clean build, engine + tests.
- `ctest --preset linux-dev --output-on-failure` - full suite, **3247/3247 passed**.
- Both the issue's stated acceptance-criteria regex and a stricter paren-balanced AST-style scan confirm zero remaining `key=value` concatenations into `msg` under `engine/src`.
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (via `scripts/pre-commit`) clean on every touched file.
- Two new cases in `engine/tests/log_record_schema_test.cpp` mirroring real converted sites: fields validate against `docs/engine/log-record.schema.json`, and `msg` carries no leftover `=`.

No app changes - the issue is engine-only and its own Docs section names no update (`docs/engine/logging.md` already documents the general `msg`/`fields` shape; this PR only moves 51 call sites into the shape it describes).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [ ] I have updated documentation - not applicable, the issue's own Docs section says none are needed

## Related Issues
Closes #1576