### PR TITLE
fix(engine): schema/runId/legacy-log gaps from #1557's reopen

### DIFF
--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -70,7 +70,7 @@ is a manual copy with the engine stopped, described in
 | Option | Description |
 |--------|-------------|
 | `-h, --help` | Show help message |
-| `-v, --verbose [LEVEL]` | Enable verbose output. LEVEL is 0 (warn/error), 1 (info) or 2 (debug); `-v`/`--verbose` on its own means 1. A level outside 0-2, or one that is not a whole number, is refused with exit code 1. The same flag `vayu-engine` has always read `-v` as |
+| `-v, --verbose [LEVEL]` | Enable verbose output. LEVEL is 0 (warn/error), 1 (info) or 2 (debug); `-v`/`--verbose` on its own means 1. A level outside 0-2, or one that is not a whole number, is refused with exit code 1. `vayu-cli` reads `-v` the same way `vayu-engine` has always read it; `-v` used to mean `--version` here and no longer does. |
 | `--version` | Show version information (long form only - `-v` is `--verbose`) |
 | *(anything else)* | Refused, naming the argument, with exit code 1 |
 | `--no-color` | Disable colored output |
@@ -211,10 +211,13 @@ not something a quiet run should hide:
 ```
 $ vayu-engine --verbose 2
 ...
-GET /health 200 0.4ms 61B
-GET /inbox 200 1.3ms 412B
-POST /runs 202 3.1ms 118B
+13:57:19.123 DEBUG http     GET /health 200 0.4ms 61B
+13:57:20.456 DEBUG http     GET /inbox 200 1.3ms 412B
+13:57:21.789 INFO  http     POST /runs 202 3.1ms 118B
 ```
+
+See [Logging](logging.md) for the record behind that rendering, its fields,
+and why a 2xx line is `debug` while a 3xx/4xx/5xx line is `info`/`warn`.
 
 ```
 $ vayu-engine --port notanumber

--- a/docs/engine/cli.md
+++ b/docs/engine/cli.md
@@ -213,7 +213,7 @@ $ vayu-engine --verbose 2
 ...
 13:57:19.123 DEBUG http     GET /health 200 0.4ms 61B
 13:57:20.456 DEBUG http     GET /inbox 200 1.3ms 412B
-13:57:21.789 INFO  http     POST /runs 202 3.1ms 118B
+13:57:21.789 INFO  http     GET /collections/missing 404 0.6ms 42B
 ```
 
 See [Logging](logging.md) for the record behind that rendering, its fields,

