### PR TITLE
docs: post-0.28.0 micro batch - mock polling, cross-links, fixed-mode fallback, em-dash, list_runs

### DIFF
--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -4240,7 +4240,7 @@ export const TOOLS: McpTool[] = [
 		invalidates: [],
 		description:
 			"List past runs (single Design-mode requests, collection runs and load tests), " +
-			`newest first - the only order the engine lists in. Returns a {data, pagination} envelope of at most ${DEFAULT_RUN_PAGE_LIMIT} runs by default (${MAX_ENGINE_PAGE_LIMIT} max); each row carries a compact summary (url/method/mode/duration/concurrency/comment), not the full config snapshot. ` +
+			`newest first - the only order the engine lists in. Returns a {data, pagination} envelope of at most ${DEFAULT_RUN_PAGE_LIMIT} runs by default (${MAX_ENGINE_PAGE_LIMIT} max); each row carries a compact summary (requestName/url/method/mode/duration/concurrency/comment), not the full config snapshot. ` +
 			"Filter to find a specific run instead of paging blocks of history: by saved request, by collection (collection runs only - a design or load run stores none), by type, by status, by text over the stored config, or to pinned baselines only. " +
 			"`pagination.total` and `hasMore` describe the filtered set, so a filtered page says how much more of that filter there is.",
 		annotations: {

--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -217,7 +217,7 @@ export default function RunItem({
 		run.summary?.comment && `"${run.summary.comment}"`,
 	]
 		.filter(Boolean)
-		.join(" — ");
+		.join(" - ");
 
 	// A bare fallback identity for the rare row with neither a url nor a
 	// scenario descriptor (a run recorded before either existed, or one still

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -402,7 +402,8 @@ Spec tab counts it.
 `MockServerControl.tsx` is the header's right-hand control and the only surface that can **start** a
 mock server (issue #481 phase 2), because it is the only one holding a collection. With none running
 for this collection it is a **Run mock server** button; with one running it is a chip carrying the
-base URL, the route count and how many of those routes have no example, plus copy and stop. It picks
+base URL, the route count and how many of those routes have no example, plus copy, an **Open mock
+server** link to the `mock-server` tab and stop. It picks
 its mock by `collectionId` and, when several match, by the **lowest port** - nothing stops a user
 starting two mocks of one collection, and the engine's list order is not stable across polls. There
 is deliberately no restart: a mock's route table is a start-time snapshot, so stop-and-start is the
@@ -955,14 +956,16 @@ table was the only thing there was to see. Once a mock also keeps a live `GET /m
 log, it needs a surface that can grow while it is watched.
 
 - `index.tsx` (`MockServerView`, screen `"mock-server"`) - the mock's base URL with a copy control,
-  the collection it serves, a stop button, and (with more than one mock running) a `Select`
-  switcher ordered by port, the same reasoning `InboxView`'s switcher follows: the engine lists
-  mocks in map order, which is not stable across polls, and a switcher whose entries move under the
-  pointer is worse than none. Below the header, two sections: **Routes**, the same start-time
-  snapshot the drawer row used to show inline (`GET /mock/:id/routes`, now carrying `mode`,
-  `exampleName` and `hits` per route from Task 8's Examples-tab mode selection) - fetched once and
-  never polled, since it cannot change under a running mock - and **Activity**, the live feed of
-  what the mock has actually served, polled like the mock list itself.
+  the collection it serves, a stop button, an **Open collection** link back to it, and (with more
+  than one mock running) a `Select` switcher ordered by port, the same reasoning `InboxView`'s
+  switcher follows: the engine lists mocks in map order, which is not stable across polls, and a
+  switcher whose entries move under the pointer is worse than none. Below the header, two sections:
+  **Routes**, the same start-time snapshot the drawer row used to show inline (`GET
+  /mock/:id/routes`, now carrying `mode`, `exampleName` and `hits` per route from Task 8's
+  Examples-tab mode selection) - and **Activity**, the live feed of what the mock has actually
+  served. Both poll at `TIMING.MOCK_ACTIVITY_POLL_INTERVAL_MS`: the route table's *shape* is a
+  start-time snapshot, but each route's `hits` moves live as traffic arrives, so it joined the fast
+  interval alongside Activity rather than the mock list's slower one.
 - **One tab, not one per mock**, and **the tab's own `entityId` is the address**, exactly as the
   inbox tab: a mock is engine-process state with no id worth restoring across a restart, and the
   address is read from the tab rather than mirrored into local state - the drawer row and this
@@ -971,13 +974,14 @@ log, it needs a surface that can grow while it is watched.
   mock stopped elsewhere) falls back to the lowest-numbered port, the same fallback `InboxView`
   uses.
 - **Entry point:** the **Services** drawer's mock-servers group, whose row opens this tab addressed
-  at the mock it names rather than expanding in place (`ServicesPanel.tsx`'s `MockServerRow`) -
-  see [Services](#services-modulesservices).
+  at the mock it names rather than expanding in place (`ServicesPanel.tsx`'s `MockServerRow`, which
+  carries its own **Open mock server** action) - see [Services](#services-modulesservices).
 
-**Data:** `queries/mock-server.ts`. The mock list and the activity log are polled at
-`TIMING.SERVICES_POLL_INTERVAL_MS`, for the same reason the inbox and issuer lists are: an MCP tool
-or a bare curl can start, stop or drive traffic at a mock this window did not touch. The route
-table is not polled - see above.
+**Data:** `queries/mock-server.ts`. The mock list is polled at `TIMING.SERVICES_POLL_INTERVAL_MS`,
+for the same reason the inbox and issuer lists are: an MCP tool or a bare curl can start or stop a
+mock this window did not touch. The route table and the activity log are polled at the faster
+`TIMING.MOCK_ACTIVITY_POLL_INTERVAL_MS` instead, since traffic - and so `hits` - can change between
+`SERVICES_POLL_INTERVAL_MS` ticks - see above.
 
 ## Welcome (`modules/welcome/`)
 

--- a/docs/engine/elements.md
+++ b/docs/engine/elements.md
@@ -496,4 +496,4 @@ only `extract.*`, `assert.*`, `timer.think` and `script.pre`/`script.post`
 - #1501 - load-time cookies that round out the kind table.
 - #1516 - the app's `ElementList` primitive and editor.
 - #1517 - MCP's `elements` fields and the `vayu://elements/kinds` resource.
-- #1518 - Postman/OpenAPI round-trip and a JMeter `.jmx` importer.
+- #1518 - OpenAPI round-trip (`x-vayu-elements`), Postman import, and a JMeter `.jmx` importer.

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -535,7 +535,10 @@ Notes:
   names no `mockExampleId`, exactly like the bodyType-without-body refusal
   above, and the change only takes effect the next time `start_mock_server`
   runs - a running mock's route table is a snapshot, not a live view of the
-  request.
+  request. A `mockExampleId` that later stops resolving (the example was
+  deleted or suppressed after the write) is not refused retroactively; the
+  mock server falls back to `"first"` at serve time, same as a `fixed` mode
+  pointed at an example that never existed.
 - **A skipped certificate check has to leave a record** (issue #795). The
   *stored* `verifySSL: false` is writable over MCP; a *per-call* one is not.
   `run_request` declares `verifySSL` only so that `false` is refused by name -


### PR DESCRIPTION
## Description

Five small items left by the 0.28.0 push (#1651), each a doc that stopped matching the code or one line of text; none changes behaviour.

- `docs/app/COMPONENTS.md` said the mock route table was "fetched once and never polled" and that the mock list and activity log shared `SERVICES_POLL_INTERVAL_MS`. Neither is true since `3a071ef3`/`2edab600`: the route table and the activity log both poll at `MOCK_ACTIVITY_POLL_INTERVAL_MS` (confirmed against `queries/mock-server.ts`), and only the mock list stays on `SERVICES_POLL_INTERVAL_MS`. Reworded to say which query is on which interval and why the route table joined the fast one. Also added the **Open mock server** / **Open collection** cross-link buttons (`3f4a95de`) that the doc never mentioned.
- `docs/engine/mcp.md`'s `update_request` notes described the write-time refusal for a `fixed` mode with no `mockExampleId`, but not what happens when a previously valid target is later deleted - added one sentence stating the runtime fallback to `"first"` (matching `pick_example` in `mock_server.cpp`, and the sentence `docs/engine/api-reference.md` already carries for the same case, so no change needed there).
- `RunItem.tsx`'s history-row hover title used `" — "` instead of the repo's `" - "` convention (the only em-dash introduced in the range verified with `git diff 371d852..bce6744`).
- `docs/engine/elements.md`'s `#1518` entry said "Postman/OpenAPI round-trip"; the actual product decision on #1518 is OpenAPI export only, Postman import-only (per `docs/compare/vayu-vs-postman.md`).
- `list_runs`'s MCP tool description enumerated the run summary fields without `requestName`, added to the summary row by `6706c472`.

## Type of Change
- [x] Documentation update
- [x] Bug fix (em-dash is user-visible text, not a comment)

## Testing
- `mkdocs build --strict -f .github/mkdocs.yml` - clean
- `cd app && pnpm format:check` - clean
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (0 warnings)
- `cd app && pnpm test RunItem` - 35 passed
- `cd app && pnpm test tools.test` - 465 passed
- `rg -n '—' app/src --glob '!*.test.*'` - no matches

No new test was added for the em-dash fix: no existing `RunItem` test renders the hover title, so per the issue there was none to update.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - doc/text-only change, no behaviour to cover
- [x] I have updated documentation

## Related Issues
Closes #1651

---
_Generated by [Claude Code](https://claude.ai/code/session_0156Cm6QDttHqKjG5R61jqdJ)_