### PR TITLE
fix(engine): carry mockResponseMode/mockExampleId through OpenAPI export

### DIFF
--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -1506,6 +1506,10 @@ const SKIPPED_LABELS: Partial<Record<string, [singular: string, plural: string]>
 		"element that failed validation and was not imported",
 		"elements that failed validation and were not imported",
 	],
+	mock_example_missing: [
+		"request whose fixed mock example is no longer in the document, so it mocks the first example instead",
+		"requests whose fixed mock example is no longer in the document, so they mock the first example instead",
+	],
 };
 
 function skippedLabel(kind: SkippedItem["kind"], count: number): string {

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -199,6 +199,15 @@ export interface SkippedItem {
 		 */
 		| "elements_invalid"
 		/**
+		 * A request's `x-vayu-mock` named a `"fixed"` target - an `examples` map
+		 * key - that this operation's response no longer declares (issue #1649):
+		 * hand-edited out, or the entry the exporter suffixed is gone. Dropped the
+		 * way `elements_invalid` is: the request keeps no `mockResponseMode` at
+		 * all, which is `pick_example`'s own "first" default at runtime, rather
+		 * than naming a target that is not there.
+		 */
+		| "mock_example_missing"
+		/**
 		 * A `.jmx` test plan's own class name, for one this parser has no mapping
 		 * for at all (issue #1518) - JMeter's own class list is open-ended (every
 		 * third-party plugin adds more), so this is not a closed set the way every

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -572,6 +572,9 @@ included - are not one of the eight: they carry through under `x-vayu-elements`,
 a vendor extension key beside `x-vayu-enabled` (issue #1518), rather than
 being dropped. A bound export writes it too, onto an operation the document
 already declares; nothing is written into a Swagger 2.0 document either way.
+A request's mock response mode is the same story under its own key,
+`x-vayu-mock` (issue #1649): a `fixed` or `random` choice carries through
+instead of every mock route reverting to `first` on re-import.
 
 A large document takes a moment to put together, and the dialog says so without
 moving anything: on the first read it holds the summary's shape until the

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2529,6 +2529,28 @@ compares a stored request against, deliberately excludes scripts and auth so a
 re-sync never silently overwrites what a user edited locally, and an element
 can carry a script.
 
+**`x-vayu-mock`** carries a request's `mockResponseMode` (issue #1649) the same
+way `x-vayu-elements` carries its `elements` - written only when the mode is
+not `"first"`, the default every unconfigured request already has, so an
+operation with no mock opinion gains no key at all. `{"mode": "random"}` needs
+no target; `{"mode": "fixed", "example": "<key>"}` names the `examples` map
+key (or the doubled key a name collision suffixed, `add_named_examples`'s
+usual rule) the chosen example was written under, resolved by value rather
+than assumed - a target this export could not itself write (a truncated body,
+no recorded media type, a response the document does not declare) is the same
+"nothing to name" case as the mode staying `"first"`, and gets no key either.
+Gated on `dialect.writable` exactly like `x-vayu-elements`: nothing is written
+into a Swagger 2.0 document's operations at all. The importer reads it back
+next to `x-vayu-elements`, matching `example` against the imported example
+that carries the same OpenAPI `examples` map key (the engine-side-only
+`specExampleKey` provenance field, issue #1457) and setting
+`mockResponseMode` / `mockExampleId` on the imported request; a key the
+document no longer has an example for degrades the way `elements_invalid`
+does - counted as `mock_example_missing` in `meta.skipped` and left on
+`pick_example`'s own `"first"` default rather than naming a target that is
+not there. Not read on the sync/diff path, for the same reason
+`x-vayu-elements` is not.
+
 **Errors:** `400` for a missing or empty `collectionId`, or a `format` other
 than `json`/`yaml`. `404` when the collection does not exist. `409` when the
 collection's binding names a document that is not stored, or when the stored

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -588,11 +588,13 @@ logged as a warning: it means a client skipped composition.
     variable default, a row's toggle as `x-vayu-enabled`, a request's or the
     collection's own `elements` (scripts included) as `x-vayu-elements`
     (#1518, read back by the importer and validated against the registry
-    before it reaches a stored request) - and counts what it cannot (other
-    variables, unmapped bodies, form values, execution settings, extra
-    example headers) in `ExportNotes`. The subtree walk stops at
-    a collection bound to a *different* document and not at one bound to the
-    same (#721), as a predicate on `collection_subtree_ids`. YAML output is
+    before it reaches a stored request), a request's `mock_response_mode` as
+    `x-vayu-mock` (#1649, its `"fixed"` target named by the `examples` map key
+    it resolves to rather than an id nothing has minted yet) - and counts
+    what it cannot (other variables, unmapped bodies, form values, execution
+    settings, extra example headers) in `ExportNotes`. The subtree walk stops
+    at a collection bound to a *different* document and not at one bound to
+    the same (#721), as a predicate on `collection_subtree_ids`. YAML output is
     `core::emit_yaml`, beside the reader on purpose: `plain_scalar` decides
     quoting, and split across two files a document would export as
     `swagger: 2.0` and re-import as a number.

--- a/engine/include/vayu/core/openapi_document.hpp
+++ b/engine/include/vayu/core/openapi_document.hpp
@@ -418,6 +418,16 @@ struct SpecRequestDraft {
      */
     std::optional<nlohmann::ordered_json> elements;
     /**
+     * The operation's `x-vayu-mock` object (issue #1649) - `{"mode": "fixed",
+     * "example": "<key>"}` or `{"mode": "random"}` - copied verbatim when the
+     * operation carries the key at all; absent when it does not, exactly like
+     * @ref elements and for the same reason: import-only, resolved by
+     * `parse_openapi` against this same draft's own `examples` (each
+     * carrying the `spec_example_key` the exporter named it under) and left
+     * unread by `spec_request_drafts_of`'s (sync/diff) callers.
+     */
+    std::optional<nlohmann::ordered_json> mock;
+    /**
      * Whether the `paths` key this hangs off is a path at all - see
      * `import_drafts_of`. Always true for a draft `spec_request_drafts_of`
      * returned, since a diff only ever sees identified operations.

--- a/engine/include/vayu/core/openapi_export.hpp
+++ b/engine/include/vayu/core/openapi_export.hpp
@@ -196,6 +196,23 @@ struct ExportRequest {
      * field added in the middle would silently shift every value after it.
      */
     nlohmann::json elements = nlohmann::json::array ();
+    /// "first" | "fixed" | "random" - mirrors `db::Request::mock_response_mode`
+    /// (issue #1649), written as `x-vayu-mock` beside `x-vayu-elements` so a
+    /// re-import keeps what the exporter's user configured instead of
+    /// reverting every mock route to "first".
+    std::string mock_response_mode = "first";
+    /**
+     * Which of `examples` above is the `mock_response_mode == "fixed"`
+     * target, absent when the mode is not `"fixed"` or the stored
+     * `mock_example_id` no longer names one of this request's examples.
+     *
+     * An index into `examples`, not the target's name: two examples can
+     * share a name (`free_key` in `openapi_export.cpp` suffixes the second),
+     * so only the specific `ExportExample` object - found by matching the
+     * stored id before it is discarded, not its name - says which document
+     * key ends up naming it.
+     */
+    std::optional<size_t> mock_example_index = std::nullopt;
 };
 
 /** What a skeleton names the API after. */

--- a/engine/src/core/import_document.cpp
+++ b/engine/src/core/import_document.cpp
@@ -2411,6 +2411,46 @@ json draft_body (const DraftBody& body) {
     return json{ { "mode", body.mode }, { "content", body.content } };
 }
 
+/**
+ * `x-vayu-mock` (issue #1649) onto @p request - which saved example a mock
+ * server answers with. `"random"` needs no target; `"fixed"` names the
+ * `examples` map key the exporter wrote it under (`spec_example_key`, issue
+ * #1457, is exactly that key), resolved here to a position in @p examples
+ * rather than an id - no id exists yet for a row this import has not
+ * created. A key the document no longer carries an example for degrades the
+ * way `elements_invalid` does: counted, and the request keeps
+ * `pick_example`'s own "first" default rather than naming a target that is
+ * not there.
+ */
+void apply_mock_extension (const std::optional<nlohmann::ordered_json>& mock,
+const std::vector<DraftExample>& examples,
+json& request,
+ImportTally& tally) {
+    if (!mock || !mock->is_object ()) {
+        return;
+    }
+    const std::string mode = mock->value ("mode", "");
+    if (mode == "random") {
+        request["mockResponseMode"] = "random";
+        return;
+    }
+    if (mode != "fixed") {
+        return;
+    }
+    const std::string key = mock->value ("example", "");
+    const auto found      = std::find_if (
+    examples.begin (), examples.end (), [&key] (const DraftExample& example) {
+        return example.spec_example_key && *example.spec_example_key == key;
+    });
+    if (found == examples.end ()) {
+        tally.add ("mock_example_missing");
+        return;
+    }
+    request["mockResponseMode"] = "fixed";
+    request["mockExampleIndex"] =
+    static_cast<size_t> (std::distance (examples.begin (), found));
+}
+
 json draft_request (const SpecRequestDraft& entry, ImportTally& tally) {
     const DraftRequest& draft = entry.draft;
     json params               = json::array ();
@@ -2463,6 +2503,7 @@ json draft_request (const SpecRequestDraft& entry, ImportTally& tally) {
             request["elements"] = *entry.elements;
         }
     }
+    apply_mock_extension (entry.mock, draft.examples, request, tally);
     if (!examples.empty ()) {
         request["examples"] = std::move (examples);
     }
@@ -2790,8 +2831,8 @@ int order) {
     item["body"]             = draft.at ("body");
     item["bodyType"] = draft.at ("body").at ("mode"); // the engine never derives this
     item["auth"] = draft.at ("auth");
-    for (const char* optional : { "followRedirects", "maxRedirects",
-         "verifySSL", "examples", "specOperation", "elements" }) {
+    for (const char* optional : { "followRedirects", "maxRedirects", "verifySSL", "examples",
+         "specOperation", "elements", "mockResponseMode", "mockExampleIndex" }) {
         carry (draft, item, optional);
     }
     item["order"] = order;

--- a/engine/src/core/openapi_drafts.cpp
+++ b/engine/src/core/openapi_drafts.cpp
@@ -1176,6 +1176,10 @@ build_drafts (const json& document, ImportTally* tally, bool include_unidentifie
         elements != nullptr && elements->is_array ()) {
             entry.elements = *elements;
         }
+        if (const json* mock = prop (operation, "x-vayu-mock");
+        mock != nullptr && mock->is_object ()) {
+            entry.mock = *mock;
+        }
 
         DraftRequest& draft = entry.draft;
         name_draft (operation, walked, draft);

--- a/engine/src/core/openapi_export.cpp
+++ b/engine/src/core/openapi_export.cpp
@@ -632,6 +632,83 @@ ExportDirection direction) {
     }
 }
 