--- a/docs/engine/log-record.schema.json
+++ b/docs/engine/log-record.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "required": ["ts", "level", "src", "cat", "msg", "pid"],
   "propertyNames": {
-    "pattern": "^[a-z][a-z0-9_]*$"
+    "pattern": "^[a-z][a-zA-Z0-9_]*$"
   },
   "properties": {
     "ts": {
@@ -36,7 +36,7 @@
     "tid": {
       "type": "string"
     },
-    "run": {
+    "runId": {
       "type": "string",
       "description": "A run id, when the record was written while a run was active."
     },

--- a/docs/engine/logging.md
+++ b/docs/engine/logging.md
@@ -44,6 +44,13 @@ and any extra fields as `key=value` pairs. `vayu-engine`'s `-v 0|1|2` still
 governs which levels reach the console; the file's own floor is the separate
 `logLevel` setting below.
 
+One request line per HTTP call (issue #1510), at the level its own status
+calls for rather than one fixed level for every call: a 2xx is `debug`, a
+3xx or 4xx is `info`, and a 5xx is `warn`, because an engine failure is not
+something a quiet run should hide. `install_request_logger`
+(`http/request_log.cpp`) is the one place this decision is made, for both
+the management server and an inbox listener.
+
 ## Categories
 
 Engine: `startup`, `config`, `http`, `db`, `run`, `script`, `inbox`, `mock`,

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -53,6 +53,11 @@ constexpr const char* ENGINE_FILE_PREFIX = "engine_";
 /// glob (issue #1557) while `prune_old_logs` still only ever deletes the
 /// generation it was asked to.
 constexpr const char* CLI_FILE_PREFIX = "cli_";
+/// Prefix of the pre-#1557 log files (`vayu_<stamp>.log`), from before the
+/// per-source `engine_`/`cli_` split. `Logger::init` removes any it finds,
+/// once per start, so an install that predates the split does not carry both
+/// generations forever.
+constexpr const char* LEGACY_FILE_PREFIX = "vayu_";
 /// Timestamp format for log filenames
 constexpr const char* TIME_FORMAT = "%Y%m%d_%H%M%S";
 /// How many per-start log files survive a start; the rest are deleted oldest

--- a/engine/include/vayu/utils/logger.hpp
+++ b/engine/include/vayu/utils/logger.hpp
@@ -169,6 +169,19 @@ std::optional<Logger::Level> parse_log_level (std::string_view name);
 std::size_t
 prune_old_logs (const std::string& log_dir, std::string_view file_prefix, std::size_t keep);
 
+/**
+ * @brief Delete every `<legacy_prefix>*.log` file (and its `.1` rotation) in
+ *        @p log_dir - the pre-#1557 naming, before the per-source `engine_`/
+ *        `cli_` split.
+ * @return How many files were deleted.
+ *
+ * Unlike `prune_old_logs`, this keeps none: the legacy generation is not a
+ * history to retain a tail of, it is dead weight from before the split, and
+ * every start pays the one directory scan to clear whatever a not-yet-upgraded
+ * install left behind.
+ */
+std::size_t remove_legacy_log_files (const std::string& log_dir, std::string_view legacy_prefix);
+
 // Convenience functions - the only way to log (issue #1557): `Logger::write`
 // is the one entry point these all route through, so a category is never
 // optional and a bad-value redaction path is not something a call site can

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -357,8 +357,9 @@ std::vector<std::string>& failure_messages) {
         }
 
         vayu::utils::log_debug ("run",
-        "Validating " + std::to_string (samples.size ()) + " response samples for step " +
-        std::to_string (i + 1) + " (" + step.name + ")...");
+        "Validating response samples for step " + std::to_string (i + 1) +
+        " (" + step.name + ")...",
+        { { "runId", context->run_id }, { "sampleCount", samples.size () } });
 
         ScriptReplay replay;
         replay.script = post_script;
@@ -441,7 +442,8 @@ vayu::db::Database& db) {
     }
 
     if (!per_step && context->metrics_collector->response_samples ().empty ()) {
-        vayu::utils::log_debug ("run", "No response samples collected for script validation");
+        vayu::utils::log_debug ("run", "No response samples collected for script validation",
+        { { "runId", context->run_id } });
         return validation;
     }
 
@@ -554,8 +556,8 @@ vayu::db::Database& db) {
         }
     } else {
         const auto& samples = context->metrics_collector->response_samples ();
-        vayu::utils::log_debug ("run",
-        "Validating " + std::to_string (samples.size ()) + " response samples with test script...");
+        vayu::utils::log_debug ("run", "Validating response samples with test script...",
+        { { "runId", context->run_id }, { "sampleCount", samples.size () } });
 
         ScriptReplay replay;
         replay.script  = &context->test_script;
@@ -587,9 +589,8 @@ vayu::db::Database& db) {
 
     store_validation_failures (db, context->run_id, failure_messages, passed, failed);
 
-    vayu::utils::log_debug ("run",
-    "  Script validation: " + std::to_string (passed) + " passed, " +
-    std::to_string (failed) + " failed");
+    vayu::utils::log_debug ("run", "Script validation",
+    { { "runId", context->run_id }, { "passed", passed }, { "failed", failed } });
 
     validation.run = ScriptValidationTotals{ sampled, passed, failed };
     return validation;
@@ -650,17 +651,17 @@ const std::shared_ptr<RunContext>& context) {
                 // must not cost the run the rest of its samples. Same rule the
                 // design-mode hook applies to the same call.
                 vayu::utils::log_warning ("run",
-                "Schema validation of a sample failed: " + std::string (e.what ()));
+                "Schema validation of a sample failed: " + std::string (e.what ()),
+                { { "runId", context->run_id } });
             }
         }
     }
 
     if (totals.sampled > 0) {
-        vayu::utils::log_debug ("run",
-        "  Schema validation: " + std::to_string (totals.checked) + " of " +
-        std::to_string (totals.sampled) + " samples checked, " +
-        std::to_string (totals.valid) + " valid, " +
-        std::to_string (totals.failed) + " failed");
+        vayu::utils::log_debug ("run", "Schema validation",
+        { { "runId", context->run_id }, { "checked", totals.checked },
+        { "sampled", totals.sampled }, { "valid", totals.valid },
+        { "failed", totals.failed } });
     }
     return totals;
 }
@@ -1138,7 +1139,7 @@ const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn) {
         std::lock_guard<std::mutex> workers_lock (workers_mtx_);
         if (shutting_down_) {
             vayu::utils::log_warning ("run",
-            "Refusing to start run " + run_id + ": engine is shutting down");
+            "Refusing to start run: engine is shutting down", { { "runId", run_id } });
             return false;
         }
 
