### PR TITLE
feat(engine): wire maxElementBodyBytes as a real config entry, fix stale POST /runs doc claim

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -712,6 +712,7 @@ governs what a run measures rather than what it keeps:
 | `maxTraceBodyBytes` | `5242880` | 1024–104857600 | Largest request/response body stored in a design run's `trace_data`. Bigger bodies are truncated with `bodyTruncated`/`bodyBytes` (see `GET /runs/:id`). |
 | `maxResponseBodyBytes` | `33554432` | 1024–1073741824 | Largest response body a **load-test** transfer reads into memory, and what a `pm.sendRequest` from that run's deferred `tests` script may read. A bigger response fails that request (see `POST /runs`). Not a storage cap and unrelated to `maxTraceBodyBytes`, which truncates what a *completed* design request writes to the database. |
 | `maxDesignResponseBodyBytes` | `33554432` | 1024–1073741824 | Largest response body a **design-mode** send - `POST /execute`, and each step of a collection run - reads into memory, and what a `pm.sendRequest` from that send's scripts may read. A bigger response is read up to this point and answered with `bodyCapped: true` (see `POST /execute`) rather than failing, because someone is watching for it - a script's own fetch is the exception and refuses, having no way to tell the script its body was cut (see [scripting](scripting.md#sending-a-request-from-a-script-pmsendrequest)). Separate from `maxResponseBodyBytes` above, which is the load path's and refuses in every case. |
+| `maxElementBodyBytes` | `1048576` | 1024–1073741824 | Largest response body an `extract.json` or `assert.jsonpath` [element](elements.md) will parse as JSON, in a design send, a collection run and a scenario load run alike. A bigger response is not parsed at all: every JSON-reading element on that step reports `skipped`, with the reason, instead of paying for - or failing on - a parse of an oversized body. The one shared parse per step is reused by every such element, so this is a per-step cost, not a per-element one. |
 | `maxSampleBodyBytes` | `32768`  | 0–104857600  | Largest response body kept for a single captured **load-run** sample. Bigger bodies are stored truncated and marked. Deliberately far below `maxTraceBodyBytes`: a design run stores one exchange the user asked for, a load run stores tens nobody asked for individually. `0` keeps headers and metadata and no body. |
 | `maxSampleBytes`    | `2097152` | 0–1073741824 | Total captured body bytes one load run may store. Once spent, samples keep their headers and metadata and only their bodies are dropped; the report counts them as `sampling.sampleBodiesDropped`. |
 | `maxResponseSampleBytes` | `268435456` | 0–1073741824 | Total response-body bytes one load run may hold for its post-run test scripts and schema checks. Two orders of magnitude above `maxSampleBytes` because these bodies are kept **whole** - a truncated one would fail a check the target passed - so past the budget whole samples are dropped instead, counted as `sampling.responseSamplesDropped`. `0` retains no sample that has a body. |
@@ -5922,15 +5923,21 @@ assertions are now actually checked under load - previously only the
 request's own `tests` string was ever sent, so a collection-level assertion
 passed in design mode and was silently never validated by a load run.
 
-**`tests` and `postRequestScript(s)` are the same field.** The post-request
-script is stored as `postRequestScript`, `POST /execute` grew up calling it
-`postRequestScript(s)`, and this endpoint calls it `tests`. All three names are
-accepted on **both** endpoints, so a payload composed for one can start the
-other kind of run unchanged - which is how a saved request's composed test
-scripts reach a load run. The names are tried in a fixed order
-(`postRequestScripts`, `postRequestScript`, then `tests`) and the first that
-yields a non-blank script wins; they are never merged. Previously each route
-knew only its own spelling and silently dropped the other.
+**`tests` and `postRequestScript(s)` are the same field, still accepted here.**
+The post-request script is stored as `postRequestScript`, `POST /execute` grew
+up calling it `postRequestScript(s)`, and this endpoint calls it `tests`. This
+single-target `POST /runs` still accepts all three names - the names are tried
+in a fixed order (`postRequestScripts`, `postRequestScript`, then `tests`) and
+the first that yields a non-blank script wins; they are never merged. **`POST
+/execute`, `PUT /requests/:id` and `PUT /collections/:id` no longer do**: since
+issue #1514, `elements` is the only script source there and a payload carrying
+any of the three (a real value, not `null`) is refused with a `400` naming
+`elements`. A payload composed for one of those and sent to this endpoint
+unchanged still starts a load run - which is how a saved request's composed
+test scripts reach one - but the reverse no longer holds. Wiring this
+endpoint's own single-target request onto the element pipeline and refusing
+the three names here too is issue #1594, not yet landed; until it does, this
+is deliberately the one route that still reads them.
 
 **There is no pre-request hook on this endpoint.** `preRequestScript(s)` in a
 run payload is not an error, but nothing runs it - only `POST /execute` executes

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -155,8 +155,9 @@ balance beside a timestamp, which no single compare-exchange can swap as a unit.
 identically, same as `timer.pacing`.
 
 The JSON-reading kinds (`extract.json`, `assert.jsonpath`) share one parse of the response body per
-step, through `ElementContext`'s lazily filled slot - a body over `maxElementBodyBytes` (default 1
-MiB) is not parsed, and every such kind on that step reports `skipped` with the reason.
+step, through `ElementContext`'s lazily filled slot - a body over the
+[`maxElementBodyBytes`](api-reference.md#get-config) config entry (default 1 MiB, restart-free)
+is not parsed, and every such kind on that step reports `skipped` with the reason.
 
 `metric.record` (issue #1500) reads a value off the response and records it as a custom `trend`
 (a distribution, reported as `count`/`p50`/`p95`/`p99`/`max`), `counter` (a running total) or `rate`

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -1033,6 +1033,17 @@ constexpr int VACUUM_MIN_FREELIST_PERCENT = 25;
  */
 constexpr int64_t VACUUM_MIN_RECLAIMABLE_BYTES = 10LL * 1024 * 1024;
 } // namespace database
+
+/**
+ * @brief Element pipeline configuration
+ */
+namespace elements {
+/// Default value of the `maxElementBodyBytes` config entry (issue #1514). A
+/// response past this is not parsed as JSON, and every JSON-reading kind on
+/// that step (`extract.json`, `assert.jsonpath`, ...) reports `skipped`
+/// rather than paying for - or failing on - a parse of an oversized body.
+constexpr size_t MAX_BODY_BYTES = size_t{ 1024 } * 1024;
+} // namespace elements
 } // namespace vayu::core::constants
 
 /**

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -42,6 +42,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "vayu/core/constants.hpp"
 #include "vayu/core/custom_metric_type.hpp"
 #include "vayu/types.hpp"
 
@@ -409,8 +410,12 @@ struct ElementContext {
     bool body_parse_attempted = false;
     /// `maxElementBodyBytes` - a response past this is not parsed, and every
     /// JSON-reading kind on the step reports `skipped` rather than paying for
-    /// (or failing on) a parse of an oversized body.
-    size_t max_body_bytes = size_t{ 1024 } * 1024;
+    /// (or failing on) a parse of an oversized body. The default is the
+    /// config entry's own default; a caller that resolves the live setting
+    /// (`EngineDefaults::max_element_body_bytes`, `ExchangeInputs::max_element_body_bytes`)
+    /// overwrites it, the way every other config-backed `ElementContext`
+    /// field here does.
+    size_t max_body_bytes = vayu::core::constants::elements::MAX_BODY_BYTES;
 
     /// Filled by `Element::apply`, reset by `ElementPipeline::run` before each
     /// call and read back into the pushed `ElementOutcome` afterwards - the

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -177,6 +177,12 @@ struct EngineDefaults {
     /// (issue #576).
     int64_t stream_max_duration_ms = constants::sse::MAX_STREAM_DURATION_MS;
     int64_t stream_max_events      = constants::sse::MAX_STREAM_EVENTS;
+
+    /// Config key `maxElementBodyBytes` (issue #1514's reopen):
+    /// `ElementContext::max_body_bytes` for a scenario load run's own
+    /// `step.after` elements, which - like everything else in this struct -
+    /// `RunContext` cannot read for itself.
+    size_t max_element_body_bytes = constants::elements::MAX_BODY_BYTES;
 };
 
 struct RunContext {
@@ -337,6 +343,13 @@ struct RunContext {
     /// computation through `ElementContext::timers_override`
     /// (`apply_timers_override`).
     vayu::core::TimersOverride timers_override;
+
+    /// `EngineDefaults::max_element_body_bytes`, copied in by the constructor
+    /// (issue #1514's reopen) - the same `EngineDefaults` fields other than
+    /// this are consumed into `MetricsCollectorConfig` are, and this one is
+    /// read directly by every scenario load `step.after` element through
+    /// `ElementContext::max_body_bytes`.
+    size_t max_element_body_bytes = constants::elements::MAX_BODY_BYTES;
 
     /// The raw seed behind @ref rng (issue #1498's `elements.seed`): from the
     /// payload when given, else drawn once from `std::random_device`. Kept

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -409,6 +409,14 @@ struct ExchangeInputs {
      */
     size_t max_response_bytes = vayu::core::constants::http::MAX_DESIGN_RESPONSE_BODY_BYTES;
 
+    /**
+     * @brief `ElementContext::max_body_bytes` (issue #1514's reopen): the
+     *        `maxElementBodyBytes` config entry, resolved once per run for
+     *        the same reason @ref max_response_bytes is - `execute_exchange`
+     *        holds no `Database` to read it from itself.
+     */
+    size_t max_element_body_bytes = vayu::core::constants::elements::MAX_BODY_BYTES;
+
     /// Bound onto `ElementContext::pacing_state` / `rng` / `timers_override`
     /// (issue #1498), for a `timer.pacing` or gaussian `timer.think` element
     /// this exchange's `step.before` / `step.between` dispatch runs. Null for
@@ -583,6 +591,15 @@ ExchangeInputs inputs);
  * though it worked. This is what a test can call.
  */
 [[nodiscard]] size_t design_response_body_bound (vayu::db::Database& db);
