### PR TITLE
fix(app): script element editor gets a definite height, per-row snippets, and a resize handle

### DIFF
--- a/app/src/components/a11y-suppressions.test.ts
+++ b/app/src/components/a11y-suppressions.test.ts
@@ -40,13 +40,13 @@ const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
  * The most directives this repository may carry.
  *
  * A ceiling, not a count to hold: 16 was what #1216 left behind, one of which
- * went with the body editor's drag handle (#1323); 17 adds the Dock's
- * worker-count tooltip (#1508). The number moves down with the list in the
- * doc when a site is fixed rather than suppressed. Raising it means adding a
- * site to the doc too, which is where the reason has to convince the next
- * reader.
+ * went with the body editor's drag handle (#1323); 17 added the Dock's
+ * worker-count tooltip (#1508); 18 adds the script element form's editor
+ * height handle (#1605). The number moves down with the list in the doc when
+ * a site is fixed rather than suppressed. Raising it means adding a site to
+ * the doc too, which is where the reason has to convince the next reader.
  */
-const CEILING = 17;
+const CEILING = 18;
 
 /** The reason marker eslint itself understands, and this repository writes. */
 const REASON = " -- ";

--- a/app/src/components/shared/ElementList/ScriptElementForm.test.tsx
+++ b/app/src/components/shared/ElementList/ScriptElementForm.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Three defects reported from the 0.27.0 Elements tab (issue #1605), all in
+ * this one form:
+ *
+ * 1. The editor box resolved `height="100%"` against an auto-height card, so
+ *    Monaco laid out at zero height and typed text was invisible. jsdom cannot
+ *    lay Monaco out either, so what is pinned here is the box's own inline
+ *    style - a definite pixel height, never a percentage.
+ * 2. `ScriptSnippets` read one shared boolean, so a `script.pre` and a
+ *    `script.post` row on the same screen could not be expanded
+ *    independently.
+ * 3. The editor could not be resized at all. The handle below the box is
+ *    pinned by keyboard (the reliable path in jsdom - `PanelResizeHandle`'s
+ *    own test pins its handle the same way) and by a direct pointer-event
+ *    dispatch for the drag path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { ScriptElementForm } from "./ScriptElementForm";
+import { useLayoutStore } from "@/stores";
+import {
+	DEFAULT_SCRIPT_EDITOR_HEIGHT,
+	SCRIPT_EDITOR_HEIGHT_STEP,
+	SCRIPT_EDITOR_MAX_HEIGHT,
+	SCRIPT_EDITOR_MIN_HEIGHT,
+} from "@/constants/layout";
+
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: ({ ariaLabel }: { ariaLabel: string }) => (
+		<div data-testid={`code-editor-${ariaLabel}`} />
+	),
+}));
+
+vi.mock("@/queries", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/queries")>()),
+	useScriptCompletionsQuery: () => ({ data: undefined, isPending: false, isError: false }),
+}));
+
+beforeEach(() => {
+	useLayoutStore.setState({
+		scriptEditorHeight: DEFAULT_SCRIPT_EDITOR_HEIGHT,
+		scriptSnippetsCollapsed: true,
+	});
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+function renderForm(kind: "script.pre" | "script.post" = "script.pre") {
+	const onChange = vi.fn();
+	render(<ScriptElementForm kind={kind} config={{}} onChange={onChange} />);
+	return {
+		onChange,
+		box: screen.getByTestId(
+			`code-editor-${kind === "script.pre" ? "Pre-request script" : "Test script"}`
+		).parentElement!,
+	};
+}
+
+function heightHandle() {
+	return screen.getByRole("separator");
+}
+
+describe("ScriptElementForm's editor box", () => {
+	it("gets a definite pixel height, equal to the store's default, not a percentage of an absent ancestor", () => {
+		const { box } = renderForm();
+
+		expect(box).toHaveStyle({ height: `${DEFAULT_SCRIPT_EDITOR_HEIGHT}px` });
+		expect(box.className).toContain("min-h-0");
+	});
+
+	it("reads whatever height the store already holds", () => {
+		useLayoutStore.setState({ scriptEditorHeight: 240 });
+		const { box } = renderForm();
+
+		expect(box).toHaveStyle({ height: "240px" });
+	});
+});
+
+describe("the resize handle", () => {
+	it("is a focusable, labelled window splitter announcing the current height", () => {
+		renderForm("script.post");
+		const handle = heightHandle();
+
+		expect(handle).toHaveAttribute("tabindex", "0");
+		expect(handle).toHaveAttribute("aria-label", "Test script editor height");
+		expect(handle).toHaveAttribute("aria-valuenow", String(DEFAULT_SCRIPT_EDITOR_HEIGHT));
+		expect(handle).toHaveAttribute("aria-valuemin", String(SCRIPT_EDITOR_MIN_HEIGHT));
+		expect(handle).toHaveAttribute("aria-valuemax", String(SCRIPT_EDITOR_MAX_HEIGHT));
+	});
+
+	it("nudges the height by the step on ArrowDown/ArrowUp, persisted after the debounce", () => {
+		vi.useFakeTimers();
+		renderForm();
+		const handle = heightHandle();
+
+		act(() => fireEvent.keyDown(handle, { key: "ArrowDown" }));
+		// Debounced, the GraphQLBody `handleVariablesResize` way - not written yet.
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(DEFAULT_SCRIPT_EDITOR_HEIGHT);
+		act(() => vi.advanceTimersByTime(200));
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(
+			DEFAULT_SCRIPT_EDITOR_HEIGHT + SCRIPT_EDITOR_HEIGHT_STEP
+		);
+
+		act(() => fireEvent.keyDown(handle, { key: "ArrowUp" }));
+		act(() => vi.advanceTimersByTime(200));
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(DEFAULT_SCRIPT_EDITOR_HEIGHT);
+
+		vi.useRealTimers();
+	});
+
+	it("clamps at the floor", () => {
+		vi.useFakeTimers();
+		useLayoutStore.setState({ scriptEditorHeight: SCRIPT_EDITOR_MIN_HEIGHT });
+		renderForm();
+
+		act(() => fireEvent.keyDown(heightHandle(), { key: "ArrowUp" }));
+		act(() => vi.advanceTimersByTime(200));
+
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(SCRIPT_EDITOR_MIN_HEIGHT);
+		vi.useRealTimers();
+	});
+
+	it("clamps at the ceiling", () => {
+		vi.useFakeTimers();
+		useLayoutStore.setState({ scriptEditorHeight: SCRIPT_EDITOR_MAX_HEIGHT });
+		renderForm();
+
+		act(() => fireEvent.keyDown(heightHandle(), { key: "ArrowDown" }));
+		act(() => vi.advanceTimersByTime(200));
+
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(SCRIPT_EDITOR_MAX_HEIGHT);
+		vi.useRealTimers();
+	});
+
+	it("drags to a new height, previewing every frame and persisting after the debounce", () => {
+		vi.useFakeTimers();
+		const { box } = renderForm();
+		const handle = heightHandle();
+
+		act(() => fireEvent.pointerDown(handle, { clientY: 100, pointerId: 1 }));
+		act(() =>
+			window.dispatchEvent(new PointerEvent("pointermove", { clientY: 140, pointerId: 1 }))
+		);
+
+		// The frame-by-frame preview: no debounce on the box's own height.
+		expect(box).toHaveStyle({ height: `${DEFAULT_SCRIPT_EDITOR_HEIGHT + 40}px` });
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(DEFAULT_SCRIPT_EDITOR_HEIGHT);
+
+		act(() => vi.advanceTimersByTime(200));
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(
+			DEFAULT_SCRIPT_EDITOR_HEIGHT + 40
+		);
+
+		act(() => window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 })));
+		vi.useRealTimers();
+	});
+
+	it("clamps a drag past the ceiling", () => {
+		vi.useFakeTimers();
+		renderForm();
+		const handle = heightHandle();
+
+		act(() => fireEvent.pointerDown(handle, { clientY: 0, pointerId: 1 }));
+		act(() =>
+			window.dispatchEvent(
+				new PointerEvent("pointermove", {
+					clientY: SCRIPT_EDITOR_MAX_HEIGHT * 2,
+					pointerId: 1,
+				})
+			)
+		);
+		act(() => vi.advanceTimersByTime(200));
+
+		expect(useLayoutStore.getState().scriptEditorHeight).toBe(SCRIPT_EDITOR_MAX_HEIGHT);
+
+		window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+		vi.useRealTimers();
+	});
+});
+
+describe("the Snippets disclosure, per row", () => {
+	it("keeps two script rows independent - opening one leaves the other closed", () => {
+		render(
+			<>
+				<ScriptElementForm kind="script.pre" config={{}} onChange={() => {}} />
+				<ScriptElementForm kind="script.post" config={{}} onChange={() => {}} />
+			</>
+		);
+		const [preToggle, postToggle] = screen.getAllByRole("button", { name: /snippets/i });
+		expect(preToggle).toHaveAttribute("aria-expanded", "false");
+		expect(postToggle).toHaveAttribute("aria-expanded", "false");
+
+		fireEvent.click(preToggle);
+
+		expect(preToggle).toHaveAttribute("aria-expanded", "true");
+		expect(postToggle).toHaveAttribute("aria-expanded", "false");
+	});
+
+	it("seeds a fresh row from the store's default", () => {
+		useLayoutStore.setState({ scriptSnippetsCollapsed: false });
+		renderForm();
+
+		expect(screen.getByRole("button", { name: /snippets/i })).toHaveAttribute(
+			"aria-expanded",
+			"true"
+		);
+	});
+
+	it("writes the toggle back as the default the next row opened will start from", () => {
+		renderForm();
+		fireEvent.click(screen.getByRole("button", { name: /snippets/i }));
+
+		expect(useLayoutStore.getState().scriptSnippetsCollapsed).toBe(false);
+	});
+});

