### PR TITLE
fix(engine): thread fixedMs/minMs-maxMs elements.timers override into the load-path scheduling hook

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -5218,11 +5218,12 @@ own unknown-key rule uses, checked before the run row is created.
   the sequential run. `timer.pacing` and `timer.throughput` schedule their
   wait before that step's `ElementContext` exists at all
   (`Element::scheduled_ready_delay_ms`, see
-  [Load paths](elements.md#load-paths)); `"off"` reaches
+  [Load paths](elements.md#load-paths)); every mode reaches
   them there too, through the run's own copy of the override
-  (`SharedScheduleState::timers_override`), so a run with `timers: "off"`
-  defers neither kind under load - `"fixedMs"`/`{"minMs", "maxMs"}` are not
-  yet threaded through that same seam.
+  (`SharedScheduleState::timers_override`, issue #1620), so a run with
+  `timers: "off"` defers neither kind under load and a run with `"fixedMs"`
+  or `{"minMs", "maxMs"}` schedules their wait from that value rather than
+  the element's own `everyMs` / `targetPerMinute`.
 - **`seed`** (issue #1498) is an optional non-negative integer that seeds this
   run's RNG, making a `timer.think` element's gaussian or uniform-random wait
   reproducible. A scenario load run derives one independent generator per

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -391,11 +391,16 @@ for the sequential run; a `perUser: false` element instead advances its own entr
 shared-pacing element id in the plan, so two VUs' concurrent completions claim distinct slots of
 the same clock rather than racing onto the same one. `SharedScheduleState::timers_override` (a
 `const TimersOverride*` alongside `pacing` and `throughput`, filled in from `RunContext` at the
-same call site) is `finish_step`'s own copy of the override for this seam: `"off"` returns
-`std::nullopt` before either kind touches its pacing state or shared clock at all, closing the gap
-this section used to disclose - a run that silences timers with `"off"` no longer defers a scenario
-load run's pacing or throughput element by its own interval first and only reports that truthfully
-after the fact.
+same call site) is `finish_step`'s own copy of the override for this seam: both kinds call the same
+`apply_timers_override` every other `timer.*` kind's `apply` calls, through `shared.timers_override`
+and a `shared.rng` (issue #1620, the VU's own generator, so a `Range` draw stays reproducible with
+`seed`) - `"off"` returns `std::nullopt` before either kind touches its pacing state or shared clock
+at all, and `"fixedMs"` / `{"minMs", "maxMs"}` replace the element's own `everyMs` /
+`targetPerMinute` with the override's value before either branch advances anything from it
+(`timer.throughput`'s shared token bucket converts the overridden interval into the equivalent rate
+per second). A run that silences or overrides timers no longer defers a scenario load run's pacing
+or throughput element by its own configured interval first and only reports that truthfully after
+the fact.
 
 **Step-level elements on the single-request load path, wired (issue #1594).**
 A single-request `POST /runs` payload's own request now has an `elements`

--- a/engine/include/vayu/core/elements.hpp
+++ b/engine/include/vayu/core/elements.hpp
@@ -170,13 +170,19 @@ class SharedThroughputBudgets {
  * reopen): this hook runs before any step's `ElementContext` exists, so it
  * cannot read `ElementContext::timers_override` the way every other
  * `timer.*` kind's `apply` does - a kind that schedules through here must
- * consult this copy instead, and check it before doing anything else, so an
- * `"off"` run books no wait and touches no pacing state at all.
+ * consult this copy instead, through `apply_timers_override`, and check it
+ * before doing anything else, so an `"off"` run books no wait and touches no
+ * pacing state at all. `rng` (issue #1620) is the VU's own generator, for
+ * `apply_timers_override`'s `Range` mode to draw from - the same
+ * `std::mt19937_64` `ElementContext::rng` binds elsewhere, so a `Range`
+ * override stays reproducible per #1498's `seed` contract whichever seam
+ * drew it.
  */
 struct SharedScheduleState {
     SharedPacingClocks* pacing            = nullptr;
     SharedThroughputBudgets* throughput   = nullptr;
     const TimersOverride* timers_override = nullptr;
+    std::mt19937_64* rng                  = nullptr;
 };
 
 /**

--- a/engine/src/core/elements/timer_pacing.cpp
+++ b/engine/src/core/elements/timer_pacing.cpp
@@ -94,11 +94,15 @@ class TimerPacingElement final : public Element {
         // The run-level `elements.timers` override cannot reach `apply`'s own
         // check here - this hook runs before any step's `ElementContext`
         // exists - so it is consulted through `shared.timers_override`
-        // instead (issue #1498's reopen). `"off"` books no wait and touches
-        // neither `pacing_state` nor the shared clock, matching `apply`'s own
-        // "off" outcome on the sequential run.
-        if (shared.timers_override != nullptr &&
-        shared.timers_override->mode == TimersOverride::Mode::Off) {
+        // instead (issue #1498's reopen), via the same `apply_timers_override`
+        // every other `timer.*` kind's `apply` calls (issue #1620): `"off"`
+        // books no wait and touches neither `pacing_state` nor the shared
+        // clock; `"fixedMs"` / `{"minMs", "maxMs"}` replace `every_ms_` with
+        // the override's value before either branch below advances anything,
+        // the same "replaced, not merged" rule `apply` follows.
+        const auto interval_ms =
+        apply_timers_override (shared.timers_override, every_ms_, shared.rng);
+        if (!interval_ms) {
             return std::nullopt;
         }
         if (!per_user_) {
@@ -106,10 +110,11 @@ class TimerPacingElement final : public Element {
             // `shared.pacing` is always non-null here, sized by the plan
             // scan that found this very element's id in the first place.
             return shared.pacing != nullptr ?
-            shared.pacing->advance (element_id_, every_ms_, now_ms) :
+            shared.pacing->advance (element_id_, *interval_ms, now_ms) :
             int64_t{ 0 };
         }
-        return detail::advance_per_user_pacing (pacing_state, element_id_, every_ms_, now_ms);
+        return detail::advance_per_user_pacing (
+        pacing_state, element_id_, *interval_ms, now_ms);
     }
 
     private:

--- a/engine/src/core/elements/timer_throughput.cpp
+++ b/engine/src/core/elements/timer_throughput.cpp
@@ -99,20 +99,38 @@ class TimerThroughputElement final : public Element {
         }
         // The run-level `elements.timers` override is consulted through
         // `shared.timers_override`, for the reason `timer_pacing.cpp`'s own
-        // comment states (issue #1498's reopen).
-        if (shared.timers_override != nullptr &&
-        shared.timers_override->mode == TimersOverride::Mode::Off) {
+        // comment states (issue #1498's reopen, extended to `Fixed`/`Range`
+        // by #1620): `apply_timers_override` hands back an interval in
+        // milliseconds, replacing `every_ms_` before either branch below
+        // advances anything from it.
+        const auto interval_ms =
+        apply_timers_override (shared.timers_override, every_ms_, shared.rng);
+        if (!interval_ms) {
             return std::nullopt;
         }
         if (!per_user_) {
             // One rate shared across every virtual user: `shared.throughput`
             // is always non-null here, sized by the plan scan that found this
-            // very element's id in the first place.
+            // very element's id in the first place. `claim` wants a rate per
+            // second; left un-overridden (`interval_ms == every_ms_`), the
+            // exact configured rate is used rather than one derived from the
+            // rounded `every_ms_`, so an un-overridden run's accuracy is
+            // unchanged. A `fixedMs`/`minMs`-`maxMs` override instead
+            // converts its interval into the equivalent rate, floored the
+            // same way `every_ms_for` floors the other direction so a
+            // near-zero interval cannot produce an unbounded rate.
+            const bool overridden = shared.timers_override != nullptr &&
+            (shared.timers_override->mode == TimersOverride::Mode::Fixed ||
+            shared.timers_override->mode == TimersOverride::Mode::Range);
+            const double rate_per_second = overridden ?
+            1000.0 / static_cast<double> (std::max<int64_t> (1, *interval_ms)) :
+            target_per_minute_ / 60.0;
             return shared.throughput != nullptr ?
-            shared.throughput->claim (element_id_, target_per_minute_ / 60.0, now_ms) :
+            shared.throughput->claim (element_id_, rate_per_second, now_ms) :
             int64_t{ 0 };
         }
-        return detail::advance_per_user_pacing (pacing_state, element_id_, every_ms_, now_ms);
+        return detail::advance_per_user_pacing (
+        pacing_state, element_id_, *interval_ms, now_ms);
     }
 
     private:

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -1191,7 +1191,8 @@ class ScenarioLoadDriver {
         schedule_next_entry_wait (plan.steps[vu->step], *vu,
         SharedScheduleState{ .pacing = &state->shared_pacing,
         .throughput                  = &state->shared_throughput_budgets,
-        .timers_override             = &context->timers_override });
+        .timers_override             = &context->timers_override,
+        .rng                         = &vu->rng });
 
         // Released *before* handle_result, which is what increments the
         // completion count `in_flight()` is derived from: a VU that became

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1111,21 +1111,24 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersFixedMsOverridesThroughputUnderLoa
     << executed << " requests over 4s, close to the un-overridden 18";
 }
 
-// Issue #1620's `{"minMs", "maxMs"}` case, and its reproducibility
-// requirement: `SharedScheduleState::rng` threads the VU's own seeded
-// generator into `apply_timers_override`'s `Range` draw, the same
-// `std::mt19937_64` every other seeded wait in this suite reads from. Five
-// runs of the same single-VU plan with the same `seed` must all draw the
-// same sequence of intervals and so complete the same number of passes -
-// looped rather than compared as a single pair, so a non-reproducible draw
-// (an unseeded fallback generator, or no `rng` at all) cannot pass by two
-// unseeded draws coinciding once, which a single-pair comparison could not
-// rule out. Mutation check: dropping `.rng = &vu->rng` at the
-// `SharedScheduleState` construction site falls back to
-// `apply_timers_override`'s unseeded thread-local generator, which reds this
-// loop's equality assertion within a handful of iterations even though any
-// one pair of unseeded draws can occasionally coincide.
-TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSeed) {
+// Issue #1620's `{"minMs", "maxMs"}` case reaching `timer.pacing`'s per-user
+// branch under load, staying inside the configured range. The acceptance
+// criteria's "reproducible with elements.seed" half is proven at the layer
+// that actually determines it - `ApplyTimersOverrideTest.
+// RangeModeIsReproducibleWithTheSameSeedAndStaysInBounds` above (two
+// identically-seeded generators draw identically) and `DeriveVuRngTest.
+// SameSeedAndIndexProduceIdenticalSequences` (a VU's generator is a pure
+// function of the run seed and its index) - not here: comparing the *count*
+// of steps two independent load runs complete inside a fixed wall-clock
+// window is not actually a test of RNG reproducibility, because which step
+// lands inside or outside that window also depends on real thread-scheduling
+// timing, which a fixed seed does not control. An earlier version of this
+// test compared exactly that and was flaky on CI (off by one or two between
+// runs on the same seed, on a busier box) for precisely this reason. Mutation
+// check: reverting `scheduled_ready_delay_ms` to read `every_ms_` directly
+// instead of the `apply_timers_override`-derived interval reds this on the
+// ceiling, the same way it reds the `FixedMs` case above.
+TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideReachesPacingUnderLoad) {
     auto execution =
     plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
 
@@ -1134,39 +1137,29 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSee
         { "elements",
         { { "timers", { { "minMs", 50 }, { "maxMs", 150 } } }, { "seed", 42 } } } };
 
-    auto first = run (config, execution);
-    ASSERT_NE (first, nullptr);
-    const size_t executed_first = first->steps_executed.load ();
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
 
-    // Sanity bound: within the 50-150ms range, 1.5s cannot produce fewer
-    // than the un-paced-first-pass-plus-one, nor more than an unpaced run.
-    EXPECT_GE (executed_first, 2u);
-    EXPECT_LE (executed_first, 30u);
-
-    for (int attempt = 0; attempt < 4; ++attempt) {
-        auto repeat = run (config, execution);
-        ASSERT_NE (repeat, nullptr);
-        const size_t executed_repeat = repeat->steps_executed.load ();
-        EXPECT_EQ (executed_first, executed_repeat)
-        << "the same seed drew a different sequence of Range waits on repeat " << attempt
-        << " - executed " << executed_first << " then " << executed_repeat;
-    }
+    // Well clear of the element's own 500ms-cadence ceiling
+    // (`APacedRunDoesNotBusySpinTheProducer` pins it at 4-6 over the same
+    // 2s shape), and short of a fully unpaced run.
+    EXPECT_GE (executed, 8u) << "elements.timers: {minMs: 50, maxMs: 150} did "
+                                "not replace timer.pacing's "
+                                "own 500ms cadence under load - got "
+                             << executed << " requests over 1.5s";
+    EXPECT_LE (executed, 30u);
 }
 
-// @copydoc ElementsTimersRangeOverrideIsReproducibleWithSeed, `timer.throughput`'s
-// shared branch (`perUser: false`, the default): the acceptance criteria ask
-// for Range reproducibility "for both kinds under load", and both call the
-// same `apply_timers_override` with `shared.rng`, but only `timer.pacing`'s
-// per-user branch had a dedicated case above. Pinned to a single virtual
-// user rather than the ten-VU shape the other throughput tests use: with
-// several VUs racing to claim the one shared budget, which VU's draw lands
-// first depends on real thread-scheduling order, not only the seed, so the
-// aggregate count is not reproducible even with a correctly-seeded `rng` -
-// concurrency itself is the confound, not this fix. One VU removes that
-// confound and still exercises the shared branch's rate conversion
-// (`shared.throughput != nullptr` -> `claim`), which is the code this test
-// exists to cover. Same mutation check as above.
-TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSeedForThroughput) {
+// @copydoc ElementsTimersRangeOverrideReachesPacingUnderLoad, `timer.throughput`'s
+// shared branch (`perUser: false`, the default) - the acceptance criteria ask
+// for Range mode to reach "both kinds under load", and only `timer.pacing`'s
+// per-user branch had a dedicated Range case above. Pinned to a single
+// virtual user rather than the ten-VU shape the other throughput tests use,
+// so the shared budget's own claim path is exercised without ten VUs racing
+// it (a confound this fix does not touch and does not need to prove
+// anything about). Same mutation check as above.
+TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideReachesThroughputUnderLoad) {
     auto execution =
     plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 120.0,
     /*scope_entry=*/true, /*per_user=*/false) });
@@ -1176,23 +1169,18 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSee
         { "elements",
         { { "timers", { { "minMs", 50 }, { "maxMs", 150 } } }, { "seed", 7 } } } };
 
-    auto first = run (config, execution);
-    ASSERT_NE (first, nullptr);
-    const size_t executed_first = first->steps_executed.load ();
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
 
-    // Sanity bound: within the 50-150ms range, 1.5s cannot produce fewer
-    // than the un-paced-first-pass-plus-one, nor more than an unpaced run.
-    EXPECT_GE (executed_first, 2u);
-    EXPECT_LE (executed_first, 30u);
-
-    for (int attempt = 0; attempt < 4; ++attempt) {
-        auto repeat = run (config, execution);
-        ASSERT_NE (repeat, nullptr);
-        const size_t executed_repeat = repeat->steps_executed.load ();
-        EXPECT_EQ (executed_first, executed_repeat)
-        << "the same seed drew a different sequence of Range waits on repeat " << attempt
-        << " - executed " << executed_first << " then " << executed_repeat;
-    }
+    // el_rate's own 120/minute (500ms per pass) would sit at the same 4-6
+    // ceiling `timer.pacing`'s 500ms case does; the 50-150ms override clears
+    // it the same way.
+    EXPECT_GE (executed, 8u) << "elements.timers: {minMs: 50, maxMs: 150} did "
+                                "not replace timer.throughput's "
+                                "own 120/minute rate under load - got "
+                             << executed << " requests over 1.5s";
+    EXPECT_LE (executed, 30u);
 }
 
 } // namespace

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1043,4 +1043,114 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
     << executed << " requests over 4s, still in the paced range";
 }
 
