### PR TITLE
feat(app): env quick actions and tab persistence

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,61 +60,12 @@
         "**/*.log": true
     },
     // =========================================================================
-    // Testing
-    // =========================================================================
-    "testMate.cpp.test.executables": "${workspaceFolder}/engine/build/vayu_tests",
-    // =========================================================================
     // General Editor Settings
     // =========================================================================
     "editor.formatOnSave": true,
-    "editor.rulers": [
-        100
-    ],
-    "editor.renderWhitespace": "boundary",
-    "editor.bracketPairColorization.enabled": true,
     // =========================================================================
     // Terminal
     // =========================================================================
     "terminal.integrated.cwd": "${workspaceFolder}",
-    "cSpell.words": [
-        "ASAN",
-        "Atharva",
-        "BIGNUM",
-        "buildsystems",
-        "ccache",
-        "cutils",
-        "DCMAKE",
-        "DVCPKG",
-        "fsanitize",
-        "httplib",
-        "Kusumbia",
-        "libbf",
-        "LIBC",
-        "libregexp",
-        "libunicode",
-        "memsize",
-        "MSVC",
-        "ncpu",
-        "ngrok",
-        "nlohmann",
-        "NOMINMAX",
-        "NONSTDC",
-        "partialize",
-        "physicalcpu",
-        "QUICKJS",
-        "SIGABRT",
-        "STREQUAL",
-        "TSAN",
-        "vayu",
-        "Wconversion",
-        "Wdouble",
-        "Werror",
-        "Wextra",
-        "Wformat",
-        "winmm",
-        "Wnull",
-        "Wpedantic",
-        "Wsign"
-    ],
     "python.languageServer": "Pylance"
 }

--- a/app/src/components/layout/TitleBar.tsx
+++ b/app/src/components/layout/TitleBar.tsx
@@ -37,14 +37,30 @@ import {
 	Cloud,
 	ArrowLeft,
 	ArrowRight,
+	Plus,
+	Download,
 } from "lucide-react";