@@ -1314,9 +1315,9 @@ int default_max_per_host) {
     loop_config.verbose = config.value ("verbose", false);
 
     vayu::utils::log_debug ("run", "EventLoop config",
-    { { "workers", configured_workers }, { "maxConcurrent", loop_config.max_concurrent },
-    { "maxPerHost", loop_config.max_per_host }, { "targetRps", target_rps },
-    { "timeoutMs", timeout_ms } });
+    { { "runId", context->run_id }, { "workers", configured_workers },
+    { "maxConcurrent", loop_config.max_concurrent }, { "maxPerHost", loop_config.max_per_host },
+    { "targetRps", target_rps }, { "timeoutMs", timeout_ms } });
 
     // Create, start, and only then publish the event loop. The metrics
     // thread has been ticking since before this thread first ran (both are
@@ -1373,7 +1374,8 @@ vayu::Request& request) {
     if (!built.ok) {
         vayu::utils::log_error ("run",
         built.parse_failed ? std::string ("Load test: invalid request format") :
-                             "Load test auth resolution failed: " + built.error_message);
+                             "Load test auth resolution failed: " + built.error_message,
+        { { "runId", context->run_id } });
         return false;
     }
     request = std::move (built.request);
@@ -1902,12 +1904,13 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
     try {
         size_t flushed = context->metrics_collector->flush_to_database (db);
         if (flushed > 0) {
-            vayu::utils::log_debug ("run",
-            "  Flushed " + std::to_string (flushed) + " results to database");
+            vayu::utils::log_debug ("run", "Flushed results to database",
+            { { "runId", context->run_id }, { "count", flushed } });
         }
     } catch (const std::exception& e) {
         vayu::utils::log_error ("run",
-        "Failed to flush results to database: " + std::string (e.what ()));
+        "Failed to flush results to database: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     // Run deferred script validation if test script is present. Its tallies
@@ -1916,8 +1919,9 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
     try {
         validation = validate_scripts (context, db);
     } catch (const std::exception& e) {
-        vayu::utils::log_error (
-        "run", "Script validation failed: " + std::string (e.what ()));
+        vayu::utils::log_error ("run",
+        "Script validation failed: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     // The other deferred pass over the same reservoirs (issue #682): what
@@ -1928,8 +1932,9 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
     try {
         schema_totals = validate_sampled_responses (context);
     } catch (const std::exception& e) {
-        vayu::utils::log_error (
-        "run", "Schema validation failed: " + std::string (e.what ()));
+        vayu::utils::log_error ("run",
+        "Schema validation failed: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     // `script.teardown` (#1499): the same collection-level elements
@@ -1962,8 +1967,9 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
         context->run_id, build_run_summary_payload (inputs).dump ());
         summary_stored = true;
     } catch (const std::exception& e) {
-        vayu::utils::log_error (
-        "run", "Failed to store run summary: " + std::string (e.what ()));
+        vayu::utils::log_error ("run",
+        "Failed to store run summary: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     // Update run status with retry logic to handle any remaining contention.
@@ -1984,22 +1990,17 @@ const std::shared_ptr<ScenarioLoadState>& scenario_state) {
     try {
         db.prune_runs_configured ();
     } catch (const std::exception& e) {
-        vayu::utils::log_warning ("run", "Run pruning failed: " + std::string (e.what ()));
+        vayu::utils::log_warning ("run", "Run pruning failed: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     vayu::utils::log_debug ("run",
-    "Load test " + context->run_id + " " + vayu::to_string (final_status));
-    vayu::utils::log_debug ("run", "  Total requests: " + std::to_string (completed));
-    vayu::utils::log_debug ("run",
-    "  Errors: " + std::to_string (errors) + " (" + std::to_string (error_rate) + "%)");
-    vayu::utils::log_debug ("run", "  Duration: " + std::to_string (total_duration_s) + " s");
-    vayu::utils::log_debug ("run",
-    "  Target RPS: " + (target_rps > 0 ? std::to_string (target_rps) : "unlimited"));
-    vayu::utils::log_debug ("run", "  Actual RPS: " + std::to_string (actual_rps));
-    vayu::utils::log_debug ("run", "  Avg latency: " + std::to_string (avg_latency) + " ms");
-    vayu::utils::log_debug ("run",
-    "  P50/P95/P99: " + std::to_string (percentiles.p50) + "/" +
-    std::to_string (percentiles.p95) + "/" + std::to_string (percentiles.p99) + " ms");
+    std::string ("Load test ") + vayu::to_string (final_status),
+    { { "runId", context->run_id }, { "totalRequests", completed },
+    { "errors", errors }, { "errorRate", error_rate }, { "durationS", total_duration_s },
+    { "targetRps", target_rps }, { "actualRps", actual_rps },
+    { "avgLatencyMs", avg_latency }, { "p50", percentiles.p50 },
+    { "p95", percentiles.p95 }, { "p99", percentiles.p99 } });
 }
 
 void execute_load_test (const std::shared_ptr<RunContext>& context,
@@ -2052,7 +2053,8 @@ RunManager& manager) {
         // load is sent.
         vayu::http::routes::ScriptVariableScopes base_scopes;
         if (auto setup_failure = run_collection_setup (db, context, base_scopes)) {
-            vayu::utils::log_error ("run", "script.setup failed: " + *setup_failure);
+            vayu::utils::log_error ("run", "script.setup failed: " + *setup_failure,
+            { { "runId", context->run_id } });
             db.update_run_status (context->run_id, vayu::RunStatus::Failed);
             context->is_running = false;
             context->join_aux_threads ();
@@ -2073,7 +2075,8 @@ RunManager& manager) {
                 strategy->execute (context, db, request);
             }
         } catch (const std::exception& e) {
-            vayu::utils::log_error ("run", "Load test failed: " + std::string (e.what ()));
+            vayu::utils::log_error ("run", "Load test failed: " + std::string (e.what ()),
+            { { "runId", context->run_id } });
             db.update_run_status (context->run_id, vayu::RunStatus::Failed);
             context->is_running = false;
             context->join_aux_threads ();
@@ -2139,7 +2142,8 @@ RunManager& manager) {
         context->is_running = false;
         context->join_aux_threads ();
 
-        vayu::utils::log_error ("run", "Load test error: " + std::string (e.what ()));
+        vayu::utils::log_error ("run", "Load test error: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
 
         // A crashed run still gets a summary, with whatever the collector holds
         // and a wall-clock duration - without one the report route would take
@@ -2184,22 +2188,25 @@ RunManager& manager) {
             context->run_id, build_run_summary_payload (inputs).dump ());
         } catch (const std::exception& ex) {
             vayu::utils::log_error ("run",
-            "Failed to store run summary for failed run: " + std::string (ex.what ()));
+            "Failed to store run summary for failed run: " + std::string (ex.what ()),
+            { { "runId", context->run_id } });
         }
 
         try {
             db.update_run_status_with_retry (context->run_id, vayu::RunStatus::Failed);
         } catch (const std::exception& ex) {
-            vayu::utils::log_error (
-            "run", "Failed to update run status: " + std::string (ex.what ()));
+            vayu::utils::log_error ("run",
+            "Failed to update run status: " + std::string (ex.what ()),
+            { { "runId", context->run_id } });
         }
 
         // Failed is terminal too - prune per the retention knobs, best-effort.
         try {
             db.prune_runs_configured ();
         } catch (const std::exception& ex) {
-            vayu::utils::log_warning (
-            "run", "Run pruning failed: " + std::string (ex.what ()));
+            vayu::utils::log_warning ("run",
+            "Run pruning failed: " + std::string (ex.what ()),
+            { { "runId", context->run_id } });
         }
     }
 
@@ -2480,9 +2487,9 @@ int64_t& first_tick_steady_ms) {
     }
 
     vayu::utils::log_debug ("run", "Metrics",
-    { { "rps", current_rps }, { "sendRate", send_rate }, { "throughput", throughput },
-    { "backpressure", backpressure }, { "errorRate", error_rate },
-    { "active", active_now }, { "sent", requests_sent } });
+    { { "runId", context->run_id }, { "rps", current_rps }, { "sendRate", send_rate },
+    { "throughput", throughput }, { "backpressure", backpressure },
+    { "errorRate", error_rate }, { "active", active_now }, { "sent", requests_sent } });
 
     // Persist the tick: one wide row, built here rather than
     // reassembled from ~18 EAV rows by every reader.
