### PR TITLE
fix(engine): the script fold works on a database that predates the elements column

### DIFF
--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1051,26 +1051,35 @@ bool is_blank_script_text (const std::string& text) {
     return text.find_first_not_of (" \t\r\n") == std::string::npos;
 }
 
-/// Whether @p table's schema still carries `pre_request_script` (issue
-/// #1514's cut-over target). False for a fresh install (the table does not
-/// exist yet) and for a database this or an earlier engine build already
-/// migrated by some other means.
-bool table_has_script_columns (sqlite3* connection, const char* table) {
+/// Every column @p table carries, empty when the table does not exist yet
+/// (a fresh install) or cannot be read.
+std::unordered_set<std::string> table_columns (sqlite3* connection, const char* table) {
     const std::string sql   = std::string ("PRAGMA table_info(") + table + ");";
     sqlite3_stmt* statement = nullptr;
+    std::unordered_set<std::string> columns;
     if (sqlite3_prepare_v2 (connection, sql.c_str (), -1, &statement, nullptr) != SQLITE_OK) {
-        return false;
+        return columns;
     }
-    bool found = false;
     while (sqlite3_step (statement) == SQLITE_ROW) {
         const auto* name = column_text (statement, 1);
-        if (name != nullptr && std::string_view (name) == "pre_request_script") {
-            found = true;
-            break;
+        if (name != nullptr) {
+            columns.emplace (name);
         }
     }
     sqlite3_finalize (statement);
-    return found;
+    return columns;
+}
+
+/// Whether @p table's schema still carries either of the two pre-cutover
+/// script columns (issue #1514's cut-over target). False for a fresh install
+/// (the table does not exist yet) and for a database this or an earlier
+/// engine build already migrated by some other means. Both columns are
+/// checked rather than only `pre_request_script`, so a database missing one
+/// of the pair is still recognised as needing the fold.
+bool table_has_script_columns (sqlite3* connection, const char* table) {
+    const auto columns = table_columns (connection, table);
+    return columns.contains ("pre_request_script") ||
+    columns.contains ("post_request_script");
 }
 
 /**
@@ -1116,18 +1125,48 @@ const std::string& post) {
 /**
  * Fold @p table's `pre_request_script` / `post_request_script` into
  * `elements`, row by row, on the still-open @p connection. Returns false on
- * the first SQLite error, which aborts the whole migration (the caller rolls
- * the transaction back) rather than leaving some rows folded and others not.
+ * the first SQLite error - writing what SQLite said into @p error - which
+ * aborts the whole migration (the caller rolls the transaction back) rather
+ * than leaving some rows folded and others not.
+ *
+ * The destination column is created here when the stored schema predates it.
+ * A genuinely pre-cutover database is *older* than issue #1513, so it has the
+ * two script columns and no `elements` at all; `sync_schema` is what would
+ * normally add that column, and it does not run until after this fold. Adding
+ * it here in the same shape `sync_schema` would (`TEXT NOT NULL DEFAULT
+ * '[]'`) is what lets the fold have somewhere to write. The one-of-the-pair
+ * cases are handled the same way, by selecting a literal empty script for a
+ * column the stored schema does not carry.
  */
-bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
-    const std::string select_sql =
-    std::string (
-    "SELECT id, pre_request_script, post_request_script, elements FROM ") +
-    table + ";";
+bool fold_table_scripts_into_elements (sqlite3* connection, const char* table, std::string& error) {
+    const auto sqlite_error = [&] {
+        const char* message = sqlite3_errmsg (connection);
+        error               = std::string (table) + ": " +
+        (message != nullptr ? message : "unknown SQLite error");
+        return false;
+    };
+
+    const auto columns  = table_columns (connection, table);
+    const bool has_pre  = columns.contains ("pre_request_script");
+    const bool has_post = columns.contains ("post_request_script");
+    if (!has_pre && !has_post) {
+        return true; // Nothing of this table's to fold.
+    }
+    if (!columns.contains ("elements")) {
+        const std::string alter_sql = std::string ("ALTER TABLE ") + table +
+        " ADD COLUMN elements TEXT NOT NULL DEFAULT '[]';";
+        if (sqlite3_exec (connection, alter_sql.c_str (), nullptr, nullptr, nullptr) != SQLITE_OK) {
+            return sqlite_error ();
+        }
+    }
+
+    const std::string select_sql = std::string ("SELECT id, ") +
+    (has_pre ? "pre_request_script" : "''") + ", " +
+    (has_post ? "post_request_script" : "''") + ", elements FROM " + table + ";";
     sqlite3_stmt* select_statement = nullptr;
     if (sqlite3_prepare_v2 (connection, select_sql.c_str (), -1,
         &select_statement, nullptr) != SQLITE_OK) {
-        return false;
+        return sqlite_error ();
     }
     const std::string update_sql =
     std::string ("UPDATE ") + table + " SET elements = ?1 WHERE id = ?2;";
@@ -1135,7 +1174,7 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
     if (sqlite3_prepare_v2 (connection, update_sql.c_str (), -1,
         &update_statement, nullptr) != SQLITE_OK) {
         sqlite3_finalize (select_statement);
-        return false;
+        return sqlite_error ();
     }
 
     const auto select_column_text = [&] (int index) {
@@ -1150,7 +1189,7 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
             break;
         }
         if (step != SQLITE_ROW) {
-            ok = false;
+            ok = sqlite_error ();
             break;
         }
         const std::string id       = select_column_text (0);
@@ -1167,7 +1206,7 @@ bool fold_table_scripts_into_elements (sqlite3* connection, const char* table) {
         sqlite3_bind_text (update_statement, 1, updated->c_str (), -1, SQLITE_TRANSIENT);
         sqlite3_bind_text (update_statement, 2, id.c_str (), -1, SQLITE_TRANSIENT);
         if (sqlite3_step (update_statement) != SQLITE_DONE) {
-            ok = false;
+            ok = sqlite_error ();
         }
     }
 
@@ -1256,19 +1295,25 @@ void migrate_before_sync (const std::string& path) {
 
     sqlite3_exec (connection.get (), "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr);
     bool ok = true;
+    std::string fold_error;
     if (requests_need_fold) {
-        ok = ok && fold_table_scripts_into_elements (connection.get (), "requests");
+        ok = ok && fold_table_scripts_into_elements (connection.get (), "requests", fold_error);
     }
     if (collections_need_fold) {
-        ok = ok && fold_table_scripts_into_elements (connection.get (), "collections");
+        ok = ok &&
+        fold_table_scripts_into_elements (connection.get (), "collections", fold_error);
     }
     if (ok) {
         sqlite3_exec (connection.get (), "PRAGMA user_version = 1;", nullptr, nullptr, nullptr);
         sqlite3_exec (connection.get (), "COMMIT;", nullptr, nullptr, nullptr);
     } else {
         sqlite3_exec (connection.get (), "ROLLBACK;", nullptr, nullptr, nullptr);
+        // The SQLite message is the whole diagnosis when this is reported from
+        // a user's machine: without it the failure names only the file, which
+        // is what issue #1593 was first reported as.
         throw std::runtime_error (
-        "Vayu could not migrate stored scripts into elements for " + path);
+        "Vayu could not migrate stored scripts into elements for " + path +
+        (fold_error.empty () ? std::string () : " (" + fold_error + ")"));
     }
 }
 

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -1981,6 +1981,24 @@ void add_legacy_script_columns (const std::string& path) {
     sqlite3_close (handle);
 }
 
+/// Drops `elements` from both tables - the half of the pre-cutover shape
+/// `add_legacy_script_columns` cannot express on its own. A database written
+/// before issue #1513 has the two script columns and no `elements` at all;
+/// re-adding the script columns to a *current* schema leaves `elements`
+/// standing and so exercises a shape no real upgrade ever has.
+void drop_elements_columns (const std::string& path) {
+    sqlite3* handle = nullptr;
+    ASSERT_EQ (sqlite3_open (path.c_str (), &handle), SQLITE_OK);
+    for (const char* table : { "requests", "collections" }) {
+        char* err = nullptr;
+        const std::string sql = std::string ("ALTER TABLE ") + table + " DROP COLUMN elements";
+        ASSERT_EQ (sqlite3_exec (handle, sql.c_str (), nullptr, nullptr, &err), SQLITE_OK)
+        << (err != nullptr ? err : "(no message)");
+        sqlite3_free (err);
+    }
+    sqlite3_close (handle);
+}
+
 void set_legacy_scripts (const std::string& path,
 const std::string& table,
 const std::string& id,
@@ -2106,6 +2124,122 @@ TEST_F (DatabaseTest, MigratesPreCutoverScriptColumnsIntoElements) {
     EXPECT_EQ (elements[0]["config"]["script"], "pm.environment.set('x', 1);");
     EXPECT_EQ (elements[1]["kind"], "script.post");
     EXPECT_EQ (elements[1]["config"]["script"], "pm.test('ok', () => {});");
+}
+
+// The shape every 0.26 -> 0.27 upgrade actually has (issue #1593): the two
+// script columns and no `elements` column at all, because `sync_schema` - the
+// only thing that ever adds it - does not run until after this fold. The
+// engine refused to start on it ("could not migrate stored scripts into
+// elements"), which is a failed upgrade for every existing install.
+//
+// Mutation check: drop the `ALTER TABLE ... ADD COLUMN elements` from
+// `fold_table_scripts_into_elements` and the `Database` open below throws.
+TEST_F (DatabaseTest, MigratesADatabaseThatPredatesTheElementsColumn) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        Collection col;
+        col.id    = "col_1";
+        col.name  = "C";
+        col.order = 0;
+        db.create_collection (col);
+        Request r;
+        r.id            = "req_1";
+        r.collection_id = "col_1";
+        r.name          = "R";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db.save_request (r);
+    }
+
+    add_legacy_script_columns (TEST_DB_PATH);
+    set_legacy_scripts (TEST_DB_PATH, "requests", "req_1",
+    "pm.environment.set('x', 1);", "pm.test('ok', () => {});");
+    set_legacy_scripts (TEST_DB_PATH, "collections", "col_1", "pm.collectionPre();", "");
+    drop_elements_columns (TEST_DB_PATH);
+    ASSERT_FALSE (table_has_column (TEST_DB_PATH, "requests", "elements"))
+    << "test setup did not reach the pre-cutover shape";
+    set_user_version (TEST_DB_PATH, 0);
+
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+
+    EXPECT_EQ (read_user_version (TEST_DB_PATH), 1);
+    EXPECT_FALSE (table_has_column (TEST_DB_PATH, "requests", "pre_request_script"));
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    auto folded = reopened.get_request ("req_1");
+    ASSERT_HAS_VALUE (folded);
+    const auto elements = nlohmann::json::parse (folded->elements);
+    ASSERT_EQ (elements.size (), 2u) << folded->elements;
+    EXPECT_EQ (elements[0]["kind"], "script.pre");
+    EXPECT_EQ (elements[0]["config"]["script"], "pm.environment.set('x', 1);");
+    EXPECT_EQ (elements[1]["kind"], "script.post");
+
+    auto collection = reopened.get_collection ("col_1");
+    ASSERT_HAS_VALUE (collection);
+    const auto collection_elements = nlohmann::json::parse (collection->elements);
+    ASSERT_EQ (collection_elements.size (), 1u) << collection->elements;
+    EXPECT_EQ (collection_elements[0]["kind"], "script.pre");
+    EXPECT_EQ (collection_elements[0]["config"]["script"], "pm.collectionPre();");
+}
+
+// Only one of the pair present is still a fold, not a refusal: the missing
+// column reads as an empty script rather than failing the `SELECT`.
+TEST_F (DatabaseTest, MigratesWhenOnlyOneScriptColumnSurvives) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        Collection col;
+        col.id    = "col_1";
+        col.name  = "C";
+        col.order = 0;
+        db.create_collection (col);
+        Request r;
+        r.id            = "req_1";
+        r.collection_id = "col_1";
+        r.name          = "R";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db.save_request (r);
+    }
+
+    add_legacy_script_columns (TEST_DB_PATH);
+    set_legacy_scripts (TEST_DB_PATH, "requests", "req_1", "", "pm.test('ok', () => {});");
+    {
+        sqlite3* handle = nullptr;
+        ASSERT_EQ (sqlite3_open (TEST_DB_PATH, &handle), SQLITE_OK);
+        for (const char* table : { "requests", "collections" }) {
+            const std::string sql =
+            std::string ("ALTER TABLE ") + table + " DROP COLUMN pre_request_script";
+            ASSERT_EQ (sqlite3_exec (handle, sql.c_str (), nullptr, nullptr, nullptr), SQLITE_OK);
+        }
+        sqlite3_close (handle);
+    }
+    set_user_version (TEST_DB_PATH, 0);
+
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    auto folded = reopened.get_request ("req_1");
+    ASSERT_HAS_VALUE (folded);
+    const auto elements = nlohmann::json::parse (folded->elements);
+    ASSERT_EQ (elements.size (), 1u) << folded->elements;
+    EXPECT_EQ (elements[0]["kind"], "script.post");
+    EXPECT_EQ (read_user_version (TEST_DB_PATH), 1);
 }
 
 // A database the additive #1513 repair pass already folded (elements already


