### PR TITLE
fix(elements): stop seeding blank scripts, treat one as absent everywhere

### DIFF
--- a/app/src/hooks/useNewRequest.ts
+++ b/app/src/hooks/useNewRequest.ts
@@ -29,7 +29,6 @@ import { useSessionStore, useTabsStore, useToastStore } from "@/stores";
 import { DEFAULT_REQUEST_NAME } from "@/constants/request";
 import { DEFAULT_COLLECTION_NAME } from "@/constants/collection";
 import { resolveNewRequestTarget } from "@/modules/welcome/targetCollection";
-import { defaultScriptElements } from "@/lib/elements";
 import type { Collection } from "@/types";
 
 const CREATE_FAILED = "Could not create the request. Check that the engine is running.";
@@ -65,7 +64,6 @@ export function useNewRequest(): UseNewRequestReturn {
 					name: DEFAULT_REQUEST_NAME,
 					method: "GET",
 					url: "",
-					elements: defaultScriptElements(),
 				});
 				openTab({ type: "request", entityId: newRequest.id });
 			} catch (error) {
@@ -92,7 +90,6 @@ export function useNewRequest(): UseNewRequestReturn {
 			try {
 				const newCollection = await createCollectionMutation.mutateAsync({
 					name: DEFAULT_COLLECTION_NAME,
-					elements: defaultScriptElements(),
 				});
 				await createRequestIn(newCollection.id);
 			} catch (error) {

--- a/app/src/lib/elements.test.ts
+++ b/app/src/lib/elements.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { isBlankScriptElement } from "./elements";
+
+describe("isBlankScriptElement", () => {
+	it("is true for an empty script.pre", () => {
+		expect(isBlankScriptElement({ kind: "script.pre", config: { script: "" } })).toBe(true);
+	});
+
+	it("is true for a whitespace-only script.post", () => {
+		expect(isBlankScriptElement({ kind: "script.post", config: { script: "  \n\t " } })).toBe(
+			true
+		);
+	});
+
+	it("is true when the script field is missing entirely", () => {
+		expect(isBlankScriptElement({ kind: "script.pre", config: {} })).toBe(true);
+	});
+
+	it("is false once the script has non-whitespace text", () => {
+		expect(
+			isBlankScriptElement({ kind: "script.post", config: { script: "pm.test()" } })
+		).toBe(false);
+	});
+
+	it("is false for a non-script kind, regardless of its config", () => {
+		expect(isBlankScriptElement({ kind: "assert.status", config: { script: "" } })).toBe(false);
+	});
+});

--- a/app/src/lib/elements.test.ts
+++ b/app/src/lib/elements.test.ts
@@ -25,9 +25,9 @@ describe("isBlankScriptElement", () => {
 	});
 
 	it("is false once the script has non-whitespace text", () => {
-		expect(
-			isBlankScriptElement({ kind: "script.post", config: { script: "pm.test()" } })
-		).toBe(false);
+		expect(isBlankScriptElement({ kind: "script.post", config: { script: "pm.test()" } })).toBe(
+			false
+		);
 	});
 
 	it("is false for a non-script kind, regardless of its config", () => {

--- a/app/src/lib/elements.ts
+++ b/app/src/lib/elements.ts
@@ -13,7 +13,6 @@
  */
 
 import type { ElementDef } from "@/types";
-import { generateId } from "@/lib/id";
 
 /**
  * The joined text of every enabled element of one script kind (`script.pre`
@@ -39,18 +38,14 @@ export function scriptTextFor(
 }
 
 /**
- * The `script.pre`/`script.post` pair every new request and collection is
- * created with, empty and enabled. The two script tabs this feature replaced
- * were always present, running only once given a non-blank body; a fresh
- * `elements: []` loses that visible slot; a fresh user has to know the
- * "Add element" menu exists before they can find where a pre-request or test
- * script goes. An empty `config.script` still passes the kind's own schema -
- * it requires the property present, not non-empty - and `scriptTextFor`
- * already treats a blank script as absent everywhere it's read.
+ * Whether a `script.pre`/`script.post` element's own text is empty or
+ * whitespace-only - the shared rule for "absent for every purpose but
+ * storage" (#1609): not composed, not run, not reported, not counted toward
+ * an inherited-elements notice. A blank element still exists as a stored row
+ * (a user may be mid-edit); only its runtime effect is inert.
  */
-export function defaultScriptElements(): ElementDef[] {
-	return [
-		{ id: `el_${generateId()}`, kind: "script.pre", enabled: true, config: { script: "" } },
-		{ id: `el_${generateId()}`, kind: "script.post", enabled: true, config: { script: "" } },
-	];
+export function isBlankScriptElement(el: Pick<ElementDef, "kind" | "config">): boolean {
+	if (el.kind !== "script.pre" && el.kind !== "script.post") return false;
+	const text = el.config.script;
+	return typeof text !== "string" || text.trim().length === 0;
 }

--- a/app/src/modules/collections/useTreeCrud.default-elements.test.tsx
+++ b/app/src/modules/collections/useTreeCrud.default-elements.test.tsx
@@ -9,14 +9,15 @@
  */
 
 /**
- * The two script tabs this feature replaced were always present, so a fresh
- * collection or request always had somewhere to type a pre-request or test
- * script. `elements: []` loses that visible slot behind an "Add element"
- * menu a new user has no reason to know about yet. Every creation path -
+ * A fresh collection or request used to be created with a seeded, empty
+ * `script.pre`/`script.post` pair, so the Elements tab looked the way the two
+ * script columns it replaced always did. That seeding is retired (#1609): it
+ * made every new collection's inherited-elements notice claim two elements
+ * would run when neither did anything, and gave the engine an "empty script"
+ * outcome to compose, run and report for no behaviour. Every creation path -
  * the sidebar's New Collection/Folder/Request, and the command palette's
- * "New Request" via `useNewRequest` - seeds a `script.pre`/`script.post`
- * pair instead, empty and enabled, so the Elements tab looks the way the
- * old two tabs did on a brand-new entity.
+ * "New Request" via `useNewRequest` - now sends no `elements` at all, so the
+ * entity starts with the engine's own default, `[]`.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -24,7 +25,6 @@ import { renderHook, act } from "@testing-library/react";
 
 import { useTreeCrud } from "./useTreeCrud";
 import type { Collection } from "@/types";
-import type { ElementDef } from "@/types";
 
 const createCollection = vi.fn();
 const createRequest = vi.fn();
@@ -54,16 +54,6 @@ function renderCrud() {
 	);
 }
 
-/** Every seeded pair looks like this, regardless of which path created it. */
-function expectScriptPair(elements: unknown) {
-	const list = elements as ElementDef[];
-	expect(list).toHaveLength(2);
-	expect(list[0]).toMatchObject({ kind: "script.pre", enabled: true, config: { script: "" } });
-	expect(list[1]).toMatchObject({ kind: "script.post", enabled: true, config: { script: "" } });
-	// Distinct ids - two elements of the same kind pair would otherwise collide.
-	expect(list[0].id).not.toBe(list[1].id);
-}
-
 beforeEach(() => {
 	createCollection.mockReset();
 	createRequest.mockReset();
@@ -71,7 +61,7 @@ beforeEach(() => {
 	createRequest.mockResolvedValue({ id: "r-new", collectionId: "c-1" });
 });
 
-describe("new-entity creation seeds a script.pre/script.post pair", () => {
+describe("new-entity creation sends no seeded elements", () => {
 	it("a top-level collection", async () => {
 		const { result } = renderCrud();
 
@@ -79,7 +69,7 @@ describe("new-entity creation seeds a script.pre/script.post pair", () => {
 		await act(async () => result.current.panel.createCollection());
 
 		expect(createCollection).toHaveBeenCalledTimes(1);
-		expectScriptPair(createCollection.mock.calls[0][0].elements);
+		expect(createCollection.mock.calls[0][0]).not.toHaveProperty("elements");
 	});
 
 	it("a subfolder", async () => {
@@ -91,7 +81,7 @@ describe("new-entity creation seeds a script.pre/script.post pair", () => {
 		expect(createCollection).toHaveBeenCalledTimes(1);
 		const sent = createCollection.mock.calls[0][0];
 		expect(sent.parentId).toBe("c-1");
-		expectScriptPair(sent.elements);
+		expect(sent).not.toHaveProperty("elements");
 	});
 
 	it("a request added from a collection's row menu", async () => {
@@ -103,6 +93,6 @@ describe("new-entity creation seeds a script.pre/script.post pair", () => {
 		await act(async () => addRequest?.onSelect());
 
 		expect(createRequest).toHaveBeenCalledTimes(1);
-		expectScriptPair(createRequest.mock.calls[0][0].elements);
+		expect(createRequest.mock.calls[0][0]).not.toHaveProperty("elements");
 	});
 });

--- a/app/src/modules/collections/useTreeCrud.ts
+++ b/app/src/modules/collections/useTreeCrud.ts
@@ -25,7 +25,6 @@ import type { RowAction } from "@/components/shared";
 import type { Collection, Request } from "@/types";
 import { DEFAULT_REQUEST_NAME } from "@/constants/request";
 import { DEFAULT_COLLECTION_NAME, DEFAULT_FOLDER_NAME } from "@/constants/collection";
-import { defaultScriptElements } from "@/lib/elements";
 
 export interface TreeCrudOptions {
 	collections: Collection[];
@@ -186,7 +185,6 @@ export function useTreeCrud({
 		try {
 			await createCollectionMutation.mutateAsync({
 				name: newCollectionName.trim(),
-				elements: defaultScriptElements(),
 			});
 		} catch (error) {
 			reportFailure(error, "Failed to create collection");
@@ -210,7 +208,6 @@ export function useTreeCrud({
 				await createCollectionMutation.mutateAsync({
 					name: newSubCollectionName.trim(),
 					parentId: parentId,
-					elements: defaultScriptElements(),
 				});
 			} catch (error) {
 				reportFailure(error, "Failed to create folder");
@@ -240,7 +237,6 @@ export function useTreeCrud({
 					name: DEFAULT_REQUEST_NAME,
 					method: "GET",
 					url: "",
-					elements: defaultScriptElements(),
 				});
 			} catch (error) {
 				reportFailure(error, "Failed to create request");

--- a/app/src/modules/request-builder/components/RequestTabs/elements-tab.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/elements-tab.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Elements tab badges a count, unlike Body/Auth/Info's presence badge -
+ * but a blank `script.pre`/`script.post` (empty or whitespace-only text) must
+ * not add to it. It is inert everywhere else (#1609: not composed, not run,
+ * not reported), so counting it here would tell a user something will run
+ * that in fact does nothing.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RequestBuilderContext } from "../../context";
+import type { RequestBuilderContextValue } from "../../types";
+import { createDefaultRequestState } from "../../utils/request-state";
+import type { ElementDef } from "@/types";
+import RequestTabs from "./index";
+
+vi.mock("@/queries", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/queries")>()),
+	useScriptCompletionsQuery: () => ({ data: undefined, isPending: true, isError: false }),
+}));
+
+vi.mock("./panels/InfoPanel", () => ({ default: () => null }));
+vi.mock("./panels/ParamsPanel", () => ({ default: () => null }));
+vi.mock("./panels/HeadersPanel", () => ({ default: () => null }));
+vi.mock("./panels/BodyPanel", () => ({ default: () => null }));
+vi.mock("./panels/AuthPanel", () => ({ default: () => null }));
+vi.mock("./panels/ElementsPanel", () => ({ default: () => null }));
+vi.mock("./panels/SettingsPanel", () => ({ default: () => null }));
+
+function renderTabs(elements: ElementDef[]) {
+	const value = {
+		request: { ...createDefaultRequestState(), elements },
+		activeTab: "elements",
+		setActiveTab: vi.fn(),
+	} as unknown as RequestBuilderContextValue;
+
+	return render(
+		<RequestBuilderContext.Provider value={value}>
+			<RequestTabs />
+		</RequestBuilderContext.Provider>
+	);
+}
+
+const labelOf = (tab: HTMLElement) =>
+	tab.querySelector('[data-slot="tab-label-reserve"]')?.nextElementSibling?.textContent ?? "";
+
+const elementsTab = () =>
+	screen.getAllByRole("tab").find((tab) => labelOf(tab).startsWith("Elements")) as HTMLElement;
+
+const countOf = (tab: HTMLElement) => tab.querySelector("sup")?.textContent ?? null;
+
+describe("the Elements tab badge", () => {
+	it("counts a real, enabled element", () => {
+		renderTabs([
+			{ id: "el_1", kind: "assert.status", enabled: true, config: { codes: [200] } },
+		]);
+		expect(countOf(elementsTab())).toBe("1");
+	});
+
+	it("excludes a blank script.pre", () => {
+		renderTabs([{ id: "el_1", kind: "script.pre", enabled: true, config: { script: "" } }]);
+		expect(countOf(elementsTab())).toBeNull();
+	});
+
+	it("excludes a whitespace-only script.post", () => {
+		renderTabs([
+			{ id: "el_1", kind: "script.post", enabled: true, config: { script: "  \n\t" } },
+		]);
+		expect(countOf(elementsTab())).toBeNull();
+	});
+
+	it("counts a script once it has real text", () => {
+		renderTabs([
+			{ id: "el_1", kind: "script.pre", enabled: true, config: { script: "" } },
+			{ id: "el_2", kind: "script.post", enabled: true, config: { script: "pm.test()" } },
+		]);
+		expect(countOf(elementsTab())).toBe("1");
+	});
+});

--- a/app/src/modules/request-builder/components/RequestTabs/index.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/index.tsx
@@ -13,6 +13,7 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger, TabLabel, TabCount } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { isBlankScriptElement } from "@/lib/elements";
 import { useRequestBuilderContext } from "../../context";
 import type { RequestTab, TabInfo } from "../../types";
 import InfoPanel from "./panels/InfoPanel";
@@ -76,7 +77,11 @@ export default function RequestTabs() {
 		{
 			id: "elements",
 			label: "Elements",
-			badge: request.elements.filter((e) => e.enabled).length || undefined,
+			// A blank script.pre/post is inert (#1609) - it does nothing, so it
+			// doesn't count toward "something is here" any more than a disabled row.
+			badge:
+				request.elements.filter((e) => e.enabled && !isBlankScriptElement(e)).length ||
+				undefined,
 		},
 		{
 			/*

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ElementsPanel.test.tsx
@@ -125,7 +125,7 @@ describe("ElementsPanel", () => {
 			inheritedElements: [
 				{
 					id: "c1",
-					kind: "script.pre",
+					kind: "extract.json",
 					enabled: true,
 					config: {},
 					origin: { kind: "collection", id: "col_1", name: "Acme" },

--- a/app/src/modules/request-builder/components/RequestTabs/panels/InheritedElementsNotice.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/InheritedElementsNotice.test.tsx
@@ -101,7 +101,9 @@ describe("InheritedElementsNotice - listing the chain's elements", () => {
 	it("lists an ancestor collection's enabled element, with its kind label", () => {
 		chain.length = 0;
 		chain.push(
-			collection("root", "Acme", [element({ id: "r1", kind: "script.pre" })]),
+			collection("root", "Acme", [
+				element({ id: "r1", kind: "script.pre", config: { script: "pm.log('x')" } }),
+			]),
 			collection("leaf", "Refunds", [])
 		);
 
@@ -114,12 +116,47 @@ describe("InheritedElementsNotice - listing the chain's elements", () => {
 	it("skips a disabled element", () => {
 		chain.length = 0;
 		chain.push(
-			collection("root", "Acme", [element({ id: "r1", kind: "script.pre", enabled: false })])
+			collection("root", "Acme", [
+				element({
+					id: "r1",
+					kind: "script.pre",
+					enabled: false,
+					config: { script: "pm.log('x')" },
+				}),
+			])
 		);
 
 		const { container } = renderNotice({ collectionId: "root" });
 
 		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("skips a blank script.pre", () => {
+		chain.length = 0;
+		chain.push(
+			collection("root", "Acme", [
+				element({ id: "r1", kind: "script.pre", config: { script: "" } }),
+			])
+		);
+
+		const { container } = renderNotice({ collectionId: "root" });
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("skips a whitespace-only script.post but lists a real one alongside it", () => {
+		chain.length = 0;
+		chain.push(
+			collection("root", "Acme", [
+				element({ id: "r1", kind: "script.post", config: { script: "  \n\t" } }),
+				element({ id: "r2", kind: "extract.json", config: {} }),
+			])
+		);
+
+		renderNotice({ collectionId: "root" });
+
+		expect(screen.getByText("Extract JSON")).toBeInTheDocument();
+		expect(screen.getByText("A collection will run before your own.")).toBeInTheDocument();
 	});
 
 	it("falls back to the raw kind string when the catalogue has no label for it", () => {
@@ -157,14 +194,14 @@ describe("InheritedElementsNotice - listing the chain's elements", () => {
 		const entries: ResolvedElement[] = [
 			{
 				id: "c1",
-				kind: "script.pre",
+				kind: "extract.json",
 				enabled: true,
 				config: {},
 				origin: { kind: "collection", id: "c1", name: "Parent Collection" },
 			},
 			{
 				id: "r1",
-				kind: "script.pre",
+				kind: "extract.json",
 				enabled: true,
 				config: {},
 				origin: { kind: "request", id: "r1" },
@@ -182,7 +219,7 @@ describe("InheritedElementsNotice - listing the chain's elements", () => {
 	it("renders the chain root to leaf, matching execution order", () => {
 		chain.length = 0;
 		chain.push(
-			collection("root", "Outer", [element({ id: "r1", kind: "script.pre" })]),
+			collection("root", "Outer", [element({ id: "r1", kind: "extract.json" })]),
 			collection("leaf", "Inner", [element({ id: "l1", kind: "extract.json" })])
 		);
 
@@ -196,7 +233,7 @@ describe("InheritedElementsNotice - listing the chain's elements", () => {
 describe("InheritedElementsNotice - the Disable / Re-enable toggle", () => {
 	it("adds an inherit.disable entry naming the element when Disable is pressed", () => {
 		chain.length = 0;
-		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "script.pre" })]));
+		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "extract.json" })]));
 
 		const onChangeOwnElements = vi.fn();
 		renderNotice({ collectionId: "root", ownElements: [], onChangeOwnElements });
@@ -215,7 +252,7 @@ describe("InheritedElementsNotice - the Disable / Re-enable toggle", () => {
 
 	it("shows Re-enable, and removes the disable entry, once the element is disabled", () => {
 		chain.length = 0;
-		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "script.pre" })]));
+		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "extract.json" })]));
 
 		const ownElements: ElementDef[] = [
 			element({ id: "el_disable_r1", kind: "inherit.disable", config: { elementId: "r1" } }),
@@ -233,7 +270,7 @@ describe("InheritedElementsNotice - the Disable / Re-enable toggle", () => {
 		// `disabledIds` marks the row, it does not hide it - only an actually
 		// disabled *ancestor* element (its own `enabled: false`) is left off.
 		chain.length = 0;
-		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "script.pre" })]));
+		chain.push(collection("root", "Acme", [element({ id: "r1", kind: "extract.json" })]));
 
 		const ownElements: ElementDef[] = [
 			element({ id: "el_disable_r1", kind: "inherit.disable", config: { elementId: "r1" } }),

--- a/app/src/modules/request-builder/components/RequestTabs/panels/InheritedElementsNotice.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/InheritedElementsNotice.tsx
@@ -12,9 +12,12 @@
  * kind. Walks the ancestor chain of the request's collection (root first, via
  * `useCollectionAncestors` - the same hook `AuthInheritBanner` uses for auth)
  * and lists every enabled element a collection in the chain carries - the
- * ones that will run before the request's own. A disable toggle writes an
- * `inherit.disable` entry into the request's own list rather than editing the
- * ancestor, which the request cannot do.
+ * ones that will run before the request's own. A blank `script.pre`/
+ * `script.post` (empty or whitespace-only text) is excluded: it is inert
+ * everywhere else (#1609), so counting it here would claim a run that never
+ * happens. A disable toggle writes an `inherit.disable` entry into the
+ * request's own list rather than editing the ancestor, which the request
+ * cannot do.
  *
  * Renders nothing when no collection in the chain carries an element. That is
  * most requests, so it must not leave an empty box behind.
@@ -27,6 +30,7 @@
 import { Folder } from "lucide-react";
 import { useCollectionAncestors } from "@/queries/collections";
 import { Button } from "@/components/ui";
+import { isBlankScriptElement } from "@/lib/elements";
 import type { Collection, ElementDef, ElementKindSchema, ResolvedElement } from "@/types";
 import ChainCard from "./ChainCard";
 
@@ -71,7 +75,11 @@ export default function InheritedElementsNotice({
 	// nobody will render.
 	const ancestors = useCollectionAncestors(entries ? null : collectionId);
 	const source = (entries ?? entriesFromChain(ancestors)).filter(
-		(e) => e.enabled && e.kind !== "inherit.disable" && e.origin?.kind === "collection"
+		(e) =>
+			e.enabled &&
+			e.kind !== "inherit.disable" &&
+			e.origin?.kind === "collection" &&
+			!isBlankScriptElement(e)
 	);
 
 	if (source.length === 0) return null;

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1612,18 +1612,20 @@ so a kind the engine adds needs no change here; `inherit.disable` is excluded
 from it, since a user never adds one by hand - it is written by the
 inheritance notice's Disable toggle.
 
-**A new request or collection is seeded with an empty `script.pre`/
-`script.post` pair** (`lib/elements.ts`'s `defaultScriptElements`), enabled
-with `config.script: ""`. The two tabs this feature replaced were always
-present and ran only once given a non-blank body; `elements: []` on a fresh
-entity would hide that slot behind the Add menu for a user with no reason yet
-to know it exists. An empty script still passes the kind's own schema (only
-the property's presence is required, not its length), and `scriptTextFor`
-already treats a blank script as absent everywhere it is read, so the pair is
-inert until someone types into it. Seeded at every creation path -
-`useTreeCrud.ts`'s New Collection / Add Folder / Add Request, and
-`useNewRequest.ts`'s command-palette flow - not in `createDefaultRequestState`,
-which only fills transient local state and is never sent as a create payload.
+**A new request or collection sends no `elements` at all** (issue #1609):
+creation used to seed an empty, enabled `script.pre`/`script.post` pair
+(`lib/elements.ts`'s retired `defaultScriptElements`) so the two script tabs
+this feature replaced still had a visible slot on a fresh entity. That made
+`InheritedElementsNotice` claim "2 elements will run before your own" about a
+collection whose two elements did nothing, and gave the engine an empty
+script to compose, run and report as a real outcome. A blank `script.*`
+element (`isBlankScriptElement`, `lib/elements.ts`) is now inert everywhere it
+is read - `scriptTextFor`, the Elements tab's badge count, and
+`InheritedElementsNotice`'s count and list - the app-side half of a rule the
+engine pipeline enforces the same way (`docs/engine/elements.md`), so the
+seeding lost its reason to exist. A fresh entity's Elements tab shows the
+existing `emptyLabel` sentence pointing at the Add menu until #1606's app
+child gives it quick-add chips instead.
 
 ## Shared Response Viewer (`components/shared/response-viewer/`)
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4201,7 +4201,8 @@ and is never re-resolved - see [POST /execute](#post-execute) and
 - **`requestId`** composes the stored request wholesale: URL, flattened enabled
   headers (later duplicates win), body, auth (absent auth defaults to
   `inherit`), the resolved `elements` list (collection chain root→leaf, then
-  the request's own, each stamped with its origin - see [Elements](elements.md)),
+  the request's own, each stamped with its origin, disabled and blank
+  `script.*` entries dropped the same way - see [Elements](elements.md)),
   the stored execution options (`followRedirects` /
   `maxRedirects` / `httpVersion` / `verifySSL`, always emitted) and its `requestName` (the
   script sandbox reads it as `pm.info.requestName`; omitted when the row's name

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -188,6 +188,14 @@ always made. The element's own outcome is whether the script ran without throwin
 `pm.test` assertions travel inside the same `vayu::ScriptResult` untouched, so a scripted step's
 trace shape is unchanged by this cut-over.
 
+A **blank** `script.pre` / `.post` / `.setup` / `.teardown` (its own `script` empty or
+whitespace-only, `is_blank_script_element`) is inert everywhere but storage (issue #1609): `POST
+/compose` does not emit it, `compile_elements` compiles it to no runnable behaviour the same way an
+unknown kind does, so `ElementPipeline::run` reports no outcome for it at all - not even `skipped` -
+and `scenario_plan.cpp`'s `step_has_script` (the pre-request-script-under-load warning, a step's
+`preRequestScript` breakdown field) does not count it as carrying one. The stored row is untouched, so
+it still lists and edits in its own request's or collection's Elements tab.
+
 `script.setup` / `script.teardown` are `collection_only` - refused (a `400` naming the index and
 kind) on a request's own `elements`, both at write time and in `GET /elements/kinds`'
 `collectionOnly` flag, because a once-per-run element attached to one request in the tree has no

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -678,12 +678,39 @@ struct CompiledElement {
  *
  * One entry in, one `CompiledElement` out, in the same order. A kind with no
  * runnable behaviour - unknown to this registry (the DB held a row a newer
- * engine wrote), or validate-only like `test.echo` - compiles to a null
+ * engine wrote), validate-only like `test.echo`, or a blank `script.*`
+ * element (issue #1609, `is_blank_script_element`) - compiles to a null
  * `element`; with no phase to dispatch it at, `ElementPipeline::run` never
  * calls it and never reports an outcome for it, the same as a kind this build
  * has simply never heard of.
  */
 [[nodiscard]] std::vector<CompiledElement> compile_elements (const nlohmann::json& elements);
+
+/**
+ * Whether @p text is empty or holds only whitespace - the one rule "blank"
+ * means everywhere a script's own text is judged (issue #1609). Shared by
+ * `is_blank_script_element` below and by `Database::migrate_before_sync`'s
+ * fold of a pre-#1514 row's legacy script columns, which has no element to
+ * check and only ever has the raw text.
+ */
+[[nodiscard]] bool is_blank_script_text (const std::string& text);
+
+/**
+ * Whether @p kind is one of the four script kinds (`script.pre`,
+ * `.post`, `.setup`, `.teardown`) and @p config's `script` is blank by
+ * {@link is_blank_script_text} (absent counts as blank too - the kind's
+ * schema requires the property present, not non-empty). A blank script
+ * element is inert everywhere but storage (issue #1609): not composed
+ * (`request_composer.cpp`'s `emit_level`), not compiled into runnable
+ * behaviour (`compile_elements` below leaves it with no `element`, the same
+ * "nothing this build can run" shape an unknown kind gets, so
+ * `ElementPipeline::run` reports no outcome for it), not counted as "this
+ * step carries a script" (`scenario_plan.cpp`'s `step_has_script`,
+ * `run_manager.cpp`'s `find_step_post_script`). The stored row is untouched -
+ * a user mid-edit still sees and can edit it in its own Elements tab.
+ */
+[[nodiscard]] bool
+is_blank_script_element (const std::string& kind, const nlohmann::json& config);
 
 /**
  * Assigns an `el_` id to every object entry of @p elements missing one - the

--- a/engine/src/core/elements/pipeline.cpp
+++ b/engine/src/core/elements/pipeline.cpp
@@ -207,7 +207,8 @@ std::vector<CompiledElement> compile_elements (const nlohmann::json& elements) {
         out.enabled = !entry.contains ("enabled") ||
         entry["enabled"].is_null () || entry.value ("enabled", true);
 
-        if (const auto* kind = registry.find (out.kind); kind != nullptr && kind->compile) {
+        if (const auto* kind = registry.find (out.kind); kind != nullptr &&
+        kind->compile && !is_blank_script_element (out.kind, out.config)) {
             // Stamped onto a *copy* passed to `compile`, never onto
             // `out.config` itself - `out.config` is what the load path's
             // deferred `script.post` replay reads back verbatim

--- a/engine/src/core/elements/script_kinds.cpp
+++ b/engine/src/core/elements/script_kinds.cpp
@@ -163,6 +163,18 @@ make_script_kind (Phase phase, const char* kind, const char* label, const char* 
 
 } // namespace
 
+bool is_blank_script_text (const std::string& text) {
+    return text.find_first_not_of (" \t\r\n") == std::string::npos;
+}
+
+bool is_blank_script_element (const std::string& kind, const nlohmann::json& config) {
+    if (kind != "script.pre" && kind != "script.post" &&
+    kind != "script.setup" && kind != "script.teardown") {
+        return false;
+    }
+    return is_blank_script_text (config.value ("script", ""));
+}
+
 ElementKind make_script_pre_kind () {
     auto kind = make_script_kind (Phase::StepBefore, "script.pre",
     "Pre-request script", "Runs before the request is sent.");

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -314,7 +314,8 @@ RunContext::ScriptsOverrideMode scripts_mode) {
             return nullptr;
         }
         if (auto found = element.config.find ("script");
-        found != element.config.end () && found->is_string ()) {
+        found != element.config.end () && found->is_string () &&
+        !vayu::core::is_blank_script_text (found->get_ref<const std::string&> ())) {
             return &found->get_ref<const std::string&> ();
         }
     }

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -729,8 +729,15 @@ bool step_has_script (const ScenarioStep& step, std::string_view kind) {
     if (!step.elements) {
         return false;
     }
+    // A blank script.pre/post is inert (#1609): it carries no behaviour to
+    // warn about (`build_run_warnings`) or report as skipped
+    // (`build_step_breakdown`), so a step whose only match is blank does not
+    // count as carrying one.
     return std::any_of (step.elements->begin (), step.elements->end (),
-    [&] (const CompiledElement& element) { return element.kind == kind; });
+    [&] (const CompiledElement& element) {
+        return element.kind == kind &&
+        !is_blank_script_element (element.kind, element.config);
+    });
 }
 
 std::unordered_map<std::string, vayu::core::ElementSpan> compute_element_spans (

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -54,6 +54,7 @@
 #include <unordered_set>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/elements.hpp"
 #include "vayu/core/spec_binding.hpp"
 #include "vayu/http/default_headers.hpp"
 #include "vayu/http/transport_policy.hpp"
@@ -1047,10 +1048,6 @@ void log_reclaim_outcome (const ReclaimOutcome& outcome) {
 /// this file predates the fold ever adding.
 constexpr int SCHEMA_VERSION = 1;
 
-bool is_blank_script_text (const std::string& text) {
-    return text.find_first_not_of (" \t\r\n") == std::string::npos;
-}
-
 /// @p table's current column names, read fresh so a caller never assumes a
 /// shape a genuinely pre-cutover database (older than #1513, no `elements`
 /// column at all) does not have.
@@ -1111,13 +1108,13 @@ const std::string& post) {
     };
 
     bool changed = false;
-    if (!is_blank_script_text (pre) && !has_kind ("script.pre")) {
+    if (!vayu::core::is_blank_script_text (pre) && !has_kind ("script.pre")) {
         elements.push_back (
         { { "id", vayu::utils::generate_id ("el_") }, { "kind", "script.pre" },
         { "enabled", true }, { "config", { { "script", pre } } } });
         changed = true;
     }
-    if (!is_blank_script_text (post) && !has_kind ("script.post")) {
+    if (!vayu::core::is_blank_script_text (post) && !has_kind ("script.post")) {
         elements.push_back (
         { { "id", vayu::utils::generate_id ("el_") }, { "kind", "script.post" },
         { "enabled", true }, { "config", { { "script", post } } } });

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <unordered_set>
 
+#include "vayu/core/elements.hpp"
 #include "vayu/http/header_names.hpp"
 #include "vayu/http/header_text.hpp"
 #include "vayu/http/routes.hpp"
@@ -881,8 +882,8 @@ const std::vector<nlohmann::json>& levels) {
     return disabled;
 }
 
-// One level's enabled, non-disabled, non-`inherit.disable` elements, each
-// stamped with where it came from.
+// One level's enabled, non-disabled, non-`inherit.disable`, non-blank-script
+// elements, each stamped with where it came from.
 void emit_level (nlohmann::json& out,
 const nlohmann::json& elements,
 const std::unordered_set<std::string>& disabled,
@@ -894,6 +895,13 @@ const std::string& origin_name) {
             continue;
         }
         if (!element.value ("enabled", true)) {
+            continue;
+        }
+        // A blank script.pre/post/setup/teardown is inert everywhere (#1609),
+        // so it is not composed either - the same rule `compile_elements`
+        // enforces at run time.
+        if (vayu::core::is_blank_script_element (element.value ("kind", ""),
+            element.value ("config", nlohmann::json::object ()))) {
             continue;
         }
         const auto id = element.value ("id", "");

--- a/engine/tests/elements_setup_teardown_test.cpp
+++ b/engine/tests/elements_setup_teardown_test.cpp
@@ -631,7 +631,7 @@ TEST_F (ScriptLifecycleTest, SingleRequestWithNoLifecycleElementsRunsNormally) {
 // `teardown[0]["id"]` reddens to `""`.
 TEST_F (ScriptLifecycleTest, SingleRequestLifecycleElementWithNoIdGetsAGeneratedIdInOutcomes) {
     const json elements = json::array (
-    { json{ { "kind", "script.teardown" }, { "config", { { "script", "" } } } } });
+    { json{ { "kind", "script.teardown" }, { "config", { { "script", "1;" } } } } });
     EXPECT_EQ (run_single_request_load (elements, /*iterations=*/1, /*concurrency=*/1),
     vayu::RunStatus::Completed);
 

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -612,6 +612,37 @@ TEST_F (RequestComposerTest, ComposesASavedRequestById) {
     EXPECT_EQ (payload["environmentId"], "env_1");
 }
 
+// Issue #1609: a blank script.pre/post is inert, including at composition -
+// it never reaches a client of POST /compose at all, the same as a disabled
+// element. Mutation check: remove the `is_blank_script_element` guard in
+// `emit_level` and this reddens to `elements.size () == 2`.
+TEST_F (RequestComposerTest, ABlankScriptIsNotComposedButARealOneAlongsideItIs) {
+    vayu::db::Collection col;
+    col.id       = "col_1";
+    col.name     = "Collection col_1";
+    col.elements = json::array (
+    { json{ { "id", "el_blank_pre" }, { "kind", "script.pre" },
+      { "enabled", true }, { "config", { { "script", "   \n\t" } } } },
+    json{ { "id", "el_real_post" }, { "kind", "script.post" }, { "enabled", true },
+    { "config", { { "script", "console.log('runs');" } } } } })
+                   .dump ();
+    col.order      = 0;
+    col.created_at = 1;
+    col.updated_at = 1;
+    db_->create_collection (col);
+
+    auto r = make_request ("req_1", "col_1");
+    db_->save_request (r);
+
+    auto [status, payload] =
+    vayu::http::compose_request_core (*db_, json{ { "requestId", "req_1" } });
+    ASSERT_EQ (status, 200) << payload.dump ();
+
+    ASSERT_EQ (payload["elements"].size (), 1u);
+    EXPECT_EQ (payload["elements"][0]["id"], "el_real_post");
+    EXPECT_EQ (payload["elements"][0]["kind"], "script.post");
+}
+
 TEST_F (RequestComposerTest, StoredRequestWithoutAuthBlobDefaultsToInherit) {
     seed_collection ("col", "", "", R"({"mode":"apikey","key":"X-Key","value":"k"})");
     auto r = make_request ("req_1", "col");

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -853,6 +853,31 @@ TEST_F (ScenarioRunnerTest, TimerThinkWaitsBetweenStepsAndReportsHowLong) {
     EXPECT_LT (rows[0].latency_ms, 100.0);
 }
 
+// Issue #1609's acceptance criterion: a blank script.pre is inert - the
+// pipeline reports no outcome for it at all, not even "skipped" - while a
+// real script.post beside it on the same step still runs and reports.
+// Mutation check: revert the `is_blank_script_element` guard in
+// `compile_elements` and `trace0["elements"].size ()` reddens to 2.
+TEST_F (ScenarioRunnerTest, ABlankScriptPreReportsNoOutcomeButARealScriptPostDoes) {
+    seed_collection ("col_1");
+    seed_request_with_elements ("req_a", 0, "/ok",
+    json::array ({ json{ { "id", "el_blank_pre" }, { "kind", "script.pre" },
+                   { "config", { { "script", "  \n" } } } },
+    json{ { "id", "el_real_post" }, { "kind", "script.post" },
+    { "config", { { "script", "console.log('runs');" } } } } }));
+
+    const auto run_id = start (/*iterations=*/1);
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+
+    auto rows = db_->get_results (run_id);
+    ASSERT_EQ (rows.size (), 1u);
+    const auto trace0 = json::parse (rows[0].trace_data);
+    ASSERT_EQ (trace0["elements"].size (), 1u);
+    EXPECT_EQ (trace0["elements"][0]["id"], "el_real_post");
+    EXPECT_EQ (trace0["elements"][0]["kind"], "script.post");
+    EXPECT_EQ (trace0["elements"][0]["outcome"], "ok");
+}
+
 // Issue #1500's acceptance criterion: a metric.record trend on one step
 // produces `customMetrics.<name>` in the sequential run's own summary
 // section, with a count equal to that step's completions.


### PR DESCRIPTION
## Description

Every new request and collection was seeded with an empty, enabled `script.pre`/`script.post` pair (`lib/elements.ts`'s `defaultScriptElements`), so a fresh collection's `InheritedElementsNotice` claimed "2 elements will run before your own" about two elements that did nothing, and the Elements tab badge counted them too.

This PR retires the seeding and makes a blank `script.*` element (empty or whitespace-only text) inert wherever it is read, on both sides:

- **App**: delete `defaultScriptElements` and its five call sites; add `isBlankScriptElement` and use it in `InheritedElementsNotice`'s count/list and the Elements tab badge, alongside the existing `enabled` filter. A blank element still lists and edits fine in its own Elements tab - only what claims it "runs" is fixed.
- **Engine**: a blank script used to compose, run and report as a real element - `POST /compose` emitted it, the pipeline dispatched it with an `"ok"` outcome, and `scenario_plan.cpp`'s `step_has_script` counted it toward the pre-request-script-under-load warning and the sampled-response reservoir decision. Added a shared `is_blank_script_element` helper and wired it into `request_composer.cpp`'s `emit_level`, `pipeline.cpp`'s `compile_elements` (a blank script now compiles to no runnable behaviour, the same "nothing to run" shape an unknown kind gets, so `ElementPipeline::run` reports no outcome for it at all - not even `skipped`), `scenario_plan.cpp`'s `step_has_script`, and `run_manager.cpp`'s `find_step_post_script`. `is_blank_script_text` moves out of `database.cpp`'s migration into the shared helper so the migration and the pipeline agree on one rule.

**No stored-data migration**: a blank element already in a database (from 0.27.0's seeding) is inert under the new rule automatically - it just sits in the row, editable, doing nothing. A user who wants it gone deletes it.

**Alternative considered and rejected**: making the pipeline report a `"skipped"` outcome for a blank script, the way a disabled element already does. Rejected because the issue's acceptance criteria and its own reading of "absent" both call for zero outcome entries, not a visible-but-inert one - a report already distinguishes "disabled by the user" from "nothing here to run," and a blank script is the second, not the first.

## Type of Change
- [x] Bug fix

## Testing

App: `pnpm test` - full suite, 727 files / 8257 passed, 1 pre-existing skip. `pnpm lint`, `pnpm format:check`, `pnpm type-check` all clean. New/updated: `elements.test.ts` (`isBlankScriptElement`), `elements-tab.test.tsx`, `InheritedElementsNotice.test.tsx`, `useTreeCrud.default-elements.test.tsx`.

Engine: `python build.py -e -t` (Linux/Debug) - clean build. `ctest --preset linux-dev` - **3266/3266 tests passed**. New/updated: `request_composer_test.cpp` (`ABlankScriptIsNotComposedButARealOneAlongsideItIs`), `scenario_runner_test.cpp` (`ABlankScriptPreReportsNoOutcomeButARealScriptPostDoes`), and `elements_setup_teardown_test.cpp`'s existing blank-teardown fixture updated to non-blank text now that blank no longer dispatches. Mutation-checked by hand: reverting the `is_blank_script_element` guard in `compile_elements` reds the new scenario-runner case (2 outcomes instead of 1); reverting it in `emit_level` reds the new composer case (2 elements instead of 1).

## Checklist
- [x] My code follows the style guidelines (app: lint/format/type-check clean; engine: clang-format and clang-tidy clean)
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/elements.md`, `docs/engine/api-reference.md`, `docs/app/COMPONENTS.md`)

## Visual changes

Not captured as a screenshot - the visible change is subtractive only (a notice/badge that incorrectly counted a blank script no longer does), verified instead through the new `InheritedElementsNotice.test.tsx` and `elements-tab.test.tsx` cases asserting the notice/badge is absent for a blank-script-only ancestor/element.

## Related Issues
Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQ395s668kkBYd45kzAqmz