-import { canGoBack, canGoForward, useSessionStore, useTabsStore, useToastStore } from "@/stores";
-import { useEnvironmentsQuery, useSetActiveEnvironmentMutation } from "@/queries";
+import {
+	canGoBack,
+	canGoForward,
+	useImportModalStore,
+	useSessionStore,
+	useTabsStore,
+	useToastStore,
+} from "@/stores";
+import {
+	useCreateEnvironmentMutation,
+	useEnvironmentsQuery,
+	useSetActiveEnvironmentMutation,
+} from "@/queries";
+import { useVariablesStore } from "@/modules/variables/variables-store";
+import { DEFAULT_ENVIRONMENT_NAME } from "@/constants/environment";
 import {
 	DropdownMenu,
 	DropdownMenuTrigger,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	TooltipIconButton,
 } from "@/components/ui";
 import {
@@ -298,8 +314,27 @@ function EnvSwitcher() {
 	const { activeEnvironmentId } = useSessionStore();
 	const { data: environments = [] } = useEnvironmentsQuery();
 	const setActiveEnvironment = useSetActiveEnvironmentMutation();
+	const createEnvironment = useCreateEnvironmentMutation();
+	const { openTab } = useTabsStore();
+	const { setSelectedCategory } = useVariablesStore();
+	const openImport = useImportModalStore((s) => s.open);
 	const showToast = useToastStore((s) => s.showToast);
 	const activeEnv = environments.find((e) => e.id === activeEnvironmentId);
+
+	/*
+	 * Create-then-navigate only, the same as the Variables sidebar's own
+	 * `handleCreateEnvironment` - it does not activate the environment. Creating
+	 * one is not a decision to make it live; that stays a deliberate, separate
+	 * choice through `selectEnvironment` below.
+	 */
+	const createNewEnvironment = async () => {
+		const newEnv = await createEnvironment.mutateAsync({
+			name: DEFAULT_ENVIRONMENT_NAME,
+			variables: {},
+		});
+		setSelectedCategory({ type: "environment", environmentId: newEnv.id });
+		openTab({ type: "variables", entityId: null });
+	};
 
 	/*
 	 * Switching environment is a silent change with loud consequences: every
@@ -391,6 +426,18 @@ function EnvSwitcher() {
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="min-w-44">
+				<DropdownMenuItem
+					onClick={() => void createNewEnvironment()}
+					className="text-xs gap-2"
+				>
+					<Plus className="w-3.5 h-3.5" />
+					<span className="flex-1">New Environment</span>
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={openImport} className="text-xs gap-2">
+					<Download className="w-3.5 h-3.5" />
+					<span className="flex-1">Import Environment...</span>
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
 				<DropdownMenuItem onClick={() => selectEnvironment(null)} className="text-xs gap-2">
 					<span className="flex-1">No Environment</span>
 					{!activeEnv && <Check className="w-3.5 h-3.5" />}

--- a/app/src/components/layout/env-switcher-quick-actions.test.tsx
+++ b/app/src/components/layout/env-switcher-quick-actions.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The environment switcher only lists and switches existing environments.
+ * These two quick actions wire in pipelines that already exist elsewhere in
+ * the app (the Variables sidebar's create flow, the global import dialog)
+ * rather than building new ones - see `VariablesCategoryTree.handleCreateEnvironment`
+ * for the pattern "New Environment" mirrors: create, then point the Variables
+ * editor's selected category at the new environment. It deliberately does not
+ * activate the environment - creating one should not change what is live.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.hoisted(() => {
+	Object.defineProperty(globalThis.window, "electronAPI", {
+		value: {
+			platform: "linux",
+			windowIsMaximized: () => Promise.resolve(false),
+			onWindowMaximized: () => () => {},
+			windowMinimize: () => {},
+			windowMaximize: () => {},
+			windowClose: () => {},
+		},
+		writable: true,
+		configurable: true,
+	});
+});
+
+import { useToastStore, useSessionStore, useTabsStore, useImportModalStore } from "@/stores";
+import { useVariablesStore } from "@/modules/variables/variables-store";
+import TitleBar from "./TitleBar";
+import { TooltipProvider } from "@/components/ui";
+
+const environments = [{ id: "env-1", name: "Staging" }];
+
+const createEnvironment = vi.fn();
+vi.mock("@/queries", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/queries")>()),
+	useEnvironmentsQuery: () => ({ data: environments }),
+	useCreateEnvironmentMutation: () => ({ mutateAsync: createEnvironment, isPending: false }),
+}));
+
+function renderTitleBar() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<TitleBar />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+function openMenu() {
+	const trigger = screen.getByRole("button", { name: /switch environment/i });
+	fireEvent.keyDown(trigger, { key: "Enter" });
+	const menu = screen.getByRole("menu");
+	expect(menu).toBeInTheDocument();
+	return within(menu);
+}
+
+beforeEach(() => {
+	cleanup();
+	useToastStore.setState({ toasts: [] });
+	useSessionStore.setState({ activeEnvironmentId: null });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, navHistory: [], navIndex: -1 });
+	useVariablesStore.setState({ selectedCategory: null });
+	useImportModalStore.setState({ isOpen: false, pendingPath: null });
+	createEnvironment.mockReset();
+	createEnvironment.mockResolvedValue({ id: "env-new", name: "New Environment" });
+});
+
+describe("environment switcher quick actions", () => {
+	it("creates a new environment and opens the Variables editor on it, without activating it", async () => {
+		renderTitleBar();
+		const menu = openMenu();
+		fireEvent.click(menu.getByText("New Environment"));
+
+		expect(createEnvironment).toHaveBeenCalledWith({ name: "New Environment", variables: {} });
+		await vi.waitFor(() =>
+			expect(useVariablesStore.getState().selectedCategory).toEqual({
+				type: "environment",
+				environmentId: "env-new",
+			})
+		);
+		expect(useTabsStore.getState().openTabs).toContainEqual(
+			expect.objectContaining({ type: "variables", entityId: null })
+		);
+		// Creating must not switch what is live.
+		expect(useSessionStore.getState().activeEnvironmentId).toBeNull();
+	});
+
+	it("opens the import dialog from Import Environment...", () => {
+		renderTitleBar();
+		const menu = openMenu();
+		fireEvent.click(menu.getByText("Import Environment..."));
+
+		expect(useImportModalStore.getState().isOpen).toBe(true);
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.spec-target.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.spec-target.test.tsx
@@ -24,6 +24,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import CollectionDetail from "./index";
 import { useTabsStore } from "@/stores";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
 
 const collection = {
 	id: "c1",
@@ -70,6 +71,10 @@ beforeEach(() => {
 		activeTabId: "t1",
 		specTabTarget: null,
 	});
+	// The Spec case below persists "c1"'s tab as "spec" - unmounting does not
+	// clear it, so a later case reusing "c1" would otherwise open on Spec
+	// instead of its own default.
+	useTabSelectionStore.getState().clearAll();
 });
 
 describe("a collection pointed at its Spec tab", () => {

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.tab-persistence.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.tab-persistence.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The collection screen's active sub-tab, kept per collection id in
+ * `tab-selection-store`.
+ *
+ * `Shell.tsx` mounts one workspace-tab's surface at a time, so switching away
+ * from a collection tab and back used to reset this screen to Info every
+ * time - `tab` was a bare `useState` with no memory of which collection it
+ * belonged to. It also has to survive the case that never unmounts at all:
+ * two open collection tabs are the same `CollectionDetail` instance (the
+ * component is not remounted when the user switches to a sibling
+ * collection's tab - see the comment above `DataTab`'s `key` prop in
+ * `index.tsx`), so a plain `useState` would carry collection A's tab
+ * straight onto collection B.
+ *
+ * Mutation check: drop the `setCollectionTab` write from the wrapped `setTab`,
+ * or drop the `getCollectionTab` read from either the mount initializer or
+ * the `tabSyncedFor` sync in `index.tsx`, and the "survives" cases below fail
+ * red; restoring either makes them green again.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
+import CollectionDetail from "./index";
+
+const collections = [
+	{ id: "c1", name: "Collection One", variables: {} },
+	{ id: "c2", name: "Collection Two", variables: {} },
+];
+
+vi.mock("@/queries", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/queries")>()),
+	useScriptCompletionsQuery: () => ({ data: undefined, isPending: true, isError: false }),
+}));
+
+vi.mock("@/queries/collections", () => ({
+	useCollectionsQuery: () => ({ data: collections, isLoading: false, isError: false }),
+	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
+}));
+
+/** Which collection's tab is "active" in the tab strip - mutated between renders. */
+let activeCollectionId = "c1";
+
+vi.mock("@/stores", () => ({
+	useTabsStore: () => ({
+		openTabs: [
+			{ id: "t1", type: "collection", entityId: "c1" },
+			{ id: "t2", type: "collection", entityId: "c2" },
+		],
+		activeTabId: activeCollectionId === "c1" ? "t1" : "t2",
+	}),
+	useSessionStore: (selector: (s: unknown) => unknown) =>
+		selector({ setLastCollectionId: vi.fn() }),
+}));
+
+// Panel content is not what these tests are about - only which trigger the
+// tab strip marks active - and several of these drag in Monaco or the engine.
+vi.mock("./InfoTab", () => ({ default: () => null }));
+vi.mock("./AuthTab", () => ({ default: () => null }));
+vi.mock("./ElementsTab", () => ({ default: () => null }));
+vi.mock("./VariablesTab", () => ({ default: () => null }));
+vi.mock("./DataTab", () => ({ default: () => null }));
+vi.mock("./SpecTab", () => ({ default: () => null }));
+vi.mock("./MockServerControl", () => ({ default: () => null }));
+
+function Screen() {
+	return (
+		<QueryClientProvider client={new QueryClient()}>
+			<TooltipProvider>
+				<CollectionDetail />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+/** Radix activates a trigger on `mousedown`, not on `click`. */
+function selectTab(label: RegExp) {
+	fireEvent.mouseDown(screen.getByRole("tab", { name: label }), { button: 0 });
+}
+
+function activeTabName(): string | null {
+	const active = screen
+		.getAllByRole("tab")
+		.filter((t) => t.getAttribute("data-state") === "active");
+	expect(active.length, "exactly one tab must be selected").toBe(1);
+	return active[0]?.textContent?.trim() ?? null;
+}
+
+beforeEach(() => {
+	useTabSelectionStore.getState().clearAll();
+	activeCollectionId = "c1";
+});
+
+describe("the active collection tab, kept per collection id", () => {
+	it("defaults to Info for a collection seen for the first time", () => {
+		render(<Screen />);
+		expect(activeTabName()).toMatch(/info/i);
+	});
+
+	it("survives Shell unmounting and remounting the screen for the same collection", () => {
+		const { unmount } = render(<Screen />);
+		selectTab(/auth/i);
+		expect(activeTabName()).toMatch(/auth/i);
+
+		unmount();
+
+		// A different collection, mounted fresh - shows its own default, not c1's.
+		activeCollectionId = "c2";
+		const { unmount: unmountB } = render(<Screen />);
+		expect(activeTabName()).toMatch(/info/i);
+		unmountB();
+
+		// Back to c1 - its own selection is still there.
+		activeCollectionId = "c1";
+		render(<Screen />);
+		expect(activeTabName()).toMatch(/auth/i);
+	});
+
+	it("also keeps each collection's tab separate when moving between two open collection tabs without a remount", () => {
+		// `CollectionDetail` is not remounted for a switch between two
+		// collection tabs - `activeTabId` changes under the same component
+		// instance, exactly what the render-time `tabSyncedFor` sync (not
+		// just the mount initializer) has to answer for.
+		const { rerender } = render(<Screen />);
+		selectTab(/elements/i);
+		expect(activeTabName()).toMatch(/elements/i);
+
+		activeCollectionId = "c2";
+		rerender(<Screen />);
+		expect(activeTabName()).toMatch(/info/i);
+
+		activeCollectionId = "c1";
+		rerender(<Screen />);
+		expect(activeTabName()).toMatch(/elements/i);
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -12,13 +12,14 @@
  * navigation-store.navigateToCollection(collectionId).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Folder } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger, TabLabel, TabCount } from "@/components/ui";
 import { DetailSkeleton, EmptyState, ErrorState } from "@/components/shared";
 import { useCollectionsQuery, useMultipleCollectionRequests } from "@/queries/collections";
 import { collectSubtreeIds } from "@/modules/collections/tree-utils";
 import { useTabsStore, useSessionStore } from "@/stores";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
 import AuthTab from "./AuthTab";
 import DataTab from "./DataTab";
 import ElementsTab from "./ElementsTab";
@@ -27,7 +28,7 @@ import MockServerControl from "./MockServerControl";
 import SpecTab from "./SpecTab";
 import VariablesTab from "./VariablesTab";
 
-type CollectionTab = "info" | "auth" | "elements" | "variables" | "data" | "spec";
+export type CollectionTab = "info" | "auth" | "elements" | "variables" | "data" | "spec";
 
 const TABS: { id: CollectionTab; label: string }[] = [
 	{ id: "info", label: "Info" },
@@ -113,11 +114,51 @@ export default function CollectionDetail() {
 		[collections, selectedCollectionId]
 	);
 
-	const [tab, setTab] = useState<CollectionTab>("info");
+	/*
+	 * Kept per collection id (`tab-selection-store`), so the active sub-tab
+	 * survives `Shell.tsx` unmounting this screen when its workspace tab is
+	 * not on screen. `CollectionDetail` is not remounted when the user
+	 * switches to a sibling collection's tab (`DataTab` above needs the same
+	 * fact), so the derived-during-render sync below restores it again on
+	 * every collection change too.
+	 */
+	const { getCollectionTab, setCollectionTab } = useTabSelectionStore();
+	const initialTab = (): CollectionTab =>
+		(selectedCollectionId ? getCollectionTab(selectedCollectionId) : null) ?? "info";
+	const [tab, setTabState] = useState<CollectionTab>(initialTab);
+	const setTab = useCallback(
+		(next: CollectionTab) => {
+			setTabState(next);
+			if (selectedCollectionId) setCollectionTab(selectedCollectionId, next);
+		},
+		[selectedCollectionId, setCollectionTab]
+	);
 	// Panels are force-mounted from their first visit onwards, not from mount:
 	// a draft can only exist in a tab the user has opened, and two of these
 	// carry a Monaco editor that costs nothing while nobody has asked for it.
-	const [visited, setVisited] = useState<ReadonlySet<CollectionTab>>(() => new Set(["info"]));
+	// Seeded from the restored tab, not a bare "info": a restored "elements"
+	// tab paints its panel this render, and an unseeded `visited` would drop
+	// it - and the draft `TABS_HOLDING_DRAFTS` exists to protect - the moment
+	// the user glanced at a sibling tab.
+	const [visited, setVisited] = useState<ReadonlySet<CollectionTab>>(
+		() => new Set([initialTab()])
+	);
+
+	/*
+	 * The `useState` initializer above only ever runs once, for whichever
+	 * collection this screen first rendered for - a later collection shown
+	 * without a remount (the sibling-tab-switch case above) needs this
+	 * derived-during-render sync instead, the same shape
+	 * `RequestBuilderProvider`'s per-request reset uses, so the previous
+	 * collection's tab never gets a frame to paint under the new one.
+	 */
+	const [tabSyncedFor, setTabSyncedFor] = useState(selectedCollectionId);
+	if (selectedCollectionId !== tabSyncedFor) {
+		setTabSyncedFor(selectedCollectionId);
+		const next = initialTab();
+		setTabState(next);
+		setVisited((prev) => (prev.has(next) ? prev : new Set(prev).add(next)));
+	}
 
 	/*
 	 * Something outside this screen pointed at a collection's Spec tab - today
@@ -139,7 +180,7 @@ export default function CollectionDetail() {
 		setTab("spec");
 		setVisited((prev) => (prev.has("spec") ? prev : new Set(prev).add("spec")));
 		clearSpecTabTarget();
-	}, [specTabTarget, selectedCollectionId, clearSpecTabTarget]);
+	}, [specTabTarget, selectedCollectionId, clearSpecTabTarget, setTab]);
 
 	// Loading and missing are different answers. `collections` defaults to `[]`,
 	// so a collection tab restored from a previous session resolves to nothing

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -19,7 +19,7 @@
  * Uses shared ResponseBody component for body display with Pretty/Raw/Preview modes.
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { BookmarkPlus } from "lucide-react";
 import {
 	Tabs,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui";
 import { useRequestBuilderContext } from "../../context";
 import { useExecutionEventsStore } from "@/stores";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
 import { chordKeys } from "@/lib/platform";
 import { SEND_CHORD } from "@/constants/shortcuts";
 import {
@@ -55,14 +56,44 @@ import TestResults from "./TestResults";
 import RawRequestResponse from "./RawRequestResponse";
 import ClientErrorView from "./ClientErrorView";
 import SaveAsExampleDialog from "./SaveAsExampleDialog";
-import type { ResponseState } from "../../types";
-
-type ResponseTab =
-	"body" | "headers" | "cookies" | "timing" | "console" | "tests" | "events" | "raw-request";
+import type { ResponseState, ResponseTab } from "../../types";
 
 export default function ResponseViewer() {
 	const { request, response, isExecuting } = useRequestBuilderContext();
-	const [activeTab, setActiveTab] = useState<ResponseTab>("body");
+	const requestId = request.id ?? null;
+
+	/*
+	 * Which sub-tab is showing, kept per request id so it survives both
+	 * `Shell.tsx` unmounting this pane when its workspace tab is not on
+	 * screen, and switching between two open request tabs, which reuses this
+	 * component without remounting it - `request.id` changes underneath the
+	 * same `useState` either way.
+	 */
+	const { getResponseTab, setResponseTab } = useTabSelectionStore();
+	const [activeTab, setActiveTabState] = useState<ResponseTab>(
+		() => (requestId ? getResponseTab(requestId) : null) ?? "body"
+	);
+	const setActiveTab = useCallback(
+		(tab: ResponseTab) => {
+			setActiveTabState(tab);
+			if (requestId) setResponseTab(requestId, tab);
+		},
+		[requestId, setResponseTab]
+	);
+	/*
+	 * The `useState` initializer above only ever runs once, for whichever
+	 * request this pane first rendered for - a later request shown without a
+	 * remount (the tab-switch case above) needs this derived-during-render
+	 * sync instead, the same shape `RequestBuilderProvider`'s per-request
+	 * reset uses, so the previous request's tab never gets a frame to paint
+	 * under the new one.
+	 */
+	const [tabSyncedFor, setTabSyncedFor] = useState(requestId);
+	if (requestId !== tabSyncedFor) {
+		setTabSyncedFor(requestId);
+		setActiveTabState((requestId ? getResponseTab(requestId) : null) ?? "body");
+	}
+
 	const [savingExample, setSavingExample] = useState(false);
 
 	/*
@@ -72,7 +103,6 @@ export default function ResponseViewer() {
 	 * does it: one builder serves every request tab, and rows from a stream
 	 * started elsewhere must not appear under this one.
 	 */
-	const requestId = request.id ?? null;
 	const streamIsMine = useExecutionEventsStore(
 		(s) => !!s.requestId && !!requestId && s.requestId === requestId
 	);

--- a/app/src/modules/request-builder/components/ResponseViewer/tab-persistence.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/tab-persistence.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The response pane's active sub-tab, kept per request id in
+ * `tab-selection-store`.
+ *
+ * `Shell.tsx` mounts one workspace-tab's surface at a time, so switching away
+ * from a request tab and back used to reset this pane to Body every time -
+ * `activeTab` was a bare `useState` with no memory of which request it was
+ * showing. It also has to survive the case that never unmounts at all: two
+ * open request tabs are the same `ResponseViewer` instance (`RequestBuilder`
+ * is not remounted when the user switches between them), so a plain
+ * `useState` would carry request A's tab straight onto request B.
+ *
+ * Mutation check: drop the `setResponseTab` call from the wrapped
+ * `setActiveTab` (or the `getResponseTab` read from either the mount
+ * initializer or the `tabSyncedFor` sync) and the "survives" cases below fail
+ * red; restoring either makes them green again.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
+import type { ResponseState } from "../../types";
+import ResponseViewer from "./index";
+
+// Monaco does not run under jsdom - see tab-strand.test.tsx for the same stub.
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: ({ value }: { value?: string }) => <div data-testid="body-content">{value}</div>,
+}));
+
+const state: {
+	response: ResponseState | null;
+	isExecuting: boolean;
+	request: { id: string | null };
+} = {
+	response: null,
+	isExecuting: false,
+	request: { id: null },
+};
+vi.mock("../../context", () => ({
+	useRequestBuilderContext: () => state,
+}));
+
+function aResponse(): ResponseState {
+	return {
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "application/json" },
+		body: "the-response-body",
+		bodyType: "json",
+		size: 18,
+		time: 12,
+	};
+}
+
+function renderViewer() {
+	return render(
+		<TooltipProvider>
+			<ResponseViewer />
+		</TooltipProvider>
+	);
+}
+
+// Radix selects a trigger on `mousedown`/focus, not on a bare `click` - see
+// tab-strand.test.tsx.
+function selectTab(name: RegExp) {
+	const trigger = screen.getByRole("tab", { name });
+	trigger.focus();
+	fireEvent.mouseDown(trigger);
+}
+
+function activeTabName(): string | null {
+	const active = screen
+		.getAllByRole("tab")
+		.filter((t) => t.getAttribute("data-state") === "active");
+	expect(active.length, "exactly one tab must be selected").toBe(1);
+	return active[0]?.textContent?.trim() ?? null;
+}
+
+beforeEach(() => {
+	useTabSelectionStore.getState().clearAll();
+	state.response = aResponse();
+	state.isExecuting = false;
+	state.request = { id: null };
+});
+
+describe("the response pane's active tab, kept per request id", () => {
+	it("defaults to Body for a request seen for the first time", () => {
+		state.request.id = "req_a";
+		renderViewer();
+
+		expect(activeTabName()).toMatch(/body/i);
+	});
+
+	it("survives Shell unmounting and remounting the pane for the same request", () => {
+		state.request.id = "req_a";
+		const { unmount } = renderViewer();
+		selectTab(/headers/i);
+		expect(activeTabName()).toMatch(/headers/i);
+
+		unmount();
+
+		// A different request, mounted fresh - shows its own default, not A's.
+		state.request.id = "req_b";
+		const { unmount: unmountB } = renderViewer();
+		expect(activeTabName()).toMatch(/body/i);
+		unmountB();
+
+		// Back to A - its own selection is still there.
+		state.request.id = "req_a";
+		renderViewer();
+		expect(activeTabName()).toMatch(/headers/i);
+	});
+
+	it("also keeps each request's tab separate when moving between two open request tabs without a remount", () => {
+		// `RequestBuilder` is not remounted for a switch between two request
+		// tabs of the same type - this pane's `request.id` changes underneath
+		// the same component instance, which a mount-time initializer alone
+		// cannot answer for.
+		state.request.id = "req_a";
+		const { rerender } = renderViewer();
+		selectTab(/timing/i);
+		expect(activeTabName()).toMatch(/timing/i);
+
+		state.request.id = "req_b";
+		rerender(
+			<TooltipProvider>
+				<ResponseViewer />
+			</TooltipProvider>
+		);
+		expect(activeTabName()).toMatch(/body/i);
+
+		state.request.id = "req_a";
+		rerender(
+			<TooltipProvider>
+				<ResponseViewer />
+			</TooltipProvider>
+		);
+		expect(activeTabName()).toMatch(/timing/i);
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
@@ -26,6 +26,7 @@ import { useEffect } from "react";
 import RequestBuilderProvider from "./RequestBuilderProvider";
 import { useRequestBuilderContext } from "./RequestBuilderContext";
 import { useRevealStore, type OperationRevealCommand } from "@/lib/graphql/reveal-store";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
 import type { BodyMode, RequestState } from "../types";
 
 // The provider is wired to variable resolution, the save manager and several
@@ -86,6 +87,11 @@ const reveal = (command: OperationRevealCommand) =>
 beforeEach(() => {
 	seen.activeTab = "";
 	useRevealStore.setState({ pending: null });
+	// Cases below reuse the request id "r1" across mounts - the reveal's own
+	// `setActiveTab("body")` now persists per id in `tab-selection-store`, and
+	// an unmount does not clear it, so a fresh mount for the same id would
+	// otherwise open on the previous case's tab instead of its own default.
+	useTabSelectionStore.getState().clearAll();
 });
 
 describe("a reveal command for the request on screen", () => {

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tab-persistence.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tab-persistence.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's active sub-tab, kept per request id in
+ * `tab-selection-store`.
+ *
+ * `Shell.tsx` mounts one workspace-tab's surface at a time, so switching away
+ * from a request tab and back used to reset `RequestTabs` to Params every
+ * time - `activeTab` was a bare `useState` with no memory of which request it
+ * belonged to. The reset block that already restores the response and the
+ * request state per `initialRequest.id` change (issue #1436's per-field
+ * merge lives right beside it) is where the tab restoration was added, since
+ * switching between two open request tabs reuses this same provider instance
+ * rather than remounting it.
+ *
+ * Mocked down to the same seams `RequestBuilderProvider.name-sync.test.tsx`
+ * uses: none of variable resolution, the save manager or the query hooks has
+ * anything to do with which tab is selected.
+ *
+ * Mutation check: drop the `setActiveTabState` restore call from the reset
+ * block, or drop `setRequestTab` from the wrapped `setActiveTab`, and the
+ * "survives" case below fails red; restoring either makes it green again.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import RequestBuilderProvider from "./RequestBuilderProvider";
+import { useRequestBuilderContext } from "./RequestBuilderContext";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
+import type { RequestState } from "../types";
+
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		resolveObject: (o: unknown) => o,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
+	useVariableWriter: () => ({ updateVariable: vi.fn(), writableScopes: [] }),
+	useSaveManager: () => ({ forceSave: vi.fn(), status: "idle", isSaving: false }),
+}));
+
+vi.mock("@/queries", () => ({
+	useElementKindsQuery: () => ({ data: [] }),
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	useConfigQuery: () => ({ data: { entries: [] } }),
+}));
+
+/** Shows which sub-tab is active, and offers a way to change it. */
+function TabProbe() {
+	const { activeTab, setActiveTab } = useRequestBuilderContext();
+	return (
+		<>
+			<span data-testid="active-tab">{activeTab}</span>
+			<button onClick={() => setActiveTab("headers")}>go to headers</button>
+		</>
+	);
+}
+
+function Harness({ id }: { id: string }) {
+	const initialRequest: Partial<RequestState> = { id };
+	return (
+		<RequestBuilderProvider initialRequest={initialRequest} collectionId="col_1">
+			<TabProbe />
+		</RequestBuilderProvider>
+	);
+}
+
+const shownTab = () => screen.getByTestId("active-tab").textContent;
+const goToHeaders = () => act(() => screen.getByText("go to headers").click());
+
+beforeEach(() => {
+	useTabSelectionStore.getState().clearAll();
+});
+
+describe("the active request-builder tab, kept per request id", () => {
+	it("defaults to Params for a request seen for the first time", () => {
+		render(<Harness id="req_a" />);
+		expect(shownTab()).toBe("params");
+	});
+
+	it("survives Shell unmounting and remounting the builder for the same request", () => {
+		const { unmount } = render(<Harness id="req_a" />);
+		goToHeaders();
+		expect(shownTab()).toBe("headers");
+
+		unmount();
+
+		// A different request, mounted fresh - shows its own default, not A's.
+		const { unmount: unmountB } = render(<Harness id="req_b" />);
+		expect(shownTab()).toBe("params");
+		unmountB();
+
+		// Back to A - its own selection is still there.
+		render(<Harness id="req_a" />);
+		expect(shownTab()).toBe("headers");
+	});
+
+	it("also keeps each request's tab separate when moving between two open request tabs without a remount", () => {
+		// `Shell.tsx` reuses this provider instance across request tabs of the
+		// same type, so `initialRequest.id` changes under the same component -
+		// exactly what the render-time reset block (not just the mount
+		// initializer) has to answer for.
+		const { rerender } = render(<Harness id="req_a" />);
+		goToHeaders();
+		expect(shownTab()).toBe("headers");
+
+		rerender(<Harness id="req_b" />);
+		expect(shownTab()).toBe("params");
+
+		rerender(<Harness id="req_a" />);
+		expect(shownTab()).toBe("headers");
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -39,6 +39,7 @@ import {
 	useTabsStore,
 	type Tab,
 } from "@/stores";
+import { useTabSelectionStore } from "@/stores/tab-selection-store";
 import { useRevealStore, type OperationRevealCommand } from "@/lib/graphql/reveal-store";
 import { apiService } from "@/services";
 import { queryClient } from "@/lib/query-client";
@@ -274,7 +275,25 @@ export default function RequestBuilderProvider({
 	}, [restoredResponse, restoredForId, storeSetResponse]);
 
 	// UI state
-	const [activeTab, setActiveTab] = useState<RequestTab>("params");
+	/*
+	 * Kept per request id (`tab-selection-store`), so the active sub-tab
+	 * survives `Shell.tsx` unmounting this builder when its workspace tab is
+	 * not on screen. The reset block further down restores it again when
+	 * `initialRequest.id` changes without a remount - switching between two
+	 * open request tabs reuses this same provider instance rather than
+	 * remounting it.
+	 */
+	const { getRequestTab, setRequestTab } = useTabSelectionStore();
+	const [activeTab, setActiveTabState] = useState<RequestTab>(
+		() => (initialRequest?.id ? getRequestTab(initialRequest.id) : null) ?? "params"
+	);
+	const setActiveTab = useCallback(
+		(tab: RequestTab) => {
+			setActiveTabState(tab);
+			if (request.id) setRequestTab(request.id, tab);
+		},
+		[request.id, setRequestTab]
+	);
 
 	/*
 	 * The context bar's GraphQL outline scrolls the query editor, and the editor
@@ -306,7 +325,7 @@ export default function RequestBuilderProvider({
 		// was written for is dropped when this provider is handed the next one.
 		serve(useRevealStore.getState().pending);
 		return useRevealStore.subscribe((s) => serve(s.pending));
-	}, [requestId, bodyMode, clearReveal]);
+	}, [requestId, bodyMode, clearReveal, setActiveTab]);
 	const [isExecuting, setIsExecuting] = useState(false);
 	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
@@ -719,6 +738,12 @@ export default function RequestBuilderProvider({
 			 */
 			setLocalResponse(initialResponse ?? null);
 		}
+
+		// Restore or default the active tab for whatever request is now on
+		// screen - the same per-request lookup the mount-time initializer
+		// above uses, needed again here because switching between two open
+		// request tabs reuses this provider instance rather than remounting it.
+		setActiveTabState(requestId ? (getRequestTab(requestId) ?? "params") : "params");
 	} else if (initialRequest && lastReset.collectionId !== collectionId) {
 		/*
 		 * The same request, moved to a different collection underneath us
@@ -1216,6 +1241,7 @@ export default function RequestBuilderProvider({
 			legacyPreScript,
 			legacyPostScript,
 			activeTab,
+			setActiveTab,
 			isExecuting,
 			isStreaming,
 			stopStream,

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -70,6 +70,10 @@ export interface TabInfo {
 	badge?: number;
 }
 
+/** The response pane's own tab strip - see `ResponseViewer`. */
+export type ResponseTab =
+	"body" | "headers" | "cookies" | "timing" | "console" | "tests" | "events" | "raw-request";
+
 // ============================================================================
 // Auth Types
 // ============================================================================

--- a/app/src/stores/index.ts
+++ b/app/src/stores/index.ts
@@ -20,6 +20,7 @@ export { useSpecFileStore, type SpecFileLocation } from "./spec-file-store";
 export { useSaveStore, type SaveStatus } from "./save-store";
 export { useCollectionAuthDraftStore, useCollectionAuthDraft } from "./collection-auth-draft-store";
 export { useResponseStore, type StoredResponse } from "./response-store";
+export { useTabSelectionStore } from "./tab-selection-store";
 export {
 	useTabsStore,
 	canGoBack,

--- a/app/src/stores/tab-selection-store.test.ts
+++ b/app/src/stores/tab-selection-store.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Three independent maps, one store, one `clearEntity`/`clearAll` pair.
+ *
+ * Mutation check: drop the `.set` line in any of `setRequestTab` /
+ * `setResponseTab` / `setCollectionTab` and its own "gets back what it set"
+ * case fails; drop one map's `.delete` from `clearEntity` and "drops all
+ * three" fails for that map alone, showing the other two were never at risk;
+ * drop the early-return guard in `clearEntity` and "an absent id changes
+ * nothing" fails, because every map would get a new reference for a delete
+ * that changed no key.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTabSelectionStore } from "./tab-selection-store";
+
+beforeEach(() => {
+	useTabSelectionStore.getState().clearAll();
+});
+
+describe("each map is independent", () => {
+	it("gets back what it set, per map", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setResponseTab("r1", "timing");
+		useTabSelectionStore.getState().setCollectionTab("c1", "elements");
+
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBe("headers");
+		expect(useTabSelectionStore.getState().getResponseTab("r1")).toBe("timing");
+		expect(useTabSelectionStore.getState().getCollectionTab("c1")).toBe("elements");
+	});
+
+	it("returns null for an id nothing has set", () => {
+		expect(useTabSelectionStore.getState().getRequestTab("never-set")).toBeNull();
+		expect(useTabSelectionStore.getState().getResponseTab("never-set")).toBeNull();
+		expect(useTabSelectionStore.getState().getCollectionTab("never-set")).toBeNull();
+	});
+
+	it("a write to one map never appears in the other two, even under the same id", () => {
+		useTabSelectionStore.getState().setRequestTab("shared-id", "auth");
+
+		expect(useTabSelectionStore.getState().getResponseTab("shared-id")).toBeNull();
+		expect(useTabSelectionStore.getState().getCollectionTab("shared-id")).toBeNull();
+	});
+
+	it("a later set for the same id replaces the earlier one", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setRequestTab("r1", "body");
+
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBe("body");
+	});
+});
+
+describe("clearEntity", () => {
+	it("drops the id from all three maps", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setResponseTab("r1", "timing");
+		useTabSelectionStore.getState().setCollectionTab("r1", "elements");
+
+		useTabSelectionStore.getState().clearEntity("r1");
+
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBeNull();
+		expect(useTabSelectionStore.getState().getResponseTab("r1")).toBeNull();
+		expect(useTabSelectionStore.getState().getCollectionTab("r1")).toBeNull();
+	});
+
+	it("leaves every other id untouched", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setRequestTab("r2", "auth");
+
+		useTabSelectionStore.getState().clearEntity("r1");
+
+		expect(useTabSelectionStore.getState().getRequestTab("r2")).toBe("auth");
+	});
+
+	it("an absent id changes nothing", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		const before = useTabSelectionStore.getState();
+
+		useTabSelectionStore.getState().clearEntity("never-set");
+
+		const after = useTabSelectionStore.getState();
+		// The same map references, not merely equal ones - a delete that hit
+		// nothing must not hand every subscriber a reason to re-render.
+		expect(after.requestTab).toBe(before.requestTab);
+		expect(after.responseTab).toBe(before.responseTab);
+		expect(after.collectionTab).toBe(before.collectionTab);
+	});
+});
+
+describe("clearAll", () => {
+	it("empties all three maps", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setResponseTab("r1", "timing");
+		useTabSelectionStore.getState().setCollectionTab("c1", "elements");
+
+		useTabSelectionStore.getState().clearAll();
+
+		expect(useTabSelectionStore.getState().requestTab.size).toBe(0);
+		expect(useTabSelectionStore.getState().responseTab.size).toBe(0);
+		expect(useTabSelectionStore.getState().collectionTab.size).toBe(0);
+	});
+});

--- a/app/src/stores/tab-selection-store.ts
+++ b/app/src/stores/tab-selection-store.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Tab Selection Store
+ *
+ * Remembers each surface's active sub-tab per entity id, so it survives:
+ * - `Shell.tsx` unmounting the whole surface when its workspace tab is not
+ *   the one on screen (one tab's surface is mounted at a time)
+ * - Switching between two open request/collection tabs of the same type,
+ *   which reuses the component instance rather than remounting it, exactly
+ *   as `response-store.ts` does for response data
+ *
+ * In memory only, like `response-store.ts` - a sub-tab pick is not worth
+ * persisting to disk. Unlike that store, this one carries no LRU cap: an
+ * entry here is one enum value rather than a response body, so even a long
+ * session's worth of distinct entities costs nothing worth bounding. Entries
+ * are dropped only when their entity is (`clearEntity`, wired at the same
+ * delete seams `response-store` uses).
+ */
+
+import { create } from "zustand";
+import type { RequestTab, ResponseTab } from "@/modules/request-builder/types";
+import type { CollectionTab } from "@/modules/collections/CollectionDetail";
+
+interface TabSelectionState {
+	requestTab: Map<string, RequestTab>;
+	responseTab: Map<string, ResponseTab>;
+	collectionTab: Map<string, CollectionTab>;
+
+	getRequestTab: (id: string) => RequestTab | null;
+	setRequestTab: (id: string, tab: RequestTab) => void;
+	getResponseTab: (id: string) => ResponseTab | null;
+	setResponseTab: (id: string, tab: ResponseTab) => void;
+	getCollectionTab: (id: string) => CollectionTab | null;
+	setCollectionTab: (id: string, tab: CollectionTab) => void;
+
+	/** Drops `id` from all three maps - a deleted request or collection. */
+	clearEntity: (id: string) => void;
+	clearAll: () => void;
+}
+
+export const useTabSelectionStore = create<TabSelectionState>((set, get) => ({
+	requestTab: new Map(),
+	responseTab: new Map(),
+	collectionTab: new Map(),
+
+	getRequestTab: (id) => get().requestTab.get(id) ?? null,
+	setRequestTab: (id, tab) => {
+		const requestTab = new Map(get().requestTab);
+		requestTab.set(id, tab);
+		set({ requestTab });
+	},
+
+	getResponseTab: (id) => get().responseTab.get(id) ?? null,
+	setResponseTab: (id, tab) => {
+		const responseTab = new Map(get().responseTab);
+		responseTab.set(id, tab);
+		set({ responseTab });
+	},
+
+	getCollectionTab: (id) => get().collectionTab.get(id) ?? null,
+	setCollectionTab: (id, tab) => {
+		const collectionTab = new Map(get().collectionTab);
+		collectionTab.set(id, tab);
+		set({ collectionTab });
+	},
+
+	clearEntity: (id) => {
+		const { requestTab, responseTab, collectionTab } = get();
+		if (!requestTab.has(id) && !responseTab.has(id) && !collectionTab.has(id)) return;
+		const nextRequestTab = new Map(requestTab);
+		nextRequestTab.delete(id);
+		const nextResponseTab = new Map(responseTab);
+		nextResponseTab.delete(id);
+		const nextCollectionTab = new Map(collectionTab);
+		nextCollectionTab.delete(id);
+		set({
+			requestTab: nextRequestTab,
+			responseTab: nextResponseTab,
+			collectionTab: nextCollectionTab,
+		});
+	},
+
+	clearAll: () => {
+		set({ requestTab: new Map(), responseTab: new Map(), collectionTab: new Map() });
+	},
+}));

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useTabsStore } from "./tabs-store";
 import { useSaveStore, type SaveContext } from "./save-store";
 import { useResponseStore } from "./response-store";
+import { useTabSelectionStore } from "./tab-selection-store";
 import { useEngineStore } from "./engine-store";
 import { useToastStore } from "./toast-store";
 
@@ -375,6 +376,60 @@ describe("closeTabsForEntities evicts stored responses", () => {
 		storeResponse("r1");
 		useTabsStore.getState().closeTabsForEntities([]);
 		expect(useResponseStore.getState().getResponse("r1")).not.toBeNull();
+	});
+});
+
+/**
+ * A deleted entity's remembered sub-tab goes with it too - the same seam as
+ * the response cache above, mirrored for `tab-selection-store`. Unlike the
+ * response clear, this one is not gated on `type`: a collection id keys
+ * `collectionTab` the same way a request id keys `requestTab`/`responseTab`,
+ * so a collection cascade has to evict here as well as a single request.
+ */
+describe("closeTabsForEntities evicts the remembered sub-tab", () => {
+	beforeEach(() => useTabSelectionStore.getState().clearAll());
+
+	it("drops a deleted request's remembered request-pane and response-pane tabs", () => {
+		useTabsStore.getState().openTab({ type: "request", entityId: "r1" });
+		useTabSelectionStore.getState().setRequestTab("r1", "headers");
+		useTabSelectionStore.getState().setResponseTab("r1", "timing");
+
+		useTabsStore.getState().closeTabsForEntities(["r1"]);
+
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBeNull();
+		expect(useTabSelectionStore.getState().getResponseTab("r1")).toBeNull();
+	});
+
+	it("drops a deleted collection's remembered tab in a cascade", () => {
+		useTabSelectionStore.getState().setCollectionTab("col_1", "elements");
+		useTabSelectionStore.getState().setRequestTab("r1", "body");
+
+		useTabsStore.getState().closeTabsForEntities(["col_1", "r1"]);
+
+		expect(useTabSelectionStore.getState().getCollectionTab("col_1")).toBeNull();
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBeNull();
+	});
+
+	it("drops the entry even when no tab was open on the entity", () => {
+		useTabSelectionStore.getState().setRequestTab("r_no_tab", "auth");
+
+		useTabsStore.getState().closeTabsForEntities(["r_no_tab"]);
+
+		expect(useTabSelectionStore.getState().getRequestTab("r_no_tab")).toBeNull();
+	});
+
+	it("still evicts for a run-scoped sweep, unlike the response clear", () => {
+		useTabSelectionStore.getState().setCollectionTab("col_1", "data");
+
+		useTabsStore.getState().closeTabsForEntities(["col_1"], "run");
+
+		expect(useTabSelectionStore.getState().getCollectionTab("col_1")).toBeNull();
+	});
+
+	it("leaves everything alone when handed nothing", () => {
+		useTabSelectionStore.getState().setRequestTab("r1", "elements");
+		useTabsStore.getState().closeTabsForEntities([]);
+		expect(useTabSelectionStore.getState().getRequestTab("r1")).toBe("elements");
 	});
 });
 

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -10,6 +10,7 @@ import { persist } from "zustand/middleware";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 import { useSaveStore, type SaveContext } from "./save-store";
 import { useResponseStore } from "./response-store";
+import { useTabSelectionStore } from "./tab-selection-store";
 import { useEngineStore } from "./engine-store";
 import { useToastStore } from "./toast-store";
 
@@ -694,6 +695,14 @@ export const useTabsStore = create<TabsState>()(
 					const { clearResponse } = useResponseStore.getState();
 					for (const id of ids) clearResponse(id);
 				}
+
+				// A deleted request or collection's remembered sub-tab goes with it
+				// too - unlike the response above, this runs for every `type`: a
+				// collection id keys `collectionTab` the same way a request id keys
+				// `requestTab`/`responseTab`, and `clearEntity` is a harmless no-op
+				// for whichever of the three maps never held the id.
+				const { clearEntity } = useTabSelectionStore.getState();
+				for (const id of ids) clearEntity(id);
 
 				const { openTabs, activeTabId, navHistory, navIndex } = get();
 				const shouldClose = (t: TabLocation) =>

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -794,6 +794,53 @@ against the backend's stored run, whose body the engine truncated at
 
 **Non-persisted** (responses are reloadable from backend).
 
+#### `tab-selection-store.ts` - Active Sub-Tab Per Entity
+
+Three independent maps remembering which sub-tab is showing, per entity id:
+the request builder's tab, the response pane's tab, and the collection
+screen's tab.
+
+**State:**
+```typescript
+{
+  requestTab: Map<string, RequestTab>       // keyed by request id
+  responseTab: Map<string, ResponseTab>     // keyed by request id
+  collectionTab: Map<string, CollectionTab> // keyed by collection id
+}
+```
+
+**Key Methods:**
+```typescript
+const { getRequestTab, setRequestTab } = useTabSelectionStore();
+const { getResponseTab, setResponseTab } = useTabSelectionStore();
+const { getCollectionTab, setCollectionTab } = useTabSelectionStore();
+useTabSelectionStore.getState().clearEntity(id); // drops id from all three maps
+useTabSelectionStore.getState().clearAll();
+```
+
+**Why a store at all.** `Shell.tsx` mounts one workspace tab's surface at a
+time, so `RequestBuilderProvider`, `ResponseViewer` and `CollectionDetail` all
+unmount whenever the user looks at a different tab and remount when they come
+back - and each held its active sub-tab in a bare `useState`, which is gone
+the moment the component is. The same three components also serve *every*
+open tab of their own type without remounting (`RequestBuilder` is not
+recreated per request tab, nor `CollectionDetail` per collection tab), so a
+tab-id change reaching the same component instance needed the same lookup a
+mount-time initializer already had to do - both call sites read and write
+through this store rather than through two different mechanisms.
+
+**In memory only, like `response-store.ts` above**, and for the same reason: a
+sub-tab pick is not worth persisting across a relaunch. Unlike that store,
+this one carries no LRU cap - an entry is one enum value rather than a
+response body, so bounding it buys nothing.
+
+**Eviction by identity:** `clearEntity` runs from `tabs-store`'s
+`closeTabsForEntities`, unconditionally rather than gated on `type` the way
+the response clear is - a collection id keys `collectionTab` exactly as a
+request id keys `requestTab` / `responseTab`, so a collection cascade has to
+evict here too, and `clearEntity` is a harmless no-op for whichever of the
+three maps never held a given id.
+
 #### `appearance-store.ts` - Pre-Paint Interface Preferences
 
 The UI font, the interface scale and the corner roundedness - the three


### PR DESCRIPTION
## Description

Two independent, small UI fixes bundled on one branch:

1. The environment switcher in the title bar could only list and switch
   existing environments. It now has "New Environment" and "Import
   Environment..." actions, wired to capabilities that already existed
   elsewhere in the app (the Variables sidebar's create flow, and the
   global import dialog, which already parses Postman environment/globals
   exports) — no new dialogs or parsing logic.
2. The request builder, response viewer, and collection detail screens all
   reset their active sub-tab back to a hardcoded default any time the user
   switched away and back, because `Shell.tsx` unmounts a workspace tab's
   whole component tree when it isn't the active one. Added a
   `tab-selection-store` (`Map<entityId, tab>`, one per surface), mirroring
   the pattern `response-store.ts` already uses to survive the same
   unmount, and wired into the existing `closeTabsForEntities` cleanup so a
   deleted request/collection doesn't leave a stale entry behind.

Not part of this change: `.vscode/settings.json` was touched on this branch
outside this PR's scope — worth pulling into its own commit/PR rather than
riding along here.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `pnpm test` — full suite, 750/751 files and 8560/8563 tests passing (2
  pre-existing skips). The one failure (`repo-js-lint-routing.test.ts`) is a
  5s-timeout flake unrelated to this diff — reruns clean in isolation in
  146ms.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` — all clean.
- New component-level tests (not just store tests) for each of the three
  tab-persistence surfaces: mount for entity A, change tab, unmount/remount
  as a different entity B, remount as A again, assert A's selection
  survived. Mutation-checked (temporarily no-op'd the read/write, confirmed
  red, restored, confirmed green) for both features.
- Not run: manual click-through in the packaged Electron app.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/app/state-management.md`)

## Related Issues
Closes #
