### PR TITLE
fix(app): close #1516's reopen gaps - stale ScriptTab docs and the missing load-run element tallies

### DIFF
--- a/app/src/modules/history/main/components/ScenarioStepsTab.test.tsx
+++ b/app/src/modules/history/main/components/ScenarioStepsTab.test.tsx
@@ -159,3 +159,59 @@ describe("the per-step test tallies", () => {
 		).toBeNull();
 	});
 });
+
+/**
+ * Non-script elements - extractors, assertions, timers - tallied per step
+ * across every virtual user and iteration (`scenario.steps[i].elements`,
+ * issue #1495). Written by the engine since #1495 but never rendered until
+ * this reopen of #1516: the sequential run's per-step outcomes show up in
+ * `ScenarioStepCard`, and a load run's counterpart had no reader at all.
+ */
+describe("the per-step element tallies", () => {
+	const WITH_ELEMENTS: RunScenarioStepStat[] = [
+		{
+			...STEPS[0],
+			elements: [{ id: "el_1", kind: "extract.json", passed: 40, failed: 0, skipped: 0 }],
+		},
+		{
+			...STEPS[1],
+			elements: [{ id: "el_2", kind: "assert.status", passed: 30, failed: 4, skipped: 2 }],
+		},
+	];
+
+	it("shows a row per element under its step, with kind and every non-zero count", () => {
+		render(<ScenarioStepsTab steps={WITH_ELEMENTS} virtualUsers={8} />);
+
+		const rows = screen.getAllByRole("row").slice(1); // drop the header row
+		// Each step row is followed by one row per element it compiled.
+		expect(rows).toHaveLength(4);
+
+		expect(within(rows[1]).getByText("extract.json")).toBeTruthy();
+		expect(within(rows[1]).getByText("40 passed")).toBeTruthy();
+
+		expect(within(rows[3]).getByText("assert.status")).toBeTruthy();
+		expect(within(rows[3]).getByText("30 passed")).toBeTruthy();
+		expect(
+			within(rows[3]).getByText("4 failed", { selector: "span.text-status-error-text" })
+		).toBeTruthy();
+		expect(within(rows[3]).getByText("2 skipped")).toBeTruthy();
+	});
+
+	it("omits the failed and skipped counts when they are zero", () => {
+		// An element that never failed or was never skipped states neither -
+		// the same "absent when nothing happened" reading the Tests column
+		// already gives a step that asserted nothing.
+		render(<ScenarioStepsTab steps={WITH_ELEMENTS} virtualUsers={8} />);
+		const rows = screen.getAllByRole("row").slice(1);
+		expect(within(rows[1]).queryByText(/failed/)).toBeNull();
+		expect(within(rows[1]).queryByText(/skipped/)).toBeNull();
+	});
+
+	it("renders no element rows for a step with none", () => {
+		// Mutation check: reverting to `STEPS` (no `elements` field on either
+		// step) must drop back to exactly one row per step.
+		render(<ScenarioStepsTab steps={STEPS} virtualUsers={8} />);
+		const rows = screen.getAllByRole("row").slice(1);
+		expect(rows).toHaveLength(2);
+	});
+});

--- a/app/src/modules/history/main/components/ScenarioStepsTab.tsx
+++ b/app/src/modules/history/main/components/ScenarioStepsTab.tsx
@@ -26,6 +26,7 @@
  * engine keeps them apart by omitting the object.
  */
 
+import { Fragment } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Badge } from "@/components/ui";
 import { TruncatedText } from "@/components/shared";
