### PR TITLE
fix(engine): elements.timers "off" now silences pacing/throughput under load

### DIFF
--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -136,9 +136,9 @@ const DEFAULT_DURATION_SECONDS = "30";
  * The `elements` run override (issue #1495), scenario-load-run only - a
  * design-mode collection run has no inline/deferred distinction to make.
  * Matches `docs/engine/api-reference.md`'s "elements" block exactly:
- * `timers` is engine-accepted but not yet wired to a kind (#1498 finishes
- * that), and `scripts` picks whether a `script.*` element runs inline on the
- * event-loop worker or stays deferred to the post-run replay.
+ * `timers` reaches every `timer.*` kind under load (`"off"` included, since
+ * #1498's reopen fix), and `scripts` picks whether a `script.*` element runs
+ * inline on the event-loop worker or stays deferred to the post-run replay.
  */
 const TIMERS_DEFAULT = "asConfigured";
 const SCRIPTS_DEFAULT = "asMarked";

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -137,8 +137,10 @@ const DEFAULT_DURATION_SECONDS = "30";
  * design-mode collection run has no inline/deferred distinction to make.
  * Matches `docs/engine/api-reference.md`'s "elements" block exactly:
  * `timers` reaches every `timer.*` kind under load (`"off"` included, since
- * #1498's reopen fix), and `scripts` picks whether a `script.*` element runs
- * inline on the event-loop worker or stays deferred to the post-run replay.
+ * #1498's reopen fix - `fixedMs`/`{minMs, maxMs}` do not yet reach
+ * `timer.pacing`/`timer.throughput` there, #1620), and `scripts` picks
+ * whether a `script.*` element runs inline on the event-loop worker or stays
+ * deferred to the post-run replay.
  */
 const TIMERS_DEFAULT = "asConfigured";
 const SCRIPTS_DEFAULT = "asMarked";

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5192,7 +5192,14 @@ own unknown-key rule uses, checked before the run row is created.
   same rule `scripts` above uses. `timer.think`'s `step.between` phase now
   dispatches on a scenario load run too (non-blocking, summed into
   `VirtualUser::ready_at_ms`), so this override reaches load runs as well as
-  the sequential run.
+  the sequential run. `timer.pacing` and `timer.throughput` schedule their
+  wait before that step's `ElementContext` exists at all
+  (`Element::scheduled_ready_delay_ms`, see
+  [Load paths](elements.md#load-paths)); `"off"` reaches
+  them there too, through the run's own copy of the override
+  (`SharedScheduleState::timers_override`), so a run with `timers: "off"`
+  defers neither kind under load - `"fixedMs"`/`{"minMs", "maxMs"}` are not
+  yet threaded through that same seam.
 - **`seed`** (issue #1498) is an optional non-negative integer that seeds this
   run's RNG, making a `timer.think` element's gaussian or uniform-random wait
   reproducible. A scenario load run derives one independent generator per

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -338,32 +338,40 @@ scenario load run reported as a hardcoded `0` before this.
 **Timers, wired end to end (issue #1498).** `elements.timers` (`"asConfigured"` (default) |
 `"off"` | `{fixedMs: N}` | `{minMs, maxMs}`) is validated on `POST /runs`, parsed into
 `RunContext::timers_override` (a `vayu::core::TimersOverride`), and applied through the one
-function every `timer.*` kind calls, `vayu::core::apply_timers_override` (`elements/pipeline.cpp`)
-- `"off"` silences the wait entirely (`waitedMs: 0`, no sleep), `fixedMs`/`{minMs,maxMs}` replace a
-kind's own computed wait with the run-wide one, whatever that kind's own config says. This also
-fixed a pre-existing dead-code bug: `RunContext::timers_disabled` was parsed from `"off"` since
-#1495 but nothing read it, because `timer.think`'s `step.between` phase was never dispatched on the
-load path at all. It is now: `ScenarioLoadDriver::run_step_between` (`scenario_load.cpp`) dispatches
-`Phase::StepBetween` on the step that just completed, non-blocking, and sums the outcomes'
-`waited_ms` into `VirtualUser::ready_at_ms`. `elements.seed` (a non-negative integer) seeds the
-run's own `std::mt19937_64` (`RunContext::rng`); a scenario load run derives one independent
-generator per virtual user off it (`vayu::core::derive_vu_rng`) rather than sharing one across
-worker threads, so a seeded run's random waits are reproducible.
+function every `timer.*` kind's `apply` calls, `vayu::core::apply_timers_override`
+(`elements/pipeline.cpp`) - `"off"` silences the wait entirely (`waitedMs: 0`, no sleep),
+`fixedMs`/`{minMs,maxMs}` replace a kind's own computed wait with the run-wide one, whatever that
+kind's own config says. This also fixed a pre-existing dead-code bug: `RunContext::timers_disabled`
+was parsed from `"off"` since #1495 but nothing read it, because `timer.think`'s `step.between`
+phase was never dispatched on the load path at all. It is now: `ScenarioLoadDriver::run_step_between`
+(`scenario_load.cpp`) dispatches `Phase::StepBetween` on the step that just completed, non-blocking,
+and sums the outcomes' `waited_ms` into `VirtualUser::ready_at_ms`. `elements.seed` (a non-negative
+integer) seeds the run's own `std::mt19937_64` (`RunContext::rng`); a scenario load run derives one
+independent generator per virtual user off it (`vayu::core::derive_vu_rng`) rather than sharing one
+across worker threads, so a seeded run's random waits are reproducible. `"off"` also reaches
+`timer.pacing` and `timer.throughput` under load (below), whose own scheduling seam runs before
+`apply_timers_override`'s call site ever exists for that step.
 
 **Non-blocking waits: `scheduled_ready_delay_ms`.** `Element::scheduled_ready_delay_ms` (issue
 #1498) is how a kind that needs to wait tells a scenario load run to hold its VU back without
 blocking a worker thread: `timer.think` (whose wait already lands through `step.between`'s own
-dispatch above) needs no override, but `timer.pacing` does, since its phase (`step.before`) fires
-only once a VU has already been selected as ready - too late to defer non-blockingly.
-`ScenarioLoadDriver::finish_step` calls the override on the VU's *upcoming* step, right after
-deciding which step comes next and before the VU can be selected again, and applies the returned
-delay to `VirtualUser::ready_at_ms`, which already gated VU selection but, before #1498, had
-nothing writing to it. Per-node "last started" timestamps live in `VirtualUser::pacing_state`
+dispatch above) needs no override, but `timer.pacing` and `timer.throughput` do, since their phase
+(`step.before`) fires only once a VU has already been selected as ready - too late to defer
+non-blockingly. `ScenarioLoadDriver::finish_step` calls the override on the VU's *upcoming* step,
+right after deciding which step comes next and before the VU can be selected again, and applies the
+returned delay to `VirtualUser::ready_at_ms`, which already gated VU selection but, before #1498,
+had nothing writing to it. Per-node "last started" timestamps live in `VirtualUser::pacing_state`
 (one map per VU, so VUs pacing the same folder run independent cadences) for `perUser: true` and
 for the sequential run; a `perUser: false` element instead advances its own entry in
 `ScenarioLoadState::shared_pacing` (a `SharedPacingClocks`, issue #1570), one atomic per
 shared-pacing element id in the plan, so two VUs' concurrent completions claim distinct slots of
-the same clock rather than racing onto the same one.
+the same clock rather than racing onto the same one. `SharedScheduleState::timers_override` (a
+`const TimersOverride*` alongside `pacing` and `throughput`, filled in from `RunContext` at the
+same call site) is `finish_step`'s own copy of the override for this seam: `"off"` returns
+`std::nullopt` before either kind touches its pacing state or shared clock at all, closing the gap
+this section used to disclose - a run that silences timers with `"off"` no longer defers a scenario
+load run's pacing or throughput element by its own interval first and only reports that truthfully
+after the fact.
 
 **Still not wired: step-level elements on the single-request load path.** `load_strategy.cpp`'s
 per-submission and per-completion hooks are unchanged: a single-request `POST /runs` payload's

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -49,6 +49,7 @@
 namespace vayu::core {
 
 struct ScenarioPlan;
+struct TimersOverride;
 
 /**
  * @brief Cross-instance shared clocks, one atomic per name (issue #1570) -
@@ -159,14 +160,23 @@ class SharedThroughputBudgets {
  * coordination shape is added, and the single call site
  * (`schedule_next_entry_wait`, `scenario_load.cpp`) fills it in once.
  *
- * Both members are null outside a scenario load run - no other caller reaches
- * this hook at all today - and a kind reading one must say what it does
- * without it (`timer.pacing` and `timer.throughput` both fall back to no
- * wait, which is what a run with no shared coordination would produce).
+ * Both `pacing` and `throughput` are null outside a scenario load run - no
+ * other caller reaches this hook at all today - and a kind reading one must
+ * say what it does without it (`timer.pacing` and `timer.throughput` both
+ * fall back to no wait, which is what a run with no shared coordination
+ * would produce).
+ *
+ * `timers_override` is the run's `elements.timers` override (issue #1498's
+ * reopen): this hook runs before any step's `ElementContext` exists, so it
+ * cannot read `ElementContext::timers_override` the way every other
+ * `timer.*` kind's `apply` does - a kind that schedules through here must
+ * consult this copy instead, and check it before doing anything else, so an
+ * `"off"` run books no wait and touches no pacing state at all.
  */
 struct SharedScheduleState {
-    SharedPacingClocks* pacing          = nullptr;
-    SharedThroughputBudgets* throughput = nullptr;
+    SharedPacingClocks* pacing            = nullptr;
+    SharedThroughputBudgets* throughput   = nullptr;
+    const TimersOverride* timers_override = nullptr;
 };
 
 /**

--- a/engine/src/core/elements/timer_pacing.cpp
+++ b/engine/src/core/elements/timer_pacing.cpp
@@ -91,15 +91,16 @@ class TimerPacingElement final : public Element {
         if (!scope_entry_) {
             return std::nullopt;
         }
-        // The run-level `elements.timers` override cannot reach this call:
-        // it is bound on `ElementContext`, which the load path's pre-select
-        // scheduling hook does not carry (it runs before any step's
-        // `ElementContext` exists). A run that silences timers with `off`
-        // still defers a scenario load run's pacing element by its own
-        // `everyMs` here; `apply`'s own override check then reports the
-        // outcome truthfully once the (already-elapsed) wait is confirmed.
-        // Disclosed in the PR as a known load-path limitation of the
-        // override, not present on the sequential run.
+        // The run-level `elements.timers` override cannot reach `apply`'s own
+        // check here - this hook runs before any step's `ElementContext`
+        // exists - so it is consulted through `shared.timers_override`
+        // instead (issue #1498's reopen). `"off"` books no wait and touches
+        // neither `pacing_state` nor the shared clock, matching `apply`'s own
+        // "off" outcome on the sequential run.
+        if (shared.timers_override != nullptr &&
+        shared.timers_override->mode == TimersOverride::Mode::Off) {
+            return std::nullopt;
+        }
         if (!per_user_) {
             // One cadence shared across every virtual user (issue #1570):
             // `shared.pacing` is always non-null here, sized by the plan

--- a/engine/src/core/elements/timer_throughput.cpp
+++ b/engine/src/core/elements/timer_throughput.cpp
@@ -97,8 +97,13 @@ class TimerThroughputElement final : public Element {
         if (!scope_entry_) {
             return std::nullopt;
         }
-        // The run-level `elements.timers` override cannot reach this call,
-        // for the reason `timer_pacing.cpp`'s own override comment states.
+        // The run-level `elements.timers` override is consulted through
+        // `shared.timers_override`, for the reason `timer_pacing.cpp`'s own
+        // comment states (issue #1498's reopen).
+        if (shared.timers_override != nullptr &&
+        shared.timers_override->mode == TimersOverride::Mode::Off) {
+            return std::nullopt;
+        }
         if (!per_user_) {
             // One rate shared across every virtual user: `shared.throughput`
             // is always non-null here, sized by the plan scan that found this

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -1213,7 +1213,8 @@ class ScenarioLoadDriver {
         // error's duration too.
         schedule_next_entry_wait (plan.steps[vu->step], *vu,
         SharedScheduleState{ .pacing = &state->shared_pacing,
-        .throughput                  = &state->shared_throughput_budgets });
+        .throughput                  = &state->shared_throughput_budgets,
+        .timers_override             = &context->timers_override });
 
         // Released *before* handle_result, which is what increments the
         // completion count `in_flight()` is derived from: a VU that became

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -670,12 +670,17 @@ TEST_F (ElementsTimersRunnerTest, GaussianTimerThinkWaitsApproximatelyItsMean) {
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
     std::chrono::steady_clock::now () - started);
-    // A generous floor, not a tight window: a gaussian draw around a 100ms
-    // mean with a 1ms deviation is essentially always >= 90ms, and a loaded
-    // CI box only ever makes this run *longer*, never shorter - there is no
-    // way for load to push it below 50ms.
-    EXPECT_GE (elapsed.count (), 50)
-    << "the think time did not hold up the run at all";
+    // A window, not a one-sided floor: a gaussian draw around a 100ms mean
+    // with a 1ms deviation is essentially always in [90, 110]ms, so 50ms was
+    // no floor at all - it passed on a run that never waited a tenth of the
+    // configured mean. The 800ms ceiling stays generous against CI jitter
+    // and the two GETs' own transfer time while still catching a wait that
+    // is off by an order of magnitude.
+    EXPECT_GE (elapsed.count (), 90)
+    << "the think time did not hold up the run for close to its configured "
+       "mean";
+    EXPECT_LT (elapsed.count (), 800)
+    << "the think time held up the run far longer than its configured mean";
 }
 
 // `timer.pacing` on a single request holds a steady cadence across
@@ -794,6 +799,10 @@ TEST_F (ElementsTimersRunnerTest, TheSameSeedReproducesTheSameThinkWaitAcrossTwo
         return trace0["elements"][0]["waitedMs"].get<int64_t> ();
     };
 
+    // Non-zero first: two runs that both happened to wait 0ms would pass the
+    // equality check below without proving the seed decided anything.
+    EXPECT_GT (waited_ms_of (run_1), 0)
+    << "the gaussian wait was 0ms - this proves nothing about the seed";
     EXPECT_EQ (waited_ms_of (run_1), waited_ms_of (run_2))
     << "the same elements.seed must draw the same gaussian wait on both runs";
 }
@@ -972,6 +981,63 @@ TEST_F (ElementsTimersLoadTest, APacedRunDoesNotBusySpinTheProducer) {
     EXPECT_GE (executed, 4u) << "the pacing interval grew - the bounded wait "
                                 "is overshooting the deferral";
     EXPECT_LE (executed, 6u) << "the pacing interval shrank or vanished";
+}
+
+// Issue #1498's reopen: `elements.timers: "off"` silences `timer.think`
+// (dispatched through `step.between`) but did not reach `timer.pacing`'s own
+// pre-selection scheduling hook (`scheduled_ready_delay_ms`), which runs
+// before any step's `ElementContext` - and therefore its bound
+// `timers_override` - exists. The run still deferred every VU by the
+// configured 500ms and only reported the (already-elapsed) wait as silenced
+// once `apply` ran. Mutation check: reverting the `shared.timers_override`
+// guard in `timer_pacing.cpp`'s `scheduled_ready_delay_ms` reds this on the
+// ceiling alone - `APacedRunDoesNotBusySpinTheProducer` above pins the paced
+// range (4 to 6) this override must clear.
+TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesPacingUnderLoad) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "constant_concurrency" }, { "concurrency", 1 },
+        { "duration", "2s" }, { "elements", { { "timers", "off" } } } };
+
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
+
+    // Back-to-back against a loopback mock over 2s comfortably clears the
+    // paced ceiling of 6 by an order of magnitude; 30 is a floor generous
+    // enough to absorb a loaded CI box while staying far above it.
+    EXPECT_GT (executed, 30u)
+    << "elements.timers: \"off\" did not silence timer.pacing under load - "
+       "got "
+    << executed << " requests over 2s, still in the paced range";
+}
+
+// @copydoc ElementsTimersOffSilencesPacingUnderLoad, `timer.throughput`'s
+// shared-budget wait (`SharedThroughputBudgets::claim`), the other kind
+// `scheduled_ready_delay_ms` defers a VU through. Mutation check: the same
+// guard reverted reds this on the ceiling `SharedThroughputHoldsTheWholeRunToTheTargetRate`
+// above pins (18 to 90).
+TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 600.0) });
+
+    auto config        = load_config ("4s");
+    config["elements"] = json{ { "timers", "off" } };
+
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
+
+    // Ten VUs free-running against a loopback mock over 4s would send
+    // thousands (the shared test's own comment); 120 clears the paced
+    // ceiling of 90 with a wide margin while staying reachable on a
+    // contended box running several tests at once.
+    EXPECT_GT (executed, 120u)
+    << "elements.timers: \"off\" did not silence timer.throughput's shared "
+       "budget under load - got "
+    << executed << " requests over 4s, still in the paced range";
 }
 
 } // namespace

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1016,12 +1016,19 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesPacingUnderLoad) {
 
 // @copydoc ElementsTimersOffSilencesPacingUnderLoad, `timer.throughput`'s
 // shared-budget wait (`SharedThroughputBudgets::claim`), the other kind
-// `scheduled_ready_delay_ms` defers a VU through. Mutation check: the same
-// guard reverted reds this on the ceiling `SharedThroughputHoldsTheWholeRunToTheTargetRate`
-// above pins (18 to 90).
+// `scheduled_ready_delay_ms` defers a VU through. A lower rate than
+// `SharedThroughputHoldsTheWholeRunToTheTargetRate` uses above: this
+// environment's own achievable ceiling for ten VUs against a loopback mock
+// over 4s measures at 39-40 regardless of any element at all (Debug build,
+// this sandbox's CPU quota), which sits *inside* that test's own 600/minute
+// target - a rate that high cannot discriminate paced from unpaced here.
+// 120/minute shared keeps the paced case (measured consistently at 18) well
+// clear of the unpaced one. Mutation check: reverting the `shared.timers_override`
+// guard reds this on the floor alone - a paced run measures 18, an unpaced
+// one 39-40, and 30 sits between them with margin on both sides.
 TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
     auto execution =
-    plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 600.0) });
+    plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 120.0) });
 
     auto config        = load_config ("4s");
     config["elements"] = json{ { "timers", "off" } };
@@ -1030,11 +1037,7 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
     ASSERT_NE (state, nullptr);
     const size_t executed = state->steps_executed.load ();
 
-    // Ten VUs free-running against a loopback mock over 4s would send
-    // thousands (the shared test's own comment); 120 clears the paced
-    // ceiling of 90 with a wide margin while staying reachable on a
-    // contended box running several tests at once.
-    EXPECT_GT (executed, 120u)
+    EXPECT_GT (executed, 30u)
     << "elements.timers: \"off\" did not silence timer.throughput's shared "
        "budget under load - got "
     << executed << " requests over 4s, still in the paced range";


### PR DESCRIPTION
## Description

`timer.pacing` and `timer.throughput`'s load-path pre-scheduling hook (`Element::scheduled_ready_delay_ms`) runs before any step's `ElementContext` exists, so it had no access to the run's `elements.timers` override - a scenario load run sent with `timers: "off"` still deferred every VU by the element's own configured interval, and only reported the wait as silenced once `apply` ran afterward on the already-elapsed wait. `docs/engine/api-reference.md` claimed the opposite.

Fix: `SharedScheduleState` (the struct this hook already receives for cross-VU coordination) gains a `timers_override` pointer, filled in at `scenario_load.cpp`'s one construction site from `RunContext::timers_override`. Both kinds check it for `Mode::Off` before touching any per-user or shared pacing state at all - not just before reporting the outcome.

**Alternative considered and rejected:** fully threading `Fixed`/`Range` modes through the same seam (the general `apply_timers_override` function already supports both). Rejected for this PR because `timer.throughput`'s shared branch takes a *rate*, not an interval, so converting a fixed/range interval into an equivalent rate needs its own design (unit conversion, rounding, reproducible RNG threading for `Range`) rather than riding along with the `"off"` fix this issue's acceptance criteria actually asked for. Filed as #1620 with the conversion approach spelled out; both docs touched here disclose the gap explicitly rather than overclaiming.

**Also fixed in this PR:** two pre-existing weak assertions in the same test file that would have passed on a wait of zero (`GaussianTimerThinkWaitsApproximatelyItsMean` only checked `elapsed >= 50ms` against a 100ms mean; `TheSameSeedReproducesTheSameThinkWaitAcrossTwoRuns` never checked the shared wait was non-zero before comparing two runs' waits for equality) - both were called out as "test-shape, not blocking" in the issue, but they're one-line fixes in a file this PR already touches.

## Type of Change
- [x] Bug fix

## Testing

- `cd engine && ctest --preset linux-dev --output-on-failure` - full suite, **3266/3266 passing**.
- Two new load-path tests (`ElementsTimersOffSilencesPacingUnderLoad`, `ElementsTimersOffSilencesThroughputUnderLoad`): the throughput one needed its target rate lowered after measuring this sandbox's actual delivery ceiling for 10 concurrent VUs against a loopback mock (39-40 requests over 4s *regardless of any timer element at all*, a Debug-build/sandbox-CPU characteristic, not a code defect) - at 600/minute that ceiling sits inside the paced range and can't discriminate the fix from its absence. Lowered to 120/minute, where a paced run measures a stable 18 and an unpaced one 39-40.
- Mutation-checked by hand: reverted the `shared.timers_override` guard in both kinds, confirmed both new tests go red (throughput measures exactly 18 - the paced value - with the guard removed), restored the guard, confirmed green again. Repeated 3x for stability given the timing-sensitive assertions.
- `clang-format-19 --dry-run -Werror` clean on every touched engine file.
- `mkdocs build --strict` not run (tool unavailable in this environment); both doc edits are prose inside existing sections referenced by an existing anchor (`elements.md#load-paths`), no headings added/moved/removed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## No user-visible change

Engine-only behavior fix plus one doc-comment precision edit in the app (`RunCollectionDialog.tsx`, no runtime change). Nothing for a screenshot to show.

## Related Issues
Closes #1498

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9JAkJGksfFAUZEA71nZnr)_