### PR TITLE
build(app): take the Electron 44.2.0 patch line

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -77,7 +77,7 @@
 		"cmdk": "^1.1.1",
 		"concurrently": "^10.0.5",
 		"cross-env": "^10.1.0",
-		"electron": "^44.1.1",
+		"electron": "^44.2.0",
 		"electron-builder": "^26.15.3",
 		"eslint": "^10.9.1",
 		"eslint-config-prettier": "^10.1.8",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       electron:
-        specifier: ^44.1.1
-        version: 44.1.1
+        specifier: ^44.2.0
+        version: 44.2.0
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -2207,8 +2207,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@44.1.1:
-    resolution: {integrity: sha512-N2WCq2sbOkqQgvXJYx2lS6UiO8bF+Yr67trDnS6JKa2WxTCRQsAjGl57SUtdW9h6r5PlduBFjIhxhgd3dzv1hg==}
+  electron@44.2.0:
+    resolution: {integrity: sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6574,7 +6574,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@44.1.1:
+  electron@44.2.0:
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0


### PR DESCRIPTION
## Description

Bumps `electron` from `44.1.1` to `44.2.0`, the newest Electron 44 release `app/pnpm-workspace.yaml`'s `minimumReleaseAge` (10080 min / 7 days) currently admits. 44.2.0 published 2026-09-04T03:15Z and matured at 2026-09-11T03:15Z; 44.3.0 (published 2026-09-08) is still inside the window and stays excluded. No entry was added to `minimumReleaseAgeExclude`.

`pnpm add -D electron@44.2.0` from `app/` touched only Electron's own tree in the lockfile (`app/package.json` and `app/pnpm-lock.yaml`, 6 insertions / 6 deletions).

44.2.0 is a fix-only patch release (net.request chunked-upload stalls in protocol handlers, a `menu.popup` crash with offscreen-rendered frames, a Windows ASAR-integrity access violation, a crash after many IPC messages, a `node::ObjectWrap` GC abort on Node 24.19+) plus Chromium 152.0.7977.76 and Node 24.20.0. None of the app-reachable ones apply: Vayu does no offscreen rendering, doesn't enable ASAR integrity validation, and loads no native addons - so no app code changes are needed here.

This follows the same pattern as #1561 (the 44.0.0 -> 44.1.0 bump): the release-notes line naming the shipping Electron/Node version is deferred to whatever notes file covers the next release, since `.github/release-notes/v0.28.0.md` is already tagged (`v0.28.0`) and no stub for the following release exists yet to receive it.

## Type of Change

- [x] Bug fix (crash fixes carried by the patch release, applied transitively)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

From `app/`, all green:
- `pnpm type-check` - renderer, electron, and electron-test tsconfigs all pass
- `pnpm lint` - zero errors, zero warnings
- `pnpm format:check` - clean
- `pnpm test` - 758 test files, 8610 tests passed, 2 skipped

No engine build was needed - this is an app-only dependency change with no engine-side surface.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, no app code changed
- [ ] I have updated documentation - not applicable this PR; see the release-notes note above

## Related Issues

Not tied to an open issue - #1377 (the original age-floor-clearing bump) was already closed by #1561. This is a follow-up patch bump once 44.2.0 itself cleared the floor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZjGrYH3PEp94n8EE5ky2r)_