### PR TITLE
fix(engine): bound the scenario-load producer's wait during a timer deferral

### DIFF
--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -991,6 +991,19 @@ deadline; only the flag's spelling is shared, through `read_stream_flag`.
 loop driven by a pure `compute_refill_deficit` primitive: each tick, refill exactly
 `target − in_flight` new requests (where `in_flight = requests_sent − completed`). On stop the
 controller is notified for prompt cancellation rather than waiting for in-flight requests to drain.
+Between ticks the loop blocks on `refill_cv` with a 50ms safety-net timeout, woken early by a
+completion (`notify_refill`) - the actual wait, not a poll, so a run with headroom to fill sends
+again within the tick rather than a full 50ms later.
+
+A scenario run's virtual users add a second reason `in_flight` can sit below target: a VU a
+`timer.pacing` or `timer.think` element deferred (issue #1498) is not in flight either, so the
+plain `target − in_flight` predicate above cannot tell "wait for a completion" and "wait for this
+VU's deferral to end" apart - both look identical. Left alone that reads as permanent headroom and
+the loop spins the 50ms wait away on every tick, pinning a full core for a run whose own request
+rate is a handful a second (issue #1596). `ScenarioLoadDriver::deferred_wait_ms` answers which case
+it is: when the last scan found only deferred VUs (as opposed to none ready because everyone is
+already in flight or retired, which the plain predicate already handles), the wait is bounded to
+the soonest deferral instead, on a predicate that only a real completion or `should_stop` satisfies.
 
 **The `target_fn` invariant, restated.** Every mode but `capacity` passes a
 `target_fn` that is a pure function of `elapsed_ms` and constants fixed when the

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -684,6 +684,28 @@ check; create fixtures over MCP and delete them with `confirmed: true`
 (destructive tools answer a preview first) - `list_runs` returns `{ data }`
 and carries no URL, so name probe runs by their request.
 
+### A paced scenario run no longer pins a core (2026-09-08, engine 0.26.x)
+
+`timer.pacing` deferred a virtual user by stamping a future `ready_at_ms`, but
+a deferred user is not in flight - so the producer's own `in_flight() <
+target` wait predicate stayed true for as long as any user was paced, and
+`refill_cv.wait_for` returned at once regardless of the duration it was given
+(issue #1596). A run's own request rate made no difference: this was the
+producer thread spinning its wait away, not real work.
+
+One virtual user, `timer.pacing` at 500ms, run for 2s in-process against the
+test mock server (`ElementsTimersLoadTest.APacedRunDoesNotBusySpinTheProducer`,
+whole-process `getrusage`/`GetProcessTimes` sampled before and after):
+
+| | producer CPU over 2s | % of one core |
+|---|---:|---:|
+| Before | ~2,059 ms | ~100% |
+| After | ~65 ms | ~3% |
+
+Pacing precision is unaffected - the bounded wait is exactly the remaining
+deferral, so a 10ms cadence still holds to about 1%, which is why nothing
+noticed this for as long as it went undiagnosed.
+
 ## Prior results (2026-07, CLI, unreconciled)
 
 These numbers were measured earlier via `scripts/test/bench-compare.sh` on a

--- a/engine/include/vayu/core/load_strategy.hpp
+++ b/engine/include/vayu/core/load_strategy.hpp
@@ -108,16 +108,29 @@ struct LoadAuthPlan {
  * submission path - is the same for both, so there is deliberately one copy of
  * this loop rather than one per executor.
  *
- * @param submit_one   submits exactly one request and increments requests_sent
+ * @param submit_one   attempts one submission and increments requests_sent;
+ *                     returns whether it actually submitted (a scenario load
+ *                     run's virtual users can all be deferred by a timer, in
+ *                     which case it does neither - issue #1596)
  * @param target_fn    desired in-flight at elapsed_ms
  * @param budget_fn    remaining submission budget (SIZE_MAX for time-bounded)
  * @param should_continue  whether to keep refilling at elapsed_ms
+ * @param deferred_wait_ms_fn  ms until the earliest candidate @p submit_one
+ *                     skipped over is due, valid only right after it returned
+ *                     false because every remaining candidate is deferred
+ *                     rather than merely without budget; `nullopt` otherwise.
+ *                     A deferred user is never in flight, so without this the
+ *                     `in_flight() < target` wait predicate stays true for as
+ *                     long as any user is deferred and the loop busy-spins
+ *                     (issue #1596). Single-request strategies have no notion
+ *                     of deferral and omit it.
  */
 void maintain_concurrency (std::shared_ptr<RunContext> context,
-const std::function<void ()>& submit_one,
+const std::function<bool ()>& submit_one,
 const std::function<size_t (int64_t)>& target_fn,
 const std::function<size_t ()>& budget_fn,
-const std::function<bool (int64_t)>& should_continue);
+const std::function<bool (int64_t)>& should_continue,
+const std::function<std::optional<int64_t> ()>& deferred_wait_ms_fn = {});
 
 /**
  * @brief Read a run-config duration field ("30s", "500ms", "5m", "2h") as

--- a/engine/include/vayu/core/scenario_load.hpp
+++ b/engine/include/vayu/core/scenario_load.hpp
@@ -228,12 +228,13 @@ struct VirtualUser {
     vayu::http::routes::ScopeOverlay scope_overlay;
     /**
      * Steady-clock milliseconds before which `take_ready_vu` will not select
-     * this VU (issue #1495). Plumbing for a `timer.pacing` / gaussian
-     * `timer.think` to schedule a VU's next submission without blocking the
-     * producer thread; nothing writes a value past 0 yet - `timer.think`'s
-     * existing `apply` blocks the calling thread instead and runs only at
-     * `step.between`, which this load path does not invoke, so it is not
-     * reachable here even by accident. See `docs/engine/elements.md`'s Load
+     * this VU (issue #1495): `run_step_between`'s `timer.think` wait and
+     * `schedule_next_entry_wait`'s `timer.pacing` schedule (both issue #1498)
+     * are its two writers, both running on the strategy thread rather than
+     * blocking a worker one. While this holds a future value the VU is
+     * deferred, not in flight - `maintain_concurrency`'s `deferred_wait_ms`
+     * bounds the producer's wait to the soonest such deadline instead of
+     * busy-spinning on it (issue #1596). See `docs/engine/elements.md`'s Load
      * paths section.
      */
     int64_t ready_at_ms = 0;

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
@@ -580,10 +581,11 @@ SubmissionRequest& live) {
 // Declared in load_strategy.hpp - the scenario load executor drives the same
 // loop with a different submit_one. See the header for the contract.
 void maintain_concurrency (std::shared_ptr<RunContext> context,
-const std::function<void ()>& submit_one,
+const std::function<bool ()>& submit_one,
 const std::function<size_t (int64_t)>& target_fn,
 const std::function<size_t ()>& budget_fn,
-const std::function<bool (int64_t)>& should_continue) {
+const std::function<bool (int64_t)>& should_continue,
+const std::function<std::optional<int64_t> ()>& deferred_wait_ms_fn) {
     using clock     = std::chrono::steady_clock;
     auto start      = clock::now ();
     auto elapsed_ms = [&start] () {
@@ -610,12 +612,38 @@ const std::function<bool (int64_t)>& should_continue) {
     update_peak (context);
 
     while (!context->should_stop) {
+        // `deferred_wait_ms_fn` answers only right after a cycle where
+        // `submit_one` returned false because every eligible candidate was
+        // deferred (issue #1596) - not merely because none had budget, which
+        // the plain `in_flight() < target` predicate below already handles by
+        // blocking until a completion raises it. A deferred user is never
+        // in flight, so while one is outstanding that predicate is true the
+        // whole time and `wait_for` would return at once no matter what
+        // duration it is given - the timeout has to come from the wait call
+        // itself, and the predicate has to become something a deferral does
+        // not already satisfy: a real completion, tracked here as
+        // `in_flight()` changing from its value when the wait began (the
+        // strategy thread is `requests_sent`'s only writer, so between here
+        // and the wait returning it can only fall, never rise).
+        const size_t in_flight_before = context->in_flight ();
+        std::optional<int64_t> defer_wait_ms =
+        deferred_wait_ms_fn ? deferred_wait_ms_fn () : std::nullopt;
+
         {
             std::unique_lock<std::mutex> lk (context->refill_mtx);
-            context->refill_cv.wait_for (lk, std::chrono::milliseconds (50), [&] () {
-                return context->should_stop.load () ||
-                context->in_flight () < target_fn (elapsed_ms ());
-            });
+            if (defer_wait_ms) {
+                const auto bound =
+                std::chrono::milliseconds (std::min<int64_t> (50, *defer_wait_ms));
+                context->refill_cv.wait_for (lk, bound, [&] () {
+                    return context->should_stop.load () ||
+                    context->in_flight () != in_flight_before;
+                });
+            } else {
+                context->refill_cv.wait_for (lk, std::chrono::milliseconds (50), [&] () {
+                    return context->should_stop.load () ||
+                    context->in_flight () < target_fn (elapsed_ms ());
+                });
+            }
         }
 
         int64_t el = elapsed_ms ();
@@ -626,7 +654,12 @@ const std::function<bool (int64_t)>& should_continue) {
         size_t deficit =
         compute_refill_deficit (target_fn (el), context->in_flight (), budget_fn ());
         for (size_t i = 0; i < deficit && !context->should_stop; ++i) {
-            submit_one ();
+            // A false return means the remaining candidates are all deferred
+            // or busy; retrying immediately just re-scans the same VUs for
+            // the same answer; `deferred_wait_ms_fn` picks it up next cycle.
+            if (!submit_one ()) {
+                break;
+            }
         }
         update_peak (context);
     }
@@ -664,6 +697,7 @@ class ConstantLoadStrategy : public LoadStrategy {
 
             auto submit_one = [&context, &db, &live] () {
                 submit_one_request (context, db, live);
+                return true;
             };
 
             maintain_concurrency (
@@ -842,6 +876,7 @@ class IterationsLoadStrategy : public LoadStrategy {
 
         auto submit_one = [&context, &db, &live] () {
             submit_one_request (context, db, live);
+            return true;
         };
 
         maintain_concurrency (
@@ -891,6 +926,7 @@ class RampUpLoadStrategy : public LoadStrategy {
 
         auto submit_one = [&context, &db, &live] () {
             submit_one_request (context, db, live);
+            return true;
         };
 
         // target(t): linear from start_concurrency to target_concurrency over
@@ -1091,6 +1127,7 @@ class CapacityLoadStrategy : public LoadStrategy {
         SubmissionRequest live (context, request);
         auto submit_one = [&context, &db, &live] () {
             submit_one_request (context, db, live);
+            return true;
         };
 
         CapacitySearch search (capacity_config, context);

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -739,14 +739,20 @@ class ScenarioLoadDriver {
         return live_vus_;
     }
 
-    /** The next step of the next ready virtual user, submitted. */
-    void submit_one () {
+    /**
+     * The next step of the next ready virtual user, submitted.
+     *
+     * @return whether a VU was actually claimed. `false` means every VU is
+     *         deferred, in flight or retired; `maintain_concurrency` waits
+     *         out the nearer of a completion or the earliest deferral
+     *         (`deferred_wait_ms`) rather than retrying at once (issue
+     *         #1596) - not counting a submission here is what keeps
+     *         `in_flight()` honest either way.
+     */
+    bool submit_one () {
         VirtualUser* vu = take_ready_vu ();
         if (vu == nullptr) {
-            // Every VU is in flight or retired. The controller's own 50ms tick
-            // retries; not counting a submission here is what keeps
-            // `in_flight()` honest.
-            return;
+            return false;
         }
 
         const size_t step_index         = vu->step;
@@ -786,7 +792,7 @@ class ScenarioLoadDriver {
                 vayu::Result<vayu::Response> (vayu::Error{
                 vayu::ErrorCode::DataBindingFailed, step.name + ": " + bound.error }),
                 ResultAnnotations{ row, step_index, iteration, vu_index });
-                return;
+                return true;
             }
         }
 
@@ -812,7 +818,7 @@ class ScenarioLoadDriver {
             state_->steps_skipped.fetch_add (1, std::memory_order_relaxed);
             finish_step (context_, state_, execution_.plan, vu, step_index,
             /*errored=*/false, nullptr);
-            return;
+            return true;
         }
         const int64_t pipeline_before_ms = before_result.elapsed_ms;
         {
@@ -893,17 +899,41 @@ class ScenarioLoadDriver {
             ResultAnnotations{ row, step_index, iteration, vu_index });
         });
         context_->requests_sent++;
+        return true;
+    }
+
+    /**
+     * Ms until the earliest deferred VU `take_ready_vu` last skipped over
+     * becomes ready, or `nullopt` when its last scan found no deferral -
+     * either it found a VU (this cycle submitted), or every VU it skipped
+     * was busy or retired rather than deferred, which `maintain_concurrency`'s
+     * plain `in_flight() < target` wait already handles correctly (issue
+     * #1596). Recomputed against the current time on every call, not cached
+     * from the scan, so a wait started slightly after the scan still ends on
+     * time.
+     */
+    [[nodiscard]] std::optional<int64_t> deferred_wait_ms () const {
+        if (!earliest_deferred_ready_at_ms_) {
+            return std::nullopt;
+        }
+        return std::max<int64_t> (0, *earliest_deferred_ready_at_ms_ - steady_now_ms ());
     }
 
     private:
     /**
-     * A virtual user that is neither busy nor retired, claimed for one step.
+     * A virtual user that is neither busy nor retired and not deferred,
+     * claimed for one step.
      *
-     * Returns null when every VU is in flight or retired: the controller's own
-     * 50ms tick retries, and not counting a submission is what keeps
-     * `in_flight()` honest.
+     * Returns null when every VU is deferred, in flight or retired - not
+     * counting a submission either way is what keeps `in_flight()` honest.
+     * The two cases are told apart for `deferred_wait_ms`'s sake: a scan that
+     * skips a deferred VU records the soonest of them in
+     * `earliest_deferred_ready_at_ms_`, reset at the top of every call so a
+     * stale value from calls ago never lingers into one that found nothing
+     * deferred at all.
      */
     VirtualUser* take_ready_vu () {
+        earliest_deferred_ready_at_ms_.reset ();
         for (size_t scanned = 0; scanned < state_->vus.size (); ++scanned) {
             VirtualUser& vu = *state_->vus[cursor_];
             cursor_         = (cursor_ + 1) % state_->vus.size ();
@@ -916,11 +946,19 @@ class ScenarioLoadDriver {
             if (vu.busy.load (std::memory_order_acquire)) {
                 continue;
             }
-            // Plumbing for a scheduled wait (#1498's `timer.pacing` / gaussian
-            // `timer.think`) - nothing writes past 0 yet, so this is a no-op
-            // for every run today. Read after the acquire above for the same
-            // reason `step` and `iteration` are.
+            // `timer.pacing` / gaussian `timer.think` (issues #1498, #1570,
+            // #1571) defer a VU by stamping this in the future. A deferred VU
+            // is never in flight, so `maintain_concurrency` cannot tell "wait
+            // for a completion" and "wait for this VU" apart from
+            // `in_flight()` alone; recording the soonest one here is what lets
+            // `deferred_wait_ms` bound the wait instead of busy-spinning
+            // (issue #1596). Read after the acquire above for the same reason
+            // `step` and `iteration` are.
             if (vu.ready_at_ms > 0 && vu.ready_at_ms > steady_now_ms ()) {
+                if (!earliest_deferred_ready_at_ms_ ||
+                vu.ready_at_ms < *earliest_deferred_ready_at_ms_) {
+                    earliest_deferred_ready_at_ms_ = vu.ready_at_ms;
+                }
                 continue;
             }
             if (vu.iteration_boundary) {
@@ -1190,6 +1228,10 @@ class ScenarioLoadDriver {
     size_t max_iterations_ = 0;
     size_t cursor_         = 0;
     size_t live_vus_       = 0;
+    // `take_ready_vu`'s single writer, `deferred_wait_ms`'s single reader -
+    // both called only from the strategy thread, so this needs no lock of
+    // its own (issue #1596).
+    std::optional<int64_t> earliest_deferred_ready_at_ms_;
 };
 
 std::shared_ptr<ScenarioLoadState> execute_scenario_load (
@@ -1319,7 +1361,7 @@ vayu::http::routes::ScriptVariableScopes base_scopes) {
         0;
 
     maintain_concurrency (
-    context, [&driver] () { driver.submit_one (); },
+    context, [&driver] () { return driver.submit_one (); },
     [type, start_vus, target_vus, ramp_ms] (int64_t elapsed) -> size_t {
         if (*type != LoadTestType::RampUp) {
             return target_vus;
@@ -1333,7 +1375,10 @@ vayu::http::routes::ScriptVariableScopes base_scopes) {
     [type, duration_ms, &driver] (int64_t elapsed) {
         return *type == LoadTestType::Iterations ? driver.live_vus () > 0 :
                                                    elapsed < duration_ms;
-    });
+    },
+    // Bounds the refill wait to the earliest deferral instead of busy-spinning
+    // while every VU is paced or thinking (issue #1596).
+    [&driver] () { return driver.deferred_wait_ms (); });
 
     return state;
 }

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -35,6 +35,12 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/resource.h>
+#endif
+
 #include "optional_assert.hpp"
 #include "step_elements_test_helper.hpp"
 #include "task_queue.hpp"
@@ -53,6 +59,38 @@ using nlohmann::json;
 using vayu::core::Registry;
 
 namespace {
+
+/// This process's own CPU time (user + system, every thread), in
+/// milliseconds - what `APacedRunDoesNotBusySpinTheProducer` samples before
+/// and after a run to catch issue #1596's regression (a producer that spins
+/// its wait away instead of sleeping it). `getrusage (RUSAGE_SELF)` sums
+/// every thread on Unix; `GetProcessTimes` is its Windows equivalent.
+int64_t process_cpu_ms () {
+#ifdef _WIN32
+    FILETIME creation{};
+    FILETIME exit{};
+    FILETIME kernel{};
+    FILETIME user{};
+    if (!GetProcessTimes (GetCurrentProcess (), &creation, &exit, &kernel, &user)) {
+        return 0;
+    }
+    auto to_ms = [] (const FILETIME& ft) -> int64_t {
+        // FILETIME is a 64-bit count of 100ns intervals split across two
+        // 32-bit words.
+        const uint64_t ticks =
+        (static_cast<uint64_t> (ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+        return static_cast<int64_t> (ticks / 10000);
+    };
+    return to_ms (kernel) + to_ms (user);
+#else
+    struct rusage usage{};
+    getrusage (RUSAGE_SELF, &usage);
+    return (static_cast<int64_t> (usage.ru_utime.tv_sec) * 1000) +
+    (usage.ru_utime.tv_usec / 1000) +
+    (static_cast<int64_t> (usage.ru_stime.tv_sec) * 1000) +
+    (usage.ru_stime.tv_usec / 1000);
+#endif
+}
 
 // ============================================================================
 // A. Registry / schema level - no run needed.
@@ -896,6 +934,44 @@ TEST_F (ElementsTimersLoadTest, PerUserThroughputGivesEveryVirtualUserItsOwnRate
     << "ten users at 60/minute each should approach 10/s in aggregate - this "
        "looks like one budget shared between them, not a per-user rate";
     EXPECT_LE (executed, 120u) << "the per-user rate did not hold at all";
+}
+
+// Issue #1596: a virtual user `timer.pacing` defers is not in flight, so the
+// producer's `in_flight() < target` wait predicate stayed true for as long as
+// any user was paced and `wait_for` returned at once regardless of the
+// duration it was given - a run sending a handful of requests over two
+// seconds cost the same full core as one sending thousands. Mutation check:
+// reverting `maintain_concurrency`'s wait to the plain predicate (dropping
+// the `deferred_wait_ms` bound) reds this on the CPU assertion alone, since
+// the step counts either side of the fix are identical - it is purely a wait
+// discipline bug, not a throughput one.
+TEST_F (ElementsTimersLoadTest, APacedRunDoesNotBusySpinTheProducer) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "constant_concurrency" }, { "concurrency", 1 }, { "duration", "2s" } };
+
+    const int64_t cpu_before = process_cpu_ms ();
+    auto state               = run (config, execution);
+    const int64_t cpu_after  = process_cpu_ms ();
+    ASSERT_NE (state, nullptr);
+
+    // Loose on purpose - the mock server and the worker pool share this
+    // process, so a tight bound is not credible - but two orders of
+    // magnitude under the roughly 2,000ms a busy-spun 2s run cost before the
+    // fix, and comfortably clear of scheduler jitter on a loaded box.
+    EXPECT_LT (cpu_after - cpu_before, 300)
+    << "the producer spun instead of waiting out the pacing interval - "
+       "consumed "
+    << (cpu_after - cpu_before) << "ms of CPU over a 2s run";
+
+    // Pacing precision must not regress: one unpaced first pass plus three or
+    // four more 500ms apart over 2s.
+    const size_t executed = state->steps_executed.load ();
+    EXPECT_GE (executed, 4u) << "the pacing interval grew - the bounded wait "
+                                "is overshooting the deferral";
+    EXPECT_LE (executed, 6u) << "the pacing interval shrank or vanished";
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A scenario load run's producer thread (`maintain_concurrency`) waits on `refill_cv` between refill ticks, gated by the predicate `in_flight() < target`. A virtual user a `timer.pacing` or `timer.think` element defers (`VirtualUser::ready_at_ms` set in the future, since #1498) is not in flight either, so while any user is deferred that predicate is trivially true the whole time - and `std::condition_variable::wait_for` checks its predicate *before* waiting at all, so it returns immediately no matter what timeout it is given. The result: a paced run (say, one request every 500ms) pinned a full core producing the same handful of requests a bounded wait would have produced for free, because the producer thread spun `wait_for` in a tight loop instead of sleeping.

**Fix.** `ScenarioLoadDriver::take_ready_vu` now records the soonest `ready_at_ms` among the virtual users it skips as deferred (as opposed to busy or retired, which the existing predicate already handles correctly - it is only the "deferred" case that was broken). `submit_one` returns whether it actually claimed a VU, and `maintain_concurrency` takes an optional `deferred_wait_ms_fn`: when the last cycle's `submit_one` failed specifically because everything eligible was deferred, the wait is bounded to the soonest deferral and its predicate becomes "a real completion happened" (tracked via `in_flight()` changing from its value when the wait began - the strategy thread is `requests_sent`'s only writer, so it can only fall during the wait) rather than the always-true level check. Single-request load strategies have no notion of deferral and pass no such function, so their behavior is unchanged.

**Alternative considered and rejected:** shortening the existing 50ms safety-net timeout unconditionally. Rejected because the timeout was never the problem - the predicate was, and a shorter timeout just spins faster without fixing the root cause (confirmed by the mutation check below, which reverts only the predicate/bound and reproduces the full-core spin even with the timeout unchanged).

A few stale code comments and one header doc-comment claiming "nothing writes `ready_at_ms` past 0 yet" (accurate before #1498 landed, wrong today) are corrected in the same files as part of this fix, since they directly describe the mechanism being changed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - full suite, **3250/3250 passed**.
- New test `ElementsTimersLoadTest.APacedRunDoesNotBusySpinTheProducer` (`engine/tests/elements_timers_test.cpp`): a one-user, `timer.pacing` 500ms plan run for 2s, whole-process CPU sampled via `getrusage`/`GetProcessTimes` before and after, asserts under 300ms consumed (two orders of magnitude under the ~2,000ms a busy-spun 2s run costs) and 4-6 steps executed (pacing precision preserved).
- **Mutation check performed**: reverted just the `deferred_wait_ms_fn` argument at the scenario-load call site (restoring the plain `in_flight() < target` predicate with no bound) and reran the new test in isolation - it reds on the CPU assertion alone (measured 2059ms, matching the issue's own ~2048ms figure), with the step count unaffected, confirming the test catches exactly this regression and nothing else. Reverted back and reconfirmed green before finalizing.
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` clean on every touched file (the pre-commit hook ran the same check).
- `mkdocs build -f .github/mkdocs.yml --strict` - clean.

No user-visible change - this is a CPU-overhead fix with no behavioral or API difference a client can observe (pacing precision is asserted unchanged). Engine-only; no app changes were needed or made.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/architecture.md`'s Closed-loop controller section, a new benchmarks entry in `docs/engine/benchmarks.md` with before/after CPU numbers)

## Related Issues
Closes #1596