@@ -2533,7 +2540,8 @@ int64_t& first_tick_steady_ms) {
         // built from the collector, not from these rows. At most
         // one line per tick, and the tick gate is 1 Hz.
         vayu::utils::log_warning ("run",
-        "Metric tick not persisted for run " + context->run_id + ": " + e.what ());
+        "Metric tick not persisted: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     last_total = current_total;
@@ -2695,9 +2703,11 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         // as the termination contract (last data before closed==true).
         emit_live_tick (nullptr, now_ms (), steady_now_ms ());
     } catch (const std::exception& e) {
-        vayu::utils::log_error ("run", "collect_metrics: " + std::string (e.what ()));
+        vayu::utils::log_error ("run", "collect_metrics: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     } catch (...) {
-        vayu::utils::log_error ("run", "collect_metrics: unknown exception");
+        vayu::utils::log_error ("run", "collect_metrics: unknown exception",
+        { { "runId", context->run_id } });
     }
 
     // Unconditional: always signal consumers so they terminate cleanly,
@@ -2726,9 +2736,9 @@ int& interval_ms) {
     if (consecutive_failures == constants::monitor::FAILURES_BEFORE_BACKOFF) {
         if (!backoff_logged) {
             vayu::utils::log_warning ("run",
-            "Monitor scrape for run " + context->run_id + " has failed " +
-            std::to_string (consecutive_failures) + " times in a row (" +
-            config.url + "); backing off, the series will show gaps");
+            "Monitor scrape has failed " + std::to_string (consecutive_failures) +
+            " times in a row (" + config.url + "); backing off, the series will show gaps",
+            { { "runId", context->run_id } });
             backoff_logged = true;
         }
         // Doubled once, not per failure: the point is to stop
@@ -2761,7 +2771,8 @@ int& interval_ms) {
         // The live frame below still goes out: a row this run could
         // not store is worth less than a series that stops drawing.
         vayu::utils::log_warning ("run",
-        "Failed to store monitor sample for run " + context->run_id + ": " + e.what ());
+        "Failed to store monitor sample: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
     context->append_event ("monitor", payload.dump ());
 }
