### PR TITLE
docs: restore vayu-vs-jmeter.md's load-run logic-jump bullet

### DIFF
--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -102,6 +102,25 @@ are things Vayu plans to catch up on:
   the extractors, assertions, timers and logic controllers in the table above)
   imports and runs; a team fluent in JMeter's full plugin ecosystem is still
   better served staying there.
+- **Your load model needs a load-run logic jump.** Think time and pacing
+  timers work under load now (`timer.think`, including a gaussian option;
+  `timer.pacing`, including its shared-cadence case, `perUser: false` -
+  one cadence held across every virtual user, not one per user; and
+  `timer.throughput`, the analogue of JMeter's Constant Throughput Timer,
+  which targets a rate - N per minute - shared across every virtual user by
+  default rather than held per user), and logic controllers - conditionals,
+  once-only, throughput, loops and named transactions - are elements
+  (`control.if` / `.once` / `.switch` / `.throughput` / `.loop` /
+  `.transaction`) that run under load too: `control.switch`'s dispatch and
+  `control.loop`'s repeat jump a scenario load run's virtual users the same
+  way they jump the sequential run, `control.throughput` can share one
+  budget across every virtual user (`perUser: false`) instead of one per
+  user, and `control.transaction` can fold a between-member `timer.*` wait
+  into its own reported latency (`includeTimers`). Correlation across a
+  scenario's steps - a login's token reaching the next step's header, per
+  virtual user - does work under load now too: mark the extracting element
+  or script `inline` (or set the run's `elements.scripts` override), or let
+  it stay in the post-run replay by default.
 - **It has to be JVM-native** for your infrastructure, monitoring, or compliance
   reasons.
 


### PR DESCRIPTION
## Description

PR #1588's merge commit (`4339cb61`) dropped the whole "Your load model needs a load-run logic jump" bullet from `docs/compare/vayu-vs-jmeter.md` (18 lines), along with the `timer.throughput` wording that same PR's own branch had added to it - a bad merge against master's newer `.jmx`-importer bullet, not an intentional edit. At current master the page names no timer or controller capability at all.

Restored the bullet, but not verbatim: two of the three follow-up issues that were open when the bullet was deleted (#1569, #1570) have since merged, so the old text's own gap - "`control.switch`/`.loop` under load ... cannot do yet" - is no longer true. The restored bullet states timers (`timer.think`, `timer.pacing` including shared cadence, `timer.throughput`) and controllers (including `control.switch`/`.loop` jumping under load, `control.throughput`'s shared budget, `control.transaction`'s `includeTimers`) as capabilities Vayu has today, cross-checked against `docs/engine/elements.md`'s current Load paths section rather than restoring the stale claim.

The #1497 reopen ask mentioned in the same issue (an assertion-verdict sentence) was already landed separately by PR #1603 - nothing left to do there.

Not in scope here (flagged in the issue as disclosed, not reopen-worthy): two `elements_timers_test.cpp` cases run shorter durations / smaller targets than their acceptance criteria state. No behavior or capability claim depends on it, so it's left for whoever next touches that test file.

## Type of Change
- [x] Documentation update

## Testing

Doc-only change, no heading added/moved/removed, no links touched - no test run needed per `CLAUDE.md`'s docs guidance. `mkdocs` is not installed in this environment, so `mkdocs build --strict` was not run; the edit is a bullet inserted into an existing list, nothing `--strict` checks (headings/links) is affected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (n/a - doc-only change)
- [x] I have updated documentation

## Related Issues
Closes #1571


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNZCWRojK2nGZvHF4Kouch)_