+// Issue #1620: `"off"` reached `scheduled_ready_delay_ms` (the reopen fix
+// above), but `"fixedMs"` / `{"minMs", "maxMs"}` did not - the hook checked
+// only `TimersOverride::Mode::Off` and fell through to the element's own
+// `every_ms_` for every other mode, so a run overriding the interval instead
+// of silencing it still deferred `timer.pacing` by its own configured 500ms.
+// `timer.pacing` defaults `perUser: true`, so this exercises the per-user
+// branch (`detail::advance_per_user_pacing`). Mutation check: reverting
+// `scheduled_ready_delay_ms` to read `every_ms_` directly instead of the
+// `apply_timers_override`-derived interval reds this on the ceiling -
+// `APacedRunDoesNotBusySpinTheProducer` above pins the element's own 500ms
+// cadence to 4-6 over the same 2s window, which is what this test's floor
+// must clear.
+TEST_F (ElementsTimersLoadTest, ElementsTimersFixedMsOverridesPacingUnderLoad) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "constant_concurrency" }, { "concurrency", 1 }, { "duration", "2s" },
+        { "elements", { { "timers", { { "fixedMs", 100 } } } } } };
+
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
+
+    // 100ms apart over 2s against a loopback mock is comfortably above the
+    // element's own 500ms ceiling of 6, and well short of a fully unpaced
+    // run's count (the "off" test above clears 30) - the bounds separate
+    // "still paced, but at the override's interval" from either extreme.
+    EXPECT_GE (executed, 10u)
+    << "elements.timers: {fixedMs: 100} did not replace timer.pacing's own "
+       "500ms cadence under load - got "
+    << executed << " requests over 2s, still in the un-overridden paced range";
+    EXPECT_LE (executed, 30u)
+    << "got " << executed << " requests over 2s - the override's own 100ms interval was not honoured either";
+}
+
+// @copydoc ElementsTimersFixedMsOverridesPacingUnderLoad, `timer.throughput`'s
+// shared branch (`SharedThroughputBudgets::claim`, which takes a rate rather
+// than an interval - the conversion this issue adds). `el_rate`'s own
+// 120/minute config measures 18 over 4s (`ElementsTimersOffSilencesThroughputUnderLoad`'s
+// comment); overriding to a 4s interval (15/minute, an order of magnitude
+// slower) should leave each of the ten virtual users its one unpaced first
+// pass and almost nothing else in the remaining window. Mutation check: same
+// as above - reverting the hook to ignore `Fixed`/`Range` reds this on the
+// ceiling, since the run would instead measure the un-overridden 18.
+TEST_F (ElementsTimersLoadTest, ElementsTimersFixedMsOverridesThroughputUnderLoad) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 120.0) });
+
+    auto config        = load_config ("4s");
+    config["elements"] = json{ { "timers", { { "fixedMs", 4000 } } } };
+
+    auto state = run (config, execution);
+    ASSERT_NE (state, nullptr);
+    const size_t executed = state->steps_executed.load ();
+
+    // Ten virtual users' unpaced first pass each is 10; the 4000ms interval
+    // (15/minute shared) allows at most one or two more claims in the
+    // remaining ~3.5s. 14 sits well below the element's own un-overridden 18
+    // and far below an unpaced run's 30+.
+    EXPECT_GE (executed, 10u)
+    << "expected at least the ten virtual users' own unpaced first pass, got " << executed;
+    EXPECT_LE (executed, 14u)
+    << "elements.timers: {fixedMs: 4000} did not replace timer.throughput's "
+       "own 120/minute rate under load - got "
+    << executed << " requests over 4s, close to the un-overridden 18";
+}
+
+// Issue #1620's `{"minMs", "maxMs"}` case, and its reproducibility
+// requirement: `SharedScheduleState::rng` threads the VU's own seeded
+// generator into `apply_timers_override`'s `Range` draw, the same
+// `std::mt19937_64` every other seeded wait in this suite reads from. Two
+// runs of the same single-VU plan with the same `seed` must draw the same
+// sequence of intervals and so complete the same number of passes; a
+// non-reproducible draw (an unseeded fallback generator, or no `rng` at all)
+// would make the two runs' counts disagree in general, though not on every
+// single run - the mutation check below is the reliable half of this test.
+// Mutation check: dropping `.rng = &vu->rng` at the `SharedScheduleState`
+// construction site falls back to `apply_timers_override`'s unseeded
+// thread-local generator, which reds this test's equality assertion across
+// repeated runs (not deterministically on the first try, since two unseeded
+// draws can coincide, but reliably under a repeat loop).
+TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSeed) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "constant_concurrency" }, { "concurrency", 1 }, { "duration", "1500ms" },
+        { "elements",
+        { { "timers", { { "minMs", 50 }, { "maxMs", 150 } } }, { "seed", 42 } } } };
+
+    auto state_a = run (config, execution);
+    ASSERT_NE (state_a, nullptr);
+    const size_t executed_a = state_a->steps_executed.load ();
+
+    auto state_b = run (config, execution);
+    ASSERT_NE (state_b, nullptr);
+    const size_t executed_b = state_b->steps_executed.load ();
+
+    EXPECT_EQ (executed_a, executed_b)
+    << "the same seed drew a different sequence of Range waits across two "
+       "runs - executed "
+    << executed_a << " then " << executed_b;
+
+    // Sanity bound: within the 50-150ms range, 1.5s cannot produce fewer
+    // than the un-paced-first-pass-plus-one, nor more than an unpaced run.
+    EXPECT_GE (executed_a, 2u);
+    EXPECT_LE (executed_a, 30u);
+}
+
 } // namespace