@@ -2785,10 +2796,11 @@ const MonitorConfig& config) {
         // shortened on a fast one, and silence would look like the setting had
         // not taken.
         vayu::utils::log_warning ("run",
-        "Monitor scrape timeout for run " + context->run_id + " capped at the scrape interval (" +
+        "Monitor scrape timeout capped at the scrape interval (" +
         std::to_string (timeout_ms) + "ms); 'monitorScrapeTimeoutMs' is " +
         std::to_string (config.scrape_timeout_ms) + "ms, which is longer than this run's " +
-        std::to_string (config.interval_ms) + "ms cadence");
+        std::to_string (config.interval_ms) + "ms cadence",
+        { { "runId", context->run_id } });
     }
 
     // No cookie jar: this is the engine talking on its own behalf, like the
@@ -2846,9 +2858,11 @@ const MonitorConfig& config) {
             }
         }
     } catch (const std::exception& e) {
-        vayu::utils::log_error ("run", "collect_monitor: " + std::string (e.what ()));
+        vayu::utils::log_error ("run", "collect_monitor: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     } catch (...) {
-        vayu::utils::log_error ("run", "collect_monitor: unknown exception");
+        vayu::utils::log_error ("run", "collect_monitor: unknown exception",
+        { { "runId", context->run_id } });
     }
 }
 

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -1059,9 +1059,9 @@ TransactionHistograms& transactions) {
             // continue-on-failure is deliberately not invented ahead of
             // demand (design doc, "Deliberately left open").
             vayu::utils::log_warning ("run",
-            "Scenario run " + base.context->run_id + ": iteration " +
-            std::to_string (base.iteration) + " ended at step '" +
-            record.step_name + "' - " + record.error);
+            "Scenario run: iteration " + std::to_string (base.iteration) +
+            " ended at step '" + record.step_name + "' - " + record.error,
+            { { "runId", base.context->run_id } });
             break;
         }
         if (end_iteration) {
@@ -1359,7 +1359,8 @@ RunManager& manager) {
             db.add_results_batch (rows);
         } catch (const std::exception& e) {
             vayu::utils::log_error ("run",
-            "Failed to store scenario step results: " + std::string (e.what ()));
+            "Failed to store scenario step results: " + std::string (e.what ()),
+            { { "runId", context->run_id } });
             summary.steps_stored = 0;
         }
 
