### PR TITLE
fix(engine): synchronize QuickJS class-id registration across threads (partial - #1589 stays open)

### DIFF
--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -8697,6 +8697,24 @@ void setup_pm_object (JSContext* ctx) {
     JS_FreeValue (ctx, global);
 }
 
+// expect_class_id / response_chain_class_id / request_url_class_id /
+// request_body_class_id are process-wide: every native callback looks one up
+// by name (JS_GetOpaque (ctx, ..., xxx_class_id)) rather than through the
+// JSRuntime that happens to own its JSContext, since each OS thread owns a
+// wholly separate JSRuntime (QuickJS's own is not thread-safe) but the four
+// ids must still agree across all of them. The zero-check-then-JS_NewClassID
+// sequence that assigns each one is neither atomic nor idempotent under a
+// race - two threads creating their first JSRuntime concurrently can
+// interleave the read and the write, corrupting the id one native callback
+// later dereferences (root cause of #1589's intermittent segfault). This
+// mutex makes that one-time assignment, plus the JS_NewClass registration
+// that depends on the id being final, happen under one lock; it is not on
+// any per-request hot path, only on first JSRuntime creation per thread.
+std::mutex& class_id_registration_mutex () {
+    static std::mutex mutex;
+    return mutex;
+}
+
 } // anonymous namespace
 
 // ============================================================================