### PR DESCRIPTION
## Description

0.27.0 cannot open any pre-existing database. `migrate_before_sync` runs #1514's script fold ahead of `sync_schema`, and the fold selected `elements` - a column a genuinely pre-cutover database does not have, because `sync_schema` is the only thing that ever adds it and has not run yet. The `SELECT` fails to prepare, the transaction rolls back, and the constructor throws, so the engine exits 1 before serving anything. 0.27.0 is the first release carrying both #1513's column and #1514's migration, so this is every 0.26.0 -> 0.27.0 upgrade with a workspace, not an edge case, and there is no in-app way out of it.

The fold creates the column here rather than deferring to `sync_schema` because the ordering is not negotiable in the other direction: `sync_schema` is what `DROP COLUMN`s the two script columns, so anything that reads them must run first. Adding `elements` in the shape `sync_schema` would (`TEXT NOT NULL DEFAULT '[]'`) is what gives the fold somewhere to write without touching that order.

Worth a look: the fold now builds its `SELECT` from the table's real column list, so a table carrying only one of the two script columns selects a literal `''` for the missing one instead of failing to prepare. That is the one piece of new behaviour with no reported case behind it - it is there because the whole class of bug here was assuming a stored schema matches the current one.

Safe to skim: the `table_has_script_columns` change (it now asks `table_columns` and accepts either column), and the error plumbing - the throw carries SQLite's own message, which is the whole diagnosis when this is reported from a user's machine rather than reproduced locally.

## Type of Change
- [x] Bug fix

## Testing

`ctest --preset linux-dev`, whole engine suite, 3247/3247.

The existing migration tests passed against the broken code because `add_legacy_script_columns` builds the "legacy" shape by re-adding the script columns to the *current* schema, which still carries `elements` - a shape no real upgrade ever has. `MigratesADatabaseThatPredatesTheElementsColumn` drops it to reach the real one; mutation check run, disabling the `ADD COLUMN` reproduces the reported error verbatim (`no such column: elements`) and fails the test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)

## Follow-up

This needs a patch release on its own: 0.27.0 as published cannot open an existing workspace, and the only user-side workaround is renaming `vayu.db`, which loses the workspace.

## Related Issues
Closes #1593