--- a/app/src/components/shared/ElementList/ScriptElementForm.tsx
+++ b/app/src/components/shared/ElementList/ScriptElementForm.tsx
@@ -17,18 +17,60 @@
  * cannot depend on - `ElementList` is used by the collection detail's
  * Elements tab too, which has no such context. Inheritance is shown once for
  * the whole list by `InheritedElementsNotice` instead of once per script row.
+ *
+ * **The editor box has a definite pixel height** (issue #1605). The element
+ * card it sits in (`ElementRow`) is an auto-height block, not a bounded
+ * ancestor a percentage or a `ResizablePanelGroup` could divide, so
+ * `CodeEditor`'s default `height="100%"` used to resolve against nothing and
+ * Monaco laid out at zero height. A drag handle below the box - the GraphQL
+ * body's `ResizableHandle` styling, without the panel group it depends on -
+ * sets that height directly, in `layout-store`'s `scriptEditorHeight`.
+ *
+ * **Each row's Snippets disclosure is its own `useState`**, seeded once from
+ * the store's persisted default and written back to it on toggle. A request
+ * or collection can show a `script.pre` and a `script.post` row on the same
+ * screen; `ScriptSnippets` used to read the store's boolean directly, so
+ * opening one opened both.
  */
 
-import { useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type * as Monaco from "monaco-editor";
 import { CodeEditor } from "@/components/ui";
 import { ScriptSnippets } from "@/components/shared";
 import { insertSnippetAtCursor } from "@/lib/editor-snippet";
+import { useLayoutStore } from "@/stores";
+import {
+	SCRIPT_EDITOR_HEIGHT_STEP,
+	SCRIPT_EDITOR_MAX_HEIGHT,
+	SCRIPT_EDITOR_MIN_HEIGHT,
+} from "@/constants/layout";
+import { cn } from "@/lib/utils";
 
 export interface ScriptElementFormProps {
 	kind: string;
 	config: Record<string, unknown>;
 	onChange: (config: Record<string, unknown>) => void;
+}
+
+function clampHeight(height: number): number {
+	return Math.max(SCRIPT_EDITOR_MIN_HEIGHT, Math.min(SCRIPT_EDITOR_MAX_HEIGHT, height));
+}
+
+/**
+ * The persisted height save, debounced the way `GraphQLBody`'s
+ * `handleVariablesResize` is: a drag fires on every pointer-move frame, and
+ * the store writes through to localStorage.
+ */
+function useDebouncedHeightSave(save: (height: number) => void) {
+	const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(() => () => clearTimeout(timeout.current ?? undefined), []);
+	return useCallback(
+		(height: number) => {
+			if (timeout.current) clearTimeout(timeout.current);
+			timeout.current = setTimeout(() => save(height), 200);
+		},
+		[save]
+	);
 }
 
 /** Inline code in the intro sentence - a bare element, not a component. */
@@ -56,23 +98,102 @@ export function ScriptElementForm({ kind, config, onChange }: ScriptElementFormP
 	const script = typeof config.script === "string" ? config.script : "";
 	const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
 	const isPre = kind === "script.pre";
+	const editorLabel = isPre ? "Pre-request script" : "Test script";
+
+	// One store value for every script row (like `graphqlVariablesSize`); a
+	// drag on this row's handle previews locally so the box tracks the pointer
+	// every frame, and the debounced save is what every other row picks up.
+	const storedHeight = useLayoutStore((s) => s.scriptEditorHeight);
+	const setStoredHeight = useLayoutStore((s) => s.setScriptEditorHeight);
+	const saveHeight = useDebouncedHeightSave(setStoredHeight);
+	const [dragHeight, setDragHeight] = useState<number | null>(null);
+	const height = dragHeight ?? storedHeight;
+
+	const startResize = (e: React.PointerEvent) => {
+		e.currentTarget.setPointerCapture(e.pointerId);
+		const startY = e.clientY;
+		const startHeight = storedHeight;
+
+		const onMove = (moveEvent: PointerEvent) => {
+			const next = clampHeight(startHeight + (moveEvent.clientY - startY));
+			setDragHeight(next);
+			saveHeight(next);
+		};
+		const onUp = () => {
+			window.removeEventListener("pointermove", onMove);
+			window.removeEventListener("pointerup", onUp);
+			setDragHeight(null);
+		};
+		window.addEventListener("pointermove", onMove);
+		window.addEventListener("pointerup", onUp);
+	};
+
+	const onHandleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			saveHeight(clampHeight(storedHeight + SCRIPT_EDITOR_HEIGHT_STEP));
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			saveHeight(clampHeight(storedHeight - SCRIPT_EDITOR_HEIGHT_STEP));
+		}
+	};
+
+	// Per-row, not a `useLayoutStore` subscription: two script rows can be on
+	// screen at once, and a shared boolean would expand or collapse both from
+	// one click. Seeded once from the persisted default; the toggle writes
+	// back to it so the *next* row a user opens starts where they left one.
+	const [snippetsCollapsed, setSnippetsCollapsed] = useState(
+		() => useLayoutStore.getState().scriptSnippetsCollapsed
+	);
+	const setScriptSnippetsCollapsed = useLayoutStore((s) => s.setScriptSnippetsCollapsed);
+	const handleSnippetsCollapsedChange = (collapsed: boolean) => {
+		setSnippetsCollapsed(collapsed);
+		setScriptSnippetsCollapsed(collapsed);
+	};
 
 	return (
-		<div className="flex min-h-40 flex-col gap-2">
+		<div className="flex flex-col gap-2">
 			<p className="text-xs text-muted-foreground">{isPre ? PRE_INTRO : POST_INTRO}</p>
-			<div className="min-h-40 flex-1 rounded-md border border-rule surface-card bg-card overflow-hidden">
-				<CodeEditor
-					language="javascript"
-					ariaLabel={isPre ? "Pre-request script" : "Test script"}
-					value={script}
-					onChange={(value) => onChange({ ...config, script: value ?? "" })}
-					onMount={(instance) => {
-						editorRef.current = instance;
-					}}
+			<div className="flex flex-col">
+				<div
+					// `min-h-0`: the GraphQL body's own trap (`GraphQLBody.tsx:812-817`) -
+					// a flex item will not shrink below its content, so a card that ever
+					// gains a flex ancestor above this one must not let the editor keep
+					// its old height and grow a second scrollbar beside Monaco's own.
+					className="min-h-0 shrink-0 rounded-t-md border border-b-0 border-rule surface-card bg-card overflow-hidden"
+					style={{ height }}
+				>
+					<CodeEditor
+						language="javascript"
+						ariaLabel={editorLabel}
+						value={script}
+						onChange={(value) => onChange({ ...config, script: value ?? "" })}
+						onMount={(instance) => {
+							editorRef.current = instance;
+						}}
+					/>
+				</div>
+				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- WAI-ARIA window splitter - a focusable `role="separator"` is its sanctioned interactive form, with the pointer drag and arrow-key handling below */}
+				<div
+					role="separator"
+					aria-orientation="horizontal"
+					aria-label={`${editorLabel} editor height`}
+					aria-valuenow={Math.round(storedHeight)}
+					aria-valuemin={SCRIPT_EDITOR_MIN_HEIGHT}
+					aria-valuemax={SCRIPT_EDITOR_MAX_HEIGHT}
+					tabIndex={0}
+					onPointerDown={startResize}
+					onKeyDown={onHandleKeyDown}
+					className={cn(
+						"h-1.5 w-full shrink-0 cursor-row-resize rounded-b-md border border-t-0 border-rule bg-rule transition-colors",
+						"hover:bg-primary focus-visible:bg-primary focus-visible:outline-none"
+					)}
 				/>
 			</div>
 			<ScriptSnippets
 				context={isPre ? "pre" : "test"}
+				collapsed={snippetsCollapsed}
+				onCollapsedChange={handleSnippetsCollapsedChange}
 				onInsert={(snippet) => insertSnippetAtCursor(editorRef.current, snippet)}
 			/>
 		</div>

--- a/app/src/components/shared/ScriptSnippets.test.tsx
+++ b/app/src/components/shared/ScriptSnippets.test.tsx
@@ -15,19 +15,21 @@
  * Three claims are worth pinning, because each replaced something the two old
  * Quick Reference blocks could not do: the list *inserts* rather than being
  * retyped, it shows the templates for the editor it sits under rather than all
- * of them, and it remembers whether the user wanted it open across the tab
- * switch that unmounts the panel.
+ * of them, and its collapsed state is the host's to control rather than this
+ * component's own (issue #1605 - two script rows on one screen must not share
+ * one boolean; `ScriptElementForm.test.tsx` covers the per-row persistence
+ * this component only exposes through `onCollapsedChange`).
  *
  * The fourth case is the deletion itself: two hand-rolled copies of this idea
  * are gone, and a source scan says so - with a floor, since a scan that reads
  * nothing passes every "is absent" assertion.
  */
 
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, screen } from "@testing-library/react";
 import { readFileSync } from "node:fs";