+/**
+ * The `examples` map key @p value already sits under in @p media, or
+ * `nullopt` when it went in bare as the singular `example` (a key-addressed
+ * vendor extension has nothing to name there) or is not present at all.
+ *
+ * A value comparison, the same one `disposition_of` already makes
+ * (`same_value`), rather than a key threaded through `write_named_examples` /
+ * `add_named_examples`: the write pipeline already decides a value's key by
+ * equality, so reading it back off the finished object costs one pass where a
+ * second out-parameter on every layer down to `add_named_examples` would cost
+ * several - and it answers the *already-declared* case too, where nothing
+ * about the write pipeline touched this value at all.
+ */
+std::optional<std::string> written_key_for (const Json& media, const Json& value) {
+    const auto map = media.find ("examples");
+    if (map == media.end () || !map->is_object ()) {
+        return std::nullopt;
+    }
+    for (auto entry = map->begin (); entry != map->end (); ++entry) {
+        const auto value_member = entry->find ("value");
+        if (entry->is_object () && value_member != entry->end () &&
+        same_value (*value_member, value)) {
+            return entry.key ();
+        }
+    }
+    return std::nullopt;
+}
+
+/**
+ * The `x-vayu-mock.example` key for @p entry's `"fixed"` target, or
+ * `nullopt` when it cannot be named - the target was deleted
+ * (`mock_example_index` absent), filtered before writing (a truncated body,
+ * no recorded media type), the response or media type this document does not
+ * declare, or written bare as a singular `example`. Read off @p responses
+ * *after* `write_response_examples` has run, or off a bound document's own
+ * declared responses when the target was already there and nothing wrote it
+ * again (`ExampleDisposition::AlreadyDeclared`).
+ */
+std::optional<std::string>
+resolve_mock_key (const Json& responses, const ExportRequest& entry) {
+    if (!entry.mock_example_index || *entry.mock_example_index >= entry.examples.size ()) {
+        return std::nullopt;
+    }
+    const ExportExample& target = entry.examples[*entry.mock_example_index];
+    const auto response = responses.find (std::to_string (target.status));
+    if (response == responses.end ()) {
+        return std::nullopt;
+    }
+    const Json* media = declared_media_of (&*response, target.content_type);
+    return media == nullptr ? std::nullopt :
+                              written_key_for (*media, example_value (target.body));
+}
+
+/**
+ * `x-vayu-mock` (issue #1649): which of a request's saved examples a mock
+ * server answers with, written beside `x-vayu-elements` under the same
+ * "additive, never a rewrite" reasoning (`patch_operation` below) - only when
+ * the mode is not `"first"`, the value every unconfigured row already has, so
+ * an operation nobody set a mock choice on gains no key at all.
+ *
+ * A `"fixed"` target this export cannot name writes nothing, the same
+ * "no opinion, serve first" answer `pick_example` gives a target this stale
+ * at runtime (issue #481 phase 3) - there is no other honest key to give it.
+ */
+void write_mock_extension (Json& operation, const ExportRequest& entry, const Json* responses) {
+    if (entry.mock_response_mode == "random") {
+        operation["x-vayu-mock"] = Json{ { "mode", "random" } };
+        return;
+    }
+    if (entry.mock_response_mode != "fixed" || responses == nullptr) {
+        return;
+    }
+    if (const auto key = resolve_mock_key (*responses, entry)) {
+        operation["x-vayu-mock"] = Json{ { "mode", "fixed" }, { "example", *key } };
+    }
+}
+
 /** A document assembled, or the sentence saying why it could not be. */
 struct Assembly {
     Json document;
@@ -933,11 +1010,13 @@ ExportNotes& notes) {
     if (entry.elements.is_array () && !entry.elements.empty ()) {
         operation["x-vayu-elements"] = entry.elements;
     }
-    if (entry.examples.empty ()) {
-        return;
+    if (!entry.examples.empty ()) {
+        write_response_examples (child_record (operation, "responses"),
+        entry.examples, notes, ExportDirection::Bound);
     }
-    write_response_examples (child_record (operation, "responses"),
-    entry.examples, notes, ExportDirection::Bound);
+    const auto responses = operation.find ("responses");
+    write_mock_extension (
+    operation, entry, responses == operation.end () ? nullptr : &*responses);
 }
 
 /**
@@ -1571,7 +1650,10 @@ SecuritySchemeRegistry& schemes) {
         // one claim this export is most likely to be believed about.
         Json responses = Json::object ();
         write_response_examples (responses, entry.examples, notes, ExportDirection::Skeleton);
+        write_mock_extension (operation, entry, &responses);
         operation["responses"] = std::move (responses);
+    } else {
+        write_mock_extension (operation, entry, nullptr);
     }
     return operation;
 }

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -779,8 +779,21 @@ std::vector<vayu::db::RequestExample>& examples_out) {
         !outcome) {
             return outcome;
         }
+        const size_t examples_start = examples_out.size ();
         if (auto outcome = build_example_rows (item, r.id, temp, now, examples_out); !outcome) {
             return outcome;
+        }
+        // `mockExampleIndex` (issue #1649): a transient wire field naming, by
+        // position among this item's own examples, an OpenAPI import's
+        // `x-vayu-mock` `"fixed"` target - never a stored column, and
+        // resolved only now that `build_example_rows` just minted the real
+        // ids no id existed for when the parser wrote this field.
+        if (const auto index_field = item.find ("mockExampleIndex");
+        index_field != item.end () && index_field->is_number_unsigned ()) {
+            const size_t index = examples_start + index_field->get<size_t> ();
+            if (index < examples_out.size ()) {
+                r.mock_example_id = examples_out[index].id;
+            }
         }
         out.push_back (std::move (r));
     }

--- a/engine/src/http/routes/spec_export.cpp
+++ b/engine/src/http/routes/spec_export.cpp
@@ -332,7 +332,12 @@ const std::string& folder_collection_id) {
     entry.verify_ssl       = row.verify_ssl;
     entry.stream           = row.stream;
     entry.folder_path = folder_path_of (collections, root_id, folder_collection_id);
+    entry.mock_response_mode = row.mock_response_mode;
     for (const auto& example : db.get_request_examples (row.id)) {
+        if (row.mock_response_mode == "fixed" && row.mock_example_id &&
+        *row.mock_example_id == example.id) {
+            entry.mock_example_index = entry.examples.size ();
+        }
         entry.examples.push_back ({ example.name, example.status, example.body,
         example.content_type, example.body_truncated,
         example.origin == vayu::core::constants::request_example::ORIGIN_IMPORT,

--- a/engine/tests/import_parse_test.cpp
+++ b/engine/tests/import_parse_test.cpp
@@ -578,6 +578,70 @@ TEST (ImportParse, ReadsXVayuElementsIntoTheImportedRequest) {
     EXPECT_EQ (request.at ("elements")[0].at ("kind"), "extract.json");
 }
 
+/// `x-vayu-mock` (issue #1649) resolves its `"fixed"` target by matching
+/// `example` against the imported example that came from the same `examples`
+/// map key - `mockExampleIndex`, a position rather than an id nothing has
+/// minted yet at parse time.
+TEST (ImportParse, ReadsAFixedXVayuMockAsAnExampleIndex) {
+    const ImportParse parsed = parse_import (R"({"openapi":"3.0.0","info":{"title":"T"},
+        "paths":{"/pets":{"get":{"responses":{"200":{"description":"ok","content":
+        {"application/json":{"examples":{
+            "first":{"value":{"id":"p1"}},
+            "second":{"value":{"id":"p2"}}
+        }}}}},
+        "x-vayu-mock":{"mode":"fixed","example":"first"}}}}})",
+    {}, {});
+    ASSERT_TRUE (parsed.ok ()) << parsed.error;
+    const nlohmann::ordered_json& request =
+    first_request (parsed.result.at ("collections")[0]);
+    EXPECT_EQ (request.at ("mockResponseMode"), "fixed");
+    // `first_named_example_entry` only ever reads the first entry of the map
+    // per status (`declared_example_value`), so "first" is what actually
+    // imports as this operation's one example - index 0 - which is exactly
+    // the entry `x-vayu-mock` names here.
+    ASSERT_TRUE (request.contains ("examples"));
+    EXPECT_EQ (request.at ("examples").size (), 1);
+    EXPECT_EQ (request.at ("mockExampleIndex"), 0);
+}
+
+/// `"random"` needs no target and is applied outright.
+TEST (ImportParse, ReadsARandomXVayuMock) {
+    const ImportParse parsed = parse_import (R"({"openapi":"3.0.0","info":{"title":"T"},
+        "paths":{"/pets":{"get":{"responses":{},
+        "x-vayu-mock":{"mode":"random"}}}}})",
+    {}, {});
+    ASSERT_TRUE (parsed.ok ()) << parsed.error;
+    const nlohmann::ordered_json& request =
+    first_request (parsed.result.at ("collections")[0]);
+    EXPECT_EQ (request.at ("mockResponseMode"), "random");
+    EXPECT_FALSE (request.contains ("mockExampleIndex"));
+}
+
+/// A `"fixed"` target naming an `examples` key this operation's response no
+/// longer declares (hand-edited, or the entry the exporter suffixed is gone)
+/// degrades the way `elements_invalid` does: counted, and the request keeps
+/// no `mockResponseMode` at all, which is `pick_example`'s own "first"
+/// default.
+TEST (ImportParse, CountsAFixedXVayuMockNamingAMissingExample) {
+    const ImportParse parsed = parse_import (R"({"openapi":"3.0.0","info":{"title":"T"},
+        "paths":{"/pets":{"get":{"responses":{"200":{"description":"ok","content":
+        {"application/json":{"examples":{"kept":{"value":{"id":"p1"}}}}}}},
+        "x-vayu-mock":{"mode":"fixed","example":"gone"}}}}})",
+    {}, {});
+    ASSERT_TRUE (parsed.ok ()) << parsed.error;
+    const nlohmann::ordered_json& request =
+    first_request (parsed.result.at ("collections")[0]);
+    EXPECT_FALSE (request.contains ("mockResponseMode"));
+    EXPECT_FALSE (request.contains ("mockExampleIndex"));
+    const nlohmann::ordered_json& skipped =
+    parsed.result.at ("meta").at ("skipped");
+    const bool counted = std::any_of (
+    skipped.begin (), skipped.end (), [] (const nlohmann::ordered_json& item) {
+        return item.at ("kind") == "mock_example_missing";
+    });
+    EXPECT_TRUE (counted);
+}
+
 /// A hand-edited `x-vayu-elements` that fails the registry (an unknown kind,
 /// here) is dropped and counted rather than applied or refusing the whole
 /// document - the same "nothing dropped quietly, nothing invalid applied"

--- a/engine/tests/openapi_export_test.cpp
+++ b/engine/tests/openapi_export_test.cpp
@@ -295,6 +295,59 @@ TEST (BoundExport, WritesOneStoredExampleAsExampleAndSeveralAsANamedMap) {
     EXPECT_EQ (exported.notes.examples_written, 3);
 }
 
+TEST (BoundExport, WritesXVayuMockOnAFixedTargetAndNoneOnFirstOrMissing) {
+    std::vector<ExportRequest> requests = bound_requests ();
+    // request[0] ("first", the default): no opinion, no key at all.
+    requests[0].examples = { example () };
+    // request[1] ("fixed", index 1 of two): names the key its target was
+    // written under. Two examples, not one, so the write lands in a named
+    // `examples` map rather than the bare `example` a lone one gets (see
+    // `WritesNoXVayuMockForAFixedTargetThatIsItsStatussOnlyExample` in the
+    // skeleton section for that case).
+    requests[1].examples = { example ("created", 201, R"({"id":"p1"})"),
+        example ("created too", 201, R"({"id":"p2"})") };
+    requests[1].mock_response_mode = "fixed";
+    requests[1].mock_example_index = 1;
+    // request[2] ("fixed", pointing past its own empty `examples`): the
+    // stored `mock_example_id` named a row that no longer exists by the time
+    // this export ran - `build_export_request` never sets an index for one,
+    // which this asserts degrades exactly like "first" rather than crashing
+    // or naming a key nothing backs.
+    requests[2].mock_response_mode = "fixed";
+
+    const Exported exported = export_json (requests, bound_fixture ());
+    EXPECT_FALSE (operation_of (exported.document, "/pets", "get").contains ("x-vayu-mock"));
+    EXPECT_EQ (operation_of (exported.document, "/pets", "post")["x-vayu-mock"],
+    json::parse (R"({"mode":"fixed","example":"created too"})"));
+    EXPECT_FALSE (
+    operation_of (exported.document, "/pets/{petId}", "delete").contains ("x-vayu-mock"));
+}
+
+TEST (BoundExport, NamesTheSuffixedKeyWhenTheFixedExampleSharesAName) {
+    std::vector<ExportRequest> requests = bound_requests ();
+    // Two examples of the same status+media type sharing a name: `free_key`
+    // suffixes the second to "created-2", and the `x-vayu-mock` this writes
+    // for the second example must name that suffixed key, not the wanted one
+    // a naive re-derivation (matching by name alone) would give.
+    requests[1].examples = { example ("created", 201, R"({"id":"p1"})"),
+        example ("created", 201, R"({"id":"p2"})") };
+    requests[1].mock_response_mode = "fixed";
+    requests[1].mock_example_index = 1;
+
+    const Exported exported = export_json (requests, bound_fixture ());
+    EXPECT_EQ (operation_of (exported.document, "/pets", "post")["x-vayu-mock"],
+    json::parse (R"({"mode":"fixed","example":"created-2"})"));
+}
+
+TEST (BoundExport, WritesXVayuMockForRandomModeEvenWithNoExamples) {
+    std::vector<ExportRequest> requests = bound_requests ();
+    requests[0].mock_response_mode      = "random";
+
+    const Exported exported = export_json (requests, bound_fixture ());
+    EXPECT_EQ (operation_of (exported.document, "/pets", "get")["x-vayu-mock"],
+    json::parse (R"({"mode":"random"})"));
+}
+
 TEST (BoundExport, WritesNothingIntoADocumentNobodyEdited) {
     const std::string content           = refs_fixture ();
     std::vector<ExportRequest> requests = refs_requests ();
@@ -600,14 +653,17 @@ TEST (BoundExport, RemovesFromASwagger20DocumentButWritesNothingIntoIt) {
     R"("get":{"operationId":"listPets","responses":{"200":{"description":"ok"}}},)"
     R"("post":{"operationId":"createPet","responses":{"200":{"description":"ok"}}}}}})";
     ExportRequest listed = bound_request ("GET", "{{baseUrl}}/pets", "listPets", "/pets");
-    listed.examples = { example () };
+    listed.examples           = { example () };
+    listed.mock_response_mode = "fixed";
+    listed.mock_example_index = 0;
 
     const Exported exported = export_json ({ listed }, swagger);
     EXPECT_FALSE (exported.document["paths"]["/pets"].contains ("post"));
-    const json& response =
-    operation_of (exported.document, "/pets", "get")["responses"]["200"];
+    const json& operation = operation_of (exported.document, "/pets", "get");
+    const json& response  = operation["responses"]["200"];
     EXPECT_FALSE (response.contains ("content"));
     EXPECT_FALSE (response.contains ("examples"));
+    EXPECT_FALSE (operation.contains ("x-vayu-mock"));
     EXPECT_TRUE (exported.notes.vocabulary_not_written);
     EXPECT_EQ (exported.notes.dialect, "Swagger 2.0");
     EXPECT_EQ (exported.notes.examples_written, 0);
@@ -886,6 +942,55 @@ TEST (SkeletonExport, WritesResponsesFromStoredExamplesAndNothingElse) {
     // A body that is not JSON is the text it is, never dropped.
     EXPECT_EQ (responses["500"]["content"]["text/plain"]["example"], "boom");
     EXPECT_EQ (exported.notes.examples_written, 2);
+}
+
+TEST (SkeletonExport, WritesXVayuMockBesideXVayuElementsAndNoneOnFirst) {
+    // Two examples of the same status+media type, so the second lands in a
+    // named `examples` map rather than bare - see the sibling test below for
+    // what happens when there is only one.
+    ExportRequest fixed      = request ("GET", "{{baseUrl}}/pets");
+    fixed.examples           = { example ("one", 200, R"({"id":"p1"})"),
+                  example ("two", 200, R"({"id":"p2"})") };
+    fixed.mock_response_mode = "fixed";
+    fixed.mock_example_index = 1;
+
+    ExportRequest first = request ("POST", "{{baseUrl}}/pets");
+    first.examples      = { example ("created", 201, R"({"id":"p1"})") };
+
+    const Exported exported = export_json ({ fixed, first });
+    EXPECT_EQ (operation_of (exported.document, "/pets", "get")["x-vayu-mock"],
+    json::parse (R"({"mode":"fixed","example":"two"})"));
+    EXPECT_FALSE (operation_of (exported.document, "/pets", "post").contains ("x-vayu-mock"));
+}
+
+TEST (SkeletonExport, WritesNoXVayuMockForAFixedTargetThatIsItsStatussOnlyExample) {
+    // A single example of its status+media type is written bare, as the
+    // singular `example`, never a named `examples` map entry (`free_key`'s
+    // whole reason to exist is a *second* example of the same pair) - so a
+    // `fixed` target here has no key to be named by. Behaviourally this is
+    // no loss: with one example, "first" and "fixed" already pick the same
+    // response, and there is no other honest key to write.
+    ExportRequest entry      = request ("GET", "{{baseUrl}}/pets");
+    entry.examples           = { example () };
+    entry.mock_response_mode = "fixed";
+    entry.mock_example_index = 0;
+
+    const Exported exported = export_json ({ entry });
+    const json& operation   = operation_of (exported.document, "/pets", "get");
+    EXPECT_TRUE (operation["responses"]["200"]["content"]["application/json"].contains ("example"));
+    EXPECT_FALSE (operation.contains ("x-vayu-mock"));
+}
+
+TEST (SkeletonExport, WritesXVayuMockForRandomModeWithNoStoredExamples) {
+    ExportRequest entry      = request ("GET", "{{baseUrl}}/pets");
+    entry.mock_response_mode = "random";
+
+    const Exported exported = export_json ({ entry });
+    EXPECT_EQ (operation_of (exported.document, "/pets", "get")["x-vayu-mock"],
+    json::parse (R"({"mode":"random"})"));
+    // No stored example and no "fixed" target: the operation gets the mode
+    // but still no invented response.
+    EXPECT_FALSE (operation_of (exported.document, "/pets", "get").contains ("responses"));
 }
 
 TEST (SkeletonExport, StripsARepeatedStatusPrefixInsteadOfAccretingOneOnEveryReimport) {

--- a/engine/tests/spec_export_route_test.cpp
+++ b/engine/tests/spec_export_route_test.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -53,6 +54,13 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json);
 std::pair<int, nlohmann::json> create_request_example_response (vayu::db::Database& db,
 const std::string& request_id,
 const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+// Defined in import.cpp - the combined parse-and-apply `POST /import`, used
+// here for the round trip a mock mode's `x-vayu-mock` export exists for.
+std::pair<int, nlohmann::json>
+import_response (vayu::db::Database& db, const nlohmann::json& body);
 } // namespace vayu::http::routes
 
 namespace {
@@ -254,6 +262,78 @@ TEST_F (SpecExportRouteTest, ExportsAFreeFormCollectionAsASkeleton) {
     EXPECT_EQ (document["openapi"], "3.1.0");
     EXPECT_EQ (document["info"]["title"], "Pets API");
     EXPECT_TRUE (document["paths"].contains ("/pets"));
+}
+
+/**
+ * The route-level round trip issue #1649 exists for: a request's `"fixed"`
+ * mock target, exported as OpenAPI and imported into a fresh collection,
+ * comes back naming *that collection's own copy* of the same example rather
+ * than reverting to `"first"`.
+ *
+ * Three stored examples, not two: the importer's `examples_v3` keeps only the
+ * *first* named example of each status (`declared_example_value`), so the
+ * fixed target - the second example this request ever gained - is put under
+ * its own status (201) rather than sharing the first one's (200), and a third
+ * example beside it there forces that status into a named `examples` map
+ * (`add_named_examples`) instead of the bare, unaddressable `example` a lone
+ * one would get. That makes the target both the first of its own status
+ * (so it survives import) and a named map entry (so `x-vayu-mock` has a key
+ * to give it) - the two properties this round trip needs at once.
+ */
+TEST_F (SpecExportRouteTest, RoundTripsAFixedMockModeThroughXVayuMock) {
+    const std::string listed = create_request (root_, "GET", "{{baseUrl}}/pets");
+    add_example (listed,
+    json{ { "name", "ok" }, { "status", 200 }, { "origin", "user" },
+    { "body", R"({"id":"p0"})" }, { "contentType", "application/json" } });
+    add_example (listed,
+    json{ { "name", "created" }, { "status", 201 }, { "origin", "user" },
+    { "body", R"({"id":"p1"})" }, { "contentType", "application/json" } });
+    add_example (listed,
+    json{ { "name", "created also" }, { "status", 201 }, { "origin", "user" },
+    { "body", R"({"id":"p2"})" }, { "contentType", "application/json" } });
+    const auto stored_examples = db_->get_request_examples (listed);
+    ASSERT_EQ (stored_examples.size (), 3);
+    const std::string target_example_id = stored_examples[1].id; // "created"
+
+    auto [update_status, update_body] = routes::update_request_response (*db_, listed,
+    json{ { "mockResponseMode", "fixed" }, { "mockExampleId", target_example_id } });
+    ASSERT_EQ (update_status, 200) << update_body.dump ();
+
+    const std::string text = export_collection ()["text"].get<std::string> ();
+
+    auto [import_status, imported] =
+    routes::import_response (*db_, json{ { "content", text } });
+    ASSERT_EQ (import_status, 200) << imported.dump ();
+
+    // The import created new collections alongside `root_` - a root plus, since
+    // this operation carries no tags, a `pets` sub-collection its path names
+    // (`folder_of`) - so the new request is gathered across all of them rather
+    // than assumed to sit directly under the new root.
+    std::vector<vayu::db::Request> new_requests;
+    for (const auto& c : db_->get_collections ()) {
+        if (c.id == root_) {
+            continue;
+        }
+        for (auto& request : db_->get_requests_in_collection (c.id)) {
+            new_requests.push_back (std::move (request));
+        }
+    }
+    ASSERT_EQ (new_requests.size (), 1);
+    const vayu::db::Request& new_request = new_requests.front ();
+    EXPECT_EQ (new_request.mock_response_mode, "fixed");
+    ASSERT_HAS_VALUE (new_request.mock_example_id);
+
+    const auto new_examples = db_->get_request_examples (new_request.id);
+    const auto target       = std::find_if (new_examples.begin (),
+          new_examples.end (), [&] (const vayu::db::RequestExample& example) {
+        return example.id == *new_request.mock_example_id;
+    });
+    ASSERT_NE (target, new_examples.end ());
+    // The body a "fixed" mock would actually serve - the proof that this
+    // resolved to "created" (`p1`) and not "created also" (`p2`) or the
+    // unrelated 200 example (`p0`).
+    EXPECT_EQ (json::parse (target->body), json::parse (R"({"id":"p1"})"));
+    EXPECT_EQ (target->status, 201);
 }
 
 TEST_F (SpecExportRouteTest, WritesYamlWhenAskedForIt) {


### PR DESCRIPTION
## Description

PR #1645 added `mockResponseMode` / `mockExampleId` to a request - which saved
example a mock server answers with - but the OpenAPI exporter never read
either field, and every `fixed` or `random` mock route reverted to `first` on
re-import even though `x-vayu-elements` already carried the rest of the
request through.

Adds `x-vayu-mock` beside the existing `x-vayu-elements` vendor extension,
under the same "additive, never a rewrite" rule and the same `dialect.writable`
gate (nothing is written into a Swagger 2.0 document).

The one non-obvious piece: a `fixed` target's `mockExampleId` cannot survive
the round trip as an id (import mints new ids), and it cannot be resolved by
name either (two examples can share a name, which is exactly what `free_key`
suffixing exists for). So the exporter resolves the target to the `examples`
map key it actually got written under - reading it back off the finished
document by value, the same equality check `disposition_of` already makes,
rather than threading a second out-parameter through `write_named_examples` /
`add_named_examples`. The importer does the mirror: it matches `x-vayu-mock`'s
`example` against the newly parsed example carrying the same `specExampleKey`,
and resolves that to a *position* among this item's own examples
(`mockExampleIndex`) rather than an id - no id exists yet for a row this
import has not created. `POST /import/apply`'s request-row builder resolves
that index to a real id only after the sibling examples are inserted and their
ids are minted.

Considered and rejected: writing the target by name and re-deriving
`free_key`'s suffix logic a second time outside the write path. Two
implementations of the same collision rule drift the moment either changes;
reading the already-decided key back off the document cannot.

## Also fixed in this PR

`draft_request` (import parsing) crossed clang-tidy's cognitive-complexity
threshold once the mock-resolution branch was added inline, so that branch is
its own function, `apply_mock_extension` - in scope for this issue, since the
mock parsing is what pushed it over.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **3374/3374 passed**, including 8 new cases in `openapi_export_test.cpp` (bound + skeleton: a fixed target, a suffixed-key collision, random mode with no examples, a lone example written bare and therefore unaddressable, Swagger 2.0 writing nothing), 3 new cases in `import_parse_test.cpp` (fixed resolves to an index, random applies outright, a missing key counts `mock_example_missing`), and a route-level round trip in `spec_export_route_test.cpp` (create three examples across two statuses, set `fixed` on the second, export, import into a fresh collection, confirm the new request's `mockExampleId` resolves to the new collection's copy of the same example body).
- Mutation-checked: reverting `write_mock_extension`'s call sites or `apply_mock_extension` reds every new export/import test; reverting the `carry(...)` addition in `apply_request` (the `/import/apply` flattening step) reproduces the exact bug this issue reports - `mockResponseMode` present in the parse preview but silently dropped before apply, which is how the initial version of this fix actually failed before catching it.
- `cd app && pnpm test && pnpm type-check && pnpm lint` - clean (762 files, 8636 tests passed, 2 pre-existing skips; the app-side change is a new `SkippedItem` kind label, no behavior change).
- `clang-format-19 --dry-run -Werror` and `clang-tidy-19` (this repo's exact pins) over every changed engine file - clean.

No user-visible change: the app renders `meta.skipped` counts generically
already (`ImportModal.tsx`'s `SKIPPED_LABELS`), which gained one more entry
for `mock_example_missing`'s friendly label - not a UI screenshot-worthy
change, and the mock mode/example selection UI itself is unchanged.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `docs/engine/api-reference.md`,
  `docs/app/openapi.md`, `engine/CLAUDE.md`'s `POST /specs/export` summary.

## Related Issues
Closes #1649