@@ -1383,7 +1384,8 @@ RunManager& manager) {
         summary.lifecycle =
         vayu::core::build_lifecycle_node (setup_outcomes, teardown_outcomes);
     } catch (const std::exception& e) {
-        vayu::utils::log_error ("run", "Scenario run error: " + std::string (e.what ()));
+        vayu::utils::log_error ("run", "Scenario run error: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
         final_status = vayu::RunStatus::Failed;
     }
 
@@ -1441,7 +1443,8 @@ RunManager& manager) {
         context->run_id, build_scenario_summary_payload (summary).dump ());
     } catch (const std::exception& e) {
         vayu::utils::log_error ("run",
-        "Failed to store scenario run summary: " + std::string (e.what ()));
+        "Failed to store scenario run summary: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     try {
@@ -1450,21 +1453,22 @@ RunManager& manager) {
         db.update_run_status_with_retry (context->run_id, final_status);
     } catch (const std::exception& e) {
         vayu::utils::log_error ("run",
-        "Failed to update scenario run status: " + std::string (e.what ()));
+        "Failed to update scenario run status: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     try {
         db.prune_runs_configured ();
     } catch (const std::exception& e) {
-        vayu::utils::log_warning ("run", "Run pruning failed: " + std::string (e.what ()));
+        vayu::utils::log_warning ("run", "Run pruning failed: " + std::string (e.what ()),
+        { { "runId", context->run_id } });
     }
 
     vayu::utils::log_debug ("run",
-    "Scenario run " + context->run_id + " " + vayu::to_string (final_status) +
-    ": " + std::to_string (summary.steps_executed) + " step(s) over " +
-    std::to_string (summary.iterations_completed) + " iteration(s), " +
-    std::to_string (summary.passed) + " passed, " + std::to_string (summary.failed) +
-    " failed, " + std::to_string (summary.errored) + " errored");
+    std::string ("Scenario run ") + vayu::to_string (final_status),
+    { { "runId", context->run_id }, { "stepsExecuted", summary.steps_executed },
+    { "iterationsCompleted", summary.iterations_completed }, { "passed", summary.passed },
+    { "failed", summary.failed }, { "errored", summary.errored } });
 
     context->is_running = false;
     // After the last step event, never before: a consumer treats `closed` as

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -206,7 +206,8 @@ MetricsCollector::Percentiles percentiles_from_latencies (std::vector<double> la
 std::optional<vayu::core::ValidationVerdict> validate_step_response (const SpecBinding& spec,
 const std::optional<ResponseSchemaIndex>& index,
 const ScenarioStep& step,
-const vayu::Response& response) {
+const vayu::Response& response,
+const std::string& run_id) {
     if (!spec.bound ()) {
         return std::nullopt;
     }
@@ -225,8 +226,9 @@ const vayu::Response& response) {
         // A validator that threw is not a response that failed, and it is
         // certainly not a step that did - the design-mode hook's rule, for its
         // reason. The step keeps its outcome and loses only its verdict.
-        vayu::utils::log_warning (
-        "run", "Step schema validation failed: " + std::string (e.what ()));
+        vayu::utils::log_warning ("run",
+        "Step schema validation failed: " + std::string (e.what ()),
+        { { "runId", run_id } });
         return std::nullopt;
     }
 }