+
+/**
+ * What this database is configured to let an `extract.json` / `assert.jsonpath`
+ * element parse as JSON (`maxElementBodyBytes`, issue #1514's reopen), for the
+ * same reason its `maxDesignResponseBodyBytes` sibling above is one function:
+ * every call site that resolves `ElementContext::max_body_bytes` shares one
+ * spelling of the key.
+ */
+[[nodiscard]] size_t element_body_bound (vayu::db::Database& db);
 
 /**
  * What this database is configured to let a load-run transfer read

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -745,6 +745,7 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
     static_cast<size_t> (config.value ("max_exemplar_results",
     static_cast<int64_t> (constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS)));
     capture_response_bodies = mc_config.capture_response_bodies;
+    max_element_body_bytes  = engine_defaults.max_element_body_bytes;
 
     // Configure response sampling for script validation. Bounded twice: in
     // count here, and in bytes by the budget below - a retained sample holds a
@@ -1104,6 +1105,9 @@ const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn) {
         engine_defaults.max_sample_body_bytes =
         static_cast<size_t> (db.get_config_int ("maxSampleBodyBytes",
         static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES)));
+        engine_defaults.max_element_body_bytes =
+        static_cast<size_t> (db.get_config_int ("maxElementBodyBytes",
+        static_cast<int> (vayu::core::constants::elements::MAX_BODY_BYTES)));
         engine_defaults.phase_histograms =
         db.get_config_bool ("phaseHistograms",
         vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS);

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -683,6 +683,7 @@ const vayu::Response& response) {
         [&context] (const std::string& name, vayu::core::CustomMetricType type, double value) {
             context->metrics_collector->record_custom_metric (name, type, value);
         },
+        .max_body_bytes = context->max_element_body_bytes,
     };
 
     vayu::core::ElementPipeline::run (vayu::core::Phase::StepAfter, ctx, *step.elements,

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -565,6 +565,11 @@ struct StepContext {
     size_t max_trace_body_bytes = 0;
     /// `maxDesignResponseBodyBytes`, read once for the run (issue #1157).
     size_t max_response_bytes = 0;
+    /// `maxElementBodyBytes`, read once for the run the same way (issue
+    /// #1514's reopen) - a step of a collection run is a design-mode send,
+    /// so it reads the same bound `ExchangeInputs::max_element_body_bytes`
+    /// carries on that path.
+    size_t max_element_body_bytes = 0;
     /// The plan-wide first/last position of every scope-spanning element
     /// (issue #1515's `control.loop` / `control.transaction`), computed
     /// once before the run's first iteration.
@@ -611,11 +616,12 @@ vayu::http::routes::ExchangeOutcome& exchange) {
     inputs.controller_state = &ctx.controller_state;
     // One user walking the sequence, which is what a collection run in design
     // mode is - the same number `{{$vu}}` binds into its requests (issue #994).
-    inputs.vu                 = SOLE_VIRTUAL_USER;
-    inputs.iteration_count    = ctx.iteration_count;
-    inputs.transport          = ctx.transport;
-    inputs.default_headers    = ctx.default_headers;
-    inputs.max_response_bytes = ctx.max_response_bytes;
+    inputs.vu                     = SOLE_VIRTUAL_USER;
+    inputs.iteration_count        = ctx.iteration_count;
+    inputs.transport              = ctx.transport;
+    inputs.default_headers        = ctx.default_headers;
+    inputs.max_response_bytes     = ctx.max_response_bytes;
+    inputs.max_element_body_bytes = ctx.max_element_body_bytes;
     // The one caller that sets it: `pm.execution` throws
     // everywhere else, because nowhere else has a sequence to
     // redirect (issue #355).
@@ -1248,6 +1254,10 @@ RunManager& manager) {
         // so it reads the design-mode bound (issue #1157).
         const auto max_response_bytes =
         vayu::http::routes::design_response_body_bound (db);
+        // Same reason, same read-once-for-the-run rule (issue #1514's
+        // reopen): a step's `extract.json` / `assert.jsonpath` must not read
+        // a different bound because Settings changed mid-sequence.
+        const auto max_element_body_bytes = vayu::http::routes::element_body_bound (db);
         ScenarioStepStore store (
         static_cast<size_t> (db.get_config_int ("maxScenarioStoredSteps",
         static_cast<int> (constants::scenario::MAX_STORED_STEPS))));
@@ -1321,10 +1331,11 @@ RunManager& manager) {
             // it: a script may send it backwards, forwards or out early, so the
             // position is a variable and the loop is bounded by the budget
             // above rather than by the plan's length.
-            const StepContext step_ctx{ context, execution, schema_index, transport,
-                default_headers, cookie_scope, data_rows, data_row_index, iteration,
-                asked.iterations, fail_on_schema_error, max_trace_body_bytes,
-                max_response_bytes, element_spans, controller_state };
+            const StepContext step_ctx{ context, execution, schema_index,
+                transport, default_headers, cookie_scope, data_rows,
+                data_row_index, iteration, asked.iterations,
+                fail_on_schema_error, max_trace_body_bytes, max_response_bytes,
+                max_element_body_bytes, element_spans, controller_state };
             run_iteration (script_engine, cookie_jar, cookie_scope, scopes,
             step_ctx, plan, step_index, max_steps_per_iteration, coverage,
             summary, store, transactions);

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -4713,6 +4713,19 @@ void Database::seed_default_config () {
     "1073741824", // 1GB
     std::nullopt, now }));
 
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxElementBodyBytes",
+    std::to_string (vayu::core::constants::elements::MAX_BODY_BYTES), "integer", "Max Element Body",
+    "Largest response body an extract.json or assert.jsonpath element will "
+    "parse as JSON. A larger response is not parsed at all: every "
+    "JSON-reading element on that step reports skipped, with the reason, "
+    "instead of paying for - or failing on - a parse of an oversized body. "
+    "The one shared parse is reused by every such element on the same step, "
+    "so this is a per-step cost, not a per-element one.",
+    "limits", std::to_string (vayu::core::constants::elements::MAX_BODY_BYTES),
+    "1024",       // 1KB
+    "1073741824", // 1GB
+    std::nullopt, now }));
+
     upsert_config (advanced (keywords ({ "infinite loop" }) (
     ConfigEntry{ "maxStepsPerIteration", "0", "integer", "Max Steps Per Iteration",
     "How many requests one iteration of a collection run may send before it is "

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -61,6 +61,11 @@ size_t design_response_body_bound (vayu::db::Database& db) {
     static_cast<int> (vayu::core::constants::http::MAX_DESIGN_RESPONSE_BODY_BYTES)));
 }
 
+size_t element_body_bound (vayu::db::Database& db) {
+    return static_cast<size_t> (db.get_config_int ("maxElementBodyBytes",
+    static_cast<int> (vayu::core::constants::elements::MAX_BODY_BYTES)));
+}
+
 size_t load_response_body_bound (vayu::db::Database& db) {
     return static_cast<size_t> (std::max (0,
     db.get_config_int ("maxResponseBodyBytes",
@@ -694,6 +699,7 @@ ExchangeInputs inputs) {
         .pacing_state    = inputs.pacing_state,
         .timers_override = inputs.timers_override,
         .record_metric   = inputs.record_metric,
+        .max_body_bytes  = inputs.max_element_body_bytes,
     };
 
     vayu::core::ElementPipeline::run (vayu::core::Phase::StepBefore,

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1435,6 +1435,11 @@ void run_streaming_execution (RouteContext& ctx, httplib::Response& res, DesignS
     // takes the design bound the buffered path's scripts take - resolved once
     // here for the same reason `transport` is.
     const size_t script_response_bound = design_response_body_bound (ctx.db);
+    // `ElementContext::max_body_bytes` for this stream's own elements (issue
+    // #1514's reopen), resolved once here for the same reason
+    // `script_response_bound` is: the post-request element pass runs on the
+    // worker thread, long after this handler's frame.
+    const size_t element_body_bytes = element_body_bound (ctx.db);
     // Loaded whether or not this send carries a script, because the
     // residual-token pass below reads them too (issue #1008): a `{{token}}`
     // that resolves on the buffered path and stays literal here would be one
@@ -1544,9 +1549,9 @@ void run_streaming_execution (RouteContext& ctx, httplib::Response& res, DesignS
     [&db = ctx.db, &jar = ctx.cookie_jar, id = run_id, cookie_scope = send.cookie_scope,
     run = send.run, script_config = send.script_config, elements = send.elements,
     request_name = send.script_request_name, scopes, iteration_data = send.data_row,
-    transport, default_headers, script_response_bound, pre_script_result,
-    pre_element_outcomes] (const vayu::Request& sent, const vayu::Response& response,
-    const vayu::http::SseStreamContext& context) mutable {
+    transport, default_headers, script_response_bound, element_body_bytes,
+    pre_script_result, pre_element_outcomes] (const vayu::Request& sent,
+    const vayu::Response& response, const vayu::http::SseStreamContext& context) mutable {
         StreamRecord record;
         nlohmann::json scripts = nlohmann::json::object ();
         std::vector<vayu::core::ElementOutcome> element_outcomes =
@@ -1620,6 +1625,7 @@ void run_streaming_execution (RouteContext& ctx, httplib::Response& res, DesignS
                         },
                         .should_stop = nullptr,
                         .record_metric = nullptr, // A streaming send has no run to record into.
+                        .max_body_bytes = element_body_bytes,
                     };
                     vayu::core::ElementPipeline::run (vayu::core::Phase::StepAfter,
                     element_ctx, *elements, element_outcomes);
@@ -1689,7 +1695,8 @@ void run_buffered_execution (RouteContext& ctx, httplib::Response& res, DesignSe
     inputs.transport       = vayu::http::resolve_transport_policy (ctx.db);
     inputs.default_headers = vayu::http::resolve_default_header_policy (
     ctx.db, vayu::http::DefaultHeaderScope::Design);
-    inputs.max_response_bytes = design_response_body_bound (ctx.db);
+    inputs.max_response_bytes     = design_response_body_bound (ctx.db);
+    inputs.max_element_body_bytes = element_body_bound (ctx.db);
     if (send.data_row) {
         inputs.iteration_data = &*send.data_row;
         // Row 0 of 1: a send-with-row *is* an iteration, and the one it is

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(vayu_tests
     main.cpp
     http_client_test.cpp
     design_read_cap_test.cpp
+    element_body_bound_test.cpp
     json_test.cpp
     invariant_test.cpp
     optional_assert_test.cpp

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -89,6 +89,27 @@ TEST_F (ConfigRouteTest, TheDesignReadBoundFollowsTheSetting) {
     EXPECT_EQ (vayu::http::routes::design_response_body_bound (*db_), 4096U);
 }
 
+// Its element-pipeline sibling (issue #1514's reopen): before this,
+// `maxElementBodyBytes` named a real config entry in `docs/engine/elements.md`
+// and in two error-message strings, but no caller ever read it - the bound
+// `ElementContext::max_body_bytes` gates on was always the compiled-in
+// default. `element_body_bound` is the one place the key is spelled now, on
+// the same "drive it through the config route rather than assert the string"
+// reasoning as the design bound above.
+
+TEST_F (ConfigRouteTest, TheElementBodyBoundDefaultsToTheCompiledInLimit) {
+    EXPECT_EQ (vayu::http::routes::element_body_bound (*db_),
+    vayu::core::constants::elements::MAX_BODY_BYTES);
+}
+
+TEST_F (ConfigRouteTest, TheElementBodyBoundFollowsTheSetting) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"maxElementBodyBytes":"4096"}})");
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    EXPECT_EQ (vayu::http::routes::element_body_bound (*db_), 4096U);
+}
+
 // Its load-path sibling, on the same reasoning (issue #1188): the deferred
 // `tests` pass reads `maxResponseBodyBytes` for what a script's own
 // `pm.sendRequest` may pull, so a mistyped key there would silently leave that

--- a/engine/tests/element_body_bound_test.cpp
+++ b/engine/tests/element_body_bound_test.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/element_body_bound_test.cpp
+ * @brief `ExchangeInputs::max_element_body_bytes` reaching
+ *        `ElementContext::max_body_bytes` (issue #1514's reopen).
+ *
+ * `element_kinds_test.cpp` pins what the bound *does* once it is on the
+ * context - `ensure_parsed_body` skips a body past it - by setting
+ * `ElementContext::max_body_bytes` directly. What it cannot see is whether a
+ * real send ever copies the resolved `maxElementBodyBytes` setting onto that
+ * context: before this issue, nothing did, so the field just kept its
+ * compiled-in 1 MiB default forever, and `config_route_test.cpp`'s
+ * `element_body_bound` cases only prove the setting resolves to a number, not
+ * that anything downstream reads it. This drives `execute_exchange` - the one
+ * sequence `POST /execute` and every collection-run step both run - against a
+ * server whose JSON body straddles the bound, with a real `extract.json`
+ * element attached, exactly the way `design_read_cap_test.cpp` drives the
+ * design-mode read bound.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "optional_assert.hpp"
+#include "step_elements_test_helper.hpp"
+#include "task_queue.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/cookie_jar.hpp"
+#include "vayu/http/request_exchange.hpp"
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
+namespace {
+
+/// A valid JSON body just over 4 KiB once padded - big enough that a bound
+/// well under it is a real gate, not a rounding.
+constexpr size_t PADDING_BYTES = size_t{ 4 } * 1024;
+
+std::string big_json_body () {
+    return R"({"padding": ")" + std::string (PADDING_BYTES, 'x') + R"(", "value": "extracted-value"})";
+}
+
+/// Serves the body above at `/big`.
+class BigJsonServer {
+    public:
+    BigJsonServer () {
+        svr_.new_task_queue = vayu::tests::pooled_task_queue (2);
+        svr_.Get ("/big", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (big_json_body (), "application/json");
+        });
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    ~BigJsonServer () {
+        svr_.stop ();
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+    BigJsonServer (const BigJsonServer&)            = delete;
+    BigJsonServer& operator= (const BigJsonServer&) = delete;
+    BigJsonServer (BigJsonServer&&)                 = delete;
+    BigJsonServer& operator= (BigJsonServer&&)      = delete;
+
+    std::string url () const {
+        return "http://127.0.0.1:" + std::to_string (port_) + "/big";
+    }
+
+    private:
+    httplib::Server svr_;
+    int port_ = 0;
+    std::thread thread_;
+};
+
+class ElementBodyBoundTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        vayu::http::global_init ();
+        server_ = std::make_unique<BigJsonServer> ();
+    }
+
+    void TearDown () override {
+        server_.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    /// One exchange against the big body, with an `extract.json` element
+    /// bound to `maxElementBodyBytes` = @p bound.
+    vayu::http::routes::ExchangeOutcome send (size_t bound) {
+        vayu::runtime::ScriptEngine engine;
+        vayu::http::CookieJar jar;
+        vayu::http::routes::ScriptVariableScopes scopes;
+
+        vayu::Request request;
+        request.method = vayu::HttpMethod::GET;
+        request.url    = server_->url ();
+
+        vayu::http::routes::ExchangeInputs inputs;
+        inputs.request  = std::move (request);
+        inputs.elements = vayu::tests::compiled_elements (
+        { vayu::tests::extract_json_element_json ("el1", "$.value", "extracted") });
+        inputs.max_element_body_bytes = bound;
+        return execute_exchange (engine, jar, "", scopes, std::move (inputs));
+    }
+
+    std::unique_ptr<BigJsonServer> server_;
+};
+
+TEST_F (ElementBodyBoundTest, ABodyOverTheBoundIsSkippedRatherThanParsed) {
+    const auto outcome = send (PADDING_BYTES / 2);
+
+    ASSERT_EQ (outcome.element_outcomes.size (), 1u);
+    const auto& first = outcome.element_outcomes[0];
+    EXPECT_EQ (first.status, "skipped");
+    ASSERT_HAS_VALUE (first.message);
+    EXPECT_NE (first.message->find ("maxElementBodyBytes"), std::string::npos);
+}
+
+TEST_F (ElementBodyBoundTest, ABodyUnderTheBoundIsParsedAndExtracted) {
+    const auto outcome = send (PADDING_BYTES * 2);
+
+    ASSERT_EQ (outcome.element_outcomes.size (), 1u);
+    EXPECT_EQ (outcome.element_outcomes[0].status, "ok");
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Closes the two gaps the closure-verification comment reopened #1514 for.

1. **`maxElementBodyBytes` was never a real config entry.** `docs/engine/elements.md` and two error-message strings already described it as configurable (default 1 MiB), but `ElementContext::max_body_bytes` was a hard-coded compiled-in default with no caller ever setting it - the same "written but never read" shape CLAUDE.md calls out, just inverted (documented but never wired). It is now a real `ConfigEntry` (category `limits`, unit `bytes`, restart-free), following `maxDesignResponseBodyBytes`'s exact shape since it sits in the same `ExchangeInputs`/`ElementContext` pipeline. The new `element_body_bound()` (mirroring `design_response_body_bound()`) is the one place the key is spelled, read once per run and threaded into every `ElementContext` construction that can actually see a parsed response body: the shared design/sequential `execute_exchange`, the streaming design send's step-after pass, and a scenario load run's step-after hook. The several other `ElementContext` construction sites (`step.before`, `step.between`, `script.setup`/`teardown`) never bind a `response`, so `ensure_parsed_body` short-circuits on all of them regardless of this bound - they're deliberately left untouched rather than set-for-consistency's-sake.
2. **A stale doc claim.** `docs/engine/api-reference.md` said `tests`/`postRequestScript(s)` "are accepted on **both**" `POST /runs` and `POST /execute` - true before #1514, false since: `POST /execute`, `PUT /requests/:id` and `PUT /collections/:id` have refused all three with a 400 naming `elements` since that PR landed. Only the single-target `POST /runs` (not yet migrated onto the element pipeline - that's #1594) still accepts them. Reworded to say exactly that.

**Alternative considered and rejected:** dropping the `maxElementBodyBytes` name from the two error-message strings and the doc instead of wiring it up, since that's the smaller diff. Rejected because the reopen comment is explicit that "the body asked for the entry" - #1514's own Scope item 4 asked for "a new config entry, default 1 MiB," and removing the name would just re-hide the gap instead of closing it.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - full suite, **3253/3253 passed**.
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (via the repo's pre-commit hook, against the real `compile_commands.json`) clean on every touched file.
- New tests: `config_route_test.cpp` gains `TheElementBodyBoundDefaultsToTheCompiledInLimit` / `TheElementBodyBoundFollowsTheSetting`, mirroring the existing `design_response_body_bound` pair - proves the config key resolves, not just that a default exists. `element_body_bound_test.cpp` is the mutation-check-style integration test: drives `execute_exchange` against a real server serving a JSON body that straddles the bound, with a real `extract.json` element attached, and asserts a body over the bound is `skipped` (message naming `maxElementBodyBytes`) while a body under it is parsed and extracted - this is what actually catches a regression to "config entry exists but nothing reads it," which the two config-route tests alone would not.

No user-visible change: `maxElementBodyBytes` appears in Settings automatically (the panel renders every config entry generically off its type/category/unit), the same as every other entry added this way - no app-side code change needed or made.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/elements.md`, `docs/engine/api-reference.md`)

## Related Issues
Closes #1514


---
_Generated by [Claude Code](https://claude.ai/code/session_01X15RhELELbJaHrYQX1C2Wc)_