### PR TITLE
fix(engine): fold pre-cutover script columns without assuming elements exists

### DIFF
--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -219,16 +219,23 @@ constructor's own validation probe) opens `path` with a raw `sqlite3` connection
    as "will not open" and quarantined the way a genuinely corrupt file is. Equal to `SCHEMA_VERSION`
    is a fast no-op. `0` (every database written before this issue, folded by #1513's pass or not)
    proceeds to fold.
-2. **Fold, if either table still has the script columns.** For each of `requests` and
-   `collections` that does: `<db>.pre-migration.bak` is written once, immediately before the first
-   row is rewritten (issue #1487's rule - the one on-disk copy of the exact pre-cutover script text
-   if the fold below were ever found wrong), then in one transaction, per row: parse `elements`,
+2. **Fold, if either table still has a script column.** For each of `requests` and `collections`
+   that does (either `pre_request_script` or `post_request_script` alone is enough - a table needs
+   folding for): `<db>.pre-migration.bak` is written once, immediately before the first row is
+   rewritten (issue #1487's rule - the one on-disk copy of the exact pre-cutover script text if the
+   fold below were ever found wrong), then in one transaction, per table: read its actual column set
+   fresh (`PRAGMA table_info`), `ALTER TABLE ... ADD COLUMN elements TEXT NOT NULL DEFAULT '[]'` when
+   the column is not there yet - a genuinely pre-cutover database (older than #1513) never ran the
+   additive pass that would have added it, so this migration is the first thing that does - and
+   select `''` for whichever script column the table does not carry, rather than a `SELECT` that
+   names a column absent from this row's table and fails to prepare. Then, per row: parse `elements`,
    append a `{"id": "el_...", "kind": "script.pre" | "script.post", "enabled": true, "config":
    {"script": "..."}}` for each non-blank script column *not already represented* in `elements` (the
    check that makes a database #1513's additive pass already folded safe to re-run through this
    migration without a duplicate), and write the row back. A database neither table needs folding
    for (a fresh install, or one some other path already brought to this shape) skips the backup and
-   the transaction.
+   the transaction. A fold failure rolls the transaction back and throws, naming the SQLite message
+   that caused it.
 3. **Set `user_version = 1`.** Only after this returns does `sync_schema ()` see a mapping with no
    `pre_request_script` / `post_request_script` columns and `ALTER TABLE ... DROP COLUMN` them -
    the ordering this migration exists to guarantee, per `engine/CLAUDE.md`'s "Removing a column"

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1051,26 +1051,39 @@ bool is_blank_script_text (const std::string& text) {
     return text.find_first_not_of (" \t\r\n") == std::string::npos;
 }
 
-/// Whether @p table's schema still carries `pre_request_script` (issue
-/// #1514's cut-over target). False for a fresh install (the table does not
-/// exist yet) and for a database this or an earlier engine build already
-/// migrated by some other means.
-bool table_has_script_columns (sqlite3* connection, const char* table) {
+/// @p table's current column names, read fresh so a caller never assumes a
+/// shape a genuinely pre-cutover database (older than #1513, no `elements`
+/// column at all) does not have.
+std::vector<std::string> table_columns (sqlite3* connection, const char* table) {
     const std::string sql   = std::string ("PRAGMA table_info(") + table + ");";
     sqlite3_stmt* statement = nullptr;
+    std::vector<std::string> columns;
     if (sqlite3_prepare_v2 (connection, sql.c_str (), -1, &statement, nullptr) != SQLITE_OK) {
-        return false;
+        return columns;
     }
-    bool found = false;
     while (sqlite3_step (statement) == SQLITE_ROW) {
         const auto* name = column_text (statement, 1);
-        if (name != nullptr && std::string_view (name) == "pre_request_script") {
-            found = true;
-            break;
+        if (name != nullptr) {
+            columns.emplace_back (name);
         }
     }
     sqlite3_finalize (statement);
-    return found;
+    return columns;
+}
+
+bool has_column (const std::vector<std::string>& columns, std::string_view name) {
+    return std::find (columns.begin (), columns.end (), name) != columns.end ();
+}
+
+/// Whether @p table's schema still carries `pre_request_script` or
+/// `post_request_script` (issue #1514's cut-over target) - either alone is
+/// enough to need the fold below, since a row can carry just one. False for a
+/// fresh install (the table does not exist yet) and for a database this or an
+/// earlier engine build already migrated by some other means.
+bool table_has_script_columns (sqlite3* connection, const char* table) {
+    const auto columns = table_columns (connection, table);
+    return has_column (columns, "pre_request_script") ||
+    has_column (columns, "post_request_script");
 }
 
 /**
@@ -1116,17 +1129,40 @@ const std::string& post) {
 /**
  * Fold @p table's `pre_request_script` / `post_request_script` into
  * `elements`, row by row, on the still-open @p connection. Returns false on
- * the first SQLite error, which aborts the whole migration (the caller rolls
- * the transaction back) rather than leaving some rows folded and others not.
+ * the first SQLite error (message left in @p error), which aborts the whole
+ * migration (the caller rolls the transaction back) rather than leaving some
+ * rows folded and others not.
+ *
+ * A genuinely pre-cutover database (older than #1513) has neither the
+ * `elements` column nor, on some rows, both script columns - only the
+ * migration this function runs ever adds `elements` for such a file, and it
+ * runs ahead of `sync_schema ()`. So the column set is read fresh here rather
+ * than assumed: a missing `elements` column is added first (the same shape
+ * `sync_schema` would create), and a missing script column reads as `''`
+ * instead of failing to prepare.
  */
-bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
+bool fold_table_scripts_into_elements (sqlite3* connection, const char* table, std::string& error) {
+    const auto columns  = table_columns (connection, table);
+    const bool has_pre  = has_column (columns, "pre_request_script");
+    const bool has_post = has_column (columns, "post_request_script");
+
+    if (!has_column (columns, "elements")) {
+        const std::string alter_sql = std::string ("ALTER TABLE ") + table +
+        " ADD COLUMN elements TEXT NOT NULL DEFAULT '[]';";
+        if (sqlite3_exec (connection, alter_sql.c_str (), nullptr, nullptr, nullptr) != SQLITE_OK) {
+            error = sqlite3_errmsg (connection);
+            return false;
+        }
+    }
+
+    const std::string pre_expr  = has_pre ? "pre_request_script" : "''";
+    const std::string post_expr = has_post ? "post_request_script" : "''";
     const std::string select_sql =
-    std::string (
-    "SELECT id, pre_request_script, post_request_script, elements FROM ") +
-    table + ";";
+    "SELECT id, " + pre_expr + ", " + post_expr + ", elements FROM " + table + ";";
     sqlite3_stmt* select_statement = nullptr;
     if (sqlite3_prepare_v2 (connection, select_sql.c_str (), -1,
         &select_statement, nullptr) != SQLITE_OK) {
+        error = sqlite3_errmsg (connection);
         return false;
     }
     const std::string update_sql =
@@ -1134,6 +1170,7 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
     sqlite3_stmt* update_statement = nullptr;
     if (sqlite3_prepare_v2 (connection, update_sql.c_str (), -1,
         &update_statement, nullptr) != SQLITE_OK) {
+        error = sqlite3_errmsg (connection);
         sqlite3_finalize (select_statement);
         return false;
     }
@@ -1150,7 +1187,8 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
             break;
         }
         if (step != SQLITE_ROW) {
-            ok = false;
+            error = sqlite3_errmsg (connection);
+            ok    = false;
             break;
         }
         const std::string id       = select_column_text (0);
@@ -1167,7 +1205,8 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
         sqlite3_bind_text (update_statement, 1, updated->c_str (), -1, SQLITE_TRANSIENT);
         sqlite3_bind_text (update_statement, 2, id.c_str (), -1, SQLITE_TRANSIENT);
         if (sqlite3_step (update_statement) != SQLITE_DONE) {
-            ok = false;
+            error = sqlite3_errmsg (connection);
+            ok    = false;
         }
     }
 
@@ -1256,11 +1295,13 @@ void migrate_before_sync (const std::string& path) {
 
     sqlite3_exec (connection.get (), "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr);
     bool ok = true;
+    std::string fold_error;
     if (requests_need_fold) {
-        ok = ok && fold_table_scripts_into_elements (connection.get (), "requests");
+        ok = ok && fold_table_scripts_into_elements (connection.get (), "requests", fold_error);
     }
     if (collections_need_fold) {
-        ok = ok && fold_table_scripts_into_elements (connection.get (), "collections");
+        ok = ok &&
+        fold_table_scripts_into_elements (connection.get (), "collections", fold_error);
     }
     if (ok) {
         sqlite3_exec (connection.get (), "PRAGMA user_version = 1;", nullptr, nullptr, nullptr);
@@ -1268,7 +1309,8 @@ void migrate_before_sync (const std::string& path) {
     } else {
         sqlite3_exec (connection.get (), "ROLLBACK;", nullptr, nullptr, nullptr);
         throw std::runtime_error (
-        "Vayu could not migrate stored scripts into elements for " + path);
+        "Vayu could not migrate stored scripts into elements for " + path +
+        ": " + (fold_error.empty () ? "unknown error" : fold_error));
     }
 }
 

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1981,6 +1981,38 @@ void add_legacy_script_columns (const std::string& path) {
     sqlite3_close (handle);
 }
 
+/// Drops `elements` from both tables - the shape a database genuinely older
+/// than issue #1513 has: it never ran the additive pass that added the
+/// column, so `elements` does not exist at all, not merely unpopulated.
+void drop_elements_column (const std::string& path) {
+    sqlite3* handle = nullptr;
+    ASSERT_EQ (sqlite3_open (path.c_str (), &handle), SQLITE_OK);
+    for (const char* table : { "requests", "collections" }) {
+        char* err = nullptr;
+        const std::string sql = std::string ("ALTER TABLE ") + table + " DROP COLUMN elements";
+        ASSERT_EQ (sqlite3_exec (handle, sql.c_str (), nullptr, nullptr, &err), SQLITE_OK)
+        << (err != nullptr ? err : "(no message)");
+        sqlite3_free (err);
+    }
+    sqlite3_close (handle);
+}
+
+/// Adds back only @p column (one of the two script columns) - the shape a
+/// row that predates the *other* script column carrying anything can have.
+void add_single_legacy_script_column (const std::string& path, const char* column) {
+    sqlite3* handle = nullptr;
+    ASSERT_EQ (sqlite3_open (path.c_str (), &handle), SQLITE_OK);
+    for (const char* table : { "requests", "collections" }) {
+        char* err             = nullptr;
+        const std::string sql = std::string ("ALTER TABLE ") + table +
+        " ADD COLUMN " + column + " TEXT DEFAULT ''";
+        ASSERT_EQ (sqlite3_exec (handle, sql.c_str (), nullptr, nullptr, &err), SQLITE_OK)
+        << (err != nullptr ? err : "(no message)");
+        sqlite3_free (err);
+    }
+    sqlite3_close (handle);
+}
+
 void set_legacy_scripts (const std::string& path,
 const std::string& table,
 const std::string& id,
@@ -2188,6 +2220,127 @@ TEST_F (DatabaseTest, ADatabaseFromANewerEngineIsRefused) {
     set_user_version (TEST_DB_PATH, 99);
 
     EXPECT_THROW ({ Database db (TEST_DB_PATH); }, std::runtime_error);
+}
+
+// Issue #1593: a database older than #1513 has no `elements` column at all,
+// not merely an unpopulated one - `fold_table_scripts_into_elements` used to
+// `SELECT ... elements` unconditionally and fail to prepare on exactly this
+// shape, which is what every 0.26 -> 0.27 upgrade hit. Mutation check: revert
+// the `ADD COLUMN elements` branch in `fold_table_scripts_into_elements` and
+// this reds with "no such column: elements" surfacing through the
+// `std::runtime_error` this test expects *not* to be thrown.
+TEST_F (DatabaseTest, MigratesADatabaseThatPredatesTheElementsColumn) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        Collection col;
+        col.id    = "col_1";
+        col.name  = "C";
+        col.order = 0;
+        db.create_collection (col);
+        Request r;
+        r.id            = "req_1";
+        r.collection_id = "col_1";
+        r.name          = "R";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db.save_request (r);
+    }
+
+    add_legacy_script_columns (TEST_DB_PATH);
+    set_legacy_scripts (TEST_DB_PATH, "requests", "req_1",
+    "pm.environment.set('x', 1);", "pm.test('ok', () => {});");
+    drop_elements_column (TEST_DB_PATH);
+    ASSERT_FALSE (table_has_column (TEST_DB_PATH, "requests", "elements"))
+    << "test setup did not remove the elements column";
+    // See `MigratesPreCutoverScriptColumnsIntoElements`: the first open above
+    // already bumped `user_version` to 1.
+    set_user_version (TEST_DB_PATH, 0);
+
+    EXPECT_NO_THROW ({
+        Database db (TEST_DB_PATH);
+        db.init ();
+    });
+
+    EXPECT_TRUE (table_has_column (TEST_DB_PATH, "requests", "elements"));
+    EXPECT_FALSE (table_has_column (TEST_DB_PATH, "requests", "pre_request_script"));
+    EXPECT_FALSE (table_has_column (TEST_DB_PATH, "requests", "post_request_script"));
+    EXPECT_EQ (read_user_version (TEST_DB_PATH), 1);
+    EXPECT_TRUE (std::filesystem::exists (std::string (TEST_DB_PATH) + ".pre-migration.bak"))
+    << "no pre-migration backup was written";
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    auto folded = reopened.get_request ("req_1");
+    ASSERT_HAS_VALUE (folded);
+    const auto elements = nlohmann::json::parse (folded->elements);
+    ASSERT_EQ (elements.size (), 2u);
+    EXPECT_EQ (elements[0]["kind"], "script.pre");
+    EXPECT_EQ (elements[0]["config"]["script"], "pm.environment.set('x', 1);");
+    EXPECT_EQ (elements[1]["kind"], "script.post");
+    EXPECT_EQ (elements[1]["config"]["script"], "pm.test('ok', () => {});");
+}
+
+// A row can predate whichever script column never carried anything for it -
+// `fold_table_scripts_into_elements` used to `SELECT` both unconditionally,
+// so a table missing either one failed to prepare the same way a missing
+// `elements` column did. Mutation check: revert the literal-`''` fallback for
+// a missing script column and this reds the same way.
+TEST_F (DatabaseTest, MigratesWhenOnlyOneScriptColumnSurvives) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        Collection col;
+        col.id    = "col_1";
+        col.name  = "C";
+        col.order = 0;
+        db.create_collection (col);
+        Request r;
+        r.id            = "req_1";
+        r.collection_id = "col_1";
+        r.name          = "R";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db.save_request (r);
+    }
+
+    add_single_legacy_script_column (TEST_DB_PATH, "post_request_script");
+    {
+        sqlite3* handle = nullptr;
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
+        sqlite3_stmt* stmt = nullptr;
+        ASSERT_EQ (sqlite3_prepare_v2 (handle, "UPDATE requests SET post_request_script = ?1 WHERE id = ?2",
+                   -1, &stmt, nullptr),
+        SQLITE_OK);
+        sqlite3_bind_text (stmt, 1, "pm.test('ok', () => {});", -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text (stmt, 2, "req_1", -1, SQLITE_TRANSIENT);
+        ASSERT_EQ (sqlite3_step (stmt), SQLITE_DONE);
+        sqlite3_finalize (stmt);
+        sqlite3_close (handle);
+    }
+    ASSERT_TRUE (table_has_column (TEST_DB_PATH, "requests", "post_request_script"));
+    ASSERT_FALSE (table_has_column (TEST_DB_PATH, "requests", "pre_request_script"));
+    set_user_version (TEST_DB_PATH, 0);
+
+    EXPECT_NO_THROW ({
+        Database db (TEST_DB_PATH);
+        db.init ();
+    });
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    auto folded = reopened.get_request ("req_1");
+    ASSERT_HAS_VALUE (folded);
+    const auto elements = nlohmann::json::parse (folded->elements);
+    ASSERT_EQ (elements.size (), 1u);
+    EXPECT_EQ (elements[0]["kind"], "script.post");
+    EXPECT_EQ (elements[0]["config"]["script"], "pm.test('ok', () => {});");
 }
 
 } // namespace


### PR DESCRIPTION
## Description

Every 0.26.0 -> 0.27.0 upgrade with an existing database failed at startup. `Database::migrate_before_sync`'s fold (`fold_table_scripts_into_elements`, `engine/src/db/database.cpp`) ran `SELECT id, pre_request_script, post_request_script, elements FROM requests` unconditionally, but a database genuinely older than #1513 never had an `elements` column at all - only this migration adds it, and it runs strictly before `sync_schema()` (per `engine/CLAUDE.md`'s "Removing a column" rule), so nothing else could have added it yet. The `sqlite3_prepare_v2` failed with `no such column: elements`, the fold returned false, the transaction rolled back, and the constructor threw - taking the whole engine down before `/health` could even answer.