--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1114,17 +1114,17 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersFixedMsOverridesThroughputUnderLoa
 // Issue #1620's `{"minMs", "maxMs"}` case, and its reproducibility
 // requirement: `SharedScheduleState::rng` threads the VU's own seeded
 // generator into `apply_timers_override`'s `Range` draw, the same
-// `std::mt19937_64` every other seeded wait in this suite reads from. Two
-// runs of the same single-VU plan with the same `seed` must draw the same
-// sequence of intervals and so complete the same number of passes; a
-// non-reproducible draw (an unseeded fallback generator, or no `rng` at all)
-// would make the two runs' counts disagree in general, though not on every
-// single run - the mutation check below is the reliable half of this test.
-// Mutation check: dropping `.rng = &vu->rng` at the `SharedScheduleState`
-// construction site falls back to `apply_timers_override`'s unseeded
-// thread-local generator, which reds this test's equality assertion across
-// repeated runs (not deterministically on the first try, since two unseeded
-// draws can coincide, but reliably under a repeat loop).
+// `std::mt19937_64` every other seeded wait in this suite reads from. Five
+// runs of the same single-VU plan with the same `seed` must all draw the
+// same sequence of intervals and so complete the same number of passes -
+// looped rather than compared as a single pair, so a non-reproducible draw
+// (an unseeded fallback generator, or no `rng` at all) cannot pass by two
+// unseeded draws coinciding once, which a single-pair comparison could not
+// rule out. Mutation check: dropping `.rng = &vu->rng` at the
+// `SharedScheduleState` construction site falls back to
+// `apply_timers_override`'s unseeded thread-local generator, which reds this
+// loop's equality assertion within a handful of iterations even though any
+// one pair of unseeded draws can occasionally coincide.
 TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSeed) {
     auto execution =
     plan_with ({ vayu::tests::timer_pacing_element_json ("el_pacing", 500) });
@@ -1134,23 +1134,65 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSee
         { "elements",
         { { "timers", { { "minMs", 50 }, { "maxMs", 150 } } }, { "seed", 42 } } } };
 