@@ -725,8 +727,8 @@ ScenarioSummaryInputs& summary) {
     // nobody made - the same reading that erases `response` from
     // their trace below.
     if (exchange.sent) {
-        record.validation = validate_step_response (
-        ctx.execution->spec, ctx.schema_index, step, exchange.response);
+        record.validation = validate_step_response (ctx.execution->spec,
+        ctx.schema_index, step, exchange.response, ctx.context->run_id);
         if (record.validation) {
             // The step's name and status ride the tally so a failure
             // example read far from the step list still says which

--- a/engine/src/utils/logger.cpp
+++ b/engine/src/utils/logger.cpp
@@ -60,6 +60,12 @@ void Logger::init (const std::string& log_dir, std::string_view source) {
     // disk for every value of N.
     prune_old_logs (log_dir_, file_prefix (),
     static_cast<std::size_t> (vayu::core::constants::logging::RETAINED_FILES));
+
+    // The pre-#1557 generation is never one of the N kept above - it has its
+    // own prefix, so `prune_old_logs` never sees it - and nothing else in the
+    // engine mentions it, so an install that predates the split would carry
+    // it forever otherwise.
+    remove_legacy_log_files (log_dir_, vayu::core::constants::logging::LEGACY_FILE_PREFIX);
 }
 
 void Logger::set_file_level (Level level) {
@@ -297,6 +303,36 @@ prune_old_logs (const std::string& log_dir, std::string_view file_prefix, std::s
         // in the directory forever, which is the growth this prune exists to
         // stop.
         fs::remove (candidates[i].string () + ".1", remove_ec);
+    }
+    return deleted;
+}
+
+std::size_t remove_legacy_log_files (const std::string& log_dir, std::string_view legacy_prefix) {
+    namespace fs = std::filesystem;
+
+    constexpr std::string_view SUFFIX = ".log";
+
+    std::error_code ec;
+    std::vector<fs::path> victims;
+    for (const auto& entry : fs::directory_iterator (log_dir, ec)) {
+        if (!entry.is_regular_file ())
+            continue;
+        const std::string name = entry.path ().filename ().string ();
+        if (name.starts_with (legacy_prefix) && name.ends_with (SUFFIX)) {
+            victims.push_back (entry.path ());
+        }
+    }
+    if (ec) {
+        return 0;
+    }
+
+    std::size_t deleted = 0;
+    for (const auto& victim : victims) {
+        std::error_code remove_ec;
+        if (fs::remove (victim, remove_ec)) {
+            ++deleted;
+        }
+        fs::remove (victim.string () + ".1", remove_ec);
     }
     return deleted;
 }

--- a/engine/tests/log_record_schema_test.cpp
+++ b/engine/tests/log_record_schema_test.cpp
@@ -204,11 +204,7 @@ TEST (LogRecordSchemaTest, AConvertedNumericFieldStaysNativeJsonNotAStringifiedS
     << record.at ("msg");
 }
 
-// Issue #1557's reopen: the propertyNames pattern was `^[a-z][a-z0-9_]*$`,
-// which refuses every lowerCamelCase field the engine actually emits -
-// `runId`, `requestId`, `environmentId`, `cacheKb`, `busyTimeoutMs` among
-// them - so a real log file failed this schema on its own field names, not
-// only on fixtures. Mirrors two real call sites
+// Issue #1557's reopen. Mirrors two real call sites
 // (`http/routes/execution.cpp`'s "Design Mode send" and `db/database.cpp`'s
 // "Database initialized with WAL mode") rather than inventing new field
 // names, so a schema change that widens the pattern enough to admit fixture

--- a/engine/tests/log_record_schema_test.cpp
+++ b/engine/tests/log_record_schema_test.cpp
@@ -204,6 +204,38 @@ TEST (LogRecordSchemaTest, AConvertedNumericFieldStaysNativeJsonNotAStringifiedS
     << record.at ("msg");
 }
 
+// Issue #1557's reopen: the propertyNames pattern was `^[a-z][a-z0-9_]*$`,
+// which refuses every lowerCamelCase field the engine actually emits -
+// `runId`, `requestId`, `environmentId`, `cacheKb`, `busyTimeoutMs` among
+// them - so a real log file failed this schema on its own field names, not
+// only on fixtures. Mirrors two real call sites
+// (`http/routes/execution.cpp`'s "Design Mode send" and `db/database.cpp`'s
+// "Database initialized with WAL mode") rather than inventing new field
+// names, so a schema change that widens the pattern enough to admit fixture
+// snake_case but not real camelCase still reds here.
+TEST (LogRecordSchemaTest, ARealCamelCaseFieldNameValidates) {
+    const nlohmann::json schema = load_schema ();
+    ScratchLogDir dir;
+    Logger::instance ().init (dir.string (), "engine");
+    Logger::instance ().set_max_file_bytes (0);
+    Logger::instance ().set_file_level (Logger::Level::DEBUG);
+
+    vayu::utils::log_info ("http", "Design Mode send",
+    { { "runId", "r1" }, { "method", "GET" }, { "url", "http://h/x" },
+    { "requestId", "req1" }, { "environmentId", "env1" } });
+    vayu::utils::log_debug ("db", "Database initialized with WAL mode",
+    { { "cacheKb", 2048 }, { "busyTimeoutMs", 5000 }, { "synchronous", "NORMAL" } });
+    Logger::instance ().flush ();
+
+    const auto records = read_records (dir.path ());
+    ASSERT_EQ (records.size (), 2u);
+    for (const auto& record : records) {
+        EXPECT_TRUE (validates (schema, record)) << record.dump ();
+    }
+    EXPECT_EQ (records.front ().at ("runId"), "r1");
+    EXPECT_EQ (records.back ().at ("cacheKb"), 2048);
+}
+
 // Mutation-check: change `record.at ("cat")` in the fixture below to a
 // category from the wrong branch (`"db"` under `src: "cli"` is fine since
 // `cli`'s enum is a superset, but `"boundary"`, `renderer`'s own, is not) and

--- a/engine/tests/logger_test.cpp
+++ b/engine/tests/logger_test.cpp
@@ -219,6 +219,26 @@ TEST (LoggerRetentionTest, AStartPrunesTheDirectoryItOpensInto) {
     EXPECT_GT (newest_log (dir.path ()).filename ().string (), std::string ("engine_2025"));
 }
 
+// A start removes the pre-#1557 generation outright: it carries no prefix
+// `prune_old_logs` was ever told to keep any of, so nothing else in the
+// engine would ever remove it. Mutation-check: drop the `remove_legacy_log_files`
+// call from `Logger::init` and the planted file survives the start below.
+TEST (LoggerRetentionTest, AStartRemovesTheLegacyGenerationOutright) {
+    ScratchLogDir dir;
+    std::ofstream (dir.path () / "vayu_20260101_000000.log") << "legacy";
+    std::ofstream (dir.path () / "vayu_20260101_000000.log.1")
+    << "legacy rotated";
+    std::ofstream (dir.path () / "vayu_20260102_000000.log") << "legacy, newer";
+
+    Logger::instance ().init (dir.string ());
+
+    const auto remaining = names_in (dir.path ());
+    EXPECT_EQ (remaining.count ("vayu_20260101_000000.log"), 0u);
+    EXPECT_EQ (remaining.count ("vayu_20260101_000000.log.1"), 0u);
+    EXPECT_EQ (remaining.count ("vayu_20260102_000000.log"), 0u)
+    << "every legacy file goes, not just the oldest";
+}
+
 // ---------------------------------------------------------------------------
 // Level: the file sink used to take DEBUG unconditionally.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

#1557 landed the `LogRecord` shape, the two renderers, redaction and the
category guard, but its closure verification (2026-09-08) found four gaps
against the issue's own acceptance criteria and fix pathway. This PR closes
them:

1. **Real records failed the schema.** `docs/engine/log-record.schema.json`'s
   `propertyNames` pattern (`^[a-z][a-z0-9_]*$`) refused every lowerCamelCase
   field the engine already emits on the wire - `runId`, `requestId`,
   `environmentId`, `cacheKb`, `busyTimeoutMs` - so a real `-v 2` log file
   failed validation on its own field names, not only on hand-written test
   fixtures. Widened to `^[a-z][a-zA-Z0-9_]*$`.
2. **No consistent `run` field on run-active records.** The schema had
   already reserved a dedicated `"run"` property for this, but every real
   call site used `runId` instead, and `run_manager.cpp` /
   `scenario_runner.cpp` mostly baked the run id into free-text message
   concatenation (`"... for run " + context->run_id`) rather than a field at
   all - so `jq 'select(.runId=="...")'` could not find most of a run's own
   log lines. Renamed the schema's property to `runId` to match the existing
   majority convention (touches one doc line) instead of renaming the ~13
   call sites that already had it right, and added `{ "runId": ... }` to
   every log call in those two files that has a `RunContext` in scope -
   including `validate_step_response`'s schema-validation-failure warning,
   which needed the id threaded in from `record_step`'s `StepContext` since
   it wasn't in scope at the function's own signature.
3. **Legacy `vayu_*.log` files were never removed.** `prune_old_logs` only
   ever prunes the prefix it is told to keep (`engine_`/`cli_`), so an
   install upgrading from before #1557's file-naming split kept its old
   `vayu_*.log` files forever. `Logger::init` now also removes every
   `vayu_*.log` (and its `.1` rotation) it finds, unconditionally, once per
   start.
4. **Two docs regressions.** `cli.md`'s `-v` table cell was cut off
   mid-sentence and its `--verbose 2` example still showed the pre-#1557
   bare `GET /health 200 ...` lines instead of the JSON-record console
   rendering; the 2xx=debug/3xx-4xx=info/5xx=warn request-line level rule
   (previously in `architecture.md`) had landed in neither doc after #1557's
   PR. Fixed the sentence, refreshed the example, and added the level rule
   to `logging.md`'s console-rendering section.

**Alternative considered and rejected** for gap 2: renaming the ~13 call
sites already using `runId` down to the schema's `run`, to match the fix
pathway's literal field name. Rejected because it touches far more code for
no behavioural difference - the schema doc is the one place this convention
is declared, so it is cheaper and less risky to move the one line.

**Also fixed in this PR** (found by an adversarial self-review pass, not in
the original reopen comment): the `-v 2` example initially showed a 202
(2xx) response rendered at `INFO`, contradicting the level rule stated two
lines above it in the same doc - replaced with a 404 so the example matches
the rule it illustrates.

## Type of Change
- [x] Bug fix

## Testing

- `python build.py -e -t && cd engine && ctest --preset linux-dev` - full
  suite green, **3238/3238**, including the new cases this PR adds
  (`LoggerRetentionTest.AStartRemovesTheLegacyGenerationOutright`,
  `LogRecordSchemaTest.ARealCamelCaseFieldNameValidates`).
- `clang-format-19 --style=file --dry-run -Werror` clean on every touched
  C++ file (docs `.md` files are outside clang-format's domain per
  `CLAUDE.md` - hand-wrapped prose, not a formatting target).
- `mkdocs build --strict` not run (mkdocs is not installed in this
  environment); the docs edits are a table-cell sentence, a fenced code
  block's content, one new paragraph, and one new same-directory relative
  link (`[Logging](logging.md)`, to a file that exists) - no page added,
  moved or renamed, no new heading anchor.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #1557
