### PR TITLE
docs: state that assertion outcomes reach a run's verdict

### DIFF
--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -75,7 +75,10 @@ end: the saved request, with its environment variables, its auth resolved
 engine-side, and its `pm.*` scripts, is what the load run drives. Collections run
 as ordered scenarios with per-step results and threshold verdicts, driven from a
 CSV, TSV, JSON or JSONL file when you need each virtual user to send different
-data. Existing work comes across too - Postman v2.0/v2.1, Insomnia v4, and
+data. As in JMeter, a failed assertion can fail the run, not just the sample it
+ran on: `assert.*` element outcomes and `pm.test` results share one failure-rate
+budget (`maxAssertionFailureRatePct`), and `thresholds.failRun` turns a missed
+budget into a `Failed` run. Existing work comes across too - Postman v2.0/v2.1, Insomnia v4, and
 OpenAPI 3.1/3.0 or Swagger 2.0 specs generate a ready-to-use collection. JMeter's
 setUp / tearDown thread groups, which run once before or once after the whole
 test, are `script.setup` / `script.teardown` here - elements on the collection

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -278,6 +278,10 @@ wrote? }`. `outcome` is one of `ok` | `failed` | `missing` | `skipped` | `error`
 is reported `skipped` without its `apply` ever running. `POST /execute`'s live response body carries
 the same array under the same key - one object, two homes, on the `scripts` node's own precedent.
 
+`assert.*` outcomes join `pm.test` results in one assertion tally the run's `maxAssertionFailureRatePct`
+threshold reads; a failed budget flips the run's terminal status to `Failed` when the run also asks for
+`thresholds.failRun: true` (`api-reference.md`'s thresholds section, #1497).
+
 ## Load paths
 
 A scenario load run's `submit_one` (the producer, one virtual user at a time) runs


### PR DESCRIPTION
## Description

Closes the one reopen gap the closure-verification comment on #1497 left open: the metric and `failRun` flip shipped in PR #1565/#1572, but the two docs section named there never gained a sentence saying so.

- `docs/engine/elements.md`'s step-trace section only had a related-issues bullet pointing at #1497; it now states in prose that `assert.*` outcomes join `pm.test` results in one tally and that `thresholds.failRun` can turn a missed budget into a `Failed` run.
- `docs/compare/vayu-vs-jmeter.md` mentioned "threshold verdicts" in passing but never made the JMeter-parity claim explicit - a failed assertion can fail the run, not just the sample - which is exactly what this page exists to claim.

Docs-only; no code changed.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Docs-only change: `mkdocs build --strict -f .github/mkdocs.yml` passes clean (no broken links or heading anchors). No code path touched, so no engine or app test run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - doc-only change, nothing to test
- [x] I have updated documentation

## Related Issues
Closes #1497


---
_Generated by [Claude Code](https://claude.ai/code/session_01JryVyVpkndPceQnUfh12YZ)_