-    auto state_a = run (config, execution);
-    ASSERT_NE (state_a, nullptr);
-    const size_t executed_a = state_a->steps_executed.load ();
-
-    auto state_b = run (config, execution);
-    ASSERT_NE (state_b, nullptr);
-    const size_t executed_b = state_b->steps_executed.load ();
-
-    EXPECT_EQ (executed_a, executed_b)
-    << "the same seed drew a different sequence of Range waits across two "
-       "runs - executed "
-    << executed_a << " then " << executed_b;
+    auto first = run (config, execution);
+    ASSERT_NE (first, nullptr);
+    const size_t executed_first = first->steps_executed.load ();
 
     // Sanity bound: within the 50-150ms range, 1.5s cannot produce fewer
     // than the un-paced-first-pass-plus-one, nor more than an unpaced run.
-    EXPECT_GE (executed_a, 2u);
-    EXPECT_LE (executed_a, 30u);
+    EXPECT_GE (executed_first, 2u);
+    EXPECT_LE (executed_first, 30u);
+
+    for (int attempt = 0; attempt < 4; ++attempt) {
+        auto repeat = run (config, execution);
+        ASSERT_NE (repeat, nullptr);
+        const size_t executed_repeat = repeat->steps_executed.load ();
+        EXPECT_EQ (executed_first, executed_repeat)
+        << "the same seed drew a different sequence of Range waits on repeat " << attempt
+        << " - executed " << executed_first << " then " << executed_repeat;
+    }
+}
+
+// @copydoc ElementsTimersRangeOverrideIsReproducibleWithSeed, `timer.throughput`'s
+// shared branch (`perUser: false`, the default): the acceptance criteria ask
+// for Range reproducibility "for both kinds under load", and both call the
+// same `apply_timers_override` with `shared.rng`, but only `timer.pacing`'s
+// per-user branch had a dedicated case above. Pinned to a single virtual
+// user rather than the ten-VU shape the other throughput tests use: with
+// several VUs racing to claim the one shared budget, which VU's draw lands
+// first depends on real thread-scheduling order, not only the seed, so the
+// aggregate count is not reproducible even with a correctly-seeded `rng` -
+// concurrency itself is the confound, not this fix. One VU removes that
+// confound and still exercises the shared branch's rate conversion
+// (`shared.throughput != nullptr` -> `claim`), which is the code this test
+// exists to cover. Same mutation check as above.
+TEST_F (ElementsTimersLoadTest, ElementsTimersRangeOverrideIsReproducibleWithSeedForThroughput) {
+    auto execution =
+    plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 120.0,
+    /*scope_entry=*/true, /*per_user=*/false) });
+
+    const json config{ { "scenario", { { "collectionId", "col_test" } } },
+        { "mode", "constant_concurrency" }, { "concurrency", 1 }, { "duration", "1500ms" },
+        { "elements",
+        { { "timers", { { "minMs", 50 }, { "maxMs", 150 } } }, { "seed", 7 } } } };
+
+    auto first = run (config, execution);
+    ASSERT_NE (first, nullptr);
+    const size_t executed_first = first->steps_executed.load ();
+
+    // Sanity bound: within the 50-150ms range, 1.5s cannot produce fewer
+    // than the un-paced-first-pass-plus-one, nor more than an unpaced run.
+    EXPECT_GE (executed_first, 2u);
+    EXPECT_LE (executed_first, 30u);
+
+    for (int attempt = 0; attempt < 4; ++attempt) {
+        auto repeat = run (config, execution);
+        ASSERT_NE (repeat, nullptr);
+        const size_t executed_repeat = repeat->steps_executed.load ();
+        EXPECT_EQ (executed_first, executed_repeat)
+        << "the same seed drew a different sequence of Range waits on repeat " << attempt
+        << " - executed " << executed_first << " then " << executed_repeat;
+    }
 }
 
 } // namespace