The existing tests missed this because `add_legacy_script_columns` (`engine/tests/db_test.cpp`) re-adds the two script columns to the *current* schema, which already has `elements` mapped - a shape no real upgrade ever has.

**Fix pathway** (`fold_table_scripts_into_elements`):
- Reads the table's actual column set fresh via `PRAGMA table_info` before building the `SELECT`.
- `ALTER TABLE ... ADD COLUMN elements TEXT NOT NULL DEFAULT '[]'` when the column is missing - the same shape `sync_schema` would eventually create - before folding.
- Selects a literal `''` for whichever script column (`pre_request_script` / `post_request_script`) the table does not carry, instead of naming an absent column and failing to prepare.
- `table_has_script_columns` now accepts either script column, not only `pre_request_script`, so a table carrying just one still triggers the fold.
- The thrown `std::runtime_error` on a fold failure now carries the underlying SQLite error message, not just the file path.

`docs/engine/db-schema.md`'s "The script-to-elements migration" section is updated in the same commit to describe the column-set read and the `ADD COLUMN elements` step.

**Alternative considered and rejected:** always unconditionally `ALTER TABLE ... ADD COLUMN elements` up front for every table, skipping the `PRAGMA table_info` read. Rejected because `ALTER TABLE ADD COLUMN` on a table that already has the column is itself a SQLite error (`duplicate column name`), so the unconditional version would have broken every *already-additively-folded* database (`#1513`'s repair pass shape) instead - trading one crash for another. Reading the column set first is the only version that is safe for all three shapes: genuinely pre-cutover, additively-folded, and current.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` - clean build, engine + tests.
- `ctest --preset linux-dev --output-on-failure` - full suite, **3247/3247 passed**.
- Two new cases in `engine/tests/db_test.cpp`: `DatabaseTest.MigratesADatabaseThatPredatesTheElementsColumn` (drops `elements` from both tables after adding the legacy script columns - the real pre-cutover shape - and asserts the open succeeds, `elements` is added, both scripts fold, `user_version` reaches 1, and the pre-migration backup exists) and `DatabaseTest.MigratesWhenOnlyOneScriptColumnSurvives` (only `post_request_script` present, `elements` present, asserts the fold reads the missing `pre_request_script` as `''` rather than failing to prepare).
- **Mutation check performed**: reverted `engine/src/db/database.cpp` to its pre-fix state, rebuilt, and reran just the two new tests - both failed (`MigratesADatabaseThatPredatesTheElementsColumn` threw `std::runtime_error`, i.e. the exact startup crash this issue reports; `MigratesWhenOnlyOneScriptColumnSurvives` asserted 0 elements folded instead of 1). Restored the fix, rebuilt, and reran the full suite green before pushing.

No app changes - this is an engine-only migration bug with no wire-visible change.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Release

0.27.0 as published cannot open any pre-existing workspace, and the only user-side workaround is renaming `vayu.db`, which loses it. This wants a patch release of its own rather than riding the next feature release.

## Related Issues
Closes #1593

Supersedes #1597 (duplicate fix, closed).