### PR TITLE
fix(app): hold a save back when an element is missing a required field

### DIFF
--- a/app/src/components/shared/ElementList/ElementList.test.tsx
+++ b/app/src/components/shared/ElementList/ElementList.test.tsx
@@ -343,6 +343,75 @@ describe("ElementList - reordering", () => {
 	});
 });
 
+describe("ElementList - a required field the config is missing (issue #1635)", () => {
+	const REQUIRED_KIND = kindSchema({
+		kind: "extract.required",
+		label: "Extract Required",
+		category: "extract",
+		configSchema: {
+			type: "object",
+			required: ["variable"],
+			properties: {
+				variable: { type: "string", title: "Variable name" },
+			},
+		},
+	});
+	const kinds: ElementKindSchema[] = [REQUIRED_KIND];
+
+	it("names the missing field by the schema's own title, not the raw key", () => {
+		render(
+			<ElementList
+				elements={[{ id: "r1", kind: "extract.required", enabled: true, config: {} }]}
+				onChange={vi.fn()}
+				kinds={kinds}
+			/>
+		);
+
+		expect(screen.getByText("Needs Variable name")).toBeInTheDocument();
+	});
+
+	it("falls back to the raw key when the schema gives it no title", () => {
+		const untitled: ElementKindSchema = {
+			...REQUIRED_KIND,
+			configSchema: { type: "object", required: ["variable"] },
+		};
+		render(
+			<ElementList
+				elements={[{ id: "r1", kind: "extract.required", enabled: true, config: {} }]}
+				onChange={vi.fn()}
+				kinds={[untitled]}
+			/>
+		);
+
+		expect(screen.getByText("Needs variable")).toBeInTheDocument();
+	});
+
+	it("clears once the required field holds a value", () => {
+		render(
+			<ElementList
+				elements={[
+					{
+						id: "r1",
+						kind: "extract.required",
+						enabled: true,
+						config: { variable: "x" },
+					},
+				]}
+				onChange={vi.fn()}
+				kinds={kinds}
+			/>
+		);
+
+		expect(screen.queryByText(/^Needs /)).not.toBeInTheDocument();
+	});
+
+	it("says nothing for a kind with no required fields at all", () => {
+		renderList([extractElement("e1")]);
+
+		expect(screen.queryByText(/^Needs /)).not.toBeInTheDocument();
+	});
+});
+
 describe("ElementList - empty state", () => {
 	it("shows the caller's empty label only when there are no elements", () => {
 		render(

--- a/app/src/components/shared/ElementList/index.tsx
+++ b/app/src/components/shared/ElementList/index.tsx
@@ -48,6 +48,7 @@ import {
 import { TruncatedText } from "@/components/shared/TruncatedText";
 import { ToggleRow } from "@/modules/settings/main/panels/SettingControls";
 import { generateId } from "@/lib/id";
+import { missingRequiredKeys } from "@/lib/elements";
 import { cn } from "@/lib/utils";
 import { useLayoutStore } from "@/stores";
 import type { ElementDef, ElementKindSchema } from "@/types";
@@ -133,6 +134,14 @@ function ElementRow({
 }) {
 	const schema = kinds.find((k) => k.kind === element.kind);
 	const Bespoke = ELEMENT_FORM_OVERRIDES[element.kind];
+	// Issue #1635: a fresh element's `config` is missing whatever its kind
+	// requires until the user fills the form below, and saving in that state
+	// 400s the whole request - `RequestBuilderProvider`/`ElementsTab` hold the
+	// save back for exactly this, so the row has to say which field is why.
+	const missingKeys = missingRequiredKeys(element, kinds);
+	const missingLabels = missingKeys.map(
+		(key) => schema?.configSchema.properties?.[key]?.title ?? key
+	);
 
 	return (
 		<div
@@ -168,6 +177,15 @@ function ElementRow({
 				<span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium shrink-0">
 					{kindLabel(element.kind, kinds)}
 				</span>
+				{missingLabels.length > 0 && (
+					<span
+						className="flex items-center gap-1.5 shrink-0 text-xs text-muted-foreground"
+						data-element-incomplete
+					>
+						<span className="h-2 w-2 rounded-full bg-warning shrink-0" aria-hidden />
+						Needs {missingLabels.join(", ")}
+					</span>
+				)}
 				<Input
 					value={element.name ?? ""}
 					placeholder="Optional name"

--- a/app/src/hooks/useSaveManager.blocked.test.tsx
+++ b/app/src/hooks/useSaveManager.blocked.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `SaveBlockedError` (issue #1635) is how a caller says "I already know this
+ * payload will 400 - do not send it, and do not retry it". These cases pin
+ * the distinction from a genuine failure: no `"error"` status, no console
+ * noise, and critically no backoff retry, since the payload that failed is
+ * exactly the payload the next attempt would still carry.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import { useClientSettingsStore } from "@/stores";
+import { useSaveStore } from "@/stores/save-store";
+import { SaveBlockedError } from "@/lib/elements";
+import { useSaveManager } from "./useSaveManager";
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function wrapper({ children }: { children: ReactNode }) {
+	return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+interface Props {
+	entityId: string;
+	onSave: () => Promise<void>;
+	hasChanges?: boolean;
+}
+
+function mountManager(initial: Props) {
+	return renderHook(
+		(props: Props) =>
+			useSaveManager({
+				entityId: props.entityId,
+				contextName: "Request",
+				onSave: props.onSave,
+				hasChanges: props.hasChanges ?? true,
+				changeToken: 1,
+			}),
+		{ initialProps: initial, wrapper }
+	);
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	useSaveStore.getState().reset();
+	useClientSettingsStore.setState({ autoSave: { enabled: true, delayMs: 5000 } });
+	queryClient.clear();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("a save an onSave callback blocks", () => {
+	it("reports pending, not error", async () => {
+		const onSave = vi.fn().mockRejectedValue(new SaveBlockedError());
+		mountManager({ entityId: "req_1", onSave });
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(useSaveStore.getState().status).toBe("pending");
+		expect(useSaveStore.getState().lastErrorMessage).toBeNull();
+	});
+
+	it("does not schedule a retry, unlike a genuine failure", async () => {
+		const onSave = vi.fn().mockRejectedValue(new SaveBlockedError());
+		mountManager({ entityId: "req_1", onSave });
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+
+		// A genuine failure would retry at this same delay (attempt 0). Nothing
+		// here should call onSave again without a new edit.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not log a console error for a blocked save", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onSave = vi.fn().mockRejectedValue(new SaveBlockedError());
+		mountManager({ entityId: "req_1", onSave });
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+
+	it("tries again once a new edit bumps the change token, same as any pending save", async () => {
+		const onSave = vi.fn().mockRejectedValueOnce(new SaveBlockedError());
+		onSave.mockResolvedValueOnce(undefined);
+		const { rerender } = renderHook(
+			({ token }: { token: number }) =>
+				useSaveManager({
+					entityId: "req_1",
+					contextName: "Request",
+					onSave,
+					hasChanges: true,
+					changeToken: token,
+				}),
+			{ initialProps: { token: 1 }, wrapper }
+		);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+
+		// The field that was blocking the save just got filled in - a real edit,
+		// which is what re-arms the debounce (not a timer of its own).
+		await act(async () => {
+			rerender({ token: 2 });
+		});
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(2);
+		expect(useSaveStore.getState().status).toBe("saved");
+	});
+});

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -22,6 +22,7 @@ import { useClientSettingsStore } from "@/stores";
 import { queryKeys } from "@/queries/keys";
 import { ApiError } from "@/services/http-client";
 import { TIMING } from "@/config/timing";
+import { SaveBlockedError } from "@/lib/elements";
 
 /**
  * The registry id this hook saves under. Three places in this file need it -
@@ -206,6 +207,15 @@ export function useSaveManager({
 					markPendingSave();
 				}
 			} catch (error) {
+				if (error instanceof SaveBlockedError) {
+					// Not a failure - the caller chose not to send. Report the same
+					// "still dirty, nothing in flight" state a plain unsaved edit
+					// has, so the status bar reads correctly and `attemptAutoSave`
+					// (which checks for `"error"`) does not arm a retry against a
+					// payload that will not have changed by the next tick.
+					markPendingSave();
+					return;
+				}
 				console.error("Save failed:", error);
 				failSave(error instanceof Error ? error.message : "Save failed");
 

--- a/app/src/lib/elements.test.ts
+++ b/app/src/lib/elements.test.ts
@@ -7,7 +7,23 @@
 
 import { describe, it, expect } from "vitest";
 
-import { isBlankScriptElement } from "./elements";
+import { hasIncompleteElement, isBlankScriptElement, missingRequiredKeys } from "./elements";
+import type { ElementKindSchema } from "@/types";
+
+/** A minimal catalogue entry - only what `missingRequiredKeys` reads. */
+function kindFixture(kind: string, required: string[]): ElementKindSchema {
+	return {
+		kind,
+		version: 1,
+		label: kind,
+		description: "",
+		category: "test",
+		hotPathClass: "declarative",
+		collectionOnly: false,
+		configSchema: { type: "object", required },
+		phases: [],
+	};
+}
 
 describe("isBlankScriptElement", () => {
 	it("is true for an empty script.pre", () => {
@@ -32,5 +48,66 @@ describe("isBlankScriptElement", () => {
 
 	it("is false for a non-script kind, regardless of its config", () => {
 		expect(isBlankScriptElement({ kind: "assert.status", config: { script: "" } })).toBe(false);
+	});
+});
+
+describe("missingRequiredKeys", () => {
+	const kinds = [
+		kindFixture("extract.json", ["variable", "path"]),
+		kindFixture("timer.pacing", []),
+	];
+
+	it("lists every required key a fresh config: {} is missing", () => {
+		expect(missingRequiredKeys({ kind: "extract.json", config: {} }, kinds)).toEqual([
+			"variable",
+			"path",
+		]);
+	});
+
+	it("drops a key once it holds any value, including an empty string", () => {
+		expect(
+			missingRequiredKeys({ kind: "extract.json", config: { variable: "" } }, kinds)
+		).toEqual(["path"]);
+	});
+
+	it("is empty once every required key is present", () => {
+		expect(
+			missingRequiredKeys(
+				{ kind: "extract.json", config: { variable: "x", path: "$.y" } },
+				kinds
+			)
+		).toEqual([]);
+	});
+
+	it("is empty for a kind with no required keys", () => {
+		expect(missingRequiredKeys({ kind: "timer.pacing", config: {} }, kinds)).toEqual([]);
+	});
+
+	it("is empty for a kind the catalogue no longer registers", () => {
+		expect(missingRequiredKeys({ kind: "extract.gone", config: {} }, kinds)).toEqual([]);
+	});
+});
+
+describe("hasIncompleteElement", () => {
+	const kinds = [kindFixture("extract.json", ["variable"]), kindFixture("timer.pacing", [])];
+
+	it("is true when any element in the list is missing a required key", () => {
+		const elements = [
+			{ id: "1", kind: "timer.pacing", enabled: true, config: {} },
+			{ id: "2", kind: "extract.json", enabled: true, config: {} },
+		];
+		expect(hasIncompleteElement(elements, kinds)).toBe(true);
+	});
+
+	it("is false once every element carries its required keys", () => {
+		const elements = [
+			{ id: "1", kind: "timer.pacing", enabled: true, config: {} },
+			{ id: "2", kind: "extract.json", enabled: true, config: { variable: "token" } },
+		];
+		expect(hasIncompleteElement(elements, kinds)).toBe(false);
+	});
+
+	it("is false for an empty list", () => {
+		expect(hasIncompleteElement([], kinds)).toBe(false);
 	});
 });

--- a/app/src/lib/elements.ts
+++ b/app/src/lib/elements.ts
@@ -12,7 +12,7 @@
  * other, so this lives in `lib/` rather than under any one of them.
  */
 
-import type { ElementDef } from "@/types";
+import type { ElementDef, ElementKindSchema } from "@/types";
 
 /**
  * The joined text of every enabled element of one script kind (`script.pre`
@@ -49,4 +49,47 @@ export function isBlankScriptElement(el: Pick<ElementDef, "kind" | "config">): b
 	if (el.kind !== "script.pre" && el.kind !== "script.post") return false;
 	const text = el.config.script;
 	return typeof text !== "string" || text.trim().length === 0;
+}
+
+/**
+ * The `required` keys of an element's kind that its own `config` is missing
+ * outright (issue #1635) - presence only, not `minLength`/`minimum`. That
+ * matches what `addElement`'s fresh `config: {}` produces exactly (no key at
+ * all), which is cheap and exact for the "just created it" case without
+ * duplicating the engine's fuller JSON Schema validation client-side; the
+ * engine's own `PUT` still owns every other constraint.
+ */
+export function missingRequiredKeys(
+	element: Pick<ElementDef, "kind" | "config">,
+	kinds: ElementKindSchema[]
+): string[] {
+	const required = kinds.find((k) => k.kind === element.kind)?.configSchema.required ?? [];
+	return required.filter((key) => element.config[key] === undefined);
+}
+
+/**
+ * Whether any element in the list is missing a required config key outright
+ * (issue #1635) - the shape that 400s the *entire* `elements` array on save,
+ * not only that one element's own edit, because the array is sent whole
+ * whenever it is touched (`buildUpdatePayload`).
+ */
+export function hasIncompleteElement(elements: ElementDef[], kinds: ElementKindSchema[]): boolean {
+	return elements.some((el) => missingRequiredKeys(el, kinds).length > 0);
+}
+
+/**
+ * Thrown by a save callback to mean "nothing was sent, and nothing should be
+ * retried" (issue #1635) - a payload the caller already knows the server
+ * will refuse (an incomplete element, per `hasIncompleteElement`), as
+ * opposed to a save that was attempted and failed. Both save paths -
+ * `useSaveManager`'s autosave and `useDraftSaveContext`'s manual-button
+ * model - read this type to report "still dirty, nothing in flight" rather
+ * than a genuine failure; neither retries against a payload that will not
+ * have changed by the next attempt.
+ */
+export class SaveBlockedError extends Error {
+	constructor(message = "Save blocked: fix the incomplete field first") {
+		super(message);
+		this.name = "SaveBlockedError";
+	}
 }

--- a/app/src/lib/elements.ts
+++ b/app/src/lib/elements.ts
@@ -6,10 +6,12 @@
  */
 
 /**
- * Small, context-free reads over an `ElementDef[]` list (issue #1512),
- * shared by the request-builder module, the collections module and the
- * generic reference scanners in `lib/` - none of which may depend on each
- * other, so this lives in `lib/` rather than under any one of them.
+ * Small, context-free reads over an `ElementDef[]` list (issue #1512), and
+ * `SaveBlockedError` (issue #1635) - the same save-path contract both a
+ * request's autosave and a collection's manual save button need - shared by
+ * the request-builder module, the collections module and the generic
+ * reference scanners in `lib/` - none of which may depend on each other, so
+ * this lives in `lib/` rather than under any one of them.
  */
 
 import type { ElementDef, ElementKindSchema } from "@/types";

--- a/app/src/modules/collections/CollectionDetail/ElementsTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ElementsTab.test.tsx
@@ -81,11 +81,29 @@ function kindSchema(kind: string, label: string, category: string): ElementKindS
 	};
 }
 
+/** A kind with a required config field, for the incompleteness cases (#1635). */
+const REQUIRED_KIND: ElementKindSchema = {
+	kind: "extract.required",
+	version: 1,
+	label: "Extract Required",
+	description: "Extract Required description",
+	category: "extract",
+	hotPathClass: "declarative",
+	collectionOnly: false,
+	configSchema: {
+		type: "object",
+		required: ["variable"],
+		properties: { variable: { type: "string", title: "Variable name" } },
+	},
+	phases: [],
+};
+
 const KINDS: ElementKindSchema[] = [
 	kindSchema("extract.json", "Extract JSON", "extract"),
 	kindSchema("assert.status", "Assert Status", "assert"),
 	kindSchema("script.pre", "Pre-request Script", "script"),
 	kindSchema("script.post", "Test Script", "script"),
+	REQUIRED_KIND,
 ];
 
 vi.mock("@/queries", async (importOriginal) => ({
@@ -213,6 +231,64 @@ describe("ElementsTab - the Save button", () => {
 		expect(
 			screen.getByText(/saved together, when you press Save Elements/i)
 		).toBeInTheDocument();
+	});
+});
+
+describe("ElementsTab - a required field an element's config is missing (issue #1635)", () => {
+	async function addRequiredElement() {
+		openAddMenu();
+		fireEvent.click((await screen.findByText("Extract Required")).closest("[cmdk-item]")!);
+	}
+
+	it("stays disabled (not merely undirtied) once an incomplete element makes the draft dirty", async () => {
+		renderTab(makeCollection([]));
+		await addRequiredElement();
+
+		// The picker's own add is what makes the draft dirty - a plain `!isDirty`
+		// check would already disable this button, so this case is only proof of
+		// the incompleteness guard if it stays disabled *while* dirty.
+		expect(screen.getByText("Extract Required")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /save elements/i })).toBeDisabled();
+	});
+
+	it("names the field on the row itself", async () => {
+		renderTab(makeCollection([]));
+		await addRequiredElement();
+
+		expect(screen.getByText("Needs Variable name")).toBeInTheDocument();
+	});
+
+	it("re-enables Save Elements once the field is filled in", async () => {
+		renderTab(makeCollection([]));
+		await addRequiredElement();
+		expect(screen.getByRole("button", { name: /save elements/i })).toBeDisabled();
+
+		const textboxes = screen.getAllByRole("textbox");
+		fireEvent.change(textboxes[textboxes.length - 1], {
+			target: { value: "token" },
+		});
+
+		expect(screen.getByRole("button", { name: /save elements/i })).toBeEnabled();
+		expect(screen.queryByText(/^Needs /)).not.toBeInTheDocument();
+	});
+
+	it("never calls the update mutation while an element is incomplete, even via a direct click", async () => {
+		renderTab(makeCollection([]));
+		await addRequiredElement();
+
+		// Disabled buttons refuse a real click too - this pins the same guard
+		// `persist` carries for Cmd+S and the quit flush, which do not read the
+		// disabled attribute at all.
+		fireEvent.click(screen.getByRole("button", { name: /save elements/i }));
+
+		expect(mutation.mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("says why saving is held back", async () => {
+		renderTab(makeCollection([]));
+		await addRequiredElement();
+
+		expect(screen.getByText(/finish the field/i)).toBeInTheDocument();
 	});
 });
 

--- a/app/src/modules/collections/CollectionDetail/ElementsTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ElementsTab.tsx
@@ -35,6 +35,7 @@ import { ElementList } from "@/components/shared/ElementList";
 import { useDataContract, useDraftSaveContext, useEntityDraft, useVariableResolver } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import { useElementKindsQuery } from "@/queries";
+import { hasIncompleteElement, SaveBlockedError } from "@/lib/elements";
 import type { Collection, ElementDef } from "@/types";
 import { InfoBanner, SaveFailed } from "./shared";
 
@@ -68,10 +69,21 @@ export default function ElementsTab({ collection, active = false }: ElementsTabP
 		mutation: updateCollection,
 	});
 
+	const kindsList = kinds ?? [];
+	const incomplete = hasIncompleteElement(elements, kindsList);
+
 	const persist = useCallback(async () => {
 		if (!isDirty) return;
+		// Same whole-array 400 as the request builder's autosave (issue #1635):
+		// this button is disabled while `incomplete`, but `useDraftSaveContext`
+		// also registers `persist` for Cmd+S and the quit flush, neither of
+		// which reads the disabled attribute - so the check has to live here
+		// too, not only on the button below. Reads `kinds` directly (not
+		// `kindsList`, a fresh `[]` reference on every render while the query is
+		// still loading) so this callback's identity does not churn with it.
+		if (hasIncompleteElement(elements, kinds ?? [])) throw new SaveBlockedError();
 		await updateCollection.mutateAsync({ id: collection.id, elements });
-	}, [isDirty, updateCollection, collection.id, elements]);
+	}, [isDirty, updateCollection, collection.id, elements, kinds]);
 
 	useDraftSaveContext({
 		id: `collection-${collection.id}-elements`,
@@ -102,7 +114,7 @@ export default function ElementsTab({ collection, active = false }: ElementsTabP
 			<ElementList
 				elements={elements}
 				onChange={setElements}
-				kinds={kinds ?? []}
+				kinds={kindsList}
 				emptyLabel="No elements yet. Add an extractor, assertion, timer or script from the menu below."
 				renderAboveForm={(element) => {
 					if (element.kind !== "script.pre" && element.kind !== "script.post")
@@ -123,10 +135,17 @@ export default function ElementsTab({ collection, active = false }: ElementsTabP
 
 			<SaveFailed mutation={updateCollection} what="the elements list" />
 
+			{incomplete && (
+				<p className="text-xs text-muted-foreground">
+					Finish the field an element marked &quot;Needs&quot; above is missing before
+					saving.
+				</p>
+			)}
+
 			<div className="flex gap-2">
 				<Button
 					onClick={handleSave}
-					disabled={!isDirty || updateCollection.isPending}
+					disabled={!isDirty || updateCollection.isPending || incomplete}
 					className="font-semibold"
 				>
 					{updateCollection.isPending ? "Saving…" : "Save Elements"}

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.bound-row.test.tsx
@@ -34,6 +34,9 @@ const environments: Array<Record<string, unknown>> = [];
 const session = { activeEnvironmentId: null as string | null };
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: globals }),
 	useCollectionsQuery: () => ({ data: collections }),
 	useCollectionAncestors: () => [],

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.external-write-merge.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.external-write-merge.test.tsx
@@ -70,6 +70,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
@@ -40,6 +40,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.incomplete-element.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.incomplete-element.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Issue #1635: `buildUpdatePayload` sends the whole `elements` array whenever
+ * it is touched, and the engine 400s the *entire* payload if any one element
+ * is missing a required config key - which is exactly what a freshly added
+ * element has. `RequestBuilderProvider`'s `handleSave` (the function it hands
+ * `useSaveManager` as `onSave`) is the one place that sees both the touched
+ * fields and the element list before a payload goes out, so it is where the
+ * skip belongs.
+ *
+ * Mutation check: comment out the `hasIncompleteElement` guard in
+ * `RequestBuilderProvider.tsx`'s `handleSave` and the first two cases below
+ * redden - the outer `onSave` prop would be called with the incomplete
+ * element still in `elements`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import RequestBuilderProvider from "./RequestBuilderProvider";
+import { useRequestBuilderContext } from "./RequestBuilderContext";
+import type { RequestState, MergeableRequestField } from "../types";
+import type { ElementKindSchema } from "@/types";
+
+type OnSave = (
+	request: RequestState,
+	changedFields: ReadonlySet<MergeableRequestField>
+) => Promise<void>;
+
+/** The options the provider handed the save manager on the last render. */
+let managerOptions: { onSave: () => Promise<void>; hasChanges: boolean; changeToken: number };
+
+const REQUIRED_KIND: ElementKindSchema = {
+	kind: "extract.json",
+	version: 1,
+	label: "Extract JSON",
+	description: "",
+	category: "extract",
+	hotPathClass: "declarative",
+	collectionOnly: false,
+	configSchema: { type: "object", required: ["variable"] },
+	phases: [],
+};
+
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		resolveObject: (o: unknown) => o,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
+	useSaveManager: (options: {
+		onSave: () => Promise<void>;
+		hasChanges: boolean;
+		changeToken: number;
+	}) => {
+		managerOptions = options;
+		return { forceSave: vi.fn(), status: "idle", isSaving: false };
+	},
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	useConfigQuery: () => ({ data: { entries: [] } }),
+	useElementKindsQuery: () => ({ data: [REQUIRED_KIND] }),
+}));
+
+/** Reads the dirty flag and offers the one edit each case makes. */
+function ElementsProbe() {
+	const { request, updateField, hasUnsavedChanges } = useRequestBuilderContext();
+	return (
+		<>
+			<span data-testid="dirty">{String(hasUnsavedChanges)}</span>
+			<span data-testid="element-count">{request.elements.length}</span>
+			<button
+				onClick={() =>
+					updateField("elements", [
+						{ id: "el_1", kind: "extract.json", enabled: true, config: {} },
+					])
+				}
+			>
+				add incomplete element
+			</button>
+			<button
+				onClick={() =>
+					updateField("elements", [
+						{
+							id: "el_1",
+							kind: "extract.json",
+							enabled: true,
+							config: { variable: "token" },
+						},
+					])
+				}
+			>
+				fill in the field
+			</button>
+			<button onClick={() => updateField("name", "renamed")}>edit something else</button>
+		</>
+	);
+}
+
+const dirty = () => screen.getByTestId("dirty").textContent;
+const click = (label: string) => act(() => screen.getByText(label).click());
+// `handleSave` (what `managerOptions.onSave` is here) throws `SaveBlockedError`
+// when the elements list is incomplete - `useSaveManager.performSave` is what
+// catches that in the real app; standing in for it here the same way lets
+// `act` await the rejection instead of letting it escape as unhandled.
+const save = () => act(() => managerOptions.onSave().catch(() => {}));
+
+describe("a save the elements list makes known-incomplete", () => {
+	let onSave: ReturnType<typeof vi.fn<OnSave>>;
+
+	beforeEach(() => {
+		onSave = vi.fn<OnSave>().mockResolvedValue(undefined);
+		const initialRequest: Partial<RequestState> = { id: "req_1", name: "Req" };
+		render(
+			<RequestBuilderProvider
+				initialRequest={initialRequest}
+				collectionId="col_1"
+				onSave={onSave}
+			>
+				<ElementsProbe />
+			</RequestBuilderProvider>
+		);
+	});
+
+	it("skips the network call rather than sending the incomplete element", async () => {
+		click("add incomplete element");
+		await save();
+
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("keeps the request dirty, so nothing is silently dropped", async () => {
+		click("add incomplete element");
+		await save();
+
+		expect(dirty()).toBe("true");
+		expect(managerOptions.hasChanges).toBe(true);
+	});
+
+	it("still skips a save that touches an unrelated field, while the element stays incomplete", async () => {
+		click("add incomplete element");
+		click("edit something else");
+		await save();
+
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("saves normally, carrying every edit made while blocked, once the field is filled in", async () => {
+		click("add incomplete element");
+		click("edit something else");
+		await save();
+		expect(onSave).not.toHaveBeenCalled();
+
+		click("fill in the field");
+		await save();
+
+		expect(onSave).toHaveBeenCalledTimes(1);
+		const [sentRequest, sentFields] = onSave.mock.calls[0] as [
+			RequestState,
+			ReadonlySet<string>,
+		];
+		expect(sentRequest.elements[0].config).toEqual({ variable: "token" });
+		// The rename from while it was blocked is still in the payload - the
+		// skip must not have dropped it.
+		expect(sentFields.has("name")).toBe(true);
+		expect(sentRequest.name).toBe("renamed");
+		expect(dirty()).toBe("false");
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.methodSource-reload.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.methodSource-reload.test.tsx
@@ -46,6 +46,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.name-sync.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.name-sync.test.tsx
@@ -52,6 +52,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.save-generation.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.save-generation.test.tsx
@@ -55,6 +55,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -24,6 +24,7 @@ import { retainKeys } from "./retain-keys";
 import { useVariableResolver, useSaveManager } from "@/hooks";
 import { resolveDataContract } from "@/lib/data-contract";
 import { mergeExternalWrite } from "@/lib/field-merge";
+import { hasIncompleteElement, SaveBlockedError } from "@/lib/elements";
 import { useDataFileLimits } from "@/hooks/useDataFileLimits";
 import {
 	useCollectionAncestors,
@@ -34,6 +35,7 @@ import {
 	useEnvironmentsQuery,
 	useUpdateEnvironmentMutation,
 	useLastDesignRunQuery,
+	useElementKindsQuery,
 } from "@/queries";
 import {
 	useSessionStore,
@@ -190,6 +192,12 @@ export default function RequestBuilderProvider({
 		...initialRequest,
 		collectionId: collectionId || null,
 	}));
+
+	// The catalogue's `required` keys per kind (issue #1635) - `handleSave`
+	// below needs it to decide whether `elements` is safe to send; cached by
+	// `useElementKindsQuery` itself, so this costs nothing beyond the fetch
+	// `ElementsPanel` already makes.
+	const { data: elementKinds } = useElementKindsQuery();
 
 	// The id of the request currently on screen. This single provider is reused
 	// across request tabs (no per-tab key), so an execute that is still in flight
@@ -846,6 +854,21 @@ export default function RequestBuilderProvider({
 		// name says what matters): a `setRequest` that lands during the await
 		// cannot silently add to what this save already claims to have sent.
 		const changedFields = touchedFields;
+		// `buildUpdatePayload` sends the whole `elements` array whenever it is
+		// touched (issue #1635) - an element the picker just added still has
+		// `config: {}`, missing whatever its kind requires, and the engine 400s
+		// the *entire* payload on that one element's behalf. Presence-only check
+		// against the catalogue's `required` keys, the same cheap and exact test
+		// `addElement`'s fresh seed needs: throwing here (instead of calling
+		// `onSave`) keeps the request dirty and skips the network call, and
+		// `useSaveManager` reads `SaveBlockedError` to stay `"pending"` rather
+		// than backing off a retry against a payload that will not have changed.
+		if (
+			changedFields.has("elements") &&
+			hasIncompleteElement(request.elements, elementKinds ?? [])
+		) {
+			throw new SaveBlockedError();
+		}
 		await onSave(request, changedFields);
 		// An edit landed, or a foreign write arrived, while this save was in
 		// flight: either way `changeTokenRef` moved and the payload that went
@@ -871,7 +894,7 @@ export default function RequestBuilderProvider({
 			setBaseline((prev) => ({ ...prev, ...(savedPatch as Partial<RequestState>) }));
 		}
 		setHasUnsavedChanges(false);
-	}, [request, changeToken, touchedFields, onSave]);
+	}, [request, changeToken, touchedFields, onSave, elementKinds]);
 
 	const {
 		forceSave,

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
@@ -42,6 +42,9 @@ const mutateCollection = vi.fn();
 const mutateEnvironment = vi.fn();
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: globals }),
 	useCollectionsQuery: () => ({ data: collections }),
 	// The provider walks this for the auth an `inherit` resolves to; nothing

--- a/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
+++ b/app/src/modules/request-builder/context/auto-records-per-request.test.tsx
@@ -61,6 +61,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
+++ b/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
@@ -57,6 +57,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/execute-request-switch.test.tsx
+++ b/app/src/modules/request-builder/context/execute-request-switch.test.tsx
@@ -45,6 +45,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/context/execute-stream-branch.test.tsx
+++ b/app/src/modules/request-builder/context/execute-stream-branch.test.tsx
@@ -55,6 +55,9 @@ const invalidateQueries = vi.fn();
 vi.mock("@/lib/query-client", () => ({ queryClient: { invalidateQueries } }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/load-test-command-surface.test.tsx
+++ b/app/src/modules/request-builder/load-test-command-surface.test.tsx
@@ -42,6 +42,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),

--- a/app/src/modules/request-builder/send-request-command-surface.test.tsx
+++ b/app/src/modules/request-builder/send-request-command-surface.test.tsx
@@ -49,6 +49,9 @@ vi.mock("@/hooks", () => ({
 }));
 
 vi.mock("@/queries", () => ({
+	// RequestBuilderProvider now reads the catalogue itself (issue #1635); an
+	// empty list means "nothing required", so the save-skip check is inert.
+	useElementKindsQuery: () => ({ data: [] }),
 	useGlobalsQuery: () => ({ data: { variables: {} } }),
 	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
 	useCollectionsQuery: () => ({ data: [] }),


### PR DESCRIPTION
## Description

`buildUpdatePayload` sends a request's whole `elements` array on any touch, and the engine validates every element's config against its kind's full JSON Schema on each `PUT /requests/:id` - so a freshly added element still holding its bare `config: {}` seed (`ElementList`'s `addElement`) 400s the *entire* save the moment the user edits anything else on the request, not just that element's own field. The same shape exists on the collection side: `ElementsTab`'s "Save Elements" button always sends the whole draft.

Fix is at the save boundary, not at element creation (seeding a fake non-blank value per kind was rejected as worse than the bug - see #1608's own script-kind case, which is the one kind with a genuinely valid empty seed and still needed this generalized fix for everything else): before either save path sends the array, check every element against the catalogue's `required` keys (presence only - matches what a fresh `{}` seed can produce, without duplicating the engine's fuller `minLength`/`minimum` validation client-side). If anything is missing, throw `SaveBlockedError` instead of sending. `useSaveManager` and `useDraftSaveContext` both already have an established contract for "rejecting is how a failure is reported" - `SaveBlockedError` reuses it but reports "still dirty, nothing in flight" rather than a genuine failure, so `useSaveManager`'s exponential backoff never fires a retry against a payload that will not have changed by the next tick.

`ElementRow` shows which field is missing, by the schema's own `title` where one exists (falls back to the raw key), reusing the dot-plus-inline-text pattern `TokenStatusRow` already established for the same "held back, here's why" shape - no new indicator primitive was needed.

**Also fixed in this PR:** thirteen existing tests fully replace the `@/queries` module mock (no `importOriginal` spread) and render `RequestBuilderProvider`, which now calls `useElementKindsQuery` itself; each mock gained a `useElementKindsQuery: () => ({ data: [] })` stub so the provider doesn't crash on an undefined import. Mechanical, required to keep the suite green, not a behavior change - safe to skim past in review.

**Deliberate scope note:** the `required`-key check is presence-only, per the issue's own stated fix pathway - it catches a freshly-added element (`config: {}`, the common case) but not a `minLength`/`minimum`-constrained field a user typed into and then cleared back to blank. The issue's own text explicitly declines replicating the engine's fuller schema validation client-side for that narrower case, so this is accepted scope, not a gap this PR missed.

## Type of Change
- [x] Bug fix

## Testing

- `cd app && pnpm test` - full suite, **733 files / 8331 passed, 2 skipped** (pre-existing skips, unrelated to this change).
- `cd app && pnpm test elements ElementList ElementsTab useSaveManager RequestBuilderProvider request-builder` - the touched suites in isolation, all green.
- `cd app && pnpm type-check && pnpm lint && pnpm format:check` - all clean.
- Mutation-checked by hand (reverted, confirmed red, restored): disabling the `hasIncompleteElement` guard in `RequestBuilderProvider.tsx`'s `handleSave` reddens all 4 cases in `RequestBuilderProvider.incomplete-element.test.tsx`; disabling the `incomplete` gate on `ElementsTab`'s Save button reddens 2 cases in `ElementsTab.test.tsx`. `useSaveManager.blocked.test.tsx` covers the `SaveBlockedError` contract directly (pending-not-error status, no retry storm, no console noise, resumes on the next real edit).
- Not run: engine tests. No engine changes in this PR - the catalogue's `required` field already exists in `GET /elements/kinds` (from #1512/#1607), this PR only reads it app-side.

## Visual changes

Not captured this run - the engine wasn't already built in this container and a from-scratch C++ build was judged disproportionate to a small, established-pattern UI affordance (a warning dot + inline text, reusing `TokenStatusRow`'s exact treatment, plus disabling a button the app already disables under other conditions). Component tests assert the exact rendered text (`"Needs Variable name"`) and the button's `disabled` state directly, including the mutation checks above.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [ ] I have updated documentation - not applicable: no documented behavior changed (the `required`-key presence check and the save-skip are new client-side guards over existing, already-documented engine validation; no doc currently describes the old "send the whole array and let it 400" behavior to correct)

## Related Issues
Closes #1635