-import { ScriptSnippets } from "./ScriptSnippets";
-import { useLayoutStore } from "@/stores";
+import { ScriptSnippets, type ScriptSnippetsProps } from "./ScriptSnippets";
 import { fromRepoRoot } from "@/lib/routed-inputs.testkit";
 import type { ScriptCompletion } from "@/types/domain";
 
@@ -89,8 +91,17 @@ function served(completions: ScriptCompletion[] = TEMPLATES) {
 
 beforeEach(() => {
 	served();
-	useLayoutStore.setState({ scriptSnippetsCollapsed: true });
 });
+
+/**
+ * A minimal controlled host, standing in for `ScriptElementForm`'s per-row
+ * `useState` - the real component under test is `ScriptSnippets` and its
+ * `collapsed`/`onCollapsedChange` contract, not any particular host's storage.
+ */
+function Controlled(props: Omit<ScriptSnippetsProps, "collapsed" | "onCollapsedChange">) {
+	const [collapsed, setCollapsed] = useState(true);
+	return <ScriptSnippets {...props} collapsed={collapsed} onCollapsedChange={setCollapsed} />;
+}
 
 function open() {
 	fireEvent.click(screen.getByRole("button", { name: /snippets/i }));
@@ -98,33 +109,50 @@ function open() {
 
 describe("ScriptSnippets", () => {
 	it("starts collapsed, because the editor is what the panel is for", () => {
-		render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
-		);
+		render(<Controlled context="pre" onInsert={() => ({ placement: "cursor" as const })} />);
 
 		expect(screen.queryByPlaceholderText(/filter snippets/i)).not.toBeInTheDocument();
 	});
 
-	it("remembers being opened, in the store that survives the tab unmount", () => {
-		const { unmount } = render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+	it("is controlled: it renders open or closed from the `collapsed` prop, not its own state", () => {
+		const { rerender } = render(
+			<ScriptSnippets
+				context="pre"
+				collapsed={false}
+				onCollapsedChange={() => {}}
+				onInsert={() => ({ placement: "cursor" as const })}
+			/>
+		);
+		expect(screen.getByPlaceholderText(/filter snippets/i)).toBeInTheDocument();
+
+		rerender(
+			<ScriptSnippets
+				context="pre"
+				collapsed={true}
+				onCollapsedChange={() => {}}
+				onInsert={() => ({ placement: "cursor" as const })}
+			/>
+		);
+		expect(screen.queryByPlaceholderText(/filter snippets/i)).not.toBeInTheDocument();
+	});
+
+	it("reports the toggle rather than tracking it, so two mounted rows never share one boolean", () => {
+		const onCollapsedChange = vi.fn();
+		render(
+			<ScriptSnippets
+				context="pre"
+				collapsed={true}
+				onCollapsedChange={onCollapsedChange}
+				onInsert={() => ({ placement: "cursor" as const })}
+			/>
 		);
 		open();
 
-		expect(useLayoutStore.getState().scriptSnippetsCollapsed).toBe(false);
-
-		// The Radix tab switch: the panel goes away and comes back.
-		unmount();
-		render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
-		);
-		expect(screen.getByPlaceholderText(/filter snippets/i)).toBeInTheDocument();
+		expect(onCollapsedChange).toHaveBeenCalledWith(false);
 	});
 
 	it("offers a pre-request editor its own templates and the shared one", () => {
-		render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
-		);
+		render(<Controlled context="pre" onInsert={() => ({ placement: "cursor" as const })} />);
 		open();
 
 		expect(screen.getByText("Set a header")).toBeInTheDocument();
@@ -135,9 +163,7 @@ describe("ScriptSnippets", () => {
 	});
 
 	it("offers a test editor the assertions instead", () => {
-		render(
-			<ScriptSnippets context="test" onInsert={() => ({ placement: "cursor" as const })} />
-		);
+		render(<Controlled context="test" onInsert={() => ({ placement: "cursor" as const })} />);
 		open();
 
 		expect(screen.getByText("Test: Status code")).toBeInTheDocument();
@@ -146,7 +172,7 @@ describe("ScriptSnippets", () => {
 
 	it("hands the caller the template, placeholders and all", () => {
 		const onInsert = vi.fn(() => ({ placement: "cursor" as const }));
-		render(<ScriptSnippets context="pre" onInsert={onInsert} />);
+		render(<Controlled context="pre" onInsert={onInsert} />);
 		open();
 
 		fireEvent.click(screen.getByText("Set a header").closest("[cmdk-item]")!);
@@ -170,7 +196,7 @@ describe("ScriptSnippets", () => {
 
 		it("names the template and where it went", () => {
 			render(
-				<ScriptSnippets
+				<Controlled
 					context="pre"
 					onInsert={() => ({ placement: "end-of-script" as const })}
 				/>
@@ -185,7 +211,7 @@ describe("ScriptSnippets", () => {
 
 		it("speaks again when the same template is inserted twice", () => {
 			render(
-				<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
+				<Controlled context="pre" onInsert={() => ({ placement: "cursor" as const })} />
 			);
 			open();
 			insertFirst();
@@ -202,7 +228,7 @@ describe("ScriptSnippets", () => {
 		});
 
 		it("shows a refusal on screen, not only to a screen reader", () => {
-			render(<ScriptSnippets context="pre" onInsert={() => null} />);
+			render(<Controlled context="pre" onInsert={() => null} />);
 			open();
 			insertFirst();
 
@@ -214,13 +240,13 @@ describe("ScriptSnippets", () => {
 
 		it("clears the refusal once an insertion lands", () => {
 			let answer: { placement: "cursor" } | null = null;
-			const { rerender } = render(<ScriptSnippets context="pre" onInsert={() => answer} />);
+			const { rerender } = render(<Controlled context="pre" onInsert={() => answer} />);
 			open();
 			insertFirst();
 			expect(screen.queryByRole("status")).toBeTruthy();
 
 			answer = { placement: "cursor" };
-			rerender(<ScriptSnippets context="pre" onInsert={() => answer} />);
+			rerender(<Controlled context="pre" onInsert={() => answer} />);
 			insertFirst();
 
 			expect(screen.queryByRole("status")).toBeNull();
@@ -229,18 +255,14 @@ describe("ScriptSnippets", () => {
 
 	it("says so when the engine is not answering, rather than looking empty", () => {
 		query.value = { data: undefined, isPending: false, isError: true };
-		render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
-		);
+		render(<Controlled context="pre" onInsert={() => ({ placement: "cursor" as const })} />);
 		open();
 
 		expect(screen.getByText(/engine, which is not answering/i)).toBeInTheDocument();
 	});
 
 	it("counts what it is holding, so a collapsed header still says there is something", () => {
-		render(
-			<ScriptSnippets context="pre" onInsert={() => ({ placement: "cursor" as const })} />
-		);
+		render(<Controlled context="pre" onInsert={() => ({ placement: "cursor" as const })} />);
 
 		expect(screen.getByRole("button", { name: /snippets/i }).textContent).toContain("2");
 	});

--- a/app/src/components/shared/ScriptSnippets.tsx
+++ b/app/src/components/shared/ScriptSnippets.tsx
@@ -23,10 +23,15 @@
  * suggestions already use - a second copy of that keyboard handling is the
  * defect `suggestion-list.tsx` was written to end.
  *
- * **Collapsed by default, and remembered in `layout-store`.** The editor is what
- * the panel is for. A list open under every editor would be the wall it replaced
- * with a chevron on it, and component state would forget the choice on the next
- * tab switch, which unmounts the panel.
+ * **Collapsed by default, remembered by the host.** The editor is what the
+ * panel is for. A list open under every editor would be the wall it replaced
+ * with a chevron on it. The collapsed flag is a controlled prop rather than
+ * this component's own `layout-store` read (issue #1605): the Elements tab can
+ * mount a `script.pre` and a `script.post` row on one screen, and a single
+ * store subscription here would toggle both at once. The host (`ScriptElementForm`)
+ * seeds its own per-row state from the store's persisted default and writes a
+ * toggle back to it, so the *next* row a user opens still starts the way they
+ * last left one - only two rows already on screen no longer share the toggle.
  */
 
 import { useState } from "react";
@@ -44,7 +49,6 @@ import {
 	EYEBROW_CLASS,
 } from "@/components/ui";
 import { useScriptCompletionsQuery } from "@/queries";
-import { useLayoutStore } from "@/stores";
 import { countSnippets, snippetsForContext } from "@/lib/script-snippets";
 import type { SnippetInsertion, SnippetPlacement } from "@/lib/editor-snippet";
 import { cn } from "@/lib/utils";
@@ -52,6 +56,10 @@ import { cn } from "@/lib/utils";
 export interface ScriptSnippetsProps {
 	/** Which editor this list sits under. */
 	context: "pre" | "test";
+	/** Whether the list is folded to its header. */
+	collapsed: boolean;
+	/** Called with the toggled value when the header is clicked. */
+	onCollapsedChange: (collapsed: boolean) => void;
 	/**
 	 * Insert the template. The host owns the editor instance, so it owns the
 	 * insertion; this list says which template was chosen and narrates what came
@@ -69,9 +77,12 @@ const PLACEMENT_PHRASE: Record<SnippetPlacement, string> = {
 	"end-of-script": "at the end of the script",
 };
 
-export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
-	const collapsed = useLayoutStore((s) => s.scriptSnippetsCollapsed);
-	const setCollapsed = useLayoutStore((s) => s.setScriptSnippetsCollapsed);
+export function ScriptSnippets({
+	context,
+	collapsed,
+	onCollapsedChange,
+	onInsert,
+}: ScriptSnippetsProps) {
 	const { data, isPending, isError } = useScriptCompletionsQuery();
 
 	const groups = snippetsForContext(data?.completions, context);
@@ -112,7 +123,7 @@ export function ScriptSnippets({ context, onInsert }: ScriptSnippetsProps) {
 	};
 
 	return (
-		<Collapsible open={!collapsed} onOpenChange={(open) => setCollapsed(!open)}>
+		<Collapsible open={!collapsed} onOpenChange={(open) => onCollapsedChange(!open)}>
 			{/*
 			 * The whole header is the control, per the composite-row hit-area rule:
 			 * a narrow activator in a wide bar leaves most of the row painting a

--- a/app/src/constants/layout.ts
+++ b/app/src/constants/layout.ts
@@ -137,3 +137,19 @@ export const GRAPHQL_VARIABLES_MAX_SIZE = 75;
  * strip of dead editor under them.
  */
 export const GRAPHQL_PANE_HEADER_HEIGHT = 28;
+
+/* ── Script element form: the editor box ─────────────────────────────────── */
+
+/**
+ * Default and bounds for a `script.pre` / `script.post` element's editor
+ * height (px), and the step a keyboard drag of its handle moves by.
+ *
+ * Pixels, not a percentage of an ancestor: the element card is an auto-height
+ * block (`ElementRow`, `rounded-md border ... p-3`), not a bounded parent a
+ * `ResizablePanelGroup` could divide, so the handle drives the box's own
+ * height directly (issue #1605).
+ */
+export const DEFAULT_SCRIPT_EDITOR_HEIGHT = 160;
+export const SCRIPT_EDITOR_MIN_HEIGHT = 120;
+export const SCRIPT_EDITOR_MAX_HEIGHT = 800;
+export const SCRIPT_EDITOR_HEIGHT_STEP = 16;

--- a/app/src/modules/request-builder/components/RequestTabs/panels/editor-fill.test.ts
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/editor-fill.test.ts
@@ -6,13 +6,12 @@
  */
 
 /**
- * No editor in a request or collection tab is mounted at a pixel height.
+ * No editor's `<CodeEditor>` prop is mounted at a pixel height.
  *
  * Three editors carried three different constants - 320px in `BodyPanel`,
  * 350px in `ScriptPanel`, 320px in the collection's `ScriptTab` - inside panes
  * that already have the window's height, so each showed a slice of an editor
- * over empty panel (#1323). They fill their pane now, with a `min-h-40` floor
- * and no ceiling.
+ * over empty panel (#1323). They fill their pane's `height="100%"` now.
  *
  * The rendered classes are asserted where the component is rendered
  * (`BodyPanel.test.tsx`, `ElementList.test.tsx`); a class arriving in a
@@ -20,6 +19,12 @@
  * coming back, which is the regression this guards: a fourth editor added
  * with `height="400px"` reads as ordinary until someone opens it in a tall
  * window.
+ *
+ * `ScriptElementForm`'s box is the one deliberate exception to "no ceiling"
+ * (issue #1605): it sits in an auto-height card, not a bounded pane, so its
+ * *wrapping* `<div>` carries an inline pixel height the user drags between
+ * `SCRIPT_EDITOR_MIN_HEIGHT` and `SCRIPT_EDITOR_MAX_HEIGHT` - `<CodeEditor>`
+ * itself still takes no `height` prop, which is what this scan reads.
  *
  * `ScriptPanel` and the collection's `ScriptTab` are gone (issue #1512): a
  * script is a `script.pre` / `script.post` element now, and its editor lives

--- a/app/src/stores/layout-store.ts
+++ b/app/src/stores/layout-store.ts
@@ -13,11 +13,14 @@ import {
 	DEFAULT_CONTEXT_BAR_WIDTH,
 	DEFAULT_DRAWER_WIDTH,
 	DEFAULT_GRAPHQL_VARIABLES_SIZE,
+	DEFAULT_SCRIPT_EDITOR_HEIGHT,
 	GRAPHQL_VARIABLES_MAX_SIZE,
 	GRAPHQL_VARIABLES_MIN_SIZE,
 	PANEL_MIN_WIDTH,
 	PANEL_MAX_WIDTH,
 	RETIRED_CONTEXT_BAR_SECTIONS,
+	SCRIPT_EDITOR_MAX_HEIGHT,
+	SCRIPT_EDITOR_MIN_HEIGHT,
 } from "@/constants/layout";
 
 export type DrawerView =
@@ -81,8 +84,25 @@ interface LayoutState {
 	 * Collapsed by default. The editor is what the panel is for, and a list that
 	 * opened itself under every script editor would be the wall of prose it
 	 * replaced, with a chevron on it.
+	 *
+	 * This is a *default* the next script row a user opens starts from, not the
+	 * live state of every row on screen (issue #1605): the Elements tab can show
+	 * a `script.pre` and a `script.post` row on one screen, each with its own
+	 * `useState` seeded from this value, so expanding one no longer expands the
+	 * other. Each row writes its own toggle back here, which is what makes the
+	 * *next* row a user opens start the way they last left one.
 	 */
 	scriptSnippetsCollapsed: boolean;
+
+	/**
+	 * Height (px) of a `script.pre` / `script.post` element's Monaco editor box.
+	 *
+	 * One value for every script row, the same "one size across every instance"
+	 * shape `graphqlVariablesSize` uses. Pixels rather than a percentage: the
+	 * element card the editor sits in is auto-height, not a bounded parent a
+	 * percentage could divide against (issue #1605).
+	 */
+	scriptEditorHeight: number;
 
 	/**
 	 * Whether the ⌘K command palette is showing.
@@ -125,6 +145,7 @@ interface LayoutState {
 	setGraphqlVariablesSize: (size: number) => void;
 
 	setScriptSnippetsCollapsed: (collapsed: boolean) => void;
+	setScriptEditorHeight: (height: number) => void;
 
 	setPaletteOpen: (open: boolean) => void;
 }
@@ -142,6 +163,7 @@ export const useLayoutStore = create<LayoutState>()(
 			graphqlVariablesCollapsed: false,
 			graphqlVariablesSize: DEFAULT_GRAPHQL_VARIABLES_SIZE,
 			scriptSnippetsCollapsed: true,
+			scriptEditorHeight: DEFAULT_SCRIPT_EDITOR_HEIGHT,
 			paletteOpen: false,
 
 			setDrawerOpen: (open) => set({ drawerOpen: open }),
@@ -187,6 +209,13 @@ export const useLayoutStore = create<LayoutState>()(
 				}),
 
 			setScriptSnippetsCollapsed: (collapsed) => set({ scriptSnippetsCollapsed: collapsed }),
+			setScriptEditorHeight: (height) =>
+				set({
+					scriptEditorHeight: Math.max(
+						SCRIPT_EDITOR_MIN_HEIGHT,
+						Math.min(SCRIPT_EDITOR_MAX_HEIGHT, height)
+					),
+				}),
 
 			setPaletteOpen: (open) => set({ paletteOpen: open }),
 		}),
@@ -240,6 +269,7 @@ export const useLayoutStore = create<LayoutState>()(
 				graphqlVariablesCollapsed: state.graphqlVariablesCollapsed,
 				graphqlVariablesSize: state.graphqlVariablesSize,
 				scriptSnippetsCollapsed: state.scriptSnippetsCollapsed,
+				scriptEditorHeight: state.scriptEditorHeight,
 			}),
 		}
 	)

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1566,13 +1566,19 @@ accepted from the completion popup. The host owns the editor instance (captured
 through `CodeEditor`'s `onMount`) and passes `onInsert`, so this list never
 learns which editor it sits under.
 
-**Collapsed by default, remembered in `layout-store`** (`scriptSnippetsCollapsed`,
-persisted). The editor is what the panel is for, and component state would forget
-the choice on the next tab switch, which unmounts the panel - the reason the
-GraphQL Variables pane's collapse lives in that store too. The whole header is
-the control, per the composite-row hit-area rule, and the body is rendered only
-while it is open. `cmdk` (`Command`) owns the arrow keys, the highlight, Enter to
-insert and the filter field, rather than a third copy of that keyboard handling.
+**Collapsed by default, remembered by the host** (`scriptSnippetsCollapsed`,
+persisted). The collapsed flag is a controlled prop (`collapsed`,
+`onCollapsedChange`), not this component's own store read (issue #1605): the
+Elements tab can mount a `script.pre` and a `script.post` row on one screen,
+and a single store subscription here would toggle both from one click.
+`ScriptElementForm` seeds its own per-row `useState` from the store's
+persisted default and writes a toggle back to it, so the *next* row a user
+opens still starts where they left one - the reason the GraphQL Variables
+pane's collapse lives in that store too, just no longer read directly here.
+The whole header is the control, per the composite-row hit-area rule, and the
+body is rendered only while it is open. `cmdk` (`Command`) owns the arrow
+keys, the highlight, Enter to insert and the filter field, rather than a
+third copy of that keyboard handling.
 
 ## Shared ElementList (`components/shared/ElementList/`)
 
@@ -1606,6 +1612,18 @@ carries none of the old `ScriptPanel`'s variable-reference chips or inherited/
 legacy notices - those read `useRequestBuilderContext`, which this primitive
 cannot depend on - so inheritance is shown once for the whole list by
 `InheritedElementsNotice` instead of once per script row.
+
+**The editor box has a definite pixel height, resizable by a handle below it**
+(issue #1605). `ElementRow` is an auto-height card, not a bounded ancestor a
+percentage or a `ResizablePanelGroup` could divide, so `CodeEditor`'s default
+`height="100%"` used to resolve against nothing and Monaco laid out at zero
+height with the typed text hidden. `ScriptElementForm` instead sets the box's
+height directly from `layout-store`'s `scriptEditorHeight` (one value for
+every script row, like `graphqlVariablesSize`); a handle below the box - the
+GraphQL body's `ResizableHandle` styling, without the panel group it depends
+on - drags it between `SCRIPT_EDITOR_MIN_HEIGHT` and `SCRIPT_EDITOR_MAX_HEIGHT`
+(`constants/layout.ts`), previewing every pointer-move frame and persisting
+debounced, plus ArrowUp/ArrowDown by `SCRIPT_EDITOR_HEIGHT_STEP`.
 
 **The Add menu groups the catalogue by category**, never a hand-written list,
 so a kind the engine adds needs no change here; `inherit.disable` is excluded

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -177,7 +177,8 @@ Manages the left drawer (collections/history/variables/settings), the right cont
   contextBarWidth: number
   contextBarCollapsedSections: string[]  // Section ids the user collapsed (`code` by default)
   requestSplitRatio: number              // 0–1; left/request pane fraction
-  scriptSnippetsCollapsed: boolean       // Is the snippets list under the script editors closed? (collapsed by default)
+  scriptSnippetsCollapsed: boolean       // Default a fresh script row's snippets list starts from (collapsed); each row keeps its own state after that
+  scriptEditorHeight: number             // Height (px) of a script.pre/script.post element's editor box - one value for every row
   paletteOpen: boolean                   // Is the ⌘K command palette showing?
 }
 ```

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1503,7 +1503,7 @@ correct one here:
   arrow/Page/Home/End and all.
 
 Everything else is suppressed at the line it happens on, with the reason and the
-file that provides the missing half. **17 directives across 11 files**, listed
+file that provides the missing half. **18 directives across 12 files**, listed
 here because a rule-level configuration is visible in one place and a line-level
 one is visible only to whoever opens that file - and because nothing otherwise
 stops the count growing one justified line at a time. `a11y-suppressions.test.ts`
@@ -1527,6 +1527,11 @@ not rule names - two of these lines silence two rules at once.
 - `components/layout/PanelResizeHandle.tsx` (1) -
   `jsx-a11y/no-noninteractive-element-interactions`: the window splitter, with
   its arrow/Page/Home/End handling in the `onKeyDown` beside it.
+- `components/shared/ElementList/ScriptElementForm.tsx` (1) -
+  `jsx-a11y/no-noninteractive-element-interactions`: the `script.pre`/
+  `script.post` editor's height handle, the same window-splitter shape as
+  `PanelResizeHandle` above, with its pointer drag and arrow-key handling in
+  the `onPointerDown`/`onKeyDown` beside it (issue #1605).
 - `components/shared/VariableInput/index.tsx` (2) -
   `jsx-a11y/click-events-have-key-events` and
   `jsx-a11y/no-static-element-interactions` on the box that widens the hit area


### PR DESCRIPTION
## Description

`ScriptElementForm`'s Monaco editor relied on `CodeEditor`'s default
`height="100%"`, but the element card it sits in (`ElementRow`) is an
auto-height block, not a bounded ancestor a percentage resolves against - so
Monaco laid out at zero height and typed text was invisible. `ScriptSnippets`
also read one shared `scriptSnippetsCollapsed` boolean directly from the
store, so a `script.pre` and a `script.post` row on the same Elements tab
toggled together. Neither editor could be resized.

The editor box now gets an explicit pixel height from `layout-store`'s new
`scriptEditorHeight` (one value shared across rows, the same shape
`graphqlVariablesSize` uses), with a drag handle below it modeled on the
GraphQL body's `ResizableHandle` styling - but built without the
`ResizablePanelGroup` it depends on, since that primitive divides a *bounded*
parent and this card has none; the handle drives the box's height directly
instead, clamped to `[SCRIPT_EDITOR_MIN_HEIGHT, SCRIPT_EDITOR_MAX_HEIGHT]`,
previewing every pointer-move frame and persisting debounced (the
`handleVariablesResize` pattern), plus ArrowUp/ArrowDown by
`SCRIPT_EDITOR_HEIGHT_STEP`.

`ScriptSnippets` becomes a controlled component (`collapsed`,
`onCollapsedChange`) rather than reading the store itself. `ScriptElementForm`
seeds a per-row `useState` from the store's persisted default and writes a
toggle back to it, so two rows on screen no longer share one boolean, while
the *next* row a user opens still starts where they last left one.

**Alternative considered and rejected:** reusing `PanelResizeHandle` (the
existing width-resize primitive for the drawer/context-bar) for this
vertical, height-bounded handle. It hardcodes `PANEL_MIN_WIDTH`/`MAX_WIDTH`
and a horizontal drag axis; generalizing it to also cover height with
different bounds would touch two already-shipped, already-tested panels for
no benefit to this fix, so I followed the issue's own fix pathway instead
(a small handle local to this form, styled like `GraphQLBody`'s hairline
handles) and reused the one thing that *is* shared: the `jsx-a11y` window-
splitter suppression pattern `PanelResizeHandle` already carries.

## Type of Change
- [x] Bug fix

## Testing

- `cd app && pnpm test ScriptElementForm ScriptSnippets ElementList layout-store editor-fill a11y-suppressions` - all green, including the new
  `ScriptElementForm.test.tsx` (box height, keyboard/pointer-drag resize with
  clamping, two-rows-independent Snippets) and the updated `ScriptSnippets.test.tsx`
  (now exercises the controlled `collapsed`/`onCollapsedChange` contract instead
  of reading `layout-store` directly).
- `cd app && pnpm test` - full suite, 728 files / 8274 passed, 1 pre-existing skip.
- `cd app && pnpm type-check` and `pnpm lint` - clean.
- `cd app && pnpm format:check` - clean (only files touched by this change were formatted).
- Engine untouched, so no engine build was needed for this fix.

**Not run:** a live Electron screenshot. jsdom cannot lay Monaco out at all, so
the new tests assert the wrapping box's inline pixel height and class
directly instead (the reliable proxy the issue's own Tests section asks
for), rather than pretending a stubbed render proves the visual fix. Building
the engine and driving a real window was judged disproportionate for a
CSS/layout-only fix already pinned at the DOM level; happy to add real
screenshots if you'd like them before merging.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/COMPONENTS.md` (the `ScriptElementForm` and `ScriptSnippets`
paragraphs), `docs/app/state-management.md` (`scriptEditorHeight` and the
redefined `scriptSnippetsCollapsed` meaning), and `docs/design-system.md`'s
Accessibility section (the new `jsx-a11y/no-noninteractive-element-interactions`
suppression on the height handle, ceiling raised 17 → 18 to match).

## Related Issues
Closes #1605

---
_Generated by [Claude Code](https://claude.ai/code/session_01A89w9qttvyEnpjNMLjuGv5)_