### PR TITLE
docs(db): document the schema-refusal startup path and release-time SCHEMA_VERSION check

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -11,6 +11,12 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
    `engine/vcpkg.json`, and refuses to run if that file has grown a `version`
    field back: CI keys the vcpkg binary cache on the manifest's hash, so a
    version there made every release rebuild every C++ dependency from source.
+   It also does not touch `SCHEMA_VERSION` (`engine/src/db/database.cpp`),
+   which is a separate constant bumped only by the commit that changes
+   `make_storage`'s mapping. A bump is one-way: an older engine refuses to
+   open a database a newer one already stamped (issue #1492), so check
+   whether this release's changes touched the schema before tagging - not
+   every version bump carries one.
 2. Check the vcpkg baseline for staleness - `cd engine && vcpkg
    x-update-baseline --dry-run`. **The release window is the cadence**: nothing
    else owns baseline freshness, and #679 found cpp-httplib five minors behind

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -391,6 +391,15 @@ one app instance may drive it:
   report itself listening. It never falls back to another port: the app and CLI
   both address the engine at a fixed one, so an engine on a different port would
   be a quieter failure than no engine at all.
+- **A database written by a newer engine refuses to open, the same way.**
+  `Database::migrate_before_sync` reads `PRAGMA user_version` before touching
+  anything else and, on a version newer than this build's `SCHEMA_VERSION`,
+  throws naming both versions instead of migrating (issue #1492) - the file is
+  never written to. The constructor throw crashes the daemon the same way a
+  bind failure does, so it takes the same path out: exit 1, and the spawn
+  failure's stderr tail (`describeSpawnFailure` in `sidecar.ts`) carries the
+  refusal message into the dialog the app already shows for a startup that
+  cannot succeed.
 - **A startup that cannot succeed fails immediately; one that is merely slow
   does not.** The readiness poll spends a 45-second budget watching the spawned
   child as well as the port: an engine that exits first - a missing shared


### PR DESCRIPTION
## Description

PR #1563 landed the code for #1492 (schema versioning, the downgrade guard, the config catalogue filter, version-matched engine adoption) but the issue was reopened for two doc gaps its own Docs section named and #1563 didn't touch: `docs/architecture.md` never described the startup-failure path a schema-refused database takes, and the `releasing` skill never mentioned `SCHEMA_VERSION` or that bumping it is a one-way upgrade. This PR closes both.

`docs/architecture.md` gets a new bullet beside the existing "a taken port is a loud failure" one, in the same shape: what throws, why the file is never written to, and how the failure surfaces through the app's existing generic spawn-failure dialog (no new UI, so no new failure-reporting path to document separately). The `releasing` skill gets a note on step 1 (the app version bump) that `SCHEMA_VERSION` lives in `engine/src/db/database.cpp`, is untouched by `--bump-version`, and needs its own look before tagging when a release's changes touch the schema.

No code changed - this is a docs-only follow-up.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Doc-only change, no new links or heading anchors added (both edits are prose inserted into existing sections), so no build was run. Verified against the code both sentences describe: `SCHEMA_VERSION` and the refusal throw in `engine/src/db/database.cpp`'s `migrate_before_sync`, and the stderr-tail path in `app/electron/sidecar.ts`'s `describeSpawnFailure`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - doc-only change, nothing to test
- [x] I have updated documentation

## Related Issues
Closes #1492


---
_Generated by [Claude Code](https://claude.ai/code/session_01CvjLUxaGdvE5c2wwZFf6Mj)_