@@ -125,91 +126,125 @@ export default function ScenarioStepsTab({
 					</thead>
 					<tbody>
 						{steps.map((step) => (
-							<tr key={step.index} className="border-b last:border-b-0">
-								<th scope="row" className="px-3 py-2 font-normal text-left">
-									<div className="flex items-center gap-2 min-w-0">
-										<span className="text-xs text-muted-foreground font-mono shrink-0">
-											{step.index + 1}
-										</span>
-										<Badge
-											variant="outline"
-											className="font-mono text-[10px] shrink-0"
-										>
-											{step.method}
-										</Badge>
-										<TruncatedText className="text-foreground min-w-0">
-											{step.name || step.requestId}
-										</TruncatedText>
-									</div>
-								</th>
-								<td className="px-3 py-2 text-right font-mono">
-									{formatNumber(step.executed)}
-									{/* A step the sequence reached fewer times than the
-									    first one did is the visible shape of an earlier
-									    step erroring out. */}
-									{step.executed < expectedPerStep && (
-										<span
-											className="ml-1 text-xs text-muted-foreground"
-											title={`${formatNumber(
-												expectedPerStep - step.executed
-											)} iterations ended before reaching this step`}
-										>
-											({formatNumber(expectedPerStep - step.executed)} short)
-										</span>
-									)}
-								</td>
-								<td
-									className={
-										step.errors > 0
-											? "px-3 py-2 text-right font-mono text-status-error-text"
-											: "px-3 py-2 text-right font-mono text-muted-foreground"
-									}
-								>
-									{formatNumber(step.errors)}
-								</td>
-								<td className="px-3 py-2 text-right font-mono">
-									{step.tests ? (
-										<span
-											title={`${formatNumber(
-												step.tests.passed
-											)} passed, ${formatNumber(
-												step.tests.failed
-											)} failed across ${formatNumber(
-												step.tests.sampled
-											)} sampled response${step.tests.sampled === 1 ? "" : "s"}`}
-										>
-											{formatNumber(step.tests.passed)}
-											{step.tests.failed > 0 && (
-												<span className="text-status-error-text">
-													{" / "}
-													{formatNumber(step.tests.failed)}
+							<Fragment key={step.index}>
+								<tr className="border-b last:border-b-0">
+									<th scope="row" className="px-3 py-2 font-normal text-left">
+										<div className="flex items-center gap-2 min-w-0">
+											<span className="text-xs text-muted-foreground font-mono shrink-0">
+												{step.index + 1}
+											</span>
+											<Badge
+												variant="outline"
+												className="font-mono text-[10px] shrink-0"
+											>
+												{step.method}
+											</Badge>
+											<TruncatedText className="text-foreground min-w-0">
+												{step.name || step.requestId}
+											</TruncatedText>
+										</div>
+									</th>
+									<td className="px-3 py-2 text-right font-mono">
+										{formatNumber(step.executed)}
+										{/* A step the sequence reached fewer times than the
+										    first one did is the visible shape of an earlier
+										    step erroring out. */}
+										{step.executed < expectedPerStep && (
+											<span
+												className="ml-1 text-xs text-muted-foreground"
+												title={`${formatNumber(
+													expectedPerStep - step.executed
+												)} iterations ended before reaching this step`}
+											>
+												({formatNumber(expectedPerStep - step.executed)}{" "}
+												short)
+											</span>
+										)}
+									</td>
+									<td
+										className={
+											step.errors > 0
+												? "px-3 py-2 text-right font-mono text-status-error-text"
+												: "px-3 py-2 text-right font-mono text-muted-foreground"
+										}
+									>
+										{formatNumber(step.errors)}
+									</td>
+									<td className="px-3 py-2 text-right font-mono">
+										{step.tests ? (
+											<span
+												title={`${formatNumber(
+													step.tests.passed
+												)} passed, ${formatNumber(
+													step.tests.failed
+												)} failed across ${formatNumber(
+													step.tests.sampled
+												)} sampled response${step.tests.sampled === 1 ? "" : "s"}`}
+											>
+												{formatNumber(step.tests.passed)}
+												{step.tests.failed > 0 && (
+													<span className="text-status-error-text">
+														{" / "}
+														{formatNumber(step.tests.failed)}
+													</span>
+												)}
+											</span>
+										) : (
+											// A step that asserted nothing. A zero here would read as
+											// "nothing failed", which is a claim the run never made.
+											<span
+												className="text-muted-foreground"
+												title="No assertions"
+											>
+												-
+											</span>
+										)}
+									</td>
+									<td className="px-3 py-2 text-right font-mono">
+										{latency(step.latency.p50)}
+									</td>
+									<td className="px-3 py-2 text-right font-mono">
+										{latency(step.latency.p95)}
+									</td>
+									<td className="px-3 py-2 text-right font-mono">
+										{latency(step.latency.p99)}
+									</td>
+									<td className="px-3 py-2 text-right font-mono">
+										{latency(step.latency.max)}
+									</td>
+								</tr>
+								{/* One row per non-script element this step compiled and
+								    ran - extractors, assertions, timers - tallied across
+								    every virtual user and iteration the way the Tests
+								    column already is for scripts (issue #1516). */}
+								{step.elements?.map((element) => (
+									<tr
+										key={`${step.index}-${element.id}`}
+										className="border-b last:border-b-0 bg-muted/20"
+									>
+										<td colSpan={8} className="px-3 py-1.5 pl-9">
+											<div className="flex items-center gap-2 text-xs">
+												<span className="text-muted-foreground font-mono">
+													{element.kind}
 												</span>
-											)}
-										</span>
-									) : (
-										// A step that asserted nothing. A zero here would read as
-										// "nothing failed", which is a claim the run never made.
-										<span
-											className="text-muted-foreground"
-											title="No assertions"
-										>
-											-
-										</span>
-									)}
-								</td>
-								<td className="px-3 py-2 text-right font-mono">
-									{latency(step.latency.p50)}
-								</td>
-								<td className="px-3 py-2 text-right font-mono">
-									{latency(step.latency.p95)}
-								</td>
-								<td className="px-3 py-2 text-right font-mono">
-									{latency(step.latency.p99)}
-								</td>
-								<td className="px-3 py-2 text-right font-mono">
-									{latency(step.latency.max)}
-								</td>
-							</tr>
+												<span className="font-mono text-status-success-text">
+													{formatNumber(element.passed)} passed
+												</span>
+												{element.failed > 0 && (
+													<span className="font-mono text-status-error-text">
+														{formatNumber(element.failed)} failed
+													</span>
+												)}
+												{element.skipped > 0 && (
+													<span className="font-mono text-muted-foreground">
+														{formatNumber(element.skipped)} skipped
+													</span>
+												)}
+											</div>
+										</td>
+									</tr>
+								))}
+							</Fragment>
 						))}
 					</tbody>
 				</table>

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1993,6 +1993,22 @@ export interface LoadTestMetrics {
 }
 
 /**
+ * One element's pass/fail/skip tally within a load run's step, from
+ * `scenario.steps[i].elements` (`StepElementTallies::build`,
+ * `engine/src/core/scenario_load.cpp`) - the load-path sibling of the
+ * sequential run's per-execution {@link ElementOutcome}. Aggregated across
+ * every virtual user and iteration rather than one outcome per execution,
+ * which is why the shape is a set of counts instead of a single `outcome`.
+ */
+export interface RunScenarioStepElementTally {
+	id: string;
+	kind: string;
+	passed: number;
+	failed: number;
+	skipped: number;
+}
+
+/**
  * One plan step's numbers in a scenario load run's report, from the summary's
  * `scenario.steps` array (`build_step_breakdown`,
  * `engine/src/core/scenario_load.cpp`).
@@ -2050,6 +2066,15 @@ export interface RunScenarioStepStat {
 		passed: number;
 		failed: number;
 	};
+	/**
+	 * This step's non-script elements - extractors, assertions, timers -
+	 * tallied across every virtual user and iteration (issue #1495). Absent
+	 * for a step with no compiled elements or none that ever ran; an element
+	 * that never ran is omitted rather than listed at zero, the same
+	 * "absent when nothing happened" convention {@link unresolvedTokens} and
+	 * {@link tests} follow.
+	 */
+	elements?: RunScenarioStepElementTally[];
 }
 
 export interface RunReport {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -582,7 +582,7 @@ The picker is told **which run it is for** (`loadTest`), because a row means som
 | `LatencyMetric.tsx`, `HistoricalChartsSection.tsx` | Metric cards + historical charts |
 | `MonitorSummary.tsx` | Per-series min/avg/max for the run's server-vitals scrape, under the Performance tab's chart. Present whenever `report.monitor` is - including the run whose every scrape failed, which has a failure count and no line to draw, and read as an unexplained empty chart before it |
 
-A **scenario load run** lands in `LoadTestDetail`, not `ScenarioRunView`: it is `type: "load"`, publishes ticks and reports percentiles like any load run, and its target simply happens to be a sequence. Two things follow, both keyed off `report.scenario.steps` being present rather than off a run-type flag - that array is what this pane actually needs to render. It has no single method and URL, so the header strip says what the sequence was instead of the "GET Unknown URL" fallback, which the reader cannot tell apart from a broken run. And it stores no per-step `results` rows - one row per step per iteration per virtual user is what a load run exists not to keep - so `ScenarioStepsTab.tsx` renders the engine's per-step histogram breakdown, the only per-step record such a run has. Its `(n short)` marker is the visible shape of an errored step ending its iterations early, which otherwise reads as a run that simply lost requests. The **Tests** column is the deferred per-step validation - each step's own post-request script replayed after the run against that step's sampled responses - and shows a dash, never a `0`, for a step that asserted nothing: the engine omits the object rather than writing zeros, because "no assertions" and "no failures" are different answers.
+A **scenario load run** lands in `LoadTestDetail`, not `ScenarioRunView`: it is `type: "load"`, publishes ticks and reports percentiles like any load run, and its target simply happens to be a sequence. Two things follow, both keyed off `report.scenario.steps` being present rather than off a run-type flag - that array is what this pane actually needs to render. It has no single method and URL, so the header strip says what the sequence was instead of the "GET Unknown URL" fallback, which the reader cannot tell apart from a broken run. And it stores no per-step `results` rows - one row per step per iteration per virtual user is what a load run exists not to keep - so `ScenarioStepsTab.tsx` renders the engine's per-step histogram breakdown, the only per-step record such a run has. Its `(n short)` marker is the visible shape of an errored step ending its iterations early, which otherwise reads as a run that simply lost requests. The **Tests** column is the deferred per-step validation - each step's own post-request script replayed after the run against that step's sampled responses - and shows a dash, never a `0`, for a step that asserted nothing: the engine omits the object rather than writing zeros, because "no assertions" and "no failures" are different answers. A step's non-script elements - extractors, assertions, timers - each get their own row beneath the step's, tallied across every virtual user and iteration (`step.elements`, issue #1495); an element that never ran is omitted rather than listed at zero, the same convention `unresolvedTokens` and `tests` follow. This is the load run's counterpart to the sequential run's per-step outcomes (`ScenarioStepCard.tsx`'s `ElementOutcomes`), aggregated as counts instead of one outcome per execution because a load run has many.
 
 > History detail reuses the live dashboard's `hero/`, `charts/`, and `stats/` components by feeding them a `DashboardDerived` built from the stored report (`reportToDerived`), so live and historical views stay visually consistent.
 
@@ -1606,14 +1606,15 @@ rather than a label list - `extract.json`'s path field is deliberately
 generic-form only, proving the point rather than special-casing it.
 
 **A bespoke override is the exception, in one map** (`elementForms.ts`), never
-inline in `ElementList`. Phase 0 ships exactly one: `script.pre` /
-`script.post` render `ScriptElementForm`'s Monaco editor and insertable
-snippets instead of the generic form's plain text field, because "the same
-editor" is what the Elements tab has to keep for a script. It deliberately
-carries none of the old `ScriptPanel`'s variable-reference chips or inherited/
-legacy notices - those read `useRequestBuilderContext`, which this primitive
-cannot depend on - so inheritance is shown once for the whole list by
-`InheritedElementsNotice` instead of once per script row.
+inline in `ElementList`. Phase 0 ships a bespoke form for every `script.*`
+kind - `script.pre` / `script.post` and, since issue #1499, `script.setup` /
+`script.teardown` - which render `ScriptElementForm`'s Monaco editor and
+insertable snippets instead of the generic form's plain text field, because
+"the same editor" is what the Elements tab has to keep for a script. It
+deliberately carries none of the old `ScriptPanel`'s variable-reference chips
+or inherited/legacy notices - those read `useRequestBuilderContext`, which
+this primitive cannot depend on - so inheritance is shown once for the whole
+list by `InheritedElementsNotice` instead of once per script row.
 
 **The editor box has a definite pixel height, resizable by a handle below it**
 (issue #1605). `ElementRow` is an auto-height card, not a bounded ancestor a

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -2365,9 +2365,9 @@ const {
 
 **Behaviour:**
 - **Seeds and resyncs while clean:** a clean draft follows `value` when it changes - a save landing, a background refetch. In `InfoTab` this is what clears the post-trim divergence, since the tab persists `name.trim()`. The request builder needs the same property for the same reason and gets it a different way, since its state is not a draft: see [the draft adopts an external write per field](#the-request-builders-draft-adopts-an-external-write-per-field).
-- **A dirty draft is never silently overwritten (#1437).** While the draft disagrees with `baseline`, an incoming change to `value` is held in `externalValue` instead of reseeding `draft` - an MCP `update_collection` landing mid-edit used to replace the user's unsaved text with whatever the agent wrote. `ScriptTab` and `AuthTab` treat `externalValue` as one value and show a "Changed elsewhere" `Callout` (`CollectionDetail/shared.tsx`'s `ExternalChangeCallout`) whose action calls `reset()` to take it. `InfoTab`'s draft has two independent fields, so it diffs `draft` and `externalValue` against `baseline` per key instead: a key the user has not touched adopts the external value immediately, the same as a clean tab; a key both sides touched surfaces its own conflict, named, and is left at the user's edit until they choose.
+- **A dirty draft is never silently overwritten (#1437).** While the draft disagrees with `baseline`, an incoming change to `value` is held in `externalValue` instead of reseeding `draft` - an MCP `update_collection` landing mid-edit used to replace the user's unsaved text with whatever the agent wrote. `ElementsTab` and `AuthTab` treat `externalValue` as one value and show a "Changed elsewhere" `Callout` (`CollectionDetail/shared.tsx`'s `ExternalChangeCallout`) whose action calls `reset()` to take it. `InfoTab`'s draft has two independent fields, so it diffs `draft` and `externalValue` against `baseline` per key instead: a key the user has not touched adopts the external value immediately, the same as a clean tab; a key both sides touched surfaces its own conflict, named, and is left at the user's edit until they choose.
 - **Tracks by JSON value, not identity:** `value` may be a fresh object literal every render (`InfoTab` builds `{ name, description }` inline); callers do not have to memoize it.
-- **`entityKey` is a switch, not an edit:** a change reseeds the draft *and* calls `mutation.reset()`, discarding any pending `externalValue` too. These editors render without a React `key`, so a different entity arrives via props on the same instance, and a TanStack mutation holds `isError` until the next `mutate` - without the reset, a failed save is reported against an entity the user never tried to save. `ScriptTab` passes `${collection.id}:${fieldKey}`, since pre- and post-request scripts are two different things to edit under one collection id.
+- **`entityKey` is a switch, not an edit:** a change reseeds the draft *and* calls `mutation.reset()`, discarding any pending `externalValue` too. These editors render without a React `key`, so a different entity arrives via props on the same instance, and a TanStack mutation holds `isError` until the next `mutate` - without the reset, a failed save is reported against an entity the user never tried to save. `ElementsTab` passes `${collection.id}:elements`, one entity key for the whole element list under one collection id (the retired `ScriptTab` passed `${collection.id}:${fieldKey}`, since pre- and post-request scripts were two separate things to edit).
 - **Requiring the mutation is the point:** the three hand-rolled copies this replaced had drifted, and the one that omitted the reset had exactly that bug.
 
 **Usage:**
@@ -2396,7 +2396,7 @@ hook's documented behaviour above, and pinned by `useEntityDraft.test.ts`.
 
 The counterpart to `useSaveManager`'s registration half, for editors using the
 `useEntityDraft` model. Located in `app/src/hooks/useDraftSaveContext.ts`. Used
-by `InfoTab`, `AuthTab` and `ScriptTab`.
+by `InfoTab`, `AuthTab` and `ElementsTab`.
 
 ```typescript
 useDraftSaveContext({
@@ -2410,11 +2410,11 @@ useDraftSaveContext({
 
 **Behaviour:**
 - **Registration only.** It schedules nothing; each editor decides when to call
-  its own `save` - `AuthTab` on its Save button, `InfoTab` and `ScriptTab` when
-  focus leaves the field. The defect it fixes is orthogonal to that choice: the
-  *other* ways to save - Ctrl/Cmd+S, the quit flush, tab eviction - could not
-  reach these editors at all, because none of the three tabs ever called
-  `registerContext`.
+  its own `save` - `AuthTab` and `ElementsTab` on their Save button, `InfoTab`
+  when focus leaves the field. The defect it fixes is orthogonal to that
+  choice: the *other* ways to save - Ctrl/Cmd+S, the quit flush, tab eviction -
+  could not reach these editors at all, because none of the three tabs ever
+  called `registerContext`.
 - **`isActive` decides who owns Ctrl/Cmd+S.** `triggerSave` prefers the active
   context, and these editors stay mounted while hidden, so without it the last
   sibling to mount would answer for the panel on screen.


### PR DESCRIPTION
## Description

Issue #1516 (the `ElementList` primitive, an Elements tab replacing the two script tabs) shipped in PR #1554, but its closure verification (comment [5585070273](https://github.com/athrvk/vayu/issues/1516#issuecomment-5585070273)) and a follow-up comment ([5585479401](https://github.com/athrvk/vayu/issues/1516#issuecomment-5585479401)) found three gaps left open, reopening the issue:

1. `docs/app/state-management.md` still described the retired `ScriptTab` as live in three places (its `entityKey` shape, `useDraftSaveContext`'s consumer list, and which tabs commit on blur vs. a Save button) - `ElementsTab` replaced it in code but not in these sentences.
2. `docs/app/COMPONENTS.md:1609` said the bespoke-form map "ships exactly one" kind (`script.pre`/`script.post`); `elementForms.ts` has carried four since #1499 (`script.setup`/`script.teardown` too).
3. **Written but never read**: a scenario load run's report has carried per-step element tallies (extractors, assertions, timers) since #1495 (`scenario.steps[i].elements`, `StepElementTallies::build` in `engine/src/core/scenario_load.cpp`), and nothing in the app displayed them. The sequential run's per-step outcomes render in `ScenarioStepCard`'s `ElementOutcomes`; the load run's counterpart had no reader at all - `RunScenarioStepStat` had no `elements` field.

Fix for gap 3: added `RunScenarioStepElementTally` (`{id, kind, passed, failed, skipped}`, matching the engine's tally shape exactly) and an `elements?` field on `RunScenarioStepStat`, then rendered one row per element beneath its step in `ScenarioStepsTab` - kind plus every non-zero count, omitted entirely when a step compiled no elements or none ran, the same "absent when nothing happened" convention `unresolvedTokens` and `tests` already follow on this type.

**Alternative considered and rejected**: reusing the sequential run's `ElementOutcome`/`ElementOutcomes` card for this too. Rejected because the shapes differ - a load run aggregates counts across every virtual user and iteration, not one outcome per execution - and the existing `ElementOutcomes` card layout doesn't fit a dense per-step table row.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test ScenarioStepsTab state-management-doc row-persistence-claims command.chrome routed-inputs LoadTestDetail conformance` - all pass (targeted + everything that reads either touched doc or the touched type).
- `cd app && pnpm test` - full suite, **730 files / 8300 passed, 2 skipped**.
- `cd app && pnpm type-check && pnpm lint && pnpm format:check` - all clean.
- Mutation check: stashed only the `ScenarioStepsTab.tsx` render fix (kept the new tests), reran `pnpm test ScenarioStepsTab` - the new "shows a row per element under its step" case reds (`expected length 4 but got 2`). Restored the fix, reran, green again.
- No engine changes in this PR - the engine has written this field since #1495 (`scenario.steps[i].elements` in `build_step_breakdown`); this PR only adds the app-side type and reader, so no engine build was needed and none was run.

## Visual changes

This does add a new, visible row per element under the load-run step breakdown (`ScenarioStepsTab.tsx`, in History). I did not capture a live screenshot: the container's vcpkg install currently fails on `cpp-httplib`'s GitHub source archive with the documented `curl operation failed with response code 403` egress issue (`CLAUDE.md`'s `vcpkg-fix-port` workaround), so building the engine to drive a real load run through the app wasn't a quick path here; a lighter renderer-only preview would have needed installing `playwright-core`, which isn't a project dependency. Given the change is a small, additive table row (new `<tr>`s only, nothing existing repositioned), I relied instead on the fixture-driven, mutation-checked component tests above, which assert the exact rendered text (kind, `"N passed"`, conditional `"N failed"`/`"N skipped"`) and row count per step - happy to add a screenshot in a follow-up round if useful.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues
Closes #1516