### PR DESCRIPTION
## Description

`timer.pacing` and `timer.throughput`'s load-path scheduling hook (`Element::scheduled_ready_delay_ms`) runs before any step's `ElementContext` exists, so it cannot read the run's `elements.timers` override the way every other `timer.*` kind's `apply()` does. Issue #1498's reopen fix (PR #1621, merged) threaded a copy of the override into `SharedScheduleState` for this hook, but only checked `Mode::Off` there and fell through to the element's own configured interval for `Fixed` (`{"fixedMs": N}`) and `Range` (`{"minMs", "maxMs"}`) - the two modes every other kind's `apply()` already handles through `apply_timers_override`.

Both kinds now call that same `apply_timers_override` from the hook, so all three override modes reach the load-path scheduling seam consistently. `timer.throughput`'s shared branch takes a rate (tokens/second) rather than an interval, so an overridden interval is converted (`1000.0 / interval_ms`, floored at 1ms the way `every_ms_for` already floors the other direction); left un-overridden, the branch keeps using the exact configured `targetPerMinute_ / 60.0` rather than deriving it from the rounded `every_ms_`, so an un-overridden run's accuracy is unchanged - the alternative (always deriving the rate from `interval_ms`) was rejected because it would introduce rounding into the default path this PR isn't meant to touch.