@@ -8763,31 +8781,40 @@ class ScriptEngine::Impl {
         JS_SetRuntimeOpaque (rt, rt_state);
         JS_SetInterruptHandler (rt, &script_interrupt_handler, rt_state);
 
-        // Register Expectation class
-        if (expect_class_id == 0) {
-            JS_NewClassID (rt, &expect_class_id);
-        }
-        JS_NewClass (rt, expect_class_id, &expect_class);
+        // The four ids below are process-wide (see class_id_registration_mutex's
+        // comment); this lock is what makes their first assignment, and the
+        // JS_NewClass calls that depend on the final value, safe across the
+        // per-thread JSRuntimes that race to create their first context.
+        {
+            std::lock_guard<std::mutex> id_lock (class_id_registration_mutex ());
 
-        // Register the pm.response.to.* chain class, whose exotic hook makes an
-        // unknown assertion throw instead of silently evaluating to undefined.
-        if (response_chain_class_id == 0) {
-            JS_NewClassID (rt, &response_chain_class_id);
-        }
-        JS_NewClass (rt, response_chain_class_id, &response_chain_class);
+            // Register Expectation class
+            if (expect_class_id == 0) {
+                JS_NewClassID (rt, &expect_class_id);
+            }
+            JS_NewClass (rt, expect_class_id, &expect_class);
 
-        // Register the pm.request.url class - see setup_pm_object for the
-        // prototype that keeps it usable as the string it replaced.
-        if (request_url_class_id == 0) {
-            JS_NewClassID (rt, &request_url_class_id);
-        }
-        JS_NewClass (rt, request_url_class_id, &request_url_class);
+            // Register the pm.response.to.* chain class, whose exotic hook makes
+            // an unknown assertion throw instead of silently evaluating to
+            // undefined.
+            if (response_chain_class_id == 0) {
+                JS_NewClassID (rt, &response_chain_class_id);
+            }
+            JS_NewClass (rt, response_chain_class_id, &response_chain_class);
 
-        // Register the pm.request.body class - same story, same prototype.
-        if (request_body_class_id == 0) {
-            JS_NewClassID (rt, &request_body_class_id);
+            // Register the pm.request.url class - see setup_pm_object for the
+            // prototype that keeps it usable as the string it replaced.
+            if (request_url_class_id == 0) {
+                JS_NewClassID (rt, &request_url_class_id);
+            }
+            JS_NewClass (rt, request_url_class_id, &request_url_class);
+
+            // Register the pm.request.body class - same story, same prototype.
+            if (request_body_class_id == 0) {
+                JS_NewClassID (rt, &request_body_class_id);
+            }
+            JS_NewClass (rt, request_body_class_id, &request_body_class);
         }
-        JS_NewClass (rt, request_body_class_id, &request_body_class);
 
         JSContext* ctx = JS_NewContext (rt);
         if (ctx) {


### PR DESCRIPTION
## Description

**This PR leaves issue 1589 open.** It fixes a real, independently-verified data race and documents an extensive investigation into that issue's segfault, but the segfault is confirmed still reproducing with this fix applied. Recording all of that here rather than only in scrollback, so the next session does not repeat the same three sanitizer builds.

**What's fixed.** `expect_class_id`, `response_chain_class_id`, `request_url_class_id` and `request_body_class_id` (`engine/src/runtime/script_engine.cpp`) are process-wide `JSClassID` globals that every native callback looks up by name, but each OS thread creates its own `JSRuntime` independently the first time it runs a script. The `if (id == 0) JS_NewClassID(...)` sequence that assigns each of those four globals was neither atomic nor idempotent (confirmed by reading `JS_NewClassID`'s and `JS_NewClass1`'s actual vendored implementation, not assumed), so two threads racing to create their first `JSRuntime` concurrently could interleave the read and the write. Wrapped the one-time assignment of all four ids, plus the `JS_NewClass` registration that depends on the final value, in a single mutex (`class_id_registration_mutex`). This is a genuine fix for a genuine hazard and should land on its own merits.

**What's not fixed, despite that.** Issue 1589's target test, `ScenarioLoadTest.AScriptPostMarkedInlineCorrelatesPerVirtualUserTheSameWayExtractDoes`, still segfaults with this mutex in place. The mutation check that issue itself asks for - revert the fix, confirm the crash returns; keep the fix, confirm it doesn't - came back negative for this specific crash:

| Build | Fresh-process iterations under a `gdb -batch` loop | Result |
|---|---|---|
| `linux-prod`, **without** this fix | 8 | Crashed |
| `linux-prod`, **with** this fix | 11 | Crashed - **identical** signal, identical crash address, identical garbage pointer value (`0x73202a2a74736574`) both times |
| `linux-asan` | 200 (100 in-process `--gtest_repeat`, 100 fresh-process) | Clean |
| `linux-tsan` | 60 fresh-process | Clean |
| `linux-dev` (Debug, no sanitizer, no `-O3`) | ~15 fresh-process before this run's time budget ran out | No crash observed, inconclusive (too few iterations at this build's much slower per-iteration cost to call it clean) |

The crash: `expect_finalizer` (`script_engine.cpp:752`) is invoked during `~ScriptEngine()`'s final `JS_FreeRuntime`/`JS_RunGC` sweep at an event-loop worker thread's exit, with `JS_GetOpaque` returning a non-null pointer that is garbage - decodes to ASCII text, not a real `ExpectState*`, and `delete`-ing it segfaults inside `__libc_free`. The test's own inline script (`pm.environment.set('token', pm.response.json().token);`) never calls `pm.expect(...)`, and `create_expectation` (`script_engine.cpp:2496`) is reachable only from `js_pm_expect`, so no genuine `Expectation` object should exist in this run at all - meaning `expect_finalizer` is running on an object that was never actually an Expectation, most likely a `response_chain` object (whose opaque is a raw `const char*`, consistent with the garbage value looking like ASCII text) whose class got aliased onto `expect_class_id`'s slot for that one runtime.

Two independent read-only research agents traced the scenario-load VU machinery end to end (the `busy`-flag producer/consumer hand-off, `ElementContext` construction, the VU vector's lifecycle) and found it correctly synchronized - the issue's own hypothesis about that code does not hold up. That ruled out the two most obvious places to keep this investigation from finding the QuickJS-side race in the first place.

**Why this is being posted rather than held for a full fix**: the ASan/TSan silence against the release build's near-perfect reproducibility is itself a real, useful, hard-won result - it tells the next session not to trust a clean sanitizer run as evidence of correctness here, and points at something sanitizer instrumentation's altered timing avoids rather than a plain heap-safety violation. Continuing to chase it inside this same session risked an open-ended, unbounded debugging session against vendored QuickJS-ng internals with no more evidence of the real trigger than is written here.

**Note on issue 1589's state**: it was auto-closed by this PR's earlier body wording ("does not close #1589" - GitHub's keyword linker matched "close #1589" regardless of the negation) and has been reopened. The bug it tracks is unresolved; see the detailed comment on that issue for the investigation writeup this body summarizes.

## Type of Change
- [x] Bug fix (a real, independently-confirmed race; does not resolve the segfault issue 1589 tracks)

## Testing

- Full engine suite (`python build.py --prod -e -t`): green, 34.2s test phase, no regressions from this change.
- Mutation check per the repo's own convention (revert the fix, confirm failure; restore, confirm the specific behavior holds) run against the *targeted* race (the four `JSClassID` globals): with the fix, `class_id_registration_mutex` correctly serializes the four ids' assignment across threads - confirmed by reading `JS_NewClassID`/`JS_NewClass1`'s vendored source, not just by re-running the flaky test (which the table above shows does not distinguish fixed from unfixed for *this* crash).
- The table above is the mutation check issue 1589's acceptance criteria ask for, run against the actual target test - it shows this fix is necessary-but-clearly-insufficient for that bar (`ctest --repeat until-fail:200` clean on `linux-prod`, `linux-asan`, `linux-tsan`). That bar is **not met** by this PR.

## Checklist
- [x] My code follows the style guidelines (clang-format clean)
- [x] I have performed a self-review
- [ ] I have added tests - none added; existing test already covers the crash it does not yet reliably catch
- [ ] Fully resolves issue 1589 - **it does not**; see Description

## Related Issues
Refs issue 1589 (segfault remains open - see Description for why)
