### PR TITLE
fix(engine): widen ElementsTimersOffSilencesThroughputUnderLoad's window to 8s

### DIFF
--- a/engine/tests/elements_timers_test.cpp
+++ b/engine/tests/elements_timers_test.cpp
@@ -1026,11 +1026,21 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesPacingUnderLoad) {
 // clear of the unpaced one. Mutation check: reverting the `shared.timers_override`
 // guard reds this on the floor alone - a paced run measures 18, an unpaced
 // one 39-40, and 30 sits between them with margin on both sides.
+//
+// The window is 8s rather than the 4s the numbers above describe: on the
+// TSan/macOS CI leg the instrumentation overhead alone ate nearly all of
+// that margin (one run measured 29 unpaced, under the 30 floor). Both sides
+// scale with wall-clock time - paced linearly with the shared rate (2/s;
+// 2*8 + 10 unpaced-first-pass = 26, still under 30), unpaced roughly
+// linearly with whatever the box can sustain - so doubling the window
+// roughly doubles the unpaced count while the paced count stays well clear
+// of the floor, restoring the separation a slow sanitizer build had
+// squeezed out.
 TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
     auto execution =
     plan_with ({ vayu::tests::timer_throughput_element_json ("el_rate", 120.0) });
 
-    auto config        = load_config ("4s");
+    auto config        = load_config ("8s");
     config["elements"] = json{ { "timers", "off" } };
 
     auto state = run (config, execution);
@@ -1040,7 +1050,7 @@ TEST_F (ElementsTimersLoadTest, ElementsTimersOffSilencesThroughputUnderLoad) {
     EXPECT_GT (executed, 30u)
     << "elements.timers: \"off\" did not silence timer.throughput's shared "
        "budget under load - got "
-    << executed << " requests over 4s, still in the paced range";
+    << executed << " requests over 8s, still in the paced range";
 }
 
 // Issue #1620: `"off"` reached `scheduled_ready_delay_ms` (the reopen fix


### PR DESCRIPTION
## Description
`ElementsTimersLoadTest.ElementsTimersOffSilencesThroughputUnderLoad` flaked on the Sanitizers (TSan/macOS) leg: `EXPECT_GT(executed, 30u)` measured 29. The test's own comment documents the mechanism - in this sandbox's Debug build, an unpaced 10-VU run against a loopback mock measures 39-40 requests over a 4s window versus 18 for the paced case, with 30 chosen as the dividing line between them. TSan's instrumentation overhead cut into that margin enough to drop the unpaced count below the floor.

Widened the run window from 4s to 8s. Both sides scale with wall-clock time but differently: the paced count is rate-bound (120/minute shared = 2/s, so `2*8 + 10 unpaced-first-pass = 26`, still comfortably under 30), while the unpaced count scales with whatever the box can sustain - so a slower (TSan-instrumented) box still gets proportionally more absolute headroom above the floor than it did in 4s. This is the same technique the sibling test `PerUserThroughputGivesEveryVirtualUserItsOwnRate` already uses (6s) for the same reason.

No ThreadSanitizer race was reported in that CI run - this is a timing-margin flake in the test's own threshold, not a concurrency bug in `timer.throughput`'s "off" path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Built the engine with tests (`python build.py -e -t`, Debug/linux-dev preset) and ran the specific test three times directly (`./vayu_tests --gtest_filter=ElementsTimersLoadTest.ElementsTimersOffSilencesThroughputUnderLoad`) - all three passed (~10.2s each, matching the new 8s window). The full `build.py -e -t` test run also completed green. No other test or source file changed, so nothing else needed re-running.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, this widens an existing test's window rather than adding coverage
- [ ] I have updated documentation - not applicable, no documented behavior changed

## Related Issues
Fixes the flaky TSan/macOS run at https://github.com/athrvk/vayu/actions/runs/34572170674/job/103176508734


---
_Generated by [Claude Code](https://claude.ai/code/session_01APavVyJxFafrmdsndJYy57)_