`SharedScheduleState` gains an `rng` field (the VU's own seeded `std::mt19937_64`, the same generator `ElementContext::rng` binds elsewhere) so a `Range` draw at this hook is reproducible with the run's `seed`, matching #1498's own contract.

## Type of Change
- [x] Bug fix

## Testing

- `python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure` - full suite, 3303/3303 passing (verified locally with the fix applied).
- `ElementsTimersLoadTest`: `ElementsTimersFixedMsOverridesPacingUnderLoad` / `...ThroughputUnderLoad` (Fixed mode, per-user and shared branches) and `ElementsTimersRangeOverrideReachesPacingUnderLoad` / `...ThroughputUnderLoad` (Range mode, both branches, bounds-only). Range mode's *reproducibility* with `elements.seed` is proven at the layer that actually determines it - the existing `ApplyTimersOverrideTest.RangeModeIsReproducibleWithTheSameSeedAndStaysInBounds` (two identically-seeded generators draw identically) and `DeriveVuRngTest.SameSeedAndIndexProduceIdenticalSequences` (a VU's generator is a pure function of the run seed and its index) - rather than by comparing step counts across two independent load runs, which an earlier version of this PR did and which CI's macOS runner correctly caught as flaky (comparing how many steps land inside a fixed wall-clock window is timing-dependent, not RNG-dependent).
- Hand-verified mutation check: reverted `elements.hpp`/`timer_pacing.cpp`/`timer_throughput.cpp`/`scenario_load.cpp` to their pre-fix state (keeping the new tests), rebuilt, and confirmed the `FixedMs` cases fail - measuring exactly the un-overridden value each element's own config would produce (5 instead of ≥10 for pacing; 18, the un-overridden rate, instead of ≤14 for throughput). Restored the fix, rebuilt, confirmed green again.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## No user-visible change

Engine-only scheduling fix; no app or MCP surface touches `scheduled_ready_delay_ms`.

## Related Issues
Closes #1620
